### PR TITLE
fix(web): fix warning text when attempting to link child appeal to lead of different appeal

### DIFF
--- a/appeals/web/src/server/appeals/appeal-details/manage-linked-appeals/__tests__/__snapshots__/manage-linked-appeals.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/manage-linked-appeals/__tests__/__snapshots__/manage-linked-appeals.test.js.snap
@@ -568,6 +568,53 @@ exports[`linked-appeals GET /linked-appeals/add/check-and-confirm should render 
 </main>"
 `;
 
+exports[`linked-appeals GET /linked-appeals/add/check-and-confirm should render the check and confirm page with appropriate warning text, no radio options, and a button linking back to the add linked appeal reference page with label text of "return to search", if the appeals are not already linked and the linking target is a child appeal and the linking candidate is a lead appeal 1`] = `
+"<main class="govuk-main-wrapper " id="main-content" role="main">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <div class="govuk-grid-row">
+                <div class="govuk-grid-column-full"><span class="govuk-caption-l govuk-!-margin-bottom-3">Appeal 351062</span>
+                    <h1                     class="govuk-heading-l">Details of the appeal you&#39;re linking to</h1>
+                </div>
+            </div>
+            <div class="govuk-warning-text"><span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+                <strong                 class="govuk-warning-text__text"><span class="govuk-warning-text__assistive">Warning</span> The appeal you
+                    are trying to link to is already a lead appeal.</strong>
+            </div>
+            <dl class="govuk-summary-list govuk-!-margin-bottom-9">
+                <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Appeal reference</dt>
+                    <dd class="govuk-summary-list__value">TEST-12345</dd>
+                </div>
+                <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Appeal status</dt>
+                    <dd class="govuk-summary-list__value">Assign case officer</dd>
+                </div>
+                <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Appeal type</dt>
+                    <dd class="govuk-summary-list__value">Householder</dd>
+                </div>
+                <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Site address</dt>
+                    <dd class="govuk-summary-list__value">96 The Avenue, Maidstone, Kent, MD21 5XY</dd>
+                </div>
+                <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Local planning authority</dt>
+                    <dd                     class="govuk-summary-list__value">Wiltshire Council</dd>
+                </div>
+                <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Appellant name</dt>
+                    <dd class="govuk-summary-list__value">Roger Simmons</dd>
+                </div>
+                <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Agent name</dt>
+                    <dd class="govuk-summary-list__value">Eva Sharma (Eva Sharma Ltd)</dd>
+                </div>
+                <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Submission date</dt>
+                    <dd class="govuk-summary-list__value">21 February 2024</dd>
+                </div>
+            </dl>
+            <form method="post" novalidate="novalidate"><a href="/appeals-service/appeal-details/1/linked-appeals/add" role="button"
+                draggable="false" class="govuk-button" data-module="govuk-button"> Return to search</a>
+            </form>
+        </div>
+    </div>
+</main>"
+`;
+
 exports[`linked-appeals GET /linked-appeals/add/check-and-confirm should render the check and confirm page with appropriate warning text, no radio options, and a button linking back to the add linked appeal reference page with label text of "return to search", if the linking candidate is a child (already has a lead) 1`] = `
 "<main class="govuk-main-wrapper " id="main-content" role="main">
     <div class="govuk-grid-row">

--- a/appeals/web/src/server/appeals/appeal-details/manage-linked-appeals/manage-linked-appeals.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/manage-linked-appeals/manage-linked-appeals.mapper.js
@@ -438,7 +438,17 @@ export function addLinkedAppealCheckAndConfirmPage(
 	}
 	// target is a child
 	else if (appealData.isChildAppeal) {
-		pageContent.pageComponents?.unshift(alreadyHasLeadWarningTextComponent);
+		if (candidateIsLead) {
+			pageContent.pageComponents?.unshift({
+				type: 'warning-text',
+				parameters: {
+					text: 'The appeal you are trying to link to is already a lead appeal.'
+				}
+			});
+		} else {
+			pageContent.pageComponents?.unshift(alreadyHasLeadWarningTextComponent);
+		}
+
 		pageContent.submitButtonProperties = {
 			text: 'Return to search',
 			href: `/appeals-service/appeal-details/${appealData.appealId}/linked-appeals/add`


### PR DESCRIPTION
## Describe your changes

fix warning text when attempting to link child appeal to lead of different appeal

## Issue ticket number and link

BOAT-1068

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [ ] I have performed a self-review of my own code
- [ ] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [ ] I have referenced the ticket number above
- [ ] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
