### PR TITLE
fix(web): makes horizonAppealBaseUrl optional

### DIFF
--- a/appeals/web/environment/schema.js
+++ b/appeals/web/environment/schema.js
@@ -27,7 +27,7 @@ export default baseSchema
 		blobStorageUrl: joi.string(),
 		blobEmulatorSasUrl: joi.string().when('useBlobEmulator', { not: 'true', then: joi.optional() }),
 		blobStorageDefaultContainer: joi.string(),
-		horizonAppealBaseUrl: joi.string(),
+		horizonAppealBaseUrl: joi.string().optional(),
 		useBlobEmulator: joi.boolean().optional(),
 		logLevelFile: joi.string().valid(...logLevel),
 		logLevelStdOut: joi.string().valid(...logLevel),


### PR DESCRIPTION
There is still some lack of clarity on Horizon URLs, until then made the horizonAppealBaseUrl ENV setting optional, to avoid the site breaking on deploy.

## Issue ticket number and link

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [ ] I have performed a self-review of my own code
- [ ] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [ ] I have referenced the ticket number above
- [ ] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
