### PR TITLE
fix(web): make external appeal linkable only if settings are found

### DIFF
--- a/appeals/web/environment/config.d.ts
+++ b/appeals/web/environment/config.d.ts
@@ -32,7 +32,7 @@ export interface EnvironmentConfig extends BaseEnvironmentConfig {
 	blobStorageUrl: string;
 	blobStorageDefaultContainer: string;
 	blobEmulatorSasUrl: string;
-	horizonAppealBaseUrl: string;
+	horizonAppealBaseUrl?: string;
 	useBlobEmulator: boolean;
 	cwd: string;
 	logLevelFile: LevelWithSilent;

--- a/appeals/web/environment/schema.js
+++ b/appeals/web/environment/schema.js
@@ -27,7 +27,7 @@ export default baseSchema
 		blobStorageUrl: joi.string(),
 		blobEmulatorSasUrl: joi.string().when('useBlobEmulator', { not: 'true', then: joi.optional() }),
 		blobStorageDefaultContainer: joi.string(),
-		horizonAppealBaseUrl: joi.string().optional(),
+		horizonAppealBaseUrl: joi.string().optional().empty(''),
 		useBlobEmulator: joi.boolean().optional(),
 		logLevelFile: joi.string().valid(...logLevel),
 		logLevelStdOut: joi.string().valid(...logLevel),

--- a/appeals/web/src/server/lib/display-page-formatter.js
+++ b/appeals/web/src/server/lib/display-page-formatter.js
@@ -356,5 +356,7 @@ export function generateHorizonAppealUrl(appealId) {
 		return '';
 	}
 
-	return `${config.horizonAppealBaseUrl}${appealId}`;
+	return config.horizonAppealBaseUrl && config.horizonAppealBaseUrl.length
+		? `${config.horizonAppealBaseUrl}${appealId}`
+		: '';
 }


### PR DESCRIPTION
As it says in the title... Avoid making links to Horizon if the setting is not available...
## Issue ticket number and link

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [ ] I have performed a self-review of my own code
- [ ] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [ ] I have referenced the ticket number above
- [ ] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
