### PR TITLE
fix(web): pre-populate update due date values on change timetable flow

### DIFF
--- a/appeals/web/src/server/appeals/appeal-details/appeal-timetables/__tests__/__snapshots__/appeal-timetables.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/appeal-timetables/__tests__/__snapshots__/appeal-timetables.test.js.snap
@@ -16,21 +16,21 @@ exports[`Appeal Timetables should render "Change Final Comment Review Date" page
                     <div class="govuk-form-group">
                         <label class="govuk-label govuk-date-input__label" for="due-date-day">Day</label>
                         <input class="govuk-input govuk-date-input__input govuk-input--width-2"
-                        id="due-date-day" name="due-date-day" type="text" inputmode="numeric">
+                        id="due-date-day" name="due-date-day" type="text" value="9" inputmode="numeric">
                     </div>
                 </div>
                 <div class="govuk-date-input__item">
                     <div class="govuk-form-group">
                         <label class="govuk-label govuk-date-input__label" for="due-date-month">Month</label>
                         <input class="govuk-input govuk-date-input__input govuk-input--width-2"
-                        id="due-date-month" name="due-date-month" type="text" inputmode="numeric">
+                        id="due-date-month" name="due-date-month" type="text" value="8" inputmode="numeric">
                     </div>
                 </div>
                 <div class="govuk-date-input__item">
                     <div class="govuk-form-group">
                         <label class="govuk-label govuk-date-input__label" for="due-date-year">Year</label>
                         <input class="govuk-input govuk-date-input__input govuk-input--width-4"
-                        id="due-date-year" name="due-date-year" type="text" inputmode="numeric">
+                        id="due-date-year" name="due-date-year" type="text" value="2023" inputmode="numeric">
                     </div>
                 </div>
             </div>
@@ -73,21 +73,21 @@ exports[`Appeal Timetables should render "Change Final Comment Review Date" with
                     <div class="govuk-form-group">
                         <label class="govuk-label govuk-date-input__label" for="due-date-day">Day</label>
                         <input class="govuk-input govuk-date-input__input govuk-input--width-2"
-                        id="due-date-day" name="due-date-day" type="text" inputmode="numeric">
+                        id="due-date-day" name="due-date-day" type="text" value="9" inputmode="numeric">
                     </div>
                 </div>
                 <div class="govuk-date-input__item">
                     <div class="govuk-form-group">
                         <label class="govuk-label govuk-date-input__label" for="due-date-month">Month</label>
                         <input class="govuk-input govuk-date-input__input govuk-input--width-2"
-                        id="due-date-month" name="due-date-month" type="text" inputmode="numeric">
+                        id="due-date-month" name="due-date-month" type="text" value="8" inputmode="numeric">
                     </div>
                 </div>
                 <div class="govuk-date-input__item">
                     <div class="govuk-form-group">
                         <label class="govuk-label govuk-date-input__label" for="due-date-year">Year</label>
                         <input class="govuk-input govuk-date-input__input govuk-input--width-4"
-                        id="due-date-year" name="due-date-year" type="text" inputmode="numeric">
+                        id="due-date-year" name="due-date-year" type="text" value="2023" inputmode="numeric">
                     </div>
                 </div>
             </div>
@@ -136,21 +136,21 @@ exports[`Appeal Timetables should render "Change Final Comment Review Date" with
                     <div class="govuk-form-group">
                         <label class="govuk-label govuk-date-input__label" for="due-date-day">Day</label>
                         <input class="govuk-input govuk-date-input__input govuk-input--width-2"
-                        id="due-date-day" name="due-date-day" type="text" inputmode="numeric">
+                        id="due-date-day" name="due-date-day" type="text" value="9" inputmode="numeric">
                     </div>
                 </div>
                 <div class="govuk-date-input__item">
                     <div class="govuk-form-group">
                         <label class="govuk-label govuk-date-input__label" for="due-date-month">Month</label>
                         <input class="govuk-input govuk-date-input__input govuk-input--width-2"
-                        id="due-date-month" name="due-date-month" type="text" inputmode="numeric">
+                        id="due-date-month" name="due-date-month" type="text" value="8" inputmode="numeric">
                     </div>
                 </div>
                 <div class="govuk-date-input__item">
                     <div class="govuk-form-group">
                         <label class="govuk-label govuk-date-input__label" for="due-date-year">Year</label>
                         <input class="govuk-input govuk-date-input__input govuk-input--width-4"
-                        id="due-date-year" name="due-date-year" type="text" inputmode="numeric">
+                        id="due-date-year" name="due-date-year" type="text" value="2023" inputmode="numeric">
                     </div>
                 </div>
             </div>
@@ -178,21 +178,21 @@ exports[`Appeal Timetables should render "Change LPA questionnaire Date" page 1`
                     <div class="govuk-form-group">
                         <label class="govuk-label govuk-date-input__label" for="due-date-day">Day</label>
                         <input class="govuk-input govuk-date-input__input govuk-input--width-2"
-                        id="due-date-day" name="due-date-day" type="text" inputmode="numeric">
+                        id="due-date-day" name="due-date-day" type="text" value="9" inputmode="numeric">
                     </div>
                 </div>
                 <div class="govuk-date-input__item">
                     <div class="govuk-form-group">
                         <label class="govuk-label govuk-date-input__label" for="due-date-month">Month</label>
                         <input class="govuk-input govuk-date-input__input govuk-input--width-2"
-                        id="due-date-month" name="due-date-month" type="text" inputmode="numeric">
+                        id="due-date-month" name="due-date-month" type="text" value="8" inputmode="numeric">
                     </div>
                 </div>
                 <div class="govuk-date-input__item">
                     <div class="govuk-form-group">
                         <label class="govuk-label govuk-date-input__label" for="due-date-year">Year</label>
                         <input class="govuk-input govuk-date-input__input govuk-input--width-4"
-                        id="due-date-year" name="due-date-year" type="text" inputmode="numeric">
+                        id="due-date-year" name="due-date-year" type="text" value="2023" inputmode="numeric">
                     </div>
                 </div>
             </div>
@@ -220,21 +220,21 @@ exports[`Appeal Timetables should render "Change issue determination" page 1`] =
                     <div class="govuk-form-group">
                         <label class="govuk-label govuk-date-input__label" for="due-date-day">Day</label>
                         <input class="govuk-input govuk-date-input__input govuk-input--width-2"
-                        id="due-date-day" name="due-date-day" type="text" inputmode="numeric">
+                        id="due-date-day" name="due-date-day" type="text" value="9" inputmode="numeric">
                     </div>
                 </div>
                 <div class="govuk-date-input__item">
                     <div class="govuk-form-group">
                         <label class="govuk-label govuk-date-input__label" for="due-date-month">Month</label>
                         <input class="govuk-input govuk-date-input__input govuk-input--width-2"
-                        id="due-date-month" name="due-date-month" type="text" inputmode="numeric">
+                        id="due-date-month" name="due-date-month" type="text" value="8" inputmode="numeric">
                     </div>
                 </div>
                 <div class="govuk-date-input__item">
                     <div class="govuk-form-group">
                         <label class="govuk-label govuk-date-input__label" for="due-date-year">Year</label>
                         <input class="govuk-input govuk-date-input__input govuk-input--width-4"
-                        id="due-date-year" name="due-date-year" type="text" inputmode="numeric">
+                        id="due-date-year" name="due-date-year" type="text" value="2023" inputmode="numeric">
                     </div>
                 </div>
             </div>
@@ -262,21 +262,21 @@ exports[`Appeal Timetables should render "Change statement review Date" page 1`]
                     <div class="govuk-form-group">
                         <label class="govuk-label govuk-date-input__label" for="due-date-day">Day</label>
                         <input class="govuk-input govuk-date-input__input govuk-input--width-2"
-                        id="due-date-day" name="due-date-day" type="text" inputmode="numeric">
+                        id="due-date-day" name="due-date-day" type="text" value="9" inputmode="numeric">
                     </div>
                 </div>
                 <div class="govuk-date-input__item">
                     <div class="govuk-form-group">
                         <label class="govuk-label govuk-date-input__label" for="due-date-month">Month</label>
                         <input class="govuk-input govuk-date-input__input govuk-input--width-2"
-                        id="due-date-month" name="due-date-month" type="text" inputmode="numeric">
+                        id="due-date-month" name="due-date-month" type="text" value="8" inputmode="numeric">
                     </div>
                 </div>
                 <div class="govuk-date-input__item">
                     <div class="govuk-form-group">
                         <label class="govuk-label govuk-date-input__label" for="due-date-year">Year</label>
                         <input class="govuk-input govuk-date-input__input govuk-input--width-4"
-                        id="due-date-year" name="due-date-year" type="text" inputmode="numeric">
+                        id="due-date-year" name="due-date-year" type="text" value="2023" inputmode="numeric">
                     </div>
                 </div>
             </div>

--- a/appeals/web/src/server/appeals/appeal-details/appeal-timetables/appeal-timetables.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/appeal-timetables/appeal-timetables.mapper.js
@@ -1,4 +1,4 @@
-import { dateToDisplayDate } from '#lib/dates.js';
+import { dateToDisplayDate, apiDateStringToDayMonthYear } from '#lib/dates.js';
 import { capitalize } from 'lodash-es';
 import { appealShortReference } from '#lib/appeals-formatter.js';
 
@@ -43,6 +43,8 @@ export const routeToObjectMapper = {
 export const mapUpdateDueDatePage = (appealTimetables, timetableType, appealDetails) => {
 	const currentDueDateIso = appealTimetables && appealTimetables[timetableType];
 	const currentDueDate = currentDueDateIso && dateToDisplayDate(currentDueDateIso);
+	const currentDueDateDayMonthYear =
+		currentDueDateIso && apiDateStringToDayMonthYear(currentDueDateIso);
 	const changeOrScheduleText = currentDueDate ? 'Change' : 'Schedule';
 	const timetableTypeText = getTimetableTypeText(timetableType);
 
@@ -56,7 +58,37 @@ export const mapUpdateDueDatePage = (appealTimetables, timetableType, appealDeta
 			text: 'Continue',
 			type: 'submit'
 		},
-		pageComponents: []
+		pageComponents: [
+			{
+				type: 'date-input',
+				parameters: {
+					id: 'due-date',
+					namePrefix: 'due-date',
+					hint: {
+						text: 'For example, 27 3 2007'
+					},
+					...(currentDueDateDayMonthYear && {
+						items: [
+							{
+								name: 'day',
+								classes: 'govuk-input--width-2',
+								value: currentDueDateDayMonthYear.day
+							},
+							{
+								name: 'month',
+								classes: 'govuk-input--width-2',
+								value: currentDueDateDayMonthYear.month
+							},
+							{
+								name: 'year',
+								classes: 'govuk-input--width-4',
+								value: currentDueDateDayMonthYear.year
+							}
+						]
+					})
+				}
+			}
+		]
 	};
 
 	if (currentDueDate) {

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/__tests__/__snapshots__/lpa-questionnaire.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/__tests__/__snapshots__/lpa-questionnaire.test.js.snap
@@ -1781,6 +1781,7 @@ exports[`LPA Questionnaire review GET /appeals-service/appeal-details/1/lpa-ques
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-full"><span class="govuk-caption-xl govuk-!-margin-bottom-1">Appeal 351062</span>
             <h1             class="govuk-fieldset__legend--xl govuk-!-margin-top-0">Update LPA questionnaire due date</h1>
+                <div class="govuk-inset-text govuk-!-margin-bottom-7">The current due date for the LPA questionnaire is 11 October 2024</div>
         </div>
     </div>
     <form method="post" novalidate="novalidate">
@@ -1822,6 +1823,7 @@ exports[`LPA Questionnaire review GET /appeals-service/appeal-details/1/lpa-ques
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-full"><span class="govuk-caption-xl govuk-!-margin-bottom-1">Appeal 351062</span>
             <h1             class="govuk-fieldset__legend--xl govuk-!-margin-top-0">Update LPA questionnaire due date</h1>
+                <div class="govuk-inset-text govuk-!-margin-bottom-7">The current due date for the LPA questionnaire is 30 November 1899</div>
         </div>
     </div>
     <form method="post" novalidate="novalidate">
@@ -5175,6 +5177,7 @@ exports[`LPA Questionnaire review POST /appeals-service/appeal-details/1/lpa-que
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-full"><span class="govuk-caption-xl govuk-!-margin-bottom-1">Appeal 351062</span>
             <h1             class="govuk-fieldset__legend--xl govuk-!-margin-top-0">Update LPA questionnaire due date</h1>
+                <div class="govuk-inset-text govuk-!-margin-bottom-7">The current due date for the LPA questionnaire is 1 March 3000</div>
         </div>
     </div>
     <form method="post" novalidate="novalidate">
@@ -5233,6 +5236,7 @@ exports[`LPA Questionnaire review POST /appeals-service/appeal-details/1/lpa-que
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-full"><span class="govuk-caption-xl govuk-!-margin-bottom-1">Appeal 351062</span>
             <h1             class="govuk-fieldset__legend--xl govuk-!-margin-top-0">Update LPA questionnaire due date</h1>
+                <div class="govuk-inset-text govuk-!-margin-bottom-7">The current due date for the LPA questionnaire is 31 December 2999</div>
         </div>
     </div>
     <form method="post" novalidate="novalidate">
@@ -5291,6 +5295,7 @@ exports[`LPA Questionnaire review POST /appeals-service/appeal-details/1/lpa-que
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-full"><span class="govuk-caption-xl govuk-!-margin-bottom-1">Appeal 351062</span>
             <h1             class="govuk-fieldset__legend--xl govuk-!-margin-top-0">Update LPA questionnaire due date</h1>
+                <div class="govuk-inset-text govuk-!-margin-bottom-7">The current due date for the LPA questionnaire is 1 February 3000</div>
         </div>
     </div>
     <form method="post" novalidate="novalidate">
@@ -5349,6 +5354,7 @@ exports[`LPA Questionnaire review POST /appeals-service/appeal-details/1/lpa-que
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-full"><span class="govuk-caption-xl govuk-!-margin-bottom-1">Appeal 351062</span>
             <h1             class="govuk-fieldset__legend--xl govuk-!-margin-top-0">Update LPA questionnaire due date</h1>
+                <div class="govuk-inset-text govuk-!-margin-bottom-7">The current due date for the LPA questionnaire is 31 December 2999</div>
         </div>
     </div>
     <form method="post" novalidate="novalidate">
@@ -5407,6 +5413,7 @@ exports[`LPA Questionnaire review POST /appeals-service/appeal-details/1/lpa-que
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-full"><span class="govuk-caption-xl govuk-!-margin-bottom-1">Appeal 351062</span>
             <h1             class="govuk-fieldset__legend--xl govuk-!-margin-top-0">Update LPA questionnaire due date</h1>
+                <div class="govuk-inset-text govuk-!-margin-bottom-7">The current due date for the LPA questionnaire is 1 December 2999</div>
         </div>
     </div>
     <form method="post" novalidate="novalidate">
@@ -5465,6 +5472,7 @@ exports[`LPA Questionnaire review POST /appeals-service/appeal-details/1/lpa-que
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-full"><span class="govuk-caption-xl govuk-!-margin-bottom-1">Appeal 351062</span>
             <h1             class="govuk-fieldset__legend--xl govuk-!-margin-top-0">Update LPA questionnaire due date</h1>
+                <div class="govuk-inset-text govuk-!-margin-bottom-7">The current due date for the LPA questionnaire is 1 January 3001</div>
         </div>
     </div>
     <form method="post" novalidate="novalidate">
@@ -5523,6 +5531,7 @@ exports[`LPA Questionnaire review POST /appeals-service/appeal-details/1/lpa-que
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-full"><span class="govuk-caption-xl govuk-!-margin-bottom-1">Appeal 351062</span>
             <h1             class="govuk-fieldset__legend--xl govuk-!-margin-top-0">Update LPA questionnaire due date</h1>
+                <div class="govuk-inset-text govuk-!-margin-bottom-7">The current due date for the LPA questionnaire is 1 December 2999</div>
         </div>
     </div>
     <form method="post" novalidate="novalidate">
@@ -5581,6 +5590,7 @@ exports[`LPA Questionnaire review POST /appeals-service/appeal-details/1/lpa-que
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-full"><span class="govuk-caption-xl govuk-!-margin-bottom-1">Appeal 351062</span>
             <h1             class="govuk-fieldset__legend--xl govuk-!-margin-top-0">Update LPA questionnaire due date</h1>
+                <div class="govuk-inset-text govuk-!-margin-bottom-7">The current due date for the LPA questionnaire is 1 January 1923</div>
         </div>
     </div>
     <form method="post" novalidate="novalidate">
@@ -5639,6 +5649,7 @@ exports[`LPA Questionnaire review POST /appeals-service/appeal-details/1/lpa-que
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-full"><span class="govuk-caption-xl govuk-!-margin-bottom-1">Appeal 351062</span>
             <h1             class="govuk-fieldset__legend--xl govuk-!-margin-top-0">Update LPA questionnaire due date</h1>
+                <div class="govuk-inset-text govuk-!-margin-bottom-7">The current due date for the LPA questionnaire is 1 January 1900</div>
         </div>
     </div>
     <form method="post" novalidate="novalidate">
@@ -5701,6 +5712,7 @@ exports[`LPA Questionnaire review POST /appeals-service/appeal-details/1/lpa-que
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-full"><span class="govuk-caption-xl govuk-!-margin-bottom-1">Appeal 351062</span>
             <h1             class="govuk-fieldset__legend--xl govuk-!-margin-top-0">Update LPA questionnaire due date</h1>
+                <div class="govuk-inset-text govuk-!-margin-bottom-7">The current due date for the LPA questionnaire is 30 November 1899</div>
         </div>
     </div>
     <form method="post" novalidate="novalidate">
@@ -5757,6 +5769,7 @@ exports[`LPA Questionnaire review POST /appeals-service/appeal-details/1/lpa-que
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-full"><span class="govuk-caption-xl govuk-!-margin-bottom-1">Appeal 351062</span>
             <h1             class="govuk-fieldset__legend--xl govuk-!-margin-top-0">Update LPA questionnaire due date</h1>
+                <div class="govuk-inset-text govuk-!-margin-bottom-7">The current due date for the LPA questionnaire is 1 January 2000</div>
         </div>
     </div>
     <form method="post" novalidate="novalidate">

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/lpa-questionnaire.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/lpa-questionnaire.mapper.js
@@ -320,6 +320,20 @@ export function updateDueDatePage(
 		]
 	};
 
+	if (existingDueDateDayMonthYear) {
+		pageContent.pageComponents?.push({
+			type: 'inset-text',
+			parameters: {
+				text: `The current due date for the LPA questionnaire is ${webDateToDisplayDate({
+					day: existingDueDateDayMonthYear.day || 0,
+					month: existingDueDateDayMonthYear.month || 0,
+					year: existingDueDateDayMonthYear.year || 0
+				})}`,
+				classes: 'govuk-!-margin-bottom-7'
+			}
+		});
+	}
+
 	return pageContent;
 }
 


### PR DESCRIPTION
## Describe your changes

pre-populate update due date values on change timetable flow, add missing inset text to lpaq incomplete flow update due date page

## Issue ticket number and link

BOAT-1078

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [ ] I have performed a self-review of my own code
- [ ] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [ ] I have referenced the ticket number above
- [ ] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
