### PR TITLE
feat(api): appeal folders for costs

### DIFF
--- a/appeals/api/src/server/endpoints/appeals.d.ts
+++ b/appeals/api/src/server/endpoints/appeals.d.ts
@@ -246,6 +246,20 @@ interface SingleAppealDetailsResponse {
 		email: string;
 	};
 	caseOfficer: string | null;
+	costs: {
+		appellantFolder: {
+			id: number;
+			path: string;
+			caseId: number;
+			documents: DocumentInfo[];
+		};
+		lpaFolder: {
+			id: number;
+			path: string;
+			caseId: number;
+			documents: DocumentInfo[];
+		};
+	};
 	decision: {
 		folderId: number;
 		outcome?: string;

--- a/appeals/api/src/server/endpoints/appeals/__tests__/appeals.test.js
+++ b/appeals/api/src/server/endpoints/appeals/__tests__/appeals.test.js
@@ -704,6 +704,7 @@ describe('appeals routes', () => {
 					appealTimetable: null,
 					appellantCaseId: 1,
 					caseOfficer: householdAppeal.caseOfficer.azureAdUserId,
+					costs: {},
 					decision: {
 						folderId: savedFolder.id
 					},
@@ -812,6 +813,7 @@ describe('appeals routes', () => {
 					appealType: fullPlanningAppeal.appealType.type,
 					appellantCaseId: 1,
 					caseOfficer: fullPlanningAppeal.caseOfficer.azureAdUserId,
+					costs: {},
 					decision: {
 						folderId: savedFolder.id
 					},
@@ -1340,6 +1342,7 @@ describe('appeals routes', () => {
 					appealTimetable: null,
 					appellantCaseId: 1,
 					caseOfficer: householdAppeal.caseOfficer.azureAdUserId,
+					costs: {},
 					decision: {
 						folderId: savedFolder.id
 					},
@@ -1448,6 +1451,7 @@ describe('appeals routes', () => {
 					appealTimetable: null,
 					appellantCaseId: 1,
 					caseOfficer: fullPlanningAppeal.caseOfficer.azureAdUserId,
+					costs: {},
 					decision: {
 						folderId: savedFolder.id
 					},

--- a/appeals/api/src/server/endpoints/appeals/appeals.controller.js
+++ b/appeals/api/src/server/endpoints/appeals/appeals.controller.js
@@ -135,7 +135,10 @@ const getMyAppeals = async (req, res) => {
  */
 const getAppeal = async (req, res) => {
 	const { appeal } = req;
-	const folders = await getFoldersForAppeal(appeal, CONFIG_APPEAL_STAGES.decision);
+	const [decisionFolders, costsFolders] = await Promise.all([
+		getFoldersForAppeal(appeal, CONFIG_APPEAL_STAGES.decision),
+		getFoldersForAppeal(appeal, CONFIG_APPEAL_STAGES.costs)
+	]);
 
 	let transferAppealTypeInfo;
 	if (appeal.resubmitTypeId && appeal.transferredCaseId) {
@@ -172,7 +175,8 @@ const getAppeal = async (req, res) => {
 
 	const formattedAppeal = formatAppeal(
 		appeal,
-		folders,
+		decisionFolders,
+		costsFolders,
 		transferAppealTypeInfo,
 		decisionInfo,
 		formattedAppealWithLinkedTypes

--- a/appeals/api/src/server/endpoints/appeals/appeals.formatter.js
+++ b/appeals/api/src/server/endpoints/appeals/appeals.formatter.js
@@ -92,7 +92,8 @@ const formatMyAppeals = (appeal, linkedAppeals) => ({
 
 /**
  * @param {RepositoryGetByIdResultItem} appeal
- * @param {Folder[]} folders
+ * @param {Folder[]} decisionFolders
+ * @param {Folder[]} costsFolders
  * @param {{ transferredAppealType: string, transferredAppealReference: string } | null} transferAppealTypeInfo
  * @param {{ letterDate: Date|null, virusCheckStatus: string|null } | null} decisionInfo
  * @param { RepositoryGetAllResultItem[] | null} referencedAppeals
@@ -100,7 +101,8 @@ const formatMyAppeals = (appeal, linkedAppeals) => ({
  */
 const formatAppeal = (
 	appeal,
-	folders,
+	decisionFolders,
+	costsFolders,
 	transferAppealTypeInfo = null,
 	decisionInfo = null,
 	referencedAppeals = null
@@ -160,19 +162,23 @@ const formatAppeal = (
 			}),
 			appellantCaseId: appeal.appellantCase?.id || 0,
 			caseOfficer: appeal.caseOfficer?.azureAdUserId || null,
+			costs: {
+				appellantFolder: costsFolders.find((f) => f.path.endsWith('appellant')),
+				lpaFolder: costsFolders.find((f) => f.path.endsWith('lpa'))
+			},
 			decision:
 				decisionInfo &&
 				appeal.inspectorDecision?.outcome &&
 				appeal.inspectorDecision?.decisionLetterGuid
 					? {
-							folderId: folders[0].id,
+							folderId: decisionFolders[0].id,
 							outcome: appeal.inspectorDecision.outcome,
 							documentId: appeal.inspectorDecision?.decisionLetterGuid,
 							letterDate: decisionInfo.letterDate,
 							virusCheckStatus: decisionInfo.virusCheckStatus
 					  }
 					: {
-							folderId: folders[0].id
+							folderId: decisionFolders[0].id
 					  },
 			healthAndSafety: {
 				appellantCase: {

--- a/appeals/api/src/server/endpoints/constants.js
+++ b/appeals/api/src/server/endpoints/constants.js
@@ -243,12 +243,15 @@ export const CONFIG_APPEAL_FOLDER_PATHS = [
 
 	// ------------------------------------------------
 	// Decision letter
-	'appeal_decision/decisionLetter'
+	'appeal_decision/decisionLetter',
+	'appeal_costs/lpa',
+	'appeal_costs/appellant'
 ];
 
 export const CONFIG_APPEAL_STAGES = {
 	// stage mapping for ODW
 	appellantCase: 'appellant_case',
 	lpaQuestionnaire: 'lpa_questionnaire',
-	decision: 'appeal_decision'
+	decision: 'appeal_decision',
+	costs: 'appeal_costs'
 };

--- a/appeals/web/testing/app/fixtures/referencedata.js
+++ b/appeals/web/testing/app/fixtures/referencedata.js
@@ -98,6 +98,20 @@ export const appealData = {
 		email: 'test3@example.com'
 	},
 	caseOfficer: null,
+	costs: {
+		appellantFolder: {
+			caseId: 1,
+			id: 1000,
+			path: 'appeal_costs/appellant',
+			documents: []
+		},
+		lpaFolder: {
+			caseId: 1,
+			id: 1000,
+			path: 'appeal_costs/lpa',
+			documents: []
+		}
+	},
 	decision: {
 		folderId: 123,
 		outcome: 'dismissed',


### PR DESCRIPTION
Adds folders for costs:

- `appeal_costs/lpa`
- `appeal_costs/appellant`

Returns the contents of those folders in a `costs` property.

## Issue ticket number and link

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [ ] I have performed a self-review of my own code
- [ ] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [ ] I have referenced the ticket number above
- [ ] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
