### PR TITLE
BOAT-1058 API - Create audit event for when doc redaction status or date receieved is changed

### DIFF
--- a/appeals/api/src/server/endpoints/constants.js
+++ b/appeals/api/src/server/endpoints/constants.js
@@ -24,6 +24,8 @@ export const AUDIT_TRAIL_DOCUMENT_UPLOADED =
 export const AUDIT_TRAIL_DOCUMENT_IMPORTED = 'The document {replacement0} was received';
 export const AUDIT_TRAIL_DOCUMENT_DELETED =
 	'Version {replacement1} of document {replacement0} was removed';
+export const AUDIT_TRAIL_DOCUMENT_REDACTED =
+	'Version {replacement1} of document {replacement0} was redacted';
 export const AUDIT_TRAIL_LPAQ_IMPORT_MSG = 'The LPA questionnaire was received';
 export const AUDIT_TRAIL_PROGRESSED_TO_STATUS = 'The case has progressed to {replacement0}';
 export const AUDIT_TRAIL_SUBMISSION_INCOMPLETE = 'The {replacement0} was marked as incomplete';


### PR DESCRIPTION
## Describe your changes

[BOAT-1058](https://pins-ds.atlassian.net/browse/BOAT-1058)

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [ ] I have performed a self-review of my own code
- [ ] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [ ] I have referenced the ticket number above
- [ ] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes


