### PR TITLE
fix(web): document delete journey improved

### DIFF
--- a/appeals/web/src/server/appeals/appeal-details/appellant-case/appellant-case.controller.js
+++ b/appeals/web/src/server/appeals/appeal-details/appellant-case/appellant-case.controller.js
@@ -358,7 +358,7 @@ export const getDeleteDocument = async (request, response) => {
 	renderDeleteDocument(
 		request,
 		response,
-		`/appeals-service/appeal-details/${request.params.appealId}/appellant-case/manage-documents/{{folderId}}`
+		`/appeals-service/appeal-details/${request.params.appealId}/appellant-case/manage-documents/{{folderId}}/{{documentId}}`
 	);
 };
 /** @type {import('@pins/express').RequestHandler<Response>} */
@@ -367,6 +367,7 @@ export const postDeleteDocument = async (request, response) => {
 		request,
 		response,
 		`/appeals-service/appeal-details/${request.params.appealId}/appellant-case`,
+		`/appeals-service/appeal-details/${request.params.appealId}/appellant-case/manage-documents/{{folderId}}/{{documentId}}`,
 		`/appeals-service/appeal-details/${request.params.appealId}/appellant-case/add-documents/{{folderId}}`
 	);
 };

--- a/appeals/web/src/server/appeals/appeal-details/costs/__tests__/costs.test.js
+++ b/appeals/web/src/server/appeals/appeal-details/costs/__tests__/costs.test.js
@@ -1196,7 +1196,7 @@ describe('costs', () => {
 				expect(errorSummaryElement.innerHTML).toContain('Answer must be provided');
 			});
 
-			it(`should not send an API request to delete the document, and should redirect to the case details page, if answer "no" was provided`, async () => {
+			it(`should not send an API request to delete the document, and should redirect to the manage document page, if answer "no" was provided`, async () => {
 				nock('http://test/')
 					.get('/appeals/1/documents/1/versions')
 					.reply(200, documentFileVersionsInfo);
@@ -1208,7 +1208,9 @@ describe('costs', () => {
 					});
 
 				expect(response.statusCode).toBe(302);
-				expect(response.text).toEqual('Found. Redirecting to /appeals-service/appeal-details/1');
+				expect(response.text).toEqual(
+					`Found. Redirecting to /appeals-service/appeal-details/1/costs/${costsCategory}/manage-documents/1/1`
+				);
 			});
 
 			it(`should send an API request to delete the document, and redirect to the case details page, if answer "yes" was provided`, async () => {
@@ -1226,7 +1228,7 @@ describe('costs', () => {
 				expect(response.text).toEqual('Found. Redirecting to /appeals-service/appeal-details/1');
 			});
 
-			it(`should send an API request to delete the document, and redirect to the upload new document page, if answer "yes, and upload another document" was provided, and there is more than one version of the document`, async () => {
+			it(`should render a 500 page, if answer "yes, and upload another document" was provided, and there is more than one version of the document`, async () => {
 				const multipleVersionsDocument = cloneDeep(documentFileVersionsInfo);
 				multipleVersionsDocument.documentVersion.push(multipleVersionsDocument.documentVersion[0]);
 
@@ -1240,13 +1242,14 @@ describe('costs', () => {
 						'delete-file-answer': 'yes-and-upload-another-document'
 					});
 
-				expect(response.statusCode).toBe(302);
-				expect(response.text).toEqual(
-					`Found. Redirecting to /appeals-service/appeal-details/1/costs/${costsCategory}/upload-documents/${costsFolder.id}/1`
+				const unprettifiedElement = parseHtml(response.text, { skipPrettyPrint: true });
+
+				expect(unprettifiedElement.innerHTML).toContain(
+					'Sorry, there is a problem with the service</h1>'
 				);
 			});
 
-			it(`should send an API request to delete the document, and redirect to the case details page, if answer "yes, and upload another document" was provided, and there is only one version of the document`, async () => {
+			it(`should send an API request to delete the document, and redirect to the upload new document version page, if answer "yes, and upload another document" was provided, and there is only one version of the document`, async () => {
 				nock('http://test/')
 					.get('/appeals/1/documents/1/versions')
 					.reply(200, documentFileVersionsInfo);
@@ -1258,7 +1261,9 @@ describe('costs', () => {
 					});
 
 				expect(response.statusCode).toBe(302);
-				expect(response.text).toEqual('Found. Redirecting to /appeals-service/appeal-details/1');
+				expect(response.text).toEqual(
+					`Found. Redirecting to /appeals-service/appeal-details/1/costs/${costsCategory}/select-document-type/${costsFolder.id}`
+				);
 			});
 		}
 	});

--- a/appeals/web/src/server/appeals/appeal-details/costs/costs.controller.js
+++ b/appeals/web/src/server/appeals/appeal-details/costs/costs.controller.js
@@ -328,7 +328,8 @@ export const postDeleteCostsDocument = async (request, response) => {
 		request,
 		response,
 		`/appeals-service/appeal-details/${request.params.appealId}`,
-		`/appeals-service/appeal-details/${currentAppeal.appealId}/costs/${costsCategory}/upload-documents/${currentFolder?.id}/{{documentId}}`
+		`/appeals-service/appeal-details/${request.params.appealId}/costs/${costsCategory}/manage-documents/{{folderId}}/{{documentId}}`,
+		`/appeals-service/appeal-details/${currentAppeal.appealId}/costs/${costsCategory}/select-document-type/{{folderId}}`
 	);
 };
 

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/lpa-questionnaire.controller.js
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/lpa-questionnaire.controller.js
@@ -368,7 +368,7 @@ export const getDeleteDocument = async (request, response) => {
 	renderDeleteDocument(
 		request,
 		response,
-		`/appeals-service/appeal-details/${request.params.appealId}/lpa-questionnaire/${request.params.lpaQuestionnaireId}/manage-documents/{{folderId}}`
+		`/appeals-service/appeal-details/${request.params.appealId}/lpa-questionnaire/${request.params.lpaQuestionnaireId}/manage-documents/{{folderId}}/{{documentId}}`
 	);
 };
 /** @type {import('@pins/express').RequestHandler<Response>} */
@@ -377,6 +377,7 @@ export const postDeleteDocument = async (request, response) => {
 		request,
 		response,
 		`/appeals-service/appeal-details/${request.params.appealId}/lpa-questionnaire/${request.params.lpaQuestionnaireId}`,
+		`/appeals-service/appeal-details/${request.params.appealId}/lpa-questionnaire/${request.params.lpaQuestionnaireId}/manage-documents/{{folderId}}/{{documentId}}`,
 		`/appeals-service/appeal-details/${request.params.appealId}/lpa-questionnaire/${request.params.lpaQuestionnaireId}/add-documents/{{folderId}}`
 	);
 };


### PR DESCRIPTION
## Describe your changes

Few improvement on the delete document journey:

- `cancelUrl` param added to `postDocumentDelete` to handle the 'No' post redirect correctly
- 'Yes, and upload another document' post consistently redirects to add document, not update document
- Back links from delete document page goes to manage document instead of manage folder

## Issue ticket number and link

[BOAT-1222](https://pins-ds.atlassian.net/browse/BOAT-1222)

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
