### PR TITLE
feat(api): appeals doc integration flow

### DIFF
--- a/appeals/api/package.json
+++ b/appeals/api/package.json
@@ -66,7 +66,7 @@
     "rhea": "3.0.1",
     "swagger-ui-express": "^4.4.0",
     "xstate": "4.32.1",
-		"pins-data-model": "github:Planning-Inspectorate/data-model#1.0.2"
+    "pins-data-model": "github:Planning-Inspectorate/data-model#1.2.1"
   },
   "devDependencies": {
     "@types/express": "^4.17.13",

--- a/appeals/api/src/database/seed/data-test.js
+++ b/appeals/api/src/database/seed/data-test.js
@@ -20,13 +20,11 @@ import isFPA from '#utils/is-fpa.js';
 import { calculateTimetable } from '#utils/business-days.js';
 import {
 	APPEAL_TYPE_SHORTHAND_HAS,
-	STATE_TARGET_COMPLETE,
-	STATE_TARGET_ISSUE_DETERMINATION,
-	STATE_TARGET_READY_TO_START,
-	STATE_TARGET_ASSIGN_CASE_OFFICER,
 	CASE_RELATIONSHIP_LINKED,
 	CASE_RELATIONSHIP_RELATED
 } from '#endpoints/constants.js';
+
+import { STATUSES } from '@pins/appeals/constants/state.js';
 
 import neighbouringSitesRepository from '#repositories/neighbouring-sites.repository.js';
 import { mapDefaultCaseFolders } from '#endpoints/documents/documents.mapper.js';
@@ -547,7 +545,7 @@ export async function seedTestData(databaseConnector) {
 			({ appealId, status, valid }) =>
 				appealId === id &&
 				valid &&
-				[STATE_TARGET_ISSUE_DETERMINATION, STATE_TARGET_COMPLETE].includes(status)
+				[STATUSES.ISSUE_DETERMINATION, STATUSES.COMPLETE].includes(status)
 		);
 
 		if (statusWithSiteVisitSet) {
@@ -598,8 +596,7 @@ export async function seedTestData(databaseConnector) {
 		const status = appealStatus.find(({ appealId }) => appealId === appellantCase.appealId);
 		const appealType = appealTypes.find(({ id }) => id === appeal?.appealTypeId);
 		const validationOutcome =
-			status?.status !== STATE_TARGET_READY_TO_START &&
-			status?.status !== STATE_TARGET_ASSIGN_CASE_OFFICER
+			status?.status !== STATUSES.READY_TO_START && status?.status !== STATUSES.ASSIGN_CASE_OFFICER
 				? appellantCaseValidationOutcomes[2]
 				: null;
 

--- a/appeals/api/src/server/endpoints/appeal-allocation/appeal-allocation-controller.js
+++ b/appeals/api/src/server/endpoints/appeal-allocation/appeal-allocation-controller.js
@@ -1,7 +1,7 @@
 import config from '#config/config.js';
 import appealAllocationRepository from '#repositories/appeal-allocation.repository.js';
 import { createAuditTrail } from '#endpoints/audit-trails/audit-trails.service.js';
-import { broadcastAppealState } from '#endpoints/integrations/integrations.service.js';
+import { broadcasters } from '#endpoints/integrations/integrations.broadcasters.js';
 import { AUDIT_TRAIL_ALLOCATION_DETAILS_ADDED } from '#endpoints/constants.js';
 
 /** @typedef {import('express').Request} Request */
@@ -41,7 +41,7 @@ export const saveAllocation = async (req, res) => {
 			details: AUDIT_TRAIL_ALLOCATION_DETAILS_ADDED
 		});
 
-		await broadcastAppealState(appeal.id);
+		await broadcasters.broadcastAppeal(appeal.id);
 	}
 
 	return res.send({

--- a/appeals/api/src/server/endpoints/appeal-decision/appeal-decision.service.js
+++ b/appeals/api/src/server/endpoints/appeal-decision/appeal-decision.service.js
@@ -1,6 +1,6 @@
 import appealRepository from '#repositories/appeal.repository.js';
 import transitionState from '#state/transition-state.js';
-import { broadcastAppealState } from '#endpoints/integrations/integrations.service.js';
+import { broadcasters } from '#endpoints/integrations/integrations.broadcasters.js';
 import { STATE_TARGET_COMPLETE } from '#endpoints/constants.js';
 
 /** @typedef {import('@pins/appeals.api').Appeals.RepositoryGetByIdResultItem} Appeal */
@@ -33,7 +33,7 @@ export const publishDecision = async (appeal, outcome, documentDate, document, a
 			appeal.appealStatus,
 			STATE_TARGET_COMPLETE
 		);
-		await broadcastAppealState(appeal.id);
+		await broadcasters.broadcastAppeal(appeal.id);
 
 		return result;
 	}

--- a/appeals/api/src/server/endpoints/appeal-timetables/appeal-timetables.controller.js
+++ b/appeals/api/src/server/endpoints/appeal-timetables/appeal-timetables.controller.js
@@ -1,5 +1,5 @@
 import { createAuditTrail } from '#endpoints/audit-trails/audit-trails.service.js';
-import { broadcastAppealState } from '#endpoints/integrations/integrations.service.js';
+import { broadcasters } from '#endpoints/integrations/integrations.broadcasters.js';
 import appealRepository from '#repositories/appeal.repository.js';
 import appealTimetableRepository from '#repositories/appeal-timetable.repository.js';
 import { calculateTimetable, recalculateDateIfNotBusinessDay } from '#utils/business-days.js';
@@ -69,7 +69,7 @@ const startAppeal = async (req, res) => {
 				STATE_TARGET_LPA_QUESTIONNAIRE_DUE
 			);
 
-			await broadcastAppealState(appeal.id);
+			await broadcasters.broadcastAppeal(appeal.id);
 			return res.send(timetable);
 		}
 
@@ -98,7 +98,7 @@ const updateAppealTimetableById = async (req, res) => {
 			details: AUDIT_TRAIL_CASE_TIMELINE_UPDATED
 		});
 
-		await broadcastAppealState(Number(params.appealId));
+		await broadcasters.broadcastAppeal(Number(params.appealId));
 	} catch (error) {
 		if (error) {
 			logger.error(error);

--- a/appeals/api/src/server/endpoints/appeals/appeals.controller.js
+++ b/appeals/api/src/server/endpoints/appeals/appeals.controller.js
@@ -4,7 +4,7 @@ import appealRepository from '#repositories/appeal.repository.js';
 import { getPageCount } from '#utils/database-pagination.js';
 import { sortAppeals } from '#utils/appeal-sorter.js';
 import { getAppealTypeByTypeId } from '#repositories/appeal-type.repository.js';
-import { broadcastAppealState } from '#endpoints/integrations/integrations.service.js';
+import { broadcasters } from '#endpoints/integrations/integrations.broadcasters.js';
 import logger from '#utils/logger.js';
 import stringTokenReplacement from '#utils/string-token-replacement.js';
 import {
@@ -244,7 +244,7 @@ const updateAppealById = async (req, res) => {
 			});
 		}
 
-		await broadcastAppealState(appeal.id);
+		await broadcasters.broadcastAppeal(appeal.id);
 	} catch (error) {
 		if (error) {
 			logger.error(error);

--- a/appeals/api/src/server/endpoints/appellant-cases/appellant-cases.service.js
+++ b/appeals/api/src/server/endpoints/appellant-cases/appellant-cases.service.js
@@ -3,7 +3,7 @@ import {
 	isOutcomeInvalid,
 	isOutcomeValid
 } from '#utils/check-validation-outcome.js';
-import { broadcastAppealState } from '#endpoints/integrations/integrations.service.js';
+import { broadcasters } from '#endpoints/integrations/integrations.broadcasters.js';
 
 import {
 	AUDIT_TRAIL_SUBMISSION_INCOMPLETE,
@@ -98,7 +98,7 @@ const updateAppellantCaseValidationOutcome = async (
 		await appealRepository.updateAppealById(appealId, { dueDate: appealDueDate });
 	}
 
-	await broadcastAppealState(appealId);
+	await broadcasters.broadcastAppeal(appealId);
 };
 
 export { checkAppellantCaseExists, updateAppellantCaseValidationOutcome };

--- a/appeals/api/src/server/endpoints/change-appeal-type/change-appeal-type.controller.js
+++ b/appeals/api/src/server/endpoints/change-appeal-type/change-appeal-type.controller.js
@@ -6,7 +6,7 @@ import {
 	STATE_TARGET_TRANSFERRED
 } from '#endpoints/constants.js';
 import transitionState from '#state/transition-state.js';
-import { broadcastAppealState } from '#endpoints/integrations/integrations.service.js';
+import { broadcasters } from '#endpoints/integrations/integrations.broadcasters.js';
 
 /** @typedef {import('express').Request} Request */
 /** @typedef {import('express').Response} Response */
@@ -52,7 +52,7 @@ export const requestChangeOfAppealType = async (req, res) => {
 			appeal.appealStatus,
 			STATE_TARGET_CLOSED
 		),
-		await broadcastAppealState(appeal.id)
+		await broadcasters.broadcastAppeal(appeal.id)
 	]);
 
 	return res.send(true);
@@ -83,7 +83,7 @@ export const requestTransferOfAppeal = async (req, res) => {
 			appeal.appealStatus,
 			STATE_TARGET_AWAITING_TRANSFER
 		),
-		await broadcastAppealState(appeal.id)
+		await broadcasters.broadcastAppeal(appeal.id)
 	]);
 
 	return res.send(true);
@@ -114,7 +114,7 @@ export const requestConfirmationTransferOfAppeal = async (req, res) => {
 			appeal.appealStatus,
 			STATE_TARGET_TRANSFERRED
 		),
-		await broadcastAppealState(appeal.id)
+		await broadcasters.broadcastAppeal(appeal.id)
 	]);
 
 	return res.send(true);

--- a/appeals/api/src/server/endpoints/integrations/integrations.broadcasters.js
+++ b/appeals/api/src/server/endpoints/integrations/integrations.broadcasters.js
@@ -1,0 +1,9 @@
+import { broadcastServiceUser } from './integrations.broadcasters/service-users.js';
+import { broadcastDocument } from './integrations.broadcasters/documents.js';
+import { broadcastAppeal } from './integrations.broadcasters/appeal.js';
+
+export const broadcasters = {
+	broadcastServiceUser,
+	broadcastDocument,
+	broadcastAppeal
+};

--- a/appeals/api/src/server/endpoints/integrations/integrations.broadcasters/appeal.js
+++ b/appeals/api/src/server/endpoints/integrations/integrations.broadcasters/appeal.js
@@ -1,0 +1,14 @@
+import config from '#config/config.js';
+import pino from '#utils/logger.js';
+import { EventType } from '@pins/event-client';
+
+export const broadcastAppeal = async (
+	/** @type {Number} */ appealId,
+	/** @type {string} */ updateType = EventType.Update
+) => {
+	if (!config.serviceBusEnabled) {
+		return false;
+	}
+
+	pino.info({ appealId, updateType });
+};

--- a/appeals/api/src/server/endpoints/integrations/integrations.broadcasters/documents.js
+++ b/appeals/api/src/server/endpoints/integrations/integrations.broadcasters/documents.js
@@ -1,0 +1,66 @@
+import pino from '#utils/logger.js';
+import config from '#config/config.js';
+import { messageMappers } from '../integrations.mappers.js';
+import { producers } from '#infrastructure/topics.js';
+import { eventClient } from '#infrastructure/event-client.js';
+import { schemas, validateFromSchema } from '../integrations.validators.js';
+import { databaseConnector } from '#utils/database-connector.js';
+import { ODW_SYSTEM_ID } from '#endpoints/constants.js';
+
+const entityInfo = {
+	name: 'AppealDocumentMetadata'
+};
+
+export const broadcastDocument = async (
+	/** @type {string} */ documentId,
+	/** @type {string} */ updateType
+) => {
+	if (!config.serviceBusEnabled) {
+		return false;
+	}
+	const document = await databaseConnector.document.findUnique({
+		where: { guid: documentId },
+		include: {
+			case: {
+				include: {
+					appealType: true
+				}
+			},
+			latestDocumentVersion: {
+				include: {
+					redactionStatus: true
+				}
+			}
+		}
+	});
+
+	if (!document || !document.latestDocumentVersion) {
+		return false;
+	}
+
+	const msg = messageMappers.mapDocument(document);
+
+	if (msg) {
+		const validationResult = await validateFromSchema(schemas.events.document, msg);
+		if (validationResult !== true && validationResult.errors) {
+			const errorDetails = validationResult.errors?.map(
+				(e) => `${e.instancePath || '/'}: ${e.message}`
+			);
+
+			pino.error(`Error validating ${entityInfo.name} entity: ${errorDetails}`);
+			return false;
+		}
+
+		const topic = producers.boDocument;
+		const res = await eventClient.sendEvents(topic, [msg], updateType, {
+			entityType: entityInfo.name,
+			sourceSystem: ODW_SYSTEM_ID
+		});
+
+		if (res) {
+			return true;
+		}
+	}
+
+	return false;
+};

--- a/appeals/api/src/server/endpoints/integrations/integrations.broadcasters/service-users.js
+++ b/appeals/api/src/server/endpoints/integrations/integrations.broadcasters/service-users.js
@@ -1,9 +1,9 @@
 import pino from '#utils/logger.js';
 import config from '#config/config.js';
-import { mapServiceUser } from './integrations.mappers/index.js';
+import { messageMappers } from '../integrations.mappers.js';
 import { producers } from '#infrastructure/topics.js';
 import { eventClient } from '#infrastructure/event-client.js';
-import { schemas, validateFromSchema } from './integrations.validators.js';
+import { schemas, validateFromSchema } from '../integrations.validators.js';
 import { databaseConnector } from '#utils/database-connector.js';
 import { ODW_SYSTEM_ID } from '#endpoints/constants.js';
 
@@ -24,10 +24,10 @@ export const broadcastServiceUser = async (
 		return false;
 	}
 
-	const msg = mapServiceUser(caseReference, user, roleName);
+	const msg = messageMappers.mapServiceUser(caseReference, user, roleName);
 
 	if (msg) {
-		const validationResult = await validateFromSchema(schemas.serviceUser, msg);
+		const validationResult = await validateFromSchema(schemas.events.serviceUser, msg);
 		if (validationResult !== true && validationResult.errors) {
 			const errorDetails = validationResult.errors?.map(
 				(e) => `${e.instancePath || '/'}: ${e.message}`

--- a/appeals/api/src/server/endpoints/integrations/integrations.mappers.js
+++ b/appeals/api/src/server/endpoints/integrations/integrations.mappers.js
@@ -2,15 +2,21 @@
 
 import { randomUUID } from 'node:crypto';
 
-import { mapAddressIn, mapAddressOut } from './address.mapper.js';
-import { mapLpaIn, mapLpaOut } from './lpa.mapper.js';
-import { mapDocumentIn, mapDocumentOut } from './document.mapper.js';
-import { mapServiceUserIn, mapServiceUserOut } from './service-user.mapper.js';
-import { mapAppellantCaseIn, mapAppellantCaseOut } from './appellant-case.mapper.js';
-import { mapQuestionnaireIn, mapQuestionnaireOut } from './questionnaire.mapper.js';
-import { mapAppealTypeIn, mapAppealTypeOut } from './appeal-type.mapper.js';
-import { mapAppealAllocationOut } from './appeal-allocation.mapper.js';
-import { mapCaseDataOut } from './casedata.mapper.js';
+import { mapAddressIn, mapAddressOut } from './integrations.mappers/address.mapper.js';
+import { mapLpaIn, mapLpaOut } from './integrations.mappers/lpa.mapper.js';
+import { mapDocumentIn, mapDocumentOut } from './integrations.mappers/document.mapper.js';
+import { mapServiceUserIn, mapServiceUserOut } from './integrations.mappers/service-user.mapper.js';
+import {
+	mapAppellantCaseIn,
+	mapAppellantCaseOut
+} from './integrations.mappers/appellant-case.mapper.js';
+import {
+	mapQuestionnaireIn,
+	mapQuestionnaireOut
+} from './integrations.mappers/questionnaire.mapper.js';
+import { mapAppealTypeIn, mapAppealTypeOut } from './integrations.mappers/appeal-type.mapper.js';
+import { mapAppealAllocationOut } from './integrations.mappers/appeal-allocation.mapper.js';
+import { mapCaseDataOut } from './integrations.mappers/casedata.mapper.js';
 
 const mappers = {
 	mapAddressIn,
@@ -35,7 +41,7 @@ const mappers = {
 /** @typedef {import('#config/../openapi-types.js').QuestionnaireData} QuestionnaireData */
 /** @typedef {import('#config/../openapi-types.js').DocumentMetaImport} DocumentMetaImport */
 
-export const mapAppealSubmission = (/** @type {AppellantCaseData} */ data) => {
+const mapAppealSubmission = (/** @type {AppellantCaseData} */ data) => {
 	const { appeal, documents } = data;
 	const { appellant, agent } = appeal;
 
@@ -63,7 +69,7 @@ export const mapAppealSubmission = (/** @type {AppellantCaseData} */ data) => {
 	};
 };
 
-export const mapQuestionnaireSubmission = (/** @type {QuestionnaireData} */ data) => {
+const mapQuestionnaireSubmission = (/** @type {QuestionnaireData} */ data) => {
 	const { questionnaire, documents } = data;
 	const questionnaireInput = mappers.mapQuestionnaireIn(questionnaire);
 	const documentsInput = (documents || []).map((document) => mappers.mapDocumentIn(document));
@@ -76,11 +82,11 @@ export const mapQuestionnaireSubmission = (/** @type {QuestionnaireData} */ data
 	};
 };
 
-export const mapDocumentSubmission = (/** @type {DocumentMetaImport} */ data) => {
+const mapDocumentSubmission = (/** @type {DocumentMetaImport} */ data) => {
 	return mappers.mapDocumentIn(data);
 };
 
-export const mapAppeal = (appeal) => {
+const mapAppeal = (appeal) => {
 	const topic = {
 		appealType: mappers.mapAppealTypeOut(appeal.appealType.shorthand),
 		caseReference: appeal.reference,
@@ -95,12 +101,21 @@ export const mapAppeal = (appeal) => {
 	return topic;
 };
 
-export const mapDocument = (doc) => {
+const mapDocument = (doc) => {
 	return mappers.mapDocumentOut(doc);
 };
 
-export const mapServiceUser = (caseReference, user, userType) => {
+const mapServiceUser = (caseReference, user, userType) => {
 	if (caseReference && user && userType) {
 		return mappers.mapServiceUserOut(user, userType, caseReference);
 	}
+};
+
+export const messageMappers = {
+	mapAppealSubmission,
+	mapQuestionnaireSubmission,
+	mapDocumentSubmission,
+	mapServiceUser,
+	mapDocument,
+	mapAppeal
 };

--- a/appeals/api/src/server/endpoints/integrations/integrations.mappers/date.mapper.js
+++ b/appeals/api/src/server/endpoints/integrations/integrations.mappers/date.mapper.js
@@ -1,0 +1,12 @@
+/**
+ *
+ * @param {Date | null | undefined} value
+ * @returns { string | null }
+ */
+export const mapDate = (value) => {
+	if (!value || value === null) {
+		return null;
+	}
+
+	return value.toISOString();
+};

--- a/appeals/api/src/server/endpoints/integrations/integrations.mappers/document.mapper.js
+++ b/appeals/api/src/server/endpoints/integrations/integrations.mappers/document.mapper.js
@@ -4,6 +4,14 @@
 import config from '#config/config.js';
 import { randomUUID } from 'node:crypto';
 import { UUID_REGEX } from '#endpoints/constants.js';
+import { mapDate } from './date.mapper.js';
+import { ODW_SYSTEM_ID, CONFIG_APPEAL_STAGES } from '#endpoints/constants.js';
+import {
+	AVSCAN_STATUS,
+	REDACTION_STATUS,
+	ORIGIN,
+	STAGE
+} from '@pins/appeals/constants/documents.js';
 
 export const mapDocumentIn = (doc) => {
 	const { filename, ...metadata } = doc;
@@ -27,7 +35,46 @@ export const mapDocumentIn = (doc) => {
 	};
 };
 
-export const mapDocumentOut = (doc) => {
+export const mapDocumentOut = (data) => {
+	if (!data || !data.latestDocumentVersion) {
+		return null;
+	}
+
+	const isPublished = mapPublishingStatus(data.latestDocumentVersion);
+	const virusCheckStatus = mapVirusCheckStatus(data.latestDocumentVersion);
+	const redactedStatus = mapRedactionStatus(data.latestDocumentVersion.redactionStatus);
+
+	const doc = {
+		documentId: data.guid,
+		caseId: data.caseId,
+		caseReference: data.case.reference,
+		version: data.latestDocumentVersion.version,
+		filename: data.latestDocumentVersion.fileName,
+		originalFilename: data.latestDocumentVersion.originalFilename,
+		size: data.latestDocumentVersion.size,
+		mime: data.latestDocumentVersion.mime,
+		documentURI: data.latestDocumentVersion.documentURI,
+		publishedDocumentURI: isPublished ? data.latestDocumentVersion.documentURI : null,
+		virusCheckStatus,
+		fileMD5: data.latestDocumentVersion.fileMD5,
+		dateCreated: mapDate(data.latestDocumentVersion.dateCreated),
+		dateReceived: mapDate(data.latestDocumentVersion.dateReceived),
+		datePublished: isPublished ? mapDate(data.latestDocumentVersion.dateCreated) : null,
+		lastModified: mapDate(
+			data.latestDocumentVersion.lastModified || data.latestDocumentVersion.dateCreated
+		),
+		caseType: data.case.appealType.shorthand,
+		redactedStatus,
+		documentType: data.latestDocumentVersion.documentType,
+		sourceSystem: ODW_SYSTEM_ID,
+		origin: mapOrigin(data.latestDocumentVersion.stage),
+		owner: null,
+		author: null,
+		description: null,
+		caseStage: mapStage(data.latestDocumentVersion.stage),
+		horizonFolderId: null
+	};
+
 	return doc;
 };
 
@@ -51,4 +98,59 @@ const mapDocumentUrl = (documentURI, fileName) => {
 		originalGuid,
 		originalFilename
 	};
+};
+
+const mapVirusCheckStatus = (documentVersion) => {
+	if (documentVersion.virusCheckStatus === 'checked') {
+		return AVSCAN_STATUS.SCANNED;
+	}
+	if (documentVersion.virusCheckStatus === 'not_checked') {
+		return AVSCAN_STATUS.NOT_SCANNED;
+	}
+
+	return AVSCAN_STATUS.AFFECTED;
+};
+
+const mapPublishingStatus = (documentVersion) => {
+	return documentVersion.stage !== 'internal';
+};
+
+const mapRedactionStatus = (status) => {
+	if (status.name === 'No redaction required') {
+		return REDACTION_STATUS.NO_REDACTION_REQUIRED;
+	}
+	if (status.name === 'Redacted') {
+		return REDACTION_STATUS.REDACTED;
+	}
+	return REDACTION_STATUS.UNREDACTED;
+};
+
+const mapOrigin = (stage) => {
+	if (stage === CONFIG_APPEAL_STAGES.appellantCase) {
+		return ORIGIN.CITIZEN;
+	}
+	if (stage === CONFIG_APPEAL_STAGES.lpaQuestionnaire) {
+		return ORIGIN.LPA;
+	}
+	if (stage === CONFIG_APPEAL_STAGES.decision || stage === CONFIG_APPEAL_STAGES.costs) {
+		return ORIGIN.PINS;
+	}
+	return null;
+};
+
+const mapStage = (stage) => {
+	if (stage === CONFIG_APPEAL_STAGES.appellantCase) {
+		return STAGE.APPELLANTCASE;
+	}
+	if (stage === CONFIG_APPEAL_STAGES.lpaQuestionnaire) {
+		return STAGE.LPAQUESTIONNAIRE;
+	}
+	if (stage === CONFIG_APPEAL_STAGES.decision) {
+		return STAGE.APPEALDECISION;
+	}
+	if (stage === CONFIG_APPEAL_STAGES.costs) {
+		return STAGE.COSTS;
+	}
+
+	return null;
 };

--- a/appeals/api/src/server/endpoints/integrations/integrations.middleware.js
+++ b/appeals/api/src/server/endpoints/integrations/integrations.middleware.js
@@ -16,7 +16,7 @@ export const validateAppellantCase = async (req, res, next) => {
 	const { body } = req;
 
 	pino.info('Received appellant case from topic', body);
-	const validationResult = await validateFromSchema(schemas.appellantCase, body);
+	const validationResult = await validateFromSchema(schemas.commands.appealSubmission, body);
 	if (validationResult !== true && validationResult.errors) {
 		const errorDetails = validationResult.errors.map(
 			(e) => `${e.instancePath || '/'}: ${e.message}`
@@ -41,14 +41,14 @@ export const validateAppellantCase = async (req, res, next) => {
 export const validateLpaQuestionnaire = async (req, res, next) => {
 	const { body } = req;
 
-	pino.info('Received LPA questionnaire from topic', body);
-	const validationResult = await validateFromSchema(schemas.lpaQuestionnaire, body);
+	pino.info('Received LPA submission from topic', body);
+	const validationResult = await validateFromSchema(schemas.commands.lpaSubmission, body);
 	if (validationResult !== true && validationResult.errors) {
 		const errorDetails = validationResult.errors.map(
 			(e) => `${e.instancePath || '/'}: ${e.message}`
 		);
 
-		pino.error(`Error validating lpa questionnaire: ${errorDetails[0]}`);
+		pino.error(`Error validating LPA submission: ${errorDetails[0]}`);
 		return res.status(400).send({
 			errors: {
 				integration: ERROR_INVALID_LPAQ_DATA,
@@ -60,7 +60,7 @@ export const validateLpaQuestionnaire = async (req, res, next) => {
 	const appealExists = await findAppealByReference(body?.questionnaire?.caseReference);
 	if (!appealExists) {
 		pino.error(
-			`Error associating LPA questionnaire to an existing appeal with reference '${body?.questionnaire?.caseReference}'`
+			`Error associating LPA submission to an existing appeal with reference '${body?.questionnaire?.caseReference}'`
 		);
 		return res.status(404).send({
 			errors: {
@@ -80,7 +80,7 @@ export const validateDocument = async (req, res, next) => {
 	const { body } = req;
 
 	pino.info('Received document from topic');
-	const validationResult = await validateFromSchema(schemas.document, body);
+	const validationResult = await validateFromSchema(schemas.commands.documentSubmission, body);
 	if (validationResult !== true && validationResult.errors) {
 		const errorDetails = validationResult.errors.map(
 			(e) => `${e.instancePath || '/'}: ${e.message}`

--- a/appeals/api/src/server/endpoints/integrations/integrations.service.js
+++ b/appeals/api/src/server/endpoints/integrations/integrations.service.js
@@ -1,178 +1,84 @@
-import pino from '#utils/logger.js';
-import config from '#config/config.js';
 import { producers } from '#infrastructure/topics.js';
 import { eventClient } from '#infrastructure/event-client.js';
-import { EventType } from '@pins/event-client';
-import { mapAppeal } from './integrations.mappers/index.js';
-import { schemas, validateFromSchema } from './integrations.validators.js';
 import { randomUUID } from 'node:crypto';
 import {
 	createAppeal,
-	createOrUpdateLpaQuestionnaire,
-	createDocument,
-	loadAppeal
+	createOrUpdateLpaQuestionnaire
 } from '#repositories/integrations.repository.js';
 import { databaseConnector } from '#utils/database-connector.js';
-import { ODW_SYSTEM_ID } from '#endpoints/constants.js';
+import { EventType } from '@pins/event-client';
+import BackOfficeAppError from '#utils/app-error.js';
 
-export const importAppellantCase = async (
-	/** @type {any} */ data,
-	/** @type {any} */ documents
-) => {
-	const existingDocs = await databaseConnector.document.findMany({
-		where: {
-			guid: {
-				in: documents.map((/** @type {{ documentGuid: string; }} */ d) => d.documentGuid)
-			}
-		}
-	});
-
-	if (existingDocs?.length > 0) {
-		const docIDs = existingDocs.map((d) => d.guid);
-		for (const document of documents) {
-			if (docIDs.indexOf(document.documentGuid) >= 0) {
-				document.documentGuid = randomUUID();
-			}
-		}
-	}
-
+const importAppellantCase = async (/** @type {*} */ data, /** @type {*} */ documents) => {
+	await checkExistingDocumentIDs(documents);
 	const result = await createAppeal(data, documents);
-	return result;
+
+	if (!result?.appeal) {
+		throw new BackOfficeAppError(`Failure importing appellant case. Appeal could not be created.`);
+	} else {
+		return result;
+	}
 };
 
-export const importLPAQuestionnaire = async (
-	/** @type {any} */ caseReference,
-	/** @type {any} */ nearbyCaseReferences,
-	/** @type {any} */ data,
-	/** @type {any} */ documents
+const importLPAQuestionnaire = async (
+	/** @type {string} */ caseReference,
+	/** @type {*} */ data,
+	/** @type {*} */ documents
 ) => {
+	await checkExistingDocumentIDs(documents);
+	const result = await createOrUpdateLpaQuestionnaire(caseReference, data, documents);
+
+	if (!result?.appeal) {
+		throw new BackOfficeAppError(
+			`Failure importing LPA questionnaire. Appeal with case reference '${caseReference}' does not exist.`
+		);
+	} else {
+		return result;
+	}
+};
+
+const importDocuments = async (
+	/** @type {any[]} */ documents,
+	/** @type {any[]} */ documentVersions
+) => {
+	if (documents.length > 0) {
+		// @ts-ignore
+		const messages = documents.map((d) => {
+			return {
+				originalURI: d.documentURI,
+				// @ts-ignore
+				importedURI: documentVersions.find((dv) => dv.documentGuid === d.documentGuid).documentURI
+			};
+		});
+		const topic = producers.boBlobMove;
+		const res = await eventClient.sendEvents(topic, messages, EventType.Create);
+		if (res) {
+			return true;
+		}
+
+		return false;
+	}
+};
+
+const checkExistingDocumentIDs = async (/** @type {any[]} */ documents) => {
 	const existingDocs = await databaseConnector.document.findMany({
 		where: {
-			guid: {
-				in: documents.map((/** @type {{ documentGuid: string; }} */ d) => d.documentGuid)
-			}
+			guid: { in: documents.map((/** @type {{ documentGuid: string; }} */ d) => d.documentGuid) }
 		}
 	});
 
 	if (existingDocs?.length > 0) {
-		const docIDs = existingDocs.map((d) => d.guid);
+		const documentGuids = existingDocs.map((d) => d.guid);
 		for (const document of documents) {
-			if (docIDs.indexOf(document.documentGuid) === 0) {
+			if (documentGuids.indexOf(document.documentGuid) >= 0) {
 				document.documentGuid = randomUUID();
 			}
 		}
 	}
-	const result = await createOrUpdateLpaQuestionnaire(
-		caseReference,
-		nearbyCaseReferences,
-		data,
-		documents
-	);
-	return result;
 };
 
-export const importDocument = async (/** @type {any} */ document) => await createDocument(document);
-
-export const produceAppealUpdate = async (
-	/** @type {any} */ appeal, // TODO: data and document types schema (PINS data model)
-	/** @type {string} */ updateType
-) => {
-	if (!config.serviceBusEnabled) {
-		return false;
-	}
-
-	// const validationResult = await validateFromSchema(schemas.appeal, appeal);
-	// if (validationResult !== true && validationResult.errors) {
-	// 	const errorDetails = validationResult.errors?.map(
-	// 		(e) => `${e.instancePath || '/'}: ${e.message}`
-	// 	);
-
-	// 	pino.error(`Error validating appeal: ${errorDetails[0]}`);
-	// 	return false;
-	// }
-
-	const topic = producers.boCaseData;
-	const res = await eventClient.sendEvents(topic, [appeal], updateType);
-	if (res) {
-		return true;
-	}
-	return false;
-};
-
-export const broadcastAppealState = async (/** @type {Number} */ id) => {
-	if (!config.serviceBusEnabled) {
-		return false;
-	}
-
-	const appeal = await loadAppeal(id);
-	if (appeal) {
-		const appealTopic = mapAppeal(appeal);
-		await produceAppealUpdate(appealTopic, EventType.Update);
-	}
-};
-
-export const produceDocumentUpdate = async (
-	/** @type {any[]} */ documents, // TODO: data and document types schema (PINS data model)
-	/** @type {string} */ updateType
-) => {
-	if (!config.serviceBusEnabled) {
-		return false;
-	}
-
-	if (documents.length > 0) {
-		const topic = producers.boDocument;
-		const res = await eventClient.sendEvents(topic, documents, updateType);
-		if (res) {
-			return true;
-		}
-
-		return false;
-	}
-};
-
-export const produceBlobMoveRequest = async (
-	/** @type {any[]} */ documents, // TODO: data and document types schema (PINS data model)
-	/** @type {string} */ updateType
-) => {
-	if (documents.length > 0) {
-		const topic = producers.boBlobMove;
-		const res = await eventClient.sendEvents(topic, documents, updateType);
-		if (res) {
-			return true;
-		}
-
-		return false;
-	}
-};
-
-export const produceServiceUsersUpdate = async (
-	/** @type {any[]} */ users, // TODO: data and document types schema (PINS data model)
-	/** @type {string} */ updateType,
-	/** @type {string} */ roleName
-) => {
-	if (!config.serviceBusEnabled) {
-		return false;
-	}
-	if (users.length === 1) {
-		const validationResult = await validateFromSchema(schemas.serviceUser, users[0]);
-		if (validationResult !== true && validationResult.errors) {
-			const errorDetails = validationResult.errors?.map(
-				(e) => `${e.instancePath || '/'}: ${e.message}`
-			);
-
-			pino.error(`Error validating service user: ${errorDetails[0]}`);
-			return false;
-		}
-
-		const topic = producers.boServiceUser;
-		const res = await eventClient.sendEvents(topic, users, updateType, {
-			entityType: roleName,
-			sourceSystem: ODW_SYSTEM_ID
-		});
-		if (res) {
-			return true;
-		}
-	}
-
-	return false;
+export const integrationService = {
+	importAppellantCase,
+	importLPAQuestionnaire,
+	importDocuments
 };

--- a/appeals/api/src/server/endpoints/integrations/integrations.validators.js
+++ b/appeals/api/src/server/endpoints/integrations/integrations.validators.js
@@ -2,21 +2,39 @@ import Ajv from 'ajv';
 import addFormats from 'ajv-formats';
 import { loadAllSchemas } from 'pins-data-model';
 import BackOfficeAppError from '#utils/app-error.js';
+import { setCache, getCache } from '#utils/cache-data.js';
 
 export const schemas = {
-	serviceUser: 'service-user'
-	//appellantCase: 'pins-appellant-case',
-	//lpaQuestionnaire: 'pins-lpa-questionnaire',
-	//document: 'pins-document',
-	//appeal: 'pins-appeal'
+	commands: {
+		appealSubmission: '',
+		lpaSubmission: '',
+		documentSubmission: ''
+	},
+	events: {
+		serviceUser: 'service-user',
+		document: 'appeal-document',
+		appeal: 'pins-appeal',
+		lpaSubmission: '',
+		appealEvent: ''
+	}
 };
 
 export const validateFromSchema = async (
 	/** @type {string} */ schema,
 	/** @type {any} */ payload
 ) => {
-	const dataModels = await loadAllSchemas();
-	const schemas = dataModels.schemas;
+	const cacheKey = 'integration-schemas';
+	let schemas = getCache(cacheKey);
+	if (!schemas) {
+		const commandsAndEvents = await loadAllSchemas();
+		schemas = {
+			...commandsAndEvents.schemas,
+			...commandsAndEvents.commands
+		};
+
+		setCache(cacheKey, schemas);
+	}
+
 	const ajv = new Ajv({ schemas });
 	addFormats(ajv);
 

--- a/appeals/api/src/server/endpoints/invalid-appeal-decision/invalid-appeal-decision.service.js
+++ b/appeals/api/src/server/endpoints/invalid-appeal-decision/invalid-appeal-decision.service.js
@@ -1,6 +1,6 @@
 import appealRepository from '#repositories/appeal.repository.js';
 import transitionState from '#state/transition-state.js';
-import { broadcastAppealState } from '#endpoints/integrations/integrations.service.js';
+import { broadcasters } from '#endpoints/integrations/integrations.broadcasters.js';
 import { CASE_OUTCOME_INVALID, STATE_TARGET_INVALID } from '#endpoints/constants.js';
 
 /** @typedef {import('@pins/appeals.api').Appeals.RepositoryGetByIdResultItem} Appeal */
@@ -30,7 +30,7 @@ export const publishInvalidDecision = async (appeal, invalidDecisionReason, azur
 			appeal.appealStatus,
 			STATE_TARGET_INVALID
 		);
-		await broadcastAppealState(appeal.id);
+		await broadcasters.broadcastAppeal(appeal.id);
 
 		return result;
 	}

--- a/appeals/api/src/server/endpoints/link-appeals/link-appeals.controller.js
+++ b/appeals/api/src/server/endpoints/link-appeals/link-appeals.controller.js
@@ -1,6 +1,6 @@
 import appealRepository from '#repositories/appeal.repository.js';
 import { createAuditTrail } from '#endpoints/audit-trails/audit-trails.service.js';
-import { broadcastAppealState } from '#endpoints/integrations/integrations.service.js';
+import { broadcasters } from '#endpoints/integrations/integrations.broadcasters.js';
 import {
 	AUDIT_TRAIL_APPEAL_LINK_ADDED,
 	AUDIT_TRAIL_APPEAL_LINK_REMOVED,
@@ -69,7 +69,7 @@ export const linkAppeal = async (req, res) => {
 			details: AUDIT_TRAIL_APPEAL_LINK_ADDED
 		});
 
-		await broadcastAppealState(currentAppeal.id);
+		await broadcasters.broadcastAppeal(currentAppeal.id);
 		return res.send(result);
 	}
 
@@ -125,7 +125,7 @@ export const linkExternalAppeal = async (req, res) => {
 		details: AUDIT_TRAIL_APPEAL_LINK_ADDED
 	});
 
-	await broadcastAppealState(currentAppeal.id);
+	await broadcasters.broadcastAppeal(currentAppeal.id);
 	return res.send(result);
 };
 
@@ -156,7 +156,7 @@ export const associateAppeal = async (req, res) => {
 			details: AUDIT_TRAIL_APPEAL_RELATION_ADDED
 		});
 
-		await broadcastAppealState(currentAppeal.id);
+		await broadcasters.broadcastAppeal(currentAppeal.id);
 		return res.send(result);
 	}
 
@@ -193,7 +193,7 @@ export const associateExternalAppeal = async (req, res) => {
 		details: AUDIT_TRAIL_APPEAL_RELATION_ADDED
 	});
 
-	await broadcastAppealState(currentAppeal.id);
+	await broadcasters.broadcastAppeal(currentAppeal.id);
 	return res.send(result);
 };
 
@@ -215,6 +215,6 @@ export const unlinkAppeal = async (req, res) => {
 				: AUDIT_TRAIL_APPEAL_RELATION_REMOVED
 	});
 
-	await broadcastAppealState(currentAppeal.id);
+	await broadcasters.broadcastAppeal(currentAppeal.id);
 	return res.status(200).send(true);
 };

--- a/appeals/api/src/server/endpoints/lpa-questionnaires/lpa-questionnaires.service.js
+++ b/appeals/api/src/server/endpoints/lpa-questionnaires/lpa-questionnaires.service.js
@@ -1,5 +1,5 @@
 import lpaQuestionnaireRepository from '#repositories/lpa-questionnaire.repository.js';
-import { broadcastAppealState } from '#endpoints/integrations/integrations.service.js';
+import { broadcasters } from '#endpoints/integrations/integrations.broadcasters.js';
 import { recalculateDateIfNotBusinessDay } from '#utils/business-days.js';
 import { isOutcomeIncomplete } from '#utils/check-validation-outcome.js';
 import transitionState from '#state/transition-state.js';
@@ -75,7 +75,7 @@ const updateLPAQuestionaireValidationOutcome = async ({
 		});
 	}
 
-	await broadcastAppealState(appealId);
+	await broadcasters.broadcastAppeal(appealId);
 
 	return timetable?.lpaQuestionnaireDueDate;
 };

--- a/appeals/api/src/server/endpoints/neighbouring-sites/neighbouring-sites.controller.js
+++ b/appeals/api/src/server/endpoints/neighbouring-sites/neighbouring-sites.controller.js
@@ -1,7 +1,7 @@
 import { ERROR_NOT_FOUND } from '#endpoints/constants.js';
 import neighbouringSitesRepository from '#repositories/neighbouring-sites.repository.js';
 import { createAuditTrail } from '#endpoints/audit-trails/audit-trails.service.js';
-import { broadcastAppealState } from '#endpoints/integrations/integrations.service.js';
+import { broadcasters } from '#endpoints/integrations/integrations.broadcasters.js';
 import {
 	AUDIT_TRAIL_ADDRESS_ADDED,
 	AUDIT_TRAIL_ADDRESS_UPDATED,
@@ -36,7 +36,7 @@ export const addNeighbouringSite = async (req, res) => {
 			details: AUDIT_TRAIL_ADDRESS_ADDED
 		});
 
-		await broadcastAppealState(appeal.id);
+		await broadcasters.broadcastAppeal(appeal.id);
 	}
 
 	return res.send({
@@ -74,7 +74,7 @@ export const updateNeighbouringSite = async (req, res) => {
 		details: AUDIT_TRAIL_ADDRESS_UPDATED
 	});
 
-	await broadcastAppealState(appeal.id);
+	await broadcasters.broadcastAppeal(appeal.id);
 	return res.send({
 		siteId
 	});
@@ -101,7 +101,7 @@ export const removeNeighbouringSite = async (req, res) => {
 		details: AUDIT_TRAIL_ADDRESS_REMOVED
 	});
 
-	await broadcastAppealState(appeal.id);
+	await broadcasters.broadcastAppeal(appeal.id);
 	return res.send({
 		siteId
 	});

--- a/appeals/api/src/server/tests/appeals/mocks.js
+++ b/appeals/api/src/server/tests/appeals/mocks.js
@@ -1,4 +1,5 @@
 import { APPEAL_TYPE_SHORTHAND_FPA, APPEAL_TYPE_SHORTHAND_HAS } from '#endpoints/constants.js';
+import { STATUSES } from '@pins/appeals/constants/state.js';
 
 import {
 	azureAdUserId,
@@ -59,7 +60,7 @@ export const householdAppeal = {
 	reference: '1345264',
 	appealStatus: [
 		{
-			status: 'assign_case_officer',
+			status: STATUSES.ASSIGN_CASE_OFFICER,
 			valid: true
 		}
 	],

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
 				"joi": "^17.7.0",
 				"node-cache": "^5.1.2",
 				"nodemon": "3.0.3",
-				"pins-data-model": "github:Planning-Inspectorate/data-model#1.0.2"
+				"pins-data-model": "github:Planning-Inspectorate/data-model#1.2.1"
 			},
 			"devDependencies": {
 				"@commitlint/cli": "17.0.1",
@@ -76,7 +76,7 @@
 				"pino": "^8.1.0",
 				"pino-http": "^8.1.0",
 				"pino-pretty": "^8.1.0",
-				"pins-data-model": "github:Planning-Inspectorate/data-model#1.0.2",
+				"pins-data-model": "github:Planning-Inspectorate/data-model#1.2.1",
 				"rhea": "3.0.1",
 				"swagger-ui-express": "^4.4.0",
 				"xstate": "4.32.1"
@@ -23078,8 +23078,9 @@
 			"license": "MIT"
 		},
 		"node_modules/pins-data-model": {
-			"version": "1.0.2",
-			"resolved": "git+ssh://git@github.com/Planning-Inspectorate/data-model.git#47188c18d5a2b7b0ee5bce8928c9231a732c5115",
+			"version": "1.2.1",
+			"resolved": "git+ssh://git@github.com/Planning-Inspectorate/data-model.git#126020709ce15496c729ccbca9b23a0f878537ae",
+			"integrity": "sha512-xk2gyAS0kAzFkiOWmo2pKvKAkQno2nER/buABJbmyVgIBsBGNSb7gQ91TmZOyn4aNEI90Q4Gxcq5w9q4+RyMpw==",
 			"license": "MIT",
 			"dependencies": {
 				"jsonc-parser": "^3.2.0"
@@ -33029,7 +33030,7 @@
 				"pino": "^8.1.0",
 				"pino-http": "^8.1.0",
 				"pino-pretty": "^8.1.0",
-				"pins-data-model": "github:Planning-Inspectorate/data-model#1.0.2",
+				"pins-data-model": "github:Planning-Inspectorate/data-model#1.2.1",
 				"prisma": "4.16.1",
 				"rhea": "3.0.1",
 				"rimraf": "^3.0.2",
@@ -46564,8 +46565,9 @@
 			"version": "4.0.0"
 		},
 		"pins-data-model": {
-			"version": "git+ssh://git@github.com/Planning-Inspectorate/data-model.git#47188c18d5a2b7b0ee5bce8928c9231a732c5115",
-			"from": "pins-data-model@github:Planning-Inspectorate/data-model#1.0.2",
+			"version": "git+ssh://git@github.com/Planning-Inspectorate/data-model.git#126020709ce15496c729ccbca9b23a0f878537ae",
+			"integrity": "sha512-xk2gyAS0kAzFkiOWmo2pKvKAkQno2nER/buABJbmyVgIBsBGNSb7gQ91TmZOyn4aNEI90Q4Gxcq5w9q4+RyMpw==",
+			"from": "pins-data-model@github:Planning-Inspectorate/data-model#126020709ce15496c729ccbca9b23a0f878537ae",
 			"requires": {
 				"jsonc-parser": "^3.2.0"
 			}

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
 		"joi": "^17.7.0",
 		"node-cache": "^5.1.2",
 		"nodemon": "3.0.3",
-		"pins-data-model": "github:Planning-Inspectorate/data-model#1.0.2"
+		"pins-data-model": "github:Planning-Inspectorate/data-model#1.2.1"
 	},
 	"devDependencies": {
 		"@commitlint/cli": "17.0.1",

--- a/packages/appeals/constants/documents.js
+++ b/packages/appeals/constants/documents.js
@@ -1,0 +1,28 @@
+export const REDACTION_STATUS = {
+	REDACTED: 'redacted',
+	UNREDACTED: 'not_redacted',
+	NO_REDACTION_REQUIRED: 'no_redaction_required'
+};
+
+export const AVSCAN_STATUS = {
+	NOT_SCANNED: 'not_scanned',
+	SCANNED: 'scanned',
+	AFFECTED: 'affected'
+};
+
+export const ORIGIN = {
+	CITIZEN: 'citizen',
+	LPA: 'lpa',
+	PINS: 'pins',
+	OGD: 'ogd'
+};
+
+export const STAGE = {
+	APPELLANTCASE: 'appellant-case',
+	LPAQUESTIONNAIRE: 'lpa-questionnaire',
+	APPEALDECISION: 'appeal-decision',
+	COSTS: 'costs',
+	STATEMENTS: 'statements',
+	THIRDPARTYCOMMENTS: 'third-party-comments',
+	FINALCOMMENTS: 'final-comments'
+};

--- a/packages/appeals/constants/state.js
+++ b/packages/appeals/constants/state.js
@@ -1,0 +1,29 @@
+export const STATUSES = {
+	ASSIGN_CASE_OFFICER: 'assign_case_officer',
+	VALIDATION: 'validation',
+	READY_TO_START: 'ready_to_start',
+	LPA_QUESTIONNAIRE: 'lpa_questionnaire',
+	STATEMENT_REVIEW: 'statement_review',
+	FINAL_COMMENT_REVIEW: 'final_comment_review',
+	ISSUE_DETERMINATION: 'issue_determination',
+	COMPLETE: 'complete',
+	INVALID: 'invalid',
+	WITHDRAWN: 'withdrawn',
+	CLOSED: 'closed',
+	AWAITING_TRANSFER: 'awaiting_transfer',
+	TRANSFERRED: 'transferred'
+};
+
+export const TRANSITIONS = {
+	ASSIGNED_CASE_OFFICER: 'assigned_case_officer',
+	VALIDATION_VALID: 'validation_valid',
+	VALIDATION_INVALID: 'validation_invalid',
+	START: 'start',
+	LPAQ_COMPLETE: 'questionnaire_complete',
+	WITHDRAWING: 'withdrawing',
+	CLOSING: 'closing',
+	AWAITING_TRANSFER: 'awaiting_transfer',
+	COMPLETING_TRANSFER: 'completing_transfer'
+};
+
+export const FINAL_STATE = 'final';


### PR DESCRIPTION
Integration flow for appeal documents

- Refactored integration controller, service
- Added granular mappers
- Started moving constants to the shared `@pins/appeals/constants` package (to make more granular and reuse from WEB)
- Created broadcaster for documents

Notes
- Documents will not be broadcasted, as `documentType` will not validate
- Document types will be remapped to the enum defined in the document schema
- POC appeal broadcast replaced with a stub for the real thing
- Some document tests have been simplified, awaiting for a refactoring of the upload flow

## Issue ticket number and link

[BOAT-1180](https://pins-ds.atlassian.net/browse/BOAT-1180)

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [ ] I have performed a self-review of my own code
- [ ] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [ ] I have referenced the ticket number above
- [ ] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
