### PR TITLE
fix(web): lpaq due date confirmation page removed and replaced with notification banner

### DIFF
--- a/appeals/web/src/server/appeals/appeal-details/appeal-timetables/__tests__/__snapshots__/appeal-timetables.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/appeal-timetables/__tests__/__snapshots__/appeal-timetables.test.js.snap
@@ -36,7 +36,7 @@ exports[`Appeal Timetables should render "Change Final Comment Review Date" page
             </div>
         </div>
         <div class="govuk-button-group">
-            <button type="submit" class="govuk-button" data-module="govuk-button">Continue</button>
+            <button type="submit" class="govuk-button" data-module="govuk-button">Confirm</button>
         </div>
     </form>
 </main>"
@@ -93,7 +93,7 @@ exports[`Appeal Timetables should render "Change Final Comment Review Date" with
             </div>
         </div>
         <div class="govuk-button-group">
-            <button type="submit" class="govuk-button" data-module="govuk-button">Continue</button>
+            <button type="submit" class="govuk-button" data-module="govuk-button">Confirm</button>
         </div>
     </form>
 </main>"
@@ -156,7 +156,7 @@ exports[`Appeal Timetables should render "Change Final Comment Review Date" with
             </div>
         </div>
         <div class="govuk-button-group">
-            <button type="submit" class="govuk-button" data-module="govuk-button">Continue</button>
+            <button type="submit" class="govuk-button" data-module="govuk-button">Confirm</button>
         </div>
     </form>
 </main>"
@@ -198,7 +198,7 @@ exports[`Appeal Timetables should render "Change LPA questionnaire Date" page 1`
             </div>
         </div>
         <div class="govuk-button-group">
-            <button type="submit" class="govuk-button" data-module="govuk-button">Continue</button>
+            <button type="submit" class="govuk-button" data-module="govuk-button">Confirm</button>
         </div>
     </form>
 </main>"
@@ -240,7 +240,7 @@ exports[`Appeal Timetables should render "Change issue determination" page 1`] =
             </div>
         </div>
         <div class="govuk-button-group">
-            <button type="submit" class="govuk-button" data-module="govuk-button">Continue</button>
+            <button type="submit" class="govuk-button" data-module="govuk-button">Confirm</button>
         </div>
     </form>
 </main>"
@@ -282,7 +282,7 @@ exports[`Appeal Timetables should render "Change statement review Date" page 1`]
             </div>
         </div>
         <div class="govuk-button-group">
-            <button type="submit" class="govuk-button" data-module="govuk-button">Continue</button>
+            <button type="submit" class="govuk-button" data-module="govuk-button">Confirm</button>
         </div>
     </form>
 </main>"
@@ -323,7 +323,7 @@ exports[`Appeal Timetables should render "Schedule Final Comment Review Date" pa
             </div>
         </div>
         <div class="govuk-button-group">
-            <button type="submit" class="govuk-button" data-module="govuk-button">Continue</button>
+            <button type="submit" class="govuk-button" data-module="govuk-button">Confirm</button>
         </div>
     </form>
 </main>"
@@ -364,7 +364,7 @@ exports[`Appeal Timetables should render "Schedule LPA questionnaire Date" page 
             </div>
         </div>
         <div class="govuk-button-group">
-            <button type="submit" class="govuk-button" data-module="govuk-button">Continue</button>
+            <button type="submit" class="govuk-button" data-module="govuk-button">Confirm</button>
         </div>
     </form>
 </main>"
@@ -405,7 +405,7 @@ exports[`Appeal Timetables should render "Schedule issue determination" page 1`]
             </div>
         </div>
         <div class="govuk-button-group">
-            <button type="submit" class="govuk-button" data-module="govuk-button">Continue</button>
+            <button type="submit" class="govuk-button" data-module="govuk-button">Confirm</button>
         </div>
     </form>
 </main>"
@@ -446,7 +446,7 @@ exports[`Appeal Timetables should render "Schedule statement review Date" page 1
             </div>
         </div>
         <div class="govuk-button-group">
-            <button type="submit" class="govuk-button" data-module="govuk-button">Continue</button>
+            <button type="submit" class="govuk-button" data-module="govuk-button">Confirm</button>
         </div>
     </form>
 </main>"

--- a/appeals/web/src/server/appeals/appeal-details/appeal-timetables/appeal-timetables.controller.js
+++ b/appeals/web/src/server/appeals/appeal-details/appeal-timetables/appeal-timetables.controller.js
@@ -4,9 +4,9 @@ import { setAppealTimetables } from './appeal-timetables.service.js';
 import {
 	routeToObjectMapper,
 	mapUpdateDueDatePage,
-	mapConfirmationPage,
 	apiErrorMapper
 } from './appeal-timetables.mapper.js';
+import { addNotificationBannerToSession } from '#lib/session-utilities.js';
 
 /**
  *
@@ -99,10 +99,9 @@ const processUpdateDueDate = async (request, response) => {
 				return response.render('app/500.njk');
 			}
 		}
+		addNotificationBannerToSession(request.session, 'lpaqDueDateUpdated', appealId);
 
-		return response.redirect(
-			`/appeals-service/appeal-details/${appealId}/appeal-timetables/${timetableType}/confirmation`
-		);
+		return response.redirect(`/appeals-service/appeal-details/${appealId}`);
 	} catch (error) {
 		logger.error(
 			error,
@@ -110,37 +109,6 @@ const processUpdateDueDate = async (request, response) => {
 		);
 
 		return response.render('app/500.njk');
-	}
-};
-
-/**
- *
- * @param {import('@pins/express/types/express.js').Request} request
- * @param {import('@pins/express/types/express.js').RenderedResponse<any, any, Number>} response
- */
-const renderConfirmationPage = async (request, response) => {
-	const { appealId, appealReference } = request.currentAppeal;
-	const { timetableType } = request.params;
-
-	if (!appealId || !appealReference) {
-		return response.render('app/500.njk');
-	}
-
-	const appealDetails = request.currentAppeal;
-	const timetableProperty = routeToObjectMapper[timetableType];
-
-	const pageContent = mapConfirmationPage(
-		appealDetails?.appealTimetable,
-		timetableProperty,
-		appealDetails
-	);
-
-	if (!pageContent) {
-		return response.render('app/500.njk');
-	} else {
-		response.render('appeals/confirmation.njk', {
-			pageContent
-		});
 	}
 };
 
@@ -152,9 +120,4 @@ export const getDueDate = async (request, response) => {
 /** @type {import('@pins/express').RequestHandler<Response>} */
 export const postDueDate = async (request, response) => {
 	processUpdateDueDate(request, response);
-};
-
-/** @type {import('@pins/express').RequestHandler<Response>}  */
-export const getConfirmation = async (request, response) => {
-	renderConfirmationPage(request, response);
 };

--- a/appeals/web/src/server/appeals/appeal-details/appeal-timetables/appeal-timetables.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/appeal-timetables/appeal-timetables.mapper.js
@@ -10,14 +10,6 @@ import { appealShortReference } from '#lib/appeals-formatter.js';
  * @typedef {Object} AppealTimetablesMap
  * @property {string | null | undefined} sideNote
  * @property { object } page
- * @property { AppealTimetablesConfirmation } confirmation
- */
-
-/**
- * @typedef {Object} AppealTimetablesConfirmation
- * @property { string } title
- * @property { string } preHeading
- * @property { object[] } rows
  */
 
 /**
@@ -55,7 +47,7 @@ export const mapUpdateDueDatePage = (appealTimetables, timetableType, appealDeta
 		preHeading: `Appeal ${appealShortReference(appealDetails.appealReference)}`,
 		heading: `${changeOrScheduleText} ${timetableTypeText} due date`,
 		submitButtonProperties: {
-			text: 'Continue',
+			text: 'Confirm',
 			type: 'submit'
 		},
 		pageComponents: [
@@ -100,65 +92,6 @@ export const mapUpdateDueDatePage = (appealTimetables, timetableType, appealDeta
 			}
 		});
 	}
-
-	return pageContent;
-};
-
-/**
- * @param {import('./appeal-timetables.service.js').AppealTimetables} appealTimetables
- * @param {AppealTimetableType} timetableType
- * @param {Appeal} appealDetails
- * @returns {PageContent}
- */
-export const mapConfirmationPage = (appealTimetables, timetableType, appealDetails) => {
-	const timetableTypeText = getTimetableTypeText(timetableType);
-	const titleText =
-		timetableType === 'lpaQuestionnaireDueDate' ? timetableTypeText : capitalize(timetableTypeText);
-
-	/** @type {PageContent} */
-	const pageContent = {
-		title: `${titleText} due date changed`,
-		pageComponents: [
-			{
-				type: 'panel',
-				parameters: {
-					titleText: `${titleText} due date changed`,
-					headingLevel: 1,
-					html: `Appeal reference<br><strong>${appealShortReference(
-						appealDetails.appealReference
-					)}</strong>`
-				}
-			},
-			{
-				type: 'html',
-				parameters: {
-					html: `<span class="govuk-body">New due date: ${dateToDisplayDate(
-						appealTimetables.lpaQuestionnaireDueDate
-					)}</span>`
-				}
-			},
-			{
-				type: 'html',
-				parameters: {
-					html: '<h2>What happens next</h2>'
-				}
-			},
-			{
-				type: 'html',
-				parameters: {
-					html: `<p class="govuk-body">The appellant${
-						timetableType === 'lpaQuestionnaireDueDate' ? ' and LPA have' : 'has'
-					} been informed.</p>`
-				}
-			},
-			{
-				type: 'html',
-				parameters: {
-					html: `<p class="govuk-body"><a class="govuk-link" href="/appeals-service/appeal-details/${appealDetails.appealId}">Go back to case details</a></p>`
-				}
-			}
-		]
-	};
 
 	return pageContent;
 };

--- a/appeals/web/src/server/appeals/appeal-details/appeal-timetables/appeal-timetables.router.js
+++ b/appeals/web/src/server/appeals/appeal-details/appeal-timetables/appeal-timetables.router.js
@@ -27,15 +27,4 @@ router
 		asyncRoute(appealTimetablesController.postDueDate)
 	);
 
-router
-	.route('/:timetableType/confirmation')
-	.get(
-		validateAppeal,
-		assertUserHasPermission(
-			permissionNames.viewCaseDetails,
-			permissionNames.viewAssignedCaseDetails
-		),
-		asyncRoute(appealTimetablesController.getConfirmation)
-	);
-
 export default router;

--- a/appeals/web/src/server/appeals/appeal-details/appellant-case/__tests__/__snapshots__/appellant-case.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/appellant-case/__tests__/__snapshots__/appellant-case.test.js.snap
@@ -7426,7 +7426,7 @@ exports[`appellant-case POST /appellant-case/incomplete/date should re-render th
                     <h2 class="govuk-error-summary__title"> There is a problem</h2>
                     <div class="govuk-error-summary__body">
                         <ul class="govuk-list govuk-error-summary__list">
-                            <li><a href="#">Date must be a date in the future</a>
+                            <li><a href="#">Date must be in the future</a>
                             </li>
                         </ul>
                     </div>

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/__tests__/__snapshots__/lpa-questionnaire.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/__tests__/__snapshots__/lpa-questionnaire.test.js.snap
@@ -5480,7 +5480,7 @@ exports[`LPA Questionnaire review POST /appeals-service/appeal-details/1/lpa-que
                     <h2 class="govuk-error-summary__title"> There is a problem</h2>
                     <div class="govuk-error-summary__body">
                         <ul class="govuk-list govuk-error-summary__list">
-                            <li><a href="#">Date must be a date in the future</a>
+                            <li><a href="#">Date must be in the future</a>
                             </li>
                         </ul>
                     </div>
@@ -6153,7 +6153,7 @@ exports[`LPA Questionnaire review POST /lpa-questionnaire/1/add-document-details
 </main>"
 `;
 
-exports[`LPA Questionnaire review POST /lpa-questionnaire/1/add-document-details/:folderId/ should re-render the document details page with the expected error message if receivedDate is a date in the future 1`] = `
+exports[`LPA Questionnaire review POST /lpa-questionnaire/1/add-document-details/:folderId/ should re-render the document details page with the expected error message if receivedDate is in the future 1`] = `
 "<main class="govuk-main-wrapper " id="main-content" role="main">
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/__tests__/lpa-questionnaire.test.js
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/__tests__/lpa-questionnaire.test.js
@@ -1491,7 +1491,7 @@ describe('LPA Questionnaire review', () => {
 			expect(element.innerHTML).toMatchSnapshot();
 		});
 
-		it('should re-render the document details page with the expected error message if receivedDate is a date in the future', async () => {
+		it('should re-render the document details page with the expected error message if receivedDate is in the future', async () => {
 			const futureDate = addDays(new Date(), 1);
 			const response = await request.post(`${baseUrl}/add-document-details/1`).send({
 				items: [

--- a/appeals/web/src/server/appeals/appeal-details/site-visit/__tests__/__snapshots__/site-visit.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/site-visit/__tests__/__snapshots__/site-visit.test.js.snap
@@ -495,7 +495,7 @@ exports[`site-visit POST /site-visit/manage-visit should re-render the manage vi
                     <h2 class="govuk-error-summary__title"> There is a problem</h2>
                     <div class="govuk-error-summary__body">
                         <ul class="govuk-list govuk-error-summary__list">
-                            <li><a href="#">Visit date must be a date in the future</a>
+                            <li><a href="#">Visit date must be in the future</a>
                             </li>
                         </ul>
                     </div>
@@ -1160,7 +1160,7 @@ exports[`site-visit POST /site-visit/manage-visit should re-render the manage vi
                         <ul class="govuk-list govuk-error-summary__list">
                             <li><a href="#visit-date-year">Visit date year must be 4 digits</a>
                             </li>
-                            <li><a href="#">Visit date must be a date in the future</a>
+                            <li><a href="#">Visit date must be in the future</a>
                             </li>
                         </ul>
                     </div>
@@ -2353,7 +2353,7 @@ exports[`site-visit POST /site-visit/schedule-visit should re-render the schedul
                     <h2 class="govuk-error-summary__title"> There is a problem</h2>
                     <div class="govuk-error-summary__body">
                         <ul class="govuk-list govuk-error-summary__list">
-                            <li><a href="#">Visit date must be a date in the future</a>
+                            <li><a href="#">Visit date must be in the future</a>
                             </li>
                         </ul>
                     </div>
@@ -3018,7 +3018,7 @@ exports[`site-visit POST /site-visit/schedule-visit should re-render the schedul
                         <ul class="govuk-list govuk-error-summary__list">
                             <li><a href="#visit-date-year">Visit date year must be 4 digits</a>
                             </li>
-                            <li><a href="#">Visit date must be a date in the future</a>
+                            <li><a href="#">Visit date must be in the future</a>
                             </li>
                         </ul>
                     </div>

--- a/appeals/web/src/server/lib/mappers/notification-banners.mapper.js
+++ b/appeals/web/src/server/lib/mappers/notification-banners.mapper.js
@@ -162,6 +162,11 @@ export const notificationBannerDefinitions = {
 		type: 'success',
 		pages: ['lpaQuestionnaire'],
 		text: 'Correct appeal type (LPA response) has been updated'
+	},
+	lpaqDueDateUpdated: {
+		type: 'success',
+		pages: ['appealDetails'],
+		text: 'LPA questionnaire due date changed'
 	}
 };
 

--- a/appeals/web/src/server/lib/validators/date-input.validator.js
+++ b/appeals/web/src/server/lib/validators/date-input.validator.js
@@ -236,9 +236,7 @@ export const createDateInputDateInFutureValidator = (
 			})
 			.withMessage(
 				capitalize(
-					`${
-						(messageFieldNamePrefix && messageFieldNamePrefix + ' ') || ''
-					}must be a date in the future`
+					`${(messageFieldNamePrefix && messageFieldNamePrefix + ' ') || ''}must be in the future`
 				)
 			)
 	);


### PR DESCRIPTION
## Describe your changes

"Change LPA questionnaire due date" page changes:

- When confirming the change, user is redirected to Appeal Details with a success notification stating 'LPA questionnaire due date changed'
- Old Confirmation page removed and all related code cleaned up
- Submit button text changed from 'Continue' to 'Confirm'
- Error message updated from 'Date must be a date in the future’ to ‘Date must be in the future’

Some other tests were affected by the error message change. Those were replaced.

## Issue ticket number and link

[BOAT-1378](https://pins-ds.atlassian.net/browse/BOAT-1378)

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
