### PR TITLE
fix(web): finalize upload cleanup only if there are errors

### DIFF
--- a/appeals/web/src/client/components/file-uploader/_client-actions.js
+++ b/appeals/web/src/client/components/file-uploader/_client-actions.js
@@ -258,10 +258,10 @@ const clientActions = (uploadForm) => {
 	 * @param {AnError[]} errors
 	 */
 	const finalizeUpload = (errors) => {
-		globalDataTransfer = new DataTransfer();
-		updateUploadButton();
-
 		if (errors.length > 0) {
+			globalDataTransfer = new DataTransfer();
+			updateUploadButton();
+
 			const failedRowIds = new Set(errors.map((error) => error.fileRowId));
 			const allRowsId = [...filesRows.children].map((row) => row.id);
 


### PR DESCRIPTION
## Describe your changes

Moved finalize upload cleanup code inside the errors condition where it's relevant. The exit condition only redirects, so there's no need for any cleanup.

The cleanup code was the cause of re-enabling the dropzone visibility.

## Issue ticket number and link

[BOAT-1239](https://pins-ds.atlassian.net/browse/BOAT-1239)

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
