### PR TITLE
fix(tooling): removing tooling sub provider on group of variables

### DIFF
--- a/infrastructure/data.tf
+++ b/infrastructure/data.tf
@@ -12,8 +12,6 @@ data "azurerm_virtual_network" "tooling" {
 data "azurerm_virtual_network" "front_office_vnet" {
   name                = var.common_infra_config.network_name
   resource_group_name = var.common_infra_config.network_rg
-
-  provider = azurerm.tooling
 }
 
 # these are owned by the "common" stack in the infrastructure-environments repo


### PR DESCRIPTION
## Describe your changes

implement vnet peering

removing `provider = azurerm.tooling` as this may have been causing the error  on the pipeline being tied to the wrong sub 
https://dev.azure.com/planninginspectorate/appeals-back-office/_build/results?buildId=83508&view=logs&j=d8c8df2e-1b9e-55db-c620-fddadb65a07b&t=ad3e177c-dc5f-5737-3548-7b4aa1a78cc5&l=348


## Issue ticket number and link

DEV 235

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
