### PR TITLE
Fix/dev235 vnet data call error

### DIFF
--- a/infrastructure/networking.tf
+++ b/infrastructure/networking.tf
@@ -61,8 +61,6 @@ resource "azurerm_virtual_network_peering" "front_office_to_bo" {
   remote_virtual_network_id = azurerm_virtual_network.main.id
   resource_group_name       = var.common_infra_config.network_rg
   virtual_network_name      = var.common_infra_config.network_name
-
-  provider = azurerm.tooling
 }
 
 ## DNS Zones for Azure Services


### PR DESCRIPTION
## Describe your changes

implement vnet peering

removing provider = azurerm.tooling from vnet peering as this may have been causing the error on the pipeline being tied to the wrong sub
https://dev.azure.com/planninginspectorate/appeals-back-office/_build/results?buildId=83522&view=logs&j=7c7b2450-8bce-52ef-39a6-dd12dfcbbdfc&t=9e596af9-2782-5afc-e1e1-f758964ee6a3&l=76

Issue ticket number and link
DEV 235

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
