### PR TITLE
feat(api): notify comms for appellant case incomplete

### DIFF
--- a/.github/workflows/deploy-c4-diagrams.yml
+++ b/.github/workflows/deploy-c4-diagrams.yml
@@ -11,7 +11,6 @@ on:
 permissions:
   contents: write
 
-
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
@@ -26,7 +25,7 @@ jobs:
       - name: Pull Structurizr Site Generator Docker image
         run: docker pull ghcr.io/avisi-cloud/structurizr-site-generatr
       - name: Generate C4 Diagrams Site
-        run:  docker run --rm -v ./:/var/model ghcr.io/avisi-cloud/structurizr-site-generatr generate-site -w workspace.dsl
+        run: docker run --rm -v ./:/var/model ghcr.io/avisi-cloud/structurizr-site-generatr generate-site -w workspace.dsl
       - name: Deploy to GitHub Pages
         uses: JamesIves/github-pages-deploy-action@v4
         with:

--- a/appeals/api/src/server/config/config.js
+++ b/appeals/api/src/server/config/config.js
@@ -44,6 +44,9 @@ const { value, error } = schema.validate({
 			appealConfirmed: {
 				id: '783f94cc-1d6d-4153-8ad7-9070e449a57c'
 			},
+			appealIncomplete: {
+				id: 'f9cbd646-be00-45e2-96fc-f47e585e5b5e'
+			},
 			decisionIsInvalidAppellant: {
 				id: 'bd117483-e7fe-4655-8f57-cf597ad57710'
 			},

--- a/appeals/api/src/server/config/schema.js
+++ b/appeals/api/src/server/config/schema.js
@@ -38,6 +38,9 @@ export default joi
 						appealConfirmed: joi.object({
 							id: joi.string().required()
 						}),
+						appealIncomplete: joi.object({
+							id: joi.string().required()
+						}),
 						decisionIsInvalidAppellant: joi.object({
 							id: joi.string()
 						}),

--- a/appeals/api/src/server/endpoints/appellant-cases/__tests__/appellant-cases.test.js
+++ b/appeals/api/src/server/endpoints/appellant-cases/__tests__/appellant-cases.test.js
@@ -232,9 +232,24 @@ describe('appellant cases routes', () => {
 		});
 
 		describe('PATCH', () => {
-			test('updates appellant case when the validation outcome is Incomplete without reason text and an appeal due date', async () => {
+			test('updates appellant case when the validation outcome is Incomplete without reason text and with an appeal due date', async () => {
+				const incompleteAppeal = {
+					...householdAppeal,
+					appellantCase: {
+						...householdAppeal.appellantCase,
+						appellantCaseIncompleteReasonsOnAppellantCases: [
+							{
+								appellantCaseIncompleteReason: {
+									id: 1,
+									name: 'Reason 1'
+								},
+								appellantCaseIncompleteReasonText: []
+							}
+						]
+					}
+				};
 				// @ts-ignore
-				databaseConnector.appeal.findUnique.mockResolvedValue(householdAppeal);
+				databaseConnector.appeal.findUnique.mockResolvedValue(incompleteAppeal);
 				// @ts-ignore
 				databaseConnector.user.upsert.mockResolvedValue({
 					id: 1,
@@ -294,14 +309,69 @@ describe('appellant cases routes', () => {
 				});
 
 				// eslint-disable-next-line no-undef
-				expect(mockSendEmail).not.toHaveBeenCalled();
+				expect(mockSendEmail).toHaveBeenCalledTimes(1);
+				// eslint-disable-next-line no-undef
+				expect(mockSendEmail).toHaveBeenCalledWith(
+					config.govNotify.template.appealIncomplete.id,
+					'test@136s7.com',
+					{
+						emailReplyToId: null,
+						personalisation: {
+							appeal_reference_number: '1345264',
+							site_address: '96 The Avenue, Leftfield, Maidstone, Kent, MD21 5XY, United Kingdom',
+							due_date: '14 July 2099',
+							reasons: ['Reason 1']
+						},
+						reference: null
+					}
+				);
 
 				expect(response.status).toEqual(200);
 			});
 
-			test('updates appellant case when the validation outcome is Incomplete with reason text', async () => {
+			test('updates appellant case when the validation outcome is Incomplete with reason text and an appeal due date', async () => {
+				const incompleteAppeal = {
+					...householdAppeal,
+					appellantCase: {
+						...householdAppeal.appellantCase,
+						appellantCaseIncompleteReasonsOnAppellantCases: [
+							{
+								appellantCaseIncompleteReason: {
+									id: 1,
+									name: 'Reason 1'
+								},
+								appellantCaseIncompleteReasonText: [
+									{
+										id: 1,
+										text: 'Reason Text 1'
+									},
+									{
+										id: 2,
+										text: 'Reason Text 2'
+									}
+								]
+							},
+							{
+								appellantCaseIncompleteReason: {
+									id: 2,
+									name: 'Reason 2'
+								},
+								appellantCaseIncompleteReasonText: [
+									{
+										id: 1,
+										text: 'Reason Text 3'
+									},
+									{
+										id: 2,
+										text: 'Reason Text 4'
+									}
+								]
+							}
+						]
+					}
+				};
 				// @ts-ignore
-				databaseConnector.appeal.findUnique.mockResolvedValue(householdAppeal);
+				databaseConnector.appeal.findUnique.mockResolvedValue(incompleteAppeal);
 				// @ts-ignore
 				databaseConnector.user.upsert.mockResolvedValue({
 					id: 1,
@@ -325,14 +395,15 @@ describe('appellant cases routes', () => {
 				);
 
 				const body = {
+					appealDueDate: '2099-07-14',
 					incompleteReasons: [
 						{
 							id: 1,
-							text: ['Reason 1', 'Reason 2']
+							text: ['Reason Text 1', 'Reason Text 2']
 						},
 						{
 							id: 2,
-							text: ['Reason 3', 'Reason 4']
+							text: ['Reason Text 3', 'Reason Text 4']
 						}
 					],
 					validationOutcome: 'Incomplete'
@@ -357,29 +428,49 @@ describe('appellant cases routes', () => {
 							{
 								appellantCaseId: appellantCase.id,
 								appellantCaseIncompleteReasonId: 1,
-								text: 'Reason 1'
+								text: 'Reason Text 1'
 							},
 							{
 								appellantCaseId: appellantCase.id,
 								appellantCaseIncompleteReasonId: 1,
-								text: 'Reason 2'
+								text: 'Reason Text 2'
 							},
 							{
 								appellantCaseId: appellantCase.id,
 								appellantCaseIncompleteReasonId: 2,
-								text: 'Reason 3'
+								text: 'Reason Text 3'
 							},
 							{
 								appellantCaseId: appellantCase.id,
 								appellantCaseIncompleteReasonId: 2,
-								text: 'Reason 4'
+								text: 'Reason Text 4'
 							}
 						]
 					}
 				);
 
 				// eslint-disable-next-line no-undef
-				expect(mockSendEmail).not.toHaveBeenCalled();
+				expect(mockSendEmail).toHaveBeenCalledTimes(1);
+				// eslint-disable-next-line no-undef
+				expect(mockSendEmail).toHaveBeenCalledWith(
+					config.govNotify.template.appealIncomplete.id,
+					'test@136s7.com',
+					{
+						emailReplyToId: null,
+						personalisation: {
+							appeal_reference_number: '1345264',
+							site_address: '96 The Avenue, Leftfield, Maidstone, Kent, MD21 5XY, United Kingdom',
+							due_date: '14 July 2099',
+							reasons: [
+								'Reason 1: Reason Text 1',
+								'Reason 1: Reason Text 2',
+								'Reason 2: Reason Text 3',
+								'Reason 2: Reason Text 4'
+							]
+						},
+						reference: null
+					}
+				);
 
 				expect(response.status).toEqual(200);
 			});
@@ -554,7 +645,7 @@ describe('appellant cases routes', () => {
 				});
 
 				// eslint-disable-next-line no-undef
-				expect(mockSendEmail).not.toHaveBeenCalled();
+				expect(mockSendEmail).toHaveBeenCalledTimes(1);
 
 				expect(response.status).toEqual(200);
 			});
@@ -626,7 +717,7 @@ describe('appellant cases routes', () => {
 				});
 
 				// eslint-disable-next-line no-undef
-				expect(mockSendEmail).not.toHaveBeenCalled();
+				expect(mockSendEmail).toHaveBeenCalledTimes(1);
 
 				expect(response.status).toEqual(200);
 			});


### PR DESCRIPTION
## Describe your changes

- `appealIncomplete` template ID added to schema
- notifyClient sends email when appellant case is incomplete
- incomplete reasons and appeal due date formatted for template

## Issue ticket number and link

[BOAT-875 API - Comms - Appellant case marked as ‘incomplete’](https://pins-ds.atlassian.net/browse/BOAT-875)

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [ ] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [ ] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
