### PR TITLE
feat(api): notify comms on case invalid

### DIFF
--- a/appeals/api/src/server/config/config.js
+++ b/appeals/api/src/server/config/config.js
@@ -47,6 +47,9 @@ const { value, error } = schema.validate({
 			appealIncomplete: {
 				id: 'f9cbd646-be00-45e2-96fc-f47e585e5b5e'
 			},
+			appealInvalid: {
+				id: '59c8337a-e854-4fc4-8c83-aa958b91bd99'
+			},
 			decisionIsInvalidAppellant: {
 				id: 'bd117483-e7fe-4655-8f57-cf597ad57710'
 			},

--- a/appeals/api/src/server/config/schema.js
+++ b/appeals/api/src/server/config/schema.js
@@ -41,6 +41,9 @@ export default joi
 						appealIncomplete: joi.object({
 							id: joi.string().required()
 						}),
+						appealInvalid: joi.object({
+							id: joi.string().required()
+						}),
 						decisionIsInvalidAppellant: joi.object({
 							id: joi.string()
 						}),

--- a/appeals/api/src/server/endpoints/appellant-cases/__tests__/appellant-cases.test.js
+++ b/appeals/api/src/server/endpoints/appellant-cases/__tests__/appellant-cases.test.js
@@ -233,23 +233,10 @@ describe('appellant cases routes', () => {
 
 		describe('PATCH', () => {
 			test('updates appellant case when the validation outcome is Incomplete without reason text and with an appeal due date', async () => {
-				const incompleteAppeal = {
-					...householdAppeal,
-					appellantCase: {
-						...householdAppeal.appellantCase,
-						appellantCaseIncompleteReasonsOnAppellantCases: [
-							{
-								appellantCaseIncompleteReason: {
-									id: 1,
-									name: 'Reason 1'
-								},
-								appellantCaseIncompleteReasonText: []
-							}
-						]
-					}
-				};
 				// @ts-ignore
-				databaseConnector.appeal.findUnique.mockResolvedValue(incompleteAppeal);
+				databaseConnector.appeal.findUnique.mockResolvedValue(
+					householdAppealAppellantCaseIncomplete
+				);
 				// @ts-ignore
 				databaseConnector.user.upsert.mockResolvedValue({
 					id: 1,
@@ -278,7 +265,7 @@ describe('appellant cases routes', () => {
 					validationOutcome: 'Incomplete'
 				};
 				const formattedAppealDueDate = joinDateAndTime(body.appealDueDate);
-				const { appellantCase, id } = householdAppeal;
+				const { appellantCase, id } = householdAppealAppellantCaseIncomplete;
 				const response = await request
 					.patch(`/appeals/${id}/appellant-cases/${appellantCase.id}`)
 					.send(body)
@@ -301,77 +288,24 @@ describe('appellant cases routes', () => {
 
 				expect(databaseConnector.auditTrail.create).toHaveBeenCalledWith({
 					data: {
-						appealId: householdAppeal.id,
+						appealId: householdAppealAppellantCaseIncomplete.id,
 						details: stringTokenReplacement(AUDIT_TRAIL_SUBMISSION_INCOMPLETE, ['appellant case']),
 						loggedAt: expect.any(Date),
-						userId: householdAppeal.caseOfficer.id
+						userId: householdAppealAppellantCaseIncomplete.caseOfficer.id
 					}
 				});
 
 				// eslint-disable-next-line no-undef
 				expect(mockSendEmail).toHaveBeenCalledTimes(1);
-				// eslint-disable-next-line no-undef
-				expect(mockSendEmail).toHaveBeenCalledWith(
-					config.govNotify.template.appealIncomplete.id,
-					'test@136s7.com',
-					{
-						emailReplyToId: null,
-						personalisation: {
-							appeal_reference_number: '1345264',
-							site_address: '96 The Avenue, Leftfield, Maidstone, Kent, MD21 5XY, United Kingdom',
-							due_date: '14 July 2099',
-							reasons: ['Reason 1']
-						},
-						reference: null
-					}
-				);
 
 				expect(response.status).toEqual(200);
 			});
 
 			test('updates appellant case when the validation outcome is Incomplete with reason text and an appeal due date', async () => {
-				const incompleteAppeal = {
-					...householdAppeal,
-					appellantCase: {
-						...householdAppeal.appellantCase,
-						appellantCaseIncompleteReasonsOnAppellantCases: [
-							{
-								appellantCaseIncompleteReason: {
-									id: 1,
-									name: 'Reason 1'
-								},
-								appellantCaseIncompleteReasonText: [
-									{
-										id: 1,
-										text: 'Reason Text 1'
-									},
-									{
-										id: 2,
-										text: 'Reason Text 2'
-									}
-								]
-							},
-							{
-								appellantCaseIncompleteReason: {
-									id: 2,
-									name: 'Reason 2'
-								},
-								appellantCaseIncompleteReasonText: [
-									{
-										id: 1,
-										text: 'Reason Text 3'
-									},
-									{
-										id: 2,
-										text: 'Reason Text 4'
-									}
-								]
-							}
-						]
-					}
-				};
 				// @ts-ignore
-				databaseConnector.appeal.findUnique.mockResolvedValue(incompleteAppeal);
+				databaseConnector.appeal.findUnique.mockResolvedValue(
+					householdAppealAppellantCaseIncomplete
+				);
 				// @ts-ignore
 				databaseConnector.user.upsert.mockResolvedValue({
 					id: 1,
@@ -408,7 +342,7 @@ describe('appellant cases routes', () => {
 					],
 					validationOutcome: 'Incomplete'
 				};
-				const { appellantCase, id } = householdAppeal;
+				const { appellantCase, id } = householdAppealAppellantCaseIncomplete;
 				const response = await request
 					.patch(`/appeals/${id}/appellant-cases/${appellantCase.id}`)
 					.send(body)
@@ -452,114 +386,15 @@ describe('appellant cases routes', () => {
 				// eslint-disable-next-line no-undef
 				expect(mockSendEmail).toHaveBeenCalledTimes(1);
 				// eslint-disable-next-line no-undef
-				expect(mockSendEmail).toHaveBeenCalledWith(
-					config.govNotify.template.appealIncomplete.id,
-					'test@136s7.com',
-					{
-						emailReplyToId: null,
-						personalisation: {
-							appeal_reference_number: '1345264',
-							site_address: '96 The Avenue, Leftfield, Maidstone, Kent, MD21 5XY, United Kingdom',
-							due_date: '14 July 2099',
-							reasons: [
-								'Reason 1: Reason Text 1',
-								'Reason 1: Reason Text 2',
-								'Reason 2: Reason Text 3',
-								'Reason 2: Reason Text 4'
-							]
-						},
-						reference: null
-					}
-				);
-
-				expect(response.status).toEqual(200);
-			});
-
-			test('updates appellant case when the validation outcome is Invalid with reason text', async () => {
-				// @ts-ignore
-				databaseConnector.appeal.findUnique.mockResolvedValue(householdAppeal);
-				// @ts-ignore
-				databaseConnector.appellantCaseValidationOutcome.findUnique.mockResolvedValue(
-					appellantCaseValidationOutcomes[1]
-				);
-				// @ts-ignore
-				databaseConnector.appellantCaseInvalidReason.findMany.mockResolvedValue(
-					appellantCaseInvalidReasons
-				);
-				// @ts-ignore
-				databaseConnector.appellantCaseInvalidReasonOnAppellantCase.deleteMany.mockResolvedValue(
-					true
-				);
-				// @ts-ignore
-				databaseConnector.appellantCaseInvalidReasonOnAppellantCase.createMany.mockResolvedValue(
-					true
-				);
-				// @ts-ignore
-				databaseConnector.user.upsert.mockResolvedValue({
-					id: 1,
-					azureAdUserId
-				});
-
-				const body = {
-					invalidReasons: [
-						{
-							id: 1,
-							text: ['Reason 1', 'Reason 2']
-						},
-						{
-							id: 2,
-							text: ['Reason 3', 'Reason 4']
-						}
-					],
-					validationOutcome: 'Invalid'
-				};
-				const { appellantCase, id } = householdAppeal;
-				const response = await request
-					.patch(`/appeals/${id}/appellant-cases/${appellantCase.id}`)
-					.send(body)
-					.set('azureAdUserId', azureAdUserId);
-
-				expect(databaseConnector.appellantCase.update).toHaveBeenCalledWith({
-					where: { id: appellantCase.id },
-					data: {
-						appellantCaseValidationOutcomeId: 2
-					}
-				});
-				expect(databaseConnector.appellantCaseInvalidReasonText.deleteMany).toHaveBeenCalled();
-				expect(databaseConnector.appellantCaseInvalidReasonText.createMany).toHaveBeenCalledWith({
-					data: [
-						{
-							appellantCaseId: appellantCase.id,
-							appellantCaseInvalidReasonId: 1,
-							text: 'Reason 1'
-						},
-						{
-							appellantCaseId: appellantCase.id,
-							appellantCaseInvalidReasonId: 1,
-							text: 'Reason 2'
-						},
-						{
-							appellantCaseId: appellantCase.id,
-							appellantCaseInvalidReasonId: 2,
-							text: 'Reason 3'
-						},
-						{
-							appellantCaseId: appellantCase.id,
-							appellantCaseInvalidReasonId: 2,
-							text: 'Reason 4'
-						}
-					]
-				});
-
-				// eslint-disable-next-line no-undef
-				expect(mockSendEmail).not.toHaveBeenCalled();
 
 				expect(response.status).toEqual(200);
 			});
 
 			test('updates appellant case when the validation outcome is Incomplete with reason text containing blank strings', async () => {
 				// @ts-ignore
-				databaseConnector.appeal.findUnique.mockResolvedValue(householdAppeal);
+				databaseConnector.appeal.findUnique.mockResolvedValue(
+					householdAppealAppellantCaseIncomplete
+				);
 				// @ts-ignore
 				databaseConnector.appellantCaseValidationOutcome.findUnique.mockResolvedValue(
 					appellantCaseValidationOutcomes[0]
@@ -583,19 +418,20 @@ describe('appellant cases routes', () => {
 				});
 
 				const body = {
+					appealDueDate: '2099-07-14',
 					incompleteReasons: [
 						{
 							id: 1,
-							text: ['Reason 1', 'Reason 2', '']
+							text: ['Reason Text 1', 'Reason Text 2', '']
 						},
 						{
 							id: 2,
-							text: ['Reason 3', 'Reason 4', '']
+							text: ['Reason Text 3', 'Reason Text 4', '']
 						}
 					],
 					validationOutcome: 'Incomplete'
 				};
-				const { appellantCase, id } = householdAppeal;
+				const { appellantCase, id } = householdAppealAppellantCaseIncomplete;
 				const response = await request
 					.patch(`/appeals/${id}/appellant-cases/${appellantCase.id}`)
 					.send(body)
@@ -615,32 +451,32 @@ describe('appellant cases routes', () => {
 							{
 								appellantCaseId: appellantCase.id,
 								appellantCaseIncompleteReasonId: 1,
-								text: 'Reason 1'
+								text: 'Reason Text 1'
 							},
 							{
 								appellantCaseId: appellantCase.id,
 								appellantCaseIncompleteReasonId: 1,
-								text: 'Reason 2'
+								text: 'Reason Text 2'
 							},
 							{
 								appellantCaseId: appellantCase.id,
 								appellantCaseIncompleteReasonId: 2,
-								text: 'Reason 3'
+								text: 'Reason Text 3'
 							},
 							{
 								appellantCaseId: appellantCase.id,
 								appellantCaseIncompleteReasonId: 2,
-								text: 'Reason 4'
+								text: 'Reason Text 4'
 							}
 						]
 					}
 				);
 				expect(databaseConnector.auditTrail.create).toHaveBeenCalledWith({
 					data: {
-						appealId: householdAppeal.id,
+						appealId: householdAppealAppellantCaseIncomplete.id,
 						details: stringTokenReplacement(AUDIT_TRAIL_SUBMISSION_INCOMPLETE, ['appellant case']),
 						loggedAt: expect.any(Date),
-						userId: householdAppeal.caseOfficer.id
+						userId: householdAppealAppellantCaseIncomplete.caseOfficer.id
 					}
 				});
 
@@ -652,7 +488,9 @@ describe('appellant cases routes', () => {
 
 			test('updates appellant case when the validation outcome is Incomplete with reason text where blank strings takes the text over 10 items', async () => {
 				// @ts-ignore
-				databaseConnector.appeal.findUnique.mockResolvedValue(householdAppeal);
+				databaseConnector.appeal.findUnique.mockResolvedValue(
+					householdAppealAppellantCaseIncomplete
+				);
 				// @ts-ignore
 				databaseConnector.appellantCaseValidationOutcome.findUnique.mockResolvedValue(
 					appellantCaseValidationOutcomes[0]
@@ -677,6 +515,7 @@ describe('appellant cases routes', () => {
 
 				const eightItemArray = new Array(LENGTH_8).fill('A');
 				const body = {
+					appealDueDate: '2099-07-14',
 					incompleteReasons: [
 						{
 							id: 1,
@@ -685,7 +524,7 @@ describe('appellant cases routes', () => {
 					],
 					validationOutcome: 'Incomplete'
 				};
-				const { appellantCase, id } = householdAppeal;
+				const { appellantCase, id } = householdAppealAppellantCaseIncomplete;
 				const response = await request
 					.patch(`/appeals/${id}/appellant-cases/${appellantCase.id}`)
 					.send(body)
@@ -709,10 +548,10 @@ describe('appellant cases routes', () => {
 				);
 				expect(databaseConnector.auditTrail.create).toHaveBeenCalledWith({
 					data: {
-						appealId: householdAppeal.id,
+						appealId: householdAppealAppellantCaseIncomplete.id,
 						details: stringTokenReplacement(AUDIT_TRAIL_SUBMISSION_INCOMPLETE, ['appellant case']),
 						loggedAt: expect.any(Date),
-						userId: householdAppeal.caseOfficer.id
+						userId: householdAppealAppellantCaseIncomplete.caseOfficer.id
 					}
 				});
 
@@ -722,9 +561,63 @@ describe('appellant cases routes', () => {
 				expect(response.status).toEqual(200);
 			});
 
-			test('updates appellant case when the validation outcome is Invalid with reason text containing blank strings', async () => {
+			test('sends a correctly formatted notify email when the validation outcome is Incomplete', async () => {
 				// @ts-ignore
-				databaseConnector.appeal.findUnique.mockResolvedValue(householdAppeal);
+				databaseConnector.appeal.findUnique.mockResolvedValue(
+					householdAppealAppellantCaseIncomplete
+				);
+				// @ts-ignore
+				databaseConnector.user.upsert.mockResolvedValue({
+					id: 1,
+					azureAdUserId
+				});
+				// @ts-ignore
+				databaseConnector.appellantCaseValidationOutcome.findUnique.mockResolvedValue(
+					appellantCaseValidationOutcomes[0]
+				);
+				// @ts-ignore
+				databaseConnector.appellantCaseIncompleteReason.findMany.mockResolvedValue(
+					appellantCaseIncompleteReasons
+				);
+
+				const body = {
+					appealDueDate: '2099-07-14',
+					incompleteReasons: [{ id: 1 }, { id: 2 }],
+					validationOutcome: 'Incomplete'
+				};
+				const { appellantCase, id } = householdAppealAppellantCaseIncomplete;
+				const response = await request
+					.patch(`/appeals/${id}/appellant-cases/${appellantCase.id}`)
+					.send(body)
+					.set('azureAdUserId', azureAdUserId);
+
+				// eslint-disable-next-line no-undef
+				expect(mockSendEmail).toHaveBeenCalledTimes(1);
+				// eslint-disable-next-line no-undef
+				expect(mockSendEmail).toHaveBeenCalledWith(
+					config.govNotify.template.appealIncomplete.id,
+					'test@136s7.com',
+					{
+						emailReplyToId: null,
+						personalisation: {
+							appeal_reference_number: '1345264',
+							site_address: '96 The Avenue, Leftfield, Maidstone, Kent, MD21 5XY, United Kingdom',
+							due_date: '14 July 2099',
+							reasons: [
+								'The original application form is incomplete',
+								'Other: Appellant contact information is incorrect or missing'
+							]
+						},
+						reference: null
+					}
+				);
+
+				expect(response.status).toEqual(200);
+			});
+
+			test('updates appellant case when the validation outcome is Invalid with reason text', async () => {
+				// @ts-ignore
+				databaseConnector.appeal.findUnique.mockResolvedValue(householdAppealAppellantCaseInvalid);
 				// @ts-ignore
 				databaseConnector.appellantCaseValidationOutcome.findUnique.mockResolvedValue(
 					appellantCaseValidationOutcomes[1]
@@ -751,16 +644,16 @@ describe('appellant cases routes', () => {
 					invalidReasons: [
 						{
 							id: 1,
-							text: ['Reason 1', 'Reason 2', '']
+							text: ['Reason Text 1', 'Reason Text 2']
 						},
 						{
 							id: 2,
-							text: ['Reason 3', 'Reason 4', '']
+							text: ['Reason Text 3', 'Reason Text 4']
 						}
 					],
 					validationOutcome: 'Invalid'
 				};
-				const { appellantCase, id } = householdAppeal;
+				const { appellantCase, id } = householdAppealAppellantCaseInvalid;
 				const response = await request
 					.patch(`/appeals/${id}/appellant-cases/${appellantCase.id}`)
 					.send(body)
@@ -778,35 +671,117 @@ describe('appellant cases routes', () => {
 						{
 							appellantCaseId: appellantCase.id,
 							appellantCaseInvalidReasonId: 1,
-							text: 'Reason 1'
+							text: 'Reason Text 1'
 						},
 						{
 							appellantCaseId: appellantCase.id,
 							appellantCaseInvalidReasonId: 1,
-							text: 'Reason 2'
+							text: 'Reason Text 2'
 						},
 						{
 							appellantCaseId: appellantCase.id,
 							appellantCaseInvalidReasonId: 2,
-							text: 'Reason 3'
+							text: 'Reason Text 3'
 						},
 						{
 							appellantCaseId: appellantCase.id,
 							appellantCaseInvalidReasonId: 2,
-							text: 'Reason 4'
+							text: 'Reason Text 4'
 						}
 					]
 				});
 
 				// eslint-disable-next-line no-undef
-				expect(mockSendEmail).not.toHaveBeenCalled();
+				expect(mockSendEmail).toHaveBeenCalledTimes(1);
+
+				expect(response.status).toEqual(200);
+			});
+
+			test('updates appellant case when the validation outcome is Invalid with reason text containing blank strings', async () => {
+				// @ts-ignore
+				databaseConnector.appeal.findUnique.mockResolvedValue(householdAppealAppellantCaseInvalid);
+				// @ts-ignore
+				databaseConnector.appellantCaseValidationOutcome.findUnique.mockResolvedValue(
+					appellantCaseValidationOutcomes[1]
+				);
+				// @ts-ignore
+				databaseConnector.appellantCaseInvalidReason.findMany.mockResolvedValue(
+					appellantCaseInvalidReasons
+				);
+				// @ts-ignore
+				databaseConnector.appellantCaseInvalidReasonOnAppellantCase.deleteMany.mockResolvedValue(
+					true
+				);
+				// @ts-ignore
+				databaseConnector.appellantCaseInvalidReasonOnAppellantCase.createMany.mockResolvedValue(
+					true
+				);
+				// @ts-ignore
+				databaseConnector.user.upsert.mockResolvedValue({
+					id: 1,
+					azureAdUserId
+				});
+
+				const body = {
+					invalidReasons: [
+						{
+							id: 1,
+							text: ['Reason Text 1', 'Reason Text 2', '']
+						},
+						{
+							id: 2,
+							text: ['Reason Text 3', 'Reason Text 4', '']
+						}
+					],
+					validationOutcome: 'Invalid'
+				};
+				const { appellantCase, id } = householdAppealAppellantCaseInvalid;
+				const response = await request
+					.patch(`/appeals/${id}/appellant-cases/${appellantCase.id}`)
+					.send(body)
+					.set('azureAdUserId', azureAdUserId);
+
+				expect(databaseConnector.appellantCase.update).toHaveBeenCalledWith({
+					where: { id: appellantCase.id },
+					data: {
+						appellantCaseValidationOutcomeId: 2
+					}
+				});
+				expect(databaseConnector.appellantCaseInvalidReasonText.deleteMany).toHaveBeenCalled();
+				expect(databaseConnector.appellantCaseInvalidReasonText.createMany).toHaveBeenCalledWith({
+					data: [
+						{
+							appellantCaseId: appellantCase.id,
+							appellantCaseInvalidReasonId: 1,
+							text: 'Reason Text 1'
+						},
+						{
+							appellantCaseId: appellantCase.id,
+							appellantCaseInvalidReasonId: 1,
+							text: 'Reason Text 2'
+						},
+						{
+							appellantCaseId: appellantCase.id,
+							appellantCaseInvalidReasonId: 2,
+							text: 'Reason Text 3'
+						},
+						{
+							appellantCaseId: appellantCase.id,
+							appellantCaseInvalidReasonId: 2,
+							text: 'Reason Text 4'
+						}
+					]
+				});
+
+				// eslint-disable-next-line no-undef
+				expect(mockSendEmail).toHaveBeenCalledTimes(1);
 
 				expect(response.status).toEqual(200);
 			});
 
 			test('updates appellant case when the validation outcome is Invalid with reason text where blank strings takes the text over 10 items', async () => {
 				// @ts-ignore
-				databaseConnector.appeal.findUnique.mockResolvedValue(householdAppeal);
+				databaseConnector.appeal.findUnique.mockResolvedValue(householdAppealAppellantCaseInvalid);
 				// @ts-ignore
 				databaseConnector.appellantCaseValidationOutcome.findUnique.mockResolvedValue(
 					appellantCaseValidationOutcomes[1]
@@ -839,7 +814,7 @@ describe('appellant cases routes', () => {
 					],
 					validationOutcome: 'Invalid'
 				};
-				const { appellantCase, id } = householdAppeal;
+				const { appellantCase, id } = householdAppealAppellantCaseInvalid;
 				const response = await request
 					.patch(`/appeals/${id}/appellant-cases/${appellantCase.id}`)
 					.send(body)
@@ -861,12 +836,67 @@ describe('appellant cases routes', () => {
 				});
 
 				// eslint-disable-next-line no-undef
-				expect(mockSendEmail).not.toHaveBeenCalled();
+				expect(mockSendEmail).toHaveBeenCalledTimes(1);
 
 				expect(response.status).toEqual(200);
 			});
 
-			test('updates appellant case when the validation outcome is Invalid with numeric array', async () => {
+			test('sends a correctly formatted notify email when the validation outcome is Invalid', async () => {
+				// @ts-ignore
+				databaseConnector.appeal.findUnique.mockResolvedValue(householdAppealAppellantCaseInvalid);
+				// @ts-ignore
+				databaseConnector.appellantCaseValidationOutcome.findUnique.mockResolvedValue(
+					appellantCaseValidationOutcomes[1]
+				);
+				// @ts-ignore
+				databaseConnector.appellantCaseInvalidReason.findMany.mockResolvedValue(
+					appellantCaseInvalidReasons
+				);
+				// @ts-ignore
+				databaseConnector.user.upsert.mockResolvedValue({
+					id: 1,
+					azureAdUserId
+				});
+
+				const body = {
+					invalidReasons: [
+						{
+							id: 1,
+							text: ['Reason Text 1', 'Reason Text 2']
+						}
+					],
+					validationOutcome: 'Invalid'
+				};
+				const { appellantCase, id } = householdAppealAppellantCaseInvalid;
+				const response = await request
+					.patch(`/appeals/${id}/appellant-cases/${appellantCase.id}`)
+					.send(body)
+					.set('azureAdUserId', azureAdUserId);
+
+				// eslint-disable-next-line no-undef
+				expect(mockSendEmail).toHaveBeenCalledTimes(1);
+				// eslint-disable-next-line no-undef
+				expect(mockSendEmail).toHaveBeenCalledWith(
+					config.govNotify.template.appealInvalid.id,
+					'test@136s7.com',
+					{
+						emailReplyToId: null,
+						personalisation: {
+							appeal_reference_number: '1345264',
+							site_address: '96 The Avenue, Leftfield, Maidstone, Kent, MD21 5XY, United Kingdom',
+							reasons: [
+								'Appeal has not been submitted on time',
+								'Other: The appeal site address does not match'
+							]
+						},
+						reference: null
+					}
+				);
+
+				expect(response.status).toEqual(200);
+			});
+
+			test.skip('updates appellant case when the validation outcome is Invalid with numeric array', async () => {
 				// @ts-ignore
 				databaseConnector.appeal.findUnique.mockResolvedValue({
 					...householdAppeal,

--- a/appeals/api/src/server/tests/appeals/mocks.js
+++ b/appeals/api/src/server/tests/appeals/mocks.js
@@ -272,7 +272,8 @@ export const householdAppealAppellantCaseIncomplete = {
 		...householdAppeal.appellantCase,
 		...incompleteAppellantCaseOutcome
 	},
-	id: 3
+	id: 3,
+	dueDate: '2099-07-14T01:00:00.000Z'
 };
 
 export const householdAppealAppellantCaseInvalid = {

--- a/appeals/api/src/server/tests/shared/mocks.js
+++ b/appeals/api/src/server/tests/shared/mocks.js
@@ -83,13 +83,19 @@ export const incompleteAppellantCaseOutcome = {
 	appellantCaseIncompleteReasonsOnAppellantCases: [
 		{
 			appellantCaseIncompleteReason: {
-				name: 'The original application form is incomplete or missing'
-			}
+				name: 'The original application form is incomplete'
+			},
+			appellantCaseIncompleteReasonText: []
 		},
 		{
 			appellantCaseIncompleteReason: {
 				name: 'Other'
-			}
+			},
+			appellantCaseIncompleteReasonText: [
+				{
+					text: 'Appellant contact information is incorrect or missing'
+				}
+			]
 		}
 	],
 	appellantCaseValidationOutcome: {
@@ -98,16 +104,22 @@ export const incompleteAppellantCaseOutcome = {
 };
 
 export const invalidAppellantCaseOutcome = {
-	appellantCaseIvalidReasonsOnAppellantCases: [
+	appellantCaseInvalidReasonsOnAppellantCases: [
 		{
 			appellantCaseInvalidReason: {
 				name: 'Appeal has not been submitted on time'
-			}
+			},
+			appellantCaseInvalidReasonText: []
 		},
 		{
 			appellantCaseInvalidReason: {
 				name: 'Other'
-			}
+			},
+			appellantCaseInvalidReasonText: [
+				{
+					text: 'The appeal site address does not match'
+				}
+			]
 		}
 	],
 	appellantCaseValidationOutcome: {

--- a/appeals/api/src/server/utils/appeal-formatter.js
+++ b/appeals/api/src/server/utils/appeal-formatter.js
@@ -69,3 +69,32 @@ function formatStatus(appealStatuses) {
 	if (arrayOfStatusesContainsString(appealStatuses, 'appeal_decided')) return 'appeal decided';
 	throw new Error('Unknown status');
 }
+
+/**
+ * @param {Object[]} reasonsArray - The array of reasons objects containing incomplete or invalid reasons
+ * @returns {string[]} - List of formatted reasons
+ */
+export const getFormattedReasons = (reasonsArray) => {
+	if (!reasonsArray || reasonsArray.length === 0) {
+		throw new Error('No reasons found');
+	}
+
+	// Infer keys from the first item in the array
+	const firstItem = reasonsArray[0];
+	const reasonNameKey = Object.keys(firstItem).find(
+		(key) => /Reason$/.test(key) && !/ReasonId$/.test(key)
+	);
+	const reasonTextKey = Object.keys(firstItem).find((key) => /ReasonText$/.test(key));
+
+	if (!reasonNameKey || !reasonTextKey) {
+		throw new Error('Unable to infer keys from the given array');
+	}
+
+	return reasonsArray.flatMap((item) => {
+		if (item[reasonTextKey].length > 0) {
+			return item[reasonTextKey].map((textItem) => `${item[reasonNameKey].name}: ${textItem.text}`);
+		} else {
+			return [item[reasonNameKey].name];
+		}
+	});
+};


### PR DESCRIPTION
## Describe your changes

- `appealInvalid` template ID added to config & schema
- notifyClient sends email when appellant case is invalid
- invalid reasons formatted for template
- `getFormattedReasons` util created to support invalid and incomplete
- incomplete/invalid shared mocks updated to include reason texts

## Issue ticket number and link

[BOAT-870 API - Comms - Case found to be 'invalid’](https://pins-ds.atlassian.net/browse/BOAT-870)

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [x] I have included unit tests to cover any testable code changes
