### PR TITLE
feat(api): notify comms on unaccompanied site visit

### DIFF
--- a/appeals/api/src/server/config/config.js
+++ b/appeals/api/src/server/config/config.js
@@ -56,6 +56,13 @@ const { value, error } = schema.validate({
 			decisionIsInvalidLPA: {
 				id: 'a0cb542f-24d3-4b22-826b-1e012892f922'
 			},
+			siteVisitSchedule: {
+				unaccompanied: {
+					appellant: {
+						id: 'a33bb800-56d9-46a4-ba64-35d9d0263666'
+					}
+				}
+			},
 			siteVisitChange: {
 				unaccompaniedToAccessRequired: {
 					appellant: {

--- a/appeals/api/src/server/config/schema.js
+++ b/appeals/api/src/server/config/schema.js
@@ -50,6 +50,13 @@ export default joi
 						decisionIsInvalidLPA: joi.object({
 							id: joi.string()
 						}),
+						siteVisitSchedule: joi.object({
+							unaccompanied: joi.object({
+								appellant: joi.object({
+									id: joi.string().required()
+								})
+							})
+						}),
 						siteVisitChange: joi.object({
 							unaccompaniedToAccessRequired: joi.object({
 								appellant: joi.object({

--- a/appeals/api/src/server/endpoints/appeals.d.ts
+++ b/appeals/api/src/server/endpoints/appeals.d.ts
@@ -614,6 +614,19 @@ interface CreateAuditTrailRequest {
 	userId: number;
 }
 
+export interface CreateSiteVisitData {
+	appealId: number;
+	visitDate?: string;
+	visitEndTime?: string;
+	visitStartTime?: string;
+	visitType?: any;
+	appellantEmail: string;
+	lpaEmail: string;
+	appealReferenceNumber: string;
+	lpaReference: string;
+	siteAddress: string;
+}
+
 export interface UpdateSiteVisitData {
 	siteVisitId: number;
 	appealId: number;

--- a/appeals/api/src/server/endpoints/site-visits/site-visits.routes.js
+++ b/appeals/api/src/server/endpoints/site-visits/site-visits.routes.js
@@ -1,6 +1,6 @@
 import { Router as createRouter } from 'express';
 import { asyncHandler } from '#middleware/async-handler.js';
-import { createSiteVisit, getSiteVisitById, rearrangeSiteVisit } from './site-visits.controller.js';
+import { postSiteVisit, getSiteVisitById, rearrangeSiteVisit } from './site-visits.controller.js';
 import checkLookupValueIsValidAndAddToRequest from '#middleware/check-lookup-value-is-valid-and-add-to-request.js';
 import { checkAppealExistsByIdAndAddToRequest } from '#middleware/check-appeal-exists-and-add-to-request.js';
 import {
@@ -44,7 +44,7 @@ router.post(
 		'siteVisitType',
 		ERROR_INVALID_SITE_VISIT_TYPE
 	),
-	asyncHandler(createSiteVisit)
+	asyncHandler(postSiteVisit)
 );
 
 router.get(

--- a/appeals/api/src/server/endpoints/site-visits/site-visits.service.js
+++ b/appeals/api/src/server/endpoints/site-visits/site-visits.service.js
@@ -1,21 +1,85 @@
 import { createAuditTrail } from '#endpoints/audit-trails/audit-trails.service.js';
 import siteVisitRepository from '#repositories/site-visit.repository.js';
 import {
+	AUDIT_TRAIL_SITE_VISIT_ARRANGED,
+	DEFAULT_DATE_FORMAT_AUDIT_TRAIL,
 	AUDIT_TRAIL_SITE_VISIT_TYPE_SELECTED,
 	ERROR_FAILED_TO_SAVE_DATA,
 	ERROR_FAILED_TO_SEND_NOTIFICATION_EMAIL
 } from '#endpoints/constants.js';
 import config from '#config/config.js';
+import stringTokenReplacement from '#utils/string-token-replacement.js';
+import { format, parseISO } from 'date-fns';
 // eslint-disable-next-line no-unused-vars
 import NotifyClient from '#utils/notify-client.js';
 
 /** @typedef {import('express').RequestHandler} RequestHandler */
 /** @typedef {import('@pins/appeals.api').Appeals.UpdateSiteVisitData} UpdateSiteVisitData */
+/** @typedef {import('@pins/appeals.api').Appeals.CreateSiteVisitData} CreateSiteVisitData */
 /** @typedef {import('@pins/appeals.api').Appeals.NotifyTemplate} NotifyTemplate */
 
 import { ERROR_NOT_FOUND } from '#endpoints/constants.js';
 import formatDate from '#utils/date-formatter.js';
 import { toCamelCase } from '#utils/string-utils.js';
+
+/**
+ * @param {string} azureAdUserId
+ * @param {CreateSiteVisitData} siteVisitData
+ * @returns {Promise<void>}
+ */
+export const createSiteVisit = async (azureAdUserId, siteVisitData, notifyClient) => {
+	try {
+		const appealId = siteVisitData.appealId;
+		const visitDate = siteVisitData.visitDate;
+		const visitEndTime = siteVisitData.visitEndTime;
+		const visitStartTime = siteVisitData.visitStartTime;
+		const visitTypeId = siteVisitData.visitType.id;
+
+		await siteVisitRepository.createSiteVisitById({
+			appealId,
+			visitDate,
+			visitEndTime,
+			visitStartTime,
+			siteVisitTypeId: visitTypeId
+		});
+
+		if (visitDate) {
+			await createAuditTrail({
+				appealId,
+				azureAdUserId,
+				details: stringTokenReplacement(AUDIT_TRAIL_SITE_VISIT_ARRANGED, [
+					format(parseISO(visitDate), DEFAULT_DATE_FORMAT_AUDIT_TRAIL)
+				])
+			});
+		}
+
+		const visitTypeKey = toCamelCase(`${siteVisitData.visitType.name}`);
+		const notifyTemplateIds = config.govNotify.template.siteVisitSchedule[visitTypeKey] || {};
+
+		const emailVariables = {
+			appeal_reference_number: siteVisitData.appealReferenceNumber,
+			lpa_reference: siteVisitData.lpaReference,
+			site_address: siteVisitData.siteAddress,
+			start_time: siteVisitData.visitStartTime || '',
+			end_time: siteVisitData.visitEndTime || '',
+			visit_date: formatDate(new Date(siteVisitData.visitDate || ''), false)
+		};
+
+		if (notifyTemplateIds.appellant && siteVisitData.appellantEmail) {
+			try {
+				await notifyClient.sendEmail(
+					notifyTemplateIds.appellant,
+					siteVisitData.appellantEmail,
+					emailVariables
+				);
+			} catch (error) {
+				throw new Error(ERROR_FAILED_TO_SEND_NOTIFICATION_EMAIL);
+			}
+		}
+	} catch (error) {
+		throw new Error(ERROR_FAILED_TO_SAVE_DATA);
+	}
+};
 
 /**
  * @type {RequestHandler}


### PR DESCRIPTION
## Describe your changes

- `siteVisitSchedule.unaccompanied.appellant` template ID added to config
- notifyClient sends email when an unaccompanied site visit is created
- `createSiteVisit` controller renamed `postSiteVisit`
- migrated controller logic into a `createSiteVisit` service
- added new test to test for the email being sent

## Issue ticket number and link

[BOAT-206 API - Comms - Visit type marked as ‘unaccompanied’](https://pins-ds.atlassian.net/browse/BOAT-206)

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [x] I have included unit tests to cover any testable code changes
