### PR TITLE
feat(api): notify comms on access required site visit

### DIFF
--- a/appeals/api/src/server/config/config.js
+++ b/appeals/api/src/server/config/config.js
@@ -69,6 +69,11 @@ const { value, error } = schema.validate({
 					lpa: {
 						id: '03a6616e-3e0c-4f28-acd5-f4e873847457'
 					}
+				},
+				accessRequired: {
+					appellant: {
+						id: '44ff947d-f93d-4333-9366-97ab7a5aa722'
+					}
 				}
 			},
 			siteVisitChange: {

--- a/appeals/api/src/server/config/schema.js
+++ b/appeals/api/src/server/config/schema.js
@@ -63,6 +63,11 @@ export default joi
 								lpa: joi.object({
 									id: joi.string().required()
 								})
+							}),
+							accessRequired: joi.object({
+								appellant: joi.object({
+									id: joi.string().required()
+								})
 							})
 						}),
 						siteVisitChange: joi.object({

--- a/appeals/api/src/server/endpoints/site-visits/__tests__/site-visits.test.js
+++ b/appeals/api/src/server/endpoints/site-visits/__tests__/site-visits.test.js
@@ -14,7 +14,8 @@ import {
 	ERROR_SITE_VISIT_REQUIRED_FIELDS_ACCOMPANIED,
 	ERROR_START_TIME_MUST_BE_EARLIER_THAN_END_TIME,
 	SITE_VISIT_TYPE_UNACCOMPANIED,
-	SITE_VISIT_TYPE_ACCOMPANIED
+	SITE_VISIT_TYPE_ACCOMPANIED,
+	SITE_VISIT_TYPE_ACCESS_REQUIRED
 } from '../../constants.js';
 
 import { householdAppeal as householdAppealData } from '#tests/appeals/mocks.js';
@@ -262,7 +263,7 @@ describe('site visit routes', () => {
 				expect(response.status).toEqual(200);
 			});
 
-			test('creates an Unaccompanied site visit and sends notify email to appellant', async () => {
+			test('creates an Unaccompanied site visit and sends notify email to appellant/agent', async () => {
 				const { siteVisit } = householdAppeal;
 
 				siteVisit.siteVisitType.name = SITE_VISIT_TYPE_UNACCOMPANIED;
@@ -366,6 +367,58 @@ describe('site visit routes', () => {
 				expect(mockSendEmail).toHaveBeenCalledWith(
 					config.govNotify.template.siteVisitSchedule.accompanied.lpa.id,
 					'maid@lpa-email.gov.uk',
+					{
+						emailReplyToId: null,
+						personalisation: {
+							appeal_reference_number: '1345264',
+							end_time: '12:00',
+							lpa_reference: '48269/APP/2021/1482',
+							site_address: '96 The Avenue, Leftfield, Maidstone, Kent, MD21 5XY, United Kingdom',
+							start_time: '11:00',
+							visit_date: '31 March 2022'
+						},
+						reference: null
+					}
+				);
+
+				expect(response.status).toEqual(200);
+			});
+
+			test('creates an Access Required site visit and sends notify email to appellant/agent', async () => {
+				const { siteVisit } = householdAppeal;
+
+				siteVisit.siteVisitType.name = SITE_VISIT_TYPE_ACCESS_REQUIRED;
+
+				// @ts-ignore
+				databaseConnector.appeal.findUnique.mockResolvedValue(householdAppeal);
+				// @ts-ignore
+				databaseConnector.siteVisitType.findUnique.mockResolvedValue(siteVisit.siteVisitType);
+
+				const visitData = {
+					visitEndTime: '12:00',
+					visitStartTime: '11:00',
+					visitType: siteVisit.siteVisitType.name
+				};
+
+				const response = await request
+					.post(`/appeals/${householdAppeal.id}/site-visits`)
+					.send({
+						visitDate: siteVisit.visitDate.split('T')[0],
+						...visitData
+					})
+					.set('azureAdUserId', azureAdUserId);
+
+				expect(response.body).toEqual({
+					visitDate: siteVisit.visitDate,
+					...visitData
+				});
+
+				// eslint-disable-next-line no-undef
+				expect(mockSendEmail).toHaveBeenCalledTimes(1);
+				// eslint-disable-next-line no-undef
+				expect(mockSendEmail).toHaveBeenCalledWith(
+					config.govNotify.template.siteVisitSchedule.accessRequired.appellant.id,
+					'test@136s7.com',
 					{
 						emailReplyToId: null,
 						personalisation: {


### PR DESCRIPTION
## Describe your changes

- access required template ID added to config
- added new test to test for the access required email being sent

no changes to the service were needed for sending the email, config updates were sufficient.

## Issue ticket number and link

[BOAT-895 API - Comms - Visit type marked as 'access required'](https://pins-ds.atlassian.net/browse/BOAT-895)

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [ ] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [x] I have included unit tests to cover any testable code changes
