### PR TITLE
feat(api): notify comms on lpaq complete

### DIFF
--- a/appeals/api/src/server/config/config.js
+++ b/appeals/api/src/server/config/config.js
@@ -56,6 +56,9 @@ const { value, error } = schema.validate({
 			decisionIsInvalidLPA: {
 				id: 'a0cb542f-24d3-4b22-826b-1e012892f922'
 			},
+			lpaqComplete: {
+				id: 'c571ee53-69c8-400e-a4c0-44ded262a081'
+			},
 			siteVisitSchedule: {
 				unaccompanied: {
 					appellant: {

--- a/appeals/api/src/server/config/schema.js
+++ b/appeals/api/src/server/config/schema.js
@@ -50,6 +50,9 @@ export default joi
 						decisionIsInvalidLPA: joi.object({
 							id: joi.string()
 						}),
+						lpaqComplete: joi.object({
+							id: joi.string().required()
+						}),
 						siteVisitSchedule: joi.object({
 							unaccompanied: joi.object({
 								appellant: joi.object({

--- a/appeals/api/src/server/endpoints/appeals.d.ts
+++ b/appeals/api/src/server/endpoints/appeals.d.ts
@@ -512,6 +512,8 @@ interface UpdateLPAQuestionaireValidationOutcomeParams {
 		id: number;
 		appealStatus: AppealStatus[];
 		appealType: AppealType;
+		reference: string;
+		lpa: LPA;
 	};
 	azureAdUserId: string;
 	data: {
@@ -520,6 +522,7 @@ interface UpdateLPAQuestionaireValidationOutcomeParams {
 	};
 	lpaQuestionnaireId: number;
 	validationOutcome: ValidationOutcome;
+	siteAddress: string;
 }
 
 interface UpdateAppellantCaseValidationOutcomeParams {

--- a/appeals/api/src/server/endpoints/lpa-questionnaires/lpa-questionnaires.controller.js
+++ b/appeals/api/src/server/endpoints/lpa-questionnaires/lpa-questionnaires.controller.js
@@ -5,6 +5,7 @@ import { formatLpaQuestionnaire } from './lpa-questionnaires.formatter.js';
 import { updateLPAQuestionaireValidationOutcome } from './lpa-questionnaires.service.js';
 import lpaQuestionnaireRepository from '#repositories/lpa-questionnaire.repository.js';
 import logger from '#utils/logger.js';
+import { formatAddressSingleLine } from '#endpoints/addresses/addresses.formatter.js';
 
 /** @typedef {import('express').Request} Request */
 /** @typedef {import('express').Response} Response */
@@ -61,16 +62,24 @@ const updateLPAQuestionnaireById = async (req, res) => {
 	} = req;
 	const lpaQuestionnaireId = Number(params.lpaQuestionnaireId);
 	const azureAdUserId = String(req.get('azureAdUserId'));
+	const siteAddress = appeal.address
+		? formatAddressSingleLine(appeal.address)
+		: 'Address not available';
+	const notifyClient = req.notifyClient;
 
 	try {
 		validationOutcome
-			? (body.lpaQuestionnaireDueDate = await updateLPAQuestionaireValidationOutcome({
-					appeal,
-					azureAdUserId,
-					data: body,
-					lpaQuestionnaireId,
-					validationOutcome
-			  }))
+			? (body.lpaQuestionnaireDueDate = await updateLPAQuestionaireValidationOutcome(
+					{
+						appeal,
+						azureAdUserId,
+						data: body,
+						lpaQuestionnaireId,
+						validationOutcome,
+						siteAddress
+					},
+					notifyClient
+			  ))
 			: await lpaQuestionnaireRepository.updateLPAQuestionnaireById(lpaQuestionnaireId, {
 					designatedSites,
 					doesAffectAListedBuilding,

--- a/appeals/api/src/server/endpoints/lpa-questionnaires/lpa-questionnaires.service.js
+++ b/appeals/api/src/server/endpoints/lpa-questionnaires/lpa-questionnaires.service.js
@@ -1,11 +1,17 @@
 import lpaQuestionnaireRepository from '#repositories/lpa-questionnaire.repository.js';
 import { broadcasters } from '#endpoints/integrations/integrations.broadcasters.js';
 import { recalculateDateIfNotBusinessDay } from '#utils/business-days.js';
-import { isOutcomeIncomplete } from '#utils/check-validation-outcome.js';
+import { isOutcomeComplete, isOutcomeIncomplete } from '#utils/check-validation-outcome.js';
 import transitionState from '#state/transition-state.js';
-import { AUDIT_TRAIL_SUBMISSION_INCOMPLETE, ERROR_NOT_FOUND } from '../constants.js';
+import {
+	AUDIT_TRAIL_SUBMISSION_INCOMPLETE,
+	ERROR_NOT_FOUND,
+	ERROR_NO_RECIPIENT_EMAIL,
+	ERROR_FAILED_TO_SEND_NOTIFICATION_EMAIL
+} from '../constants.js';
 import { createAuditTrail } from '#endpoints/audit-trails/audit-trails.service.js';
 import stringTokenReplacement from '#utils/string-token-replacement.js';
+import config from '#config/config.js';
 
 /** @typedef {import('express').RequestHandler} RequestHandler */
 /** @typedef {import('@pins/appeals.api').Appeals.UpdateLPAQuestionaireValidationOutcomeParams} UpdateLPAQuestionaireValidationOutcomeParams */
@@ -30,15 +36,13 @@ const checkLPAQuestionnaireExists = (req, res, next) => {
 
 /**
  * @param {UpdateLPAQuestionaireValidationOutcomeParams} param0
+ * @param { import('#endpoints/appeals.js').NotifyClient } notifyClient
  * @returns {Promise<Date | undefined>}
  */
-const updateLPAQuestionaireValidationOutcome = async ({
-	appeal,
-	azureAdUserId,
-	data,
-	lpaQuestionnaireId,
-	validationOutcome
-}) => {
+const updateLPAQuestionaireValidationOutcome = async (
+	{ appeal, azureAdUserId, data, lpaQuestionnaireId, validationOutcome, siteAddress },
+	notifyClient
+) => {
 	let timetable = undefined;
 
 	const { id: appealId, appealStatus, appealType } = appeal;
@@ -73,6 +77,23 @@ const updateLPAQuestionaireValidationOutcome = async ({
 			azureAdUserId,
 			details: stringTokenReplacement(AUDIT_TRAIL_SUBMISSION_INCOMPLETE, ['LPA questionnaire'])
 		});
+	}
+
+	if (isOutcomeComplete(validationOutcome.name)) {
+		const recipientEmail = appeal.lpa?.email;
+		if (!recipientEmail) {
+			throw new Error(ERROR_NO_RECIPIENT_EMAIL);
+		}
+		try {
+			await notifyClient.sendEmail(config.govNotify.template.lpaqComplete, recipientEmail, {
+				appeal_reference_number: appeal.reference,
+				site_address: siteAddress
+			});
+		} catch (error) {
+			if (error) {
+				throw new Error(ERROR_FAILED_TO_SEND_NOTIFICATION_EMAIL);
+			}
+		}
 	}
 
 	await broadcasters.broadcastAppeal(appealId);

--- a/appeals/api/src/server/utils/check-validation-outcome.js
+++ b/appeals/api/src/server/utils/check-validation-outcome.js
@@ -1,5 +1,6 @@
 import {
 	VALIDATION_OUTCOME_INCOMPLETE,
+	VALIDATION_OUTCOME_COMPLETE,
 	VALIDATION_OUTCOME_INVALID,
 	VALIDATION_OUTCOME_VALID
 } from '#endpoints/constants.js';
@@ -16,6 +17,13 @@ const isOutcomeIncomplete = (validationOutcome) =>
  * @param {string} validationOutcome
  * @returns {boolean}
  */
+const isOutcomeComplete = (validationOutcome) =>
+	checkStringsMatch(validationOutcome, VALIDATION_OUTCOME_COMPLETE);
+
+/**
+ * @param {string} validationOutcome
+ * @returns {boolean}
+ */
 const isOutcomeInvalid = (validationOutcome) =>
 	checkStringsMatch(validationOutcome, VALIDATION_OUTCOME_INVALID);
 
@@ -26,4 +34,4 @@ const isOutcomeInvalid = (validationOutcome) =>
 const isOutcomeValid = (validationOutcome) =>
 	checkStringsMatch(validationOutcome, VALIDATION_OUTCOME_VALID);
 
-export { isOutcomeIncomplete, isOutcomeInvalid, isOutcomeValid };
+export { isOutcomeIncomplete, isOutcomeComplete, isOutcomeInvalid, isOutcomeValid };

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/__tests__/__snapshots__/lpa-questionnaire.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/__tests__/__snapshots__/lpa-questionnaire.test.js.snap
@@ -303,7 +303,7 @@ exports[`LPA Questionnaire review GET / should render the LPA Questionnaire page
                     </div>
                 </div>
                 <div class="govuk-inset-text">Confirming this review will inform the relevant parties of the outcome</div>
-                <button                 class="govuk-button" data-module="govuk-button">Continue</button>
+                <button                 class="govuk-button" data-module="govuk-button">Confirm</button>
             </form>
         </div>
     </div>
@@ -653,7 +653,7 @@ exports[`LPA Questionnaire review GET / with unchecked documents should render a
                     </div>
                 </div>
                 <div class="govuk-inset-text">Confirming this review will inform the relevant parties of the outcome</div>
-                <button                 class="govuk-button" data-module="govuk-button">Continue</button>
+                <button                 class="govuk-button" data-module="govuk-button">Confirm</button>
             </form>
         </div>
     </div>
@@ -1018,7 +1018,7 @@ exports[`LPA Questionnaire review GET / with unchecked documents should render a
                     </div>
                 </div>
                 <div class="govuk-inset-text">Confirming this review will inform the relevant parties of the outcome</div>
-                <button                 class="govuk-button" data-module="govuk-button">Continue</button>
+                <button                 class="govuk-button" data-module="govuk-button">Confirm</button>
             </form>
         </div>
     </div>
@@ -3554,7 +3554,7 @@ exports[`LPA Questionnaire review POST / should render LPA Questionnaire review 
                     </div>
                 </div>
                 <div class="govuk-inset-text">Confirming this review will inform the relevant parties of the outcome</div>
-                <button                 class="govuk-button" data-module="govuk-button">Continue</button>
+                <button                 class="govuk-button" data-module="govuk-button">Confirm</button>
             </form>
         </div>
     </div>

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/lpa-questionnaire.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/lpa-questionnaire.mapper.js
@@ -246,7 +246,8 @@ export async function lpaQuestionnairePage(
 			additionalDocumentsSummary,
 			...reviewOutcomeComponents,
 			insetTextComponent
-		]
+		],
+		submitButtonText: 'Confirm'
 	};
 
 	if (


### PR DESCRIPTION
## Describe your changes

- lpaqComplete template ID added to config
- notifyClient sends email to lpa when LPA questionnaire is set as complete
- added new test to test for the LPA questionnaire complete emails being sent

Minor web update
- Changed the submit button content from 'Continue' to 'Confirm'

## Issue ticket number and link

[BOAT-1214 API - Comms - LPA questionnaire is complete](https://pins-ds.atlassian.net/browse/BOAT-1214)

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [ ] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [x] I have included unit tests to cover any testable code changes
