### PR TITLE
fix(infrastructure): move functions onto the function app service plan

### DIFF
--- a/infrastructure/function-casedata-import.tf
+++ b/infrastructure/function-casedata-import.tf
@@ -12,7 +12,7 @@ module "function_casedata_import" {
   tags            = local.tags
 
   # service plan
-  app_service_plan_id = azurerm_service_plan.apps.id
+  app_service_plan_id = azurerm_service_plan.functions.id
 
   # storage
   function_apps_storage_account            = azurerm_storage_account.functions.name

--- a/infrastructure/function-doc-processing.tf
+++ b/infrastructure/function-doc-processing.tf
@@ -12,7 +12,7 @@ module "function_doc_processing" {
   tags            = local.tags
 
   # service plan
-  app_service_plan_id = azurerm_service_plan.apps.id
+  app_service_plan_id = azurerm_service_plan.functions.id
 
   # storage
   function_apps_storage_account            = azurerm_storage_account.functions.name

--- a/infrastructure/function-scheduled-jobs.tf
+++ b/infrastructure/function-scheduled-jobs.tf
@@ -12,7 +12,7 @@ module "function_scheduled_jobs" {
   tags            = local.tags
 
   # service plan
-  app_service_plan_id = azurerm_service_plan.apps.id
+  app_service_plan_id = azurerm_service_plan.functions.id
 
   # storage
   function_apps_storage_account            = azurerm_storage_account.functions.name

--- a/infrastructure/function-user-import.tf
+++ b/infrastructure/function-user-import.tf
@@ -12,7 +12,7 @@ module "function_user_import" {
   tags            = local.tags
 
   # service plan
-  app_service_plan_id = azurerm_service_plan.apps.id
+  app_service_plan_id = azurerm_service_plan.functions.id
 
   # storage
   function_apps_storage_account            = azurerm_storage_account.functions.name


### PR DESCRIPTION
## Describe your changes

I noticed when looking at Portal that the Function App Service Plan was unused... this corrects that!

## Issue ticket number and link

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [ ] I have performed a self-review of my own code
- [ ] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [ ] I have referenced the ticket number above
- [ ] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
