### PR TITLE
feat(api): notify comms on lpaq incomplete

### DIFF
--- a/appeals/api/src/server/config/config.js
+++ b/appeals/api/src/server/config/config.js
@@ -59,6 +59,9 @@ const { value, error } = schema.validate({
 			lpaqComplete: {
 				id: 'c571ee53-69c8-400e-a4c0-44ded262a081'
 			},
+			lpaqIncomplete: {
+				id: '4701bc3c-2f24-4ed8-8841-14d93c3b9964'
+			},
 			siteVisitSchedule: {
 				unaccompanied: {
 					appellant: {

--- a/appeals/api/src/server/config/schema.js
+++ b/appeals/api/src/server/config/schema.js
@@ -53,6 +53,9 @@ export default joi
 						lpaqComplete: joi.object({
 							id: joi.string().required()
 						}),
+						lpaqIncomplete: joi.object({
+							id: joi.string().required()
+						}),
 						siteVisitSchedule: joi.object({
 							unaccompanied: joi.object({
 								appellant: joi.object({

--- a/appeals/api/src/server/endpoints/appeals.d.ts
+++ b/appeals/api/src/server/endpoints/appeals.d.ts
@@ -344,11 +344,14 @@ interface UpdateLPAQuestionnaireRequest {
 	validationOutcomeId?: number;
 }
 
-interface UpdateLPAQuestionaireValidationOutcomeParams {
+interface UpdateLPAQuestionnaireValidationOutcomeParams {
 	appeal: {
 		id: number;
 		appealStatus: AppealStatus[];
 		appealType: AppealType;
+		lpa: LPA;
+		reference: string;
+		applicationReference: string;
 	};
 	azureAdUserId: string;
 	data: {
@@ -600,7 +603,7 @@ interface UpdateLPAQuestionnaireRequest {
 	validationOutcomeId?: number;
 }
 
-interface UpdateLPAQuestionaireValidationOutcomeParams {
+interface UpdateLPAQuestionnaireValidationOutcomeParams {
 	appeal: {
 		id: number;
 		appealStatus: AppealStatus[];
@@ -826,7 +829,7 @@ export {
 	UpdateAppellantRequest,
 	UpdateDocumentsRequest,
 	UpdateDocumentsAvCheckRequest,
-	UpdateLPAQuestionaireValidationOutcomeParams,
+	UpdateLPAQuestionnaireValidationOutcomeParams,
 	UpdateLPAQuestionnaireRequest,
 	UpdateTimetableRequest,
 	UsersToAssign,

--- a/appeals/api/src/server/endpoints/lpa-questionnaires/__tests__/lpa-questionnaires.test.js
+++ b/appeals/api/src/server/endpoints/lpa-questionnaires/__tests__/lpa-questionnaires.test.js
@@ -342,6 +342,7 @@ describe('lpa questionnaires routes', () => {
 			});
 
 			test('updates an lpa questionnaire when the validation outcome is incomplete and lpaQuestionnaireDueDate is a weekday', async () => {
+				const householdAppeal = householdAppealLPAQuestionnaireIncomplete;
 				// @ts-ignore
 				databaseConnector.appeal.findUnique.mockResolvedValue(householdAppeal);
 				// @ts-ignore
@@ -397,6 +398,7 @@ describe('lpa questionnaires routes', () => {
 			});
 
 			test('updates an lpa questionnaire when the validation outcome is incomplete and lpaQuestionnaireDueDate is a weekend day with a bank holiday on the following Monday', async () => {
+				const householdAppeal = householdAppealLPAQuestionnaireIncomplete;
 				// @ts-ignore
 				databaseConnector.appeal.findUnique.mockResolvedValue(householdAppeal);
 				// @ts-ignore
@@ -452,6 +454,7 @@ describe('lpa questionnaires routes', () => {
 			});
 
 			test('updates an lpa questionnaire when the validation outcome is incomplete and lpaQuestionnaireDueDate is a bank holiday Friday with a folowing bank holiday Monday', async () => {
+				const householdAppeal = householdAppealLPAQuestionnaireIncomplete;
 				// @ts-ignore
 				databaseConnector.appeal.findUnique.mockResolvedValue(householdAppeal);
 				// @ts-ignore
@@ -507,6 +510,7 @@ describe('lpa questionnaires routes', () => {
 			});
 
 			test('updates an lpa questionnaire when the validation outcome is incomplete and lpaQuestionnaireDueDate is a bank holiday with a bank holiday the next day', async () => {
+				const householdAppeal = householdAppealLPAQuestionnaireIncomplete;
 				// @ts-ignore
 				databaseConnector.appeal.findUnique.mockResolvedValue(householdAppeal);
 				// @ts-ignore
@@ -562,6 +566,7 @@ describe('lpa questionnaires routes', () => {
 			});
 
 			test('updates an lpa questionnaire when the validation outcome is Incomplete without reason text', async () => {
+				const householdAppeal = householdAppealLPAQuestionnaireIncomplete;
 				// @ts-ignore
 				databaseConnector.appeal.findUnique.mockResolvedValue(householdAppeal);
 				// @ts-ignore
@@ -617,6 +622,7 @@ describe('lpa questionnaires routes', () => {
 			});
 
 			test('updates an lpa questionnaire when the validation outcome is Incomplete with reason text', async () => {
+				const householdAppeal = householdAppealLPAQuestionnaireIncomplete;
 				// @ts-ignore
 				databaseConnector.appeal.findUnique.mockResolvedValue(householdAppeal);
 				// @ts-ignore
@@ -710,6 +716,7 @@ describe('lpa questionnaires routes', () => {
 			});
 
 			test('updates an lpa questionnaire when the validation outcome is Incomplete with reason text containing blank strings', async () => {
+				const householdAppeal = householdAppealLPAQuestionnaireIncomplete;
 				// @ts-ignore
 				databaseConnector.appeal.findUnique.mockResolvedValue(householdAppeal);
 				// @ts-ignore
@@ -803,6 +810,7 @@ describe('lpa questionnaires routes', () => {
 			});
 
 			test('updates an lpa questionnaire when the validation outcome is Incomplete with reason text where blank strings takes the text over 10 items', async () => {
+				const householdAppeal = householdAppealLPAQuestionnaireIncomplete;
 				// @ts-ignore
 				databaseConnector.appeal.findUnique.mockResolvedValue(householdAppeal);
 				// @ts-ignore
@@ -872,6 +880,46 @@ describe('lpa questionnaires routes', () => {
 						text: 'A'
 					})
 				});
+				expect(response.status).toEqual(200);
+			});
+
+			test('sends a correctly formatted notify email when the outcome is incomplete for a household appeal', async () => {
+				const householdAppeal = householdAppealLPAQuestionnaireIncomplete;
+				// @ts-ignore
+				databaseConnector.appeal.findUnique.mockResolvedValue(householdAppeal);
+
+				const body = {
+					incompleteReasons: [{ id: 1 }, { id: 2 }],
+					lpaQuestionnaireDueDate: '2099-06-22',
+					validationOutcome: 'Incomplete'
+				};
+				const { id, lpaQuestionnaire } = householdAppeal;
+				const response = await request
+					.patch(`/appeals/${id}/lpa-questionnaires/${lpaQuestionnaire.id}`)
+					.send(body)
+					.set('azureAdUserId', azureAdUserId);
+
+				// eslint-disable-next-line no-undef
+				expect(mockSendEmail).toHaveBeenCalledTimes(1);
+				// eslint-disable-next-line no-undef
+				expect(mockSendEmail).toHaveBeenCalledWith(
+					config.govNotify.template.lpaqIncomplete.id,
+					'maid@lpa-email.gov.uk',
+					{
+						emailReplyToId: null,
+						personalisation: {
+							appeal_reference_number: '1345264',
+							lpa_reference: '48269/APP/2021/1482',
+							site_address: '96 The Avenue, Leftfield, Maidstone, Kent, MD21 5XY, United Kingdom',
+							due_date: '22 June 2099',
+							reasons: [
+								'Documents or information are missing: Policy is missing',
+								'Other: Addresses are incorrect or missing'
+							]
+						},
+						reference: null
+					}
+				);
 				expect(response.status).toEqual(200);
 			});
 

--- a/appeals/api/src/server/endpoints/lpa-questionnaires/lpa-questionnaires.controller.js
+++ b/appeals/api/src/server/endpoints/lpa-questionnaires/lpa-questionnaires.controller.js
@@ -2,7 +2,7 @@ import { ERROR_FAILED_TO_SAVE_DATA } from '#endpoints/constants.js';
 import { STAGE } from '@pins/appeals/constants/documents.js';
 import { getFoldersForAppeal } from '#endpoints/documents/documents.service.js';
 import { formatLpaQuestionnaire } from './lpa-questionnaires.formatter.js';
-import { updateLPAQuestionaireValidationOutcome } from './lpa-questionnaires.service.js';
+import { updateLPAQuestionnaireValidationOutcome } from './lpa-questionnaires.service.js';
 import lpaQuestionnaireRepository from '#repositories/lpa-questionnaire.repository.js';
 import logger from '#utils/logger.js';
 import { formatAddressSingleLine } from '#endpoints/addresses/addresses.formatter.js';
@@ -69,7 +69,7 @@ const updateLPAQuestionnaireById = async (req, res) => {
 
 	try {
 		validationOutcome
-			? (body.lpaQuestionnaireDueDate = await updateLPAQuestionaireValidationOutcome(
+			? (body.lpaQuestionnaireDueDate = await updateLPAQuestionnaireValidationOutcome(
 					{
 						appeal,
 						azureAdUserId,

--- a/appeals/api/src/server/tests/shared/mocks.js
+++ b/appeals/api/src/server/tests/shared/mocks.js
@@ -138,12 +138,22 @@ export const incompleteLPAQuestionnaireOutcome = {
 		{
 			lpaQuestionnaireIncompleteReason: {
 				name: 'Documents or information are missing'
-			}
+			},
+			lpaQuestionnaireIncompleteReasonText: [
+				{
+					text: 'Policy is missing'
+				}
+			]
 		},
 		{
 			lpaQuestionnaireIncompleteReason: {
 				name: 'Other'
-			}
+			},
+			lpaQuestionnaireIncompleteReasonText: [
+				{
+					text: 'Addresses are incorrect or missing'
+				}
+			]
 		}
 	],
 	lpaQuestionnaireValidationOutcome: {


### PR DESCRIPTION
## Describe your changes

- lpaqIncomplete template ID added to config
- notifyClient sends email to lpa when LPA questionnaire is set as incomplete
- added new test to test for the LPA questionnaire incomplete emails being sent
- fixed typo `questionaire` to `questionnaire` (two n's)

## Issue ticket number and link

[BOAT-874 API - Comms - LPAQ REVIEW - Case marked as ‘incomplete’](https://pins-ds.atlassian.net/browse/BOAT-874)

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [ ] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [x] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [x] I have included unit tests to cover any testable code changes
