### PR TITLE
feat(appeals): add element attributes for cypress

### DIFF
--- a/appeals/web/src/server/appeals/appeal-details/__tests__/__snapshots__/appeal-details.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/__tests__/__snapshots__/appeal-details.test.js.snap
@@ -8,7 +8,8 @@ data-module="govuk-notification-banner">
     </div>
     <div class="govuk-notification-banner__content">
         <p class="govuk-notification-banner__heading">Appeal ready to be assigned to case officer</p>
-        <p><a class="govuk-notification-banner__link" href="/appeals-service/appeal-details/2/assign-user/case-officer">Assign case officer</a>
+        <p><a class="govuk-notification-banner__link" href="/appeals-service/appeal-details/2/assign-user/case-officer"
+            data-cy="assign-case-officer">Assign case officer</a>
         </p>
     </div>
 </div>"
@@ -80,7 +81,7 @@ role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govu
     <div class="govuk-notification-banner__content">
         <p class="govuk-notification-banner__heading">This appeal is awaiting transfer</p>
         <p class="govuk-body">The appeal must be transferred to Horizon. When this is done, <a class="govuk-link"
-            href="/appeals-service/appeal-details/2/change-appeal-type/add-horizon-reference">update the appeal with the new horizon reference</a>.</p>
+            data-cy="awaiting-transfer" href="/appeals-service/appeal-details/2/change-appeal-type/add-horizon-reference">update the appeal with the new horizon reference</a>.</p>
     </div>
 </div>"
 `;
@@ -303,7 +304,8 @@ exports[`appeal-details GET /:appealId should not render action links to the man
                     <dl class="govuk-summary-list">
                         <div class="govuk-summary-list__row appeal-appeal-type"><dt class="govuk-summary-list__key"> Appeal type</dt>
                             <dd class="govuk-summary-list__value">Householder</dd>
-                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/change-appeal-type/appeal-type"> Change<span class="govuk-visually-hidden"> Appeal type</span></a>
+                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/change-appeal-type/appeal-type"
+                                data-cy="change-appeal-type"> Change<span class="govuk-visually-hidden"> Appeal type</span></a>
                             </dd>
                         </div>
                         <div class="govuk-summary-list__row govuk-summary-list__row--no-actions appeal-case-procedure"><dt class="govuk-summary-list__key"> Case procedure</dt>
@@ -312,10 +314,13 @@ exports[`appeal-details GET /:appealId should not render action links to the man
                         <div class="govuk-summary-list__row appeal-linked-appeals"><dt class="govuk-summary-list__key"> Linked appeals</dt>
                             <dd class="govuk-summary-list__value">
                                 <ul class="govuk-list govuk-list--bullet">
-                                    <li><a href="/appeals-service/appeal-details/5449" class="govuk-link" aria-label="Appeal 7 8 4 7 0 6">784706</a> (Child)</li>
+                                    <li><a href="/appeals-service/appeal-details/5449" class="govuk-link" data-cy="linked-appeal-784706"
+                                        aria-label="Appeal 7 8 4 7 0 6">784706</a> (Child)</li>
                                     <li><span class="govuk-body">87326527</span> (Child)</li>
-                                    <li><a href="/appeals-service/appeal-details/5464" class="govuk-link" aria-label="Appeal 1 4 0 0 7 9">140079</a> (Lead)</li>
-                                    <li><a href="/appeals-service/appeal-details/5451" class="govuk-link" aria-label="Appeal 7 2 1 0 8 6">721086</a> (Child)</li>
+                                    <li><a href="/appeals-service/appeal-details/5464" class="govuk-link" data-cy="linked-appeal-140079"
+                                        aria-label="Appeal 1 4 0 0 7 9">140079</a> (Lead)</li>
+                                    <li><a href="/appeals-service/appeal-details/5451" class="govuk-link" data-cy="linked-appeal-721086"
+                                        aria-label="Appeal 7 2 1 0 8 6">721086</a> (Child)</li>
                                     <li><span class="govuk-body">76215416</span> (Lead)</li>
                                 </ul>
                             </dd>
@@ -323,7 +328,8 @@ exports[`appeal-details GET /:appealId should not render action links to the man
                         <div class="govuk-summary-list__row appeal-other-appeals"><dt class="govuk-summary-list__key"> Related appeals</dt>
                             <dd class="govuk-summary-list__value"><span>No appeals</span>
                             </dd>
-                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/other-appeals/add"> Add<span class="govuk-visually-hidden"> Related appeals</span></a>
+                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/other-appeals/add"
+                                data-cy="add-related-appeals"> Add<span class="govuk-visually-hidden"> Related appeals</span></a>
                             </dd>
                         </div>
                         <div class="govuk-summary-list__row appeal-allocation-details"><dt class="govuk-summary-list__key"> Allocation level</dt>
@@ -335,7 +341,8 @@ exports[`appeal-details GET /:appealId should not render action links to the man
                                     <li>Architecture design</li>
                                 </ul>
                             </dd>
-                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/allocation-details/allocation-level"> Change<span class="govuk-visually-hidden"> Allocation level</span></a>
+                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/allocation-details/allocation-level"
+                                data-cy="change-allocation-level"> Change<span class="govuk-visually-hidden"> Allocation level</span></a>
                             </dd>
                         </div>
                         <div class="govuk-summary-list__row govuk-summary-list__row--no-actions appeal-lpa-reference"><dt class="govuk-summary-list__key"> LPA application reference</dt>
@@ -357,18 +364,21 @@ exports[`appeal-details GET /:appealId should not render action links to the man
                         <div class="govuk-summary-list__row appeal-lpa-inspector-access"><dt class="govuk-summary-list__key"> Inspection access (LPA answer)</dt>
                             <dd                             class="govuk-summary-list__value"><span>No answer provided</span>
                                 </dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/inspector-access/change/lpa"> Change<span class="govuk-visually-hidden"> inspection access (L P A answer)</span></a>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/inspector-access/change/lpa"
+                                    data-cy="change-inspection-access-lpa"> Change<span class="govuk-visually-hidden"> inspection access (L P A answer)</span></a>
                                 </dd>
                         </div>
                         <div class="govuk-summary-list__row appeal-appellant-inspector-access"><dt class="govuk-summary-list__key"> Inspection access (appellant answer)</dt>
                             <dd                             class="govuk-summary-list__value"><span>No</span>
                                 </dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/inspector-access/change/appellant"> Change<span class="govuk-visually-hidden"> inspection access (appellant answer)</span></a>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/inspector-access/change/appellant"
+                                    data-cy="change-inspection-access-appellant"> Change<span class="govuk-visually-hidden"> inspection access (appellant answer)</span></a>
                                 </dd>
                         </div>
                         <div class="govuk-summary-list__row appeal-neighbouring-site-is-affected"><dt class="govuk-summary-list__key"> Could a neighbouring site be affected?</dt>
                             <dd                             class="govuk-summary-list__value">Yes</dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/neighbouring-sites/change/affected"> Change<span class="govuk-visually-hidden"> could a neighbouring site be affected</span></a>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/neighbouring-sites/change/affected"
+                                    data-cy="change-neighbouuring-site-is-affected"> Change<span class="govuk-visually-hidden"> could a neighbouring site be affected</span></a>
                                 </dd>
                         </div>
                         <div class="govuk-summary-list__row appeal-neighbouring-sites-inspector"><dt class="govuk-summary-list__key"> Neighbouring sites (LPA)</dt>
@@ -381,7 +391,8 @@ exports[`appeal-details GET /:appealId should not render action links to the man
                                     <ul class="govuk-summary-list__actions-list">
                                         <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/neighbouring-sites/manage"> Manage<span class="govuk-visually-hidden"> Neighbouring sites (L P A)</span></a>
                                         </li>
-                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/neighbouring-sites/add/lpa"> Add<span class="govuk-visually-hidden"> Neighbouring sites (LPA)</span></a>
+                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/neighbouring-sites/add/lpa"
+                                            data-cy="add-neighbouring-site-lpa"> Add<span class="govuk-visually-hidden"> Neighbouring sites (LPA)</span></a>
                                         </li>
                                     </ul>
                                 </dd>
@@ -394,9 +405,11 @@ exports[`appeal-details GET /:appealId should not render action links to the man
                                 </dd>
                                 <dd class="govuk-summary-list__actions">
                                     <ul class="govuk-summary-list__actions-list">
-                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/neighbouring-sites/manage"> Manage<span class="govuk-visually-hidden"> Neighbouring sites (inspector and or third party request)</span></a>
+                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/neighbouring-sites/manage"
+                                            data-cy="manage-neighbouring-sites-inspector"> Manage<span class="govuk-visually-hidden"> Neighbouring sites (inspector and or third party request)</span></a>
                                         </li>
-                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/neighbouring-sites/add/back-office"> Add<span class="govuk-visually-hidden"> Neighbouring sites (inspector and or third party request)</span></a>
+                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/neighbouring-sites/add/back-office"
+                                            data-cy="add-neighbouring-sites-inspector"> Add<span class="govuk-visually-hidden"> Neighbouring sites (inspector and or third party request)</span></a>
                                         </li>
                                     </ul>
                                 </dd>
@@ -404,19 +417,22 @@ exports[`appeal-details GET /:appealId should not render action links to the man
                         <div class="govuk-summary-list__row appeal-lpa-health-and-safety"><dt class="govuk-summary-list__key"> Potential safety risks (LPA answer)</dt>
                             <dd                             class="govuk-summary-list__value"><span>No answer provided</span>
                                 </dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/safety-risks/change/lpa"> Change<span class="govuk-visually-hidden"> potential safety risks (L P A answer)</span></a>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/safety-risks/change/lpa"
+                                    data-cy="change-lpa-health-and-safety"> Change<span class="govuk-visually-hidden"> potential safety risks (L P A answer)</span></a>
                                 </dd>
                         </div>
                         <div class="govuk-summary-list__row appeal-appellant-health-and-safety"><dt class="govuk-summary-list__key"> Potential safety risks (appellant answer)</dt>
                             <dd                             class="govuk-summary-list__value"><span>Yes</span>
                                 <br><span>Dogs on site</span>
                                 </dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/safety-risks/change/appellant"> Change<span class="govuk-visually-hidden"> potential safety risks (appellant answer)</span></a>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/safety-risks/change/appellant"
+                                    data-cy="change-appellant-case-health-and-safety"> Change<span class="govuk-visually-hidden"> potential safety risks (appellant answer)</span></a>
                                 </dd>
                         </div>
                         <div class="govuk-summary-list__row appeal-visit-type"><dt class="govuk-summary-list__key"> Visit type</dt>
                             <dd class="govuk-summary-list__value">Accompanied</dd>
-                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/visit-booked"> Change<span class="govuk-visually-hidden"> visit type</span></a>
+                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/visit-booked"
+                                data-cy="change-set-visit-type"> Change<span class="govuk-visually-hidden"> visit type</span></a>
                             </dd>
                         </div>
                     </dl>
@@ -431,7 +447,8 @@ exports[`appeal-details GET /:appealId should not render action links to the man
                     <dl class="govuk-summary-list">
                         <div class="govuk-summary-list__row appeal-valid-date"><dt class="govuk-summary-list__key"> Valid date</dt>
                             <dd class="govuk-summary-list__value">23 May 2023</dd>
-                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/valid/date"> Change<span class="govuk-visually-hidden"> The date all case documentation was received and the appeal was valid</span></a>
+                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/valid/date"
+                                data-cy="change-valid-date"> Change<span class="govuk-visually-hidden"> The date all case documentation was received and the appeal was valid</span></a>
                             </dd>
                         </div>
                         <div class="govuk-summary-list__row appeal-start-date"><dt class="govuk-summary-list__key"> Start date</dt>
@@ -441,7 +458,8 @@ exports[`appeal-details GET /:appealId should not render action links to the man
                         </div>
                         <div class="govuk-summary-list__row appeal-lpa-questionnaire-due-date"><dt class="govuk-summary-list__key"> LPA questionnaire due</dt>
                             <dd class="govuk-summary-list__value">11 October 2023</dd>
-                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appeal-timetables/lpa-questionnaire"> Change<span class="govuk-visually-hidden"> L P A questionnaire due</span></a>
+                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appeal-timetables/lpa-questionnaire"
+                                data-cy="change-lpa-questionnaire-due-date"> Change<span class="govuk-visually-hidden"> L P A questionnaire due</span></a>
                             </dd>
                         </div>
                         <div class="govuk-summary-list__row appeal-site-visit"><dt class="govuk-summary-list__key"> Site visit</dt>
@@ -451,7 +469,8 @@ exports[`appeal-details GET /:appealId should not render action links to the man
                                     <li>9:38am - 10:44am</li>
                                 </ul>
                             </dd>
-                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/manage-visit"> Change<span class="govuk-visually-hidden"> site visit</span></a>
+                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/manage-visit"
+                                data-cy="change-schedule-visit"> Change<span class="govuk-visually-hidden"> site visit</span></a>
                             </dd>
                         </div>
                     </dl>
@@ -477,7 +496,8 @@ exports[`appeal-details GET /:appealId should not render action links to the man
                                 <th scope="row" class="govuk-table__header">Appellant case</th>
                                 <td class="govuk-table__cell">Received</td>
                                 <td class="govuk-table__cell">2 August 2024</td>
-                                <td class="govuk-table__cell"><a href="/appeals-service/appeal-details/1/appellant-case" class="govuk-link">Review <span class="govuk-visually-hidden">appellant case</span></a>
+                                <td class="govuk-table__cell"><a href="/appeals-service/appeal-details/1/appellant-case" data-cy="review-appellant-case"
+                                    class="govuk-link">Review <span class="govuk-visually-hidden">appellant case</span></a>
                                 </td>
                             </tr>
                             <tr class="govuk-table__row">
@@ -492,7 +512,7 @@ exports[`appeal-details GET /:appealId should not render action links to the man
                                 <td class="govuk-table__cell appeal-costs-appellant-due-date"></td>
                                 <td class="govuk-table__cell appeal-costs-appellant-actions">
                                     <ul class="govuk-summary-list__actions-list">
-                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/costs/appellant/select-document-type/1">Add</a>
+                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-appeallant" href="/appeals-service/appeal-details/1/costs/appellant/select-document-type/1">Add</a>
                                         </li>
                                     </ul>
                                 </td>
@@ -503,7 +523,7 @@ exports[`appeal-details GET /:appealId should not render action links to the man
                                 <td class="govuk-table__cell appeal-costs-lpa-due-date"></td>
                                 <td class="govuk-table__cell appeal-costs-lpa-actions">
                                     <ul class="govuk-summary-list__actions-list">
-                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/costs/lpa/select-document-type/2">Add</a>
+                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-lpa" href="/appeals-service/appeal-details/1/costs/lpa/select-document-type/2">Add</a>
                                         </li>
                                     </ul>
                                 </td>
@@ -514,7 +534,7 @@ exports[`appeal-details GET /:appealId should not render action links to the man
                                 <td class="govuk-table__cell appeal-costs-decision-due-date"></td>
                                 <td class="govuk-table__cell appeal-costs-decision-actions">
                                     <ul class="govuk-summary-list__actions-list">
-                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/costs/decision/upload-documents/3">Add</a>
+                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-decision" href="/appeals-service/appeal-details/1/costs/decision/upload-documents/3">Add</a>
                                         </li>
                                     </ul>
                                 </td>
@@ -537,7 +557,8 @@ exports[`appeal-details GET /:appealId should not render action links to the man
                                     <li>test3@example.com</li>
                                 </ul>
                             </dd>
-                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/service-user/change/appellant"> Change<span class="govuk-visually-hidden"> Appellant</span></a>
+                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/service-user/change/appellant"
+                                data-cy="change-appellant"> Change<span class="govuk-visually-hidden"> Appellant</span></a>
                             </dd>
                         </div>
                         <div class="govuk-summary-list__row appeal-agent"><dt class="govuk-summary-list__key"> Agent</dt>
@@ -547,7 +568,8 @@ exports[`appeal-details GET /:appealId should not render action links to the man
                                     <li>test2@example.com</li>
                                 </ul>
                             </dd>
-                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/service-user/change/agent"> Change<span class="govuk-visually-hidden"> Agent</span></a>
+                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/service-user/change/agent"
+                                data-cy="change-agent"> Change<span class="govuk-visually-hidden"> Agent</span></a>
                             </dd>
                         </div>
                         <div class="govuk-summary-list__row govuk-summary-list__row--no-actions appeal-local-planning-authority"><dt class="govuk-summary-list__key"> LPA</dt>
@@ -565,12 +587,14 @@ exports[`appeal-details GET /:appealId should not render action links to the man
                     <dl class="govuk-summary-list">
                         <div class="govuk-summary-list__row appeal-case-officer"><dt class="govuk-summary-list__key"> Case officer</dt>
                             <dd class="govuk-summary-list__value"></dd>
-                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/assign-user/case-officer"> Assign<span class="govuk-visually-hidden"> case officer</span></a>
+                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/assign-user/case-officer"
+                                data-cy="assign-case-officer"> Assign<span class="govuk-visually-hidden"> case officer</span></a>
                             </dd>
                         </div>
                         <div class="govuk-summary-list__row appeal-inspector"><dt class="govuk-summary-list__key"> Inspector</dt>
                             <dd class="govuk-summary-list__value"></dd>
-                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/assign-user/inspector"> Assign<span class="govuk-visually-hidden"> inspector</span></a>
+                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/assign-user/inspector"
+                                data-cy="assign-inspector"> Assign<span class="govuk-visually-hidden"> inspector</span></a>
                             </dd>
                         </div>
                     </dl>
@@ -603,7 +627,7 @@ data-module="govuk-notification-banner">
     </div>
     <div class="govuk-notification-banner__content">
         <p class="govuk-notification-banner__heading">Appeal valid</p>
-        <p><a class="govuk-notification-banner__link" href="/appeals-service/appeal-details/2/start-case/add">Start case</a>
+        <p><a class="govuk-notification-banner__link" data-cy="ready-to-start" href="/appeals-service/appeal-details/2/start-case/add">Start case</a>
         </p>
     </div>
 </div>"
@@ -640,7 +664,8 @@ exports[`appeal-details GET /:appealId should render a Decision inset panel when
                     <dl class="govuk-summary-list">
                         <div class="govuk-summary-list__row appeal-appeal-type"><dt class="govuk-summary-list__key"> Appeal type</dt>
                             <dd class="govuk-summary-list__value">Householder</dd>
-                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/change-appeal-type/appeal-type"> Change<span class="govuk-visually-hidden"> Appeal type</span></a>
+                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/change-appeal-type/appeal-type"
+                                data-cy="change-appeal-type"> Change<span class="govuk-visually-hidden"> Appeal type</span></a>
                             </dd>
                         </div>
                         <div class="govuk-summary-list__row govuk-summary-list__row--no-actions appeal-case-procedure"><dt class="govuk-summary-list__key"> Case procedure</dt>
@@ -649,13 +674,15 @@ exports[`appeal-details GET /:appealId should render a Decision inset panel when
                         <div class="govuk-summary-list__row appeal-linked-appeals"><dt class="govuk-summary-list__key"> Linked appeals</dt>
                             <dd class="govuk-summary-list__value"><span>No appeals</span>
                             </dd>
-                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/linked-appeals/add"> Add<span class="govuk-visually-hidden"> Linked appeals</span></a>
+                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/linked-appeals/add"
+                                data-cy="add-linked-appeal"> Add<span class="govuk-visually-hidden"> Linked appeals</span></a>
                             </dd>
                         </div>
                         <div class="govuk-summary-list__row appeal-other-appeals"><dt class="govuk-summary-list__key"> Related appeals</dt>
                             <dd class="govuk-summary-list__value"><span>No appeals</span>
                             </dd>
-                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/other-appeals/add"> Add<span class="govuk-visually-hidden"> Related appeals</span></a>
+                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/other-appeals/add"
+                                data-cy="add-related-appeals"> Add<span class="govuk-visually-hidden"> Related appeals</span></a>
                             </dd>
                         </div>
                         <div class="govuk-summary-list__row appeal-allocation-details"><dt class="govuk-summary-list__key"> Allocation level</dt>
@@ -667,7 +694,8 @@ exports[`appeal-details GET /:appealId should render a Decision inset panel when
                                     <li>Architecture design</li>
                                 </ul>
                             </dd>
-                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/allocation-details/allocation-level"> Change<span class="govuk-visually-hidden"> Allocation level</span></a>
+                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/allocation-details/allocation-level"
+                                data-cy="change-allocation-level"> Change<span class="govuk-visually-hidden"> Allocation level</span></a>
                             </dd>
                         </div>
                         <div class="govuk-summary-list__row govuk-summary-list__row--no-actions appeal-lpa-reference"><dt class="govuk-summary-list__key"> LPA application reference</dt>
@@ -689,18 +717,21 @@ exports[`appeal-details GET /:appealId should render a Decision inset panel when
                         <div class="govuk-summary-list__row appeal-lpa-inspector-access"><dt class="govuk-summary-list__key"> Inspection access (LPA answer)</dt>
                             <dd                             class="govuk-summary-list__value"><span>No answer provided</span>
                                 </dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/inspector-access/change/lpa"> Change<span class="govuk-visually-hidden"> inspection access (L P A answer)</span></a>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/inspector-access/change/lpa"
+                                    data-cy="change-inspection-access-lpa"> Change<span class="govuk-visually-hidden"> inspection access (L P A answer)</span></a>
                                 </dd>
                         </div>
                         <div class="govuk-summary-list__row appeal-appellant-inspector-access"><dt class="govuk-summary-list__key"> Inspection access (appellant answer)</dt>
                             <dd                             class="govuk-summary-list__value"><span>No</span>
                                 </dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/inspector-access/change/appellant"> Change<span class="govuk-visually-hidden"> inspection access (appellant answer)</span></a>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/inspector-access/change/appellant"
+                                    data-cy="change-inspection-access-appellant"> Change<span class="govuk-visually-hidden"> inspection access (appellant answer)</span></a>
                                 </dd>
                         </div>
                         <div class="govuk-summary-list__row appeal-neighbouring-site-is-affected"><dt class="govuk-summary-list__key"> Could a neighbouring site be affected?</dt>
                             <dd                             class="govuk-summary-list__value">Yes</dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/neighbouring-sites/change/affected"> Change<span class="govuk-visually-hidden"> could a neighbouring site be affected</span></a>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/neighbouring-sites/change/affected"
+                                    data-cy="change-neighbouuring-site-is-affected"> Change<span class="govuk-visually-hidden"> could a neighbouring site be affected</span></a>
                                 </dd>
                         </div>
                         <div class="govuk-summary-list__row appeal-neighbouring-sites-inspector"><dt class="govuk-summary-list__key"> Neighbouring sites (LPA)</dt>
@@ -713,7 +744,8 @@ exports[`appeal-details GET /:appealId should render a Decision inset panel when
                                     <ul class="govuk-summary-list__actions-list">
                                         <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/2/neighbouring-sites/manage"> Manage<span class="govuk-visually-hidden"> Neighbouring sites (L P A)</span></a>
                                         </li>
-                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/2/neighbouring-sites/add/lpa"> Add<span class="govuk-visually-hidden"> Neighbouring sites (LPA)</span></a>
+                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/2/neighbouring-sites/add/lpa"
+                                            data-cy="add-neighbouring-site-lpa"> Add<span class="govuk-visually-hidden"> Neighbouring sites (LPA)</span></a>
                                         </li>
                                     </ul>
                                 </dd>
@@ -726,9 +758,11 @@ exports[`appeal-details GET /:appealId should render a Decision inset panel when
                                 </dd>
                                 <dd class="govuk-summary-list__actions">
                                     <ul class="govuk-summary-list__actions-list">
-                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/2/neighbouring-sites/manage"> Manage<span class="govuk-visually-hidden"> Neighbouring sites (inspector and or third party request)</span></a>
+                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/2/neighbouring-sites/manage"
+                                            data-cy="manage-neighbouring-sites-inspector"> Manage<span class="govuk-visually-hidden"> Neighbouring sites (inspector and or third party request)</span></a>
                                         </li>
-                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/2/neighbouring-sites/add/back-office"> Add<span class="govuk-visually-hidden"> Neighbouring sites (inspector and or third party request)</span></a>
+                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/2/neighbouring-sites/add/back-office"
+                                            data-cy="add-neighbouring-sites-inspector"> Add<span class="govuk-visually-hidden"> Neighbouring sites (inspector and or third party request)</span></a>
                                         </li>
                                     </ul>
                                 </dd>
@@ -736,19 +770,22 @@ exports[`appeal-details GET /:appealId should render a Decision inset panel when
                         <div class="govuk-summary-list__row appeal-lpa-health-and-safety"><dt class="govuk-summary-list__key"> Potential safety risks (LPA answer)</dt>
                             <dd                             class="govuk-summary-list__value"><span>No answer provided</span>
                                 </dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/safety-risks/change/lpa"> Change<span class="govuk-visually-hidden"> potential safety risks (L P A answer)</span></a>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/safety-risks/change/lpa"
+                                    data-cy="change-lpa-health-and-safety"> Change<span class="govuk-visually-hidden"> potential safety risks (L P A answer)</span></a>
                                 </dd>
                         </div>
                         <div class="govuk-summary-list__row appeal-appellant-health-and-safety"><dt class="govuk-summary-list__key"> Potential safety risks (appellant answer)</dt>
                             <dd                             class="govuk-summary-list__value"><span>Yes</span>
                                 <br><span>Dogs on site</span>
                                 </dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/safety-risks/change/appellant"> Change<span class="govuk-visually-hidden"> potential safety risks (appellant answer)</span></a>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/safety-risks/change/appellant"
+                                    data-cy="change-appellant-case-health-and-safety"> Change<span class="govuk-visually-hidden"> potential safety risks (appellant answer)</span></a>
                                 </dd>
                         </div>
                         <div class="govuk-summary-list__row appeal-visit-type"><dt class="govuk-summary-list__key"> Visit type</dt>
                             <dd class="govuk-summary-list__value">Accompanied</dd>
-                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/site-visit/visit-booked"> Change<span class="govuk-visually-hidden"> visit type</span></a>
+                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/site-visit/visit-booked"
+                                data-cy="change-set-visit-type"> Change<span class="govuk-visually-hidden"> visit type</span></a>
                             </dd>
                         </div>
                     </dl>
@@ -763,7 +800,8 @@ exports[`appeal-details GET /:appealId should render a Decision inset panel when
                     <dl class="govuk-summary-list">
                         <div class="govuk-summary-list__row appeal-valid-date"><dt class="govuk-summary-list__key"> Valid date</dt>
                             <dd class="govuk-summary-list__value">23 May 2023</dd>
-                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/appellant-case/valid/date"> Change<span class="govuk-visually-hidden"> The date all case documentation was received and the appeal was valid</span></a>
+                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/appellant-case/valid/date"
+                                data-cy="change-valid-date"> Change<span class="govuk-visually-hidden"> The date all case documentation was received and the appeal was valid</span></a>
                             </dd>
                         </div>
                         <div class="govuk-summary-list__row appeal-start-date"><dt class="govuk-summary-list__key"> Start date</dt>
@@ -773,7 +811,8 @@ exports[`appeal-details GET /:appealId should render a Decision inset panel when
                         </div>
                         <div class="govuk-summary-list__row appeal-lpa-questionnaire-due-date"><dt class="govuk-summary-list__key"> LPA questionnaire due</dt>
                             <dd class="govuk-summary-list__value">11 October 2023</dd>
-                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/appeal-timetables/lpa-questionnaire"> Change<span class="govuk-visually-hidden"> L P A questionnaire due</span></a>
+                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/appeal-timetables/lpa-questionnaire"
+                                data-cy="change-lpa-questionnaire-due-date"> Change<span class="govuk-visually-hidden"> L P A questionnaire due</span></a>
                             </dd>
                         </div>
                         <div class="govuk-summary-list__row appeal-site-visit"><dt class="govuk-summary-list__key"> Site visit</dt>
@@ -783,7 +822,8 @@ exports[`appeal-details GET /:appealId should render a Decision inset panel when
                                     <li>9:38am - 10:44am</li>
                                 </ul>
                             </dd>
-                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/site-visit/manage-visit"> Change<span class="govuk-visually-hidden"> site visit</span></a>
+                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/site-visit/manage-visit"
+                                data-cy="change-schedule-visit"> Change<span class="govuk-visually-hidden"> site visit</span></a>
                             </dd>
                         </div>
                     </dl>
@@ -809,7 +849,8 @@ exports[`appeal-details GET /:appealId should render a Decision inset panel when
                                 <th scope="row" class="govuk-table__header">Appellant case</th>
                                 <td class="govuk-table__cell">Received</td>
                                 <td class="govuk-table__cell">2 August 2024</td>
-                                <td class="govuk-table__cell"><a href="/appeals-service/appeal-details/2/appellant-case" class="govuk-link">Review <span class="govuk-visually-hidden">appellant case</span></a>
+                                <td class="govuk-table__cell"><a href="/appeals-service/appeal-details/2/appellant-case" data-cy="review-appellant-case"
+                                    class="govuk-link">Review <span class="govuk-visually-hidden">appellant case</span></a>
                                 </td>
                             </tr>
                             <tr class="govuk-table__row">
@@ -824,7 +865,7 @@ exports[`appeal-details GET /:appealId should render a Decision inset panel when
                                 <td class="govuk-table__cell appeal-costs-appellant-due-date"></td>
                                 <td class="govuk-table__cell appeal-costs-appellant-actions">
                                     <ul class="govuk-summary-list__actions-list">
-                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/2/costs/appellant/select-document-type/1">Add</a>
+                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-appeallant" href="/appeals-service/appeal-details/2/costs/appellant/select-document-type/1">Add</a>
                                         </li>
                                     </ul>
                                 </td>
@@ -835,7 +876,7 @@ exports[`appeal-details GET /:appealId should render a Decision inset panel when
                                 <td class="govuk-table__cell appeal-costs-lpa-due-date"></td>
                                 <td class="govuk-table__cell appeal-costs-lpa-actions">
                                     <ul class="govuk-summary-list__actions-list">
-                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/2/costs/lpa/select-document-type/2">Add</a>
+                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-lpa" href="/appeals-service/appeal-details/2/costs/lpa/select-document-type/2">Add</a>
                                         </li>
                                     </ul>
                                 </td>
@@ -846,7 +887,7 @@ exports[`appeal-details GET /:appealId should render a Decision inset panel when
                                 <td class="govuk-table__cell appeal-costs-decision-due-date"></td>
                                 <td class="govuk-table__cell appeal-costs-decision-actions">
                                     <ul class="govuk-summary-list__actions-list">
-                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/2/costs/decision/upload-documents/3">Add</a>
+                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-decision" href="/appeals-service/appeal-details/2/costs/decision/upload-documents/3">Add</a>
                                         </li>
                                     </ul>
                                 </td>
@@ -869,7 +910,8 @@ exports[`appeal-details GET /:appealId should render a Decision inset panel when
                                     <li>test3@example.com</li>
                                 </ul>
                             </dd>
-                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/service-user/change/appellant"> Change<span class="govuk-visually-hidden"> Appellant</span></a>
+                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/service-user/change/appellant"
+                                data-cy="change-appellant"> Change<span class="govuk-visually-hidden"> Appellant</span></a>
                             </dd>
                         </div>
                         <div class="govuk-summary-list__row appeal-agent"><dt class="govuk-summary-list__key"> Agent</dt>
@@ -879,7 +921,8 @@ exports[`appeal-details GET /:appealId should render a Decision inset panel when
                                     <li>test2@example.com</li>
                                 </ul>
                             </dd>
-                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/service-user/change/agent"> Change<span class="govuk-visually-hidden"> Agent</span></a>
+                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/service-user/change/agent"
+                                data-cy="change-agent"> Change<span class="govuk-visually-hidden"> Agent</span></a>
                             </dd>
                         </div>
                         <div class="govuk-summary-list__row govuk-summary-list__row--no-actions appeal-local-planning-authority"><dt class="govuk-summary-list__key"> LPA</dt>
@@ -897,12 +940,14 @@ exports[`appeal-details GET /:appealId should render a Decision inset panel when
                     <dl class="govuk-summary-list">
                         <div class="govuk-summary-list__row appeal-case-officer"><dt class="govuk-summary-list__key"> Case officer</dt>
                             <dd class="govuk-summary-list__value"></dd>
-                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/assign-user/case-officer"> Assign<span class="govuk-visually-hidden"> case officer</span></a>
+                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/assign-user/case-officer"
+                                data-cy="assign-case-officer"> Assign<span class="govuk-visually-hidden"> case officer</span></a>
                             </dd>
                         </div>
                         <div class="govuk-summary-list__row appeal-inspector"><dt class="govuk-summary-list__key"> Inspector</dt>
                             <dd class="govuk-summary-list__value"></dd>
-                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/assign-user/inspector"> Assign<span class="govuk-visually-hidden"> inspector</span></a>
+                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/assign-user/inspector"
+                                data-cy="assign-inspector"> Assign<span class="govuk-visually-hidden"> inspector</span></a>
                             </dd>
                         </div>
                     </dl>
@@ -938,7 +983,8 @@ exports[`appeal-details GET /:appealId should render a Issue a decision action b
                 </div>
                 <div class="govuk-notification-banner__content">
                     <p class="govuk-notification-banner__heading">Ready for decision</p>
-                    <p><a class="govuk-notification-banner__link" href="/appeals-service/appeal-details/1/issue-decision/decision">Issue decision</a>
+                    <p><a class="govuk-notification-banner__link" data-cy="issue-determination"
+                        href="/appeals-service/appeal-details/1/issue-decision/decision">Issue decision</a>
                     </p>
                 </div>
             </div>
@@ -967,7 +1013,8 @@ exports[`appeal-details GET /:appealId should render a Issue a decision action b
                     <dl class="govuk-summary-list">
                         <div class="govuk-summary-list__row appeal-appeal-type"><dt class="govuk-summary-list__key"> Appeal type</dt>
                             <dd class="govuk-summary-list__value">Householder</dd>
-                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/change-appeal-type/appeal-type"> Change<span class="govuk-visually-hidden"> Appeal type</span></a>
+                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/change-appeal-type/appeal-type"
+                                data-cy="change-appeal-type"> Change<span class="govuk-visually-hidden"> Appeal type</span></a>
                             </dd>
                         </div>
                         <div class="govuk-summary-list__row govuk-summary-list__row--no-actions appeal-case-procedure"><dt class="govuk-summary-list__key"> Case procedure</dt>
@@ -976,13 +1023,15 @@ exports[`appeal-details GET /:appealId should render a Issue a decision action b
                         <div class="govuk-summary-list__row appeal-linked-appeals"><dt class="govuk-summary-list__key"> Linked appeals</dt>
                             <dd class="govuk-summary-list__value"><span>No appeals</span>
                             </dd>
-                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/linked-appeals/add"> Add<span class="govuk-visually-hidden"> Linked appeals</span></a>
+                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/linked-appeals/add"
+                                data-cy="add-linked-appeal"> Add<span class="govuk-visually-hidden"> Linked appeals</span></a>
                             </dd>
                         </div>
                         <div class="govuk-summary-list__row appeal-other-appeals"><dt class="govuk-summary-list__key"> Related appeals</dt>
                             <dd class="govuk-summary-list__value"><span>No appeals</span>
                             </dd>
-                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/other-appeals/add"> Add<span class="govuk-visually-hidden"> Related appeals</span></a>
+                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/other-appeals/add"
+                                data-cy="add-related-appeals"> Add<span class="govuk-visually-hidden"> Related appeals</span></a>
                             </dd>
                         </div>
                         <div class="govuk-summary-list__row appeal-allocation-details"><dt class="govuk-summary-list__key"> Allocation level</dt>
@@ -994,7 +1043,8 @@ exports[`appeal-details GET /:appealId should render a Issue a decision action b
                                     <li>Architecture design</li>
                                 </ul>
                             </dd>
-                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/allocation-details/allocation-level"> Change<span class="govuk-visually-hidden"> Allocation level</span></a>
+                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/allocation-details/allocation-level"
+                                data-cy="change-allocation-level"> Change<span class="govuk-visually-hidden"> Allocation level</span></a>
                             </dd>
                         </div>
                         <div class="govuk-summary-list__row govuk-summary-list__row--no-actions appeal-lpa-reference"><dt class="govuk-summary-list__key"> LPA application reference</dt>
@@ -1016,18 +1066,21 @@ exports[`appeal-details GET /:appealId should render a Issue a decision action b
                         <div class="govuk-summary-list__row appeal-lpa-inspector-access"><dt class="govuk-summary-list__key"> Inspection access (LPA answer)</dt>
                             <dd                             class="govuk-summary-list__value"><span>No answer provided</span>
                                 </dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/inspector-access/change/lpa"> Change<span class="govuk-visually-hidden"> inspection access (L P A answer)</span></a>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/inspector-access/change/lpa"
+                                    data-cy="change-inspection-access-lpa"> Change<span class="govuk-visually-hidden"> inspection access (L P A answer)</span></a>
                                 </dd>
                         </div>
                         <div class="govuk-summary-list__row appeal-appellant-inspector-access"><dt class="govuk-summary-list__key"> Inspection access (appellant answer)</dt>
                             <dd                             class="govuk-summary-list__value"><span>No</span>
                                 </dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/inspector-access/change/appellant"> Change<span class="govuk-visually-hidden"> inspection access (appellant answer)</span></a>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/inspector-access/change/appellant"
+                                    data-cy="change-inspection-access-appellant"> Change<span class="govuk-visually-hidden"> inspection access (appellant answer)</span></a>
                                 </dd>
                         </div>
                         <div class="govuk-summary-list__row appeal-neighbouring-site-is-affected"><dt class="govuk-summary-list__key"> Could a neighbouring site be affected?</dt>
                             <dd                             class="govuk-summary-list__value">Yes</dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/neighbouring-sites/change/affected"> Change<span class="govuk-visually-hidden"> could a neighbouring site be affected</span></a>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/neighbouring-sites/change/affected"
+                                    data-cy="change-neighbouuring-site-is-affected"> Change<span class="govuk-visually-hidden"> could a neighbouring site be affected</span></a>
                                 </dd>
                         </div>
                         <div class="govuk-summary-list__row appeal-neighbouring-sites-inspector"><dt class="govuk-summary-list__key"> Neighbouring sites (LPA)</dt>
@@ -1040,7 +1093,8 @@ exports[`appeal-details GET /:appealId should render a Issue a decision action b
                                     <ul class="govuk-summary-list__actions-list">
                                         <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/2/neighbouring-sites/manage"> Manage<span class="govuk-visually-hidden"> Neighbouring sites (L P A)</span></a>
                                         </li>
-                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/2/neighbouring-sites/add/lpa"> Add<span class="govuk-visually-hidden"> Neighbouring sites (LPA)</span></a>
+                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/2/neighbouring-sites/add/lpa"
+                                            data-cy="add-neighbouring-site-lpa"> Add<span class="govuk-visually-hidden"> Neighbouring sites (LPA)</span></a>
                                         </li>
                                     </ul>
                                 </dd>
@@ -1053,9 +1107,11 @@ exports[`appeal-details GET /:appealId should render a Issue a decision action b
                                 </dd>
                                 <dd class="govuk-summary-list__actions">
                                     <ul class="govuk-summary-list__actions-list">
-                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/2/neighbouring-sites/manage"> Manage<span class="govuk-visually-hidden"> Neighbouring sites (inspector and or third party request)</span></a>
+                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/2/neighbouring-sites/manage"
+                                            data-cy="manage-neighbouring-sites-inspector"> Manage<span class="govuk-visually-hidden"> Neighbouring sites (inspector and or third party request)</span></a>
                                         </li>
-                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/2/neighbouring-sites/add/back-office"> Add<span class="govuk-visually-hidden"> Neighbouring sites (inspector and or third party request)</span></a>
+                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/2/neighbouring-sites/add/back-office"
+                                            data-cy="add-neighbouring-sites-inspector"> Add<span class="govuk-visually-hidden"> Neighbouring sites (inspector and or third party request)</span></a>
                                         </li>
                                     </ul>
                                 </dd>
@@ -1063,19 +1119,22 @@ exports[`appeal-details GET /:appealId should render a Issue a decision action b
                         <div class="govuk-summary-list__row appeal-lpa-health-and-safety"><dt class="govuk-summary-list__key"> Potential safety risks (LPA answer)</dt>
                             <dd                             class="govuk-summary-list__value"><span>No answer provided</span>
                                 </dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/safety-risks/change/lpa"> Change<span class="govuk-visually-hidden"> potential safety risks (L P A answer)</span></a>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/safety-risks/change/lpa"
+                                    data-cy="change-lpa-health-and-safety"> Change<span class="govuk-visually-hidden"> potential safety risks (L P A answer)</span></a>
                                 </dd>
                         </div>
                         <div class="govuk-summary-list__row appeal-appellant-health-and-safety"><dt class="govuk-summary-list__key"> Potential safety risks (appellant answer)</dt>
                             <dd                             class="govuk-summary-list__value"><span>Yes</span>
                                 <br><span>Dogs on site</span>
                                 </dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/safety-risks/change/appellant"> Change<span class="govuk-visually-hidden"> potential safety risks (appellant answer)</span></a>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/safety-risks/change/appellant"
+                                    data-cy="change-appellant-case-health-and-safety"> Change<span class="govuk-visually-hidden"> potential safety risks (appellant answer)</span></a>
                                 </dd>
                         </div>
                         <div class="govuk-summary-list__row appeal-visit-type"><dt class="govuk-summary-list__key"> Visit type</dt>
                             <dd class="govuk-summary-list__value">Accompanied</dd>
-                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/site-visit/visit-booked"> Change<span class="govuk-visually-hidden"> visit type</span></a>
+                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/site-visit/visit-booked"
+                                data-cy="change-set-visit-type"> Change<span class="govuk-visually-hidden"> visit type</span></a>
                             </dd>
                         </div>
                     </dl>
@@ -1090,7 +1149,8 @@ exports[`appeal-details GET /:appealId should render a Issue a decision action b
                     <dl class="govuk-summary-list">
                         <div class="govuk-summary-list__row appeal-valid-date"><dt class="govuk-summary-list__key"> Valid date</dt>
                             <dd class="govuk-summary-list__value">23 May 2023</dd>
-                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/appellant-case/valid/date"> Change<span class="govuk-visually-hidden"> The date all case documentation was received and the appeal was valid</span></a>
+                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/appellant-case/valid/date"
+                                data-cy="change-valid-date"> Change<span class="govuk-visually-hidden"> The date all case documentation was received and the appeal was valid</span></a>
                             </dd>
                         </div>
                         <div class="govuk-summary-list__row appeal-start-date"><dt class="govuk-summary-list__key"> Start date</dt>
@@ -1100,7 +1160,8 @@ exports[`appeal-details GET /:appealId should render a Issue a decision action b
                         </div>
                         <div class="govuk-summary-list__row appeal-lpa-questionnaire-due-date"><dt class="govuk-summary-list__key"> LPA questionnaire due</dt>
                             <dd class="govuk-summary-list__value">11 October 2023</dd>
-                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/appeal-timetables/lpa-questionnaire"> Change<span class="govuk-visually-hidden"> L P A questionnaire due</span></a>
+                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/appeal-timetables/lpa-questionnaire"
+                                data-cy="change-lpa-questionnaire-due-date"> Change<span class="govuk-visually-hidden"> L P A questionnaire due</span></a>
                             </dd>
                         </div>
                         <div class="govuk-summary-list__row appeal-site-visit"><dt class="govuk-summary-list__key"> Site visit</dt>
@@ -1110,7 +1171,8 @@ exports[`appeal-details GET /:appealId should render a Issue a decision action b
                                     <li>9:38am - 10:44am</li>
                                 </ul>
                             </dd>
-                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/site-visit/manage-visit"> Change<span class="govuk-visually-hidden"> site visit</span></a>
+                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/site-visit/manage-visit"
+                                data-cy="change-schedule-visit"> Change<span class="govuk-visually-hidden"> site visit</span></a>
                             </dd>
                         </div>
                     </dl>
@@ -1136,7 +1198,8 @@ exports[`appeal-details GET /:appealId should render a Issue a decision action b
                                 <th scope="row" class="govuk-table__header">Appellant case</th>
                                 <td class="govuk-table__cell">Received</td>
                                 <td class="govuk-table__cell">2 August 2024</td>
-                                <td class="govuk-table__cell"><a href="/appeals-service/appeal-details/2/appellant-case" class="govuk-link">Review <span class="govuk-visually-hidden">appellant case</span></a>
+                                <td class="govuk-table__cell"><a href="/appeals-service/appeal-details/2/appellant-case" data-cy="review-appellant-case"
+                                    class="govuk-link">Review <span class="govuk-visually-hidden">appellant case</span></a>
                                 </td>
                             </tr>
                             <tr class="govuk-table__row">
@@ -1151,7 +1214,7 @@ exports[`appeal-details GET /:appealId should render a Issue a decision action b
                                 <td class="govuk-table__cell appeal-costs-appellant-due-date"></td>
                                 <td class="govuk-table__cell appeal-costs-appellant-actions">
                                     <ul class="govuk-summary-list__actions-list">
-                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/2/costs/appellant/select-document-type/1">Add</a>
+                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-appeallant" href="/appeals-service/appeal-details/2/costs/appellant/select-document-type/1">Add</a>
                                         </li>
                                     </ul>
                                 </td>
@@ -1162,7 +1225,7 @@ exports[`appeal-details GET /:appealId should render a Issue a decision action b
                                 <td class="govuk-table__cell appeal-costs-lpa-due-date"></td>
                                 <td class="govuk-table__cell appeal-costs-lpa-actions">
                                     <ul class="govuk-summary-list__actions-list">
-                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/2/costs/lpa/select-document-type/2">Add</a>
+                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-lpa" href="/appeals-service/appeal-details/2/costs/lpa/select-document-type/2">Add</a>
                                         </li>
                                     </ul>
                                 </td>
@@ -1173,7 +1236,7 @@ exports[`appeal-details GET /:appealId should render a Issue a decision action b
                                 <td class="govuk-table__cell appeal-costs-decision-due-date"></td>
                                 <td class="govuk-table__cell appeal-costs-decision-actions">
                                     <ul class="govuk-summary-list__actions-list">
-                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/2/costs/decision/upload-documents/3">Add</a>
+                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-decision" href="/appeals-service/appeal-details/2/costs/decision/upload-documents/3">Add</a>
                                         </li>
                                     </ul>
                                 </td>
@@ -1196,7 +1259,8 @@ exports[`appeal-details GET /:appealId should render a Issue a decision action b
                                     <li>test3@example.com</li>
                                 </ul>
                             </dd>
-                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/service-user/change/appellant"> Change<span class="govuk-visually-hidden"> Appellant</span></a>
+                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/service-user/change/appellant"
+                                data-cy="change-appellant"> Change<span class="govuk-visually-hidden"> Appellant</span></a>
                             </dd>
                         </div>
                         <div class="govuk-summary-list__row appeal-agent"><dt class="govuk-summary-list__key"> Agent</dt>
@@ -1206,7 +1270,8 @@ exports[`appeal-details GET /:appealId should render a Issue a decision action b
                                     <li>test2@example.com</li>
                                 </ul>
                             </dd>
-                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/service-user/change/agent"> Change<span class="govuk-visually-hidden"> Agent</span></a>
+                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/service-user/change/agent"
+                                data-cy="change-agent"> Change<span class="govuk-visually-hidden"> Agent</span></a>
                             </dd>
                         </div>
                         <div class="govuk-summary-list__row govuk-summary-list__row--no-actions appeal-local-planning-authority"><dt class="govuk-summary-list__key"> LPA</dt>
@@ -1224,12 +1289,14 @@ exports[`appeal-details GET /:appealId should render a Issue a decision action b
                     <dl class="govuk-summary-list">
                         <div class="govuk-summary-list__row appeal-case-officer"><dt class="govuk-summary-list__key"> Case officer</dt>
                             <dd class="govuk-summary-list__value"></dd>
-                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/assign-user/case-officer"> Assign<span class="govuk-visually-hidden"> case officer</span></a>
+                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/assign-user/case-officer"
+                                data-cy="assign-case-officer"> Assign<span class="govuk-visually-hidden"> case officer</span></a>
                             </dd>
                         </div>
                         <div class="govuk-summary-list__row appeal-inspector"><dt class="govuk-summary-list__key"> Inspector</dt>
                             <dd class="govuk-summary-list__value"></dd>
-                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/assign-user/inspector"> Assign<span class="govuk-visually-hidden"> inspector</span></a>
+                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/assign-user/inspector"
+                                data-cy="assign-inspector"> Assign<span class="govuk-visually-hidden"> inspector</span></a>
                             </dd>
                         </div>
                     </dl>
@@ -1280,7 +1347,8 @@ exports[`appeal-details GET /:appealId should render a child tag next to the app
                     <dl class="govuk-summary-list">
                         <div class="govuk-summary-list__row appeal-appeal-type"><dt class="govuk-summary-list__key"> Appeal type</dt>
                             <dd class="govuk-summary-list__value">Householder</dd>
-                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/change-appeal-type/appeal-type"> Change<span class="govuk-visually-hidden"> Appeal type</span></a>
+                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/change-appeal-type/appeal-type"
+                                data-cy="change-appeal-type"> Change<span class="govuk-visually-hidden"> Appeal type</span></a>
                             </dd>
                         </div>
                         <div class="govuk-summary-list__row govuk-summary-list__row--no-actions appeal-case-procedure"><dt class="govuk-summary-list__key"> Case procedure</dt>
@@ -1289,14 +1357,17 @@ exports[`appeal-details GET /:appealId should render a child tag next to the app
                         <div class="govuk-summary-list__row appeal-linked-appeals"><dt class="govuk-summary-list__key"> Linked appeals</dt>
                             <dd class="govuk-summary-list__value">
                                 <ul class="govuk-list govuk-list--bullet">
-                                    <li><a href="/appeals-service/appeal-details/5464" class="govuk-link" aria-label="Appeal 1 4 0 0 7 9">140079</a> (Lead)</li>
+                                    <li><a href="/appeals-service/appeal-details/5464" class="govuk-link" data-cy="linked-appeal-140079"
+                                        aria-label="Appeal 1 4 0 0 7 9">140079</a> (Lead)</li>
                                 </ul>
                             </dd>
                             <dd class="govuk-summary-list__actions">
                                 <ul class="govuk-summary-list__actions-list">
-                                    <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/linked-appeals/manage"> Manage<span class="govuk-visually-hidden"> Linked appeals</span></a>
+                                    <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/linked-appeals/manage"
+                                        data-cy="manage-linked-appeals"> Manage<span class="govuk-visually-hidden"> Linked appeals</span></a>
                                     </li>
-                                    <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/linked-appeals/add"> Add<span class="govuk-visually-hidden"> Linked appeals</span></a>
+                                    <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/linked-appeals/add"
+                                        data-cy="add-linked-appeal"> Add<span class="govuk-visually-hidden"> Linked appeals</span></a>
                                     </li>
                                 </ul>
                             </dd>
@@ -1304,7 +1375,8 @@ exports[`appeal-details GET /:appealId should render a child tag next to the app
                         <div class="govuk-summary-list__row appeal-other-appeals"><dt class="govuk-summary-list__key"> Related appeals</dt>
                             <dd class="govuk-summary-list__value"><span>No appeals</span>
                             </dd>
-                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/other-appeals/add"> Add<span class="govuk-visually-hidden"> Related appeals</span></a>
+                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/other-appeals/add"
+                                data-cy="add-related-appeals"> Add<span class="govuk-visually-hidden"> Related appeals</span></a>
                             </dd>
                         </div>
                         <div class="govuk-summary-list__row appeal-allocation-details"><dt class="govuk-summary-list__key"> Allocation level</dt>
@@ -1316,7 +1388,8 @@ exports[`appeal-details GET /:appealId should render a child tag next to the app
                                     <li>Architecture design</li>
                                 </ul>
                             </dd>
-                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/allocation-details/allocation-level"> Change<span class="govuk-visually-hidden"> Allocation level</span></a>
+                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/allocation-details/allocation-level"
+                                data-cy="change-allocation-level"> Change<span class="govuk-visually-hidden"> Allocation level</span></a>
                             </dd>
                         </div>
                         <div class="govuk-summary-list__row govuk-summary-list__row--no-actions appeal-lpa-reference"><dt class="govuk-summary-list__key"> LPA application reference</dt>
@@ -1338,18 +1411,21 @@ exports[`appeal-details GET /:appealId should render a child tag next to the app
                         <div class="govuk-summary-list__row appeal-lpa-inspector-access"><dt class="govuk-summary-list__key"> Inspection access (LPA answer)</dt>
                             <dd                             class="govuk-summary-list__value"><span>No answer provided</span>
                                 </dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/inspector-access/change/lpa"> Change<span class="govuk-visually-hidden"> inspection access (L P A answer)</span></a>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/inspector-access/change/lpa"
+                                    data-cy="change-inspection-access-lpa"> Change<span class="govuk-visually-hidden"> inspection access (L P A answer)</span></a>
                                 </dd>
                         </div>
                         <div class="govuk-summary-list__row appeal-appellant-inspector-access"><dt class="govuk-summary-list__key"> Inspection access (appellant answer)</dt>
                             <dd                             class="govuk-summary-list__value"><span>No</span>
                                 </dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/inspector-access/change/appellant"> Change<span class="govuk-visually-hidden"> inspection access (appellant answer)</span></a>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/inspector-access/change/appellant"
+                                    data-cy="change-inspection-access-appellant"> Change<span class="govuk-visually-hidden"> inspection access (appellant answer)</span></a>
                                 </dd>
                         </div>
                         <div class="govuk-summary-list__row appeal-neighbouring-site-is-affected"><dt class="govuk-summary-list__key"> Could a neighbouring site be affected?</dt>
                             <dd                             class="govuk-summary-list__value">Yes</dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/neighbouring-sites/change/affected"> Change<span class="govuk-visually-hidden"> could a neighbouring site be affected</span></a>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/neighbouring-sites/change/affected"
+                                    data-cy="change-neighbouuring-site-is-affected"> Change<span class="govuk-visually-hidden"> could a neighbouring site be affected</span></a>
                                 </dd>
                         </div>
                         <div class="govuk-summary-list__row appeal-neighbouring-sites-inspector"><dt class="govuk-summary-list__key"> Neighbouring sites (LPA)</dt>
@@ -1362,7 +1438,8 @@ exports[`appeal-details GET /:appealId should render a child tag next to the app
                                     <ul class="govuk-summary-list__actions-list">
                                         <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/neighbouring-sites/manage"> Manage<span class="govuk-visually-hidden"> Neighbouring sites (L P A)</span></a>
                                         </li>
-                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/neighbouring-sites/add/lpa"> Add<span class="govuk-visually-hidden"> Neighbouring sites (LPA)</span></a>
+                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/neighbouring-sites/add/lpa"
+                                            data-cy="add-neighbouring-site-lpa"> Add<span class="govuk-visually-hidden"> Neighbouring sites (LPA)</span></a>
                                         </li>
                                     </ul>
                                 </dd>
@@ -1375,9 +1452,11 @@ exports[`appeal-details GET /:appealId should render a child tag next to the app
                                 </dd>
                                 <dd class="govuk-summary-list__actions">
                                     <ul class="govuk-summary-list__actions-list">
-                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/neighbouring-sites/manage"> Manage<span class="govuk-visually-hidden"> Neighbouring sites (inspector and or third party request)</span></a>
+                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/neighbouring-sites/manage"
+                                            data-cy="manage-neighbouring-sites-inspector"> Manage<span class="govuk-visually-hidden"> Neighbouring sites (inspector and or third party request)</span></a>
                                         </li>
-                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/neighbouring-sites/add/back-office"> Add<span class="govuk-visually-hidden"> Neighbouring sites (inspector and or third party request)</span></a>
+                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/neighbouring-sites/add/back-office"
+                                            data-cy="add-neighbouring-sites-inspector"> Add<span class="govuk-visually-hidden"> Neighbouring sites (inspector and or third party request)</span></a>
                                         </li>
                                     </ul>
                                 </dd>
@@ -1385,19 +1464,22 @@ exports[`appeal-details GET /:appealId should render a child tag next to the app
                         <div class="govuk-summary-list__row appeal-lpa-health-and-safety"><dt class="govuk-summary-list__key"> Potential safety risks (LPA answer)</dt>
                             <dd                             class="govuk-summary-list__value"><span>No answer provided</span>
                                 </dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/safety-risks/change/lpa"> Change<span class="govuk-visually-hidden"> potential safety risks (L P A answer)</span></a>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/safety-risks/change/lpa"
+                                    data-cy="change-lpa-health-and-safety"> Change<span class="govuk-visually-hidden"> potential safety risks (L P A answer)</span></a>
                                 </dd>
                         </div>
                         <div class="govuk-summary-list__row appeal-appellant-health-and-safety"><dt class="govuk-summary-list__key"> Potential safety risks (appellant answer)</dt>
                             <dd                             class="govuk-summary-list__value"><span>Yes</span>
                                 <br><span>Dogs on site</span>
                                 </dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/safety-risks/change/appellant"> Change<span class="govuk-visually-hidden"> potential safety risks (appellant answer)</span></a>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/safety-risks/change/appellant"
+                                    data-cy="change-appellant-case-health-and-safety"> Change<span class="govuk-visually-hidden"> potential safety risks (appellant answer)</span></a>
                                 </dd>
                         </div>
                         <div class="govuk-summary-list__row appeal-visit-type"><dt class="govuk-summary-list__key"> Visit type</dt>
                             <dd class="govuk-summary-list__value">Accompanied</dd>
-                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/visit-booked"> Change<span class="govuk-visually-hidden"> visit type</span></a>
+                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/visit-booked"
+                                data-cy="change-set-visit-type"> Change<span class="govuk-visually-hidden"> visit type</span></a>
                             </dd>
                         </div>
                     </dl>
@@ -1412,7 +1494,8 @@ exports[`appeal-details GET /:appealId should render a child tag next to the app
                     <dl class="govuk-summary-list">
                         <div class="govuk-summary-list__row appeal-valid-date"><dt class="govuk-summary-list__key"> Valid date</dt>
                             <dd class="govuk-summary-list__value">23 May 2023</dd>
-                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/valid/date"> Change<span class="govuk-visually-hidden"> The date all case documentation was received and the appeal was valid</span></a>
+                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/valid/date"
+                                data-cy="change-valid-date"> Change<span class="govuk-visually-hidden"> The date all case documentation was received and the appeal was valid</span></a>
                             </dd>
                         </div>
                         <div class="govuk-summary-list__row appeal-start-date"><dt class="govuk-summary-list__key"> Start date</dt>
@@ -1422,7 +1505,8 @@ exports[`appeal-details GET /:appealId should render a child tag next to the app
                         </div>
                         <div class="govuk-summary-list__row appeal-lpa-questionnaire-due-date"><dt class="govuk-summary-list__key"> LPA questionnaire due</dt>
                             <dd class="govuk-summary-list__value">11 October 2023</dd>
-                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appeal-timetables/lpa-questionnaire"> Change<span class="govuk-visually-hidden"> L P A questionnaire due</span></a>
+                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appeal-timetables/lpa-questionnaire"
+                                data-cy="change-lpa-questionnaire-due-date"> Change<span class="govuk-visually-hidden"> L P A questionnaire due</span></a>
                             </dd>
                         </div>
                         <div class="govuk-summary-list__row appeal-site-visit"><dt class="govuk-summary-list__key"> Site visit</dt>
@@ -1432,7 +1516,8 @@ exports[`appeal-details GET /:appealId should render a child tag next to the app
                                     <li>9:38am - 10:44am</li>
                                 </ul>
                             </dd>
-                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/manage-visit"> Change<span class="govuk-visually-hidden"> site visit</span></a>
+                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/manage-visit"
+                                data-cy="change-schedule-visit"> Change<span class="govuk-visually-hidden"> site visit</span></a>
                             </dd>
                         </div>
                     </dl>
@@ -1458,7 +1543,8 @@ exports[`appeal-details GET /:appealId should render a child tag next to the app
                                 <th scope="row" class="govuk-table__header">Appellant case</th>
                                 <td class="govuk-table__cell">Received</td>
                                 <td class="govuk-table__cell">2 August 2024</td>
-                                <td class="govuk-table__cell"><a href="/appeals-service/appeal-details/1/appellant-case" class="govuk-link">Review <span class="govuk-visually-hidden">appellant case</span></a>
+                                <td class="govuk-table__cell"><a href="/appeals-service/appeal-details/1/appellant-case" data-cy="review-appellant-case"
+                                    class="govuk-link">Review <span class="govuk-visually-hidden">appellant case</span></a>
                                 </td>
                             </tr>
                             <tr class="govuk-table__row">
@@ -1473,7 +1559,7 @@ exports[`appeal-details GET /:appealId should render a child tag next to the app
                                 <td class="govuk-table__cell appeal-costs-appellant-due-date"></td>
                                 <td class="govuk-table__cell appeal-costs-appellant-actions">
                                     <ul class="govuk-summary-list__actions-list">
-                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/costs/appellant/select-document-type/1">Add</a>
+                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-appeallant" href="/appeals-service/appeal-details/1/costs/appellant/select-document-type/1">Add</a>
                                         </li>
                                     </ul>
                                 </td>
@@ -1484,7 +1570,7 @@ exports[`appeal-details GET /:appealId should render a child tag next to the app
                                 <td class="govuk-table__cell appeal-costs-lpa-due-date"></td>
                                 <td class="govuk-table__cell appeal-costs-lpa-actions">
                                     <ul class="govuk-summary-list__actions-list">
-                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/costs/lpa/select-document-type/2">Add</a>
+                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-lpa" href="/appeals-service/appeal-details/1/costs/lpa/select-document-type/2">Add</a>
                                         </li>
                                     </ul>
                                 </td>
@@ -1495,7 +1581,7 @@ exports[`appeal-details GET /:appealId should render a child tag next to the app
                                 <td class="govuk-table__cell appeal-costs-decision-due-date"></td>
                                 <td class="govuk-table__cell appeal-costs-decision-actions">
                                     <ul class="govuk-summary-list__actions-list">
-                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/costs/decision/upload-documents/3">Add</a>
+                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-decision" href="/appeals-service/appeal-details/1/costs/decision/upload-documents/3">Add</a>
                                         </li>
                                     </ul>
                                 </td>
@@ -1518,7 +1604,8 @@ exports[`appeal-details GET /:appealId should render a child tag next to the app
                                     <li>test3@example.com</li>
                                 </ul>
                             </dd>
-                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/service-user/change/appellant"> Change<span class="govuk-visually-hidden"> Appellant</span></a>
+                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/service-user/change/appellant"
+                                data-cy="change-appellant"> Change<span class="govuk-visually-hidden"> Appellant</span></a>
                             </dd>
                         </div>
                         <div class="govuk-summary-list__row appeal-agent"><dt class="govuk-summary-list__key"> Agent</dt>
@@ -1528,7 +1615,8 @@ exports[`appeal-details GET /:appealId should render a child tag next to the app
                                     <li>test2@example.com</li>
                                 </ul>
                             </dd>
-                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/service-user/change/agent"> Change<span class="govuk-visually-hidden"> Agent</span></a>
+                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/service-user/change/agent"
+                                data-cy="change-agent"> Change<span class="govuk-visually-hidden"> Agent</span></a>
                             </dd>
                         </div>
                         <div class="govuk-summary-list__row govuk-summary-list__row--no-actions appeal-local-planning-authority"><dt class="govuk-summary-list__key"> LPA</dt>
@@ -1546,12 +1634,14 @@ exports[`appeal-details GET /:appealId should render a child tag next to the app
                     <dl class="govuk-summary-list">
                         <div class="govuk-summary-list__row appeal-case-officer"><dt class="govuk-summary-list__key"> Case officer</dt>
                             <dd class="govuk-summary-list__value"></dd>
-                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/assign-user/case-officer"> Assign<span class="govuk-visually-hidden"> case officer</span></a>
+                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/assign-user/case-officer"
+                                data-cy="assign-case-officer"> Assign<span class="govuk-visually-hidden"> case officer</span></a>
                             </dd>
                         </div>
                         <div class="govuk-summary-list__row appeal-inspector"><dt class="govuk-summary-list__key"> Inspector</dt>
                             <dd class="govuk-summary-list__value"></dd>
-                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/assign-user/inspector"> Assign<span class="govuk-visually-hidden"> inspector</span></a>
+                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/assign-user/inspector"
+                                data-cy="assign-inspector"> Assign<span class="govuk-visually-hidden"> inspector</span></a>
                             </dd>
                         </div>
                     </dl>
@@ -1602,7 +1692,8 @@ exports[`appeal-details GET /:appealId should render a lead tag next to the appe
                     <dl class="govuk-summary-list">
                         <div class="govuk-summary-list__row appeal-appeal-type"><dt class="govuk-summary-list__key"> Appeal type</dt>
                             <dd class="govuk-summary-list__value">Householder</dd>
-                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/change-appeal-type/appeal-type"> Change<span class="govuk-visually-hidden"> Appeal type</span></a>
+                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/change-appeal-type/appeal-type"
+                                data-cy="change-appeal-type"> Change<span class="govuk-visually-hidden"> Appeal type</span></a>
                             </dd>
                         </div>
                         <div class="govuk-summary-list__row govuk-summary-list__row--no-actions appeal-case-procedure"><dt class="govuk-summary-list__key"> Case procedure</dt>
@@ -1611,16 +1702,20 @@ exports[`appeal-details GET /:appealId should render a lead tag next to the appe
                         <div class="govuk-summary-list__row appeal-linked-appeals"><dt class="govuk-summary-list__key"> Linked appeals</dt>
                             <dd class="govuk-summary-list__value">
                                 <ul class="govuk-list govuk-list--bullet">
-                                    <li><a href="/appeals-service/appeal-details/5449" class="govuk-link" aria-label="Appeal 7 8 4 7 0 6">784706</a> (Child)</li>
+                                    <li><a href="/appeals-service/appeal-details/5449" class="govuk-link" data-cy="linked-appeal-784706"
+                                        aria-label="Appeal 7 8 4 7 0 6">784706</a> (Child)</li>
                                     <li><span class="govuk-body">87326527</span> (Child)</li>
-                                    <li><a href="/appeals-service/appeal-details/5451" class="govuk-link" aria-label="Appeal 7 2 1 0 8 6">721086</a> (Child)</li>
+                                    <li><a href="/appeals-service/appeal-details/5451" class="govuk-link" data-cy="linked-appeal-721086"
+                                        aria-label="Appeal 7 2 1 0 8 6">721086</a> (Child)</li>
                                 </ul>
                             </dd>
                             <dd class="govuk-summary-list__actions">
                                 <ul class="govuk-summary-list__actions-list">
-                                    <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/linked-appeals/manage"> Manage<span class="govuk-visually-hidden"> Linked appeals</span></a>
+                                    <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/linked-appeals/manage"
+                                        data-cy="manage-linked-appeals"> Manage<span class="govuk-visually-hidden"> Linked appeals</span></a>
                                     </li>
-                                    <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/linked-appeals/add"> Add<span class="govuk-visually-hidden"> Linked appeals</span></a>
+                                    <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/linked-appeals/add"
+                                        data-cy="add-linked-appeal"> Add<span class="govuk-visually-hidden"> Linked appeals</span></a>
                                     </li>
                                 </ul>
                             </dd>
@@ -1628,7 +1723,8 @@ exports[`appeal-details GET /:appealId should render a lead tag next to the appe
                         <div class="govuk-summary-list__row appeal-other-appeals"><dt class="govuk-summary-list__key"> Related appeals</dt>
                             <dd class="govuk-summary-list__value"><span>No appeals</span>
                             </dd>
-                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/other-appeals/add"> Add<span class="govuk-visually-hidden"> Related appeals</span></a>
+                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/other-appeals/add"
+                                data-cy="add-related-appeals"> Add<span class="govuk-visually-hidden"> Related appeals</span></a>
                             </dd>
                         </div>
                         <div class="govuk-summary-list__row appeal-allocation-details"><dt class="govuk-summary-list__key"> Allocation level</dt>
@@ -1640,7 +1736,8 @@ exports[`appeal-details GET /:appealId should render a lead tag next to the appe
                                     <li>Architecture design</li>
                                 </ul>
                             </dd>
-                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/allocation-details/allocation-level"> Change<span class="govuk-visually-hidden"> Allocation level</span></a>
+                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/allocation-details/allocation-level"
+                                data-cy="change-allocation-level"> Change<span class="govuk-visually-hidden"> Allocation level</span></a>
                             </dd>
                         </div>
                         <div class="govuk-summary-list__row govuk-summary-list__row--no-actions appeal-lpa-reference"><dt class="govuk-summary-list__key"> LPA application reference</dt>
@@ -1662,18 +1759,21 @@ exports[`appeal-details GET /:appealId should render a lead tag next to the appe
                         <div class="govuk-summary-list__row appeal-lpa-inspector-access"><dt class="govuk-summary-list__key"> Inspection access (LPA answer)</dt>
                             <dd                             class="govuk-summary-list__value"><span>No answer provided</span>
                                 </dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/inspector-access/change/lpa"> Change<span class="govuk-visually-hidden"> inspection access (L P A answer)</span></a>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/inspector-access/change/lpa"
+                                    data-cy="change-inspection-access-lpa"> Change<span class="govuk-visually-hidden"> inspection access (L P A answer)</span></a>
                                 </dd>
                         </div>
                         <div class="govuk-summary-list__row appeal-appellant-inspector-access"><dt class="govuk-summary-list__key"> Inspection access (appellant answer)</dt>
                             <dd                             class="govuk-summary-list__value"><span>No</span>
                                 </dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/inspector-access/change/appellant"> Change<span class="govuk-visually-hidden"> inspection access (appellant answer)</span></a>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/inspector-access/change/appellant"
+                                    data-cy="change-inspection-access-appellant"> Change<span class="govuk-visually-hidden"> inspection access (appellant answer)</span></a>
                                 </dd>
                         </div>
                         <div class="govuk-summary-list__row appeal-neighbouring-site-is-affected"><dt class="govuk-summary-list__key"> Could a neighbouring site be affected?</dt>
                             <dd                             class="govuk-summary-list__value">Yes</dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/neighbouring-sites/change/affected"> Change<span class="govuk-visually-hidden"> could a neighbouring site be affected</span></a>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/neighbouring-sites/change/affected"
+                                    data-cy="change-neighbouuring-site-is-affected"> Change<span class="govuk-visually-hidden"> could a neighbouring site be affected</span></a>
                                 </dd>
                         </div>
                         <div class="govuk-summary-list__row appeal-neighbouring-sites-inspector"><dt class="govuk-summary-list__key"> Neighbouring sites (LPA)</dt>
@@ -1686,7 +1786,8 @@ exports[`appeal-details GET /:appealId should render a lead tag next to the appe
                                     <ul class="govuk-summary-list__actions-list">
                                         <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/neighbouring-sites/manage"> Manage<span class="govuk-visually-hidden"> Neighbouring sites (L P A)</span></a>
                                         </li>
-                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/neighbouring-sites/add/lpa"> Add<span class="govuk-visually-hidden"> Neighbouring sites (LPA)</span></a>
+                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/neighbouring-sites/add/lpa"
+                                            data-cy="add-neighbouring-site-lpa"> Add<span class="govuk-visually-hidden"> Neighbouring sites (LPA)</span></a>
                                         </li>
                                     </ul>
                                 </dd>
@@ -1699,9 +1800,11 @@ exports[`appeal-details GET /:appealId should render a lead tag next to the appe
                                 </dd>
                                 <dd class="govuk-summary-list__actions">
                                     <ul class="govuk-summary-list__actions-list">
-                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/neighbouring-sites/manage"> Manage<span class="govuk-visually-hidden"> Neighbouring sites (inspector and or third party request)</span></a>
+                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/neighbouring-sites/manage"
+                                            data-cy="manage-neighbouring-sites-inspector"> Manage<span class="govuk-visually-hidden"> Neighbouring sites (inspector and or third party request)</span></a>
                                         </li>
-                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/neighbouring-sites/add/back-office"> Add<span class="govuk-visually-hidden"> Neighbouring sites (inspector and or third party request)</span></a>
+                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/neighbouring-sites/add/back-office"
+                                            data-cy="add-neighbouring-sites-inspector"> Add<span class="govuk-visually-hidden"> Neighbouring sites (inspector and or third party request)</span></a>
                                         </li>
                                     </ul>
                                 </dd>
@@ -1709,19 +1812,22 @@ exports[`appeal-details GET /:appealId should render a lead tag next to the appe
                         <div class="govuk-summary-list__row appeal-lpa-health-and-safety"><dt class="govuk-summary-list__key"> Potential safety risks (LPA answer)</dt>
                             <dd                             class="govuk-summary-list__value"><span>No answer provided</span>
                                 </dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/safety-risks/change/lpa"> Change<span class="govuk-visually-hidden"> potential safety risks (L P A answer)</span></a>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/safety-risks/change/lpa"
+                                    data-cy="change-lpa-health-and-safety"> Change<span class="govuk-visually-hidden"> potential safety risks (L P A answer)</span></a>
                                 </dd>
                         </div>
                         <div class="govuk-summary-list__row appeal-appellant-health-and-safety"><dt class="govuk-summary-list__key"> Potential safety risks (appellant answer)</dt>
                             <dd                             class="govuk-summary-list__value"><span>Yes</span>
                                 <br><span>Dogs on site</span>
                                 </dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/safety-risks/change/appellant"> Change<span class="govuk-visually-hidden"> potential safety risks (appellant answer)</span></a>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/safety-risks/change/appellant"
+                                    data-cy="change-appellant-case-health-and-safety"> Change<span class="govuk-visually-hidden"> potential safety risks (appellant answer)</span></a>
                                 </dd>
                         </div>
                         <div class="govuk-summary-list__row appeal-visit-type"><dt class="govuk-summary-list__key"> Visit type</dt>
                             <dd class="govuk-summary-list__value">Accompanied</dd>
-                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/visit-booked"> Change<span class="govuk-visually-hidden"> visit type</span></a>
+                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/visit-booked"
+                                data-cy="change-set-visit-type"> Change<span class="govuk-visually-hidden"> visit type</span></a>
                             </dd>
                         </div>
                     </dl>
@@ -1736,7 +1842,8 @@ exports[`appeal-details GET /:appealId should render a lead tag next to the appe
                     <dl class="govuk-summary-list">
                         <div class="govuk-summary-list__row appeal-valid-date"><dt class="govuk-summary-list__key"> Valid date</dt>
                             <dd class="govuk-summary-list__value">23 May 2023</dd>
-                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/valid/date"> Change<span class="govuk-visually-hidden"> The date all case documentation was received and the appeal was valid</span></a>
+                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/valid/date"
+                                data-cy="change-valid-date"> Change<span class="govuk-visually-hidden"> The date all case documentation was received and the appeal was valid</span></a>
                             </dd>
                         </div>
                         <div class="govuk-summary-list__row appeal-start-date"><dt class="govuk-summary-list__key"> Start date</dt>
@@ -1746,7 +1853,8 @@ exports[`appeal-details GET /:appealId should render a lead tag next to the appe
                         </div>
                         <div class="govuk-summary-list__row appeal-lpa-questionnaire-due-date"><dt class="govuk-summary-list__key"> LPA questionnaire due</dt>
                             <dd class="govuk-summary-list__value">11 October 2023</dd>
-                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appeal-timetables/lpa-questionnaire"> Change<span class="govuk-visually-hidden"> L P A questionnaire due</span></a>
+                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appeal-timetables/lpa-questionnaire"
+                                data-cy="change-lpa-questionnaire-due-date"> Change<span class="govuk-visually-hidden"> L P A questionnaire due</span></a>
                             </dd>
                         </div>
                         <div class="govuk-summary-list__row appeal-site-visit"><dt class="govuk-summary-list__key"> Site visit</dt>
@@ -1756,7 +1864,8 @@ exports[`appeal-details GET /:appealId should render a lead tag next to the appe
                                     <li>9:38am - 10:44am</li>
                                 </ul>
                             </dd>
-                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/manage-visit"> Change<span class="govuk-visually-hidden"> site visit</span></a>
+                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/manage-visit"
+                                data-cy="change-schedule-visit"> Change<span class="govuk-visually-hidden"> site visit</span></a>
                             </dd>
                         </div>
                     </dl>
@@ -1782,7 +1891,8 @@ exports[`appeal-details GET /:appealId should render a lead tag next to the appe
                                 <th scope="row" class="govuk-table__header">Appellant case</th>
                                 <td class="govuk-table__cell">Received</td>
                                 <td class="govuk-table__cell">2 August 2024</td>
-                                <td class="govuk-table__cell"><a href="/appeals-service/appeal-details/1/appellant-case" class="govuk-link">Review <span class="govuk-visually-hidden">appellant case</span></a>
+                                <td class="govuk-table__cell"><a href="/appeals-service/appeal-details/1/appellant-case" data-cy="review-appellant-case"
+                                    class="govuk-link">Review <span class="govuk-visually-hidden">appellant case</span></a>
                                 </td>
                             </tr>
                             <tr class="govuk-table__row">
@@ -1797,7 +1907,7 @@ exports[`appeal-details GET /:appealId should render a lead tag next to the appe
                                 <td class="govuk-table__cell appeal-costs-appellant-due-date"></td>
                                 <td class="govuk-table__cell appeal-costs-appellant-actions">
                                     <ul class="govuk-summary-list__actions-list">
-                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/costs/appellant/select-document-type/1">Add</a>
+                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-appeallant" href="/appeals-service/appeal-details/1/costs/appellant/select-document-type/1">Add</a>
                                         </li>
                                     </ul>
                                 </td>
@@ -1808,7 +1918,7 @@ exports[`appeal-details GET /:appealId should render a lead tag next to the appe
                                 <td class="govuk-table__cell appeal-costs-lpa-due-date"></td>
                                 <td class="govuk-table__cell appeal-costs-lpa-actions">
                                     <ul class="govuk-summary-list__actions-list">
-                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/costs/lpa/select-document-type/2">Add</a>
+                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-lpa" href="/appeals-service/appeal-details/1/costs/lpa/select-document-type/2">Add</a>
                                         </li>
                                     </ul>
                                 </td>
@@ -1819,7 +1929,7 @@ exports[`appeal-details GET /:appealId should render a lead tag next to the appe
                                 <td class="govuk-table__cell appeal-costs-decision-due-date"></td>
                                 <td class="govuk-table__cell appeal-costs-decision-actions">
                                     <ul class="govuk-summary-list__actions-list">
-                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/costs/decision/upload-documents/3">Add</a>
+                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-decision" href="/appeals-service/appeal-details/1/costs/decision/upload-documents/3">Add</a>
                                         </li>
                                     </ul>
                                 </td>
@@ -1842,7 +1952,8 @@ exports[`appeal-details GET /:appealId should render a lead tag next to the appe
                                     <li>test3@example.com</li>
                                 </ul>
                             </dd>
-                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/service-user/change/appellant"> Change<span class="govuk-visually-hidden"> Appellant</span></a>
+                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/service-user/change/appellant"
+                                data-cy="change-appellant"> Change<span class="govuk-visually-hidden"> Appellant</span></a>
                             </dd>
                         </div>
                         <div class="govuk-summary-list__row appeal-agent"><dt class="govuk-summary-list__key"> Agent</dt>
@@ -1852,7 +1963,8 @@ exports[`appeal-details GET /:appealId should render a lead tag next to the appe
                                     <li>test2@example.com</li>
                                 </ul>
                             </dd>
-                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/service-user/change/agent"> Change<span class="govuk-visually-hidden"> Agent</span></a>
+                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/service-user/change/agent"
+                                data-cy="change-agent"> Change<span class="govuk-visually-hidden"> Agent</span></a>
                             </dd>
                         </div>
                         <div class="govuk-summary-list__row govuk-summary-list__row--no-actions appeal-local-planning-authority"><dt class="govuk-summary-list__key"> LPA</dt>
@@ -1870,12 +1982,14 @@ exports[`appeal-details GET /:appealId should render a lead tag next to the appe
                     <dl class="govuk-summary-list">
                         <div class="govuk-summary-list__row appeal-case-officer"><dt class="govuk-summary-list__key"> Case officer</dt>
                             <dd class="govuk-summary-list__value"></dd>
-                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/assign-user/case-officer"> Assign<span class="govuk-visually-hidden"> case officer</span></a>
+                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/assign-user/case-officer"
+                                data-cy="assign-case-officer"> Assign<span class="govuk-visually-hidden"> case officer</span></a>
                             </dd>
                         </div>
                         <div class="govuk-summary-list__row appeal-inspector"><dt class="govuk-summary-list__key"> Inspector</dt>
                             <dd class="govuk-summary-list__value"></dd>
-                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/assign-user/inspector"> Assign<span class="govuk-visually-hidden"> inspector</span></a>
+                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/assign-user/inspector"
+                                data-cy="assign-inspector"> Assign<span class="govuk-visually-hidden"> inspector</span></a>
                             </dd>
                         </div>
                     </dl>
@@ -1939,7 +2053,8 @@ exports[`appeal-details GET /:appealId should render action links to the manage 
                     <dl class="govuk-summary-list">
                         <div class="govuk-summary-list__row appeal-appeal-type"><dt class="govuk-summary-list__key"> Appeal type</dt>
                             <dd class="govuk-summary-list__value">Householder</dd>
-                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/change-appeal-type/appeal-type"> Change<span class="govuk-visually-hidden"> Appeal type</span></a>
+                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/change-appeal-type/appeal-type"
+                                data-cy="change-appeal-type"> Change<span class="govuk-visually-hidden"> Appeal type</span></a>
                             </dd>
                         </div>
                         <div class="govuk-summary-list__row govuk-summary-list__row--no-actions appeal-case-procedure"><dt class="govuk-summary-list__key"> Case procedure</dt>
@@ -1948,17 +2063,22 @@ exports[`appeal-details GET /:appealId should render action links to the manage 
                         <div class="govuk-summary-list__row appeal-linked-appeals"><dt class="govuk-summary-list__key"> Linked appeals</dt>
                             <dd class="govuk-summary-list__value">
                                 <ul class="govuk-list govuk-list--bullet">
-                                    <li><a href="/appeals-service/appeal-details/5449" class="govuk-link" aria-label="Appeal 7 8 4 7 0 6">784706</a> (Child)</li>
+                                    <li><a href="/appeals-service/appeal-details/5449" class="govuk-link" data-cy="linked-appeal-784706"
+                                        aria-label="Appeal 7 8 4 7 0 6">784706</a> (Child)</li>
                                     <li><span class="govuk-body">87326527</span> (Child)</li>
-                                    <li><a href="/appeals-service/appeal-details/5464" class="govuk-link" aria-label="Appeal 1 4 0 0 7 9">140079</a> (Lead)</li>
-                                    <li><a href="/appeals-service/appeal-details/5451" class="govuk-link" aria-label="Appeal 7 2 1 0 8 6">721086</a> (Child)</li>
+                                    <li><a href="/appeals-service/appeal-details/5464" class="govuk-link" data-cy="linked-appeal-140079"
+                                        aria-label="Appeal 1 4 0 0 7 9">140079</a> (Lead)</li>
+                                    <li><a href="/appeals-service/appeal-details/5451" class="govuk-link" data-cy="linked-appeal-721086"
+                                        aria-label="Appeal 7 2 1 0 8 6">721086</a> (Child)</li>
                                 </ul>
                             </dd>
                             <dd class="govuk-summary-list__actions">
                                 <ul class="govuk-summary-list__actions-list">
-                                    <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/linked-appeals/manage"> Manage<span class="govuk-visually-hidden"> Linked appeals</span></a>
+                                    <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/linked-appeals/manage"
+                                        data-cy="manage-linked-appeals"> Manage<span class="govuk-visually-hidden"> Linked appeals</span></a>
                                     </li>
-                                    <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/linked-appeals/add"> Add<span class="govuk-visually-hidden"> Linked appeals</span></a>
+                                    <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/linked-appeals/add"
+                                        data-cy="add-linked-appeal"> Add<span class="govuk-visually-hidden"> Linked appeals</span></a>
                                     </li>
                                 </ul>
                             </dd>
@@ -1966,7 +2086,8 @@ exports[`appeal-details GET /:appealId should render action links to the manage 
                         <div class="govuk-summary-list__row appeal-other-appeals"><dt class="govuk-summary-list__key"> Related appeals</dt>
                             <dd class="govuk-summary-list__value"><span>No appeals</span>
                             </dd>
-                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/other-appeals/add"> Add<span class="govuk-visually-hidden"> Related appeals</span></a>
+                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/other-appeals/add"
+                                data-cy="add-related-appeals"> Add<span class="govuk-visually-hidden"> Related appeals</span></a>
                             </dd>
                         </div>
                         <div class="govuk-summary-list__row appeal-allocation-details"><dt class="govuk-summary-list__key"> Allocation level</dt>
@@ -1978,7 +2099,8 @@ exports[`appeal-details GET /:appealId should render action links to the manage 
                                     <li>Architecture design</li>
                                 </ul>
                             </dd>
-                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/allocation-details/allocation-level"> Change<span class="govuk-visually-hidden"> Allocation level</span></a>
+                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/allocation-details/allocation-level"
+                                data-cy="change-allocation-level"> Change<span class="govuk-visually-hidden"> Allocation level</span></a>
                             </dd>
                         </div>
                         <div class="govuk-summary-list__row govuk-summary-list__row--no-actions appeal-lpa-reference"><dt class="govuk-summary-list__key"> LPA application reference</dt>
@@ -2000,18 +2122,21 @@ exports[`appeal-details GET /:appealId should render action links to the manage 
                         <div class="govuk-summary-list__row appeal-lpa-inspector-access"><dt class="govuk-summary-list__key"> Inspection access (LPA answer)</dt>
                             <dd                             class="govuk-summary-list__value"><span>No answer provided</span>
                                 </dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/inspector-access/change/lpa"> Change<span class="govuk-visually-hidden"> inspection access (L P A answer)</span></a>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/inspector-access/change/lpa"
+                                    data-cy="change-inspection-access-lpa"> Change<span class="govuk-visually-hidden"> inspection access (L P A answer)</span></a>
                                 </dd>
                         </div>
                         <div class="govuk-summary-list__row appeal-appellant-inspector-access"><dt class="govuk-summary-list__key"> Inspection access (appellant answer)</dt>
                             <dd                             class="govuk-summary-list__value"><span>No</span>
                                 </dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/inspector-access/change/appellant"> Change<span class="govuk-visually-hidden"> inspection access (appellant answer)</span></a>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/inspector-access/change/appellant"
+                                    data-cy="change-inspection-access-appellant"> Change<span class="govuk-visually-hidden"> inspection access (appellant answer)</span></a>
                                 </dd>
                         </div>
                         <div class="govuk-summary-list__row appeal-neighbouring-site-is-affected"><dt class="govuk-summary-list__key"> Could a neighbouring site be affected?</dt>
                             <dd                             class="govuk-summary-list__value">Yes</dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/neighbouring-sites/change/affected"> Change<span class="govuk-visually-hidden"> could a neighbouring site be affected</span></a>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/neighbouring-sites/change/affected"
+                                    data-cy="change-neighbouuring-site-is-affected"> Change<span class="govuk-visually-hidden"> could a neighbouring site be affected</span></a>
                                 </dd>
                         </div>
                         <div class="govuk-summary-list__row appeal-neighbouring-sites-inspector"><dt class="govuk-summary-list__key"> Neighbouring sites (LPA)</dt>
@@ -2024,7 +2149,8 @@ exports[`appeal-details GET /:appealId should render action links to the manage 
                                     <ul class="govuk-summary-list__actions-list">
                                         <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/neighbouring-sites/manage"> Manage<span class="govuk-visually-hidden"> Neighbouring sites (L P A)</span></a>
                                         </li>
-                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/neighbouring-sites/add/lpa"> Add<span class="govuk-visually-hidden"> Neighbouring sites (LPA)</span></a>
+                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/neighbouring-sites/add/lpa"
+                                            data-cy="add-neighbouring-site-lpa"> Add<span class="govuk-visually-hidden"> Neighbouring sites (LPA)</span></a>
                                         </li>
                                     </ul>
                                 </dd>
@@ -2037,9 +2163,11 @@ exports[`appeal-details GET /:appealId should render action links to the manage 
                                 </dd>
                                 <dd class="govuk-summary-list__actions">
                                     <ul class="govuk-summary-list__actions-list">
-                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/neighbouring-sites/manage"> Manage<span class="govuk-visually-hidden"> Neighbouring sites (inspector and or third party request)</span></a>
+                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/neighbouring-sites/manage"
+                                            data-cy="manage-neighbouring-sites-inspector"> Manage<span class="govuk-visually-hidden"> Neighbouring sites (inspector and or third party request)</span></a>
                                         </li>
-                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/neighbouring-sites/add/back-office"> Add<span class="govuk-visually-hidden"> Neighbouring sites (inspector and or third party request)</span></a>
+                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/neighbouring-sites/add/back-office"
+                                            data-cy="add-neighbouring-sites-inspector"> Add<span class="govuk-visually-hidden"> Neighbouring sites (inspector and or third party request)</span></a>
                                         </li>
                                     </ul>
                                 </dd>
@@ -2047,19 +2175,22 @@ exports[`appeal-details GET /:appealId should render action links to the manage 
                         <div class="govuk-summary-list__row appeal-lpa-health-and-safety"><dt class="govuk-summary-list__key"> Potential safety risks (LPA answer)</dt>
                             <dd                             class="govuk-summary-list__value"><span>No answer provided</span>
                                 </dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/safety-risks/change/lpa"> Change<span class="govuk-visually-hidden"> potential safety risks (L P A answer)</span></a>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/safety-risks/change/lpa"
+                                    data-cy="change-lpa-health-and-safety"> Change<span class="govuk-visually-hidden"> potential safety risks (L P A answer)</span></a>
                                 </dd>
                         </div>
                         <div class="govuk-summary-list__row appeal-appellant-health-and-safety"><dt class="govuk-summary-list__key"> Potential safety risks (appellant answer)</dt>
                             <dd                             class="govuk-summary-list__value"><span>Yes</span>
                                 <br><span>Dogs on site</span>
                                 </dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/safety-risks/change/appellant"> Change<span class="govuk-visually-hidden"> potential safety risks (appellant answer)</span></a>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/safety-risks/change/appellant"
+                                    data-cy="change-appellant-case-health-and-safety"> Change<span class="govuk-visually-hidden"> potential safety risks (appellant answer)</span></a>
                                 </dd>
                         </div>
                         <div class="govuk-summary-list__row appeal-visit-type"><dt class="govuk-summary-list__key"> Visit type</dt>
                             <dd class="govuk-summary-list__value">Accompanied</dd>
-                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/visit-booked"> Change<span class="govuk-visually-hidden"> visit type</span></a>
+                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/visit-booked"
+                                data-cy="change-set-visit-type"> Change<span class="govuk-visually-hidden"> visit type</span></a>
                             </dd>
                         </div>
                     </dl>
@@ -2074,7 +2205,8 @@ exports[`appeal-details GET /:appealId should render action links to the manage 
                     <dl class="govuk-summary-list">
                         <div class="govuk-summary-list__row appeal-valid-date"><dt class="govuk-summary-list__key"> Valid date</dt>
                             <dd class="govuk-summary-list__value">23 May 2023</dd>
-                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/valid/date"> Change<span class="govuk-visually-hidden"> The date all case documentation was received and the appeal was valid</span></a>
+                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/valid/date"
+                                data-cy="change-valid-date"> Change<span class="govuk-visually-hidden"> The date all case documentation was received and the appeal was valid</span></a>
                             </dd>
                         </div>
                         <div class="govuk-summary-list__row appeal-start-date"><dt class="govuk-summary-list__key"> Start date</dt>
@@ -2084,7 +2216,8 @@ exports[`appeal-details GET /:appealId should render action links to the manage 
                         </div>
                         <div class="govuk-summary-list__row appeal-lpa-questionnaire-due-date"><dt class="govuk-summary-list__key"> LPA questionnaire due</dt>
                             <dd class="govuk-summary-list__value">11 October 2023</dd>
-                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appeal-timetables/lpa-questionnaire"> Change<span class="govuk-visually-hidden"> L P A questionnaire due</span></a>
+                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appeal-timetables/lpa-questionnaire"
+                                data-cy="change-lpa-questionnaire-due-date"> Change<span class="govuk-visually-hidden"> L P A questionnaire due</span></a>
                             </dd>
                         </div>
                         <div class="govuk-summary-list__row appeal-site-visit"><dt class="govuk-summary-list__key"> Site visit</dt>
@@ -2094,7 +2227,8 @@ exports[`appeal-details GET /:appealId should render action links to the manage 
                                     <li>9:38am - 10:44am</li>
                                 </ul>
                             </dd>
-                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/manage-visit"> Change<span class="govuk-visually-hidden"> site visit</span></a>
+                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/manage-visit"
+                                data-cy="change-schedule-visit"> Change<span class="govuk-visually-hidden"> site visit</span></a>
                             </dd>
                         </div>
                     </dl>
@@ -2120,7 +2254,8 @@ exports[`appeal-details GET /:appealId should render action links to the manage 
                                 <th scope="row" class="govuk-table__header">Appellant case</th>
                                 <td class="govuk-table__cell">Received</td>
                                 <td class="govuk-table__cell">2 August 2024</td>
-                                <td class="govuk-table__cell"><a href="/appeals-service/appeal-details/1/appellant-case" class="govuk-link">Review <span class="govuk-visually-hidden">appellant case</span></a>
+                                <td class="govuk-table__cell"><a href="/appeals-service/appeal-details/1/appellant-case" data-cy="review-appellant-case"
+                                    class="govuk-link">Review <span class="govuk-visually-hidden">appellant case</span></a>
                                 </td>
                             </tr>
                             <tr class="govuk-table__row">
@@ -2135,7 +2270,7 @@ exports[`appeal-details GET /:appealId should render action links to the manage 
                                 <td class="govuk-table__cell appeal-costs-appellant-due-date"></td>
                                 <td class="govuk-table__cell appeal-costs-appellant-actions">
                                     <ul class="govuk-summary-list__actions-list">
-                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/costs/appellant/select-document-type/1">Add</a>
+                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-appeallant" href="/appeals-service/appeal-details/1/costs/appellant/select-document-type/1">Add</a>
                                         </li>
                                     </ul>
                                 </td>
@@ -2146,7 +2281,7 @@ exports[`appeal-details GET /:appealId should render action links to the manage 
                                 <td class="govuk-table__cell appeal-costs-lpa-due-date"></td>
                                 <td class="govuk-table__cell appeal-costs-lpa-actions">
                                     <ul class="govuk-summary-list__actions-list">
-                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/costs/lpa/select-document-type/2">Add</a>
+                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-lpa" href="/appeals-service/appeal-details/1/costs/lpa/select-document-type/2">Add</a>
                                         </li>
                                     </ul>
                                 </td>
@@ -2157,7 +2292,7 @@ exports[`appeal-details GET /:appealId should render action links to the manage 
                                 <td class="govuk-table__cell appeal-costs-decision-due-date"></td>
                                 <td class="govuk-table__cell appeal-costs-decision-actions">
                                     <ul class="govuk-summary-list__actions-list">
-                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/costs/decision/upload-documents/3">Add</a>
+                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-decision" href="/appeals-service/appeal-details/1/costs/decision/upload-documents/3">Add</a>
                                         </li>
                                     </ul>
                                 </td>
@@ -2180,7 +2315,8 @@ exports[`appeal-details GET /:appealId should render action links to the manage 
                                     <li>test3@example.com</li>
                                 </ul>
                             </dd>
-                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/service-user/change/appellant"> Change<span class="govuk-visually-hidden"> Appellant</span></a>
+                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/service-user/change/appellant"
+                                data-cy="change-appellant"> Change<span class="govuk-visually-hidden"> Appellant</span></a>
                             </dd>
                         </div>
                         <div class="govuk-summary-list__row appeal-agent"><dt class="govuk-summary-list__key"> Agent</dt>
@@ -2190,7 +2326,8 @@ exports[`appeal-details GET /:appealId should render action links to the manage 
                                     <li>test2@example.com</li>
                                 </ul>
                             </dd>
-                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/service-user/change/agent"> Change<span class="govuk-visually-hidden"> Agent</span></a>
+                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/service-user/change/agent"
+                                data-cy="change-agent"> Change<span class="govuk-visually-hidden"> Agent</span></a>
                             </dd>
                         </div>
                         <div class="govuk-summary-list__row govuk-summary-list__row--no-actions appeal-local-planning-authority"><dt class="govuk-summary-list__key"> LPA</dt>
@@ -2208,12 +2345,14 @@ exports[`appeal-details GET /:appealId should render action links to the manage 
                     <dl class="govuk-summary-list">
                         <div class="govuk-summary-list__row appeal-case-officer"><dt class="govuk-summary-list__key"> Case officer</dt>
                             <dd class="govuk-summary-list__value"></dd>
-                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/assign-user/case-officer"> Assign<span class="govuk-visually-hidden"> case officer</span></a>
+                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/assign-user/case-officer"
+                                data-cy="assign-case-officer"> Assign<span class="govuk-visually-hidden"> case officer</span></a>
                             </dd>
                         </div>
                         <div class="govuk-summary-list__row appeal-inspector"><dt class="govuk-summary-list__key"> Inspector</dt>
                             <dd class="govuk-summary-list__value"></dd>
-                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/assign-user/inspector"> Assign<span class="govuk-visually-hidden"> inspector</span></a>
+                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/assign-user/inspector"
+                                data-cy="assign-inspector"> Assign<span class="govuk-visually-hidden"> inspector</span></a>
                             </dd>
                         </div>
                     </dl>
@@ -2263,7 +2402,8 @@ exports[`appeal-details GET /:appealId should render an action link to the add l
                     <dl class="govuk-summary-list">
                         <div class="govuk-summary-list__row appeal-appeal-type"><dt class="govuk-summary-list__key"> Appeal type</dt>
                             <dd class="govuk-summary-list__value">Householder</dd>
-                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/change-appeal-type/appeal-type"> Change<span class="govuk-visually-hidden"> Appeal type</span></a>
+                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/change-appeal-type/appeal-type"
+                                data-cy="change-appeal-type"> Change<span class="govuk-visually-hidden"> Appeal type</span></a>
                             </dd>
                         </div>
                         <div class="govuk-summary-list__row govuk-summary-list__row--no-actions appeal-case-procedure"><dt class="govuk-summary-list__key"> Case procedure</dt>
@@ -2272,13 +2412,15 @@ exports[`appeal-details GET /:appealId should render an action link to the add l
                         <div class="govuk-summary-list__row appeal-linked-appeals"><dt class="govuk-summary-list__key"> Linked appeals</dt>
                             <dd class="govuk-summary-list__value"><span>No appeals</span>
                             </dd>
-                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/linked-appeals/add"> Add<span class="govuk-visually-hidden"> Linked appeals</span></a>
+                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/linked-appeals/add"
+                                data-cy="add-linked-appeal"> Add<span class="govuk-visually-hidden"> Linked appeals</span></a>
                             </dd>
                         </div>
                         <div class="govuk-summary-list__row appeal-other-appeals"><dt class="govuk-summary-list__key"> Related appeals</dt>
                             <dd class="govuk-summary-list__value"><span>No appeals</span>
                             </dd>
-                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/other-appeals/add"> Add<span class="govuk-visually-hidden"> Related appeals</span></a>
+                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/other-appeals/add"
+                                data-cy="add-related-appeals"> Add<span class="govuk-visually-hidden"> Related appeals</span></a>
                             </dd>
                         </div>
                         <div class="govuk-summary-list__row appeal-allocation-details"><dt class="govuk-summary-list__key"> Allocation level</dt>
@@ -2290,7 +2432,8 @@ exports[`appeal-details GET /:appealId should render an action link to the add l
                                     <li>Architecture design</li>
                                 </ul>
                             </dd>
-                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/allocation-details/allocation-level"> Change<span class="govuk-visually-hidden"> Allocation level</span></a>
+                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/allocation-details/allocation-level"
+                                data-cy="change-allocation-level"> Change<span class="govuk-visually-hidden"> Allocation level</span></a>
                             </dd>
                         </div>
                         <div class="govuk-summary-list__row govuk-summary-list__row--no-actions appeal-lpa-reference"><dt class="govuk-summary-list__key"> LPA application reference</dt>
@@ -2312,18 +2455,21 @@ exports[`appeal-details GET /:appealId should render an action link to the add l
                         <div class="govuk-summary-list__row appeal-lpa-inspector-access"><dt class="govuk-summary-list__key"> Inspection access (LPA answer)</dt>
                             <dd                             class="govuk-summary-list__value"><span>No answer provided</span>
                                 </dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/inspector-access/change/lpa"> Change<span class="govuk-visually-hidden"> inspection access (L P A answer)</span></a>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/inspector-access/change/lpa"
+                                    data-cy="change-inspection-access-lpa"> Change<span class="govuk-visually-hidden"> inspection access (L P A answer)</span></a>
                                 </dd>
                         </div>
                         <div class="govuk-summary-list__row appeal-appellant-inspector-access"><dt class="govuk-summary-list__key"> Inspection access (appellant answer)</dt>
                             <dd                             class="govuk-summary-list__value"><span>No</span>
                                 </dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/inspector-access/change/appellant"> Change<span class="govuk-visually-hidden"> inspection access (appellant answer)</span></a>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/inspector-access/change/appellant"
+                                    data-cy="change-inspection-access-appellant"> Change<span class="govuk-visually-hidden"> inspection access (appellant answer)</span></a>
                                 </dd>
                         </div>
                         <div class="govuk-summary-list__row appeal-neighbouring-site-is-affected"><dt class="govuk-summary-list__key"> Could a neighbouring site be affected?</dt>
                             <dd                             class="govuk-summary-list__value">Yes</dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/neighbouring-sites/change/affected"> Change<span class="govuk-visually-hidden"> could a neighbouring site be affected</span></a>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/neighbouring-sites/change/affected"
+                                    data-cy="change-neighbouuring-site-is-affected"> Change<span class="govuk-visually-hidden"> could a neighbouring site be affected</span></a>
                                 </dd>
                         </div>
                         <div class="govuk-summary-list__row appeal-neighbouring-sites-inspector"><dt class="govuk-summary-list__key"> Neighbouring sites (LPA)</dt>
@@ -2336,7 +2482,8 @@ exports[`appeal-details GET /:appealId should render an action link to the add l
                                     <ul class="govuk-summary-list__actions-list">
                                         <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/neighbouring-sites/manage"> Manage<span class="govuk-visually-hidden"> Neighbouring sites (L P A)</span></a>
                                         </li>
-                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/neighbouring-sites/add/lpa"> Add<span class="govuk-visually-hidden"> Neighbouring sites (LPA)</span></a>
+                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/neighbouring-sites/add/lpa"
+                                            data-cy="add-neighbouring-site-lpa"> Add<span class="govuk-visually-hidden"> Neighbouring sites (LPA)</span></a>
                                         </li>
                                     </ul>
                                 </dd>
@@ -2349,9 +2496,11 @@ exports[`appeal-details GET /:appealId should render an action link to the add l
                                 </dd>
                                 <dd class="govuk-summary-list__actions">
                                     <ul class="govuk-summary-list__actions-list">
-                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/neighbouring-sites/manage"> Manage<span class="govuk-visually-hidden"> Neighbouring sites (inspector and or third party request)</span></a>
+                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/neighbouring-sites/manage"
+                                            data-cy="manage-neighbouring-sites-inspector"> Manage<span class="govuk-visually-hidden"> Neighbouring sites (inspector and or third party request)</span></a>
                                         </li>
-                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/neighbouring-sites/add/back-office"> Add<span class="govuk-visually-hidden"> Neighbouring sites (inspector and or third party request)</span></a>
+                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/neighbouring-sites/add/back-office"
+                                            data-cy="add-neighbouring-sites-inspector"> Add<span class="govuk-visually-hidden"> Neighbouring sites (inspector and or third party request)</span></a>
                                         </li>
                                     </ul>
                                 </dd>
@@ -2359,19 +2508,22 @@ exports[`appeal-details GET /:appealId should render an action link to the add l
                         <div class="govuk-summary-list__row appeal-lpa-health-and-safety"><dt class="govuk-summary-list__key"> Potential safety risks (LPA answer)</dt>
                             <dd                             class="govuk-summary-list__value"><span>No answer provided</span>
                                 </dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/safety-risks/change/lpa"> Change<span class="govuk-visually-hidden"> potential safety risks (L P A answer)</span></a>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/safety-risks/change/lpa"
+                                    data-cy="change-lpa-health-and-safety"> Change<span class="govuk-visually-hidden"> potential safety risks (L P A answer)</span></a>
                                 </dd>
                         </div>
                         <div class="govuk-summary-list__row appeal-appellant-health-and-safety"><dt class="govuk-summary-list__key"> Potential safety risks (appellant answer)</dt>
                             <dd                             class="govuk-summary-list__value"><span>Yes</span>
                                 <br><span>Dogs on site</span>
                                 </dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/safety-risks/change/appellant"> Change<span class="govuk-visually-hidden"> potential safety risks (appellant answer)</span></a>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/safety-risks/change/appellant"
+                                    data-cy="change-appellant-case-health-and-safety"> Change<span class="govuk-visually-hidden"> potential safety risks (appellant answer)</span></a>
                                 </dd>
                         </div>
                         <div class="govuk-summary-list__row appeal-visit-type"><dt class="govuk-summary-list__key"> Visit type</dt>
                             <dd class="govuk-summary-list__value">Accompanied</dd>
-                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/visit-booked"> Change<span class="govuk-visually-hidden"> visit type</span></a>
+                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/visit-booked"
+                                data-cy="change-set-visit-type"> Change<span class="govuk-visually-hidden"> visit type</span></a>
                             </dd>
                         </div>
                     </dl>
@@ -2386,7 +2538,8 @@ exports[`appeal-details GET /:appealId should render an action link to the add l
                     <dl class="govuk-summary-list">
                         <div class="govuk-summary-list__row appeal-valid-date"><dt class="govuk-summary-list__key"> Valid date</dt>
                             <dd class="govuk-summary-list__value">23 May 2023</dd>
-                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/valid/date"> Change<span class="govuk-visually-hidden"> The date all case documentation was received and the appeal was valid</span></a>
+                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/valid/date"
+                                data-cy="change-valid-date"> Change<span class="govuk-visually-hidden"> The date all case documentation was received and the appeal was valid</span></a>
                             </dd>
                         </div>
                         <div class="govuk-summary-list__row appeal-start-date"><dt class="govuk-summary-list__key"> Start date</dt>
@@ -2396,7 +2549,8 @@ exports[`appeal-details GET /:appealId should render an action link to the add l
                         </div>
                         <div class="govuk-summary-list__row appeal-lpa-questionnaire-due-date"><dt class="govuk-summary-list__key"> LPA questionnaire due</dt>
                             <dd class="govuk-summary-list__value">11 October 2023</dd>
-                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appeal-timetables/lpa-questionnaire"> Change<span class="govuk-visually-hidden"> L P A questionnaire due</span></a>
+                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appeal-timetables/lpa-questionnaire"
+                                data-cy="change-lpa-questionnaire-due-date"> Change<span class="govuk-visually-hidden"> L P A questionnaire due</span></a>
                             </dd>
                         </div>
                         <div class="govuk-summary-list__row appeal-site-visit"><dt class="govuk-summary-list__key"> Site visit</dt>
@@ -2406,7 +2560,8 @@ exports[`appeal-details GET /:appealId should render an action link to the add l
                                     <li>9:38am - 10:44am</li>
                                 </ul>
                             </dd>
-                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/manage-visit"> Change<span class="govuk-visually-hidden"> site visit</span></a>
+                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/manage-visit"
+                                data-cy="change-schedule-visit"> Change<span class="govuk-visually-hidden"> site visit</span></a>
                             </dd>
                         </div>
                     </dl>
@@ -2432,7 +2587,8 @@ exports[`appeal-details GET /:appealId should render an action link to the add l
                                 <th scope="row" class="govuk-table__header">Appellant case</th>
                                 <td class="govuk-table__cell">Received</td>
                                 <td class="govuk-table__cell">2 August 2024</td>
-                                <td class="govuk-table__cell"><a href="/appeals-service/appeal-details/1/appellant-case" class="govuk-link">Review <span class="govuk-visually-hidden">appellant case</span></a>
+                                <td class="govuk-table__cell"><a href="/appeals-service/appeal-details/1/appellant-case" data-cy="review-appellant-case"
+                                    class="govuk-link">Review <span class="govuk-visually-hidden">appellant case</span></a>
                                 </td>
                             </tr>
                             <tr class="govuk-table__row">
@@ -2447,7 +2603,7 @@ exports[`appeal-details GET /:appealId should render an action link to the add l
                                 <td class="govuk-table__cell appeal-costs-appellant-due-date"></td>
                                 <td class="govuk-table__cell appeal-costs-appellant-actions">
                                     <ul class="govuk-summary-list__actions-list">
-                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/costs/appellant/select-document-type/1">Add</a>
+                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-appeallant" href="/appeals-service/appeal-details/1/costs/appellant/select-document-type/1">Add</a>
                                         </li>
                                     </ul>
                                 </td>
@@ -2458,7 +2614,7 @@ exports[`appeal-details GET /:appealId should render an action link to the add l
                                 <td class="govuk-table__cell appeal-costs-lpa-due-date"></td>
                                 <td class="govuk-table__cell appeal-costs-lpa-actions">
                                     <ul class="govuk-summary-list__actions-list">
-                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/costs/lpa/select-document-type/2">Add</a>
+                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-lpa" href="/appeals-service/appeal-details/1/costs/lpa/select-document-type/2">Add</a>
                                         </li>
                                     </ul>
                                 </td>
@@ -2469,7 +2625,7 @@ exports[`appeal-details GET /:appealId should render an action link to the add l
                                 <td class="govuk-table__cell appeal-costs-decision-due-date"></td>
                                 <td class="govuk-table__cell appeal-costs-decision-actions">
                                     <ul class="govuk-summary-list__actions-list">
-                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/costs/decision/upload-documents/3">Add</a>
+                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-decision" href="/appeals-service/appeal-details/1/costs/decision/upload-documents/3">Add</a>
                                         </li>
                                     </ul>
                                 </td>
@@ -2492,7 +2648,8 @@ exports[`appeal-details GET /:appealId should render an action link to the add l
                                     <li>test3@example.com</li>
                                 </ul>
                             </dd>
-                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/service-user/change/appellant"> Change<span class="govuk-visually-hidden"> Appellant</span></a>
+                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/service-user/change/appellant"
+                                data-cy="change-appellant"> Change<span class="govuk-visually-hidden"> Appellant</span></a>
                             </dd>
                         </div>
                         <div class="govuk-summary-list__row appeal-agent"><dt class="govuk-summary-list__key"> Agent</dt>
@@ -2502,7 +2659,8 @@ exports[`appeal-details GET /:appealId should render an action link to the add l
                                     <li>test2@example.com</li>
                                 </ul>
                             </dd>
-                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/service-user/change/agent"> Change<span class="govuk-visually-hidden"> Agent</span></a>
+                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/service-user/change/agent"
+                                data-cy="change-agent"> Change<span class="govuk-visually-hidden"> Agent</span></a>
                             </dd>
                         </div>
                         <div class="govuk-summary-list__row govuk-summary-list__row--no-actions appeal-local-planning-authority"><dt class="govuk-summary-list__key"> LPA</dt>
@@ -2520,12 +2678,14 @@ exports[`appeal-details GET /:appealId should render an action link to the add l
                     <dl class="govuk-summary-list">
                         <div class="govuk-summary-list__row appeal-case-officer"><dt class="govuk-summary-list__key"> Case officer</dt>
                             <dd class="govuk-summary-list__value"></dd>
-                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/assign-user/case-officer"> Assign<span class="govuk-visually-hidden"> case officer</span></a>
+                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/assign-user/case-officer"
+                                data-cy="assign-case-officer"> Assign<span class="govuk-visually-hidden"> case officer</span></a>
                             </dd>
                         </div>
                         <div class="govuk-summary-list__row appeal-inspector"><dt class="govuk-summary-list__key"> Inspector</dt>
                             <dd class="govuk-summary-list__value"></dd>
-                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/assign-user/inspector"> Assign<span class="govuk-visually-hidden"> inspector</span></a>
+                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/assign-user/inspector"
+                                data-cy="assign-inspector"> Assign<span class="govuk-visually-hidden"> inspector</span></a>
                             </dd>
                         </div>
                     </dl>
@@ -2575,7 +2735,8 @@ exports[`appeal-details GET /:appealId should render the appellant case status a
                     <dl class="govuk-summary-list">
                         <div class="govuk-summary-list__row appeal-appeal-type"><dt class="govuk-summary-list__key"> Appeal type</dt>
                             <dd class="govuk-summary-list__value">Householder</dd>
-                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/change-appeal-type/appeal-type"> Change<span class="govuk-visually-hidden"> Appeal type</span></a>
+                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/change-appeal-type/appeal-type"
+                                data-cy="change-appeal-type"> Change<span class="govuk-visually-hidden"> Appeal type</span></a>
                             </dd>
                         </div>
                         <div class="govuk-summary-list__row govuk-summary-list__row--no-actions appeal-case-procedure"><dt class="govuk-summary-list__key"> Case procedure</dt>
@@ -2584,13 +2745,15 @@ exports[`appeal-details GET /:appealId should render the appellant case status a
                         <div class="govuk-summary-list__row appeal-linked-appeals"><dt class="govuk-summary-list__key"> Linked appeals</dt>
                             <dd class="govuk-summary-list__value"><span>No appeals</span>
                             </dd>
-                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/linked-appeals/add"> Add<span class="govuk-visually-hidden"> Linked appeals</span></a>
+                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/linked-appeals/add"
+                                data-cy="add-linked-appeal"> Add<span class="govuk-visually-hidden"> Linked appeals</span></a>
                             </dd>
                         </div>
                         <div class="govuk-summary-list__row appeal-other-appeals"><dt class="govuk-summary-list__key"> Related appeals</dt>
                             <dd class="govuk-summary-list__value"><span>No appeals</span>
                             </dd>
-                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/other-appeals/add"> Add<span class="govuk-visually-hidden"> Related appeals</span></a>
+                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/other-appeals/add"
+                                data-cy="add-related-appeals"> Add<span class="govuk-visually-hidden"> Related appeals</span></a>
                             </dd>
                         </div>
                         <div class="govuk-summary-list__row appeal-allocation-details"><dt class="govuk-summary-list__key"> Allocation level</dt>
@@ -2602,7 +2765,8 @@ exports[`appeal-details GET /:appealId should render the appellant case status a
                                     <li>Architecture design</li>
                                 </ul>
                             </dd>
-                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/allocation-details/allocation-level"> Change<span class="govuk-visually-hidden"> Allocation level</span></a>
+                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/allocation-details/allocation-level"
+                                data-cy="change-allocation-level"> Change<span class="govuk-visually-hidden"> Allocation level</span></a>
                             </dd>
                         </div>
                         <div class="govuk-summary-list__row govuk-summary-list__row--no-actions appeal-lpa-reference"><dt class="govuk-summary-list__key"> LPA application reference</dt>
@@ -2624,18 +2788,21 @@ exports[`appeal-details GET /:appealId should render the appellant case status a
                         <div class="govuk-summary-list__row appeal-lpa-inspector-access"><dt class="govuk-summary-list__key"> Inspection access (LPA answer)</dt>
                             <dd                             class="govuk-summary-list__value"><span>No answer provided</span>
                                 </dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/inspector-access/change/lpa"> Change<span class="govuk-visually-hidden"> inspection access (L P A answer)</span></a>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/inspector-access/change/lpa"
+                                    data-cy="change-inspection-access-lpa"> Change<span class="govuk-visually-hidden"> inspection access (L P A answer)</span></a>
                                 </dd>
                         </div>
                         <div class="govuk-summary-list__row appeal-appellant-inspector-access"><dt class="govuk-summary-list__key"> Inspection access (appellant answer)</dt>
                             <dd                             class="govuk-summary-list__value"><span>No</span>
                                 </dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/inspector-access/change/appellant"> Change<span class="govuk-visually-hidden"> inspection access (appellant answer)</span></a>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/inspector-access/change/appellant"
+                                    data-cy="change-inspection-access-appellant"> Change<span class="govuk-visually-hidden"> inspection access (appellant answer)</span></a>
                                 </dd>
                         </div>
                         <div class="govuk-summary-list__row appeal-neighbouring-site-is-affected"><dt class="govuk-summary-list__key"> Could a neighbouring site be affected?</dt>
                             <dd                             class="govuk-summary-list__value">Yes</dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/neighbouring-sites/change/affected"> Change<span class="govuk-visually-hidden"> could a neighbouring site be affected</span></a>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/neighbouring-sites/change/affected"
+                                    data-cy="change-neighbouuring-site-is-affected"> Change<span class="govuk-visually-hidden"> could a neighbouring site be affected</span></a>
                                 </dd>
                         </div>
                         <div class="govuk-summary-list__row appeal-neighbouring-sites-inspector"><dt class="govuk-summary-list__key"> Neighbouring sites (LPA)</dt>
@@ -2648,7 +2815,8 @@ exports[`appeal-details GET /:appealId should render the appellant case status a
                                     <ul class="govuk-summary-list__actions-list">
                                         <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/2/neighbouring-sites/manage"> Manage<span class="govuk-visually-hidden"> Neighbouring sites (L P A)</span></a>
                                         </li>
-                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/2/neighbouring-sites/add/lpa"> Add<span class="govuk-visually-hidden"> Neighbouring sites (LPA)</span></a>
+                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/2/neighbouring-sites/add/lpa"
+                                            data-cy="add-neighbouring-site-lpa"> Add<span class="govuk-visually-hidden"> Neighbouring sites (LPA)</span></a>
                                         </li>
                                     </ul>
                                 </dd>
@@ -2661,9 +2829,11 @@ exports[`appeal-details GET /:appealId should render the appellant case status a
                                 </dd>
                                 <dd class="govuk-summary-list__actions">
                                     <ul class="govuk-summary-list__actions-list">
-                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/2/neighbouring-sites/manage"> Manage<span class="govuk-visually-hidden"> Neighbouring sites (inspector and or third party request)</span></a>
+                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/2/neighbouring-sites/manage"
+                                            data-cy="manage-neighbouring-sites-inspector"> Manage<span class="govuk-visually-hidden"> Neighbouring sites (inspector and or third party request)</span></a>
                                         </li>
-                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/2/neighbouring-sites/add/back-office"> Add<span class="govuk-visually-hidden"> Neighbouring sites (inspector and or third party request)</span></a>
+                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/2/neighbouring-sites/add/back-office"
+                                            data-cy="add-neighbouring-sites-inspector"> Add<span class="govuk-visually-hidden"> Neighbouring sites (inspector and or third party request)</span></a>
                                         </li>
                                     </ul>
                                 </dd>
@@ -2671,19 +2841,22 @@ exports[`appeal-details GET /:appealId should render the appellant case status a
                         <div class="govuk-summary-list__row appeal-lpa-health-and-safety"><dt class="govuk-summary-list__key"> Potential safety risks (LPA answer)</dt>
                             <dd                             class="govuk-summary-list__value"><span>No answer provided</span>
                                 </dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/safety-risks/change/lpa"> Change<span class="govuk-visually-hidden"> potential safety risks (L P A answer)</span></a>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/safety-risks/change/lpa"
+                                    data-cy="change-lpa-health-and-safety"> Change<span class="govuk-visually-hidden"> potential safety risks (L P A answer)</span></a>
                                 </dd>
                         </div>
                         <div class="govuk-summary-list__row appeal-appellant-health-and-safety"><dt class="govuk-summary-list__key"> Potential safety risks (appellant answer)</dt>
                             <dd                             class="govuk-summary-list__value"><span>Yes</span>
                                 <br><span>Dogs on site</span>
                                 </dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/safety-risks/change/appellant"> Change<span class="govuk-visually-hidden"> potential safety risks (appellant answer)</span></a>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/safety-risks/change/appellant"
+                                    data-cy="change-appellant-case-health-and-safety"> Change<span class="govuk-visually-hidden"> potential safety risks (appellant answer)</span></a>
                                 </dd>
                         </div>
                         <div class="govuk-summary-list__row appeal-visit-type"><dt class="govuk-summary-list__key"> Visit type</dt>
                             <dd class="govuk-summary-list__value">Accompanied</dd>
-                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/site-visit/visit-booked"> Change<span class="govuk-visually-hidden"> visit type</span></a>
+                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/site-visit/visit-booked"
+                                data-cy="change-set-visit-type"> Change<span class="govuk-visually-hidden"> visit type</span></a>
                             </dd>
                         </div>
                     </dl>
@@ -2698,7 +2871,8 @@ exports[`appeal-details GET /:appealId should render the appellant case status a
                     <dl class="govuk-summary-list">
                         <div class="govuk-summary-list__row appeal-valid-date"><dt class="govuk-summary-list__key"> Valid date</dt>
                             <dd class="govuk-summary-list__value">23 May 2023</dd>
-                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/appellant-case/valid/date"> Change<span class="govuk-visually-hidden"> The date all case documentation was received and the appeal was valid</span></a>
+                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/appellant-case/valid/date"
+                                data-cy="change-valid-date"> Change<span class="govuk-visually-hidden"> The date all case documentation was received and the appeal was valid</span></a>
                             </dd>
                         </div>
                         <div class="govuk-summary-list__row govuk-summary-list__row--no-actions appeal-start-date"><dt class="govuk-summary-list__key"> Start date</dt>
@@ -2706,7 +2880,8 @@ exports[`appeal-details GET /:appealId should render the appellant case status a
                         </div>
                         <div class="govuk-summary-list__row appeal-lpa-questionnaire-due-date"><dt class="govuk-summary-list__key"> LPA questionnaire due</dt>
                             <dd class="govuk-summary-list__value">11 October 2023</dd>
-                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/appeal-timetables/lpa-questionnaire"> Change<span class="govuk-visually-hidden"> L P A questionnaire due</span></a>
+                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/appeal-timetables/lpa-questionnaire"
+                                data-cy="change-lpa-questionnaire-due-date"> Change<span class="govuk-visually-hidden"> L P A questionnaire due</span></a>
                             </dd>
                         </div>
                         <div class="govuk-summary-list__row appeal-site-visit"><dt class="govuk-summary-list__key"> Site visit</dt>
@@ -2716,7 +2891,8 @@ exports[`appeal-details GET /:appealId should render the appellant case status a
                                     <li>9:38am - 10:44am</li>
                                 </ul>
                             </dd>
-                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/site-visit/manage-visit"> Change<span class="govuk-visually-hidden"> site visit</span></a>
+                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/site-visit/manage-visit"
+                                data-cy="change-schedule-visit"> Change<span class="govuk-visually-hidden"> site visit</span></a>
                             </dd>
                         </div>
                     </dl>
@@ -2742,14 +2918,16 @@ exports[`appeal-details GET /:appealId should render the appellant case status a
                                 <th scope="row" class="govuk-table__header">Appellant case</th>
                                 <td class="govuk-table__cell">Incomplete</td>
                                 <td class="govuk-table__cell"></td>
-                                <td class="govuk-table__cell"><a href="/appeals-service/appeal-details/2/appellant-case" class="govuk-link">Review <span class="govuk-visually-hidden">appellant case</span></a>
+                                <td class="govuk-table__cell"><a href="/appeals-service/appeal-details/2/appellant-case" data-cy="review-appellant-case"
+                                    class="govuk-link">Review <span class="govuk-visually-hidden">appellant case</span></a>
                                 </td>
                             </tr>
                             <tr class="govuk-table__row">
                                 <th scope="row" class="govuk-table__header">LPA questionnaire</th>
                                 <td class="govuk-table__cell"></td>
                                 <td class="govuk-table__cell"></td>
-                                <td class="govuk-table__cell"><a href="/appeals-service/appeal-details/2/lpa-questionnaire/1" class="govuk-link">Review <span class="govuk-visually-hidden">L P A questionnaire</span></a>
+                                <td class="govuk-table__cell"><a href="/appeals-service/appeal-details/2/lpa-questionnaire/1" data-cy="review-lpa-questionnaire"
+                                    class="govuk-link">Review <span class="govuk-visually-hidden">L P A questionnaire</span></a>
                                 </td>
                             </tr>
                             <tr class="govuk-table__row">
@@ -2758,7 +2936,7 @@ exports[`appeal-details GET /:appealId should render the appellant case status a
                                 <td class="govuk-table__cell appeal-costs-appellant-due-date"></td>
                                 <td class="govuk-table__cell appeal-costs-appellant-actions">
                                     <ul class="govuk-summary-list__actions-list">
-                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/2/costs/appellant/select-document-type/1">Add</a>
+                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-appeallant" href="/appeals-service/appeal-details/2/costs/appellant/select-document-type/1">Add</a>
                                         </li>
                                     </ul>
                                 </td>
@@ -2769,7 +2947,7 @@ exports[`appeal-details GET /:appealId should render the appellant case status a
                                 <td class="govuk-table__cell appeal-costs-lpa-due-date"></td>
                                 <td class="govuk-table__cell appeal-costs-lpa-actions">
                                     <ul class="govuk-summary-list__actions-list">
-                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/2/costs/lpa/select-document-type/2">Add</a>
+                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-lpa" href="/appeals-service/appeal-details/2/costs/lpa/select-document-type/2">Add</a>
                                         </li>
                                     </ul>
                                 </td>
@@ -2780,7 +2958,7 @@ exports[`appeal-details GET /:appealId should render the appellant case status a
                                 <td class="govuk-table__cell appeal-costs-decision-due-date"></td>
                                 <td class="govuk-table__cell appeal-costs-decision-actions">
                                     <ul class="govuk-summary-list__actions-list">
-                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/2/costs/decision/upload-documents/3">Add</a>
+                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-decision" href="/appeals-service/appeal-details/2/costs/decision/upload-documents/3">Add</a>
                                         </li>
                                     </ul>
                                 </td>
@@ -2803,7 +2981,8 @@ exports[`appeal-details GET /:appealId should render the appellant case status a
                                     <li>test3@example.com</li>
                                 </ul>
                             </dd>
-                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/service-user/change/appellant"> Change<span class="govuk-visually-hidden"> Appellant</span></a>
+                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/service-user/change/appellant"
+                                data-cy="change-appellant"> Change<span class="govuk-visually-hidden"> Appellant</span></a>
                             </dd>
                         </div>
                         <div class="govuk-summary-list__row appeal-agent"><dt class="govuk-summary-list__key"> Agent</dt>
@@ -2813,7 +2992,8 @@ exports[`appeal-details GET /:appealId should render the appellant case status a
                                     <li>test2@example.com</li>
                                 </ul>
                             </dd>
-                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/service-user/change/agent"> Change<span class="govuk-visually-hidden"> Agent</span></a>
+                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/service-user/change/agent"
+                                data-cy="change-agent"> Change<span class="govuk-visually-hidden"> Agent</span></a>
                             </dd>
                         </div>
                         <div class="govuk-summary-list__row govuk-summary-list__row--no-actions appeal-local-planning-authority"><dt class="govuk-summary-list__key"> LPA</dt>
@@ -2831,12 +3011,14 @@ exports[`appeal-details GET /:appealId should render the appellant case status a
                     <dl class="govuk-summary-list">
                         <div class="govuk-summary-list__row appeal-case-officer"><dt class="govuk-summary-list__key"> Case officer</dt>
                             <dd class="govuk-summary-list__value"></dd>
-                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/assign-user/case-officer"> Assign<span class="govuk-visually-hidden"> case officer</span></a>
+                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/assign-user/case-officer"
+                                data-cy="assign-case-officer"> Assign<span class="govuk-visually-hidden"> case officer</span></a>
                             </dd>
                         </div>
                         <div class="govuk-summary-list__row appeal-inspector"><dt class="govuk-summary-list__key"> Inspector</dt>
                             <dd class="govuk-summary-list__value"></dd>
-                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/assign-user/inspector"> Assign<span class="govuk-visually-hidden"> inspector</span></a>
+                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/assign-user/inspector"
+                                data-cy="assign-inspector"> Assign<span class="govuk-visually-hidden"> inspector</span></a>
                             </dd>
                         </div>
                     </dl>
@@ -2886,7 +3068,8 @@ exports[`appeal-details GET /:appealId should render the appellant case status a
                     <dl class="govuk-summary-list">
                         <div class="govuk-summary-list__row appeal-appeal-type"><dt class="govuk-summary-list__key"> Appeal type</dt>
                             <dd class="govuk-summary-list__value">Householder</dd>
-                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/change-appeal-type/appeal-type"> Change<span class="govuk-visually-hidden"> Appeal type</span></a>
+                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/change-appeal-type/appeal-type"
+                                data-cy="change-appeal-type"> Change<span class="govuk-visually-hidden"> Appeal type</span></a>
                             </dd>
                         </div>
                         <div class="govuk-summary-list__row govuk-summary-list__row--no-actions appeal-case-procedure"><dt class="govuk-summary-list__key"> Case procedure</dt>
@@ -2895,13 +3078,15 @@ exports[`appeal-details GET /:appealId should render the appellant case status a
                         <div class="govuk-summary-list__row appeal-linked-appeals"><dt class="govuk-summary-list__key"> Linked appeals</dt>
                             <dd class="govuk-summary-list__value"><span>No appeals</span>
                             </dd>
-                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/linked-appeals/add"> Add<span class="govuk-visually-hidden"> Linked appeals</span></a>
+                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/linked-appeals/add"
+                                data-cy="add-linked-appeal"> Add<span class="govuk-visually-hidden"> Linked appeals</span></a>
                             </dd>
                         </div>
                         <div class="govuk-summary-list__row appeal-other-appeals"><dt class="govuk-summary-list__key"> Related appeals</dt>
                             <dd class="govuk-summary-list__value"><span>No appeals</span>
                             </dd>
-                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/other-appeals/add"> Add<span class="govuk-visually-hidden"> Related appeals</span></a>
+                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/other-appeals/add"
+                                data-cy="add-related-appeals"> Add<span class="govuk-visually-hidden"> Related appeals</span></a>
                             </dd>
                         </div>
                         <div class="govuk-summary-list__row appeal-allocation-details"><dt class="govuk-summary-list__key"> Allocation level</dt>
@@ -2913,7 +3098,8 @@ exports[`appeal-details GET /:appealId should render the appellant case status a
                                     <li>Architecture design</li>
                                 </ul>
                             </dd>
-                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/allocation-details/allocation-level"> Change<span class="govuk-visually-hidden"> Allocation level</span></a>
+                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/allocation-details/allocation-level"
+                                data-cy="change-allocation-level"> Change<span class="govuk-visually-hidden"> Allocation level</span></a>
                             </dd>
                         </div>
                         <div class="govuk-summary-list__row govuk-summary-list__row--no-actions appeal-lpa-reference"><dt class="govuk-summary-list__key"> LPA application reference</dt>
@@ -2935,18 +3121,21 @@ exports[`appeal-details GET /:appealId should render the appellant case status a
                         <div class="govuk-summary-list__row appeal-lpa-inspector-access"><dt class="govuk-summary-list__key"> Inspection access (LPA answer)</dt>
                             <dd                             class="govuk-summary-list__value"><span>No answer provided</span>
                                 </dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/inspector-access/change/lpa"> Change<span class="govuk-visually-hidden"> inspection access (L P A answer)</span></a>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/inspector-access/change/lpa"
+                                    data-cy="change-inspection-access-lpa"> Change<span class="govuk-visually-hidden"> inspection access (L P A answer)</span></a>
                                 </dd>
                         </div>
                         <div class="govuk-summary-list__row appeal-appellant-inspector-access"><dt class="govuk-summary-list__key"> Inspection access (appellant answer)</dt>
                             <dd                             class="govuk-summary-list__value"><span>No</span>
                                 </dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/inspector-access/change/appellant"> Change<span class="govuk-visually-hidden"> inspection access (appellant answer)</span></a>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/inspector-access/change/appellant"
+                                    data-cy="change-inspection-access-appellant"> Change<span class="govuk-visually-hidden"> inspection access (appellant answer)</span></a>
                                 </dd>
                         </div>
                         <div class="govuk-summary-list__row appeal-neighbouring-site-is-affected"><dt class="govuk-summary-list__key"> Could a neighbouring site be affected?</dt>
                             <dd                             class="govuk-summary-list__value">Yes</dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/neighbouring-sites/change/affected"> Change<span class="govuk-visually-hidden"> could a neighbouring site be affected</span></a>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/neighbouring-sites/change/affected"
+                                    data-cy="change-neighbouuring-site-is-affected"> Change<span class="govuk-visually-hidden"> could a neighbouring site be affected</span></a>
                                 </dd>
                         </div>
                         <div class="govuk-summary-list__row appeal-neighbouring-sites-inspector"><dt class="govuk-summary-list__key"> Neighbouring sites (LPA)</dt>
@@ -2959,7 +3148,8 @@ exports[`appeal-details GET /:appealId should render the appellant case status a
                                     <ul class="govuk-summary-list__actions-list">
                                         <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/2/neighbouring-sites/manage"> Manage<span class="govuk-visually-hidden"> Neighbouring sites (L P A)</span></a>
                                         </li>
-                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/2/neighbouring-sites/add/lpa"> Add<span class="govuk-visually-hidden"> Neighbouring sites (LPA)</span></a>
+                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/2/neighbouring-sites/add/lpa"
+                                            data-cy="add-neighbouring-site-lpa"> Add<span class="govuk-visually-hidden"> Neighbouring sites (LPA)</span></a>
                                         </li>
                                     </ul>
                                 </dd>
@@ -2972,9 +3162,11 @@ exports[`appeal-details GET /:appealId should render the appellant case status a
                                 </dd>
                                 <dd class="govuk-summary-list__actions">
                                     <ul class="govuk-summary-list__actions-list">
-                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/2/neighbouring-sites/manage"> Manage<span class="govuk-visually-hidden"> Neighbouring sites (inspector and or third party request)</span></a>
+                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/2/neighbouring-sites/manage"
+                                            data-cy="manage-neighbouring-sites-inspector"> Manage<span class="govuk-visually-hidden"> Neighbouring sites (inspector and or third party request)</span></a>
                                         </li>
-                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/2/neighbouring-sites/add/back-office"> Add<span class="govuk-visually-hidden"> Neighbouring sites (inspector and or third party request)</span></a>
+                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/2/neighbouring-sites/add/back-office"
+                                            data-cy="add-neighbouring-sites-inspector"> Add<span class="govuk-visually-hidden"> Neighbouring sites (inspector and or third party request)</span></a>
                                         </li>
                                     </ul>
                                 </dd>
@@ -2982,19 +3174,22 @@ exports[`appeal-details GET /:appealId should render the appellant case status a
                         <div class="govuk-summary-list__row appeal-lpa-health-and-safety"><dt class="govuk-summary-list__key"> Potential safety risks (LPA answer)</dt>
                             <dd                             class="govuk-summary-list__value"><span>No answer provided</span>
                                 </dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/safety-risks/change/lpa"> Change<span class="govuk-visually-hidden"> potential safety risks (L P A answer)</span></a>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/safety-risks/change/lpa"
+                                    data-cy="change-lpa-health-and-safety"> Change<span class="govuk-visually-hidden"> potential safety risks (L P A answer)</span></a>
                                 </dd>
                         </div>
                         <div class="govuk-summary-list__row appeal-appellant-health-and-safety"><dt class="govuk-summary-list__key"> Potential safety risks (appellant answer)</dt>
                             <dd                             class="govuk-summary-list__value"><span>Yes</span>
                                 <br><span>Dogs on site</span>
                                 </dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/safety-risks/change/appellant"> Change<span class="govuk-visually-hidden"> potential safety risks (appellant answer)</span></a>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/safety-risks/change/appellant"
+                                    data-cy="change-appellant-case-health-and-safety"> Change<span class="govuk-visually-hidden"> potential safety risks (appellant answer)</span></a>
                                 </dd>
                         </div>
                         <div class="govuk-summary-list__row appeal-visit-type"><dt class="govuk-summary-list__key"> Visit type</dt>
                             <dd class="govuk-summary-list__value">Accompanied</dd>
-                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/site-visit/visit-booked"> Change<span class="govuk-visually-hidden"> visit type</span></a>
+                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/site-visit/visit-booked"
+                                data-cy="change-set-visit-type"> Change<span class="govuk-visually-hidden"> visit type</span></a>
                             </dd>
                         </div>
                     </dl>
@@ -3009,7 +3204,8 @@ exports[`appeal-details GET /:appealId should render the appellant case status a
                     <dl class="govuk-summary-list">
                         <div class="govuk-summary-list__row appeal-valid-date"><dt class="govuk-summary-list__key"> Valid date</dt>
                             <dd class="govuk-summary-list__value">23 May 2023</dd>
-                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/appellant-case/valid/date"> Change<span class="govuk-visually-hidden"> The date all case documentation was received and the appeal was valid</span></a>
+                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/appellant-case/valid/date"
+                                data-cy="change-valid-date"> Change<span class="govuk-visually-hidden"> The date all case documentation was received and the appeal was valid</span></a>
                             </dd>
                         </div>
                         <div class="govuk-summary-list__row govuk-summary-list__row--no-actions appeal-start-date"><dt class="govuk-summary-list__key"> Start date</dt>
@@ -3017,7 +3213,8 @@ exports[`appeal-details GET /:appealId should render the appellant case status a
                         </div>
                         <div class="govuk-summary-list__row appeal-lpa-questionnaire-due-date"><dt class="govuk-summary-list__key"> LPA questionnaire due</dt>
                             <dd class="govuk-summary-list__value">11 October 2023</dd>
-                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/appeal-timetables/lpa-questionnaire"> Change<span class="govuk-visually-hidden"> L P A questionnaire due</span></a>
+                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/appeal-timetables/lpa-questionnaire"
+                                data-cy="change-lpa-questionnaire-due-date"> Change<span class="govuk-visually-hidden"> L P A questionnaire due</span></a>
                             </dd>
                         </div>
                         <div class="govuk-summary-list__row appeal-site-visit"><dt class="govuk-summary-list__key"> Site visit</dt>
@@ -3027,7 +3224,8 @@ exports[`appeal-details GET /:appealId should render the appellant case status a
                                     <li>9:38am - 10:44am</li>
                                 </ul>
                             </dd>
-                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/site-visit/manage-visit"> Change<span class="govuk-visually-hidden"> site visit</span></a>
+                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/site-visit/manage-visit"
+                                data-cy="change-schedule-visit"> Change<span class="govuk-visually-hidden"> site visit</span></a>
                             </dd>
                         </div>
                     </dl>
@@ -3053,14 +3251,16 @@ exports[`appeal-details GET /:appealId should render the appellant case status a
                                 <th scope="row" class="govuk-table__header">Appellant case</th>
                                 <td class="govuk-table__cell">Incomplete</td>
                                 <td class="govuk-table__cell"></td>
-                                <td class="govuk-table__cell"><a href="/appeals-service/appeal-details/2/appellant-case" class="govuk-link">Review <span class="govuk-visually-hidden">appellant case</span></a>
+                                <td class="govuk-table__cell"><a href="/appeals-service/appeal-details/2/appellant-case" data-cy="review-appellant-case"
+                                    class="govuk-link">Review <span class="govuk-visually-hidden">appellant case</span></a>
                                 </td>
                             </tr>
                             <tr class="govuk-table__row">
                                 <th scope="row" class="govuk-table__header">LPA questionnaire</th>
                                 <td class="govuk-table__cell"></td>
                                 <td class="govuk-table__cell"></td>
-                                <td class="govuk-table__cell"><a href="/appeals-service/appeal-details/2/lpa-questionnaire/1" class="govuk-link">Review <span class="govuk-visually-hidden">L P A questionnaire</span></a>
+                                <td class="govuk-table__cell"><a href="/appeals-service/appeal-details/2/lpa-questionnaire/1" data-cy="review-lpa-questionnaire"
+                                    class="govuk-link">Review <span class="govuk-visually-hidden">L P A questionnaire</span></a>
                                 </td>
                             </tr>
                             <tr class="govuk-table__row">
@@ -3069,7 +3269,7 @@ exports[`appeal-details GET /:appealId should render the appellant case status a
                                 <td class="govuk-table__cell appeal-costs-appellant-due-date"></td>
                                 <td class="govuk-table__cell appeal-costs-appellant-actions">
                                     <ul class="govuk-summary-list__actions-list">
-                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/2/costs/appellant/select-document-type/1">Add</a>
+                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-appeallant" href="/appeals-service/appeal-details/2/costs/appellant/select-document-type/1">Add</a>
                                         </li>
                                     </ul>
                                 </td>
@@ -3080,7 +3280,7 @@ exports[`appeal-details GET /:appealId should render the appellant case status a
                                 <td class="govuk-table__cell appeal-costs-lpa-due-date"></td>
                                 <td class="govuk-table__cell appeal-costs-lpa-actions">
                                     <ul class="govuk-summary-list__actions-list">
-                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/2/costs/lpa/select-document-type/2">Add</a>
+                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-lpa" href="/appeals-service/appeal-details/2/costs/lpa/select-document-type/2">Add</a>
                                         </li>
                                     </ul>
                                 </td>
@@ -3091,7 +3291,7 @@ exports[`appeal-details GET /:appealId should render the appellant case status a
                                 <td class="govuk-table__cell appeal-costs-decision-due-date"></td>
                                 <td class="govuk-table__cell appeal-costs-decision-actions">
                                     <ul class="govuk-summary-list__actions-list">
-                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/2/costs/decision/upload-documents/3">Add</a>
+                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-decision" href="/appeals-service/appeal-details/2/costs/decision/upload-documents/3">Add</a>
                                         </li>
                                     </ul>
                                 </td>
@@ -3114,7 +3314,8 @@ exports[`appeal-details GET /:appealId should render the appellant case status a
                                     <li>test3@example.com</li>
                                 </ul>
                             </dd>
-                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/service-user/change/appellant"> Change<span class="govuk-visually-hidden"> Appellant</span></a>
+                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/service-user/change/appellant"
+                                data-cy="change-appellant"> Change<span class="govuk-visually-hidden"> Appellant</span></a>
                             </dd>
                         </div>
                         <div class="govuk-summary-list__row appeal-agent"><dt class="govuk-summary-list__key"> Agent</dt>
@@ -3124,7 +3325,8 @@ exports[`appeal-details GET /:appealId should render the appellant case status a
                                     <li>test2@example.com</li>
                                 </ul>
                             </dd>
-                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/service-user/change/agent"> Change<span class="govuk-visually-hidden"> Agent</span></a>
+                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/service-user/change/agent"
+                                data-cy="change-agent"> Change<span class="govuk-visually-hidden"> Agent</span></a>
                             </dd>
                         </div>
                         <div class="govuk-summary-list__row govuk-summary-list__row--no-actions appeal-local-planning-authority"><dt class="govuk-summary-list__key"> LPA</dt>
@@ -3142,12 +3344,14 @@ exports[`appeal-details GET /:appealId should render the appellant case status a
                     <dl class="govuk-summary-list">
                         <div class="govuk-summary-list__row appeal-case-officer"><dt class="govuk-summary-list__key"> Case officer</dt>
                             <dd class="govuk-summary-list__value"></dd>
-                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/assign-user/case-officer"> Assign<span class="govuk-visually-hidden"> case officer</span></a>
+                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/assign-user/case-officer"
+                                data-cy="assign-case-officer"> Assign<span class="govuk-visually-hidden"> case officer</span></a>
                             </dd>
                         </div>
                         <div class="govuk-summary-list__row appeal-inspector"><dt class="govuk-summary-list__key"> Inspector</dt>
                             <dd class="govuk-summary-list__value"></dd>
-                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/assign-user/inspector"> Assign<span class="govuk-visually-hidden"> inspector</span></a>
+                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/assign-user/inspector"
+                                data-cy="assign-inspector"> Assign<span class="govuk-visually-hidden"> inspector</span></a>
                             </dd>
                         </div>
                     </dl>
@@ -3197,7 +3401,8 @@ exports[`appeal-details GET /:appealId should render the appellant case status a
                     <dl class="govuk-summary-list">
                         <div class="govuk-summary-list__row appeal-appeal-type"><dt class="govuk-summary-list__key"> Appeal type</dt>
                             <dd class="govuk-summary-list__value">Householder</dd>
-                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/change-appeal-type/appeal-type"> Change<span class="govuk-visually-hidden"> Appeal type</span></a>
+                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/change-appeal-type/appeal-type"
+                                data-cy="change-appeal-type"> Change<span class="govuk-visually-hidden"> Appeal type</span></a>
                             </dd>
                         </div>
                         <div class="govuk-summary-list__row govuk-summary-list__row--no-actions appeal-case-procedure"><dt class="govuk-summary-list__key"> Case procedure</dt>
@@ -3206,13 +3411,15 @@ exports[`appeal-details GET /:appealId should render the appellant case status a
                         <div class="govuk-summary-list__row appeal-linked-appeals"><dt class="govuk-summary-list__key"> Linked appeals</dt>
                             <dd class="govuk-summary-list__value"><span>No appeals</span>
                             </dd>
-                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/linked-appeals/add"> Add<span class="govuk-visually-hidden"> Linked appeals</span></a>
+                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/linked-appeals/add"
+                                data-cy="add-linked-appeal"> Add<span class="govuk-visually-hidden"> Linked appeals</span></a>
                             </dd>
                         </div>
                         <div class="govuk-summary-list__row appeal-other-appeals"><dt class="govuk-summary-list__key"> Related appeals</dt>
                             <dd class="govuk-summary-list__value"><span>No appeals</span>
                             </dd>
-                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/other-appeals/add"> Add<span class="govuk-visually-hidden"> Related appeals</span></a>
+                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/other-appeals/add"
+                                data-cy="add-related-appeals"> Add<span class="govuk-visually-hidden"> Related appeals</span></a>
                             </dd>
                         </div>
                         <div class="govuk-summary-list__row appeal-allocation-details"><dt class="govuk-summary-list__key"> Allocation level</dt>
@@ -3224,7 +3431,8 @@ exports[`appeal-details GET /:appealId should render the appellant case status a
                                     <li>Architecture design</li>
                                 </ul>
                             </dd>
-                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/allocation-details/allocation-level"> Change<span class="govuk-visually-hidden"> Allocation level</span></a>
+                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/allocation-details/allocation-level"
+                                data-cy="change-allocation-level"> Change<span class="govuk-visually-hidden"> Allocation level</span></a>
                             </dd>
                         </div>
                         <div class="govuk-summary-list__row govuk-summary-list__row--no-actions appeal-lpa-reference"><dt class="govuk-summary-list__key"> LPA application reference</dt>
@@ -3246,18 +3454,21 @@ exports[`appeal-details GET /:appealId should render the appellant case status a
                         <div class="govuk-summary-list__row appeal-lpa-inspector-access"><dt class="govuk-summary-list__key"> Inspection access (LPA answer)</dt>
                             <dd                             class="govuk-summary-list__value"><span>No answer provided</span>
                                 </dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/inspector-access/change/lpa"> Change<span class="govuk-visually-hidden"> inspection access (L P A answer)</span></a>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/inspector-access/change/lpa"
+                                    data-cy="change-inspection-access-lpa"> Change<span class="govuk-visually-hidden"> inspection access (L P A answer)</span></a>
                                 </dd>
                         </div>
                         <div class="govuk-summary-list__row appeal-appellant-inspector-access"><dt class="govuk-summary-list__key"> Inspection access (appellant answer)</dt>
                             <dd                             class="govuk-summary-list__value"><span>No</span>
                                 </dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/inspector-access/change/appellant"> Change<span class="govuk-visually-hidden"> inspection access (appellant answer)</span></a>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/inspector-access/change/appellant"
+                                    data-cy="change-inspection-access-appellant"> Change<span class="govuk-visually-hidden"> inspection access (appellant answer)</span></a>
                                 </dd>
                         </div>
                         <div class="govuk-summary-list__row appeal-neighbouring-site-is-affected"><dt class="govuk-summary-list__key"> Could a neighbouring site be affected?</dt>
                             <dd                             class="govuk-summary-list__value">Yes</dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/neighbouring-sites/change/affected"> Change<span class="govuk-visually-hidden"> could a neighbouring site be affected</span></a>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/neighbouring-sites/change/affected"
+                                    data-cy="change-neighbouuring-site-is-affected"> Change<span class="govuk-visually-hidden"> could a neighbouring site be affected</span></a>
                                 </dd>
                         </div>
                         <div class="govuk-summary-list__row appeal-neighbouring-sites-inspector"><dt class="govuk-summary-list__key"> Neighbouring sites (LPA)</dt>
@@ -3270,7 +3481,8 @@ exports[`appeal-details GET /:appealId should render the appellant case status a
                                     <ul class="govuk-summary-list__actions-list">
                                         <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/2/neighbouring-sites/manage"> Manage<span class="govuk-visually-hidden"> Neighbouring sites (L P A)</span></a>
                                         </li>
-                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/2/neighbouring-sites/add/lpa"> Add<span class="govuk-visually-hidden"> Neighbouring sites (LPA)</span></a>
+                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/2/neighbouring-sites/add/lpa"
+                                            data-cy="add-neighbouring-site-lpa"> Add<span class="govuk-visually-hidden"> Neighbouring sites (LPA)</span></a>
                                         </li>
                                     </ul>
                                 </dd>
@@ -3283,9 +3495,11 @@ exports[`appeal-details GET /:appealId should render the appellant case status a
                                 </dd>
                                 <dd class="govuk-summary-list__actions">
                                     <ul class="govuk-summary-list__actions-list">
-                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/2/neighbouring-sites/manage"> Manage<span class="govuk-visually-hidden"> Neighbouring sites (inspector and or third party request)</span></a>
+                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/2/neighbouring-sites/manage"
+                                            data-cy="manage-neighbouring-sites-inspector"> Manage<span class="govuk-visually-hidden"> Neighbouring sites (inspector and or third party request)</span></a>
                                         </li>
-                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/2/neighbouring-sites/add/back-office"> Add<span class="govuk-visually-hidden"> Neighbouring sites (inspector and or third party request)</span></a>
+                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/2/neighbouring-sites/add/back-office"
+                                            data-cy="add-neighbouring-sites-inspector"> Add<span class="govuk-visually-hidden"> Neighbouring sites (inspector and or third party request)</span></a>
                                         </li>
                                     </ul>
                                 </dd>
@@ -3293,19 +3507,22 @@ exports[`appeal-details GET /:appealId should render the appellant case status a
                         <div class="govuk-summary-list__row appeal-lpa-health-and-safety"><dt class="govuk-summary-list__key"> Potential safety risks (LPA answer)</dt>
                             <dd                             class="govuk-summary-list__value"><span>No answer provided</span>
                                 </dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/safety-risks/change/lpa"> Change<span class="govuk-visually-hidden"> potential safety risks (L P A answer)</span></a>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/safety-risks/change/lpa"
+                                    data-cy="change-lpa-health-and-safety"> Change<span class="govuk-visually-hidden"> potential safety risks (L P A answer)</span></a>
                                 </dd>
                         </div>
                         <div class="govuk-summary-list__row appeal-appellant-health-and-safety"><dt class="govuk-summary-list__key"> Potential safety risks (appellant answer)</dt>
                             <dd                             class="govuk-summary-list__value"><span>Yes</span>
                                 <br><span>Dogs on site</span>
                                 </dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/safety-risks/change/appellant"> Change<span class="govuk-visually-hidden"> potential safety risks (appellant answer)</span></a>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/safety-risks/change/appellant"
+                                    data-cy="change-appellant-case-health-and-safety"> Change<span class="govuk-visually-hidden"> potential safety risks (appellant answer)</span></a>
                                 </dd>
                         </div>
                         <div class="govuk-summary-list__row appeal-visit-type"><dt class="govuk-summary-list__key"> Visit type</dt>
                             <dd class="govuk-summary-list__value">Accompanied</dd>
-                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/site-visit/visit-booked"> Change<span class="govuk-visually-hidden"> visit type</span></a>
+                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/site-visit/visit-booked"
+                                data-cy="change-set-visit-type"> Change<span class="govuk-visually-hidden"> visit type</span></a>
                             </dd>
                         </div>
                     </dl>
@@ -3320,7 +3537,8 @@ exports[`appeal-details GET /:appealId should render the appellant case status a
                     <dl class="govuk-summary-list">
                         <div class="govuk-summary-list__row appeal-valid-date"><dt class="govuk-summary-list__key"> Valid date</dt>
                             <dd class="govuk-summary-list__value">23 May 2023</dd>
-                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/appellant-case/valid/date"> Change<span class="govuk-visually-hidden"> The date all case documentation was received and the appeal was valid</span></a>
+                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/appellant-case/valid/date"
+                                data-cy="change-valid-date"> Change<span class="govuk-visually-hidden"> The date all case documentation was received and the appeal was valid</span></a>
                             </dd>
                         </div>
                         <div class="govuk-summary-list__row govuk-summary-list__row--no-actions appeal-start-date"><dt class="govuk-summary-list__key"> Start date</dt>
@@ -3328,7 +3546,8 @@ exports[`appeal-details GET /:appealId should render the appellant case status a
                         </div>
                         <div class="govuk-summary-list__row appeal-lpa-questionnaire-due-date"><dt class="govuk-summary-list__key"> LPA questionnaire due</dt>
                             <dd class="govuk-summary-list__value">11 October 2023</dd>
-                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/appeal-timetables/lpa-questionnaire"> Change<span class="govuk-visually-hidden"> L P A questionnaire due</span></a>
+                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/appeal-timetables/lpa-questionnaire"
+                                data-cy="change-lpa-questionnaire-due-date"> Change<span class="govuk-visually-hidden"> L P A questionnaire due</span></a>
                             </dd>
                         </div>
                         <div class="govuk-summary-list__row appeal-site-visit"><dt class="govuk-summary-list__key"> Site visit</dt>
@@ -3338,7 +3557,8 @@ exports[`appeal-details GET /:appealId should render the appellant case status a
                                     <li>9:38am - 10:44am</li>
                                 </ul>
                             </dd>
-                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/site-visit/manage-visit"> Change<span class="govuk-visually-hidden"> site visit</span></a>
+                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/site-visit/manage-visit"
+                                data-cy="change-schedule-visit"> Change<span class="govuk-visually-hidden"> site visit</span></a>
                             </dd>
                         </div>
                     </dl>
@@ -3364,14 +3584,16 @@ exports[`appeal-details GET /:appealId should render the appellant case status a
                                 <th scope="row" class="govuk-table__header">Appellant case</th>
                                 <td class="govuk-table__cell">Overdue</td>
                                 <td class="govuk-table__cell"></td>
-                                <td class="govuk-table__cell"><a href="/appeals-service/appeal-details/2/appellant-case" class="govuk-link">Review <span class="govuk-visually-hidden">appellant case</span></a>
+                                <td class="govuk-table__cell"><a href="/appeals-service/appeal-details/2/appellant-case" data-cy="review-appellant-case"
+                                    class="govuk-link">Review <span class="govuk-visually-hidden">appellant case</span></a>
                                 </td>
                             </tr>
                             <tr class="govuk-table__row">
                                 <th scope="row" class="govuk-table__header">LPA questionnaire</th>
                                 <td class="govuk-table__cell"></td>
                                 <td class="govuk-table__cell"></td>
-                                <td class="govuk-table__cell"><a href="/appeals-service/appeal-details/2/lpa-questionnaire/1" class="govuk-link">Review <span class="govuk-visually-hidden">L P A questionnaire</span></a>
+                                <td class="govuk-table__cell"><a href="/appeals-service/appeal-details/2/lpa-questionnaire/1" data-cy="review-lpa-questionnaire"
+                                    class="govuk-link">Review <span class="govuk-visually-hidden">L P A questionnaire</span></a>
                                 </td>
                             </tr>
                             <tr class="govuk-table__row">
@@ -3380,7 +3602,7 @@ exports[`appeal-details GET /:appealId should render the appellant case status a
                                 <td class="govuk-table__cell appeal-costs-appellant-due-date"></td>
                                 <td class="govuk-table__cell appeal-costs-appellant-actions">
                                     <ul class="govuk-summary-list__actions-list">
-                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/2/costs/appellant/select-document-type/1">Add</a>
+                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-appeallant" href="/appeals-service/appeal-details/2/costs/appellant/select-document-type/1">Add</a>
                                         </li>
                                     </ul>
                                 </td>
@@ -3391,7 +3613,7 @@ exports[`appeal-details GET /:appealId should render the appellant case status a
                                 <td class="govuk-table__cell appeal-costs-lpa-due-date"></td>
                                 <td class="govuk-table__cell appeal-costs-lpa-actions">
                                     <ul class="govuk-summary-list__actions-list">
-                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/2/costs/lpa/select-document-type/2">Add</a>
+                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-lpa" href="/appeals-service/appeal-details/2/costs/lpa/select-document-type/2">Add</a>
                                         </li>
                                     </ul>
                                 </td>
@@ -3402,7 +3624,7 @@ exports[`appeal-details GET /:appealId should render the appellant case status a
                                 <td class="govuk-table__cell appeal-costs-decision-due-date"></td>
                                 <td class="govuk-table__cell appeal-costs-decision-actions">
                                     <ul class="govuk-summary-list__actions-list">
-                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/2/costs/decision/upload-documents/3">Add</a>
+                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-decision" href="/appeals-service/appeal-details/2/costs/decision/upload-documents/3">Add</a>
                                         </li>
                                     </ul>
                                 </td>
@@ -3425,7 +3647,8 @@ exports[`appeal-details GET /:appealId should render the appellant case status a
                                     <li>test3@example.com</li>
                                 </ul>
                             </dd>
-                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/service-user/change/appellant"> Change<span class="govuk-visually-hidden"> Appellant</span></a>
+                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/service-user/change/appellant"
+                                data-cy="change-appellant"> Change<span class="govuk-visually-hidden"> Appellant</span></a>
                             </dd>
                         </div>
                         <div class="govuk-summary-list__row appeal-agent"><dt class="govuk-summary-list__key"> Agent</dt>
@@ -3435,7 +3658,8 @@ exports[`appeal-details GET /:appealId should render the appellant case status a
                                     <li>test2@example.com</li>
                                 </ul>
                             </dd>
-                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/service-user/change/agent"> Change<span class="govuk-visually-hidden"> Agent</span></a>
+                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/service-user/change/agent"
+                                data-cy="change-agent"> Change<span class="govuk-visually-hidden"> Agent</span></a>
                             </dd>
                         </div>
                         <div class="govuk-summary-list__row govuk-summary-list__row--no-actions appeal-local-planning-authority"><dt class="govuk-summary-list__key"> LPA</dt>
@@ -3453,12 +3677,14 @@ exports[`appeal-details GET /:appealId should render the appellant case status a
                     <dl class="govuk-summary-list">
                         <div class="govuk-summary-list__row appeal-case-officer"><dt class="govuk-summary-list__key"> Case officer</dt>
                             <dd class="govuk-summary-list__value"></dd>
-                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/assign-user/case-officer"> Assign<span class="govuk-visually-hidden"> case officer</span></a>
+                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/assign-user/case-officer"
+                                data-cy="assign-case-officer"> Assign<span class="govuk-visually-hidden"> case officer</span></a>
                             </dd>
                         </div>
                         <div class="govuk-summary-list__row appeal-inspector"><dt class="govuk-summary-list__key"> Inspector</dt>
                             <dd class="govuk-summary-list__value"></dd>
-                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/assign-user/inspector"> Assign<span class="govuk-visually-hidden"> inspector</span></a>
+                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/assign-user/inspector"
+                                data-cy="assign-inspector"> Assign<span class="govuk-visually-hidden"> inspector</span></a>
                             </dd>
                         </div>
                     </dl>
@@ -3509,7 +3735,8 @@ exports[`appeal-details GET /:appealId should render the case reference for each
                     <dl class="govuk-summary-list">
                         <div class="govuk-summary-list__row appeal-appeal-type"><dt class="govuk-summary-list__key"> Appeal type</dt>
                             <dd class="govuk-summary-list__value">Householder</dd>
-                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/change-appeal-type/appeal-type"> Change<span class="govuk-visually-hidden"> Appeal type</span></a>
+                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/change-appeal-type/appeal-type"
+                                data-cy="change-appeal-type"> Change<span class="govuk-visually-hidden"> Appeal type</span></a>
                             </dd>
                         </div>
                         <div class="govuk-summary-list__row govuk-summary-list__row--no-actions appeal-case-procedure"><dt class="govuk-summary-list__key"> Case procedure</dt>
@@ -3518,17 +3745,22 @@ exports[`appeal-details GET /:appealId should render the case reference for each
                         <div class="govuk-summary-list__row appeal-linked-appeals"><dt class="govuk-summary-list__key"> Linked appeals</dt>
                             <dd class="govuk-summary-list__value">
                                 <ul class="govuk-list govuk-list--bullet">
-                                    <li><a href="/appeals-service/appeal-details/5449" class="govuk-link" aria-label="Appeal 7 8 4 7 0 6">784706</a> (Child)</li>
+                                    <li><a href="/appeals-service/appeal-details/5449" class="govuk-link" data-cy="linked-appeal-784706"
+                                        aria-label="Appeal 7 8 4 7 0 6">784706</a> (Child)</li>
                                     <li><span class="govuk-body">87326527</span> (Child)</li>
-                                    <li><a href="/appeals-service/appeal-details/5464" class="govuk-link" aria-label="Appeal 1 4 0 0 7 9">140079</a> (Lead)</li>
-                                    <li><a href="/appeals-service/appeal-details/5451" class="govuk-link" aria-label="Appeal 7 2 1 0 8 6">721086</a> (Child)</li>
+                                    <li><a href="/appeals-service/appeal-details/5464" class="govuk-link" data-cy="linked-appeal-140079"
+                                        aria-label="Appeal 1 4 0 0 7 9">140079</a> (Lead)</li>
+                                    <li><a href="/appeals-service/appeal-details/5451" class="govuk-link" data-cy="linked-appeal-721086"
+                                        aria-label="Appeal 7 2 1 0 8 6">721086</a> (Child)</li>
                                 </ul>
                             </dd>
                             <dd class="govuk-summary-list__actions">
                                 <ul class="govuk-summary-list__actions-list">
-                                    <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/linked-appeals/manage"> Manage<span class="govuk-visually-hidden"> Linked appeals</span></a>
+                                    <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/linked-appeals/manage"
+                                        data-cy="manage-linked-appeals"> Manage<span class="govuk-visually-hidden"> Linked appeals</span></a>
                                     </li>
-                                    <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/linked-appeals/add"> Add<span class="govuk-visually-hidden"> Linked appeals</span></a>
+                                    <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/linked-appeals/add"
+                                        data-cy="add-linked-appeal"> Add<span class="govuk-visually-hidden"> Linked appeals</span></a>
                                     </li>
                                 </ul>
                             </dd>
@@ -3536,7 +3768,8 @@ exports[`appeal-details GET /:appealId should render the case reference for each
                         <div class="govuk-summary-list__row appeal-other-appeals"><dt class="govuk-summary-list__key"> Related appeals</dt>
                             <dd class="govuk-summary-list__value"><span>No appeals</span>
                             </dd>
-                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/other-appeals/add"> Add<span class="govuk-visually-hidden"> Related appeals</span></a>
+                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/other-appeals/add"
+                                data-cy="add-related-appeals"> Add<span class="govuk-visually-hidden"> Related appeals</span></a>
                             </dd>
                         </div>
                         <div class="govuk-summary-list__row appeal-allocation-details"><dt class="govuk-summary-list__key"> Allocation level</dt>
@@ -3548,7 +3781,8 @@ exports[`appeal-details GET /:appealId should render the case reference for each
                                     <li>Architecture design</li>
                                 </ul>
                             </dd>
-                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/allocation-details/allocation-level"> Change<span class="govuk-visually-hidden"> Allocation level</span></a>
+                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/allocation-details/allocation-level"
+                                data-cy="change-allocation-level"> Change<span class="govuk-visually-hidden"> Allocation level</span></a>
                             </dd>
                         </div>
                         <div class="govuk-summary-list__row govuk-summary-list__row--no-actions appeal-lpa-reference"><dt class="govuk-summary-list__key"> LPA application reference</dt>
@@ -3570,18 +3804,21 @@ exports[`appeal-details GET /:appealId should render the case reference for each
                         <div class="govuk-summary-list__row appeal-lpa-inspector-access"><dt class="govuk-summary-list__key"> Inspection access (LPA answer)</dt>
                             <dd                             class="govuk-summary-list__value"><span>No answer provided</span>
                                 </dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/inspector-access/change/lpa"> Change<span class="govuk-visually-hidden"> inspection access (L P A answer)</span></a>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/inspector-access/change/lpa"
+                                    data-cy="change-inspection-access-lpa"> Change<span class="govuk-visually-hidden"> inspection access (L P A answer)</span></a>
                                 </dd>
                         </div>
                         <div class="govuk-summary-list__row appeal-appellant-inspector-access"><dt class="govuk-summary-list__key"> Inspection access (appellant answer)</dt>
                             <dd                             class="govuk-summary-list__value"><span>No</span>
                                 </dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/inspector-access/change/appellant"> Change<span class="govuk-visually-hidden"> inspection access (appellant answer)</span></a>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/inspector-access/change/appellant"
+                                    data-cy="change-inspection-access-appellant"> Change<span class="govuk-visually-hidden"> inspection access (appellant answer)</span></a>
                                 </dd>
                         </div>
                         <div class="govuk-summary-list__row appeal-neighbouring-site-is-affected"><dt class="govuk-summary-list__key"> Could a neighbouring site be affected?</dt>
                             <dd                             class="govuk-summary-list__value">Yes</dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/neighbouring-sites/change/affected"> Change<span class="govuk-visually-hidden"> could a neighbouring site be affected</span></a>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/neighbouring-sites/change/affected"
+                                    data-cy="change-neighbouuring-site-is-affected"> Change<span class="govuk-visually-hidden"> could a neighbouring site be affected</span></a>
                                 </dd>
                         </div>
                         <div class="govuk-summary-list__row appeal-neighbouring-sites-inspector"><dt class="govuk-summary-list__key"> Neighbouring sites (LPA)</dt>
@@ -3594,7 +3831,8 @@ exports[`appeal-details GET /:appealId should render the case reference for each
                                     <ul class="govuk-summary-list__actions-list">
                                         <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/neighbouring-sites/manage"> Manage<span class="govuk-visually-hidden"> Neighbouring sites (L P A)</span></a>
                                         </li>
-                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/neighbouring-sites/add/lpa"> Add<span class="govuk-visually-hidden"> Neighbouring sites (LPA)</span></a>
+                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/neighbouring-sites/add/lpa"
+                                            data-cy="add-neighbouring-site-lpa"> Add<span class="govuk-visually-hidden"> Neighbouring sites (LPA)</span></a>
                                         </li>
                                     </ul>
                                 </dd>
@@ -3607,9 +3845,11 @@ exports[`appeal-details GET /:appealId should render the case reference for each
                                 </dd>
                                 <dd class="govuk-summary-list__actions">
                                     <ul class="govuk-summary-list__actions-list">
-                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/neighbouring-sites/manage"> Manage<span class="govuk-visually-hidden"> Neighbouring sites (inspector and or third party request)</span></a>
+                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/neighbouring-sites/manage"
+                                            data-cy="manage-neighbouring-sites-inspector"> Manage<span class="govuk-visually-hidden"> Neighbouring sites (inspector and or third party request)</span></a>
                                         </li>
-                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/neighbouring-sites/add/back-office"> Add<span class="govuk-visually-hidden"> Neighbouring sites (inspector and or third party request)</span></a>
+                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/neighbouring-sites/add/back-office"
+                                            data-cy="add-neighbouring-sites-inspector"> Add<span class="govuk-visually-hidden"> Neighbouring sites (inspector and or third party request)</span></a>
                                         </li>
                                     </ul>
                                 </dd>
@@ -3617,19 +3857,22 @@ exports[`appeal-details GET /:appealId should render the case reference for each
                         <div class="govuk-summary-list__row appeal-lpa-health-and-safety"><dt class="govuk-summary-list__key"> Potential safety risks (LPA answer)</dt>
                             <dd                             class="govuk-summary-list__value"><span>No answer provided</span>
                                 </dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/safety-risks/change/lpa"> Change<span class="govuk-visually-hidden"> potential safety risks (L P A answer)</span></a>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/safety-risks/change/lpa"
+                                    data-cy="change-lpa-health-and-safety"> Change<span class="govuk-visually-hidden"> potential safety risks (L P A answer)</span></a>
                                 </dd>
                         </div>
                         <div class="govuk-summary-list__row appeal-appellant-health-and-safety"><dt class="govuk-summary-list__key"> Potential safety risks (appellant answer)</dt>
                             <dd                             class="govuk-summary-list__value"><span>Yes</span>
                                 <br><span>Dogs on site</span>
                                 </dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/safety-risks/change/appellant"> Change<span class="govuk-visually-hidden"> potential safety risks (appellant answer)</span></a>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/safety-risks/change/appellant"
+                                    data-cy="change-appellant-case-health-and-safety"> Change<span class="govuk-visually-hidden"> potential safety risks (appellant answer)</span></a>
                                 </dd>
                         </div>
                         <div class="govuk-summary-list__row appeal-visit-type"><dt class="govuk-summary-list__key"> Visit type</dt>
                             <dd class="govuk-summary-list__value">Accompanied</dd>
-                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/visit-booked"> Change<span class="govuk-visually-hidden"> visit type</span></a>
+                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/visit-booked"
+                                data-cy="change-set-visit-type"> Change<span class="govuk-visually-hidden"> visit type</span></a>
                             </dd>
                         </div>
                     </dl>
@@ -3644,7 +3887,8 @@ exports[`appeal-details GET /:appealId should render the case reference for each
                     <dl class="govuk-summary-list">
                         <div class="govuk-summary-list__row appeal-valid-date"><dt class="govuk-summary-list__key"> Valid date</dt>
                             <dd class="govuk-summary-list__value">23 May 2023</dd>
-                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/valid/date"> Change<span class="govuk-visually-hidden"> The date all case documentation was received and the appeal was valid</span></a>
+                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/valid/date"
+                                data-cy="change-valid-date"> Change<span class="govuk-visually-hidden"> The date all case documentation was received and the appeal was valid</span></a>
                             </dd>
                         </div>
                         <div class="govuk-summary-list__row appeal-start-date"><dt class="govuk-summary-list__key"> Start date</dt>
@@ -3654,7 +3898,8 @@ exports[`appeal-details GET /:appealId should render the case reference for each
                         </div>
                         <div class="govuk-summary-list__row appeal-lpa-questionnaire-due-date"><dt class="govuk-summary-list__key"> LPA questionnaire due</dt>
                             <dd class="govuk-summary-list__value">11 October 2023</dd>
-                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appeal-timetables/lpa-questionnaire"> Change<span class="govuk-visually-hidden"> L P A questionnaire due</span></a>
+                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appeal-timetables/lpa-questionnaire"
+                                data-cy="change-lpa-questionnaire-due-date"> Change<span class="govuk-visually-hidden"> L P A questionnaire due</span></a>
                             </dd>
                         </div>
                         <div class="govuk-summary-list__row appeal-site-visit"><dt class="govuk-summary-list__key"> Site visit</dt>
@@ -3664,7 +3909,8 @@ exports[`appeal-details GET /:appealId should render the case reference for each
                                     <li>9:38am - 10:44am</li>
                                 </ul>
                             </dd>
-                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/manage-visit"> Change<span class="govuk-visually-hidden"> site visit</span></a>
+                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/manage-visit"
+                                data-cy="change-schedule-visit"> Change<span class="govuk-visually-hidden"> site visit</span></a>
                             </dd>
                         </div>
                     </dl>
@@ -3690,7 +3936,8 @@ exports[`appeal-details GET /:appealId should render the case reference for each
                                 <th scope="row" class="govuk-table__header">Appellant case</th>
                                 <td class="govuk-table__cell">Received</td>
                                 <td class="govuk-table__cell">2 August 2024</td>
-                                <td class="govuk-table__cell"><a href="/appeals-service/appeal-details/1/appellant-case" class="govuk-link">Review <span class="govuk-visually-hidden">appellant case</span></a>
+                                <td class="govuk-table__cell"><a href="/appeals-service/appeal-details/1/appellant-case" data-cy="review-appellant-case"
+                                    class="govuk-link">Review <span class="govuk-visually-hidden">appellant case</span></a>
                                 </td>
                             </tr>
                             <tr class="govuk-table__row">
@@ -3705,7 +3952,7 @@ exports[`appeal-details GET /:appealId should render the case reference for each
                                 <td class="govuk-table__cell appeal-costs-appellant-due-date"></td>
                                 <td class="govuk-table__cell appeal-costs-appellant-actions">
                                     <ul class="govuk-summary-list__actions-list">
-                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/costs/appellant/select-document-type/1">Add</a>
+                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-appeallant" href="/appeals-service/appeal-details/1/costs/appellant/select-document-type/1">Add</a>
                                         </li>
                                     </ul>
                                 </td>
@@ -3716,7 +3963,7 @@ exports[`appeal-details GET /:appealId should render the case reference for each
                                 <td class="govuk-table__cell appeal-costs-lpa-due-date"></td>
                                 <td class="govuk-table__cell appeal-costs-lpa-actions">
                                     <ul class="govuk-summary-list__actions-list">
-                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/costs/lpa/select-document-type/2">Add</a>
+                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-lpa" href="/appeals-service/appeal-details/1/costs/lpa/select-document-type/2">Add</a>
                                         </li>
                                     </ul>
                                 </td>
@@ -3727,7 +3974,7 @@ exports[`appeal-details GET /:appealId should render the case reference for each
                                 <td class="govuk-table__cell appeal-costs-decision-due-date"></td>
                                 <td class="govuk-table__cell appeal-costs-decision-actions">
                                     <ul class="govuk-summary-list__actions-list">
-                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/costs/decision/upload-documents/3">Add</a>
+                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-decision" href="/appeals-service/appeal-details/1/costs/decision/upload-documents/3">Add</a>
                                         </li>
                                     </ul>
                                 </td>
@@ -3750,7 +3997,8 @@ exports[`appeal-details GET /:appealId should render the case reference for each
                                     <li>test3@example.com</li>
                                 </ul>
                             </dd>
-                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/service-user/change/appellant"> Change<span class="govuk-visually-hidden"> Appellant</span></a>
+                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/service-user/change/appellant"
+                                data-cy="change-appellant"> Change<span class="govuk-visually-hidden"> Appellant</span></a>
                             </dd>
                         </div>
                         <div class="govuk-summary-list__row appeal-agent"><dt class="govuk-summary-list__key"> Agent</dt>
@@ -3760,7 +4008,8 @@ exports[`appeal-details GET /:appealId should render the case reference for each
                                     <li>test2@example.com</li>
                                 </ul>
                             </dd>
-                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/service-user/change/agent"> Change<span class="govuk-visually-hidden"> Agent</span></a>
+                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/service-user/change/agent"
+                                data-cy="change-agent"> Change<span class="govuk-visually-hidden"> Agent</span></a>
                             </dd>
                         </div>
                         <div class="govuk-summary-list__row govuk-summary-list__row--no-actions appeal-local-planning-authority"><dt class="govuk-summary-list__key"> LPA</dt>
@@ -3778,12 +4027,14 @@ exports[`appeal-details GET /:appealId should render the case reference for each
                     <dl class="govuk-summary-list">
                         <div class="govuk-summary-list__row appeal-case-officer"><dt class="govuk-summary-list__key"> Case officer</dt>
                             <dd class="govuk-summary-list__value"></dd>
-                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/assign-user/case-officer"> Assign<span class="govuk-visually-hidden"> case officer</span></a>
+                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/assign-user/case-officer"
+                                data-cy="assign-case-officer"> Assign<span class="govuk-visually-hidden"> case officer</span></a>
                             </dd>
                         </div>
                         <div class="govuk-summary-list__row appeal-inspector"><dt class="govuk-summary-list__key"> Inspector</dt>
                             <dd class="govuk-summary-list__value"></dd>
-                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/assign-user/inspector"> Assign<span class="govuk-visually-hidden"> inspector</span></a>
+                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/assign-user/inspector"
+                                data-cy="assign-inspector"> Assign<span class="govuk-visually-hidden"> inspector</span></a>
                             </dd>
                         </div>
                     </dl>
@@ -3974,7 +4225,8 @@ exports[`appeal-details GET /:appealId should render the lead or child status af
                     <dl class="govuk-summary-list">
                         <div class="govuk-summary-list__row appeal-appeal-type"><dt class="govuk-summary-list__key"> Appeal type</dt>
                             <dd class="govuk-summary-list__value">Householder</dd>
-                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/change-appeal-type/appeal-type"> Change<span class="govuk-visually-hidden"> Appeal type</span></a>
+                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/change-appeal-type/appeal-type"
+                                data-cy="change-appeal-type"> Change<span class="govuk-visually-hidden"> Appeal type</span></a>
                             </dd>
                         </div>
                         <div class="govuk-summary-list__row govuk-summary-list__row--no-actions appeal-case-procedure"><dt class="govuk-summary-list__key"> Case procedure</dt>
@@ -3983,17 +4235,22 @@ exports[`appeal-details GET /:appealId should render the lead or child status af
                         <div class="govuk-summary-list__row appeal-linked-appeals"><dt class="govuk-summary-list__key"> Linked appeals</dt>
                             <dd class="govuk-summary-list__value">
                                 <ul class="govuk-list govuk-list--bullet">
-                                    <li><a href="/appeals-service/appeal-details/5449" class="govuk-link" aria-label="Appeal 7 8 4 7 0 6">784706</a> (Child)</li>
+                                    <li><a href="/appeals-service/appeal-details/5449" class="govuk-link" data-cy="linked-appeal-784706"
+                                        aria-label="Appeal 7 8 4 7 0 6">784706</a> (Child)</li>
                                     <li><span class="govuk-body">87326527</span> (Child)</li>
-                                    <li><a href="/appeals-service/appeal-details/5464" class="govuk-link" aria-label="Appeal 1 4 0 0 7 9">140079</a> (Lead)</li>
-                                    <li><a href="/appeals-service/appeal-details/5451" class="govuk-link" aria-label="Appeal 7 2 1 0 8 6">721086</a> (Child)</li>
+                                    <li><a href="/appeals-service/appeal-details/5464" class="govuk-link" data-cy="linked-appeal-140079"
+                                        aria-label="Appeal 1 4 0 0 7 9">140079</a> (Lead)</li>
+                                    <li><a href="/appeals-service/appeal-details/5451" class="govuk-link" data-cy="linked-appeal-721086"
+                                        aria-label="Appeal 7 2 1 0 8 6">721086</a> (Child)</li>
                                 </ul>
                             </dd>
                             <dd class="govuk-summary-list__actions">
                                 <ul class="govuk-summary-list__actions-list">
-                                    <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/linked-appeals/manage"> Manage<span class="govuk-visually-hidden"> Linked appeals</span></a>
+                                    <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/linked-appeals/manage"
+                                        data-cy="manage-linked-appeals"> Manage<span class="govuk-visually-hidden"> Linked appeals</span></a>
                                     </li>
-                                    <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/linked-appeals/add"> Add<span class="govuk-visually-hidden"> Linked appeals</span></a>
+                                    <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/linked-appeals/add"
+                                        data-cy="add-linked-appeal"> Add<span class="govuk-visually-hidden"> Linked appeals</span></a>
                                     </li>
                                 </ul>
                             </dd>
@@ -4001,7 +4258,8 @@ exports[`appeal-details GET /:appealId should render the lead or child status af
                         <div class="govuk-summary-list__row appeal-other-appeals"><dt class="govuk-summary-list__key"> Related appeals</dt>
                             <dd class="govuk-summary-list__value"><span>No appeals</span>
                             </dd>
-                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/other-appeals/add"> Add<span class="govuk-visually-hidden"> Related appeals</span></a>
+                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/other-appeals/add"
+                                data-cy="add-related-appeals"> Add<span class="govuk-visually-hidden"> Related appeals</span></a>
                             </dd>
                         </div>
                         <div class="govuk-summary-list__row appeal-allocation-details"><dt class="govuk-summary-list__key"> Allocation level</dt>
@@ -4013,7 +4271,8 @@ exports[`appeal-details GET /:appealId should render the lead or child status af
                                     <li>Architecture design</li>
                                 </ul>
                             </dd>
-                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/allocation-details/allocation-level"> Change<span class="govuk-visually-hidden"> Allocation level</span></a>
+                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/allocation-details/allocation-level"
+                                data-cy="change-allocation-level"> Change<span class="govuk-visually-hidden"> Allocation level</span></a>
                             </dd>
                         </div>
                         <div class="govuk-summary-list__row govuk-summary-list__row--no-actions appeal-lpa-reference"><dt class="govuk-summary-list__key"> LPA application reference</dt>
@@ -4035,18 +4294,21 @@ exports[`appeal-details GET /:appealId should render the lead or child status af
                         <div class="govuk-summary-list__row appeal-lpa-inspector-access"><dt class="govuk-summary-list__key"> Inspection access (LPA answer)</dt>
                             <dd                             class="govuk-summary-list__value"><span>No answer provided</span>
                                 </dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/inspector-access/change/lpa"> Change<span class="govuk-visually-hidden"> inspection access (L P A answer)</span></a>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/inspector-access/change/lpa"
+                                    data-cy="change-inspection-access-lpa"> Change<span class="govuk-visually-hidden"> inspection access (L P A answer)</span></a>
                                 </dd>
                         </div>
                         <div class="govuk-summary-list__row appeal-appellant-inspector-access"><dt class="govuk-summary-list__key"> Inspection access (appellant answer)</dt>
                             <dd                             class="govuk-summary-list__value"><span>No</span>
                                 </dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/inspector-access/change/appellant"> Change<span class="govuk-visually-hidden"> inspection access (appellant answer)</span></a>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/inspector-access/change/appellant"
+                                    data-cy="change-inspection-access-appellant"> Change<span class="govuk-visually-hidden"> inspection access (appellant answer)</span></a>
                                 </dd>
                         </div>
                         <div class="govuk-summary-list__row appeal-neighbouring-site-is-affected"><dt class="govuk-summary-list__key"> Could a neighbouring site be affected?</dt>
                             <dd                             class="govuk-summary-list__value">Yes</dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/neighbouring-sites/change/affected"> Change<span class="govuk-visually-hidden"> could a neighbouring site be affected</span></a>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/neighbouring-sites/change/affected"
+                                    data-cy="change-neighbouuring-site-is-affected"> Change<span class="govuk-visually-hidden"> could a neighbouring site be affected</span></a>
                                 </dd>
                         </div>
                         <div class="govuk-summary-list__row appeal-neighbouring-sites-inspector"><dt class="govuk-summary-list__key"> Neighbouring sites (LPA)</dt>
@@ -4059,7 +4321,8 @@ exports[`appeal-details GET /:appealId should render the lead or child status af
                                     <ul class="govuk-summary-list__actions-list">
                                         <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/neighbouring-sites/manage"> Manage<span class="govuk-visually-hidden"> Neighbouring sites (L P A)</span></a>
                                         </li>
-                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/neighbouring-sites/add/lpa"> Add<span class="govuk-visually-hidden"> Neighbouring sites (LPA)</span></a>
+                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/neighbouring-sites/add/lpa"
+                                            data-cy="add-neighbouring-site-lpa"> Add<span class="govuk-visually-hidden"> Neighbouring sites (LPA)</span></a>
                                         </li>
                                     </ul>
                                 </dd>
@@ -4072,9 +4335,11 @@ exports[`appeal-details GET /:appealId should render the lead or child status af
                                 </dd>
                                 <dd class="govuk-summary-list__actions">
                                     <ul class="govuk-summary-list__actions-list">
-                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/neighbouring-sites/manage"> Manage<span class="govuk-visually-hidden"> Neighbouring sites (inspector and or third party request)</span></a>
+                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/neighbouring-sites/manage"
+                                            data-cy="manage-neighbouring-sites-inspector"> Manage<span class="govuk-visually-hidden"> Neighbouring sites (inspector and or third party request)</span></a>
                                         </li>
-                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/neighbouring-sites/add/back-office"> Add<span class="govuk-visually-hidden"> Neighbouring sites (inspector and or third party request)</span></a>
+                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/neighbouring-sites/add/back-office"
+                                            data-cy="add-neighbouring-sites-inspector"> Add<span class="govuk-visually-hidden"> Neighbouring sites (inspector and or third party request)</span></a>
                                         </li>
                                     </ul>
                                 </dd>
@@ -4082,19 +4347,22 @@ exports[`appeal-details GET /:appealId should render the lead or child status af
                         <div class="govuk-summary-list__row appeal-lpa-health-and-safety"><dt class="govuk-summary-list__key"> Potential safety risks (LPA answer)</dt>
                             <dd                             class="govuk-summary-list__value"><span>No answer provided</span>
                                 </dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/safety-risks/change/lpa"> Change<span class="govuk-visually-hidden"> potential safety risks (L P A answer)</span></a>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/safety-risks/change/lpa"
+                                    data-cy="change-lpa-health-and-safety"> Change<span class="govuk-visually-hidden"> potential safety risks (L P A answer)</span></a>
                                 </dd>
                         </div>
                         <div class="govuk-summary-list__row appeal-appellant-health-and-safety"><dt class="govuk-summary-list__key"> Potential safety risks (appellant answer)</dt>
                             <dd                             class="govuk-summary-list__value"><span>Yes</span>
                                 <br><span>Dogs on site</span>
                                 </dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/safety-risks/change/appellant"> Change<span class="govuk-visually-hidden"> potential safety risks (appellant answer)</span></a>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/safety-risks/change/appellant"
+                                    data-cy="change-appellant-case-health-and-safety"> Change<span class="govuk-visually-hidden"> potential safety risks (appellant answer)</span></a>
                                 </dd>
                         </div>
                         <div class="govuk-summary-list__row appeal-visit-type"><dt class="govuk-summary-list__key"> Visit type</dt>
                             <dd class="govuk-summary-list__value">Accompanied</dd>
-                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/visit-booked"> Change<span class="govuk-visually-hidden"> visit type</span></a>
+                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/visit-booked"
+                                data-cy="change-set-visit-type"> Change<span class="govuk-visually-hidden"> visit type</span></a>
                             </dd>
                         </div>
                     </dl>
@@ -4109,7 +4377,8 @@ exports[`appeal-details GET /:appealId should render the lead or child status af
                     <dl class="govuk-summary-list">
                         <div class="govuk-summary-list__row appeal-valid-date"><dt class="govuk-summary-list__key"> Valid date</dt>
                             <dd class="govuk-summary-list__value">23 May 2023</dd>
-                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/valid/date"> Change<span class="govuk-visually-hidden"> The date all case documentation was received and the appeal was valid</span></a>
+                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/valid/date"
+                                data-cy="change-valid-date"> Change<span class="govuk-visually-hidden"> The date all case documentation was received and the appeal was valid</span></a>
                             </dd>
                         </div>
                         <div class="govuk-summary-list__row appeal-start-date"><dt class="govuk-summary-list__key"> Start date</dt>
@@ -4119,7 +4388,8 @@ exports[`appeal-details GET /:appealId should render the lead or child status af
                         </div>
                         <div class="govuk-summary-list__row appeal-lpa-questionnaire-due-date"><dt class="govuk-summary-list__key"> LPA questionnaire due</dt>
                             <dd class="govuk-summary-list__value">11 October 2023</dd>
-                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appeal-timetables/lpa-questionnaire"> Change<span class="govuk-visually-hidden"> L P A questionnaire due</span></a>
+                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appeal-timetables/lpa-questionnaire"
+                                data-cy="change-lpa-questionnaire-due-date"> Change<span class="govuk-visually-hidden"> L P A questionnaire due</span></a>
                             </dd>
                         </div>
                         <div class="govuk-summary-list__row appeal-site-visit"><dt class="govuk-summary-list__key"> Site visit</dt>
@@ -4129,7 +4399,8 @@ exports[`appeal-details GET /:appealId should render the lead or child status af
                                     <li>9:38am - 10:44am</li>
                                 </ul>
                             </dd>
-                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/manage-visit"> Change<span class="govuk-visually-hidden"> site visit</span></a>
+                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/manage-visit"
+                                data-cy="change-schedule-visit"> Change<span class="govuk-visually-hidden"> site visit</span></a>
                             </dd>
                         </div>
                     </dl>
@@ -4155,7 +4426,8 @@ exports[`appeal-details GET /:appealId should render the lead or child status af
                                 <th scope="row" class="govuk-table__header">Appellant case</th>
                                 <td class="govuk-table__cell">Received</td>
                                 <td class="govuk-table__cell">2 August 2024</td>
-                                <td class="govuk-table__cell"><a href="/appeals-service/appeal-details/1/appellant-case" class="govuk-link">Review <span class="govuk-visually-hidden">appellant case</span></a>
+                                <td class="govuk-table__cell"><a href="/appeals-service/appeal-details/1/appellant-case" data-cy="review-appellant-case"
+                                    class="govuk-link">Review <span class="govuk-visually-hidden">appellant case</span></a>
                                 </td>
                             </tr>
                             <tr class="govuk-table__row">
@@ -4170,7 +4442,7 @@ exports[`appeal-details GET /:appealId should render the lead or child status af
                                 <td class="govuk-table__cell appeal-costs-appellant-due-date"></td>
                                 <td class="govuk-table__cell appeal-costs-appellant-actions">
                                     <ul class="govuk-summary-list__actions-list">
-                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/costs/appellant/select-document-type/1">Add</a>
+                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-appeallant" href="/appeals-service/appeal-details/1/costs/appellant/select-document-type/1">Add</a>
                                         </li>
                                     </ul>
                                 </td>
@@ -4181,7 +4453,7 @@ exports[`appeal-details GET /:appealId should render the lead or child status af
                                 <td class="govuk-table__cell appeal-costs-lpa-due-date"></td>
                                 <td class="govuk-table__cell appeal-costs-lpa-actions">
                                     <ul class="govuk-summary-list__actions-list">
-                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/costs/lpa/select-document-type/2">Add</a>
+                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-lpa" href="/appeals-service/appeal-details/1/costs/lpa/select-document-type/2">Add</a>
                                         </li>
                                     </ul>
                                 </td>
@@ -4192,7 +4464,7 @@ exports[`appeal-details GET /:appealId should render the lead or child status af
                                 <td class="govuk-table__cell appeal-costs-decision-due-date"></td>
                                 <td class="govuk-table__cell appeal-costs-decision-actions">
                                     <ul class="govuk-summary-list__actions-list">
-                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/costs/decision/upload-documents/3">Add</a>
+                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-decision" href="/appeals-service/appeal-details/1/costs/decision/upload-documents/3">Add</a>
                                         </li>
                                     </ul>
                                 </td>
@@ -4215,7 +4487,8 @@ exports[`appeal-details GET /:appealId should render the lead or child status af
                                     <li>test3@example.com</li>
                                 </ul>
                             </dd>
-                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/service-user/change/appellant"> Change<span class="govuk-visually-hidden"> Appellant</span></a>
+                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/service-user/change/appellant"
+                                data-cy="change-appellant"> Change<span class="govuk-visually-hidden"> Appellant</span></a>
                             </dd>
                         </div>
                         <div class="govuk-summary-list__row appeal-agent"><dt class="govuk-summary-list__key"> Agent</dt>
@@ -4225,7 +4498,8 @@ exports[`appeal-details GET /:appealId should render the lead or child status af
                                     <li>test2@example.com</li>
                                 </ul>
                             </dd>
-                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/service-user/change/agent"> Change<span class="govuk-visually-hidden"> Agent</span></a>
+                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/service-user/change/agent"
+                                data-cy="change-agent"> Change<span class="govuk-visually-hidden"> Agent</span></a>
                             </dd>
                         </div>
                         <div class="govuk-summary-list__row govuk-summary-list__row--no-actions appeal-local-planning-authority"><dt class="govuk-summary-list__key"> LPA</dt>
@@ -4243,12 +4517,14 @@ exports[`appeal-details GET /:appealId should render the lead or child status af
                     <dl class="govuk-summary-list">
                         <div class="govuk-summary-list__row appeal-case-officer"><dt class="govuk-summary-list__key"> Case officer</dt>
                             <dd class="govuk-summary-list__value"></dd>
-                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/assign-user/case-officer"> Assign<span class="govuk-visually-hidden"> case officer</span></a>
+                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/assign-user/case-officer"
+                                data-cy="assign-case-officer"> Assign<span class="govuk-visually-hidden"> case officer</span></a>
                             </dd>
                         </div>
                         <div class="govuk-summary-list__row appeal-inspector"><dt class="govuk-summary-list__key"> Inspector</dt>
                             <dd class="govuk-summary-list__value"></dd>
-                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/assign-user/inspector"> Assign<span class="govuk-visually-hidden"> inspector</span></a>
+                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/assign-user/inspector"
+                                data-cy="assign-inspector"> Assign<span class="govuk-visually-hidden"> inspector</span></a>
                             </dd>
                         </div>
                     </dl>
@@ -4298,7 +4574,8 @@ exports[`appeal-details GET /:appealId should render the received appeal details
                     <dl class="govuk-summary-list">
                         <div class="govuk-summary-list__row appeal-appeal-type"><dt class="govuk-summary-list__key"> Appeal type</dt>
                             <dd class="govuk-summary-list__value">Householder</dd>
-                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/change-appeal-type/appeal-type"> Change<span class="govuk-visually-hidden"> Appeal type</span></a>
+                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/change-appeal-type/appeal-type"
+                                data-cy="change-appeal-type"> Change<span class="govuk-visually-hidden"> Appeal type</span></a>
                             </dd>
                         </div>
                         <div class="govuk-summary-list__row govuk-summary-list__row--no-actions appeal-case-procedure"><dt class="govuk-summary-list__key"> Case procedure</dt>
@@ -4307,13 +4584,15 @@ exports[`appeal-details GET /:appealId should render the received appeal details
                         <div class="govuk-summary-list__row appeal-linked-appeals"><dt class="govuk-summary-list__key"> Linked appeals</dt>
                             <dd class="govuk-summary-list__value"><span>No appeals</span>
                             </dd>
-                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/linked-appeals/add"> Add<span class="govuk-visually-hidden"> Linked appeals</span></a>
+                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/linked-appeals/add"
+                                data-cy="add-linked-appeal"> Add<span class="govuk-visually-hidden"> Linked appeals</span></a>
                             </dd>
                         </div>
                         <div class="govuk-summary-list__row appeal-other-appeals"><dt class="govuk-summary-list__key"> Related appeals</dt>
                             <dd class="govuk-summary-list__value"><span>No appeals</span>
                             </dd>
-                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/other-appeals/add"> Add<span class="govuk-visually-hidden"> Related appeals</span></a>
+                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/other-appeals/add"
+                                data-cy="add-related-appeals"> Add<span class="govuk-visually-hidden"> Related appeals</span></a>
                             </dd>
                         </div>
                         <div class="govuk-summary-list__row appeal-allocation-details"><dt class="govuk-summary-list__key"> Allocation level</dt>
@@ -4325,7 +4604,8 @@ exports[`appeal-details GET /:appealId should render the received appeal details
                                     <li>Architecture design</li>
                                 </ul>
                             </dd>
-                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/allocation-details/allocation-level"> Change<span class="govuk-visually-hidden"> Allocation level</span></a>
+                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/allocation-details/allocation-level"
+                                data-cy="change-allocation-level"> Change<span class="govuk-visually-hidden"> Allocation level</span></a>
                             </dd>
                         </div>
                         <div class="govuk-summary-list__row govuk-summary-list__row--no-actions appeal-lpa-reference"><dt class="govuk-summary-list__key"> LPA application reference</dt>
@@ -4347,18 +4627,21 @@ exports[`appeal-details GET /:appealId should render the received appeal details
                         <div class="govuk-summary-list__row appeal-lpa-inspector-access"><dt class="govuk-summary-list__key"> Inspection access (LPA answer)</dt>
                             <dd                             class="govuk-summary-list__value"><span>No answer provided</span>
                                 </dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/inspector-access/change/lpa"> Change<span class="govuk-visually-hidden"> inspection access (L P A answer)</span></a>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/inspector-access/change/lpa"
+                                    data-cy="change-inspection-access-lpa"> Change<span class="govuk-visually-hidden"> inspection access (L P A answer)</span></a>
                                 </dd>
                         </div>
                         <div class="govuk-summary-list__row appeal-appellant-inspector-access"><dt class="govuk-summary-list__key"> Inspection access (appellant answer)</dt>
                             <dd                             class="govuk-summary-list__value"><span>No</span>
                                 </dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/inspector-access/change/appellant"> Change<span class="govuk-visually-hidden"> inspection access (appellant answer)</span></a>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/inspector-access/change/appellant"
+                                    data-cy="change-inspection-access-appellant"> Change<span class="govuk-visually-hidden"> inspection access (appellant answer)</span></a>
                                 </dd>
                         </div>
                         <div class="govuk-summary-list__row appeal-neighbouring-site-is-affected"><dt class="govuk-summary-list__key"> Could a neighbouring site be affected?</dt>
                             <dd                             class="govuk-summary-list__value">Yes</dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/neighbouring-sites/change/affected"> Change<span class="govuk-visually-hidden"> could a neighbouring site be affected</span></a>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/neighbouring-sites/change/affected"
+                                    data-cy="change-neighbouuring-site-is-affected"> Change<span class="govuk-visually-hidden"> could a neighbouring site be affected</span></a>
                                 </dd>
                         </div>
                         <div class="govuk-summary-list__row appeal-neighbouring-sites-inspector"><dt class="govuk-summary-list__key"> Neighbouring sites (LPA)</dt>
@@ -4371,7 +4654,8 @@ exports[`appeal-details GET /:appealId should render the received appeal details
                                     <ul class="govuk-summary-list__actions-list">
                                         <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/neighbouring-sites/manage"> Manage<span class="govuk-visually-hidden"> Neighbouring sites (L P A)</span></a>
                                         </li>
-                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/neighbouring-sites/add/lpa"> Add<span class="govuk-visually-hidden"> Neighbouring sites (LPA)</span></a>
+                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/neighbouring-sites/add/lpa"
+                                            data-cy="add-neighbouring-site-lpa"> Add<span class="govuk-visually-hidden"> Neighbouring sites (LPA)</span></a>
                                         </li>
                                     </ul>
                                 </dd>
@@ -4384,9 +4668,11 @@ exports[`appeal-details GET /:appealId should render the received appeal details
                                 </dd>
                                 <dd class="govuk-summary-list__actions">
                                     <ul class="govuk-summary-list__actions-list">
-                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/neighbouring-sites/manage"> Manage<span class="govuk-visually-hidden"> Neighbouring sites (inspector and or third party request)</span></a>
+                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/neighbouring-sites/manage"
+                                            data-cy="manage-neighbouring-sites-inspector"> Manage<span class="govuk-visually-hidden"> Neighbouring sites (inspector and or third party request)</span></a>
                                         </li>
-                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/neighbouring-sites/add/back-office"> Add<span class="govuk-visually-hidden"> Neighbouring sites (inspector and or third party request)</span></a>
+                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/neighbouring-sites/add/back-office"
+                                            data-cy="add-neighbouring-sites-inspector"> Add<span class="govuk-visually-hidden"> Neighbouring sites (inspector and or third party request)</span></a>
                                         </li>
                                     </ul>
                                 </dd>
@@ -4394,19 +4680,22 @@ exports[`appeal-details GET /:appealId should render the received appeal details
                         <div class="govuk-summary-list__row appeal-lpa-health-and-safety"><dt class="govuk-summary-list__key"> Potential safety risks (LPA answer)</dt>
                             <dd                             class="govuk-summary-list__value"><span>No answer provided</span>
                                 </dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/safety-risks/change/lpa"> Change<span class="govuk-visually-hidden"> potential safety risks (L P A answer)</span></a>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/safety-risks/change/lpa"
+                                    data-cy="change-lpa-health-and-safety"> Change<span class="govuk-visually-hidden"> potential safety risks (L P A answer)</span></a>
                                 </dd>
                         </div>
                         <div class="govuk-summary-list__row appeal-appellant-health-and-safety"><dt class="govuk-summary-list__key"> Potential safety risks (appellant answer)</dt>
                             <dd                             class="govuk-summary-list__value"><span>Yes</span>
                                 <br><span>Dogs on site</span>
                                 </dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/safety-risks/change/appellant"> Change<span class="govuk-visually-hidden"> potential safety risks (appellant answer)</span></a>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/safety-risks/change/appellant"
+                                    data-cy="change-appellant-case-health-and-safety"> Change<span class="govuk-visually-hidden"> potential safety risks (appellant answer)</span></a>
                                 </dd>
                         </div>
                         <div class="govuk-summary-list__row appeal-visit-type"><dt class="govuk-summary-list__key"> Visit type</dt>
                             <dd class="govuk-summary-list__value">Accompanied</dd>
-                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/visit-booked"> Change<span class="govuk-visually-hidden"> visit type</span></a>
+                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/visit-booked"
+                                data-cy="change-set-visit-type"> Change<span class="govuk-visually-hidden"> visit type</span></a>
                             </dd>
                         </div>
                     </dl>
@@ -4421,7 +4710,8 @@ exports[`appeal-details GET /:appealId should render the received appeal details
                     <dl class="govuk-summary-list">
                         <div class="govuk-summary-list__row appeal-valid-date"><dt class="govuk-summary-list__key"> Valid date</dt>
                             <dd class="govuk-summary-list__value">23 May 2023</dd>
-                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/valid/date"> Change<span class="govuk-visually-hidden"> The date all case documentation was received and the appeal was valid</span></a>
+                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/valid/date"
+                                data-cy="change-valid-date"> Change<span class="govuk-visually-hidden"> The date all case documentation was received and the appeal was valid</span></a>
                             </dd>
                         </div>
                         <div class="govuk-summary-list__row appeal-start-date"><dt class="govuk-summary-list__key"> Start date</dt>
@@ -4431,7 +4721,8 @@ exports[`appeal-details GET /:appealId should render the received appeal details
                         </div>
                         <div class="govuk-summary-list__row appeal-lpa-questionnaire-due-date"><dt class="govuk-summary-list__key"> LPA questionnaire due</dt>
                             <dd class="govuk-summary-list__value">11 October 2023</dd>
-                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appeal-timetables/lpa-questionnaire"> Change<span class="govuk-visually-hidden"> L P A questionnaire due</span></a>
+                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appeal-timetables/lpa-questionnaire"
+                                data-cy="change-lpa-questionnaire-due-date"> Change<span class="govuk-visually-hidden"> L P A questionnaire due</span></a>
                             </dd>
                         </div>
                         <div class="govuk-summary-list__row appeal-site-visit"><dt class="govuk-summary-list__key"> Site visit</dt>
@@ -4441,7 +4732,8 @@ exports[`appeal-details GET /:appealId should render the received appeal details
                                     <li>9:38am - 10:44am</li>
                                 </ul>
                             </dd>
-                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/manage-visit"> Change<span class="govuk-visually-hidden"> site visit</span></a>
+                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/manage-visit"
+                                data-cy="change-schedule-visit"> Change<span class="govuk-visually-hidden"> site visit</span></a>
                             </dd>
                         </div>
                     </dl>
@@ -4467,7 +4759,8 @@ exports[`appeal-details GET /:appealId should render the received appeal details
                                 <th scope="row" class="govuk-table__header">Appellant case</th>
                                 <td class="govuk-table__cell">Received</td>
                                 <td class="govuk-table__cell">2 August 2024</td>
-                                <td class="govuk-table__cell"><a href="/appeals-service/appeal-details/1/appellant-case" class="govuk-link">Review <span class="govuk-visually-hidden">appellant case</span></a>
+                                <td class="govuk-table__cell"><a href="/appeals-service/appeal-details/1/appellant-case" data-cy="review-appellant-case"
+                                    class="govuk-link">Review <span class="govuk-visually-hidden">appellant case</span></a>
                                 </td>
                             </tr>
                             <tr class="govuk-table__row">
@@ -4482,7 +4775,7 @@ exports[`appeal-details GET /:appealId should render the received appeal details
                                 <td class="govuk-table__cell appeal-costs-appellant-due-date"></td>
                                 <td class="govuk-table__cell appeal-costs-appellant-actions">
                                     <ul class="govuk-summary-list__actions-list">
-                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/costs/appellant/select-document-type/1">Add</a>
+                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-appeallant" href="/appeals-service/appeal-details/1/costs/appellant/select-document-type/1">Add</a>
                                         </li>
                                     </ul>
                                 </td>
@@ -4493,7 +4786,7 @@ exports[`appeal-details GET /:appealId should render the received appeal details
                                 <td class="govuk-table__cell appeal-costs-lpa-due-date"></td>
                                 <td class="govuk-table__cell appeal-costs-lpa-actions">
                                     <ul class="govuk-summary-list__actions-list">
-                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/costs/lpa/select-document-type/2">Add</a>
+                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-lpa" href="/appeals-service/appeal-details/1/costs/lpa/select-document-type/2">Add</a>
                                         </li>
                                     </ul>
                                 </td>
@@ -4504,7 +4797,7 @@ exports[`appeal-details GET /:appealId should render the received appeal details
                                 <td class="govuk-table__cell appeal-costs-decision-due-date"></td>
                                 <td class="govuk-table__cell appeal-costs-decision-actions">
                                     <ul class="govuk-summary-list__actions-list">
-                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/costs/decision/upload-documents/3">Add</a>
+                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-decision" href="/appeals-service/appeal-details/1/costs/decision/upload-documents/3">Add</a>
                                         </li>
                                     </ul>
                                 </td>
@@ -4527,7 +4820,8 @@ exports[`appeal-details GET /:appealId should render the received appeal details
                                     <li>test3@example.com</li>
                                 </ul>
                             </dd>
-                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/service-user/change/appellant"> Change<span class="govuk-visually-hidden"> Appellant</span></a>
+                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/service-user/change/appellant"
+                                data-cy="change-appellant"> Change<span class="govuk-visually-hidden"> Appellant</span></a>
                             </dd>
                         </div>
                         <div class="govuk-summary-list__row appeal-agent"><dt class="govuk-summary-list__key"> Agent</dt>
@@ -4537,7 +4831,8 @@ exports[`appeal-details GET /:appealId should render the received appeal details
                                     <li>test2@example.com</li>
                                 </ul>
                             </dd>
-                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/service-user/change/agent"> Change<span class="govuk-visually-hidden"> Agent</span></a>
+                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/service-user/change/agent"
+                                data-cy="change-agent"> Change<span class="govuk-visually-hidden"> Agent</span></a>
                             </dd>
                         </div>
                         <div class="govuk-summary-list__row govuk-summary-list__row--no-actions appeal-local-planning-authority"><dt class="govuk-summary-list__key"> LPA</dt>
@@ -4555,12 +4850,14 @@ exports[`appeal-details GET /:appealId should render the received appeal details
                     <dl class="govuk-summary-list">
                         <div class="govuk-summary-list__row appeal-case-officer"><dt class="govuk-summary-list__key"> Case officer</dt>
                             <dd class="govuk-summary-list__value"></dd>
-                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/assign-user/case-officer"> Assign<span class="govuk-visually-hidden"> case officer</span></a>
+                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/assign-user/case-officer"
+                                data-cy="assign-case-officer"> Assign<span class="govuk-visually-hidden"> case officer</span></a>
                             </dd>
                         </div>
                         <div class="govuk-summary-list__row appeal-inspector"><dt class="govuk-summary-list__key"> Inspector</dt>
                             <dd class="govuk-summary-list__value"></dd>
-                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/assign-user/inspector"> Assign<span class="govuk-visually-hidden"> inspector</span></a>
+                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/assign-user/inspector"
+                                data-cy="assign-inspector"> Assign<span class="govuk-visually-hidden"> inspector</span></a>
                             </dd>
                         </div>
                     </dl>
@@ -4610,7 +4907,8 @@ exports[`appeal-details GET /:appealId should render the received appeal details
                     <dl class="govuk-summary-list">
                         <div class="govuk-summary-list__row appeal-appeal-type"><dt class="govuk-summary-list__key"> Appeal type</dt>
                             <dd class="govuk-summary-list__value">Householder</dd>
-                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/3/change-appeal-type/appeal-type"> Change<span class="govuk-visually-hidden"> Appeal type</span></a>
+                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/3/change-appeal-type/appeal-type"
+                                data-cy="change-appeal-type"> Change<span class="govuk-visually-hidden"> Appeal type</span></a>
                             </dd>
                         </div>
                         <div class="govuk-summary-list__row govuk-summary-list__row--no-actions appeal-case-procedure"><dt class="govuk-summary-list__key"> Case procedure</dt>
@@ -4619,13 +4917,15 @@ exports[`appeal-details GET /:appealId should render the received appeal details
                         <div class="govuk-summary-list__row appeal-linked-appeals"><dt class="govuk-summary-list__key"> Linked appeals</dt>
                             <dd class="govuk-summary-list__value"><span>No appeals</span>
                             </dd>
-                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/3/linked-appeals/add"> Add<span class="govuk-visually-hidden"> Linked appeals</span></a>
+                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/3/linked-appeals/add"
+                                data-cy="add-linked-appeal"> Add<span class="govuk-visually-hidden"> Linked appeals</span></a>
                             </dd>
                         </div>
                         <div class="govuk-summary-list__row appeal-other-appeals"><dt class="govuk-summary-list__key"> Related appeals</dt>
                             <dd class="govuk-summary-list__value"><span>No appeals</span>
                             </dd>
-                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/3/other-appeals/add"> Add<span class="govuk-visually-hidden"> Related appeals</span></a>
+                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/3/other-appeals/add"
+                                data-cy="add-related-appeals"> Add<span class="govuk-visually-hidden"> Related appeals</span></a>
                             </dd>
                         </div>
                         <div class="govuk-summary-list__row appeal-allocation-details"><dt class="govuk-summary-list__key"> Allocation level</dt>
@@ -4637,7 +4937,8 @@ exports[`appeal-details GET /:appealId should render the received appeal details
                                     <li>Architecture design</li>
                                 </ul>
                             </dd>
-                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/3/allocation-details/allocation-level"> Change<span class="govuk-visually-hidden"> Allocation level</span></a>
+                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/3/allocation-details/allocation-level"
+                                data-cy="change-allocation-level"> Change<span class="govuk-visually-hidden"> Allocation level</span></a>
                             </dd>
                         </div>
                         <div class="govuk-summary-list__row govuk-summary-list__row--no-actions appeal-lpa-reference"><dt class="govuk-summary-list__key"> LPA application reference</dt>
@@ -4659,18 +4960,21 @@ exports[`appeal-details GET /:appealId should render the received appeal details
                         <div class="govuk-summary-list__row appeal-lpa-inspector-access"><dt class="govuk-summary-list__key"> Inspection access (LPA answer)</dt>
                             <dd                             class="govuk-summary-list__value"><span>No answer provided</span>
                                 </dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/3/inspector-access/change/lpa"> Change<span class="govuk-visually-hidden"> inspection access (L P A answer)</span></a>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/3/inspector-access/change/lpa"
+                                    data-cy="change-inspection-access-lpa"> Change<span class="govuk-visually-hidden"> inspection access (L P A answer)</span></a>
                                 </dd>
                         </div>
                         <div class="govuk-summary-list__row appeal-appellant-inspector-access"><dt class="govuk-summary-list__key"> Inspection access (appellant answer)</dt>
                             <dd                             class="govuk-summary-list__value"><span>No</span>
                                 </dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/3/inspector-access/change/appellant"> Change<span class="govuk-visually-hidden"> inspection access (appellant answer)</span></a>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/3/inspector-access/change/appellant"
+                                    data-cy="change-inspection-access-appellant"> Change<span class="govuk-visually-hidden"> inspection access (appellant answer)</span></a>
                                 </dd>
                         </div>
                         <div class="govuk-summary-list__row appeal-neighbouring-site-is-affected"><dt class="govuk-summary-list__key"> Could a neighbouring site be affected?</dt>
                             <dd                             class="govuk-summary-list__value">Yes</dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/3/neighbouring-sites/change/affected"> Change<span class="govuk-visually-hidden"> could a neighbouring site be affected</span></a>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/3/neighbouring-sites/change/affected"
+                                    data-cy="change-neighbouuring-site-is-affected"> Change<span class="govuk-visually-hidden"> could a neighbouring site be affected</span></a>
                                 </dd>
                         </div>
                         <div class="govuk-summary-list__row appeal-neighbouring-sites-inspector"><dt class="govuk-summary-list__key"> Neighbouring sites (LPA)</dt>
@@ -4683,7 +4987,8 @@ exports[`appeal-details GET /:appealId should render the received appeal details
                                     <ul class="govuk-summary-list__actions-list">
                                         <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/3/neighbouring-sites/manage"> Manage<span class="govuk-visually-hidden"> Neighbouring sites (L P A)</span></a>
                                         </li>
-                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/3/neighbouring-sites/add/lpa"> Add<span class="govuk-visually-hidden"> Neighbouring sites (LPA)</span></a>
+                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/3/neighbouring-sites/add/lpa"
+                                            data-cy="add-neighbouring-site-lpa"> Add<span class="govuk-visually-hidden"> Neighbouring sites (LPA)</span></a>
                                         </li>
                                     </ul>
                                 </dd>
@@ -4696,9 +5001,11 @@ exports[`appeal-details GET /:appealId should render the received appeal details
                                 </dd>
                                 <dd class="govuk-summary-list__actions">
                                     <ul class="govuk-summary-list__actions-list">
-                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/3/neighbouring-sites/manage"> Manage<span class="govuk-visually-hidden"> Neighbouring sites (inspector and or third party request)</span></a>
+                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/3/neighbouring-sites/manage"
+                                            data-cy="manage-neighbouring-sites-inspector"> Manage<span class="govuk-visually-hidden"> Neighbouring sites (inspector and or third party request)</span></a>
                                         </li>
-                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/3/neighbouring-sites/add/back-office"> Add<span class="govuk-visually-hidden"> Neighbouring sites (inspector and or third party request)</span></a>
+                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/3/neighbouring-sites/add/back-office"
+                                            data-cy="add-neighbouring-sites-inspector"> Add<span class="govuk-visually-hidden"> Neighbouring sites (inspector and or third party request)</span></a>
                                         </li>
                                     </ul>
                                 </dd>
@@ -4706,19 +5013,22 @@ exports[`appeal-details GET /:appealId should render the received appeal details
                         <div class="govuk-summary-list__row appeal-lpa-health-and-safety"><dt class="govuk-summary-list__key"> Potential safety risks (LPA answer)</dt>
                             <dd                             class="govuk-summary-list__value"><span>No answer provided</span>
                                 </dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/3/safety-risks/change/lpa"> Change<span class="govuk-visually-hidden"> potential safety risks (L P A answer)</span></a>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/3/safety-risks/change/lpa"
+                                    data-cy="change-lpa-health-and-safety"> Change<span class="govuk-visually-hidden"> potential safety risks (L P A answer)</span></a>
                                 </dd>
                         </div>
                         <div class="govuk-summary-list__row appeal-appellant-health-and-safety"><dt class="govuk-summary-list__key"> Potential safety risks (appellant answer)</dt>
                             <dd                             class="govuk-summary-list__value"><span>Yes</span>
                                 <br><span>Dogs on site</span>
                                 </dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/3/safety-risks/change/appellant"> Change<span class="govuk-visually-hidden"> potential safety risks (appellant answer)</span></a>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/3/safety-risks/change/appellant"
+                                    data-cy="change-appellant-case-health-and-safety"> Change<span class="govuk-visually-hidden"> potential safety risks (appellant answer)</span></a>
                                 </dd>
                         </div>
                         <div class="govuk-summary-list__row appeal-visit-type"><dt class="govuk-summary-list__key"> Visit type</dt>
                             <dd class="govuk-summary-list__value">Accompanied</dd>
-                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/3/site-visit/visit-booked"> Change<span class="govuk-visually-hidden"> visit type</span></a>
+                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/3/site-visit/visit-booked"
+                                data-cy="change-set-visit-type"> Change<span class="govuk-visually-hidden"> visit type</span></a>
                             </dd>
                         </div>
                     </dl>
@@ -4733,7 +5043,8 @@ exports[`appeal-details GET /:appealId should render the received appeal details
                     <dl class="govuk-summary-list">
                         <div class="govuk-summary-list__row appeal-valid-date"><dt class="govuk-summary-list__key"> Valid date</dt>
                             <dd class="govuk-summary-list__value">23 May 2023</dd>
-                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/3/appellant-case/valid/date"> Change<span class="govuk-visually-hidden"> The date all case documentation was received and the appeal was valid</span></a>
+                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/3/appellant-case/valid/date"
+                                data-cy="change-valid-date"> Change<span class="govuk-visually-hidden"> The date all case documentation was received and the appeal was valid</span></a>
                             </dd>
                         </div>
                         <div class="govuk-summary-list__row appeal-start-date"><dt class="govuk-summary-list__key"> Start date</dt>
@@ -4743,7 +5054,8 @@ exports[`appeal-details GET /:appealId should render the received appeal details
                         </div>
                         <div class="govuk-summary-list__row appeal-lpa-questionnaire-due-date"><dt class="govuk-summary-list__key"> LPA questionnaire due</dt>
                             <dd class="govuk-summary-list__value">11 October 2023</dd>
-                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/3/appeal-timetables/lpa-questionnaire"> Change<span class="govuk-visually-hidden"> L P A questionnaire due</span></a>
+                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/3/appeal-timetables/lpa-questionnaire"
+                                data-cy="change-lpa-questionnaire-due-date"> Change<span class="govuk-visually-hidden"> L P A questionnaire due</span></a>
                             </dd>
                         </div>
                         <div class="govuk-summary-list__row appeal-site-visit"><dt class="govuk-summary-list__key"> Site visit</dt>
@@ -4753,7 +5065,8 @@ exports[`appeal-details GET /:appealId should render the received appeal details
                                     <li>9:38am - 10:44am</li>
                                 </ul>
                             </dd>
-                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/3/site-visit/manage-visit"> Change<span class="govuk-visually-hidden"> site visit</span></a>
+                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/3/site-visit/manage-visit"
+                                data-cy="change-schedule-visit"> Change<span class="govuk-visually-hidden"> site visit</span></a>
                             </dd>
                         </div>
                     </dl>
@@ -4779,7 +5092,8 @@ exports[`appeal-details GET /:appealId should render the received appeal details
                                 <th scope="row" class="govuk-table__header">Appellant case</th>
                                 <td class="govuk-table__cell">Received</td>
                                 <td class="govuk-table__cell">2 August 2024</td>
-                                <td class="govuk-table__cell"><a href="/appeals-service/appeal-details/3/appellant-case" class="govuk-link">Review <span class="govuk-visually-hidden">appellant case</span></a>
+                                <td class="govuk-table__cell"><a href="/appeals-service/appeal-details/3/appellant-case" data-cy="review-appellant-case"
+                                    class="govuk-link">Review <span class="govuk-visually-hidden">appellant case</span></a>
                                 </td>
                             </tr>
                             <tr class="govuk-table__row">
@@ -4794,7 +5108,7 @@ exports[`appeal-details GET /:appealId should render the received appeal details
                                 <td class="govuk-table__cell appeal-costs-appellant-due-date"></td>
                                 <td class="govuk-table__cell appeal-costs-appellant-actions">
                                     <ul class="govuk-summary-list__actions-list">
-                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/3/costs/appellant/select-document-type/1">Add</a>
+                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-appeallant" href="/appeals-service/appeal-details/3/costs/appellant/select-document-type/1">Add</a>
                                         </li>
                                     </ul>
                                 </td>
@@ -4805,7 +5119,7 @@ exports[`appeal-details GET /:appealId should render the received appeal details
                                 <td class="govuk-table__cell appeal-costs-lpa-due-date"></td>
                                 <td class="govuk-table__cell appeal-costs-lpa-actions">
                                     <ul class="govuk-summary-list__actions-list">
-                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/3/costs/lpa/select-document-type/2">Add</a>
+                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-lpa" href="/appeals-service/appeal-details/3/costs/lpa/select-document-type/2">Add</a>
                                         </li>
                                     </ul>
                                 </td>
@@ -4816,7 +5130,7 @@ exports[`appeal-details GET /:appealId should render the received appeal details
                                 <td class="govuk-table__cell appeal-costs-decision-due-date"></td>
                                 <td class="govuk-table__cell appeal-costs-decision-actions">
                                     <ul class="govuk-summary-list__actions-list">
-                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/3/costs/decision/upload-documents/3">Add</a>
+                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-decision" href="/appeals-service/appeal-details/3/costs/decision/upload-documents/3">Add</a>
                                         </li>
                                     </ul>
                                 </td>
@@ -4839,7 +5153,8 @@ exports[`appeal-details GET /:appealId should render the received appeal details
                                     <li>test3@example.com</li>
                                 </ul>
                             </dd>
-                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/3/service-user/change/appellant"> Change<span class="govuk-visually-hidden"> Appellant</span></a>
+                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/3/service-user/change/appellant"
+                                data-cy="change-appellant"> Change<span class="govuk-visually-hidden"> Appellant</span></a>
                             </dd>
                         </div>
                         <div class="govuk-summary-list__row appeal-agent"><dt class="govuk-summary-list__key"> Agent</dt>
@@ -4849,7 +5164,8 @@ exports[`appeal-details GET /:appealId should render the received appeal details
                                     <li>test2@example.com</li>
                                 </ul>
                             </dd>
-                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/3/service-user/change/agent"> Change<span class="govuk-visually-hidden"> Agent</span></a>
+                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/3/service-user/change/agent"
+                                data-cy="change-agent"> Change<span class="govuk-visually-hidden"> Agent</span></a>
                             </dd>
                         </div>
                         <div class="govuk-summary-list__row govuk-summary-list__row--no-actions appeal-local-planning-authority"><dt class="govuk-summary-list__key"> LPA</dt>
@@ -4867,12 +5183,14 @@ exports[`appeal-details GET /:appealId should render the received appeal details
                     <dl class="govuk-summary-list">
                         <div class="govuk-summary-list__row appeal-case-officer"><dt class="govuk-summary-list__key"> Case officer</dt>
                             <dd class="govuk-summary-list__value"></dd>
-                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/3/assign-user/case-officer"> Assign<span class="govuk-visually-hidden"> case officer</span></a>
+                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/3/assign-user/case-officer"
+                                data-cy="assign-case-officer"> Assign<span class="govuk-visually-hidden"> case officer</span></a>
                             </dd>
                         </div>
                         <div class="govuk-summary-list__row appeal-inspector"><dt class="govuk-summary-list__key"> Inspector</dt>
                             <dd class="govuk-summary-list__value"></dd>
-                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/3/assign-user/inspector"> Assign<span class="govuk-visually-hidden"> inspector</span></a>
+                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/3/assign-user/inspector"
+                                data-cy="assign-inspector"> Assign<span class="govuk-visually-hidden"> inspector</span></a>
                             </dd>
                         </div>
                     </dl>
@@ -4923,7 +5241,8 @@ exports[`appeal-details GET /:appealId should render the received appeal details
                     <dl class="govuk-summary-list">
                         <div class="govuk-summary-list__row appeal-appeal-type"><dt class="govuk-summary-list__key"> Appeal type</dt>
                             <dd class="govuk-summary-list__value">Householder</dd>
-                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/change-appeal-type/appeal-type"> Change<span class="govuk-visually-hidden"> Appeal type</span></a>
+                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/change-appeal-type/appeal-type"
+                                data-cy="change-appeal-type"> Change<span class="govuk-visually-hidden"> Appeal type</span></a>
                             </dd>
                         </div>
                         <div class="govuk-summary-list__row govuk-summary-list__row--no-actions appeal-case-procedure"><dt class="govuk-summary-list__key"> Case procedure</dt>
@@ -4932,14 +5251,17 @@ exports[`appeal-details GET /:appealId should render the received appeal details
                         <div class="govuk-summary-list__row appeal-linked-appeals"><dt class="govuk-summary-list__key"> Linked appeals</dt>
                             <dd class="govuk-summary-list__value">
                                 <ul class="govuk-list govuk-list--bullet">
-                                    <li><a href="/appeals-service/appeal-details/1" class="govuk-link" aria-label="Appeal 7 2 5 2 8 4">725284</a> (Child)</li>
+                                    <li><a href="/appeals-service/appeal-details/1" class="govuk-link" data-cy="linked-appeal-725284"
+                                        aria-label="Appeal 7 2 5 2 8 4">725284</a> (Child)</li>
                                 </ul>
                             </dd>
                             <dd class="govuk-summary-list__actions">
                                 <ul class="govuk-summary-list__actions-list">
-                                    <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/2/linked-appeals/manage"> Manage<span class="govuk-visually-hidden"> Linked appeals</span></a>
+                                    <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/2/linked-appeals/manage"
+                                        data-cy="manage-linked-appeals"> Manage<span class="govuk-visually-hidden"> Linked appeals</span></a>
                                     </li>
-                                    <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/2/linked-appeals/add"> Add<span class="govuk-visually-hidden"> Linked appeals</span></a>
+                                    <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/2/linked-appeals/add"
+                                        data-cy="add-linked-appeal"> Add<span class="govuk-visually-hidden"> Linked appeals</span></a>
                                     </li>
                                 </ul>
                             </dd>
@@ -4947,15 +5269,18 @@ exports[`appeal-details GET /:appealId should render the received appeal details
                         <div class="govuk-summary-list__row appeal-other-appeals"><dt class="govuk-summary-list__key"> Related appeals</dt>
                             <dd class="govuk-summary-list__value">
                                 <ul class="govuk-list govuk-list--bullet">
-                                    <li><a href="/appeals-service/appeal-details/3" class="govuk-link" aria-label="Appeal 7 6 5 4 1 3">765413</a>
+                                    <li><a href="/appeals-service/appeal-details/3" class="govuk-link" data-cy="related-appeal-765413"
+                                        aria-label="Appeal 7 6 5 4 1 3">765413</a>
                                     </li>
                                 </ul>
                             </dd>
                             <dd class="govuk-summary-list__actions">
                                 <ul class="govuk-summary-list__actions-list">
-                                    <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/2/other-appeals/manage"> Manage<span class="govuk-visually-hidden"> Related appeals</span></a>
+                                    <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/2/other-appeals/manage"
+                                        data-cy="manage-related-appeals"> Manage<span class="govuk-visually-hidden"> Related appeals</span></a>
                                     </li>
-                                    <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/2/other-appeals/add"> Add<span class="govuk-visually-hidden"> Related appeals</span></a>
+                                    <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/2/other-appeals/add"
+                                        data-cy="add-related-appeals"> Add<span class="govuk-visually-hidden"> Related appeals</span></a>
                                     </li>
                                 </ul>
                             </dd>
@@ -4969,7 +5294,8 @@ exports[`appeal-details GET /:appealId should render the received appeal details
                                     <li>Architecture design</li>
                                 </ul>
                             </dd>
-                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/allocation-details/allocation-level"> Change<span class="govuk-visually-hidden"> Allocation level</span></a>
+                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/allocation-details/allocation-level"
+                                data-cy="change-allocation-level"> Change<span class="govuk-visually-hidden"> Allocation level</span></a>
                             </dd>
                         </div>
                         <div class="govuk-summary-list__row govuk-summary-list__row--no-actions appeal-lpa-reference"><dt class="govuk-summary-list__key"> LPA application reference</dt>
@@ -4991,18 +5317,21 @@ exports[`appeal-details GET /:appealId should render the received appeal details
                         <div class="govuk-summary-list__row appeal-lpa-inspector-access"><dt class="govuk-summary-list__key"> Inspection access (LPA answer)</dt>
                             <dd                             class="govuk-summary-list__value"><span>No answer provided</span>
                                 </dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/inspector-access/change/lpa"> Change<span class="govuk-visually-hidden"> inspection access (L P A answer)</span></a>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/inspector-access/change/lpa"
+                                    data-cy="change-inspection-access-lpa"> Change<span class="govuk-visually-hidden"> inspection access (L P A answer)</span></a>
                                 </dd>
                         </div>
                         <div class="govuk-summary-list__row appeal-appellant-inspector-access"><dt class="govuk-summary-list__key"> Inspection access (appellant answer)</dt>
                             <dd                             class="govuk-summary-list__value"><span>No</span>
                                 </dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/inspector-access/change/appellant"> Change<span class="govuk-visually-hidden"> inspection access (appellant answer)</span></a>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/inspector-access/change/appellant"
+                                    data-cy="change-inspection-access-appellant"> Change<span class="govuk-visually-hidden"> inspection access (appellant answer)</span></a>
                                 </dd>
                         </div>
                         <div class="govuk-summary-list__row appeal-neighbouring-site-is-affected"><dt class="govuk-summary-list__key"> Could a neighbouring site be affected?</dt>
                             <dd                             class="govuk-summary-list__value">Yes</dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/neighbouring-sites/change/affected"> Change<span class="govuk-visually-hidden"> could a neighbouring site be affected</span></a>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/neighbouring-sites/change/affected"
+                                    data-cy="change-neighbouuring-site-is-affected"> Change<span class="govuk-visually-hidden"> could a neighbouring site be affected</span></a>
                                 </dd>
                         </div>
                         <div class="govuk-summary-list__row appeal-neighbouring-sites-inspector"><dt class="govuk-summary-list__key"> Neighbouring sites (LPA)</dt>
@@ -5015,7 +5344,8 @@ exports[`appeal-details GET /:appealId should render the received appeal details
                                     <ul class="govuk-summary-list__actions-list">
                                         <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/2/neighbouring-sites/manage"> Manage<span class="govuk-visually-hidden"> Neighbouring sites (L P A)</span></a>
                                         </li>
-                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/2/neighbouring-sites/add/lpa"> Add<span class="govuk-visually-hidden"> Neighbouring sites (LPA)</span></a>
+                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/2/neighbouring-sites/add/lpa"
+                                            data-cy="add-neighbouring-site-lpa"> Add<span class="govuk-visually-hidden"> Neighbouring sites (LPA)</span></a>
                                         </li>
                                     </ul>
                                 </dd>
@@ -5028,9 +5358,11 @@ exports[`appeal-details GET /:appealId should render the received appeal details
                                 </dd>
                                 <dd class="govuk-summary-list__actions">
                                     <ul class="govuk-summary-list__actions-list">
-                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/2/neighbouring-sites/manage"> Manage<span class="govuk-visually-hidden"> Neighbouring sites (inspector and or third party request)</span></a>
+                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/2/neighbouring-sites/manage"
+                                            data-cy="manage-neighbouring-sites-inspector"> Manage<span class="govuk-visually-hidden"> Neighbouring sites (inspector and or third party request)</span></a>
                                         </li>
-                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/2/neighbouring-sites/add/back-office"> Add<span class="govuk-visually-hidden"> Neighbouring sites (inspector and or third party request)</span></a>
+                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/2/neighbouring-sites/add/back-office"
+                                            data-cy="add-neighbouring-sites-inspector"> Add<span class="govuk-visually-hidden"> Neighbouring sites (inspector and or third party request)</span></a>
                                         </li>
                                     </ul>
                                 </dd>
@@ -5038,19 +5370,22 @@ exports[`appeal-details GET /:appealId should render the received appeal details
                         <div class="govuk-summary-list__row appeal-lpa-health-and-safety"><dt class="govuk-summary-list__key"> Potential safety risks (LPA answer)</dt>
                             <dd                             class="govuk-summary-list__value"><span>No answer provided</span>
                                 </dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/safety-risks/change/lpa"> Change<span class="govuk-visually-hidden"> potential safety risks (L P A answer)</span></a>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/safety-risks/change/lpa"
+                                    data-cy="change-lpa-health-and-safety"> Change<span class="govuk-visually-hidden"> potential safety risks (L P A answer)</span></a>
                                 </dd>
                         </div>
                         <div class="govuk-summary-list__row appeal-appellant-health-and-safety"><dt class="govuk-summary-list__key"> Potential safety risks (appellant answer)</dt>
                             <dd                             class="govuk-summary-list__value"><span>Yes</span>
                                 <br><span>Dogs on site</span>
                                 </dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/safety-risks/change/appellant"> Change<span class="govuk-visually-hidden"> potential safety risks (appellant answer)</span></a>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/safety-risks/change/appellant"
+                                    data-cy="change-appellant-case-health-and-safety"> Change<span class="govuk-visually-hidden"> potential safety risks (appellant answer)</span></a>
                                 </dd>
                         </div>
                         <div class="govuk-summary-list__row appeal-visit-type"><dt class="govuk-summary-list__key"> Visit type</dt>
                             <dd class="govuk-summary-list__value">Accompanied</dd>
-                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/site-visit/visit-booked"> Change<span class="govuk-visually-hidden"> visit type</span></a>
+                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/site-visit/visit-booked"
+                                data-cy="change-set-visit-type"> Change<span class="govuk-visually-hidden"> visit type</span></a>
                             </dd>
                         </div>
                     </dl>
@@ -5065,7 +5400,8 @@ exports[`appeal-details GET /:appealId should render the received appeal details
                     <dl class="govuk-summary-list">
                         <div class="govuk-summary-list__row appeal-valid-date"><dt class="govuk-summary-list__key"> Valid date</dt>
                             <dd class="govuk-summary-list__value">23 May 2023</dd>
-                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/appellant-case/valid/date"> Change<span class="govuk-visually-hidden"> The date all case documentation was received and the appeal was valid</span></a>
+                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/appellant-case/valid/date"
+                                data-cy="change-valid-date"> Change<span class="govuk-visually-hidden"> The date all case documentation was received and the appeal was valid</span></a>
                             </dd>
                         </div>
                         <div class="govuk-summary-list__row appeal-start-date"><dt class="govuk-summary-list__key"> Start date</dt>
@@ -5075,7 +5411,8 @@ exports[`appeal-details GET /:appealId should render the received appeal details
                         </div>
                         <div class="govuk-summary-list__row appeal-lpa-questionnaire-due-date"><dt class="govuk-summary-list__key"> LPA questionnaire due</dt>
                             <dd class="govuk-summary-list__value">11 October 2023</dd>
-                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/appeal-timetables/lpa-questionnaire"> Change<span class="govuk-visually-hidden"> L P A questionnaire due</span></a>
+                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/appeal-timetables/lpa-questionnaire"
+                                data-cy="change-lpa-questionnaire-due-date"> Change<span class="govuk-visually-hidden"> L P A questionnaire due</span></a>
                             </dd>
                         </div>
                         <div class="govuk-summary-list__row appeal-site-visit"><dt class="govuk-summary-list__key"> Site visit</dt>
@@ -5085,7 +5422,8 @@ exports[`appeal-details GET /:appealId should render the received appeal details
                                     <li>9:38am - 10:44am</li>
                                 </ul>
                             </dd>
-                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/site-visit/manage-visit"> Change<span class="govuk-visually-hidden"> site visit</span></a>
+                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/site-visit/manage-visit"
+                                data-cy="change-schedule-visit"> Change<span class="govuk-visually-hidden"> site visit</span></a>
                             </dd>
                         </div>
                     </dl>
@@ -5111,7 +5449,8 @@ exports[`appeal-details GET /:appealId should render the received appeal details
                                 <th scope="row" class="govuk-table__header">Appellant case</th>
                                 <td class="govuk-table__cell">Received</td>
                                 <td class="govuk-table__cell">2 August 2024</td>
-                                <td class="govuk-table__cell"><a href="/appeals-service/appeal-details/2/appellant-case" class="govuk-link">Review <span class="govuk-visually-hidden">appellant case</span></a>
+                                <td class="govuk-table__cell"><a href="/appeals-service/appeal-details/2/appellant-case" data-cy="review-appellant-case"
+                                    class="govuk-link">Review <span class="govuk-visually-hidden">appellant case</span></a>
                                 </td>
                             </tr>
                             <tr class="govuk-table__row">
@@ -5126,7 +5465,7 @@ exports[`appeal-details GET /:appealId should render the received appeal details
                                 <td class="govuk-table__cell appeal-costs-appellant-due-date"></td>
                                 <td class="govuk-table__cell appeal-costs-appellant-actions">
                                     <ul class="govuk-summary-list__actions-list">
-                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/2/costs/appellant/select-document-type/1">Add</a>
+                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-appeallant" href="/appeals-service/appeal-details/2/costs/appellant/select-document-type/1">Add</a>
                                         </li>
                                     </ul>
                                 </td>
@@ -5137,7 +5476,7 @@ exports[`appeal-details GET /:appealId should render the received appeal details
                                 <td class="govuk-table__cell appeal-costs-lpa-due-date"></td>
                                 <td class="govuk-table__cell appeal-costs-lpa-actions">
                                     <ul class="govuk-summary-list__actions-list">
-                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/2/costs/lpa/select-document-type/2">Add</a>
+                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-lpa" href="/appeals-service/appeal-details/2/costs/lpa/select-document-type/2">Add</a>
                                         </li>
                                     </ul>
                                 </td>
@@ -5148,7 +5487,7 @@ exports[`appeal-details GET /:appealId should render the received appeal details
                                 <td class="govuk-table__cell appeal-costs-decision-due-date"></td>
                                 <td class="govuk-table__cell appeal-costs-decision-actions">
                                     <ul class="govuk-summary-list__actions-list">
-                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/2/costs/decision/upload-documents/3">Add</a>
+                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-decision" href="/appeals-service/appeal-details/2/costs/decision/upload-documents/3">Add</a>
                                         </li>
                                     </ul>
                                 </td>
@@ -5171,7 +5510,8 @@ exports[`appeal-details GET /:appealId should render the received appeal details
                                     <li>test3@example.com</li>
                                 </ul>
                             </dd>
-                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/service-user/change/appellant"> Change<span class="govuk-visually-hidden"> Appellant</span></a>
+                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/service-user/change/appellant"
+                                data-cy="change-appellant"> Change<span class="govuk-visually-hidden"> Appellant</span></a>
                             </dd>
                         </div>
                         <div class="govuk-summary-list__row appeal-agent"><dt class="govuk-summary-list__key"> Agent</dt>
@@ -5181,7 +5521,8 @@ exports[`appeal-details GET /:appealId should render the received appeal details
                                     <li>test2@example.com</li>
                                 </ul>
                             </dd>
-                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/service-user/change/agent"> Change<span class="govuk-visually-hidden"> Agent</span></a>
+                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/service-user/change/agent"
+                                data-cy="change-agent"> Change<span class="govuk-visually-hidden"> Agent</span></a>
                             </dd>
                         </div>
                         <div class="govuk-summary-list__row govuk-summary-list__row--no-actions appeal-local-planning-authority"><dt class="govuk-summary-list__key"> LPA</dt>
@@ -5199,12 +5540,14 @@ exports[`appeal-details GET /:appealId should render the received appeal details
                     <dl class="govuk-summary-list">
                         <div class="govuk-summary-list__row appeal-case-officer"><dt class="govuk-summary-list__key"> Case officer</dt>
                             <dd class="govuk-summary-list__value"></dd>
-                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/assign-user/case-officer"> Assign<span class="govuk-visually-hidden"> case officer</span></a>
+                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/assign-user/case-officer"
+                                data-cy="assign-case-officer"> Assign<span class="govuk-visually-hidden"> case officer</span></a>
                             </dd>
                         </div>
                         <div class="govuk-summary-list__row appeal-inspector"><dt class="govuk-summary-list__key"> Inspector</dt>
                             <dd class="govuk-summary-list__value"></dd>
-                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/assign-user/inspector"> Assign<span class="govuk-visually-hidden"> inspector</span></a>
+                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/assign-user/inspector"
+                                data-cy="assign-inspector"> Assign<span class="govuk-visually-hidden"> inspector</span></a>
                             </dd>
                         </div>
                     </dl>
@@ -5254,7 +5597,8 @@ exports[`appeal-details GET /:appealId should render the received appeal details
                     <dl class="govuk-summary-list">
                         <div class="govuk-summary-list__row appeal-appeal-type"><dt class="govuk-summary-list__key"> Appeal type</dt>
                             <dd class="govuk-summary-list__value">Householder</dd>
-                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/change-appeal-type/appeal-type"> Change<span class="govuk-visually-hidden"> Appeal type</span></a>
+                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/change-appeal-type/appeal-type"
+                                data-cy="change-appeal-type"> Change<span class="govuk-visually-hidden"> Appeal type</span></a>
                             </dd>
                         </div>
                         <div class="govuk-summary-list__row govuk-summary-list__row--no-actions appeal-case-procedure"><dt class="govuk-summary-list__key"> Case procedure</dt>
@@ -5263,13 +5607,15 @@ exports[`appeal-details GET /:appealId should render the received appeal details
                         <div class="govuk-summary-list__row appeal-linked-appeals"><dt class="govuk-summary-list__key"> Linked appeals</dt>
                             <dd class="govuk-summary-list__value"><span>No appeals</span>
                             </dd>
-                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/linked-appeals/add"> Add<span class="govuk-visually-hidden"> Linked appeals</span></a>
+                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/linked-appeals/add"
+                                data-cy="add-linked-appeal"> Add<span class="govuk-visually-hidden"> Linked appeals</span></a>
                             </dd>
                         </div>
                         <div class="govuk-summary-list__row appeal-other-appeals"><dt class="govuk-summary-list__key"> Related appeals</dt>
                             <dd class="govuk-summary-list__value"><span>No appeals</span>
                             </dd>
-                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/other-appeals/add"> Add<span class="govuk-visually-hidden"> Related appeals</span></a>
+                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/other-appeals/add"
+                                data-cy="add-related-appeals"> Add<span class="govuk-visually-hidden"> Related appeals</span></a>
                             </dd>
                         </div>
                         <div class="govuk-summary-list__row appeal-allocation-details"><dt class="govuk-summary-list__key"> Allocation level</dt>
@@ -5281,7 +5627,8 @@ exports[`appeal-details GET /:appealId should render the received appeal details
                                     <li>Architecture design</li>
                                 </ul>
                             </dd>
-                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/allocation-details/allocation-level"> Change<span class="govuk-visually-hidden"> Allocation level</span></a>
+                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/allocation-details/allocation-level"
+                                data-cy="change-allocation-level"> Change<span class="govuk-visually-hidden"> Allocation level</span></a>
                             </dd>
                         </div>
                         <div class="govuk-summary-list__row govuk-summary-list__row--no-actions appeal-lpa-reference"><dt class="govuk-summary-list__key"> LPA application reference</dt>
@@ -5303,18 +5650,21 @@ exports[`appeal-details GET /:appealId should render the received appeal details
                         <div class="govuk-summary-list__row appeal-lpa-inspector-access"><dt class="govuk-summary-list__key"> Inspection access (LPA answer)</dt>
                             <dd                             class="govuk-summary-list__value"><span>No answer provided</span>
                                 </dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/inspector-access/change/lpa"> Change<span class="govuk-visually-hidden"> inspection access (L P A answer)</span></a>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/inspector-access/change/lpa"
+                                    data-cy="change-inspection-access-lpa"> Change<span class="govuk-visually-hidden"> inspection access (L P A answer)</span></a>
                                 </dd>
                         </div>
                         <div class="govuk-summary-list__row appeal-appellant-inspector-access"><dt class="govuk-summary-list__key"> Inspection access (appellant answer)</dt>
                             <dd                             class="govuk-summary-list__value"><span>No</span>
                                 </dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/inspector-access/change/appellant"> Change<span class="govuk-visually-hidden"> inspection access (appellant answer)</span></a>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/inspector-access/change/appellant"
+                                    data-cy="change-inspection-access-appellant"> Change<span class="govuk-visually-hidden"> inspection access (appellant answer)</span></a>
                                 </dd>
                         </div>
                         <div class="govuk-summary-list__row appeal-neighbouring-site-is-affected"><dt class="govuk-summary-list__key"> Could a neighbouring site be affected?</dt>
                             <dd                             class="govuk-summary-list__value">Yes</dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/neighbouring-sites/change/affected"> Change<span class="govuk-visually-hidden"> could a neighbouring site be affected</span></a>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/neighbouring-sites/change/affected"
+                                    data-cy="change-neighbouuring-site-is-affected"> Change<span class="govuk-visually-hidden"> could a neighbouring site be affected</span></a>
                                 </dd>
                         </div>
                         <div class="govuk-summary-list__row appeal-neighbouring-sites-inspector"><dt class="govuk-summary-list__key"> Neighbouring sites (LPA)</dt>
@@ -5327,7 +5677,8 @@ exports[`appeal-details GET /:appealId should render the received appeal details
                                     <ul class="govuk-summary-list__actions-list">
                                         <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/2/neighbouring-sites/manage"> Manage<span class="govuk-visually-hidden"> Neighbouring sites (L P A)</span></a>
                                         </li>
-                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/2/neighbouring-sites/add/lpa"> Add<span class="govuk-visually-hidden"> Neighbouring sites (LPA)</span></a>
+                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/2/neighbouring-sites/add/lpa"
+                                            data-cy="add-neighbouring-site-lpa"> Add<span class="govuk-visually-hidden"> Neighbouring sites (LPA)</span></a>
                                         </li>
                                     </ul>
                                 </dd>
@@ -5340,9 +5691,11 @@ exports[`appeal-details GET /:appealId should render the received appeal details
                                 </dd>
                                 <dd class="govuk-summary-list__actions">
                                     <ul class="govuk-summary-list__actions-list">
-                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/2/neighbouring-sites/manage"> Manage<span class="govuk-visually-hidden"> Neighbouring sites (inspector and or third party request)</span></a>
+                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/2/neighbouring-sites/manage"
+                                            data-cy="manage-neighbouring-sites-inspector"> Manage<span class="govuk-visually-hidden"> Neighbouring sites (inspector and or third party request)</span></a>
                                         </li>
-                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/2/neighbouring-sites/add/back-office"> Add<span class="govuk-visually-hidden"> Neighbouring sites (inspector and or third party request)</span></a>
+                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/2/neighbouring-sites/add/back-office"
+                                            data-cy="add-neighbouring-sites-inspector"> Add<span class="govuk-visually-hidden"> Neighbouring sites (inspector and or third party request)</span></a>
                                         </li>
                                     </ul>
                                 </dd>
@@ -5350,19 +5703,22 @@ exports[`appeal-details GET /:appealId should render the received appeal details
                         <div class="govuk-summary-list__row appeal-lpa-health-and-safety"><dt class="govuk-summary-list__key"> Potential safety risks (LPA answer)</dt>
                             <dd                             class="govuk-summary-list__value"><span>No answer provided</span>
                                 </dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/safety-risks/change/lpa"> Change<span class="govuk-visually-hidden"> potential safety risks (L P A answer)</span></a>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/safety-risks/change/lpa"
+                                    data-cy="change-lpa-health-and-safety"> Change<span class="govuk-visually-hidden"> potential safety risks (L P A answer)</span></a>
                                 </dd>
                         </div>
                         <div class="govuk-summary-list__row appeal-appellant-health-and-safety"><dt class="govuk-summary-list__key"> Potential safety risks (appellant answer)</dt>
                             <dd                             class="govuk-summary-list__value"><span>Yes</span>
                                 <br><span>Dogs on site</span>
                                 </dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/safety-risks/change/appellant"> Change<span class="govuk-visually-hidden"> potential safety risks (appellant answer)</span></a>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/safety-risks/change/appellant"
+                                    data-cy="change-appellant-case-health-and-safety"> Change<span class="govuk-visually-hidden"> potential safety risks (appellant answer)</span></a>
                                 </dd>
                         </div>
                         <div class="govuk-summary-list__row appeal-visit-type"><dt class="govuk-summary-list__key"> Visit type</dt>
                             <dd class="govuk-summary-list__value">Accompanied</dd>
-                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/site-visit/visit-booked"> Change<span class="govuk-visually-hidden"> visit type</span></a>
+                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/site-visit/visit-booked"
+                                data-cy="change-set-visit-type"> Change<span class="govuk-visually-hidden"> visit type</span></a>
                             </dd>
                         </div>
                     </dl>
@@ -5377,7 +5733,8 @@ exports[`appeal-details GET /:appealId should render the received appeal details
                     <dl class="govuk-summary-list">
                         <div class="govuk-summary-list__row appeal-valid-date"><dt class="govuk-summary-list__key"> Valid date</dt>
                             <dd class="govuk-summary-list__value">23 May 2023</dd>
-                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/appellant-case/valid/date"> Change<span class="govuk-visually-hidden"> The date all case documentation was received and the appeal was valid</span></a>
+                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/appellant-case/valid/date"
+                                data-cy="change-valid-date"> Change<span class="govuk-visually-hidden"> The date all case documentation was received and the appeal was valid</span></a>
                             </dd>
                         </div>
                         <div class="govuk-summary-list__row appeal-start-date"><dt class="govuk-summary-list__key"> Start date</dt>
@@ -5408,7 +5765,8 @@ exports[`appeal-details GET /:appealId should render the received appeal details
                                 <th scope="row" class="govuk-table__header">Appellant case</th>
                                 <td class="govuk-table__cell">Received</td>
                                 <td class="govuk-table__cell">2 August 2024</td>
-                                <td class="govuk-table__cell"><a href="/appeals-service/appeal-details/2/appellant-case" class="govuk-link">Review <span class="govuk-visually-hidden">appellant case</span></a>
+                                <td class="govuk-table__cell"><a href="/appeals-service/appeal-details/2/appellant-case" data-cy="review-appellant-case"
+                                    class="govuk-link">Review <span class="govuk-visually-hidden">appellant case</span></a>
                                 </td>
                             </tr>
                             <tr class="govuk-table__row">
@@ -5423,7 +5781,7 @@ exports[`appeal-details GET /:appealId should render the received appeal details
                                 <td class="govuk-table__cell appeal-costs-appellant-due-date"></td>
                                 <td class="govuk-table__cell appeal-costs-appellant-actions">
                                     <ul class="govuk-summary-list__actions-list">
-                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/2/costs/appellant/select-document-type/1">Add</a>
+                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-appeallant" href="/appeals-service/appeal-details/2/costs/appellant/select-document-type/1">Add</a>
                                         </li>
                                     </ul>
                                 </td>
@@ -5434,7 +5792,7 @@ exports[`appeal-details GET /:appealId should render the received appeal details
                                 <td class="govuk-table__cell appeal-costs-lpa-due-date"></td>
                                 <td class="govuk-table__cell appeal-costs-lpa-actions">
                                     <ul class="govuk-summary-list__actions-list">
-                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/2/costs/lpa/select-document-type/2">Add</a>
+                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-lpa" href="/appeals-service/appeal-details/2/costs/lpa/select-document-type/2">Add</a>
                                         </li>
                                     </ul>
                                 </td>
@@ -5445,7 +5803,7 @@ exports[`appeal-details GET /:appealId should render the received appeal details
                                 <td class="govuk-table__cell appeal-costs-decision-due-date"></td>
                                 <td class="govuk-table__cell appeal-costs-decision-actions">
                                     <ul class="govuk-summary-list__actions-list">
-                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/2/costs/decision/upload-documents/3">Add</a>
+                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-decision" href="/appeals-service/appeal-details/2/costs/decision/upload-documents/3">Add</a>
                                         </li>
                                     </ul>
                                 </td>
@@ -5468,7 +5826,8 @@ exports[`appeal-details GET /:appealId should render the received appeal details
                                     <li>test3@example.com</li>
                                 </ul>
                             </dd>
-                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/service-user/change/appellant"> Change<span class="govuk-visually-hidden"> Appellant</span></a>
+                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/service-user/change/appellant"
+                                data-cy="change-appellant"> Change<span class="govuk-visually-hidden"> Appellant</span></a>
                             </dd>
                         </div>
                         <div class="govuk-summary-list__row appeal-agent"><dt class="govuk-summary-list__key"> Agent</dt>
@@ -5478,7 +5837,8 @@ exports[`appeal-details GET /:appealId should render the received appeal details
                                     <li>test2@example.com</li>
                                 </ul>
                             </dd>
-                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/service-user/change/agent"> Change<span class="govuk-visually-hidden"> Agent</span></a>
+                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/service-user/change/agent"
+                                data-cy="change-agent"> Change<span class="govuk-visually-hidden"> Agent</span></a>
                             </dd>
                         </div>
                         <div class="govuk-summary-list__row govuk-summary-list__row--no-actions appeal-local-planning-authority"><dt class="govuk-summary-list__key"> LPA</dt>
@@ -5496,12 +5856,14 @@ exports[`appeal-details GET /:appealId should render the received appeal details
                     <dl class="govuk-summary-list">
                         <div class="govuk-summary-list__row appeal-case-officer"><dt class="govuk-summary-list__key"> Case officer</dt>
                             <dd class="govuk-summary-list__value"></dd>
-                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/assign-user/case-officer"> Assign<span class="govuk-visually-hidden"> case officer</span></a>
+                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/assign-user/case-officer"
+                                data-cy="assign-case-officer"> Assign<span class="govuk-visually-hidden"> case officer</span></a>
                             </dd>
                         </div>
                         <div class="govuk-summary-list__row appeal-inspector"><dt class="govuk-summary-list__key"> Inspector</dt>
                             <dd class="govuk-summary-list__value"></dd>
-                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/assign-user/inspector"> Assign<span class="govuk-visually-hidden"> inspector</span></a>
+                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/assign-user/inspector"
+                                data-cy="assign-inspector"> Assign<span class="govuk-visually-hidden"> inspector</span></a>
                             </dd>
                         </div>
                     </dl>
@@ -5692,7 +6054,8 @@ exports[`appeal-details should not render a back button 1`] = `
                                 <dl class="govuk-summary-list">
                                     <div class="govuk-summary-list__row appeal-appeal-type"><dt class="govuk-summary-list__key"> Appeal type</dt>
                                         <dd class="govuk-summary-list__value">Householder</dd>
-                                        <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/change-appeal-type/appeal-type"> Change<span class="govuk-visually-hidden"> Appeal type</span></a>
+                                        <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/change-appeal-type/appeal-type"
+                                            data-cy="change-appeal-type"> Change<span class="govuk-visually-hidden"> Appeal type</span></a>
                                         </dd>
                                     </div>
                                     <div class="govuk-summary-list__row govuk-summary-list__row--no-actions appeal-case-procedure"><dt class="govuk-summary-list__key"> Case procedure</dt>
@@ -5701,13 +6064,15 @@ exports[`appeal-details should not render a back button 1`] = `
                                     <div class="govuk-summary-list__row appeal-linked-appeals"><dt class="govuk-summary-list__key"> Linked appeals</dt>
                                         <dd class="govuk-summary-list__value"><span>No appeals</span>
                                         </dd>
-                                        <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/linked-appeals/add"> Add<span class="govuk-visually-hidden"> Linked appeals</span></a>
+                                        <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/linked-appeals/add"
+                                            data-cy="add-linked-appeal"> Add<span class="govuk-visually-hidden"> Linked appeals</span></a>
                                         </dd>
                                     </div>
                                     <div class="govuk-summary-list__row appeal-other-appeals"><dt class="govuk-summary-list__key"> Related appeals</dt>
                                         <dd class="govuk-summary-list__value"><span>No appeals</span>
                                         </dd>
-                                        <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/other-appeals/add"> Add<span class="govuk-visually-hidden"> Related appeals</span></a>
+                                        <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/other-appeals/add"
+                                            data-cy="add-related-appeals"> Add<span class="govuk-visually-hidden"> Related appeals</span></a>
                                         </dd>
                                     </div>
                                     <div class="govuk-summary-list__row appeal-allocation-details"><dt class="govuk-summary-list__key"> Allocation level</dt>
@@ -5719,7 +6084,8 @@ exports[`appeal-details should not render a back button 1`] = `
                                                 <li>Architecture design</li>
                                             </ul>
                                         </dd>
-                                        <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/allocation-details/allocation-level"> Change<span class="govuk-visually-hidden"> Allocation level</span></a>
+                                        <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/allocation-details/allocation-level"
+                                            data-cy="change-allocation-level"> Change<span class="govuk-visually-hidden"> Allocation level</span></a>
                                         </dd>
                                     </div>
                                     <div class="govuk-summary-list__row govuk-summary-list__row--no-actions appeal-lpa-reference"><dt class="govuk-summary-list__key"> LPA application reference</dt>
@@ -5741,18 +6107,21 @@ exports[`appeal-details should not render a back button 1`] = `
                                     <div class="govuk-summary-list__row appeal-lpa-inspector-access"><dt class="govuk-summary-list__key"> Inspection access (LPA answer)</dt>
                                         <dd                                         class="govuk-summary-list__value"><span>No answer provided</span>
                                             </dd>
-                                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/inspector-access/change/lpa"> Change<span class="govuk-visually-hidden"> inspection access (L P A answer)</span></a>
+                                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/inspector-access/change/lpa"
+                                                data-cy="change-inspection-access-lpa"> Change<span class="govuk-visually-hidden"> inspection access (L P A answer)</span></a>
                                             </dd>
                                     </div>
                                     <div class="govuk-summary-list__row appeal-appellant-inspector-access"><dt class="govuk-summary-list__key"> Inspection access (appellant answer)</dt>
                                         <dd                                         class="govuk-summary-list__value"><span>No</span>
                                             </dd>
-                                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/inspector-access/change/appellant"> Change<span class="govuk-visually-hidden"> inspection access (appellant answer)</span></a>
+                                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/inspector-access/change/appellant"
+                                                data-cy="change-inspection-access-appellant"> Change<span class="govuk-visually-hidden"> inspection access (appellant answer)</span></a>
                                             </dd>
                                     </div>
                                     <div class="govuk-summary-list__row appeal-neighbouring-site-is-affected"><dt class="govuk-summary-list__key"> Could a neighbouring site be affected?</dt>
                                         <dd                                         class="govuk-summary-list__value">Yes</dd>
-                                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/neighbouring-sites/change/affected"> Change<span class="govuk-visually-hidden"> could a neighbouring site be affected</span></a>
+                                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/neighbouring-sites/change/affected"
+                                                data-cy="change-neighbouuring-site-is-affected"> Change<span class="govuk-visually-hidden"> could a neighbouring site be affected</span></a>
                                             </dd>
                                     </div>
                                     <div class="govuk-summary-list__row appeal-neighbouring-sites-inspector"><dt class="govuk-summary-list__key"> Neighbouring sites (LPA)</dt>
@@ -5765,7 +6134,8 @@ exports[`appeal-details should not render a back button 1`] = `
                                                 <ul class="govuk-summary-list__actions-list">
                                                     <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/2/neighbouring-sites/manage"> Manage<span class="govuk-visually-hidden"> Neighbouring sites (L P A)</span></a>
                                                     </li>
-                                                    <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/2/neighbouring-sites/add/lpa"> Add<span class="govuk-visually-hidden"> Neighbouring sites (LPA)</span></a>
+                                                    <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/2/neighbouring-sites/add/lpa"
+                                                        data-cy="add-neighbouring-site-lpa"> Add<span class="govuk-visually-hidden"> Neighbouring sites (LPA)</span></a>
                                                     </li>
                                                 </ul>
                                             </dd>
@@ -5778,9 +6148,11 @@ exports[`appeal-details should not render a back button 1`] = `
                                             </dd>
                                             <dd class="govuk-summary-list__actions">
                                                 <ul class="govuk-summary-list__actions-list">
-                                                    <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/2/neighbouring-sites/manage"> Manage<span class="govuk-visually-hidden"> Neighbouring sites (inspector and or third party request)</span></a>
+                                                    <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/2/neighbouring-sites/manage"
+                                                        data-cy="manage-neighbouring-sites-inspector"> Manage<span class="govuk-visually-hidden"> Neighbouring sites (inspector and or third party request)</span></a>
                                                     </li>
-                                                    <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/2/neighbouring-sites/add/back-office"> Add<span class="govuk-visually-hidden"> Neighbouring sites (inspector and or third party request)</span></a>
+                                                    <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/2/neighbouring-sites/add/back-office"
+                                                        data-cy="add-neighbouring-sites-inspector"> Add<span class="govuk-visually-hidden"> Neighbouring sites (inspector and or third party request)</span></a>
                                                     </li>
                                                 </ul>
                                             </dd>
@@ -5788,19 +6160,22 @@ exports[`appeal-details should not render a back button 1`] = `
                                     <div class="govuk-summary-list__row appeal-lpa-health-and-safety"><dt class="govuk-summary-list__key"> Potential safety risks (LPA answer)</dt>
                                         <dd                                         class="govuk-summary-list__value"><span>No answer provided</span>
                                             </dd>
-                                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/safety-risks/change/lpa"> Change<span class="govuk-visually-hidden"> potential safety risks (L P A answer)</span></a>
+                                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/safety-risks/change/lpa"
+                                                data-cy="change-lpa-health-and-safety"> Change<span class="govuk-visually-hidden"> potential safety risks (L P A answer)</span></a>
                                             </dd>
                                     </div>
                                     <div class="govuk-summary-list__row appeal-appellant-health-and-safety"><dt class="govuk-summary-list__key"> Potential safety risks (appellant answer)</dt>
                                         <dd                                         class="govuk-summary-list__value"><span>Yes</span>
                                             <br><span>Dogs on site</span>
                                             </dd>
-                                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/safety-risks/change/appellant"> Change<span class="govuk-visually-hidden"> potential safety risks (appellant answer)</span></a>
+                                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/safety-risks/change/appellant"
+                                                data-cy="change-appellant-case-health-and-safety"> Change<span class="govuk-visually-hidden"> potential safety risks (appellant answer)</span></a>
                                             </dd>
                                     </div>
                                     <div class="govuk-summary-list__row appeal-visit-type"><dt class="govuk-summary-list__key"> Visit type</dt>
                                         <dd class="govuk-summary-list__value">Accompanied</dd>
-                                        <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/site-visit/visit-booked"> Change<span class="govuk-visually-hidden"> visit type</span></a>
+                                        <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/site-visit/visit-booked"
+                                            data-cy="change-set-visit-type"> Change<span class="govuk-visually-hidden"> visit type</span></a>
                                         </dd>
                                     </div>
                                 </dl>
@@ -5815,7 +6190,8 @@ exports[`appeal-details should not render a back button 1`] = `
                                 <dl class="govuk-summary-list">
                                     <div class="govuk-summary-list__row appeal-valid-date"><dt class="govuk-summary-list__key"> Valid date</dt>
                                         <dd class="govuk-summary-list__value">23 May 2023</dd>
-                                        <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/appellant-case/valid/date"> Change<span class="govuk-visually-hidden"> The date all case documentation was received and the appeal was valid</span></a>
+                                        <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/appellant-case/valid/date"
+                                            data-cy="change-valid-date"> Change<span class="govuk-visually-hidden"> The date all case documentation was received and the appeal was valid</span></a>
                                         </dd>
                                     </div>
                                     <div class="govuk-summary-list__row appeal-start-date"><dt class="govuk-summary-list__key"> Start date</dt>
@@ -5825,7 +6201,8 @@ exports[`appeal-details should not render a back button 1`] = `
                                     </div>
                                     <div class="govuk-summary-list__row appeal-lpa-questionnaire-due-date"><dt class="govuk-summary-list__key"> LPA questionnaire due</dt>
                                         <dd class="govuk-summary-list__value">11 October 2023</dd>
-                                        <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/appeal-timetables/lpa-questionnaire"> Change<span class="govuk-visually-hidden"> L P A questionnaire due</span></a>
+                                        <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/appeal-timetables/lpa-questionnaire"
+                                            data-cy="change-lpa-questionnaire-due-date"> Change<span class="govuk-visually-hidden"> L P A questionnaire due</span></a>
                                         </dd>
                                     </div>
                                     <div class="govuk-summary-list__row appeal-site-visit"><dt class="govuk-summary-list__key"> Site visit</dt>
@@ -5835,7 +6212,8 @@ exports[`appeal-details should not render a back button 1`] = `
                                                 <li>9:38am - 10:44am</li>
                                             </ul>
                                         </dd>
-                                        <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/site-visit/manage-visit"> Change<span class="govuk-visually-hidden"> site visit</span></a>
+                                        <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/site-visit/manage-visit"
+                                            data-cy="change-schedule-visit"> Change<span class="govuk-visually-hidden"> site visit</span></a>
                                         </dd>
                                     </div>
                                 </dl>
@@ -5861,7 +6239,8 @@ exports[`appeal-details should not render a back button 1`] = `
                                             <th scope="row" class="govuk-table__header">Appellant case</th>
                                             <td class="govuk-table__cell">Received</td>
                                             <td class="govuk-table__cell">2 August 2024</td>
-                                            <td class="govuk-table__cell"><a href="/appeals-service/appeal-details/2/appellant-case" class="govuk-link">Review <span class="govuk-visually-hidden">appellant case</span></a>
+                                            <td class="govuk-table__cell"><a href="/appeals-service/appeal-details/2/appellant-case" data-cy="review-appellant-case"
+                                                class="govuk-link">Review <span class="govuk-visually-hidden">appellant case</span></a>
                                             </td>
                                         </tr>
                                         <tr class="govuk-table__row">
@@ -5876,7 +6255,7 @@ exports[`appeal-details should not render a back button 1`] = `
                                             <td class="govuk-table__cell appeal-costs-appellant-due-date"></td>
                                             <td class="govuk-table__cell appeal-costs-appellant-actions">
                                                 <ul class="govuk-summary-list__actions-list">
-                                                    <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/2/costs/appellant/select-document-type/1">Add</a>
+                                                    <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-appeallant" href="/appeals-service/appeal-details/2/costs/appellant/select-document-type/1">Add</a>
                                                     </li>
                                                 </ul>
                                             </td>
@@ -5887,7 +6266,7 @@ exports[`appeal-details should not render a back button 1`] = `
                                             <td class="govuk-table__cell appeal-costs-lpa-due-date"></td>
                                             <td class="govuk-table__cell appeal-costs-lpa-actions">
                                                 <ul class="govuk-summary-list__actions-list">
-                                                    <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/2/costs/lpa/select-document-type/2">Add</a>
+                                                    <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-lpa" href="/appeals-service/appeal-details/2/costs/lpa/select-document-type/2">Add</a>
                                                     </li>
                                                 </ul>
                                             </td>
@@ -5898,7 +6277,7 @@ exports[`appeal-details should not render a back button 1`] = `
                                             <td class="govuk-table__cell appeal-costs-decision-due-date"></td>
                                             <td class="govuk-table__cell appeal-costs-decision-actions">
                                                 <ul class="govuk-summary-list__actions-list">
-                                                    <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/2/costs/decision/upload-documents/3">Add</a>
+                                                    <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-decision" href="/appeals-service/appeal-details/2/costs/decision/upload-documents/3">Add</a>
                                                     </li>
                                                 </ul>
                                             </td>
@@ -5921,7 +6300,8 @@ exports[`appeal-details should not render a back button 1`] = `
                                                 <li>test3@example.com</li>
                                             </ul>
                                         </dd>
-                                        <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/service-user/change/appellant"> Change<span class="govuk-visually-hidden"> Appellant</span></a>
+                                        <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/service-user/change/appellant"
+                                            data-cy="change-appellant"> Change<span class="govuk-visually-hidden"> Appellant</span></a>
                                         </dd>
                                     </div>
                                     <div class="govuk-summary-list__row appeal-agent"><dt class="govuk-summary-list__key"> Agent</dt>
@@ -5931,7 +6311,8 @@ exports[`appeal-details should not render a back button 1`] = `
                                                 <li>test2@example.com</li>
                                             </ul>
                                         </dd>
-                                        <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/service-user/change/agent"> Change<span class="govuk-visually-hidden"> Agent</span></a>
+                                        <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/service-user/change/agent"
+                                            data-cy="change-agent"> Change<span class="govuk-visually-hidden"> Agent</span></a>
                                         </dd>
                                     </div>
                                     <div class="govuk-summary-list__row govuk-summary-list__row--no-actions appeal-local-planning-authority"><dt class="govuk-summary-list__key"> LPA</dt>
@@ -5949,12 +6330,14 @@ exports[`appeal-details should not render a back button 1`] = `
                                 <dl class="govuk-summary-list">
                                     <div class="govuk-summary-list__row appeal-case-officer"><dt class="govuk-summary-list__key"> Case officer</dt>
                                         <dd class="govuk-summary-list__value"></dd>
-                                        <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/assign-user/case-officer"> Assign<span class="govuk-visually-hidden"> case officer</span></a>
+                                        <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/assign-user/case-officer"
+                                            data-cy="assign-case-officer"> Assign<span class="govuk-visually-hidden"> case officer</span></a>
                                         </dd>
                                     </div>
                                     <div class="govuk-summary-list__row appeal-inspector"><dt class="govuk-summary-list__key"> Inspector</dt>
                                         <dd class="govuk-summary-list__value"></dd>
-                                        <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/assign-user/inspector"> Assign<span class="govuk-visually-hidden"> inspector</span></a>
+                                        <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/assign-user/inspector"
+                                            data-cy="assign-inspector"> Assign<span class="govuk-visually-hidden"> inspector</span></a>
                                         </dd>
                                     </div>
                                 </dl>

--- a/appeals/web/src/server/appeals/appeal-details/__tests__/appeal-details.test.js
+++ b/appeals/web/src/server/appeals/appeal-details/__tests__/appeal-details.test.js
@@ -937,10 +937,10 @@ describe('appeal-details', () => {
 			});
 
 			expect(linkedAppealsRowElement.innerHTML).toContain(
-				'href="/appeals-service/appeal-details/1/linked-appeals/manage"> Manage<span class="govuk-visually-hidden"> Linked appeals</span></a>'
+				'href="/appeals-service/appeal-details/1/linked-appeals/manage" data-cy="manage-linked-appeals"> Manage<span class="govuk-visually-hidden"> Linked appeals</span></a>'
 			);
 			expect(linkedAppealsRowElement.innerHTML).toContain(
-				'href="/appeals-service/appeal-details/1/linked-appeals/add"> Add<span class="govuk-visually-hidden"> Linked appeals</span></a>'
+				'href="/appeals-service/appeal-details/1/linked-appeals/add" data-cy="add-linked-appeal"> Add<span class="govuk-visually-hidden"> Linked appeals</span></a>'
 			);
 		});
 

--- a/appeals/web/src/server/appeals/appeal-details/appeal-details.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/appeal-details.mapper.js
@@ -359,7 +359,7 @@ function mapStatusDependentNotifications(appealDetails, session, accordionCompon
 				session,
 				'assignCaseOfficer',
 				appealDetails.appealId,
-				`<p class="govuk-notification-banner__heading">Appeal ready to be assigned to case officer</p><p><a class="govuk-notification-banner__link" href="/appeals-service/appeal-details/${appealDetails.appealId}/assign-user/case-officer">Assign case officer</a></p>`
+				`<p class="govuk-notification-banner__heading">Appeal ready to be assigned to case officer</p><p><a class="govuk-notification-banner__link" href="/appeals-service/appeal-details/${appealDetails.appealId}/assign-user/case-officer" data-cy="assign-case-officer">Assign case officer</a></p>`
 			);
 			break;
 		case 'issue_determination':
@@ -367,7 +367,7 @@ function mapStatusDependentNotifications(appealDetails, session, accordionCompon
 				session,
 				'readyForDecision',
 				appealDetails.appealId,
-				`<p class="govuk-notification-banner__heading">Ready for decision</p><p><a class="govuk-notification-banner__link" href="${generateIssueDecisionUrl(
+				`<p class="govuk-notification-banner__heading">Ready for decision</p><p><a class="govuk-notification-banner__link" data-cy="issue-determination" href="${generateIssueDecisionUrl(
 					appealDetails.appealId
 				)}">Issue decision</a></p>`
 			);
@@ -377,7 +377,7 @@ function mapStatusDependentNotifications(appealDetails, session, accordionCompon
 				session,
 				'appealValidAndReadyToStart',
 				appealDetails.appealId,
-				`<p class="govuk-notification-banner__heading">Appeal valid</p><p><a class="govuk-notification-banner__link" href="${generateStartTimetableUrl(
+				`<p class="govuk-notification-banner__heading">Appeal valid</p><p><a class="govuk-notification-banner__link" data-cy="ready-to-start" href="${generateStartTimetableUrl(
 					appealDetails.appealId
 				)}">Start case</a></p>`
 			);
@@ -387,7 +387,7 @@ function mapStatusDependentNotifications(appealDetails, session, accordionCompon
 				session,
 				'appealAwaitingTransfer',
 				appealDetails.appealId,
-				`<p class="govuk-notification-banner__heading">This appeal is awaiting transfer</p><p class="govuk-body">The appeal must be transferred to Horizon. When this is done, <a class="govuk-link" href="/appeals-service/appeal-details/${appealDetails.appealId}/change-appeal-type/add-horizon-reference">update the appeal with the new horizon reference</a>.</p>`
+				`<p class="govuk-notification-banner__heading">This appeal is awaiting transfer</p><p class="govuk-body">The appeal must be transferred to Horizon. When this is done, <a class="govuk-link" data-cy="awaiting-transfer" href="/appeals-service/appeal-details/${appealDetails.appealId}/change-appeal-type/add-horizon-reference">update the appeal with the new horizon reference</a>.</p>`
 			);
 			removeAccordionComponentsActions(accordionComponents);
 			break;

--- a/appeals/web/src/server/appeals/appeal-details/appellant-case/__tests__/__snapshots__/appellant-case.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/appellant-case/__tests__/__snapshots__/appellant-case.test.js.snap
@@ -53,7 +53,8 @@ exports[`appellant-case GET /appellant-case should render a "LPA application ref
                             <li>test3@example.com</li>
                         </ul>
                     </dd>
-                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/service-user/change/appellant"> Change<span class="govuk-visually-hidden"> Appellant</span></a>
+                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/service-user/change/appellant"
+                        data-cy="appellant"> Change<span class="govuk-visually-hidden"> Appellant</span></a>
                     </dd>
                 </div>
                 <div class="govuk-summary-list__row appeal-agent"><dt class="govuk-summary-list__key"> Agent</dt>
@@ -63,12 +64,14 @@ exports[`appellant-case GET /appellant-case should render a "LPA application ref
                             <li>test2@example.com</li>
                         </ul>
                     </dd>
-                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/service-user/change/agent"> Change<span class="govuk-visually-hidden"> Agent</span></a>
+                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/service-user/change/agent"
+                        data-cy="change-agent"> Change<span class="govuk-visually-hidden"> Agent</span></a>
                     </dd>
                 </div>
                 <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> LPA application reference</dt>
                     <dd                     class="govuk-summary-list__value">48269/APP/2021/1482</dd>
-                        <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/lpa-reference/change"> Change<span class="govuk-visually-hidden"> LPA application reference</span></a>
+                        <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/lpa-reference/change"
+                            data-cy="change-application-reference"> Change<span class="govuk-visually-hidden"> LPA application reference</span></a>
                         </dd>
                 </div>
             </dl>
@@ -82,35 +85,41 @@ exports[`appellant-case GET /appellant-case should render a "LPA application ref
             <dl class="govuk-summary-list">
                 <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Site address</dt>
                     <dd class="govuk-summary-list__value">96 The Avenue, Maidstone, Kent, MD21 5XY</dd>
-                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/site-address/change/1"> Change<span class="govuk-visually-hidden"> Site address</span></a>
+                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/site-address/change/1"
+                        data-cy="change-site-address"> Change<span class="govuk-visually-hidden"> Site address</span></a>
                     </dd>
                 </div>
                 <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Site ownership</dt>
                     <dd class="govuk-summary-list__value">Fully owned</dd>
-                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/site-ownership/change"> Change<span class="govuk-visually-hidden"> Site ownership</span></a>
+                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/site-ownership/change"
+                        data-cy="change-site-ownership"> Change<span class="govuk-visually-hidden"> Site ownership</span></a>
                     </dd>
                 </div>
                 <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> All owners known</dt>
                     <dd class="govuk-summary-list__value"></dd>
-                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/change-appeal-details/all-owners-known"> Change<span class="govuk-visually-hidden"> All owners known</span></a>
+                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/change-appeal-details/all-owners-known"
+                        data-cy="change-all-owners-known"> Change<span class="govuk-visually-hidden"> All owners known</span></a>
                     </dd>
                 </div>
                 <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Advertised appeal</dt>
                     <dd class="govuk-summary-list__value"></dd>
-                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/change-appeal-details/advertised-appeal"> Change<span class="govuk-visually-hidden"> Advertised appeal</span></a>
+                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/change-appeal-details/advertised-appeal"
+                        data-cy="change-advertised-appeal"> Change<span class="govuk-visually-hidden"> Advertised appeal</span></a>
                     </dd>
                 </div>
                 <div class="govuk-summary-list__row appellantcase-inspector-access"><dt class="govuk-summary-list__key"> Inspection access required</dt>
                     <dd                     class="govuk-summary-list__value"><span>No</span>
                         </dd>
-                        <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/inspector-access/change/appellant"> Change<span class="govuk-visually-hidden"> Inspector access required</span></a>
+                        <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/inspector-access/change/appellant"
+                            data-cy="change-inspector-access"> Change<span class="govuk-visually-hidden"> Inspector access required</span></a>
                         </dd>
                 </div>
                 <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Potential safety risks</dt>
                     <dd class="govuk-summary-list__value"><span>Yes</span>
                         <br><span>Dogs on site</span>
                     </dd>
-                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/safety-risks/change/appellant"> Change<span class="govuk-visually-hidden"> potential safety risks</span></a>
+                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/safety-risks/change/appellant"
+                        data-cy="change-appellant-case-health-and-safety"> Change<span class="govuk-visually-hidden"> potential safety risks</span></a>
                     </dd>
                 </div>
             </dl>
@@ -124,17 +133,20 @@ exports[`appellant-case GET /appellant-case should render a "LPA application ref
             <dl class="govuk-summary-list" id="appeal-summary">
                 <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Application form</dt>
                     <dd class="govuk-summary-list__value"></dd>
-                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/add-documents/70457"> Add<span class="govuk-visually-hidden"> Application form</span></a>
+                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/add-documents/70457"
+                        data-cy="add-application-form"> Add<span class="govuk-visually-hidden"> Application form</span></a>
                     </dd>
                 </div>
                 <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Decision letter</dt>
                     <dd class="govuk-summary-list__value"></dd>
-                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/add-documents/70458"> Add<span class="govuk-visually-hidden"> Decision letter</span></a>
+                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/add-documents/70458"
+                        data-cy="add-decision-letter"> Add<span class="govuk-visually-hidden"> Decision letter</span></a>
                     </dd>
                 </div>
                 <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Appeal statement</dt>
                     <dd class="govuk-summary-list__value"></dd>
-                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/add-documents/70456"> Add<span class="govuk-visually-hidden"> Appeal statement</span></a>
+                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/add-documents/70456"
+                        data-cy="add-appeal-statement"> Add<span class="govuk-visually-hidden"> Appeal statement</span></a>
                     </dd>
                 </div>
             </dl>
@@ -268,7 +280,8 @@ exports[`appellant-case GET /appellant-case should render the appellant case pag
                             <li>test3@example.com</li>
                         </ul>
                     </dd>
-                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/service-user/change/appellant"> Change<span class="govuk-visually-hidden"> Appellant</span></a>
+                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/service-user/change/appellant"
+                        data-cy="appellant"> Change<span class="govuk-visually-hidden"> Appellant</span></a>
                     </dd>
                 </div>
                 <div class="govuk-summary-list__row appeal-agent"><dt class="govuk-summary-list__key"> Agent</dt>
@@ -278,12 +291,14 @@ exports[`appellant-case GET /appellant-case should render the appellant case pag
                             <li>test2@example.com</li>
                         </ul>
                     </dd>
-                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/service-user/change/agent"> Change<span class="govuk-visually-hidden"> Agent</span></a>
+                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/service-user/change/agent"
+                        data-cy="change-agent"> Change<span class="govuk-visually-hidden"> Agent</span></a>
                     </dd>
                 </div>
                 <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> LPA application reference</dt>
                     <dd                     class="govuk-summary-list__value">48269/APP/2021/1482</dd>
-                        <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/lpa-reference/change"> Change<span class="govuk-visually-hidden"> LPA application reference</span></a>
+                        <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/lpa-reference/change"
+                            data-cy="change-application-reference"> Change<span class="govuk-visually-hidden"> LPA application reference</span></a>
                         </dd>
                 </div>
             </dl>
@@ -297,35 +312,41 @@ exports[`appellant-case GET /appellant-case should render the appellant case pag
             <dl class="govuk-summary-list">
                 <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Site address</dt>
                     <dd class="govuk-summary-list__value">96 The Avenue, Maidstone, Kent, MD21 5XY</dd>
-                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/site-address/change/1"> Change<span class="govuk-visually-hidden"> Site address</span></a>
+                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/site-address/change/1"
+                        data-cy="change-site-address"> Change<span class="govuk-visually-hidden"> Site address</span></a>
                     </dd>
                 </div>
                 <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Site ownership</dt>
                     <dd class="govuk-summary-list__value">Fully owned</dd>
-                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/site-ownership/change"> Change<span class="govuk-visually-hidden"> Site ownership</span></a>
+                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/site-ownership/change"
+                        data-cy="change-site-ownership"> Change<span class="govuk-visually-hidden"> Site ownership</span></a>
                     </dd>
                 </div>
                 <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> All owners known</dt>
                     <dd class="govuk-summary-list__value"></dd>
-                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/change-appeal-details/all-owners-known"> Change<span class="govuk-visually-hidden"> All owners known</span></a>
+                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/change-appeal-details/all-owners-known"
+                        data-cy="change-all-owners-known"> Change<span class="govuk-visually-hidden"> All owners known</span></a>
                     </dd>
                 </div>
                 <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Advertised appeal</dt>
                     <dd class="govuk-summary-list__value"></dd>
-                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/change-appeal-details/advertised-appeal"> Change<span class="govuk-visually-hidden"> Advertised appeal</span></a>
+                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/change-appeal-details/advertised-appeal"
+                        data-cy="change-advertised-appeal"> Change<span class="govuk-visually-hidden"> Advertised appeal</span></a>
                     </dd>
                 </div>
                 <div class="govuk-summary-list__row appellantcase-inspector-access"><dt class="govuk-summary-list__key"> Inspection access required</dt>
                     <dd                     class="govuk-summary-list__value"><span>No</span>
                         </dd>
-                        <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/inspector-access/change/appellant"> Change<span class="govuk-visually-hidden"> Inspector access required</span></a>
+                        <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/inspector-access/change/appellant"
+                            data-cy="change-inspector-access"> Change<span class="govuk-visually-hidden"> Inspector access required</span></a>
                         </dd>
                 </div>
                 <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Potential safety risks</dt>
                     <dd class="govuk-summary-list__value"><span>Yes</span>
                         <br><span>Dogs on site</span>
                     </dd>
-                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/safety-risks/change/appellant"> Change<span class="govuk-visually-hidden"> potential safety risks</span></a>
+                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/safety-risks/change/appellant"
+                        data-cy="change-appellant-case-health-and-safety"> Change<span class="govuk-visually-hidden"> potential safety risks</span></a>
                     </dd>
                 </div>
             </dl>
@@ -339,17 +360,20 @@ exports[`appellant-case GET /appellant-case should render the appellant case pag
             <dl class="govuk-summary-list" id="appeal-summary">
                 <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Application form</dt>
                     <dd class="govuk-summary-list__value"></dd>
-                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/add-documents/70457"> Add<span class="govuk-visually-hidden"> Application form</span></a>
+                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/add-documents/70457"
+                        data-cy="add-application-form"> Add<span class="govuk-visually-hidden"> Application form</span></a>
                     </dd>
                 </div>
                 <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Decision letter</dt>
                     <dd class="govuk-summary-list__value"></dd>
-                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/add-documents/70458"> Add<span class="govuk-visually-hidden"> Decision letter</span></a>
+                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/add-documents/70458"
+                        data-cy="add-decision-letter"> Add<span class="govuk-visually-hidden"> Decision letter</span></a>
                     </dd>
                 </div>
                 <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Appeal statement</dt>
                     <dd class="govuk-summary-list__value"></dd>
-                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/add-documents/70456"> Add<span class="govuk-visually-hidden"> Appeal statement</span></a>
+                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/add-documents/70456"
+                        data-cy="add-appeal-statement"> Add<span class="govuk-visually-hidden"> Appeal statement</span></a>
                     </dd>
                 </div>
             </dl>
@@ -447,7 +471,8 @@ exports[`appellant-case GET /appellant-case with unchecked documents should rend
                             <li>test3@example.com</li>
                         </ul>
                     </dd>
-                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/service-user/change/appellant"> Change<span class="govuk-visually-hidden"> Appellant</span></a>
+                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/service-user/change/appellant"
+                        data-cy="appellant"> Change<span class="govuk-visually-hidden"> Appellant</span></a>
                     </dd>
                 </div>
                 <div class="govuk-summary-list__row appeal-agent"><dt class="govuk-summary-list__key"> Agent</dt>
@@ -457,12 +482,14 @@ exports[`appellant-case GET /appellant-case with unchecked documents should rend
                             <li>test2@example.com</li>
                         </ul>
                     </dd>
-                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/service-user/change/agent"> Change<span class="govuk-visually-hidden"> Agent</span></a>
+                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/service-user/change/agent"
+                        data-cy="change-agent"> Change<span class="govuk-visually-hidden"> Agent</span></a>
                     </dd>
                 </div>
                 <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> LPA application reference</dt>
                     <dd                     class="govuk-summary-list__value">48269/APP/2021/1482</dd>
-                        <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/lpa-reference/change"> Change<span class="govuk-visually-hidden"> LPA application reference</span></a>
+                        <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/lpa-reference/change"
+                            data-cy="change-application-reference"> Change<span class="govuk-visually-hidden"> LPA application reference</span></a>
                         </dd>
                 </div>
             </dl>
@@ -476,35 +503,41 @@ exports[`appellant-case GET /appellant-case with unchecked documents should rend
             <dl class="govuk-summary-list">
                 <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Site address</dt>
                     <dd class="govuk-summary-list__value">96 The Avenue, Maidstone, Kent, MD21 5XY</dd>
-                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/site-address/change/1"> Change<span class="govuk-visually-hidden"> Site address</span></a>
+                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/site-address/change/1"
+                        data-cy="change-site-address"> Change<span class="govuk-visually-hidden"> Site address</span></a>
                     </dd>
                 </div>
                 <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Site ownership</dt>
                     <dd class="govuk-summary-list__value">Fully owned</dd>
-                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/site-ownership/change"> Change<span class="govuk-visually-hidden"> Site ownership</span></a>
+                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/site-ownership/change"
+                        data-cy="change-site-ownership"> Change<span class="govuk-visually-hidden"> Site ownership</span></a>
                     </dd>
                 </div>
                 <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> All owners known</dt>
                     <dd class="govuk-summary-list__value"></dd>
-                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/change-appeal-details/all-owners-known"> Change<span class="govuk-visually-hidden"> All owners known</span></a>
+                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/change-appeal-details/all-owners-known"
+                        data-cy="change-all-owners-known"> Change<span class="govuk-visually-hidden"> All owners known</span></a>
                     </dd>
                 </div>
                 <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Advertised appeal</dt>
                     <dd class="govuk-summary-list__value"></dd>
-                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/change-appeal-details/advertised-appeal"> Change<span class="govuk-visually-hidden"> Advertised appeal</span></a>
+                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/change-appeal-details/advertised-appeal"
+                        data-cy="change-advertised-appeal"> Change<span class="govuk-visually-hidden"> Advertised appeal</span></a>
                     </dd>
                 </div>
                 <div class="govuk-summary-list__row appellantcase-inspector-access"><dt class="govuk-summary-list__key"> Inspection access required</dt>
                     <dd                     class="govuk-summary-list__value"><span>No</span>
                         </dd>
-                        <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/inspector-access/change/appellant"> Change<span class="govuk-visually-hidden"> Inspector access required</span></a>
+                        <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/inspector-access/change/appellant"
+                            data-cy="change-inspector-access"> Change<span class="govuk-visually-hidden"> Inspector access required</span></a>
                         </dd>
                 </div>
                 <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Potential safety risks</dt>
                     <dd class="govuk-summary-list__value"><span>Yes</span>
                         <br><span>Dogs on site</span>
                     </dd>
-                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/safety-risks/change/appellant"> Change<span class="govuk-visually-hidden"> potential safety risks</span></a>
+                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/safety-risks/change/appellant"
+                        data-cy="change-appellant-case-health-and-safety"> Change<span class="govuk-visually-hidden"> potential safety risks</span></a>
                     </dd>
                 </div>
             </dl>
@@ -518,17 +551,20 @@ exports[`appellant-case GET /appellant-case with unchecked documents should rend
             <dl class="govuk-summary-list" id="appeal-summary">
                 <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Application form</dt>
                     <dd class="govuk-summary-list__value"></dd>
-                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/add-documents/70457"> Add<span class="govuk-visually-hidden"> Application form</span></a>
+                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/add-documents/70457"
+                        data-cy="add-application-form"> Add<span class="govuk-visually-hidden"> Application form</span></a>
                     </dd>
                 </div>
                 <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Decision letter</dt>
                     <dd class="govuk-summary-list__value"></dd>
-                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/add-documents/70458"> Add<span class="govuk-visually-hidden"> Decision letter</span></a>
+                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/add-documents/70458"
+                        data-cy="add-decision-letter"> Add<span class="govuk-visually-hidden"> Decision letter</span></a>
                     </dd>
                 </div>
                 <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Appeal statement</dt>
                     <dd class="govuk-summary-list__value"></dd>
-                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/add-documents/70456"> Add<span class="govuk-visually-hidden"> Appeal statement</span></a>
+                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/add-documents/70456"
+                        data-cy="add-appeal-statement"> Add<span class="govuk-visually-hidden"> Appeal statement</span></a>
                     </dd>
                 </div>
             </dl>
@@ -634,7 +670,8 @@ exports[`appellant-case GET /appellant-case with unchecked documents should rend
                             <li>test3@example.com</li>
                         </ul>
                     </dd>
-                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/service-user/change/appellant"> Change<span class="govuk-visually-hidden"> Appellant</span></a>
+                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/service-user/change/appellant"
+                        data-cy="appellant"> Change<span class="govuk-visually-hidden"> Appellant</span></a>
                     </dd>
                 </div>
                 <div class="govuk-summary-list__row appeal-agent"><dt class="govuk-summary-list__key"> Agent</dt>
@@ -644,12 +681,14 @@ exports[`appellant-case GET /appellant-case with unchecked documents should rend
                             <li>test2@example.com</li>
                         </ul>
                     </dd>
-                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/service-user/change/agent"> Change<span class="govuk-visually-hidden"> Agent</span></a>
+                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/service-user/change/agent"
+                        data-cy="change-agent"> Change<span class="govuk-visually-hidden"> Agent</span></a>
                     </dd>
                 </div>
                 <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> LPA application reference</dt>
                     <dd                     class="govuk-summary-list__value">48269/APP/2021/1482</dd>
-                        <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/lpa-reference/change"> Change<span class="govuk-visually-hidden"> LPA application reference</span></a>
+                        <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/lpa-reference/change"
+                            data-cy="change-application-reference"> Change<span class="govuk-visually-hidden"> LPA application reference</span></a>
                         </dd>
                 </div>
             </dl>
@@ -663,35 +702,41 @@ exports[`appellant-case GET /appellant-case with unchecked documents should rend
             <dl class="govuk-summary-list">
                 <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Site address</dt>
                     <dd class="govuk-summary-list__value">96 The Avenue, Maidstone, Kent, MD21 5XY</dd>
-                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/site-address/change/1"> Change<span class="govuk-visually-hidden"> Site address</span></a>
+                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/site-address/change/1"
+                        data-cy="change-site-address"> Change<span class="govuk-visually-hidden"> Site address</span></a>
                     </dd>
                 </div>
                 <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Site ownership</dt>
                     <dd class="govuk-summary-list__value">Fully owned</dd>
-                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/site-ownership/change"> Change<span class="govuk-visually-hidden"> Site ownership</span></a>
+                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/site-ownership/change"
+                        data-cy="change-site-ownership"> Change<span class="govuk-visually-hidden"> Site ownership</span></a>
                     </dd>
                 </div>
                 <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> All owners known</dt>
                     <dd class="govuk-summary-list__value"></dd>
-                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/change-appeal-details/all-owners-known"> Change<span class="govuk-visually-hidden"> All owners known</span></a>
+                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/change-appeal-details/all-owners-known"
+                        data-cy="change-all-owners-known"> Change<span class="govuk-visually-hidden"> All owners known</span></a>
                     </dd>
                 </div>
                 <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Advertised appeal</dt>
                     <dd class="govuk-summary-list__value"></dd>
-                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/change-appeal-details/advertised-appeal"> Change<span class="govuk-visually-hidden"> Advertised appeal</span></a>
+                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/change-appeal-details/advertised-appeal"
+                        data-cy="change-advertised-appeal"> Change<span class="govuk-visually-hidden"> Advertised appeal</span></a>
                     </dd>
                 </div>
                 <div class="govuk-summary-list__row appellantcase-inspector-access"><dt class="govuk-summary-list__key"> Inspection access required</dt>
                     <dd                     class="govuk-summary-list__value"><span>No</span>
                         </dd>
-                        <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/inspector-access/change/appellant"> Change<span class="govuk-visually-hidden"> Inspector access required</span></a>
+                        <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/inspector-access/change/appellant"
+                            data-cy="change-inspector-access"> Change<span class="govuk-visually-hidden"> Inspector access required</span></a>
                         </dd>
                 </div>
                 <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Potential safety risks</dt>
                     <dd class="govuk-summary-list__value"><span>Yes</span>
                         <br><span>Dogs on site</span>
                     </dd>
-                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/safety-risks/change/appellant"> Change<span class="govuk-visually-hidden"> potential safety risks</span></a>
+                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/safety-risks/change/appellant"
+                        data-cy="change-appellant-case-health-and-safety"> Change<span class="govuk-visually-hidden"> potential safety risks</span></a>
                     </dd>
                 </div>
             </dl>
@@ -705,17 +750,20 @@ exports[`appellant-case GET /appellant-case with unchecked documents should rend
             <dl class="govuk-summary-list" id="appeal-summary">
                 <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Application form</dt>
                     <dd class="govuk-summary-list__value"></dd>
-                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/add-documents/70457"> Add<span class="govuk-visually-hidden"> Application form</span></a>
+                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/add-documents/70457"
+                        data-cy="add-application-form"> Add<span class="govuk-visually-hidden"> Application form</span></a>
                     </dd>
                 </div>
                 <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Decision letter</dt>
                     <dd class="govuk-summary-list__value"></dd>
-                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/add-documents/70458"> Add<span class="govuk-visually-hidden"> Decision letter</span></a>
+                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/add-documents/70458"
+                        data-cy="add-decision-letter"> Add<span class="govuk-visually-hidden"> Decision letter</span></a>
                     </dd>
                 </div>
                 <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Appeal statement</dt>
                     <dd class="govuk-summary-list__value"></dd>
-                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/add-documents/70456"> Add<span class="govuk-visually-hidden"> Appeal statement</span></a>
+                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/add-documents/70456"
+                        data-cy="add-appeal-statement"> Add<span class="govuk-visually-hidden"> Appeal statement</span></a>
                     </dd>
                 </div>
             </dl>
@@ -2749,7 +2797,8 @@ exports[`appellant-case POST /appellant-case should re-render the appellant case
                             <li>test3@example.com</li>
                         </ul>
                     </dd>
-                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/service-user/change/appellant"> Change<span class="govuk-visually-hidden"> Appellant</span></a>
+                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/service-user/change/appellant"
+                        data-cy="appellant"> Change<span class="govuk-visually-hidden"> Appellant</span></a>
                     </dd>
                 </div>
                 <div class="govuk-summary-list__row appeal-agent"><dt class="govuk-summary-list__key"> Agent</dt>
@@ -2759,12 +2808,14 @@ exports[`appellant-case POST /appellant-case should re-render the appellant case
                             <li>test2@example.com</li>
                         </ul>
                     </dd>
-                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/service-user/change/agent"> Change<span class="govuk-visually-hidden"> Agent</span></a>
+                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/service-user/change/agent"
+                        data-cy="change-agent"> Change<span class="govuk-visually-hidden"> Agent</span></a>
                     </dd>
                 </div>
                 <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> LPA application reference</dt>
                     <dd                     class="govuk-summary-list__value">48269/APP/2021/1482</dd>
-                        <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/lpa-reference/change"> Change<span class="govuk-visually-hidden"> LPA application reference</span></a>
+                        <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/lpa-reference/change"
+                            data-cy="change-application-reference"> Change<span class="govuk-visually-hidden"> LPA application reference</span></a>
                         </dd>
                 </div>
             </dl>
@@ -2778,35 +2829,41 @@ exports[`appellant-case POST /appellant-case should re-render the appellant case
             <dl class="govuk-summary-list">
                 <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Site address</dt>
                     <dd class="govuk-summary-list__value">96 The Avenue, Maidstone, Kent, MD21 5XY</dd>
-                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/site-address/change/1"> Change<span class="govuk-visually-hidden"> Site address</span></a>
+                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/site-address/change/1"
+                        data-cy="change-site-address"> Change<span class="govuk-visually-hidden"> Site address</span></a>
                     </dd>
                 </div>
                 <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Site ownership</dt>
                     <dd class="govuk-summary-list__value">Fully owned</dd>
-                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/site-ownership/change"> Change<span class="govuk-visually-hidden"> Site ownership</span></a>
+                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/site-ownership/change"
+                        data-cy="change-site-ownership"> Change<span class="govuk-visually-hidden"> Site ownership</span></a>
                     </dd>
                 </div>
                 <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> All owners known</dt>
                     <dd class="govuk-summary-list__value"></dd>
-                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/change-appeal-details/all-owners-known"> Change<span class="govuk-visually-hidden"> All owners known</span></a>
+                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/change-appeal-details/all-owners-known"
+                        data-cy="change-all-owners-known"> Change<span class="govuk-visually-hidden"> All owners known</span></a>
                     </dd>
                 </div>
                 <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Advertised appeal</dt>
                     <dd class="govuk-summary-list__value"></dd>
-                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/change-appeal-details/advertised-appeal"> Change<span class="govuk-visually-hidden"> Advertised appeal</span></a>
+                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/change-appeal-details/advertised-appeal"
+                        data-cy="change-advertised-appeal"> Change<span class="govuk-visually-hidden"> Advertised appeal</span></a>
                     </dd>
                 </div>
                 <div class="govuk-summary-list__row appellantcase-inspector-access"><dt class="govuk-summary-list__key"> Inspection access required</dt>
                     <dd                     class="govuk-summary-list__value"><span>No</span>
                         </dd>
-                        <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/inspector-access/change/appellant"> Change<span class="govuk-visually-hidden"> Inspector access required</span></a>
+                        <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/inspector-access/change/appellant"
+                            data-cy="change-inspector-access"> Change<span class="govuk-visually-hidden"> Inspector access required</span></a>
                         </dd>
                 </div>
                 <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Potential safety risks</dt>
                     <dd class="govuk-summary-list__value"><span>Yes</span>
                         <br><span>Dogs on site</span>
                     </dd>
-                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/safety-risks/change/appellant"> Change<span class="govuk-visually-hidden"> potential safety risks</span></a>
+                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/safety-risks/change/appellant"
+                        data-cy="change-appellant-case-health-and-safety"> Change<span class="govuk-visually-hidden"> potential safety risks</span></a>
                     </dd>
                 </div>
             </dl>
@@ -2820,17 +2877,20 @@ exports[`appellant-case POST /appellant-case should re-render the appellant case
             <dl class="govuk-summary-list" id="appeal-summary">
                 <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Application form</dt>
                     <dd class="govuk-summary-list__value"></dd>
-                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/add-documents/70457"> Add<span class="govuk-visually-hidden"> Application form</span></a>
+                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/add-documents/70457"
+                        data-cy="add-application-form"> Add<span class="govuk-visually-hidden"> Application form</span></a>
                     </dd>
                 </div>
                 <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Decision letter</dt>
                     <dd class="govuk-summary-list__value"></dd>
-                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/add-documents/70458"> Add<span class="govuk-visually-hidden"> Decision letter</span></a>
+                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/add-documents/70458"
+                        data-cy="add-decision-letter"> Add<span class="govuk-visually-hidden"> Decision letter</span></a>
                     </dd>
                 </div>
                 <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Appeal statement</dt>
                     <dd class="govuk-summary-list__value"></dd>
-                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/add-documents/70456"> Add<span class="govuk-visually-hidden"> Appeal statement</span></a>
+                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/add-documents/70456"
+                        data-cy="add-appeal-statement"> Add<span class="govuk-visually-hidden"> Appeal statement</span></a>
                     </dd>
                 </div>
             </dl>

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/__tests__/__snapshots__/lpa-questionnaire.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/__tests__/__snapshots__/lpa-questionnaire.test.js.snap
@@ -23,12 +23,14 @@ exports[`LPA Questionnaire review GET / should render the LPA Questionnaire page
             <dl class="govuk-summary-list" id="constraints-summary">
                 <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Correct appeal type</dt>
                     <dd class="govuk-summary-list__value">Yes</dd>
-                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/is-correct-appeal-type/change"> Change<span class="govuk-visually-hidden"> Correct appeal type</span></a>
+                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/is-correct-appeal-type/change"
+                        data-cy="change-is-correct-appeal-type"> Change<span class="govuk-visually-hidden"> Correct appeal type</span></a>
                     </dd>
                 </div>
                 <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Affects a listed building</dt>
                     <dd                     class="govuk-summary-list__value">Yes</dd>
-                        <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/change-lpa-questionnaire/does-affect-a-listed-building"> Change<span class="govuk-visually-hidden"> Affects a listed building</span></a>
+                        <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/change-lpa-questionnaire/does-affect-a-listed-building"
+                            data-cy="change-does-affect-a-listed-building"> Change<span class="govuk-visually-hidden"> Affects a listed building</span></a>
                         </dd>
                 </div>
                 <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Affected listed building details</dt>
@@ -39,12 +41,14 @@ exports[`LPA Questionnaire review GET / should render the LPA Questionnaire page
                             </li>
                         </ul>
                         </dd>
-                        <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/change-lpa-questionnaire/affects-listed-building-details"> Change<span class="govuk-visually-hidden"> Affects listed building details</span></a>
+                        <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/change-lpa-questionnaire/affects-listed-building-details"
+                            data-cy="change-affects-listed-building-details"> Change<span class="govuk-visually-hidden"> Affects listed building details</span></a>
                         </dd>
                 </div>
                 <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Conservation area</dt>
                     <dd class="govuk-summary-list__value">Yes</dd>
-                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/change-lpa-questionnaire/in-or-relates-to-ca"> Change<span class="govuk-visually-hidden"> Conservation area</span></a>
+                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/change-lpa-questionnaire/in-or-relates-to-ca"
+                        data-cy="change-in-or-relates-to-ca"> Change<span class="govuk-visually-hidden"> Conservation area</span></a>
                     </dd>
                 </div>
                 <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Conservation area map and guidance</dt>
@@ -56,16 +60,19 @@ exports[`LPA Questionnaire review GET / should render the LPA Questionnaire page
                         </dd>
                         <dd class="govuk-summary-list__actions">
                             <ul class="govuk-summary-list__actions-list">
-                                <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/manage-documents/1/"> Manage<span class="govuk-visually-hidden"> Conservation area map and guidance</span></a>
+                                <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/manage-documents/1/"
+                                    data-cy="manage-conservation-area-map"> Manage<span class="govuk-visually-hidden"> Conservation area map and guidance</span></a>
                                 </li>
-                                <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/add-documents/1"> Add<span class="govuk-visually-hidden"> Conservation area map and guidance</span></a>
+                                <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/add-documents/1"
+                                    data-cy="add-conservation-area-map"> Add<span class="govuk-visually-hidden"> Conservation area map and guidance</span></a>
                                 </li>
                             </ul>
                         </dd>
                 </div>
                 <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Green belt</dt>
                     <dd class="govuk-summary-list__value">Yes</dd>
-                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/change-lpa-questionnaire/site-within-green-belt"> Change<span class="govuk-visually-hidden"> Green belt</span></a>
+                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/change-lpa-questionnaire/site-within-green-belt"
+                        data-cy="change-site-within-green-belt"> Change<span class="govuk-visually-hidden"> Green belt</span></a>
                     </dd>
                 </div>
             </dl>
@@ -86,9 +93,11 @@ exports[`LPA Questionnaire review GET / should render the LPA Questionnaire page
                     </dd>
                     <dd class="govuk-summary-list__actions">
                         <ul class="govuk-summary-list__actions-list">
-                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/manage-documents/2/"> Manage<span class="govuk-visually-hidden"> Who was notified</span></a>
+                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/manage-documents/2/"
+                                data-cy="manage-notifying-parties"> Manage<span class="govuk-visually-hidden"> Who was notified</span></a>
                             </li>
-                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/add-documents/2"> Add<span class="govuk-visually-hidden"> Who was notified</span></a>
+                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/add-documents/2"
+                                data-cy="add-notifying-parties"> Add<span class="govuk-visually-hidden"> Who was notified</span></a>
                             </li>
                         </ul>
                     </dd>
@@ -100,7 +109,8 @@ exports[`LPA Questionnaire review GET / should render the LPA Questionnaire page
                             <li>Letter/email to interested parties</li>
                         </ul>
                     </dd>
-                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/change-lpa-questionnaire/notification-methods"> Change<span class="govuk-visually-hidden"> Notification methods</span></a>
+                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/change-lpa-questionnaire/notification-methods"
+                        data-cy="change-notification-methods"> Change<span class="govuk-visually-hidden"> Notification methods</span></a>
                     </dd>
                 </div>
             </dl>
@@ -114,7 +124,8 @@ exports[`LPA Questionnaire review GET / should render the LPA Questionnaire page
             <dl class="govuk-summary-list">
                 <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Representations from other parties</dt>
                     <dd                     class="govuk-summary-list__value">Yes</dd>
-                        <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/change-lpa-questionnaire/has-representations-from-other-parties"> Change<span class="govuk-visually-hidden"> Representations from other parties</span></a>
+                        <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/change-lpa-questionnaire/has-representations-from-other-parties"
+                            data-cy="change-has-representations-from-other-parties"> Change<span class="govuk-visually-hidden"> Representations from other parties</span></a>
                         </dd>
                 </div>
                 <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Representations from other parties documents</dt>
@@ -126,9 +137,11 @@ exports[`LPA Questionnaire review GET / should render the LPA Questionnaire page
                         </dd>
                         <dd class="govuk-summary-list__actions">
                             <ul class="govuk-summary-list__actions-list">
-                                <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/manage-documents/6/"> Manage<span class="govuk-visually-hidden"> Representations from other parties documents</span></a>
+                                <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/manage-documents/6/"
+                                    data-cy="manage-representations-from-other-parties"> Manage<span class="govuk-visually-hidden"> Representations from other parties documents</span></a>
                                 </li>
-                                <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/add-documents/6"> Add<span class="govuk-visually-hidden"> Representations from other parties documents</span></a>
+                                <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/add-documents/6"
+                                    data-cy="add-representations-from-other-parties"> Add<span class="govuk-visually-hidden"> Representations from other parties documents</span></a>
                                 </li>
                             </ul>
                         </dd>
@@ -151,9 +164,11 @@ exports[`LPA Questionnaire review GET / should render the LPA Questionnaire page
                         </dd>
                         <dd class="govuk-summary-list__actions">
                             <ul class="govuk-summary-list__actions-list">
-                                <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/manage-documents/7/"> Manage<span class="govuk-visually-hidden"> Planning officer&#39;s report</span></a>
+                                <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/manage-documents/7/"
+                                    data-cy="manage-officers-report"> Manage<span class="govuk-visually-hidden"> Planning officer&#39;s report</span></a>
                                 </li>
-                                <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/add-documents/7"> Add<span class="govuk-visually-hidden"> Planning officer&#39;s report</span></a>
+                                <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/add-documents/7"
+                                    data-cy="add-officers-report"> Add<span class="govuk-visually-hidden"> Planning officer&#39;s report</span></a>
                                 </li>
                             </ul>
                         </dd>
@@ -171,12 +186,14 @@ exports[`LPA Questionnaire review GET / should render the LPA Questionnaire page
                     <dd class="govuk-summary-list__value"><span>Yes</span>
                         <br><span>The entrance is at the back of the property</span>
                     </dd>
-                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/inspector-access/change/lpa"> Change<span class="govuk-visually-hidden"> Site access required</span></a>
+                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/inspector-access/change/lpa"
+                        data-cy="change-does-site-require-inspector-access"> Change<span class="govuk-visually-hidden"> Site access required</span></a>
                     </dd>
                 </div>
                 <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Affects neighbouring sites</dt>
                     <dd                     class="govuk-summary-list__value">Yes</dd>
-                        <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/neighbouring-sites/change/affected"> Change<span class="govuk-visually-hidden"> Affects neighbouring sites</span></a>
+                        <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/neighbouring-sites/change/affected"
+                            data-cy="change-is-affecting-neighbouring-sites"> Change<span class="govuk-visually-hidden"> Affects neighbouring sites</span></a>
                         </dd>
                 </div>
                 <div class="govuk-summary-list__row appeal-neighbouring-sites-inspector"><dt class="govuk-summary-list__key"> Neighbouring sites (LPA)</dt>
@@ -189,7 +206,8 @@ exports[`LPA Questionnaire review GET / should render the LPA Questionnaire page
                             <ul class="govuk-summary-list__actions-list">
                                 <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/neighbouring-sites/manage"> Manage<span class="govuk-visually-hidden"> Neighbouring sites (L P A)</span></a>
                                 </li>
-                                <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/neighbouring-sites/add/lpa"> Add<span class="govuk-visually-hidden"> Neighbouring sites (LPA)</span></a>
+                                <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/neighbouring-sites/add/lpa"
+                                    data-cy="add-neighbouring-site-lpa"> Add<span class="govuk-visually-hidden"> Neighbouring sites (LPA)</span></a>
                                 </li>
                             </ul>
                         </dd>
@@ -198,7 +216,8 @@ exports[`LPA Questionnaire review GET / should render the LPA Questionnaire page
                     <dd class="govuk-summary-list__value"><span>Yes</span>
                         <br><span>There is no mobile signal at the property</span>
                     </dd>
-                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/safety-risks/change/lpa"> Change<span class="govuk-visually-hidden"> potential safety risks</span></a>
+                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/safety-risks/change/lpa"
+                        data-cy="change-health-and-safety"> Change<span class="govuk-visually-hidden"> potential safety risks</span></a>
                     </dd>
                 </div>
             </dl>
@@ -213,11 +232,13 @@ exports[`LPA Questionnaire review GET / should render the LPA Questionnaire page
                 <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Appeals near the site</dt>
                     <dd class="govuk-summary-list__value">
                         <ul class="govuk-list govuk-list--bullet">
-                            <li><a href="/appeals-service/appeal-details/2" class="govuk-link" aria-label="Appeal 7 2 5 2 8 4">725284</a>
+                            <li><a href="/appeals-service/appeal-details/2" class="govuk-link" data-cy="related-appeal-725284"
+                                aria-label="Appeal 7 2 5 2 8 4">725284</a>
                             </li>
                         </ul>
                     </dd>
-                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/change-lpa-questionnaire/other-appeals"> Change<span class="govuk-visually-hidden"> Appeals near the site</span></a>
+                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/change-lpa-questionnaire/other-appeals"
+                        data-cy="change-other-appeals"> Change<span class="govuk-visually-hidden"> Appeals near the site</span></a>
                     </dd>
                 </div>
                 <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Extra conditions</dt>
@@ -360,12 +381,14 @@ exports[`LPA Questionnaire review GET / with unchecked documents should render a
             <dl class="govuk-summary-list" id="constraints-summary">
                 <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Correct appeal type</dt>
                     <dd class="govuk-summary-list__value">Yes</dd>
-                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/is-correct-appeal-type/change"> Change<span class="govuk-visually-hidden"> Correct appeal type</span></a>
+                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/is-correct-appeal-type/change"
+                        data-cy="change-is-correct-appeal-type"> Change<span class="govuk-visually-hidden"> Correct appeal type</span></a>
                     </dd>
                 </div>
                 <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Affects a listed building</dt>
                     <dd                     class="govuk-summary-list__value">Yes</dd>
-                        <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/change-lpa-questionnaire/does-affect-a-listed-building"> Change<span class="govuk-visually-hidden"> Affects a listed building</span></a>
+                        <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/change-lpa-questionnaire/does-affect-a-listed-building"
+                            data-cy="change-does-affect-a-listed-building"> Change<span class="govuk-visually-hidden"> Affects a listed building</span></a>
                         </dd>
                 </div>
                 <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Affected listed building details</dt>
@@ -376,12 +399,14 @@ exports[`LPA Questionnaire review GET / with unchecked documents should render a
                             </li>
                         </ul>
                         </dd>
-                        <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/change-lpa-questionnaire/affects-listed-building-details"> Change<span class="govuk-visually-hidden"> Affects listed building details</span></a>
+                        <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/change-lpa-questionnaire/affects-listed-building-details"
+                            data-cy="change-affects-listed-building-details"> Change<span class="govuk-visually-hidden"> Affects listed building details</span></a>
                         </dd>
                 </div>
                 <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Conservation area</dt>
                     <dd class="govuk-summary-list__value">Yes</dd>
-                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/change-lpa-questionnaire/in-or-relates-to-ca"> Change<span class="govuk-visually-hidden"> Conservation area</span></a>
+                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/change-lpa-questionnaire/in-or-relates-to-ca"
+                        data-cy="change-in-or-relates-to-ca"> Change<span class="govuk-visually-hidden"> Conservation area</span></a>
                     </dd>
                 </div>
                 <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Conservation area map and guidance</dt>
@@ -395,16 +420,19 @@ exports[`LPA Questionnaire review GET / with unchecked documents should render a
                         </dd>
                         <dd class="govuk-summary-list__actions">
                             <ul class="govuk-summary-list__actions-list">
-                                <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/manage-documents/1/"> Manage<span class="govuk-visually-hidden"> Conservation area map and guidance</span></a>
+                                <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/manage-documents/1/"
+                                    data-cy="manage-conservation-area-map"> Manage<span class="govuk-visually-hidden"> Conservation area map and guidance</span></a>
                                 </li>
-                                <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/add-documents/1"> Add<span class="govuk-visually-hidden"> Conservation area map and guidance</span></a>
+                                <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/add-documents/1"
+                                    data-cy="add-conservation-area-map"> Add<span class="govuk-visually-hidden"> Conservation area map and guidance</span></a>
                                 </li>
                             </ul>
                         </dd>
                 </div>
                 <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Green belt</dt>
                     <dd class="govuk-summary-list__value">Yes</dd>
-                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/change-lpa-questionnaire/site-within-green-belt"> Change<span class="govuk-visually-hidden"> Green belt</span></a>
+                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/change-lpa-questionnaire/site-within-green-belt"
+                        data-cy="change-site-within-green-belt"> Change<span class="govuk-visually-hidden"> Green belt</span></a>
                     </dd>
                 </div>
             </dl>
@@ -425,9 +453,11 @@ exports[`LPA Questionnaire review GET / with unchecked documents should render a
                     </dd>
                     <dd class="govuk-summary-list__actions">
                         <ul class="govuk-summary-list__actions-list">
-                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/manage-documents/2/"> Manage<span class="govuk-visually-hidden"> Who was notified</span></a>
+                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/manage-documents/2/"
+                                data-cy="manage-notifying-parties"> Manage<span class="govuk-visually-hidden"> Who was notified</span></a>
                             </li>
-                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/add-documents/2"> Add<span class="govuk-visually-hidden"> Who was notified</span></a>
+                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/add-documents/2"
+                                data-cy="add-notifying-parties"> Add<span class="govuk-visually-hidden"> Who was notified</span></a>
                             </li>
                         </ul>
                     </dd>
@@ -439,7 +469,8 @@ exports[`LPA Questionnaire review GET / with unchecked documents should render a
                             <li>Letter/email to interested parties</li>
                         </ul>
                     </dd>
-                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/change-lpa-questionnaire/notification-methods"> Change<span class="govuk-visually-hidden"> Notification methods</span></a>
+                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/change-lpa-questionnaire/notification-methods"
+                        data-cy="change-notification-methods"> Change<span class="govuk-visually-hidden"> Notification methods</span></a>
                     </dd>
                 </div>
             </dl>
@@ -453,7 +484,8 @@ exports[`LPA Questionnaire review GET / with unchecked documents should render a
             <dl class="govuk-summary-list">
                 <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Representations from other parties</dt>
                     <dd                     class="govuk-summary-list__value">Yes</dd>
-                        <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/change-lpa-questionnaire/has-representations-from-other-parties"> Change<span class="govuk-visually-hidden"> Representations from other parties</span></a>
+                        <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/change-lpa-questionnaire/has-representations-from-other-parties"
+                            data-cy="change-has-representations-from-other-parties"> Change<span class="govuk-visually-hidden"> Representations from other parties</span></a>
                         </dd>
                 </div>
                 <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Representations from other parties documents</dt>
@@ -465,9 +497,11 @@ exports[`LPA Questionnaire review GET / with unchecked documents should render a
                         </dd>
                         <dd class="govuk-summary-list__actions">
                             <ul class="govuk-summary-list__actions-list">
-                                <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/manage-documents/6/"> Manage<span class="govuk-visually-hidden"> Representations from other parties documents</span></a>
+                                <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/manage-documents/6/"
+                                    data-cy="manage-representations-from-other-parties"> Manage<span class="govuk-visually-hidden"> Representations from other parties documents</span></a>
                                 </li>
-                                <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/add-documents/6"> Add<span class="govuk-visually-hidden"> Representations from other parties documents</span></a>
+                                <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/add-documents/6"
+                                    data-cy="add-representations-from-other-parties"> Add<span class="govuk-visually-hidden"> Representations from other parties documents</span></a>
                                 </li>
                             </ul>
                         </dd>
@@ -490,9 +524,11 @@ exports[`LPA Questionnaire review GET / with unchecked documents should render a
                         </dd>
                         <dd class="govuk-summary-list__actions">
                             <ul class="govuk-summary-list__actions-list">
-                                <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/manage-documents/7/"> Manage<span class="govuk-visually-hidden"> Planning officer&#39;s report</span></a>
+                                <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/manage-documents/7/"
+                                    data-cy="manage-officers-report"> Manage<span class="govuk-visually-hidden"> Planning officer&#39;s report</span></a>
                                 </li>
-                                <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/add-documents/7"> Add<span class="govuk-visually-hidden"> Planning officer&#39;s report</span></a>
+                                <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/add-documents/7"
+                                    data-cy="add-officers-report"> Add<span class="govuk-visually-hidden"> Planning officer&#39;s report</span></a>
                                 </li>
                             </ul>
                         </dd>
@@ -510,12 +546,14 @@ exports[`LPA Questionnaire review GET / with unchecked documents should render a
                     <dd class="govuk-summary-list__value"><span>Yes</span>
                         <br><span>The entrance is at the back of the property</span>
                     </dd>
-                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/inspector-access/change/lpa"> Change<span class="govuk-visually-hidden"> Site access required</span></a>
+                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/inspector-access/change/lpa"
+                        data-cy="change-does-site-require-inspector-access"> Change<span class="govuk-visually-hidden"> Site access required</span></a>
                     </dd>
                 </div>
                 <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Affects neighbouring sites</dt>
                     <dd                     class="govuk-summary-list__value">Yes</dd>
-                        <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/neighbouring-sites/change/affected"> Change<span class="govuk-visually-hidden"> Affects neighbouring sites</span></a>
+                        <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/neighbouring-sites/change/affected"
+                            data-cy="change-is-affecting-neighbouring-sites"> Change<span class="govuk-visually-hidden"> Affects neighbouring sites</span></a>
                         </dd>
                 </div>
                 <div class="govuk-summary-list__row appeal-neighbouring-sites-inspector"><dt class="govuk-summary-list__key"> Neighbouring sites (LPA)</dt>
@@ -528,7 +566,8 @@ exports[`LPA Questionnaire review GET / with unchecked documents should render a
                             <ul class="govuk-summary-list__actions-list">
                                 <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/neighbouring-sites/manage"> Manage<span class="govuk-visually-hidden"> Neighbouring sites (L P A)</span></a>
                                 </li>
-                                <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/neighbouring-sites/add/lpa"> Add<span class="govuk-visually-hidden"> Neighbouring sites (LPA)</span></a>
+                                <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/neighbouring-sites/add/lpa"
+                                    data-cy="add-neighbouring-site-lpa"> Add<span class="govuk-visually-hidden"> Neighbouring sites (LPA)</span></a>
                                 </li>
                             </ul>
                         </dd>
@@ -537,7 +576,8 @@ exports[`LPA Questionnaire review GET / with unchecked documents should render a
                     <dd class="govuk-summary-list__value"><span>Yes</span>
                         <br><span>There is no mobile signal at the property</span>
                     </dd>
-                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/safety-risks/change/lpa"> Change<span class="govuk-visually-hidden"> potential safety risks</span></a>
+                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/safety-risks/change/lpa"
+                        data-cy="change-health-and-safety"> Change<span class="govuk-visually-hidden"> potential safety risks</span></a>
                     </dd>
                 </div>
             </dl>
@@ -552,11 +592,13 @@ exports[`LPA Questionnaire review GET / with unchecked documents should render a
                 <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Appeals near the site</dt>
                     <dd class="govuk-summary-list__value">
                         <ul class="govuk-list govuk-list--bullet">
-                            <li><a href="/appeals-service/appeal-details/2" class="govuk-link" aria-label="Appeal 7 2 5 2 8 4">725284</a>
+                            <li><a href="/appeals-service/appeal-details/2" class="govuk-link" data-cy="related-appeal-725284"
+                                aria-label="Appeal 7 2 5 2 8 4">725284</a>
                             </li>
                         </ul>
                     </dd>
-                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/change-lpa-questionnaire/other-appeals"> Change<span class="govuk-visually-hidden"> Appeals near the site</span></a>
+                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/change-lpa-questionnaire/other-appeals"
+                        data-cy="change-other-appeals"> Change<span class="govuk-visually-hidden"> Appeals near the site</span></a>
                     </dd>
                 </div>
                 <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Extra conditions</dt>
@@ -699,12 +741,14 @@ exports[`LPA Questionnaire review GET / with unchecked documents should render a
             <dl class="govuk-summary-list" id="constraints-summary">
                 <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Correct appeal type</dt>
                     <dd class="govuk-summary-list__value">Yes</dd>
-                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/is-correct-appeal-type/change"> Change<span class="govuk-visually-hidden"> Correct appeal type</span></a>
+                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/is-correct-appeal-type/change"
+                        data-cy="change-is-correct-appeal-type"> Change<span class="govuk-visually-hidden"> Correct appeal type</span></a>
                     </dd>
                 </div>
                 <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Affects a listed building</dt>
                     <dd                     class="govuk-summary-list__value">Yes</dd>
-                        <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/change-lpa-questionnaire/does-affect-a-listed-building"> Change<span class="govuk-visually-hidden"> Affects a listed building</span></a>
+                        <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/change-lpa-questionnaire/does-affect-a-listed-building"
+                            data-cy="change-does-affect-a-listed-building"> Change<span class="govuk-visually-hidden"> Affects a listed building</span></a>
                         </dd>
                 </div>
                 <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Affected listed building details</dt>
@@ -715,12 +759,14 @@ exports[`LPA Questionnaire review GET / with unchecked documents should render a
                             </li>
                         </ul>
                         </dd>
-                        <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/change-lpa-questionnaire/affects-listed-building-details"> Change<span class="govuk-visually-hidden"> Affects listed building details</span></a>
+                        <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/change-lpa-questionnaire/affects-listed-building-details"
+                            data-cy="change-affects-listed-building-details"> Change<span class="govuk-visually-hidden"> Affects listed building details</span></a>
                         </dd>
                 </div>
                 <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Conservation area</dt>
                     <dd class="govuk-summary-list__value">Yes</dd>
-                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/change-lpa-questionnaire/in-or-relates-to-ca"> Change<span class="govuk-visually-hidden"> Conservation area</span></a>
+                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/change-lpa-questionnaire/in-or-relates-to-ca"
+                        data-cy="change-in-or-relates-to-ca"> Change<span class="govuk-visually-hidden"> Conservation area</span></a>
                     </dd>
                 </div>
                 <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Conservation area map and guidance</dt>
@@ -734,16 +780,19 @@ exports[`LPA Questionnaire review GET / with unchecked documents should render a
                         </dd>
                         <dd class="govuk-summary-list__actions">
                             <ul class="govuk-summary-list__actions-list">
-                                <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/manage-documents/1/"> Manage<span class="govuk-visually-hidden"> Conservation area map and guidance</span></a>
+                                <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/manage-documents/1/"
+                                    data-cy="manage-conservation-area-map"> Manage<span class="govuk-visually-hidden"> Conservation area map and guidance</span></a>
                                 </li>
-                                <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/add-documents/1"> Add<span class="govuk-visually-hidden"> Conservation area map and guidance</span></a>
+                                <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/add-documents/1"
+                                    data-cy="add-conservation-area-map"> Add<span class="govuk-visually-hidden"> Conservation area map and guidance</span></a>
                                 </li>
                             </ul>
                         </dd>
                 </div>
                 <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Green belt</dt>
                     <dd class="govuk-summary-list__value">Yes</dd>
-                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/change-lpa-questionnaire/site-within-green-belt"> Change<span class="govuk-visually-hidden"> Green belt</span></a>
+                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/change-lpa-questionnaire/site-within-green-belt"
+                        data-cy="change-site-within-green-belt"> Change<span class="govuk-visually-hidden"> Green belt</span></a>
                     </dd>
                 </div>
             </dl>
@@ -764,9 +813,11 @@ exports[`LPA Questionnaire review GET / with unchecked documents should render a
                     </dd>
                     <dd class="govuk-summary-list__actions">
                         <ul class="govuk-summary-list__actions-list">
-                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/manage-documents/2/"> Manage<span class="govuk-visually-hidden"> Who was notified</span></a>
+                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/manage-documents/2/"
+                                data-cy="manage-notifying-parties"> Manage<span class="govuk-visually-hidden"> Who was notified</span></a>
                             </li>
-                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/add-documents/2"> Add<span class="govuk-visually-hidden"> Who was notified</span></a>
+                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/add-documents/2"
+                                data-cy="add-notifying-parties"> Add<span class="govuk-visually-hidden"> Who was notified</span></a>
                             </li>
                         </ul>
                     </dd>
@@ -778,7 +829,8 @@ exports[`LPA Questionnaire review GET / with unchecked documents should render a
                             <li>Letter/email to interested parties</li>
                         </ul>
                     </dd>
-                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/change-lpa-questionnaire/notification-methods"> Change<span class="govuk-visually-hidden"> Notification methods</span></a>
+                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/change-lpa-questionnaire/notification-methods"
+                        data-cy="change-notification-methods"> Change<span class="govuk-visually-hidden"> Notification methods</span></a>
                     </dd>
                 </div>
             </dl>
@@ -792,7 +844,8 @@ exports[`LPA Questionnaire review GET / with unchecked documents should render a
             <dl class="govuk-summary-list">
                 <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Representations from other parties</dt>
                     <dd                     class="govuk-summary-list__value">Yes</dd>
-                        <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/change-lpa-questionnaire/has-representations-from-other-parties"> Change<span class="govuk-visually-hidden"> Representations from other parties</span></a>
+                        <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/change-lpa-questionnaire/has-representations-from-other-parties"
+                            data-cy="change-has-representations-from-other-parties"> Change<span class="govuk-visually-hidden"> Representations from other parties</span></a>
                         </dd>
                 </div>
                 <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Representations from other parties documents</dt>
@@ -804,9 +857,11 @@ exports[`LPA Questionnaire review GET / with unchecked documents should render a
                         </dd>
                         <dd class="govuk-summary-list__actions">
                             <ul class="govuk-summary-list__actions-list">
-                                <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/manage-documents/6/"> Manage<span class="govuk-visually-hidden"> Representations from other parties documents</span></a>
+                                <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/manage-documents/6/"
+                                    data-cy="manage-representations-from-other-parties"> Manage<span class="govuk-visually-hidden"> Representations from other parties documents</span></a>
                                 </li>
-                                <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/add-documents/6"> Add<span class="govuk-visually-hidden"> Representations from other parties documents</span></a>
+                                <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/add-documents/6"
+                                    data-cy="add-representations-from-other-parties"> Add<span class="govuk-visually-hidden"> Representations from other parties documents</span></a>
                                 </li>
                             </ul>
                         </dd>
@@ -829,9 +884,11 @@ exports[`LPA Questionnaire review GET / with unchecked documents should render a
                         </dd>
                         <dd class="govuk-summary-list__actions">
                             <ul class="govuk-summary-list__actions-list">
-                                <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/manage-documents/7/"> Manage<span class="govuk-visually-hidden"> Planning officer&#39;s report</span></a>
+                                <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/manage-documents/7/"
+                                    data-cy="manage-officers-report"> Manage<span class="govuk-visually-hidden"> Planning officer&#39;s report</span></a>
                                 </li>
-                                <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/add-documents/7"> Add<span class="govuk-visually-hidden"> Planning officer&#39;s report</span></a>
+                                <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/add-documents/7"
+                                    data-cy="add-officers-report"> Add<span class="govuk-visually-hidden"> Planning officer&#39;s report</span></a>
                                 </li>
                             </ul>
                         </dd>
@@ -849,12 +906,14 @@ exports[`LPA Questionnaire review GET / with unchecked documents should render a
                     <dd class="govuk-summary-list__value"><span>Yes</span>
                         <br><span>The entrance is at the back of the property</span>
                     </dd>
-                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/inspector-access/change/lpa"> Change<span class="govuk-visually-hidden"> Site access required</span></a>
+                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/inspector-access/change/lpa"
+                        data-cy="change-does-site-require-inspector-access"> Change<span class="govuk-visually-hidden"> Site access required</span></a>
                     </dd>
                 </div>
                 <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Affects neighbouring sites</dt>
                     <dd                     class="govuk-summary-list__value">Yes</dd>
-                        <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/neighbouring-sites/change/affected"> Change<span class="govuk-visually-hidden"> Affects neighbouring sites</span></a>
+                        <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/neighbouring-sites/change/affected"
+                            data-cy="change-is-affecting-neighbouring-sites"> Change<span class="govuk-visually-hidden"> Affects neighbouring sites</span></a>
                         </dd>
                 </div>
                 <div class="govuk-summary-list__row appeal-neighbouring-sites-inspector"><dt class="govuk-summary-list__key"> Neighbouring sites (LPA)</dt>
@@ -867,7 +926,8 @@ exports[`LPA Questionnaire review GET / with unchecked documents should render a
                             <ul class="govuk-summary-list__actions-list">
                                 <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/neighbouring-sites/manage"> Manage<span class="govuk-visually-hidden"> Neighbouring sites (L P A)</span></a>
                                 </li>
-                                <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/neighbouring-sites/add/lpa"> Add<span class="govuk-visually-hidden"> Neighbouring sites (LPA)</span></a>
+                                <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/neighbouring-sites/add/lpa"
+                                    data-cy="add-neighbouring-site-lpa"> Add<span class="govuk-visually-hidden"> Neighbouring sites (LPA)</span></a>
                                 </li>
                             </ul>
                         </dd>
@@ -876,7 +936,8 @@ exports[`LPA Questionnaire review GET / with unchecked documents should render a
                     <dd class="govuk-summary-list__value"><span>Yes</span>
                         <br><span>There is no mobile signal at the property</span>
                     </dd>
-                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/safety-risks/change/lpa"> Change<span class="govuk-visually-hidden"> potential safety risks</span></a>
+                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/safety-risks/change/lpa"
+                        data-cy="change-health-and-safety"> Change<span class="govuk-visually-hidden"> potential safety risks</span></a>
                     </dd>
                 </div>
             </dl>
@@ -891,11 +952,13 @@ exports[`LPA Questionnaire review GET / with unchecked documents should render a
                 <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Appeals near the site</dt>
                     <dd class="govuk-summary-list__value">
                         <ul class="govuk-list govuk-list--bullet">
-                            <li><a href="/appeals-service/appeal-details/2" class="govuk-link" aria-label="Appeal 7 2 5 2 8 4">725284</a>
+                            <li><a href="/appeals-service/appeal-details/2" class="govuk-link" data-cy="related-appeal-725284"
+                                aria-label="Appeal 7 2 5 2 8 4">725284</a>
                             </li>
                         </ul>
                     </dd>
-                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/change-lpa-questionnaire/other-appeals"> Change<span class="govuk-visually-hidden"> Appeals near the site</span></a>
+                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/change-lpa-questionnaire/other-appeals"
+                        data-cy="change-other-appeals"> Change<span class="govuk-visually-hidden"> Appeals near the site</span></a>
                     </dd>
                 </div>
                 <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Extra conditions</dt>
@@ -2726,12 +2789,14 @@ exports[`LPA Questionnaire review POST / should render LPA Questionnaire review 
             <dl class="govuk-summary-list" id="constraints-summary">
                 <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Correct appeal type</dt>
                     <dd class="govuk-summary-list__value">Yes</dd>
-                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/is-correct-appeal-type/change"> Change<span class="govuk-visually-hidden"> Correct appeal type</span></a>
+                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/is-correct-appeal-type/change"
+                        data-cy="change-is-correct-appeal-type"> Change<span class="govuk-visually-hidden"> Correct appeal type</span></a>
                     </dd>
                 </div>
                 <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Affects a listed building</dt>
                     <dd                     class="govuk-summary-list__value">Yes</dd>
-                        <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/change-lpa-questionnaire/does-affect-a-listed-building"> Change<span class="govuk-visually-hidden"> Affects a listed building</span></a>
+                        <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/change-lpa-questionnaire/does-affect-a-listed-building"
+                            data-cy="change-does-affect-a-listed-building"> Change<span class="govuk-visually-hidden"> Affects a listed building</span></a>
                         </dd>
                 </div>
                 <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Affected listed building details</dt>
@@ -2742,12 +2807,14 @@ exports[`LPA Questionnaire review POST / should render LPA Questionnaire review 
                             </li>
                         </ul>
                         </dd>
-                        <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/change-lpa-questionnaire/affects-listed-building-details"> Change<span class="govuk-visually-hidden"> Affects listed building details</span></a>
+                        <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/change-lpa-questionnaire/affects-listed-building-details"
+                            data-cy="change-affects-listed-building-details"> Change<span class="govuk-visually-hidden"> Affects listed building details</span></a>
                         </dd>
                 </div>
                 <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Conservation area</dt>
                     <dd class="govuk-summary-list__value">Yes</dd>
-                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/change-lpa-questionnaire/in-or-relates-to-ca"> Change<span class="govuk-visually-hidden"> Conservation area</span></a>
+                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/change-lpa-questionnaire/in-or-relates-to-ca"
+                        data-cy="change-in-or-relates-to-ca"> Change<span class="govuk-visually-hidden"> Conservation area</span></a>
                     </dd>
                 </div>
                 <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Conservation area map and guidance</dt>
@@ -2759,16 +2826,19 @@ exports[`LPA Questionnaire review POST / should render LPA Questionnaire review 
                         </dd>
                         <dd class="govuk-summary-list__actions">
                             <ul class="govuk-summary-list__actions-list">
-                                <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/manage-documents/1/"> Manage<span class="govuk-visually-hidden"> Conservation area map and guidance</span></a>
+                                <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/manage-documents/1/"
+                                    data-cy="manage-conservation-area-map"> Manage<span class="govuk-visually-hidden"> Conservation area map and guidance</span></a>
                                 </li>
-                                <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/add-documents/1"> Add<span class="govuk-visually-hidden"> Conservation area map and guidance</span></a>
+                                <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/add-documents/1"
+                                    data-cy="add-conservation-area-map"> Add<span class="govuk-visually-hidden"> Conservation area map and guidance</span></a>
                                 </li>
                             </ul>
                         </dd>
                 </div>
                 <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Green belt</dt>
                     <dd class="govuk-summary-list__value">Yes</dd>
-                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/change-lpa-questionnaire/site-within-green-belt"> Change<span class="govuk-visually-hidden"> Green belt</span></a>
+                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/change-lpa-questionnaire/site-within-green-belt"
+                        data-cy="change-site-within-green-belt"> Change<span class="govuk-visually-hidden"> Green belt</span></a>
                     </dd>
                 </div>
             </dl>
@@ -2789,9 +2859,11 @@ exports[`LPA Questionnaire review POST / should render LPA Questionnaire review 
                     </dd>
                     <dd class="govuk-summary-list__actions">
                         <ul class="govuk-summary-list__actions-list">
-                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/manage-documents/2/"> Manage<span class="govuk-visually-hidden"> Who was notified</span></a>
+                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/manage-documents/2/"
+                                data-cy="manage-notifying-parties"> Manage<span class="govuk-visually-hidden"> Who was notified</span></a>
                             </li>
-                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/add-documents/2"> Add<span class="govuk-visually-hidden"> Who was notified</span></a>
+                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/add-documents/2"
+                                data-cy="add-notifying-parties"> Add<span class="govuk-visually-hidden"> Who was notified</span></a>
                             </li>
                         </ul>
                     </dd>
@@ -2803,7 +2875,8 @@ exports[`LPA Questionnaire review POST / should render LPA Questionnaire review 
                             <li>Letter/email to interested parties</li>
                         </ul>
                     </dd>
-                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/change-lpa-questionnaire/notification-methods"> Change<span class="govuk-visually-hidden"> Notification methods</span></a>
+                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/change-lpa-questionnaire/notification-methods"
+                        data-cy="change-notification-methods"> Change<span class="govuk-visually-hidden"> Notification methods</span></a>
                     </dd>
                 </div>
             </dl>
@@ -2817,7 +2890,8 @@ exports[`LPA Questionnaire review POST / should render LPA Questionnaire review 
             <dl class="govuk-summary-list">
                 <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Representations from other parties</dt>
                     <dd                     class="govuk-summary-list__value">Yes</dd>
-                        <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/change-lpa-questionnaire/has-representations-from-other-parties"> Change<span class="govuk-visually-hidden"> Representations from other parties</span></a>
+                        <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/change-lpa-questionnaire/has-representations-from-other-parties"
+                            data-cy="change-has-representations-from-other-parties"> Change<span class="govuk-visually-hidden"> Representations from other parties</span></a>
                         </dd>
                 </div>
                 <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Representations from other parties documents</dt>
@@ -2829,9 +2903,11 @@ exports[`LPA Questionnaire review POST / should render LPA Questionnaire review 
                         </dd>
                         <dd class="govuk-summary-list__actions">
                             <ul class="govuk-summary-list__actions-list">
-                                <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/manage-documents/6/"> Manage<span class="govuk-visually-hidden"> Representations from other parties documents</span></a>
+                                <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/manage-documents/6/"
+                                    data-cy="manage-representations-from-other-parties"> Manage<span class="govuk-visually-hidden"> Representations from other parties documents</span></a>
                                 </li>
-                                <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/add-documents/6"> Add<span class="govuk-visually-hidden"> Representations from other parties documents</span></a>
+                                <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/add-documents/6"
+                                    data-cy="add-representations-from-other-parties"> Add<span class="govuk-visually-hidden"> Representations from other parties documents</span></a>
                                 </li>
                             </ul>
                         </dd>
@@ -2854,9 +2930,11 @@ exports[`LPA Questionnaire review POST / should render LPA Questionnaire review 
                         </dd>
                         <dd class="govuk-summary-list__actions">
                             <ul class="govuk-summary-list__actions-list">
-                                <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/manage-documents/7/"> Manage<span class="govuk-visually-hidden"> Planning officer&#39;s report</span></a>
+                                <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/manage-documents/7/"
+                                    data-cy="manage-officers-report"> Manage<span class="govuk-visually-hidden"> Planning officer&#39;s report</span></a>
                                 </li>
-                                <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/add-documents/7"> Add<span class="govuk-visually-hidden"> Planning officer&#39;s report</span></a>
+                                <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/add-documents/7"
+                                    data-cy="add-officers-report"> Add<span class="govuk-visually-hidden"> Planning officer&#39;s report</span></a>
                                 </li>
                             </ul>
                         </dd>
@@ -2874,12 +2952,14 @@ exports[`LPA Questionnaire review POST / should render LPA Questionnaire review 
                     <dd class="govuk-summary-list__value"><span>Yes</span>
                         <br><span>The entrance is at the back of the property</span>
                     </dd>
-                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/inspector-access/change/lpa"> Change<span class="govuk-visually-hidden"> Site access required</span></a>
+                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/inspector-access/change/lpa"
+                        data-cy="change-does-site-require-inspector-access"> Change<span class="govuk-visually-hidden"> Site access required</span></a>
                     </dd>
                 </div>
                 <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Affects neighbouring sites</dt>
                     <dd                     class="govuk-summary-list__value">Yes</dd>
-                        <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/neighbouring-sites/change/affected"> Change<span class="govuk-visually-hidden"> Affects neighbouring sites</span></a>
+                        <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/neighbouring-sites/change/affected"
+                            data-cy="change-is-affecting-neighbouring-sites"> Change<span class="govuk-visually-hidden"> Affects neighbouring sites</span></a>
                         </dd>
                 </div>
                 <div class="govuk-summary-list__row appeal-neighbouring-sites-inspector"><dt class="govuk-summary-list__key"> Neighbouring sites (LPA)</dt>
@@ -2892,7 +2972,8 @@ exports[`LPA Questionnaire review POST / should render LPA Questionnaire review 
                             <ul class="govuk-summary-list__actions-list">
                                 <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/neighbouring-sites/manage"> Manage<span class="govuk-visually-hidden"> Neighbouring sites (L P A)</span></a>
                                 </li>
-                                <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/neighbouring-sites/add/lpa"> Add<span class="govuk-visually-hidden"> Neighbouring sites (LPA)</span></a>
+                                <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/neighbouring-sites/add/lpa"
+                                    data-cy="add-neighbouring-site-lpa"> Add<span class="govuk-visually-hidden"> Neighbouring sites (LPA)</span></a>
                                 </li>
                             </ul>
                         </dd>
@@ -2901,7 +2982,8 @@ exports[`LPA Questionnaire review POST / should render LPA Questionnaire review 
                     <dd class="govuk-summary-list__value"><span>Yes</span>
                         <br><span>There is no mobile signal at the property</span>
                     </dd>
-                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/safety-risks/change/lpa"> Change<span class="govuk-visually-hidden"> potential safety risks</span></a>
+                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/safety-risks/change/lpa"
+                        data-cy="change-health-and-safety"> Change<span class="govuk-visually-hidden"> potential safety risks</span></a>
                     </dd>
                 </div>
             </dl>
@@ -2916,11 +2998,13 @@ exports[`LPA Questionnaire review POST / should render LPA Questionnaire review 
                 <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Appeals near the site</dt>
                     <dd class="govuk-summary-list__value">
                         <ul class="govuk-list govuk-list--bullet">
-                            <li><a href="/appeals-service/appeal-details/2" class="govuk-link" aria-label="Appeal 7 2 5 2 8 4">725284</a>
+                            <li><a href="/appeals-service/appeal-details/2" class="govuk-link" data-cy="related-appeal-725284"
+                                aria-label="Appeal 7 2 5 2 8 4">725284</a>
                             </li>
                         </ul>
                     </dd>
-                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/change-lpa-questionnaire/other-appeals"> Change<span class="govuk-visually-hidden"> Appeals near the site</span></a>
+                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/change-lpa-questionnaire/other-appeals"
+                        data-cy="change-other-appeals"> Change<span class="govuk-visually-hidden"> Appeals near the site</span></a>
                     </dd>
                 </div>
                 <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Extra conditions</dt>

--- a/appeals/web/src/server/appeals/appeal-details/manage-linked-appeals/__tests__/__snapshots__/manage-linked-appeals.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/manage-linked-appeals/__tests__/__snapshots__/manage-linked-appeals.test.js.snap
@@ -1028,10 +1028,11 @@ exports[`linked-appeals GET /linked-appeals/manage should render the manage link
         </thead>
         <tbody class="govuk-table__body">
             <tr class="govuk-table__row">
-                <td class="govuk-table__cell"><a class="govuk-link" href="https://test-horizon-url.gov.uk?appealId=3">76215416</a>
+                <td class="govuk-table__cell"><a class="govuk-link" href="https://test-horizon-url.gov.uk?appealId=3"
+                    data-cy="76215416">76215416</a>
                 </td>
                 <td class="govuk-table__cell">Commercial</td>
-                <td class="govuk-table__cell"><a class="govuk-link" href="/appeals-service/appeal-details/1/linked-appeals/unlink-appeal/3/3047/2">Unlink</a>
+                <td class="govuk-table__cell"><a class="govuk-link" data-cy="unlink-appeal-APP/Q9999/D/21/351062" href="/appeals-service/appeal-details/1/linked-appeals/unlink-appeal/3/3047/2">Unlink</a>
                 </td>
             </tr>
         </tbody>
@@ -1059,17 +1060,19 @@ exports[`linked-appeals GET /linked-appeals/manage should render the manage link
         </thead>
         <tbody class="govuk-table__body">
             <tr class="govuk-table__row">
-                <td class="govuk-table__cell"><a class="govuk-link" href="/appeals-service/appeal-details/2" aria-label="Appeal 7 2 5 2 8 4">725284</a>
+                <td class="govuk-table__cell"><a class="govuk-link" href="/appeals-service/appeal-details/2" aria-label="Appeal 7 2 5 2 8 4"
+                    data-cy="APP/Q9999/D/21/725284">725284</a>
                 </td>
                 <td class="govuk-table__cell">Householder</td>
-                <td class="govuk-table__cell"><a class="govuk-link" href="/appeals-service/appeal-details/1/linked-appeals/unlink-appeal/2/3046/1">Unlink</a>
+                <td class="govuk-table__cell"><a class="govuk-link" data-cy="unlink-appeal-APP/Q9999/D/21/351062" href="/appeals-service/appeal-details/1/linked-appeals/unlink-appeal/2/3046/1">Unlink</a>
                 </td>
             </tr>
             <tr class="govuk-table__row">
-                <td class="govuk-table__cell"><a class="govuk-link" href="https://test-horizon-url.gov.uk?appealId=3">76215416</a>
+                <td class="govuk-table__cell"><a class="govuk-link" href="https://test-horizon-url.gov.uk?appealId=3"
+                    data-cy="76215416">76215416</a>
                 </td>
                 <td class="govuk-table__cell">Commercial</td>
-                <td class="govuk-table__cell"><a class="govuk-link" href="/appeals-service/appeal-details/1/linked-appeals/unlink-appeal/3/3047/1">Unlink</a>
+                <td class="govuk-table__cell"><a class="govuk-link" data-cy="unlink-appeal-APP/Q9999/D/21/351062" href="/appeals-service/appeal-details/1/linked-appeals/unlink-appeal/3/3047/1">Unlink</a>
                 </td>
             </tr>
         </tbody>

--- a/appeals/web/src/server/appeals/appeal-details/manage-linked-appeals/manage-linked-appeals.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/manage-linked-appeals/manage-linked-appeals.mapper.js
@@ -95,12 +95,14 @@ export function manageLinkedAppealsPage(appealData, appealId, leadLinkedAppeal, 
 							html: linkedAppeal.externalSource
 								? `<a class="govuk-link" href="${generateHorizonAppealUrl(
 										linkedAppeal?.appealId
-								  )}">${linkedAppeal?.appealReference}</a>`
+								  )}" data-cy="${linkedAppeal?.appealReference}"
+								  >${linkedAppeal?.appealReference}</a>`
 								: `<a class="govuk-link" href="/appeals-service/appeal-details/${
 										linkedAppeal?.appealId
 								  }" aria-label="Appeal ${numberToAccessibleDigitLabel(
 										appealShortReference(linkedAppeal?.appealReference) || ''
-								  )}">${appealShortReference(linkedAppeal?.appealReference)}</a>`
+								  )}" data-cy="${linkedAppeal?.appealReference}"
+								  >${appealShortReference(linkedAppeal?.appealReference)}</a>`
 						},
 						{
 							text:
@@ -109,7 +111,7 @@ export function manageLinkedAppealsPage(appealData, appealId, leadLinkedAppeal, 
 									: linkedAppeal.appealType) || 'Unknown'
 						},
 						{
-							html: `<a class="govuk-link" href="/appeals-service/appeal-details/${appealData.appealId}/linked-appeals/unlink-appeal/${linkedAppeal.appealId}/${linkedAppeal.relationshipId}/${appealId}">Unlink</a>`
+							html: `<a class="govuk-link" data-cy="unlink-appeal-${appealData.appealReference}" href="/appeals-service/appeal-details/${appealData.appealId}/linked-appeals/unlink-appeal/${linkedAppeal.appealId}/${linkedAppeal.relationshipId}/${appealId}">Unlink</a>`
 						}
 					];
 				})

--- a/appeals/web/src/server/appeals/appeal-details/other-appeals/__tests__/__snapshots__/other-appeals.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/other-appeals/__tests__/__snapshots__/other-appeals.test.js.snap
@@ -193,13 +193,13 @@ exports[`other-appeals GET /other-appeals/manage should render the "Manage relat
                 <td class="govuk-table__cell"><a class="govuk-link" href="/appeals-service/appeal-details/2" aria-label="Appeal 2">2</a>
                 </td>
                 <td class="govuk-table__cell"></td>
-                <td class="govuk-table__cell"><a class="govuk-link" href="/appeals-service/appeal-details/1/other-appeals/remove/2/100">Remove</a>
+                <td class="govuk-table__cell"><a class="govuk-link" data-cy="remove-appeal-APP/Q9999/D/21/351062" href="/appeals-service/appeal-details/1/other-appeals/remove/2/100">Remove</a>
                 </td>
             </tr>
             <tr class="govuk-table__row">
                 <td class="govuk-table__cell">3 (Horizon)</td>
                 <td class="govuk-table__cell"></td>
-                <td class="govuk-table__cell"><a class="govuk-link" href="/appeals-service/appeal-details/1/other-appeals/remove/3/101">Remove</a>
+                <td class="govuk-table__cell"><a class="govuk-link" data-cy="remove-appeal-APP/Q9999/D/21/351062" href="/appeals-service/appeal-details/1/other-appeals/remove/3/101">Remove</a>
                 </td>
             </tr>
         </tbody>

--- a/appeals/web/src/server/appeals/appeal-details/other-appeals/other-appeals.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/other-appeals/other-appeals.mapper.js
@@ -240,7 +240,7 @@ export function manageOtherAppealsPage(appealData, request) {
 				text: otherAppeal.appealType || ''
 			},
 			{
-				html: `<a class="govuk-link" href="/appeals-service/appeal-details/${appealData.appealId}/other-appeals/remove/${shortAppealReference}/${otherAppeal.relationshipId}">Remove</a>`
+				html: `<a class="govuk-link" data-cy="remove-appeal-${appealData.appealReference}" href="/appeals-service/appeal-details/${appealData.appealId}/other-appeals/remove/${shortAppealReference}/${otherAppeal.relationshipId}">Remove</a>`
 			}
 		];
 	});

--- a/appeals/web/src/server/appeals/appeal-details/safety-risks/__tests__/__snapshots__/safety-risks.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/safety-risks/__tests__/__snapshots__/safety-risks.test.js.snap
@@ -116,6 +116,44 @@ exports[`safety-risks GET /change/:source should render changeSafetyRisksAccess 
 </main>"
 `;
 
+exports[`safety-risks GET /change/:source should render changeSafetyRisksAccess page for the appellant answer when source is appellant from appeals details 2`] = `
+"<main class="govuk-main-wrapper " id="main-content" role="main">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <div class="govuk-grid-row">
+                <div class="govuk-grid-column-full"><span class="govuk-caption-l govuk-!-margin-bottom-3">Appeal 351062</span>
+                    <h1                     class="govuk-heading-l govuk-!-margin-bottom-3">Change the site health and safety risks (appellant answer)</h1>
+                </div>
+            </div>
+            <form method="POST" novalidate="novalidate">
+                <div class="govuk-form-group">
+                    <div class="govuk-radios" data-module="govuk-radios">
+                        <div class="govuk-radios__item">
+                            <input class="govuk-radios__input" id="safetyRisksRadio" name="safetyRisksRadio"
+                            type="radio" value="yes" checked data-aria-controls="conditional-safetyRisksRadio">
+                            <label class="govuk-label govuk-radios__label" for="safetyRisksRadio">Yes</label>
+                        </div>
+                        <div class="govuk-radios__conditional" id="conditional-safetyRisksRadio">
+                            <div class="govuk-form-group">
+                                <label class="govuk-label" for="safety-risk-details">Health and safety risks (appellant details)</label>
+                                <textarea class="govuk-textarea"
+                                id="safety-risk-details" name="safetyRisksDetails" rows="3">Dogs on site</textarea>
+                            </div>
+                        </div>
+                        <div class="govuk-radios__item">
+                            <input class="govuk-radios__input" id="safetyRisksRadio-2" name="safetyRisksRadio"
+                            type="radio" value="no">
+                            <label class="govuk-label govuk-radios__label" for="safetyRisksRadio-2">No</label>
+                        </div>
+                    </div>
+                </div>
+                <button type="submit" class="govuk-button" data-module="govuk-button">Continue</button>
+            </form>
+        </div>
+    </div>
+</main>"
+`;
+
 exports[`safety-risks GET /change/:source should render changeSafetyRisksAccess page for the appellant answer when source is appellant from appellant case 1`] = `
 "<main class="govuk-main-wrapper " id="main-content" role="main">
     <div class="govuk-grid-row">

--- a/appeals/web/src/server/appeals/appeal-details/safety-risks/__tests__/__snapshots__/safety-risks.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/safety-risks/__tests__/__snapshots__/safety-risks.test.js.snap
@@ -116,44 +116,6 @@ exports[`safety-risks GET /change/:source should render changeSafetyRisksAccess 
 </main>"
 `;
 
-exports[`safety-risks GET /change/:source should render changeSafetyRisksAccess page for the appellant answer when source is appellant from appeals details 2`] = `
-"<main class="govuk-main-wrapper " id="main-content" role="main">
-    <div class="govuk-grid-row">
-        <div class="govuk-grid-column-two-thirds">
-            <div class="govuk-grid-row">
-                <div class="govuk-grid-column-full"><span class="govuk-caption-l govuk-!-margin-bottom-3">Appeal 351062</span>
-                    <h1                     class="govuk-heading-l govuk-!-margin-bottom-3">Change the site health and safety risks (appellant answer)</h1>
-                </div>
-            </div>
-            <form method="POST" novalidate="novalidate">
-                <div class="govuk-form-group">
-                    <div class="govuk-radios" data-module="govuk-radios">
-                        <div class="govuk-radios__item">
-                            <input class="govuk-radios__input" id="safetyRisksRadio" name="safetyRisksRadio"
-                            type="radio" value="yes" checked data-aria-controls="conditional-safetyRisksRadio">
-                            <label class="govuk-label govuk-radios__label" for="safetyRisksRadio">Yes</label>
-                        </div>
-                        <div class="govuk-radios__conditional" id="conditional-safetyRisksRadio">
-                            <div class="govuk-form-group">
-                                <label class="govuk-label" for="safety-risk-details">Health and safety risks (appellant details)</label>
-                                <textarea class="govuk-textarea"
-                                id="safety-risk-details" name="safetyRisksDetails" rows="3">Dogs on site</textarea>
-                            </div>
-                        </div>
-                        <div class="govuk-radios__item">
-                            <input class="govuk-radios__input" id="safetyRisksRadio-2" name="safetyRisksRadio"
-                            type="radio" value="no">
-                            <label class="govuk-label govuk-radios__label" for="safetyRisksRadio-2">No</label>
-                        </div>
-                    </div>
-                </div>
-                <button type="submit" class="govuk-button" data-module="govuk-button">Continue</button>
-            </form>
-        </div>
-    </div>
-</main>"
-`;
-
 exports[`safety-risks GET /change/:source should render changeSafetyRisksAccess page for the appellant answer when source is appellant from appellant case 1`] = `
 "<main class="govuk-main-wrapper " id="main-content" role="main">
     <div class="govuk-grid-row">

--- a/appeals/web/src/server/appeals/national-list/__tests__/__snapshots__/national-list.test.js.snap
+++ b/appeals/web/src/server/appeals/national-list/__tests__/__snapshots__/national-list.test.js.snap
@@ -14,7 +14,7 @@ exports[`national-list GET / should render national list - 10 pages - all page i
                     <label class="govuk-label govuk-caption-m govuk-!-margin-bottom-3 colour--secondary"
                     for="searchTerm">Enter appeal reference or postcode (include spaces)</label>
                     <input class="govuk-input"
-                    id="searchTerm" name="searchTerm" type="text">
+                    id="searchTerm" name="searchTerm" type="text" data-cy="search-term">
                 </div>
                 <div class="govuk-button-group">
                     <button type="submit" class="govuk-button govuk-button" data-module="govuk-button"
@@ -32,7 +32,8 @@ exports[`national-list GET / should render national list - 10 pages - all page i
                 <form method="GET">
                     <div class="govuk-form-group">
                         <label class="govuk-label">Filter by case status</label>
-                        <select class="govuk-select" id="" name="appealStatusFilter">
+                        <select class="govuk-select" id="" name="appealStatusFilter"
+                        data-cy="filter-by-case-status">
                             <option value="all">All</option>
                             <option value="assign_case_officer">Assign case officer</option>
                             <option value="ready_to_start">Ready to start</option>
@@ -43,7 +44,8 @@ exports[`national-list GET / should render national list - 10 pages - all page i
                     </div>
                     <div class="govuk-form-group">
                         <label class="govuk-label">Filter by inspector status</label>
-                        <select class="govuk-select" id="" name="inspectorStatusFilter">
+                        <select class="govuk-select" id="" name="inspectorStatusFilter"
+                        data-cy="filter-by-inspector-status">
                             <option value="all">All</option>
                             <option value="assigned">Assigned</option>
                             <option value="unassigned">Unassigned</option>
@@ -51,7 +53,8 @@ exports[`national-list GET / should render national list - 10 pages - all page i
                     </div>
                     <div class="govuk-button-group">
                         <button type="submit" class="govuk-button govuk-button--secondary" data-module="govuk-button"
-                        id="filters-submit">Apply</button><a class="govuk-link" href="/appeals-service/all-cases">Clear filter</a>
+                        data-cy="filter-submit" id="filters-submit">Apply</button><a class="govuk-link" href="/appeals-service/all-cases"
+                        data-cy="filter-clear">Clear filter</a>
                     </div>
                 </form>
             </div>
@@ -69,7 +72,8 @@ exports[`national-list GET / should render national list - 10 pages - all page i
         </thead>
         <tbody class="govuk-table__body">
             <tr class="govuk-table__row">
-                <td class="govuk-table__cell"><a class="govuk-link" href="/appeals-service/appeal-details/1" aria-label="Appeal 9 4 3 2 4 5">943245</a>
+                <td class="govuk-table__cell"><a class="govuk-link" href="/appeals-service/appeal-details/1" aria-label="Appeal 9 4 3 2 4 5"
+                    data-cy="943245">943245</a>
                 </td>
                 <td class="govuk-table__cell">Copthalls, Clevedon Road, West Hill, BS48 1PN</td>
                 <td class="govuk-table__cell">Wiltshire Council</td>
@@ -78,7 +82,8 @@ exports[`national-list GET / should render national list - 10 pages - all page i
                 </td>
             </tr>
             <tr class="govuk-table__row">
-                <td class="govuk-table__cell"><a class="govuk-link" href="/appeals-service/appeal-details/2" aria-label="Appeal 1 2 9 2 8 5">129285</a>
+                <td class="govuk-table__cell"><a class="govuk-link" href="/appeals-service/appeal-details/2" aria-label="Appeal 1 2 9 2 8 5"
+                    data-cy="129285">129285</a>
                 </td>
                 <td class="govuk-table__cell">19 Beauchamp Road, Bristol, BS7 8LQ</td>
                 <td class="govuk-table__cell">Dorset Council</td>
@@ -142,7 +147,7 @@ exports[`national-list GET / should render national list - 15 pages - pagination
                     <label class="govuk-label govuk-caption-m govuk-!-margin-bottom-3 colour--secondary"
                     for="searchTerm">Enter appeal reference or postcode (include spaces)</label>
                     <input class="govuk-input"
-                    id="searchTerm" name="searchTerm" type="text">
+                    id="searchTerm" name="searchTerm" type="text" data-cy="search-term">
                 </div>
                 <div class="govuk-button-group">
                     <button type="submit" class="govuk-button govuk-button" data-module="govuk-button"
@@ -160,7 +165,8 @@ exports[`national-list GET / should render national list - 15 pages - pagination
                 <form method="GET">
                     <div class="govuk-form-group">
                         <label class="govuk-label">Filter by case status</label>
-                        <select class="govuk-select" id="" name="appealStatusFilter">
+                        <select class="govuk-select" id="" name="appealStatusFilter"
+                        data-cy="filter-by-case-status">
                             <option value="all">All</option>
                             <option value="assign_case_officer">Assign case officer</option>
                             <option value="ready_to_start">Ready to start</option>
@@ -171,7 +177,8 @@ exports[`national-list GET / should render national list - 15 pages - pagination
                     </div>
                     <div class="govuk-form-group">
                         <label class="govuk-label">Filter by inspector status</label>
-                        <select class="govuk-select" id="" name="inspectorStatusFilter">
+                        <select class="govuk-select" id="" name="inspectorStatusFilter"
+                        data-cy="filter-by-inspector-status">
                             <option value="all">All</option>
                             <option value="assigned">Assigned</option>
                             <option value="unassigned">Unassigned</option>
@@ -179,7 +186,8 @@ exports[`national-list GET / should render national list - 15 pages - pagination
                     </div>
                     <div class="govuk-button-group">
                         <button type="submit" class="govuk-button govuk-button--secondary" data-module="govuk-button"
-                        id="filters-submit">Apply</button><a class="govuk-link" href="/appeals-service/all-cases">Clear filter</a>
+                        data-cy="filter-submit" id="filters-submit">Apply</button><a class="govuk-link" href="/appeals-service/all-cases"
+                        data-cy="filter-clear">Clear filter</a>
                     </div>
                 </form>
             </div>
@@ -197,7 +205,8 @@ exports[`national-list GET / should render national list - 15 pages - pagination
         </thead>
         <tbody class="govuk-table__body">
             <tr class="govuk-table__row">
-                <td class="govuk-table__cell"><a class="govuk-link" href="/appeals-service/appeal-details/1" aria-label="Appeal 9 4 3 2 4 5">943245</a>
+                <td class="govuk-table__cell"><a class="govuk-link" href="/appeals-service/appeal-details/1" aria-label="Appeal 9 4 3 2 4 5"
+                    data-cy="943245">943245</a>
                 </td>
                 <td class="govuk-table__cell">Copthalls, Clevedon Road, West Hill, BS48 1PN</td>
                 <td class="govuk-table__cell">Wiltshire Council</td>
@@ -206,7 +215,8 @@ exports[`national-list GET / should render national list - 15 pages - pagination
                 </td>
             </tr>
             <tr class="govuk-table__row">
-                <td class="govuk-table__cell"><a class="govuk-link" href="/appeals-service/appeal-details/2" aria-label="Appeal 1 2 9 2 8 5">129285</a>
+                <td class="govuk-table__cell"><a class="govuk-link" href="/appeals-service/appeal-details/2" aria-label="Appeal 1 2 9 2 8 5"
+                    data-cy="129285">129285</a>
                 </td>
                 <td class="govuk-table__cell">19 Beauchamp Road, Bristol, BS7 8LQ</td>
                 <td class="govuk-table__cell">Dorset Council</td>
@@ -250,7 +260,7 @@ exports[`national-list GET / should render national list - no pagination 1`] = `
                     <label class="govuk-label govuk-caption-m govuk-!-margin-bottom-3 colour--secondary"
                     for="searchTerm">Enter appeal reference or postcode (include spaces)</label>
                     <input class="govuk-input"
-                    id="searchTerm" name="searchTerm" type="text">
+                    id="searchTerm" name="searchTerm" type="text" data-cy="search-term">
                 </div>
                 <div class="govuk-button-group">
                     <button type="submit" class="govuk-button govuk-button" data-module="govuk-button"
@@ -268,7 +278,8 @@ exports[`national-list GET / should render national list - no pagination 1`] = `
                 <form method="GET">
                     <div class="govuk-form-group">
                         <label class="govuk-label">Filter by case status</label>
-                        <select class="govuk-select" id="" name="appealStatusFilter">
+                        <select class="govuk-select" id="" name="appealStatusFilter"
+                        data-cy="filter-by-case-status">
                             <option value="all">All</option>
                             <option value="assign_case_officer">Assign case officer</option>
                             <option value="ready_to_start">Ready to start</option>
@@ -279,7 +290,8 @@ exports[`national-list GET / should render national list - no pagination 1`] = `
                     </div>
                     <div class="govuk-form-group">
                         <label class="govuk-label">Filter by inspector status</label>
-                        <select class="govuk-select" id="" name="inspectorStatusFilter">
+                        <select class="govuk-select" id="" name="inspectorStatusFilter"
+                        data-cy="filter-by-inspector-status">
                             <option value="all">All</option>
                             <option value="assigned">Assigned</option>
                             <option value="unassigned">Unassigned</option>
@@ -287,7 +299,8 @@ exports[`national-list GET / should render national list - no pagination 1`] = `
                     </div>
                     <div class="govuk-button-group">
                         <button type="submit" class="govuk-button govuk-button--secondary" data-module="govuk-button"
-                        id="filters-submit">Apply</button><a class="govuk-link" href="/appeals-service/all-cases">Clear filter</a>
+                        data-cy="filter-submit" id="filters-submit">Apply</button><a class="govuk-link" href="/appeals-service/all-cases"
+                        data-cy="filter-clear">Clear filter</a>
                     </div>
                 </form>
             </div>
@@ -305,7 +318,8 @@ exports[`national-list GET / should render national list - no pagination 1`] = `
         </thead>
         <tbody class="govuk-table__body">
             <tr class="govuk-table__row">
-                <td class="govuk-table__cell"><a class="govuk-link" href="/appeals-service/appeal-details/1" aria-label="Appeal 9 4 3 2 4 5">943245</a>
+                <td class="govuk-table__cell"><a class="govuk-link" href="/appeals-service/appeal-details/1" aria-label="Appeal 9 4 3 2 4 5"
+                    data-cy="943245">943245</a>
                 </td>
                 <td class="govuk-table__cell">Copthalls, Clevedon Road, West Hill, BS48 1PN</td>
                 <td class="govuk-table__cell">Wiltshire Council</td>
@@ -314,7 +328,8 @@ exports[`national-list GET / should render national list - no pagination 1`] = `
                 </td>
             </tr>
             <tr class="govuk-table__row">
-                <td class="govuk-table__cell"><a class="govuk-link" href="/appeals-service/appeal-details/2" aria-label="Appeal 1 2 9 2 8 5">129285</a>
+                <td class="govuk-table__cell"><a class="govuk-link" href="/appeals-service/appeal-details/2" aria-label="Appeal 1 2 9 2 8 5"
+                    data-cy="129285">129285</a>
                 </td>
                 <td class="govuk-table__cell">19 Beauchamp Road, Bristol, BS7 8LQ</td>
                 <td class="govuk-table__cell">Dorset Council</td>
@@ -341,7 +356,7 @@ exports[`national-list GET / should render national list - no search term - filt
                     <label class="govuk-label govuk-caption-m govuk-!-margin-bottom-3 colour--secondary"
                     for="searchTerm">Enter appeal reference or postcode (include spaces)</label>
                     <input class="govuk-input"
-                    id="searchTerm" name="searchTerm" type="text">
+                    id="searchTerm" name="searchTerm" type="text" data-cy="search-term">
                 </div>
                 <div class="govuk-button-group">
                     <button type="submit" class="govuk-button govuk-button" data-module="govuk-button"
@@ -362,7 +377,8 @@ exports[`national-list GET / should render national list - no search term - filt
                 <form method="GET">
                     <div class="govuk-form-group">
                         <label class="govuk-label">Filter by case status</label>
-                        <select class="govuk-select" id="" name="appealStatusFilter">
+                        <select class="govuk-select" id="" name="appealStatusFilter"
+                        data-cy="filter-by-case-status">
                             <option value="all">All</option>
                             <option value="assign_case_officer">Assign case officer</option>
                             <option value="ready_to_start">Ready to start</option>
@@ -373,7 +389,8 @@ exports[`national-list GET / should render national list - no search term - filt
                     </div>
                     <div class="govuk-form-group">
                         <label class="govuk-label">Filter by inspector status</label>
-                        <select class="govuk-select" id="" name="inspectorStatusFilter">
+                        <select class="govuk-select" id="" name="inspectorStatusFilter"
+                        data-cy="filter-by-inspector-status">
                             <option value="all">All</option>
                             <option value="assigned">Assigned</option>
                             <option value="unassigned">Unassigned</option>
@@ -381,7 +398,8 @@ exports[`national-list GET / should render national list - no search term - filt
                     </div>
                     <div class="govuk-button-group">
                         <button type="submit" class="govuk-button govuk-button--secondary" data-module="govuk-button"
-                        id="filters-submit">Apply</button><a class="govuk-link" href="/appeals-service/all-cases">Clear filter</a>
+                        data-cy="filter-submit" id="filters-submit">Apply</button><a class="govuk-link" href="/appeals-service/all-cases"
+                        data-cy="filter-clear">Clear filter</a>
                     </div>
                 </form>
             </div>
@@ -399,7 +417,8 @@ exports[`national-list GET / should render national list - no search term - filt
         </thead>
         <tbody class="govuk-table__body">
             <tr class="govuk-table__row">
-                <td class="govuk-table__cell"><a class="govuk-link" href="/appeals-service/appeal-details/1" aria-label="Appeal 9 4 3 2 4 5">943245</a>
+                <td class="govuk-table__cell"><a class="govuk-link" href="/appeals-service/appeal-details/1" aria-label="Appeal 9 4 3 2 4 5"
+                    data-cy="943245">943245</a>
                 </td>
                 <td class="govuk-table__cell">Copthalls, Clevedon Road, West Hill, BS48 1PN</td>
                 <td class="govuk-table__cell">Wiltshire Council</td>
@@ -426,11 +445,12 @@ exports[`national-list GET / should render national list - search term - filter 
                     <label class="govuk-label govuk-caption-m govuk-!-margin-bottom-3 colour--secondary"
                     for="searchTerm">Enter appeal reference or postcode (include spaces)</label>
                     <input class="govuk-input"
-                    id="searchTerm" name="searchTerm" type="text" value="BS7 8LQ">
+                    id="searchTerm" name="searchTerm" type="text" value="BS7 8LQ" data-cy="search-term">
                 </div>
                 <div class="govuk-button-group">
                     <button type="submit" class="govuk-button govuk-button" data-module="govuk-button"
-                    id="filters-submit">Search</button><a class="govuk-link" href="/appeals-service/all-cases">Clear search</a>
+                    id="filters-submit">Search</button><a class="govuk-link" href="/appeals-service/all-cases"
+                    data-cy="clear-search">Clear search</a>
                 </div>
             </form>
             <div class="govuk-section-break--visible govuk-!-margin-top-2 govuk-!-margin-bottom-6"></div>
@@ -445,10 +465,11 @@ exports[`national-list GET / should render national list - search term - filter 
             </summary>
             <div class="govuk-details__text">
                 <form method="GET">
-                    <input type="hidden" name="searchTerm" value="BS7 8LQ">
+                    <input type="hidden" name="searchTerm" value="BS7 8LQ" data-cy="search-term">
                     <div class="govuk-form-group">
                         <label class="govuk-label">Filter by case status</label>
-                        <select class="govuk-select" id="" name="appealStatusFilter">
+                        <select class="govuk-select" id="" name="appealStatusFilter"
+                        data-cy="filter-by-case-status">
                             <option value="all">All</option>
                             <option value="assign_case_officer">Assign case officer</option>
                             <option value="ready_to_start">Ready to start</option>
@@ -459,7 +480,8 @@ exports[`national-list GET / should render national list - search term - filter 
                     </div>
                     <div class="govuk-form-group">
                         <label class="govuk-label">Filter by inspector status</label>
-                        <select class="govuk-select" id="" name="inspectorStatusFilter">
+                        <select class="govuk-select" id="" name="inspectorStatusFilter"
+                        data-cy="filter-by-inspector-status">
                             <option value="all">All</option>
                             <option value="assigned">Assigned</option>
                             <option value="unassigned">Unassigned</option>
@@ -467,7 +489,8 @@ exports[`national-list GET / should render national list - search term - filter 
                     </div>
                     <div class="govuk-button-group">
                         <button type="submit" class="govuk-button govuk-button--secondary" data-module="govuk-button"
-                        id="filters-submit">Apply</button><a class="govuk-link" href="/appeals-service/all-cases?searchTerm=BS7%208LQ">Clear filter</a>
+                        data-cy="filter-submit" id="filters-submit">Apply</button><a class="govuk-link" href="/appeals-service/all-cases?searchTerm=BS7%208LQ"
+                        data-cy="filter-clear">Clear filter</a>
                     </div>
                 </form>
             </div>
@@ -485,7 +508,8 @@ exports[`national-list GET / should render national list - search term - filter 
         </thead>
         <tbody class="govuk-table__body">
             <tr class="govuk-table__row">
-                <td class="govuk-table__cell"><a class="govuk-link" href="/appeals-service/appeal-details/1" aria-label="Appeal 9 4 3 2 4 5">943245</a>
+                <td class="govuk-table__cell"><a class="govuk-link" href="/appeals-service/appeal-details/1" aria-label="Appeal 9 4 3 2 4 5"
+                    data-cy="943245">943245</a>
                 </td>
                 <td class="govuk-table__cell">Copthalls, Clevedon Road, West Hill, BS48 1PN</td>
                 <td class="govuk-table__cell">Wiltshire Council</td>
@@ -512,11 +536,12 @@ exports[`national-list GET / should render national list - search term - no resu
                     <label class="govuk-label govuk-caption-m govuk-!-margin-bottom-3 colour--secondary"
                     for="searchTerm">Enter appeal reference or postcode (include spaces)</label>
                     <input class="govuk-input"
-                    id="searchTerm" name="searchTerm" type="text" value="NORESULT">
+                    id="searchTerm" name="searchTerm" type="text" value="NORESULT" data-cy="search-term">
                 </div>
                 <div class="govuk-button-group">
                     <button type="submit" class="govuk-button govuk-button" data-module="govuk-button"
-                    id="filters-submit">Search</button><a class="govuk-link" href="/appeals-service/all-cases">Clear search</a>
+                    id="filters-submit">Search</button><a class="govuk-link" href="/appeals-service/all-cases"
+                    data-cy="clear-search">Clear search</a>
                 </div>
             </form>
             <div class="govuk-section-break--visible govuk-!-margin-top-2 govuk-!-margin-bottom-6"></div>
@@ -531,10 +556,11 @@ exports[`national-list GET / should render national list - search term - no resu
             </summary>
             <div class="govuk-details__text">
                 <form method="GET">
-                    <input type="hidden" name="searchTerm" value="NORESULT">
+                    <input type="hidden" name="searchTerm" value="NORESULT" data-cy="search-term">
                     <div class="govuk-form-group">
                         <label class="govuk-label">Filter by case status</label>
-                        <select class="govuk-select" id="" name="appealStatusFilter">
+                        <select class="govuk-select" id="" name="appealStatusFilter"
+                        data-cy="filter-by-case-status">
                             <option value="all">All</option>
                             <option value="assign_case_officer">Assign case officer</option>
                             <option value="ready_to_start">Ready to start</option>
@@ -545,7 +571,8 @@ exports[`national-list GET / should render national list - search term - no resu
                     </div>
                     <div class="govuk-form-group">
                         <label class="govuk-label">Filter by inspector status</label>
-                        <select class="govuk-select" id="" name="inspectorStatusFilter">
+                        <select class="govuk-select" id="" name="inspectorStatusFilter"
+                        data-cy="filter-by-inspector-status">
                             <option value="all">All</option>
                             <option value="assigned">Assigned</option>
                             <option value="unassigned">Unassigned</option>
@@ -553,7 +580,8 @@ exports[`national-list GET / should render national list - search term - no resu
                     </div>
                     <div class="govuk-button-group">
                         <button type="submit" class="govuk-button govuk-button--secondary" data-module="govuk-button"
-                        id="filters-submit">Apply</button><a class="govuk-link" href="/appeals-service/all-cases?searchTerm=NORESULT">Clear filter</a>
+                        data-cy="filter-submit" id="filters-submit">Apply</button><a class="govuk-link" href="/appeals-service/all-cases?searchTerm=NORESULT"
+                        data-cy="filter-clear">Clear filter</a>
                     </div>
                 </form>
             </div>
@@ -576,11 +604,12 @@ exports[`national-list GET / should render national list - search term 1`] = `
                     <label class="govuk-label govuk-caption-m govuk-!-margin-bottom-3 colour--secondary"
                     for="searchTerm">Enter appeal reference or postcode (include spaces)</label>
                     <input class="govuk-input"
-                    id="searchTerm" name="searchTerm" type="text" value="BS7 8LQ">
+                    id="searchTerm" name="searchTerm" type="text" value="BS7 8LQ" data-cy="search-term">
                 </div>
                 <div class="govuk-button-group">
                     <button type="submit" class="govuk-button govuk-button" data-module="govuk-button"
-                    id="filters-submit">Search</button><a class="govuk-link" href="/appeals-service/all-cases">Clear search</a>
+                    id="filters-submit">Search</button><a class="govuk-link" href="/appeals-service/all-cases"
+                    data-cy="clear-search">Clear search</a>
                 </div>
             </form>
             <div class="govuk-section-break--visible govuk-!-margin-top-2 govuk-!-margin-bottom-6"></div>
@@ -595,10 +624,11 @@ exports[`national-list GET / should render national list - search term 1`] = `
             </summary>
             <div class="govuk-details__text">
                 <form method="GET">
-                    <input type="hidden" name="searchTerm" value="BS7 8LQ">
+                    <input type="hidden" name="searchTerm" value="BS7 8LQ" data-cy="search-term">
                     <div class="govuk-form-group">
                         <label class="govuk-label">Filter by case status</label>
-                        <select class="govuk-select" id="" name="appealStatusFilter">
+                        <select class="govuk-select" id="" name="appealStatusFilter"
+                        data-cy="filter-by-case-status">
                             <option value="all">All</option>
                             <option value="assign_case_officer">Assign case officer</option>
                             <option value="ready_to_start">Ready to start</option>
@@ -609,7 +639,8 @@ exports[`national-list GET / should render national list - search term 1`] = `
                     </div>
                     <div class="govuk-form-group">
                         <label class="govuk-label">Filter by inspector status</label>
-                        <select class="govuk-select" id="" name="inspectorStatusFilter">
+                        <select class="govuk-select" id="" name="inspectorStatusFilter"
+                        data-cy="filter-by-inspector-status">
                             <option value="all">All</option>
                             <option value="assigned">Assigned</option>
                             <option value="unassigned">Unassigned</option>
@@ -617,7 +648,8 @@ exports[`national-list GET / should render national list - search term 1`] = `
                     </div>
                     <div class="govuk-button-group">
                         <button type="submit" class="govuk-button govuk-button--secondary" data-module="govuk-button"
-                        id="filters-submit">Apply</button><a class="govuk-link" href="/appeals-service/all-cases?searchTerm=BS7%208LQ">Clear filter</a>
+                        data-cy="filter-submit" id="filters-submit">Apply</button><a class="govuk-link" href="/appeals-service/all-cases?searchTerm=BS7%208LQ"
+                        data-cy="filter-clear">Clear filter</a>
                     </div>
                 </form>
             </div>
@@ -635,7 +667,8 @@ exports[`national-list GET / should render national list - search term 1`] = `
         </thead>
         <tbody class="govuk-table__body">
             <tr class="govuk-table__row">
-                <td class="govuk-table__cell"><a class="govuk-link" href="/appeals-service/appeal-details/1" aria-label="Appeal 9 4 3 2 4 5">943245</a>
+                <td class="govuk-table__cell"><a class="govuk-link" href="/appeals-service/appeal-details/1" aria-label="Appeal 9 4 3 2 4 5"
+                    data-cy="943245">943245</a>
                 </td>
                 <td class="govuk-table__cell">Copthalls, Clevedon Road, West Hill, BS48 1PN</td>
                 <td class="govuk-table__cell">Wiltshire Council</td>
@@ -644,7 +677,8 @@ exports[`national-list GET / should render national list - search term 1`] = `
                 </td>
             </tr>
             <tr class="govuk-table__row">
-                <td class="govuk-table__cell"><a class="govuk-link" href="/appeals-service/appeal-details/2" aria-label="Appeal 1 2 9 2 8 5">129285</a>
+                <td class="govuk-table__cell"><a class="govuk-link" href="/appeals-service/appeal-details/2" aria-label="Appeal 1 2 9 2 8 5"
+                    data-cy="129285">129285</a>
                 </td>
                 <td class="govuk-table__cell">19 Beauchamp Road, Bristol, BS7 8LQ</td>
                 <td class="govuk-table__cell">Dorset Council</td>

--- a/appeals/web/src/server/appeals/national-list/national-list.mapper.js
+++ b/appeals/web/src/server/appeals/national-list/national-list.mapper.js
@@ -102,6 +102,7 @@ export function nationalListPage(
 					classes: 'govuk-caption-m govuk-!-margin-bottom-3 colour--secondary'
 				},
 				value: searchTerm,
+				attributes: { 'data-cy': 'search-term' },
 				...searchInputErrorMessage
 			}
 		},
@@ -124,7 +125,9 @@ export function nationalListPage(
 			type: 'html',
 			parameters: {
 				html: `${
-					searchTerm ? `<a class="govuk-link" href="${urlWithoutQuery}">Clear search</a>` : ''
+					searchTerm
+						? `<a class="govuk-link" href="${urlWithoutQuery}" data-cy="clear-search">Clear search</a>`
+						: ''
 				}</div></form><div class="govuk-section-break--visible govuk-!-margin-top-2 govuk-!-margin-bottom-6"></div></div></div>`
 			}
 		},
@@ -156,7 +159,7 @@ export function nationalListPage(
 						type: 'html',
 						parameters: {
 							html: searchTerm
-								? `<input type="hidden" name="searchTerm" value="${searchTerm}" />`
+								? `<input type="hidden" name="searchTerm" value="${searchTerm}" data-cy="search-term" />`
 								: ''
 						}
 					},
@@ -168,7 +171,8 @@ export function nationalListPage(
 							},
 							name: 'appealStatusFilter',
 							value: 'all',
-							items: appealStatusFilterItemsArray
+							items: appealStatusFilterItemsArray,
+							attributes: { 'data-cy': 'filter-by-case-status' }
 						}
 					},
 					{
@@ -179,7 +183,8 @@ export function nationalListPage(
 							},
 							name: 'inspectorStatusFilter',
 							value: 'all',
-							items: inspectorStatusFilterItemsArray
+							items: inspectorStatusFilterItemsArray,
+							attributes: { 'data-cy': 'filter-by-inspector-status' }
 						}
 					},
 					{
@@ -194,13 +199,14 @@ export function nationalListPage(
 							id: 'filters-submit',
 							type: 'submit',
 							classes: 'govuk-button--secondary',
-							text: 'Apply'
+							text: 'Apply',
+							attributes: { 'data-cy': 'filter-submit' }
 						}
 					},
 					{
 						type: 'html',
 						parameters: {
-							html: `<a class="govuk-link" href="${clearFilterUrl}">Clear filter</a></div></form>`
+							html: `<a class="govuk-link" href="${clearFilterUrl}" data-cy="filter-clear">Clear filter</a></div></form>`
 						}
 					}
 				]
@@ -240,7 +246,7 @@ export function nationalListPage(
 										appeal.appealId
 									}" aria-label="Appeal ${numberToAccessibleDigitLabel(
 										shortReference || ''
-									)}">${shortReference}</a>`
+									)}" data-cy="${shortReference}" >${shortReference}</a>`
 								},
 								{
 									text: addressToString(appeal.appealSite)

--- a/appeals/web/src/server/lib/display-page-formatter.js
+++ b/appeals/web/src/server/lib/display-page-formatter.js
@@ -82,7 +82,7 @@ export const formatListOfLinkedAppeals = (listOfAppeals) => {
 
 			formattedLinks +=
 				linkUrl.length > 0
-					? `<li><a href="${linkUrl}" class="govuk-link" aria-label="${linkAriaLabel}">${shortAppealReference}</a> ${relationshipText}</li>`
+					? `<li><a href="${linkUrl}" class="govuk-link" data-cy="linked-appeal-${shortAppealReference}" aria-label="${linkAriaLabel}">${shortAppealReference}</a> ${relationshipText}</li>`
 					: `<li><span class="govuk-body">${shortAppealReference}</span> ${relationshipText}</li>`;
 		}
 
@@ -110,7 +110,7 @@ export const formatListOfRelatedAppeals = (listOfAppeals) => {
 
 			formattedLinks +=
 				linkUrl.length > 0
-					? `<li><a href="${linkUrl}" class="govuk-link" aria-label="${linkAriaLabel}">${shortAppealReference}</a></li>`
+					? `<li><a href="${linkUrl}" class="govuk-link" data-cy="related-appeal-${shortAppealReference}" aria-label="${linkAriaLabel}">${shortAppealReference}</a></li>`
 					: `<li><span class="govuk-body">${shortAppealReference}</span></li>`;
 		}
 
@@ -171,7 +171,7 @@ export const formatDocumentValues = (appealId, listOfDocuments, addLateEntryStat
 				documentPageComponents.push({
 					type: 'html',
 					parameters: {
-						html: `<a href='/documents/${appealId}/download/${document.id}/preview' target="'_blank'" class="govuk-link">${document.name}</a>`
+						html: `<a href='/documents/${appealId}/download/${document.id}/preview' data-cy='document-${document.id}' target="'_blank'" class="govuk-link">${document.name}</a>`
 					}
 				});
 			} else {

--- a/appeals/web/src/server/lib/mappers/appeal.mapper.js
+++ b/appeals/web/src/server/lib/mappers/appeal.mapper.js
@@ -73,7 +73,8 @@ export async function initialiseAndMapAppealData(
 						mapActionComponent(permissionNames.updateCase, session, {
 							text: 'Change',
 							href: `${currentRoute}/change-appeal-type/appeal-type`,
-							visuallyHiddenText: 'Appeal type'
+							visuallyHiddenText: 'Appeal type',
+							attributes: { 'data-cy': 'change-appeal-type' }
 						})
 					]
 				},
@@ -119,7 +120,8 @@ export async function initialiseAndMapAppealData(
 						mapActionComponent(permissionNames.updateCase, session, {
 							text: 'Change',
 							href: `${currentRoute}/change-appeal-details/case-procedure`,
-							visuallyHiddenText: 'Case procedure'
+							visuallyHiddenText: 'Case procedure',
+							attributes: { 'data-cy': 'change-case-procedure' }
 						})
 					]
 				},
@@ -176,7 +178,8 @@ export async function initialiseAndMapAppealData(
 						mapActionComponent(permissionNames.updateCase, session, {
 							text: 'Change',
 							href: `${currentRoute}/service-user/change/appellant`,
-							visuallyHiddenText: 'Appellant'
+							visuallyHiddenText: 'Appellant',
+							attributes: { 'data-cy': 'change-appellant' }
 						})
 					]
 				},
@@ -201,7 +204,8 @@ export async function initialiseAndMapAppealData(
 						mapActionComponent(permissionNames.updateCase, session, {
 							text: 'Change',
 							href: `${currentRoute}/service-user/change/agent`,
-							visuallyHiddenText: 'Agent'
+							visuallyHiddenText: 'Agent',
+							attributes: { 'data-cy': 'change-agent' }
 						})
 					]
 				},
@@ -234,14 +238,16 @@ export async function initialiseAndMapAppealData(
 												{
 													text: 'Manage',
 													href: generateLinkedAppealsManageLinkHref(appealDetails),
-													visuallyHiddenText: 'Linked appeals'
+													visuallyHiddenText: 'Linked appeals',
+													attributes: { 'data-cy': 'manage-linked-appeals' }
 												}
 										  ]
 										: []),
 									{
 										text: 'Add',
 										href: `/appeals-service/appeal-details/${appealDetails.appealId}/linked-appeals/add`,
-										visuallyHiddenText: 'Linked appeals'
+										visuallyHiddenText: 'Linked appeals',
+										attributes: { 'data-cy': 'add-linked-appeal' }
 									}
 							  ])
 							: []
@@ -280,7 +286,8 @@ export async function initialiseAndMapAppealData(
 			mapActionComponent(permissionNames.updateCase, session, {
 				text: 'Manage',
 				href: `${currentRoute}/other-appeals/manage`,
-				visuallyHiddenText: 'Related appeals'
+				visuallyHiddenText: 'Related appeals',
+				attributes: { 'data-cy': 'manage-related-appeals' }
 			})
 		);
 	}
@@ -289,7 +296,8 @@ export async function initialiseAndMapAppealData(
 		mapActionComponent(permissionNames.updateCase, session, {
 			text: 'Add',
 			href: `${currentRoute}/other-appeals/add`,
-			visuallyHiddenText: 'Related appeals'
+			visuallyHiddenText: 'Related appeals',
+			attributes: { 'data-cy': 'add-related-appeals' }
 		})
 	);
 
@@ -356,7 +364,11 @@ export async function initialiseAndMapAppealData(
 						mapActionComponent(permissionNames.updateCase, session, {
 							text: appealDetails.allocationDetails ? 'Change' : 'Add',
 							href: `${currentRoute}/allocation-details/allocation-level`,
-							visuallyHiddenText: 'Allocation level'
+							visuallyHiddenText: 'Allocation level',
+							attributes: {
+								'data-cy':
+									(appealDetails.allocationDetails ? 'change' : 'add') + '-allocation-level'
+							}
 						})
 					]
 				},
@@ -422,7 +434,8 @@ export async function initialiseAndMapAppealData(
 						{
 							text: 'Change',
 							href: `${currentRoute}/lpa-reference/change`,
-							visuallyHiddenText: 'L P A reference'
+							visuallyHiddenText: 'L P A reference',
+							attributes: { 'data-cy': 'change-lpa-reference' }
 						}
 					]
 				},
@@ -494,7 +507,8 @@ export async function initialiseAndMapAppealData(
 						{
 							text: 'Change',
 							href: `${currentRoute}/change-appeal-details/site-address`,
-							visuallyHiddenText: 'site address'
+							visuallyHiddenText: 'site address',
+							attributes: { 'data-cy': 'change-site-address' }
 						}
 					]
 				},
@@ -522,7 +536,8 @@ export async function initialiseAndMapAppealData(
 						{
 							text: 'Change',
 							href: `${currentRoute}/change-appeal-details/local-planning-authority`,
-							visuallyHiddenText: 'local planning authority (LPA)'
+							visuallyHiddenText: 'local planning authority (LPA)',
+							attributes: { 'data-cy': 'change-local-planning-authority' }
 						}
 					]
 				},
@@ -571,7 +586,8 @@ export async function initialiseAndMapAppealData(
 						{
 							text: 'Change',
 							href: `${currentRoute}/inspector-access/change/lpa`,
-							visuallyHiddenText: 'inspection access (L P A answer)'
+							visuallyHiddenText: 'inspection access (L P A answer)',
+							attributes: { 'data-cy': 'change-inspection-access-lpa' }
 						}
 					]
 				},
@@ -631,7 +647,8 @@ export async function initialiseAndMapAppealData(
 						{
 							text: 'Change',
 							href: `${currentRoute}/inspector-access/change/appellant`,
-							visuallyHiddenText: 'inspection access (appellant answer)'
+							visuallyHiddenText: 'inspection access (appellant answer)',
+							attributes: { 'data-cy': 'change-inspection-access-appellant' }
 						}
 					]
 				},
@@ -689,7 +706,8 @@ export async function initialiseAndMapAppealData(
 						{
 							text: 'Change',
 							href: `${currentRoute}/neighbouring-sites/change/affected`,
-							visuallyHiddenText: 'could a neighbouring site be affected'
+							visuallyHiddenText: 'could a neighbouring site be affected',
+							attributes: { 'data-cy': 'change-neighbouuring-site-is-affected' }
 						}
 					]
 				},
@@ -751,7 +769,8 @@ export async function initialiseAndMapAppealData(
 						{
 							text: 'Add',
 							href: `${currentRoute}/neighbouring-sites/add/lpa`,
-							visuallyHiddenText: 'Neighbouring sites (LPA)'
+							visuallyHiddenText: 'Neighbouring sites (LPA)',
+							attributes: { 'data-cy': 'add-neighbouring-site-lpa' }
 						}
 					]
 				},
@@ -783,14 +802,16 @@ export async function initialiseAndMapAppealData(
 									{
 										text: 'Manage',
 										href: `${currentRoute}/neighbouring-sites/manage`,
-										visuallyHiddenText: 'Neighbouring sites (inspector and or third party request)'
+										visuallyHiddenText: 'Neighbouring sites (inspector and or third party request)',
+										attributes: { 'data-cy': 'manage-neighbouring-sites-inspector' }
 									}
 							  ]
 							: []),
 						{
 							text: 'Add',
 							href: `${currentRoute}/neighbouring-sites/add/back-office`,
-							visuallyHiddenText: 'Neighbouring sites (inspector and or third party request)'
+							visuallyHiddenText: 'Neighbouring sites (inspector and or third party request)',
+							attributes: { 'data-cy': 'add-neighbouring-sites-inspector' }
 						}
 					]
 				},
@@ -819,7 +840,8 @@ export async function initialiseAndMapAppealData(
 						{
 							text: 'Change',
 							href: `${currentRoute}/safety-risks/change/lpa`,
-							visuallyHiddenText: 'potential safety risks (L P A answer)'
+							visuallyHiddenText: 'potential safety risks (L P A answer)',
+							attributes: { 'data-cy': 'change-lpa-health-and-safety' }
 						}
 					]
 				},
@@ -848,7 +870,8 @@ export async function initialiseAndMapAppealData(
 						{
 							text: 'Change',
 							href: `${currentRoute}/safety-risks/change/appellant`,
-							visuallyHiddenText: 'potential safety risks (appellant answer)'
+							visuallyHiddenText: 'potential safety risks (appellant answer)',
+							attributes: { 'data-cy': 'change-appellant-case-health-and-safety' }
 						}
 					]
 				},
@@ -875,7 +898,8 @@ export async function initialiseAndMapAppealData(
 							href: `${currentRoute}/site-visit/${
 								appealDetails.siteVisit?.visitType ? 'visit-booked' : 'schedule-visit'
 							}`,
-							visuallyHiddenText: 'visit type'
+							visuallyHiddenText: 'visit type',
+							attributes: { 'data-cy': 'change-set-visit-type' }
 						}
 					]
 				},
@@ -902,7 +926,8 @@ export async function initialiseAndMapAppealData(
 									text: 'Change',
 									href: `${currentRoute}/appellant-case/valid/date`,
 									visuallyHiddenText:
-										'The date all case documentation was received and the appeal was valid'
+										'The date all case documentation was received and the appeal was valid',
+									attributes: { 'data-cy': 'change-valid-date' }
 							  }
 							: {}
 					]
@@ -972,7 +997,8 @@ export async function initialiseAndMapAppealData(
 						{
 							text: 'Change',
 							href: `${currentRoute}/appeal-timetables/lpa-questionnaire`,
-							visuallyHiddenText: 'L P A questionnaire due'
+							visuallyHiddenText: 'L P A questionnaire due',
+							attributes: { 'data-cy': 'change-lpa-questionnaire-due-date' }
 						}
 					]
 				},
@@ -999,7 +1025,8 @@ export async function initialiseAndMapAppealData(
 						{
 							text: appealDetails.appealTimetable?.statementReviewDate ? 'Change' : 'Schedule',
 							href: `${currentRoute}/appeal-timetables/statement-review`,
-							visuallyHiddenText: 'statement review due date'
+							visuallyHiddenText: 'statement review due date',
+							attributes: { 'data-cy': 'statement-review-due-date' }
 						}
 					]
 				},
@@ -1026,7 +1053,8 @@ export async function initialiseAndMapAppealData(
 						{
 							text: appealDetails.appealTimetable?.finalCommentReviewDate ? 'Change' : 'Schedule',
 							href: `${currentRoute}/appeal-timetables/final-comment-review`,
-							visuallyHiddenText: 'final comment review due date'
+							visuallyHiddenText: 'final comment review due date',
+							attributes: { 'data-cy': 'final-comment-review-due-date' }
 						}
 					]
 				},
@@ -1058,7 +1086,11 @@ export async function initialiseAndMapAppealData(
 							href: `${currentRoute}/site-visit/${
 								appealDetails.siteVisit?.visitDate ? 'manage' : 'schedule'
 							}-visit`,
-							visuallyHiddenText: 'site visit'
+							visuallyHiddenText: 'site visit',
+							attributes: {
+								'data-cy':
+									(appealDetails.siteVisit?.visitDate ? 'change' : 'arrange') + '-schedule-visit'
+							}
 						}
 					]
 				},
@@ -1099,7 +1131,10 @@ export async function initialiseAndMapAppealData(
 						{
 							text: appealDetails.caseOfficer ? 'Change' : 'Assign',
 							href: `${currentRoute}/assign-user/case-officer`,
-							visuallyHiddenText: 'case officer'
+							visuallyHiddenText: 'case officer',
+							attributes: {
+								'data-cy': (appealDetails.caseOfficer ? 'change' : 'assign') + '-case-officer'
+							}
 						}
 					]
 				},
@@ -1140,7 +1175,10 @@ export async function initialiseAndMapAppealData(
 						{
 							text: appealDetails.inspector ? 'Change' : 'Assign',
 							href: `${currentRoute}/assign-user/inspector`,
-							visuallyHiddenText: 'inspector'
+							visuallyHiddenText: 'inspector',
+							attributes: {
+								'data-cy': (appealDetails.inspector ? 'change' : 'assign') + '-inspector'
+							}
 						}
 					]
 				},
@@ -1190,7 +1228,7 @@ export async function initialiseAndMapAppealData(
 				{
 					html:
 						appealDetails?.documentationSummary?.appellantCase?.status !== 'not_received'
-							? `<a href="${currentRoute}/appellant-case" class="govuk-link">Review <span class="govuk-visually-hidden">appellant case</span></a>`
+							? `<a href="${currentRoute}/appellant-case" data-cy="review-appellant-case" class="govuk-link">Review <span class="govuk-visually-hidden">appellant case</span></a>`
 							: ''
 				}
 			]
@@ -1216,7 +1254,7 @@ export async function initialiseAndMapAppealData(
 				{
 					html:
 						appealDetails?.documentationSummary?.lpaQuestionnaire?.status !== 'not_received'
-							? `<a href="${currentRoute}/lpa-questionnaire/${appealDetails?.lpaQuestionnaireId}" class="govuk-link">Review <span class="govuk-visually-hidden">L P A questionnaire</span></a>`
+							? `<a href="${currentRoute}/lpa-questionnaire/${appealDetails?.lpaQuestionnaireId}" data-cy="review-lpa-questionnaire" class="govuk-link">Review <span class="govuk-visually-hidden">L P A questionnaire</span></a>`
 							: ''
 				}
 			]
@@ -1252,7 +1290,7 @@ export async function initialiseAndMapAppealData(
 								: ''
 						}<li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="${currentRoute}/costs/appellant/select-document-type/${
 						appealDetails?.costs?.appellantFolder?.folderId
-					}">Add</a></li></ul>`,
+					}" data-cy="add-costs-appeallant" >Add</a></li></ul>`,
 					classes: 'appeal-costs-appellant-actions'
 				}
 			]
@@ -1288,7 +1326,7 @@ export async function initialiseAndMapAppealData(
 								: ''
 						}<li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="${currentRoute}/costs/lpa/select-document-type/${
 						appealDetails?.costs?.lpaFolder?.folderId
-					}">Add</a></li></ul>`,
+					}" data-cy="add-costs-lpa" >Add</a></li></ul>`,
 					classes: 'appeal-costs-lpa-actions'
 				}
 			]
@@ -1324,7 +1362,7 @@ export async function initialiseAndMapAppealData(
 								: ''
 						}<li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="${currentRoute}/costs/decision/upload-documents/${
 						appealDetails?.costs?.decisionFolder?.folderId
-					}">Add</a></li></ul>`,
+					}" data-cy="add-costs-decision" >Add</a></li></ul>`,
 					classes: 'appeal-costs-decision-actions'
 				}
 			]
@@ -1348,7 +1386,12 @@ export async function initialiseAndMapAppealData(
 					items: [
 						{
 							text: appealDetails.appealTimetable?.issueDeterminationDate ? 'Change' : 'Schedule',
-							href: `${currentRoute}/appeal-timetables/issue-determination`
+							href: `${currentRoute}/appeal-timetables/issue-determination`,
+							attributes: {
+								'data-cy':
+									(appealDetails.appealTimetable?.issueDeterminationDate ? 'change' : 'schedule') +
+									'-issue-determination'
+							}
 						}
 					]
 				},
@@ -1373,7 +1416,12 @@ export async function initialiseAndMapAppealData(
 					items: [
 						{
 							text: appealDetails.appealTimetable?.completeDate ? 'Change' : 'Schedule',
-							href: `${currentRoute}/change-appeal-details/complete-date`
+							href: `${currentRoute}/change-appeal-details/complete-date`,
+							attributes: {
+								'data-cy':
+									(appealDetails.appealTimetable?.completeDate ? 'change' : 'schedule') +
+									'-complete-date'
+							}
 						}
 					]
 				},

--- a/appeals/web/src/server/lib/mappers/appeal.mapper.js
+++ b/appeals/web/src/server/lib/mappers/appeal.mapper.js
@@ -1288,9 +1288,9 @@ export async function initialiseAndMapAppealData(
 							appealHasAppellantCostsDocuments
 								? `<li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="${currentRoute}/costs/appellant/manage-documents/${appealDetails?.costs?.appellantFolder?.folderId}">Manage</a></li>`
 								: ''
-						}<li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="${currentRoute}/costs/appellant/select-document-type/${
+						}<li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-appeallant" href="${currentRoute}/costs/appellant/select-document-type/${
 						appealDetails?.costs?.appellantFolder?.folderId
-					}" data-cy="add-costs-appeallant" >Add</a></li></ul>`,
+					}" >Add</a></li></ul>`,
 					classes: 'appeal-costs-appellant-actions'
 				}
 			]
@@ -1324,9 +1324,9 @@ export async function initialiseAndMapAppealData(
 							appealHasLPACostsDocuments
 								? `<li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="${currentRoute}/costs/lpa/manage-documents/${appealDetails?.costs?.lpaFolder?.folderId}">Manage</a></li>`
 								: ''
-						}<li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="${currentRoute}/costs/lpa/select-document-type/${
+						}<li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-lpa" href="${currentRoute}/costs/lpa/select-document-type/${
 						appealDetails?.costs?.lpaFolder?.folderId
-					}" data-cy="add-costs-lpa" >Add</a></li></ul>`,
+					}" >Add</a></li></ul>`,
 					classes: 'appeal-costs-lpa-actions'
 				}
 			]
@@ -1360,9 +1360,9 @@ export async function initialiseAndMapAppealData(
 							appealHasCostsDecisionDocuments
 								? `<li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="${currentRoute}/costs/decision/manage-documents/${appealDetails?.costs?.decisionFolder?.folderId}">Manage</a></li>`
 								: ''
-						}<li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="${currentRoute}/costs/decision/upload-documents/${
+						}<li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-decision" href="${currentRoute}/costs/decision/upload-documents/${
 						appealDetails?.costs?.decisionFolder?.folderId
-					}" data-cy="add-costs-decision" >Add</a></li></ul>`,
+					}" >Add</a></li></ul>`,
 					classes: 'appeal-costs-decision-actions'
 				}
 			]

--- a/appeals/web/src/server/lib/mappers/appellantCase.mapper.js
+++ b/appeals/web/src/server/lib/mappers/appellantCase.mapper.js
@@ -47,7 +47,8 @@ export function initialiseAndMapData(appellantCaseData, appealDetails, currentRo
 						mapActionComponent(permissionNames.updateCase, session, {
 							text: 'Change',
 							href: `${currentRoute}/service-user/change/appellant`,
-							visuallyHiddenText: 'Appellant'
+							visuallyHiddenText: 'Appellant',
+							attributes: { 'data-cy': 'appellant' }
 						})
 					]
 				},
@@ -71,7 +72,8 @@ export function initialiseAndMapData(appellantCaseData, appealDetails, currentRo
 						mapActionComponent(permissionNames.updateCase, session, {
 							text: 'Change',
 							href: `${currentRoute}/service-user/change/agent`,
-							visuallyHiddenText: 'Agent'
+							visuallyHiddenText: 'Agent',
+							attributes: { 'data-cy': 'change-agent' }
 						})
 					]
 				},
@@ -96,7 +98,8 @@ export function initialiseAndMapData(appellantCaseData, appealDetails, currentRo
 						{
 							text: 'Change',
 							visuallyHiddenText: 'LPA application reference',
-							href: `${currentRoute}/lpa-reference/change`
+							href: `${currentRoute}/lpa-reference/change`,
+							attributes: { 'data-cy': 'change-application-reference' }
 						}
 					]
 				}
@@ -134,7 +137,8 @@ export function initialiseAndMapData(appellantCaseData, appealDetails, currentRo
 						{
 							text: 'Change',
 							visuallyHiddenText: 'Site address',
-							href: `${currentRoute}/site-address/change/${appealDetails.appealSite.addressId}`
+							href: `${currentRoute}/site-address/change/${appealDetails.appealSite.addressId}`,
+							attributes: { 'data-cy': 'change-site-address' }
 						}
 					]
 				}
@@ -164,7 +168,8 @@ export function initialiseAndMapData(appellantCaseData, appealDetails, currentRo
 						{
 							text: 'Change',
 							visuallyHiddenText: 'local planning authority (LPA)',
-							href: `${currentRoute}/change-appeal-details/local-planning-authority`
+							href: `${currentRoute}/change-appeal-details/local-planning-authority`,
+							attributes: { 'data-cy': 'change-local-planning-authority' }
 						}
 					]
 				}
@@ -202,7 +207,8 @@ export function initialiseAndMapData(appellantCaseData, appealDetails, currentRo
 						{
 							text: 'Change',
 							visuallyHiddenText: 'Site ownership',
-							href: `${currentRoute}/site-ownership/change`
+							href: `${currentRoute}/site-ownership/change`,
+							attributes: { 'data-cy': 'change-site-ownership' }
 						}
 					]
 				}
@@ -226,7 +232,8 @@ export function initialiseAndMapData(appellantCaseData, appealDetails, currentRo
 						{
 							text: 'Change',
 							visuallyHiddenText: 'Site partially owned',
-							href: `${currentRoute}/change-appeal-details/site-partially-owned`
+							href: `${currentRoute}/change-appeal-details/site-partially-owned`,
+							attributes: { 'data-cy': 'change-site-partially-owned' }
 						}
 					]
 				}
@@ -275,7 +282,8 @@ export function initialiseAndMapData(appellantCaseData, appealDetails, currentRo
 						{
 							text: 'Change',
 							visuallyHiddenText: 'All owners known',
-							href: `${currentRoute}/change-appeal-details/all-owners-known`
+							href: `${currentRoute}/change-appeal-details/all-owners-known`,
+							attributes: { 'data-cy': 'change-all-owners-known' }
 						}
 					]
 				}
@@ -324,7 +332,8 @@ export function initialiseAndMapData(appellantCaseData, appealDetails, currentRo
 						{
 							text: 'Change',
 							visuallyHiddenText: 'Advertised appeal',
-							href: `${currentRoute}/change-appeal-details/advertised-appeal`
+							href: `${currentRoute}/change-appeal-details/advertised-appeal`,
+							attributes: { 'data-cy': 'change-advertised-appeal' }
 						}
 					]
 				}
@@ -377,7 +386,8 @@ export function initialiseAndMapData(appellantCaseData, appealDetails, currentRo
 						{
 							text: 'Change',
 							href: `${currentRoute}/inspector-access/change/appellant`,
-							visuallyHiddenText: 'Inspector access required'
+							visuallyHiddenText: 'Inspector access required',
+							attributes: { 'data-cy': 'change-inspector-access' }
 						}
 					]
 				},
@@ -406,7 +416,8 @@ export function initialiseAndMapData(appellantCaseData, appealDetails, currentRo
 						{
 							text: 'Change',
 							href: `${currentRoute}/safety-risks/change/appellant`,
-							visuallyHiddenText: 'potential safety risks'
+							visuallyHiddenText: 'potential safety risks',
+							attributes: { 'data-cy': 'change-appellant-case-health-and-safety' }
 						}
 					]
 				}
@@ -455,7 +466,8 @@ export function initialiseAndMapData(appellantCaseData, appealDetails, currentRo
 								appellantCaseData.appealId,
 								appellantCaseData.documents.originalApplicationForm,
 								documentUploadUrlTemplate
-							)
+							),
+							attributes: { 'data-cy': 'add-application-form' }
 						}
 					]
 				}
@@ -492,7 +504,8 @@ export function initialiseAndMapData(appellantCaseData, appealDetails, currentRo
 											isFolderInfo(appellantCaseData.documents.applicationDecisionLetter)
 												? appellantCaseData.documents.applicationDecisionLetter.folderId
 												: undefined
-										)
+										),
+										attributes: { 'data-cy': 'manage-decision-letter' }
 									}
 							  ]
 							: []),
@@ -503,7 +516,8 @@ export function initialiseAndMapData(appellantCaseData, appealDetails, currentRo
 								appellantCaseData.appealId,
 								appellantCaseData.documents.applicationDecisionLetter,
 								documentUploadUrlTemplate
-							)
+							),
+							attributes: { 'data-cy': 'add-decision-letter' }
 						}
 					]
 				}
@@ -540,7 +554,8 @@ export function initialiseAndMapData(appellantCaseData, appealDetails, currentRo
 											isFolderInfo(appellantCaseData.documents.appellantStatement)
 												? appellantCaseData.documents.appellantStatement.folderId
 												: undefined
-										)
+										),
+										attributes: { 'data-cy': 'manage-appeal-statement' }
 									}
 							  ]
 							: []),
@@ -551,7 +566,8 @@ export function initialiseAndMapData(appellantCaseData, appealDetails, currentRo
 								appellantCaseData.appealId,
 								appellantCaseData.documents.appellantStatement,
 								documentUploadUrlTemplate
-							)
+							),
+							attributes: { 'data-cy': 'add-appeal-statement' }
 						}
 					]
 				}
@@ -618,7 +634,8 @@ export function initialiseAndMapData(appellantCaseData, appealDetails, currentRo
 						{
 							text: 'Change',
 							visuallyHiddenText: 'Appellant case review outcome',
-							href: `/appeals-service/appeal-details/${appellantCaseData.appealId}/lpa-questionnaire`
+							href: `/appeals-service/appeal-details/${appellantCaseData.appealId}/lpa-questionnaire`,
+							attributes: { 'data-cy': 'change-review-outcome' }
 						}
 					]
 				}

--- a/appeals/web/src/server/lib/mappers/lpaQuestionnaire.mapper.js
+++ b/appeals/web/src/server/lib/mappers/lpaQuestionnaire.mapper.js
@@ -40,7 +40,8 @@ export function initialiseAndMapLPAQData(data, currentRoute) {
 						{
 							text: 'Change',
 							visuallyHiddenText: 'Listed building',
-							href: `${currentRoute}/change-lpa-questionnaire/is-listed-building`
+							href: `${currentRoute}/change-lpa-questionnaire/is-listed-building`,
+							attributes: { 'data-cy': 'change-is-listed-building' }
 						}
 					]
 				}
@@ -65,7 +66,8 @@ export function initialiseAndMapLPAQData(data, currentRoute) {
 							{
 								text: 'Change',
 								visuallyHiddenText: 'Listed building details',
-								href: `${currentRoute}/change-lpa-questionnaire/listed-building-details`
+								href: `${currentRoute}/change-lpa-questionnaire/listed-building-details`,
+								attributes: { 'data-cy': 'change-listed-building-details' }
 							}
 						]
 					}
@@ -90,7 +92,8 @@ export function initialiseAndMapLPAQData(data, currentRoute) {
 						{
 							text: 'Change',
 							visuallyHiddenText: 'Affects a listed building',
-							href: `${currentRoute}/change-lpa-questionnaire/does-affect-a-listed-building`
+							href: `${currentRoute}/change-lpa-questionnaire/does-affect-a-listed-building`,
+							attributes: { 'data-cy': 'change-does-affect-a-listed-building' }
 						}
 					]
 				}
@@ -140,7 +143,8 @@ export function initialiseAndMapLPAQData(data, currentRoute) {
 							{
 								text: 'Change',
 								visuallyHiddenText: 'Affects listed building details',
-								href: `${currentRoute}/change-lpa-questionnaire/affects-listed-building-details`
+								href: `${currentRoute}/change-lpa-questionnaire/affects-listed-building-details`,
+								attributes: { 'data-cy': 'change-affects-listed-building-details' }
 							}
 						]
 					}
@@ -165,7 +169,8 @@ export function initialiseAndMapLPAQData(data, currentRoute) {
 						{
 							text: 'Change',
 							visuallyHiddenText: 'Affects a scheduled monument',
-							href: `${currentRoute}/change-lpa-questionnaire/affects-scheduled-monument`
+							href: `${currentRoute}/change-lpa-questionnaire/affects-scheduled-monument`,
+							attributes: { 'data-cy': 'change-effects-scheduled-monument' }
 						}
 					]
 				}
@@ -212,7 +217,8 @@ export function initialiseAndMapLPAQData(data, currentRoute) {
 						{
 							text: 'Change',
 							visuallyHiddenText: 'Correct appeal type',
-							href: `${currentRoute}/is-correct-appeal-type/change`
+							href: `${currentRoute}/is-correct-appeal-type/change`,
+							attributes: { 'data-cy': 'change-is-correct-appeal-type' }
 						}
 					]
 				}
@@ -235,7 +241,8 @@ export function initialiseAndMapLPAQData(data, currentRoute) {
 						{
 							text: 'Change',
 							visuallyHiddenText: 'Conservation area',
-							href: `${currentRoute}/change-lpa-questionnaire/in-or-relates-to-ca`
+							href: `${currentRoute}/change-lpa-questionnaire/in-or-relates-to-ca`,
+							attributes: { 'data-cy': 'change-in-or-relates-to-ca' }
 						}
 					]
 				}
@@ -296,7 +303,8 @@ export function initialiseAndMapLPAQData(data, currentRoute) {
 											isFolderInfo(data.documents.conservationMap)
 												? data.documents.conservationMap.folderId
 												: undefined
-										)
+										),
+										attributes: { 'data-cy': 'manage-conservation-area-map' }
 									}
 							  ]
 							: []),
@@ -307,7 +315,8 @@ export function initialiseAndMapLPAQData(data, currentRoute) {
 								data.appealId,
 								data.documents.conservationMap,
 								buildDocumentUploadUrlTemplate(data.lpaQuestionnaireId)
-							)
+							),
+							attributes: { 'data-cy': 'add-conservation-area-map' }
 						}
 					]
 				}
@@ -331,7 +340,8 @@ export function initialiseAndMapLPAQData(data, currentRoute) {
 						{
 							text: 'Change',
 							visuallyHiddenText: 'Green belt',
-							href: `${currentRoute}/change-lpa-questionnaire/site-within-green-belt`
+							href: `${currentRoute}/change-lpa-questionnaire/site-within-green-belt`,
+							attributes: { 'data-cy': 'change-site-within-green-belt' }
 						}
 					]
 				}
@@ -390,7 +400,8 @@ export function initialiseAndMapLPAQData(data, currentRoute) {
 											isFolderInfo(data.documents.whoNotified)
 												? data.documents.whoNotified.folderId
 												: undefined
-										)
+										),
+										attributes: { 'data-cy': 'manage-notifying-parties' }
 									}
 							  ]
 							: []),
@@ -401,7 +412,8 @@ export function initialiseAndMapLPAQData(data, currentRoute) {
 								data.appealId,
 								data.documents.whoNotified,
 								buildDocumentUploadUrlTemplate(data.lpaQuestionnaireId)
-							)
+							),
+							attributes: { 'data-cy': 'add-notifying-parties' }
 						}
 					]
 				}
@@ -427,7 +439,8 @@ export function initialiseAndMapLPAQData(data, currentRoute) {
 						{
 							text: 'Change',
 							visuallyHiddenText: 'Notification methods',
-							href: `${currentRoute}/change-lpa-questionnaire/notification-methods`
+							href: `${currentRoute}/change-lpa-questionnaire/notification-methods`,
+							attributes: { 'data-cy': 'change-notification-methods' }
 						}
 					]
 				}
@@ -485,7 +498,8 @@ export function initialiseAndMapLPAQData(data, currentRoute) {
 						{
 							text: 'Change',
 							visuallyHiddenText: 'Representations from other parties',
-							href: `${currentRoute}/change-lpa-questionnaire/has-representations-from-other-parties`
+							href: `${currentRoute}/change-lpa-questionnaire/has-representations-from-other-parties`,
+							attributes: { 'data-cy': 'change-has-representations-from-other-parties' }
 						}
 					]
 				}
@@ -546,7 +560,8 @@ export function initialiseAndMapLPAQData(data, currentRoute) {
 											isFolderInfo(data.documents.otherPartyRepresentations)
 												? data.documents.otherPartyRepresentations.folderId
 												: undefined
-										)
+										),
+										attributes: { 'data-cy': 'manage-representations-from-other-parties' }
 									}
 							  ]
 							: []),
@@ -557,7 +572,8 @@ export function initialiseAndMapLPAQData(data, currentRoute) {
 								data.appealId,
 								data.documents.otherPartyRepresentations,
 								buildDocumentUploadUrlTemplate(data.lpaQuestionnaireId)
-							)
+							),
+							attributes: { 'data-cy': 'add-representations-from-other-parties' }
 						}
 					]
 				}
@@ -595,7 +611,8 @@ export function initialiseAndMapLPAQData(data, currentRoute) {
 											isFolderInfo(data.documents.planningOfficerReport)
 												? data.documents.planningOfficerReport.folderId
 												: undefined
-										)
+										),
+										attributes: { 'data-cy': 'manage-officers-report' }
 									}
 							  ]
 							: []),
@@ -606,7 +623,8 @@ export function initialiseAndMapLPAQData(data, currentRoute) {
 								data.appealId,
 								data.documents.planningOfficerReport,
 								buildDocumentUploadUrlTemplate(data.lpaQuestionnaireId)
-							)
+							),
+							attributes: { 'data-cy': 'add-officers-report' }
 						}
 					]
 				}
@@ -633,7 +651,8 @@ export function initialiseAndMapLPAQData(data, currentRoute) {
 						{
 							text: 'Change',
 							visuallyHiddenText: 'Site access required',
-							href: `${currentRoute}/inspector-access/change/lpa`
+							href: `${currentRoute}/inspector-access/change/lpa`,
+							attributes: { 'data-cy': 'change-does-site-require-inspector-access' }
 						}
 					]
 				}
@@ -680,7 +699,8 @@ export function initialiseAndMapLPAQData(data, currentRoute) {
 						{
 							text: 'Change',
 							visuallyHiddenText: 'Affects neighbouring sites',
-							href: `${currentRoute}/neighbouring-sites/change/affected`
+							href: `${currentRoute}/neighbouring-sites/change/affected`,
+							attributes: { 'data-cy': 'change-is-affecting-neighbouring-sites' }
 						}
 					]
 				}
@@ -731,7 +751,8 @@ export function initialiseAndMapLPAQData(data, currentRoute) {
 						{
 							text: 'Change',
 							href: `${currentRoute}/safety-risks/change/lpa`,
-							visuallyHiddenText: 'potential safety risks'
+							visuallyHiddenText: 'potential safety risks',
+							attributes: { 'data-cy': 'change-health-and-safety' }
 						}
 					]
 				},
@@ -757,7 +778,8 @@ export function initialiseAndMapLPAQData(data, currentRoute) {
 						{
 							text: 'Change',
 							visuallyHiddenText: 'Appeals near the site',
-							href: `${currentRoute}/change-lpa-questionnaire/other-appeals`
+							href: `${currentRoute}/change-lpa-questionnaire/other-appeals`,
+							attributes: { 'data-cy': 'change-other-appeals' }
 						}
 					]
 				}
@@ -896,7 +918,8 @@ export function initialiseAndMapLPAQData(data, currentRoute) {
 						{
 							text: 'Change',
 							visuallyHiddenText: 'LPA Questionnaire review outcome',
-							href: `/appeals-service/appeal-details/${data.appealId}/lpa-questionnaire/${data.lpaQuestionnaireId}`
+							href: `/appeals-service/appeal-details/${data.appealId}/lpa-questionnaire/${data.lpaQuestionnaireId}`,
+							attributes: { 'data-cy': 'change-review-outcome' }
 						}
 					]
 				}

--- a/appeals/web/src/server/lib/mappers/notification-banners.mapper.js
+++ b/appeals/web/src/server/lib/mappers/notification-banners.mapper.js
@@ -74,7 +74,7 @@ export const notificationBannerDefinitions = {
 	},
 	notCheckedDocument: {
 		pages: ['lpaQuestionnaire', 'manageDocuments', 'appellantCase', 'manageFolder'],
-		html: '<p class="govuk-notification-banner__heading">Virus scan in progress</p></br><a class="govuk-notification-banner__link" href="./">Refresh page to see if scan has finished</a>'
+		html: '<p class="govuk-notification-banner__heading">Virus scan in progress</p></br><a class="govuk-notification-banner__link" href="./" data-cy/"refresh-page/" >Refresh page to see if scan has finished</a>'
 	},
 	appealAwaitingTransfer: {
 		pages: ['appealDetails'],

--- a/appeals/web/src/server/views/appeals/components/appeals-table.njk
+++ b/appeals/web/src/server/views/appeals/components/appeals-table.njk
@@ -3,7 +3,7 @@
 
 {%- macro appealsTable(params) -%}
 	{%- macro createReferenceCell(appeal) -%}
-		<a class="govuk-link" href="/appeals-service/appeal-details/{{appeal.appealId}}" aria-label="appeal {{ appeal.appealReference | appealShortReference | numberToAccessibleDigitLabel }}">
+		<a class="govuk-link" href="/appeals-service/appeal-details/{{appeal.appealId}}" aria-label="appeal {{ appeal.appealReference | appealShortReference | numberToAccessibleDigitLabel }}" data-cy="{{ appeal.appealReference | appealShortReference }}">
 			{{ appeal.appealReference | appealShortReference }}
 		</a>
 	{%- endmacro -%}


### PR DESCRIPTION
## Describe your changes
This adds `data-cy` attributes to key page elements so that the E2E Cypress tests will be less brittle. This is following the recommended best practise, as per https://docs.cypress.io/guides/references/best-practices#Selecting-Elements

Next steps are to update and extend the existing E2E tests, before using again in the pipeline and allow individual devs to run locally to perform a quick regression test locally.

## Issue ticket number and link
Relates to [BOAT-1198](https://pins-ds.atlassian.net/browse/BOAT-1198) and [BOAT-1148](https://pins-ds.atlassian.net/browse/BOAT-1148]

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [ ] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
