### PR TITLE
fix(api): fix address update to allow removal of data from optional fields

### DIFF
--- a/appeals/api/src/server/common/validators/string-parameter.js
+++ b/appeals/api/src/server/common/validators/string-parameter.js
@@ -31,7 +31,7 @@ const validateStringParameter = (parameterName, maxLength = LENGTH_300) =>
  */
 export const validateStringParameterAllowingEmpty = (parameterName, maxLength = LENGTH_300) =>
 	body(parameterName)
-		.optional()
+		.optional({ nullable: true })
 		.isString()
 		.withMessage(ERROR_MUST_BE_STRING)
 		.isLength({ max: maxLength })

--- a/appeals/api/src/server/endpoints/addresses/__tests__/addresses.test.js
+++ b/appeals/api/src/server/endpoints/addresses/__tests__/addresses.test.js
@@ -283,25 +283,6 @@ describe('addresses routes', () => {
 				});
 			});
 
-			test('returns an error if addressLine2 is an empty string', async () => {
-				// @ts-ignore
-				databaseConnector.appeal.findUnique.mockResolvedValue(householdAppeal);
-
-				const response = await request
-					.patch(`/appeals/${householdAppeal.id}/addresses/${householdAppeal.address.id}`)
-					.send({
-						addressLine2: ''
-					})
-					.set('azureAdUserId', azureAdUserId);
-
-				expect(response.status).toEqual(400);
-				expect(response.body).toEqual({
-					errors: {
-						addressLine2: ERROR_CANNOT_BE_EMPTY_STRING
-					}
-				});
-			});
-
 			test('returns an error if addressLine2 is more than 300 characters', async () => {
 				// @ts-ignore
 				databaseConnector.appeal.findUnique.mockResolvedValue(householdAppeal);
@@ -393,25 +374,6 @@ describe('addresses routes', () => {
 				expect(response.body).toEqual({
 					errors: {
 						county: ERROR_MUST_BE_STRING
-					}
-				});
-			});
-
-			test('returns an error if county is an empty string', async () => {
-				// @ts-ignore
-				databaseConnector.appeal.findUnique.mockResolvedValue(householdAppeal);
-
-				const response = await request
-					.patch(`/appeals/${householdAppeal.id}/addresses/${householdAppeal.address.id}`)
-					.send({
-						county: ''
-					})
-					.set('azureAdUserId', azureAdUserId);
-
-				expect(response.status).toEqual(400);
-				expect(response.body).toEqual({
-					errors: {
-						county: ERROR_CANNOT_BE_EMPTY_STRING
 					}
 				});
 			});

--- a/appeals/api/src/server/endpoints/addresses/addresses.validators.js
+++ b/appeals/api/src/server/endpoints/addresses/addresses.validators.js
@@ -1,7 +1,9 @@
 import { composeMiddleware } from '@pins/express';
 import { validationErrorHandler } from '#middleware/error-handler.js';
 import validateIdParameter from '#common/validators/id-parameter.js';
-import validateStringParameter from '#common/validators/string-parameter.js';
+import validateStringParameter, {
+	validateStringParameterAllowingEmpty
+} from '#common/validators/string-parameter.js';
 import { LENGTH_8 } from '#endpoints/constants.js';
 
 const getAddressValidator = composeMiddleware(
@@ -14,9 +16,9 @@ const patchAddressValidator = composeMiddleware(
 	validateIdParameter('appealId'),
 	validateIdParameter('addressId'),
 	validateStringParameter('addressLine1'),
-	validateStringParameter('addressLine2'),
+	validateStringParameterAllowingEmpty('addressLine2'),
 	validateStringParameter('country'),
-	validateStringParameter('county'),
+	validateStringParameterAllowingEmpty('county'),
 	validateStringParameter('postcode', LENGTH_8),
 	validateStringParameter('town'),
 	validationErrorHandler

--- a/appeals/web/src/server/appeals/appeal-details/address/address.service.js
+++ b/appeals/web/src/server/appeals/appeal-details/address/address.service.js
@@ -9,8 +9,8 @@
 export function changeSiteAddress(apiClient, appealId, siteAddress, addressId) {
 	const formattedSiteAddress = {
 		addressLine1: siteAddress.addressLine1,
-		...(siteAddress.addressLine2 && { addressLine2: siteAddress.addressLine2 }),
-		...(siteAddress.county && { county: siteAddress.county }),
+		addressLine2: siteAddress.addressLine2,
+		county: siteAddress.county,
 		postcode: siteAddress.postCode,
 		town: siteAddress.town
 	};


### PR DESCRIPTION
Was unable to clear data when it was no longer required, so changing addressLine2 from a string to an empty is now possible.

## Describe your changes

<!--
    Please include a summary of the change along with any relevant context.
    List any dependencies that are required for this change.
-->

## Issue ticket number and link

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [x] I have made corresponding changes to the documentation
- [x] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [x] I have included unit tests to cover any testable code changes
