### PR TITLE
feat(appeals): broadcasting appeal HAS - ASI-17

### DIFF
--- a/appeals/api/package.json
+++ b/appeals/api/package.json
@@ -66,7 +66,7 @@
     "rhea": "3.0.1",
     "swagger-ui-express": "^5.0.1",
     "xstate": "4.32.1",
-    "pins-data-model": "github:Planning-Inspectorate/data-model#1.5.1"
+    "pins-data-model": "github:Planning-Inspectorate/data-model#1.6.2"
   },
   "devDependencies": {
     "@types/express": "^4.17.13",

--- a/appeals/api/src/database/migrations/20240624093507_missing_owners_informed/migration.sql
+++ b/appeals/api/src/database/migrations/20240624093507_missing_owners_informed/migration.sql
@@ -1,0 +1,19 @@
+BEGIN TRY
+
+BEGIN TRAN;
+
+-- AlterTable
+ALTER TABLE [dbo].[AppellantCase] ADD [ownersInformed] BIT;
+
+COMMIT TRAN;
+
+END TRY
+BEGIN CATCH
+
+IF @@TRANCOUNT > 0
+BEGIN
+    ROLLBACK TRAN;
+END;
+THROW
+
+END CATCH

--- a/appeals/api/src/database/migrations/20240624102831_enforcement_notice/migration.sql
+++ b/appeals/api/src/database/migrations/20240624102831_enforcement_notice/migration.sql
@@ -1,0 +1,19 @@
+BEGIN TRY
+
+BEGIN TRAN;
+
+-- AlterTable
+ALTER TABLE [dbo].[AppellantCase] ADD [enforcementNotice] BIT;
+
+COMMIT TRAN;
+
+END TRY
+BEGIN CATCH
+
+IF @@TRANCOUNT > 0
+BEGIN
+    ROLLBACK TRAN;
+END;
+THROW
+
+END CATCH

--- a/appeals/api/src/database/migrations/20240624225640_appeal_relationship_refactor/migration.sql
+++ b/appeals/api/src/database/migrations/20240624225640_appeal_relationship_refactor/migration.sql
@@ -1,0 +1,22 @@
+BEGIN TRY
+
+BEGIN TRAN;
+
+-- AddForeignKey
+ALTER TABLE [dbo].[AppealRelationship] ADD CONSTRAINT [AppealRelationship_parentId_fkey] FOREIGN KEY ([parentId]) REFERENCES [dbo].[Appeal]([id]) ON DELETE NO ACTION ON UPDATE NO ACTION;
+
+-- AddForeignKey
+ALTER TABLE [dbo].[AppealRelationship] ADD CONSTRAINT [AppealRelationship_childId_fkey] FOREIGN KEY ([childId]) REFERENCES [dbo].[Appeal]([id]) ON DELETE NO ACTION ON UPDATE NO ACTION;
+
+COMMIT TRAN;
+
+END TRY
+BEGIN CATCH
+
+IF @@TRANCOUNT > 0
+BEGIN
+    ROLLBACK TRAN;
+END;
+THROW
+
+END CATCH

--- a/appeals/api/src/database/schema.d.ts
+++ b/appeals/api/src/database/schema.d.ts
@@ -3,6 +3,8 @@ import * as schema from '#utils/db-client';
 import { CaseOfficer, Inspector } from '@pins/appeals';
 
 export interface Appeal extends schema.Appeal {
+	parentAppeals: AppealRelationship[];
+	childAppeals: AppealRelationship[];
 	appealStatus: AppealStatus[];
 	appealType?: AppealType | null;
 	lpa?: LPA | null;
@@ -18,8 +20,8 @@ export interface Appeal extends schema.Appeal {
 	appealTimetable?: AppealTimetable | null;
 	appellantCase?: AppellantCase | null;
 	lpaQuestionnaire?: LPAQuestionnaire | null;
-	caseOfficer?: CaseOfficer | null;
-	inspector?: Inspector | null;
+	caseOfficer?: User | null;
+	inspector?: User | null;
 	siteVisit?: SiteVisit | null;
 	inspectorDecision?: InspectorDecision | null;
 	neighbouringSites?: NeighbouringSite[] | null;

--- a/appeals/api/src/database/schema.prisma
+++ b/appeals/api/src/database/schema.prisma
@@ -11,22 +11,22 @@ datasource db {
 /// Appeal model
 /// Contains information of an appeal managed in the Back-Office.
 model Appeal {
-  id                    Int                @id @default(autoincrement())
-  reference             String             @unique
+  id                    Int                  @id @default(autoincrement())
+  reference             String               @unique
   appealTimetable       AppealTimetable?
   appealStatus          AppealStatus[]
-  appealType            AppealType?        @relation(fields: [appealTypeId], references: [id])
+  appealType            AppealType?          @relation(fields: [appealTypeId], references: [id])
   appealTypeId          Int?
-  procedureType         ProcedureType?     @relation(fields: [procedureTypeId], references: [id])
+  procedureType         ProcedureType?       @relation(fields: [procedureTypeId], references: [id])
   procedureTypeId       Int?
-  address               Address?           @relation(fields: [addressId], references: [id])
+  address               Address?             @relation(fields: [addressId], references: [id])
   addressId             Int?
   neighbouringSites     NeighbouringSite[]
-  lpa                   LPA                @relation(fields: [lpaId], references: [id], onDelete: NoAction, onUpdate: NoAction)
+  lpa                   LPA                  @relation(fields: [lpaId], references: [id], onDelete: NoAction, onUpdate: NoAction)
   lpaId                 Int
   applicationReference  String?
-  caseCreatedDate       DateTime           @default(now())
-  caseUpdatedDate       DateTime           @default(now())
+  caseCreatedDate       DateTime             @default(now())
+  caseUpdatedDate       DateTime             @default(now())
   caseValidDate         DateTime?
   caseExtensionDate     DateTime?
   caseStartedDate       DateTime?
@@ -37,13 +37,13 @@ model Appeal {
   specialisms           AppealSpecialism[]
   allocation            AppealAllocation?
   allocationId          Int?
-  appellant             ServiceUser?       @relation("appellant", fields: [appellantId], references: [id], onDelete: NoAction, onUpdate: NoAction)
+  appellant             ServiceUser?         @relation("appellant", fields: [appellantId], references: [id], onDelete: NoAction, onUpdate: NoAction)
   appellantId           Int?
-  agent                 ServiceUser?       @relation("agent", fields: [agentId], references: [id], onDelete: NoAction, onUpdate: NoAction)
+  agent                 ServiceUser?         @relation("agent", fields: [agentId], references: [id], onDelete: NoAction, onUpdate: NoAction)
   agentId               Int?
-  caseOfficer           User?              @relation("caseOfficer", fields: [caseOfficerUserId], references: [id], onDelete: NoAction, onUpdate: NoAction)
+  caseOfficer           User?                @relation("caseOfficer", fields: [caseOfficerUserId], references: [id], onDelete: NoAction, onUpdate: NoAction)
   caseOfficerUserId     Int?
-  inspector             User?              @relation("inspector", fields: [inspectorUserId], references: [id], onDelete: NoAction, onUpdate: NoAction)
+  inspector             User?                @relation("inspector", fields: [inspectorUserId], references: [id], onDelete: NoAction, onUpdate: NoAction)
   inspectorUserId       Int?
   appellantCase         AppellantCase?
   lpaQuestionnaire      LPAQuestionnaire?
@@ -52,6 +52,8 @@ model Appeal {
   folders               Folder[]
   documents             Document[]
   auditTrail            AuditTrail[]
+  parentAppeals         AppealRelationship[] @relation("childAppeal")
+  childAppeals          AppealRelationship[] @relation("parentAppeal")
 }
 
 /// AppealRelationship model
@@ -63,7 +65,9 @@ model AppealRelationship {
   type              String   @default("linked") // linked | related
   parentRef         String
   childRef          String
+  parent            Appeal?  @relation("parentAppeal", fields: [parentId], references: [id], onDelete: NoAction, onUpdate: NoAction)
   parentId          Int?
+  child             Appeal?  @relation("childAppeal", fields: [childId], references: [id], onDelete: NoAction, onUpdate: NoAction)
   childId           Int?
   externalSource    Boolean?
   externaAppealType String?
@@ -241,6 +245,8 @@ model AppellantCase {
   appellantCostsAppliedFor               Boolean?
   originalDevelopmentDescription         String?
   changedDevelopmentDescription          Boolean?
+  ownersInformed                         Boolean?
+  enforcementNotice                      Boolean?
 }
 
 /// AppellantCaseValidationOutcome model

--- a/appeals/api/src/server/endpoints/appeal-timetables/__tests__/appeal-timetables.test.js
+++ b/appeals/api/src/server/endpoints/appeal-timetables/__tests__/appeal-timetables.test.js
@@ -25,13 +25,14 @@ const futureDateAndTime = joinDateAndTime(futureDate);
 const houseAppealWithTimetable = {
 	...householdAppeal,
 	caseStartedDate: new Date(2022, 4, 18),
+	caseValidationDate: new Date(2022, 4, 20),
 	caseValidDate: new Date(2022, 4, 20),
 	appealTimetable: {
 		appealId: 1,
 		finalCommentReviewDate: null,
 		id: 1,
 		issueDeterminationDate: null,
-		lpaQuestionnaireDueDate: '2023-05-16T01:00:00.000Z',
+		lpaQuestionnaireDueDate: new Date('2023-05-16T01:00:00.000Z'),
 		statementReviewDate: null
 	}
 };
@@ -39,13 +40,14 @@ const houseAppealWithTimetable = {
 const fullPlanningAppealWithTimetable = {
 	...fullPlanningAppeal,
 	caseStartedDate: new Date(2022, 4, 18),
+	caseValidationDate: new Date(2022, 4, 20),
 	caseValidDate: new Date(2022, 4, 20),
 	appealTimetable: {
 		appealId: 1,
 		finalCommentReviewDate: null,
 		id: 1,
 		issueDeterminationDate: null,
-		lpaQuestionnaireDueDate: '2023-05-16T01:00:00.000Z',
+		lpaQuestionnaireDueDate: new Date('2023-05-16T01:00:00.000Z'),
 		statementReviewDate: null
 	}
 };

--- a/appeals/api/src/server/endpoints/appeals.d.ts
+++ b/appeals/api/src/server/endpoints/appeals.d.ts
@@ -117,6 +117,10 @@ interface SingleAppellantCaseResponse {
 		firstName: string | null;
 		surname: string | null;
 	};
+	applicationDate: Date;
+	applicationDecisionDate: Date | null;
+	caseSubmissionDueDate: Date | null;
+	caseSubmittedDate: Date | null;
 	isAppellantNamedOnApplication: boolean | null;
 	planningApplicationReference: string;
 	hasAdvertisedAppeal: boolean | null;
@@ -126,9 +130,11 @@ interface SingleAppellantCaseResponse {
 	};
 	localPlanningDepartment: string;
 	procedureType?: string;
+	enforcementNotice?: boolean | null;
 	siteOwnership: {
 		areAllOwnersKnown: string | null;
 		knowsOtherLandowners: string | null;
+		ownersInformed: boolean | null;
 		isFullyOwned: boolean | null;
 		isPartiallyOwned: boolean | null;
 		floorSpaceSquareMetres: decimal | null;
@@ -215,7 +221,6 @@ interface SingleLPAQuestionnaireResponse {
 	lpaNotificationMethods?: LPANotificationMethodDetails[] | null;
 	affectsListedBuildingDetails?: ListedBuildingDetailsResponse | null;
 	listedBuildingDetails?: ListedBuildingDetailsResponse | null;
-
 	healthAndSafetyDetails?: string | null;
 	doesSiteHaveHealthAndSafetyIssues?: boolean | null;
 	inspectorAccessDetails?: string | null;
@@ -223,11 +228,9 @@ interface SingleLPAQuestionnaireResponse {
 	isConservationArea?: boolean | null;
 	siteWithinGreenBelt?: boolean | null;
 	isCorrectAppealType?: boolean | null;
-
 	submittedAt?: Date | null;
 	receivedAt: Date;
 	otherAppeals?: string[] | null;
-
 	costsAppliedFor?: boolean | null;
 	lpaStatement?: string | null;
 	extraConditions?: string | null;

--- a/appeals/api/src/server/endpoints/appeals/__tests__/appeals.test.js
+++ b/appeals/api/src/server/endpoints/appeals/__tests__/appeals.test.js
@@ -677,11 +677,10 @@ describe('appeals routes', () => {
 				// @ts-ignore
 				databaseConnector.folder.findMany.mockResolvedValue([decisionFolder]);
 				// @ts-ignore
-				databaseConnector.appeal.findUnique.mockResolvedValue(householdAppeal);
-				// @ts-ignore
-				databaseConnector.appealRelationship.findMany
-					// @ts-ignore
-					.mockResolvedValueOnce(linkedAppeals);
+				databaseConnector.appeal.findUnique.mockResolvedValue({
+					...householdAppeal,
+					childAppeals: linkedAppeals
+				});
 
 				const response = await request
 					.get(`/appeals/${householdAppeal.id}`)
@@ -729,13 +728,11 @@ describe('appeals routes', () => {
 					documentationSummary: {
 						appellantCase: {
 							status: 'received',
-							dueDate: householdAppeal.caseExtensionDate,
 							receivedAt: householdAppeal.caseCreatedDate.toISOString()
 						},
 						lpaQuestionnaire: {
-							dueDate: null,
 							status: 'received',
-							receivedAt: householdAppeal.lpaQuestionnaire.lpaqCreatedDate
+							receivedAt: householdAppeal.lpaQuestionnaire.lpaqCreatedDate.toISOString()
 						}
 					},
 					healthAndSafety: {
@@ -765,7 +762,7 @@ describe('appeals routes', () => {
 						return {
 							appealReference: a.childRef,
 							isParentAppeal: false,
-							linkingDate: a.linkingDate,
+							linkingDate: a.linkingDate.toISOString(),
 							appealType: 'Unknown',
 							externalSource: true
 						};
@@ -777,14 +774,12 @@ describe('appeals routes', () => {
 					procedureType: householdAppeal.procedureType.name,
 					siteVisit: {
 						siteVisitId: householdAppeal.siteVisit.id,
-						visitDate: householdAppeal.siteVisit.visitDate,
+						visitDate: householdAppeal.siteVisit.visitDate.toISOString(),
 						visitStartTime: householdAppeal.siteVisit.visitStartTime,
 						visitEndTime: householdAppeal.siteVisit.visitEndTime,
 						visitType: householdAppeal.siteVisit.siteVisitType.name
 					},
 					createdAt: householdAppeal.caseCreatedDate.toISOString()
-					//startedAt: householdAppeal.startedAt.toISOString(),
-					//validAt: householdAppeal.validAt.toISOString()
 				});
 			});
 
@@ -840,13 +835,11 @@ describe('appeals routes', () => {
 					documentationSummary: {
 						appellantCase: {
 							status: 'received',
-							dueDate: fullPlanningAppeal.caseExtensionDate,
 							receivedAt: householdAppeal.caseCreatedDate.toISOString()
 						},
 						lpaQuestionnaire: {
-							dueDate: null,
 							status: 'received',
-							receivedAt: householdAppeal.lpaQuestionnaire.lpaqCreatedDate
+							receivedAt: householdAppeal.lpaQuestionnaire.lpaqCreatedDate.toISOString()
 						}
 					},
 					healthAndSafety: {
@@ -880,14 +873,12 @@ describe('appeals routes', () => {
 					procedureType: fullPlanningAppeal.procedureType.name,
 					siteVisit: {
 						siteVisitId: fullPlanningAppeal.siteVisit.id,
-						visitDate: fullPlanningAppeal.siteVisit.visitDate,
+						visitDate: fullPlanningAppeal.siteVisit.visitDate.toISOString(),
 						visitStartTime: fullPlanningAppeal.siteVisit.visitStartTime,
 						visitEndTime: fullPlanningAppeal.siteVisit.visitEndTime,
 						visitType: fullPlanningAppeal.siteVisit.siteVisitType.name
 					},
 					createdAt: householdAppeal.caseCreatedDate.toISOString()
-					//startedAt: fullPlanningAppeal.startedAt.toISOString(),
-					//validAt: householdAppeal.validAt.toISOString()
 				});
 			});
 
@@ -1392,11 +1383,10 @@ describe('appeals/case-reference/:caseReference', () => {
 			// @ts-ignore
 			databaseConnector.folder.findMany.mockResolvedValue([decisionFolder]);
 			// @ts-ignore
-			databaseConnector.appeal.findUnique.mockResolvedValue(householdAppeal);
-			// @ts-ignore
-			databaseConnector.appealRelationship.findMany
-				// @ts-ignore
-				.mockResolvedValueOnce(linkedAppeals);
+			databaseConnector.appeal.findUnique.mockResolvedValue({
+				...householdAppeal,
+				childAppeals: linkedAppeals
+			});
 
 			const response = await request
 				.get(`/appeals/case-reference/${householdAppeal.reference}`)
@@ -1444,13 +1434,11 @@ describe('appeals/case-reference/:caseReference', () => {
 				documentationSummary: {
 					appellantCase: {
 						status: 'received',
-						dueDate: householdAppeal.caseExtensionDate,
 						receivedAt: householdAppeal.caseCreatedDate.toISOString()
 					},
 					lpaQuestionnaire: {
-						dueDate: null,
 						status: 'received',
-						receivedAt: householdAppeal.lpaQuestionnaire.lpaqCreatedDate
+						receivedAt: householdAppeal.lpaQuestionnaire.lpaqCreatedDate.toISOString()
 					}
 				},
 				healthAndSafety: {
@@ -1480,7 +1468,7 @@ describe('appeals/case-reference/:caseReference', () => {
 					return {
 						appealReference: a.childRef,
 						isParentAppeal: false,
-						linkingDate: a.linkingDate,
+						linkingDate: a.linkingDate.toISOString(),
 						appealType: 'Unknown',
 						externalSource: true
 					};
@@ -1492,14 +1480,12 @@ describe('appeals/case-reference/:caseReference', () => {
 				procedureType: householdAppeal.procedureType.name,
 				siteVisit: {
 					siteVisitId: householdAppeal.siteVisit.id,
-					visitDate: householdAppeal.siteVisit.visitDate,
+					visitDate: householdAppeal.siteVisit.visitDate.toISOString(),
 					visitStartTime: householdAppeal.siteVisit.visitStartTime,
 					visitEndTime: householdAppeal.siteVisit.visitEndTime,
 					visitType: householdAppeal.siteVisit.siteVisitType.name
 				},
 				createdAt: householdAppeal.caseCreatedDate.toISOString()
-				//startedAt: householdAppeal.startedAt.toISOString(),
-				//validAt: householdAppeal.validAt.toISOString()
 			});
 		});
 
@@ -1555,13 +1541,11 @@ describe('appeals/case-reference/:caseReference', () => {
 				documentationSummary: {
 					appellantCase: {
 						status: 'received',
-						dueDate: fullPlanningAppeal.caseExtensionDate,
 						receivedAt: householdAppeal.caseCreatedDate.toISOString()
 					},
 					lpaQuestionnaire: {
-						dueDate: null,
 						status: 'received',
-						receivedAt: householdAppeal.lpaQuestionnaire.lpaqCreatedDate
+						receivedAt: householdAppeal.lpaQuestionnaire.lpaqCreatedDate.toISOString()
 					}
 				},
 				healthAndSafety: {
@@ -1595,14 +1579,12 @@ describe('appeals/case-reference/:caseReference', () => {
 				procedureType: fullPlanningAppeal.procedureType.name,
 				siteVisit: {
 					siteVisitId: fullPlanningAppeal.siteVisit.id,
-					visitDate: fullPlanningAppeal.siteVisit.visitDate,
+					visitDate: fullPlanningAppeal.siteVisit.visitDate.toISOString(),
 					visitStartTime: fullPlanningAppeal.siteVisit.visitStartTime,
 					visitEndTime: fullPlanningAppeal.siteVisit.visitEndTime,
 					visitType: fullPlanningAppeal.siteVisit.siteVisitType.name
 				},
 				createdAt: fullPlanningAppeal.caseCreatedDate.toISOString()
-				//startedAt: fullPlanningAppeal.startedAt.toISOString(),
-				//validAt: fullPlanningAppeal.validAt.toISOString()
 			});
 		});
 		test('returns an error if appealId is not found', async () => {

--- a/appeals/api/src/server/endpoints/appeals/appeals.controller.js
+++ b/appeals/api/src/server/endpoints/appeals/appeals.controller.js
@@ -214,11 +214,11 @@ const updateAppealById = async (req, res) => {
 				details = stringTokenReplacement(AUDIT_TRAIL_ASSIGNED_INSPECTOR, [inspector]);
 			} else if (caseOfficer === null && appeal.caseOfficer) {
 				details = stringTokenReplacement(AUDIT_TRAIL_REMOVED_CASE_OFFICER, [
-					appeal.caseOfficer.azureAdUserId
+					appeal.caseOfficer.azureAdUserId || ''
 				]);
 			} else if (inspector === null && appeal.inspector) {
 				details = stringTokenReplacement(AUDIT_TRAIL_REMOVED_INSPECTOR, [
-					appeal.inspector.azureAdUserId
+					appeal.inspector.azureAdUserId || ''
 				]);
 			}
 

--- a/appeals/api/src/server/endpoints/appeals/appeals.formatter.js
+++ b/appeals/api/src/server/endpoints/appeals/appeals.formatter.js
@@ -156,10 +156,19 @@ const formatAppeal = (
 			appealTimetable: appeal.appealTimetable
 				? {
 						appealTimetableId: appeal.appealTimetable.id,
-						lpaQuestionnaireDueDate: appeal.appealTimetable.lpaQuestionnaireDueDate || null,
+						lpaQuestionnaireDueDate:
+							(appeal.appealTimetable.lpaQuestionnaireDueDate &&
+								appeal.appealTimetable.lpaQuestionnaireDueDate) ||
+							null,
 						...(isFPA(appeal.appealType?.key || '') && {
-							finalCommentReviewDate: appeal.appealTimetable.finalCommentReviewDate || null,
-							statementReviewDate: appeal.appealTimetable.statementReviewDate || null
+							finalCommentReviewDate:
+								(appeal.appealTimetable.finalCommentReviewDate &&
+									appeal.appealTimetable.finalCommentReviewDate) ||
+								null,
+							statementReviewDate:
+								(appeal.appealTimetable.statementReviewDate &&
+									appeal.appealTimetable.statementReviewDate) ||
+								null
 						})
 				  }
 				: null,
@@ -182,7 +191,8 @@ const formatAppeal = (
 							folderId: decisionFolders[0].id,
 							outcome: appeal.inspectorDecision.outcome,
 							documentId: appeal.inspectorDecision?.decisionLetterGuid,
-							letterDate: decisionInfo.letterDate,
+							letterDate:
+								(decisionInfo.letterDate && decisionInfo.letterDate?.toISOString()) || null,
 							virusCheckStatus: decisionInfo.virusCheckStatus
 					  }
 					: {
@@ -228,25 +238,29 @@ const formatAppeal = (
 			...(appeal.siteVisit?.id && {
 				siteVisit: {
 					siteVisitId: appeal.siteVisit.id,
-					visitDate: appeal.siteVisit.visitDate || null,
+					visitDate: appeal.siteVisit.visitDate?.toISOString() || null,
 					visitStartTime: appeal.siteVisit.visitStartTime,
 					visitEndTime: appeal.siteVisit?.visitEndTime || null,
 					visitType: appeal.siteVisit.siteVisitType.name
 				}
 			}),
-			createdAt: appeal.caseCreatedDate,
-			startedAt: appeal.caseStartedDate,
-			validAt: appeal.caseValidDate,
+			createdAt: appeal.caseCreatedDate.toISOString(),
+			startedAt: appeal.caseStartedDate && appeal.caseStartedDate?.toISOString(),
+			validAt: appeal.caseValidDate && appeal.caseValidDate?.toISOString(),
 			documentationSummary: {
 				appellantCase: {
 					status: formatAppellantCaseDocumentationStatus(appeal),
-					dueDate: appeal.caseExtensionDate,
-					receivedAt: appeal.caseCreatedDate
+					dueDate: appeal.caseExtensionDate && appeal.caseExtensionDate?.toISOString(),
+					receivedAt: appeal.caseCreatedDate.toISOString()
 				},
 				lpaQuestionnaire: {
 					status: formatLpaQuestionnaireDocumentationStatus(appeal),
-					dueDate: appeal.appealTimetable?.lpaQuestionnaireDueDate || null,
-					receivedAt: appeal.lpaQuestionnaire?.lpaqCreatedDate || null
+					dueDate:
+						appeal.appealTimetable?.lpaQuestionnaireDueDate &&
+						appeal.appealTimetable?.lpaQuestionnaireDueDate.toISOString(),
+					receivedAt:
+						appeal.lpaQuestionnaire?.lpaqCreatedDate &&
+						appeal.lpaQuestionnaire?.lpaqCreatedDate.toISOString()
 				}
 			}
 		};

--- a/appeals/api/src/server/endpoints/appellant-cases/appellant-cases.formatter.js
+++ b/appeals/api/src/server/endpoints/appellant-cases/appellant-cases.formatter.js
@@ -16,7 +16,6 @@ const formatAppellantCase = (appeal, folders = null) => {
 	const { appellantCase } = appeal;
 
 	if (appellantCase) {
-		// @ts-ignore
 		return {
 			appealId: appeal.id,
 			appealReference: appeal.reference,
@@ -30,6 +29,18 @@ const formatAppellantCase = (appeal, folders = null) => {
 				surname: appeal.appellant?.lastName || ''
 			},
 			isAppellantNamedOnApplication: appeal.agent == null,
+			// @ts-ignore
+			applicationDate: appellantCase.applicationDate && appellantCase.applicationDate.toISOString(),
+			// @ts-ignore
+			applicationDecisionDate:
+				appellantCase.applicationDecisionDate &&
+				appellantCase.applicationDecisionDate?.toISOString(),
+			// @ts-ignore
+			caseSubmissionDueDate:
+				appellantCase.caseSubmissionDueDate && appellantCase.caseSubmissionDueDate?.toISOString(),
+			// @ts-ignore
+			caseSubmittedDate:
+				appellantCase.caseSubmittedDate && appellantCase.caseSubmittedDate?.toISOString(),
 			planningApplicationReference: appeal.applicationReference || '',
 			hasAdvertisedAppeal: appellantCase.hasAdvertisedAppeal,
 			healthAndSafety: {
@@ -38,9 +49,11 @@ const formatAppellantCase = (appeal, folders = null) => {
 			},
 			localPlanningDepartment: appeal.lpa?.name || '',
 			procedureType: appeal.procedureType?.name,
+			enforcementNotice: appellantCase?.enforcementNotice || null,
 			siteOwnership: {
 				areAllOwnersKnown: appellantCase.knowsAllOwners?.name || null,
 				knowsOtherLandowners: appellantCase.knowsOtherOwners?.name || null,
+				ownersInformed: appellantCase.ownersInformed || null,
 				isFullyOwned: appellantCase.ownsAllLand || null,
 				isPartiallyOwned: appellantCase.ownsSomeLand || null,
 				floorSpaceSquareMetres: appellantCase.floorSpaceSquareMetres || null,

--- a/appeals/api/src/server/endpoints/integrations/integrations.broadcasters/appeal.js
+++ b/appeals/api/src/server/endpoints/integrations/integrations.broadcasters/appeal.js
@@ -1,65 +1,117 @@
 import config from '#config/config.js';
-//import { databaseConnector } from '#utils/database-connector.js';
 import pino from '#utils/logger.js';
+import { databaseConnector } from '#utils/database-connector.js';
 import { EventType } from '@pins/event-client';
+import { messageMappers } from '../integrations.mappers.js';
+import { schemas, validateFromSchema } from '../integrations.validators.js';
+import { producers } from '#infrastructure/topics.js';
+import { eventClient } from '#infrastructure/event-client.js';
+import { ODW_SYSTEM_ID } from '@pins/appeals/constants/common.js';
+import { CASE_RELATIONSHIP_LINKED, CASE_RELATIONSHIP_RELATED } from '#endpoints/constants.js';
 
-export const broadcastAppeal = async (
-	/** @type {Number} */ appealId,
-	/** @type {string} */ updateType = EventType.Update
-) => {
+/**
+ *
+ * @param {number} appealId
+ * @param {string} updateType
+ */
+export const broadcastAppeal = async (appealId, updateType = EventType.Update) => {
 	if (!config.serviceBusEnabled) {
-		//return false;
+		return false;
 	}
 
 	pino.info({ appealId, updateType });
-	// const appeal = await databaseConnector.appeal.findUnique({
-	// 	where: { id: appealId },
-	// 	include: {
-	// 		address: true,
-	// 		appealTimetable: true,
-	// 		procedureType: true,
-	// 		appealType: true,
-	// 		appealStatus: true,
-	// 		caseOfficer: true,
-	// 		inspector: true,
-	// 		lpa: true,
-	// 		allocation: true,
-	// 		siteVisit: true,
-	// 		specialisms: {
-	// 			include: {
-	// 				specialism: true
-	// 			}
-	// 		},
-	// 		appellantCase: {
-	// 			include: {
-	// 				appellantCaseInvalidReasonsSelected: {
-	// 					include: {
-	// 						appellantCaseInvalidReason: true,
-	// 						appellantCaseInvalidReasonText: true
-	// 					}
-	// 				},
-	// 				appellantCaseIncompleteReasonsSelected: {
-	// 					include: {
-	// 						appellantCaseIncompleteReason: true,
-	// 						appellantCaseIncompleteReasonText: true
-	// 					}
-	// 				},
-	// 				knowsAllOwners: true,
-	// 				knowsOtherOwners: true
-	// 			}
-	// 		},
-	// 		lpaQuestionnaire: {
-	// 			include: {
-	// 				lpaQuestionnaireIncompleteReasonsSelected: {
-	// 					include: {
-	// 						lpaQuestionnaireIncompleteReason: true,
-	// 						lpaQuestionnaireIncompleteReasonText: true
-	// 					}
-	// 				}
-	// 			}
-	// 		}
-	// 	}
-	// });
+	const appeal = await databaseConnector.appeal.findUnique({
+		where: { id: appealId },
+		include: {
+			address: true,
+			appealTimetable: true,
+			procedureType: true,
+			appealType: true,
+			appealStatus: true,
+			caseOfficer: true,
+			inspector: true,
+			lpa: true,
+			allocation: true,
+			siteVisit: true,
+			inspectorDecision: true,
+			specialisms: {
+				include: {
+					specialism: true
+				}
+			},
+			parentAppeals: true,
+			childAppeals: true,
+			appellantCase: {
+				include: {
+					appellantCaseValidationOutcome: true,
+					appellantCaseInvalidReasonsSelected: {
+						include: {
+							appellantCaseInvalidReason: true,
+							appellantCaseInvalidReasonText: true
+						}
+					},
+					appellantCaseIncompleteReasonsSelected: {
+						include: {
+							appellantCaseIncompleteReason: true,
+							appellantCaseIncompleteReasonText: true
+						}
+					},
+					knowsAllOwners: true,
+					knowsOtherOwners: true
+				}
+			},
+			lpaQuestionnaire: {
+				include: {
+					lpaQuestionnaireValidationOutcome: true,
+					lpaQuestionnaireIncompleteReasonsSelected: {
+						include: {
+							lpaQuestionnaireIncompleteReason: true,
+							lpaQuestionnaireIncompleteReasonText: true
+						}
+					}
+				}
+			}
+		}
+	});
 
-	//console.log(appeal)
+	if (!appeal) {
+		pino.error(`Trying to broadcast info for appeal ${appealId} , but it was not found.`);
+		return false;
+	}
+
+	const appealRelationships = [...appeal.parentAppeals, ...appeal.childAppeals];
+
+	const linkedAppeals = appealRelationships.filter(
+		(relationship) => relationship.type === CASE_RELATIONSHIP_LINKED
+	);
+	const relatedAppeals = appealRelationships.filter(
+		(relationship) => relationship.type === CASE_RELATIONSHIP_RELATED
+	);
+
+	// @ts-ignore
+	const msg = messageMappers.mapAppeal({
+		...appeal,
+		linkedAppeals,
+		relatedAppeals
+	});
+	if (msg) {
+		const validationResult = await validateFromSchema(schemas.events.appeal, msg);
+		if (validationResult !== true && validationResult.errors) {
+			const errorDetails = validationResult.errors?.map(
+				(e) => `${e.instancePath || '/'}: ${e.message}`
+			);
+
+			pino.error(`Error validating appeal: ${errorDetails[0]}`);
+			return false;
+		}
+
+		const topic = producers.boCaseData;
+		const res = await eventClient.sendEvents(topic, [msg], updateType, {
+			sourceSystem: ODW_SYSTEM_ID
+		});
+
+		if (res) {
+			return true;
+		}
+	}
 };

--- a/appeals/api/src/server/endpoints/integrations/integrations.broadcasters/documents.js
+++ b/appeals/api/src/server/endpoints/integrations/integrations.broadcasters/documents.js
@@ -11,11 +11,14 @@ const entityInfo = {
 	name: 'AppealDocumentMetadata'
 };
 
-export const broadcastDocument = async (
-	/** @type {string} */ documentId,
-	/** @type {number} */ version,
-	/** @type {string} */ updateType
-) => {
+/**
+ *
+ * @param {string} documentId
+ * @param {number} version
+ * @param {string} updateType
+ * @returns
+ */
+export const broadcastDocument = async (documentId, version, updateType) => {
 	if (!config.serviceBusEnabled) {
 		return false;
 	}

--- a/appeals/api/src/server/endpoints/integrations/integrations.broadcasters/service-users.js
+++ b/appeals/api/src/server/endpoints/integrations/integrations.broadcasters/service-users.js
@@ -7,12 +7,15 @@ import { schemas, validateFromSchema } from '../integrations.validators.js';
 import { databaseConnector } from '#utils/database-connector.js';
 import { ODW_SYSTEM_ID } from '@pins/appeals/constants/common.js';
 
-export const broadcastServiceUser = async (
-	/** @type {Number} */ userId,
-	/** @type {string} */ updateType,
-	/** @type {string} */ roleName,
-	/** @type {string} */ caseReference
-) => {
+/**
+ *
+ * @param {number} userId
+ * @param {string} updateType
+ * @param {string} roleName
+ * @param {string} caseReference
+ * @returns
+ */
+export const broadcastServiceUser = async (userId, updateType, roleName, caseReference) => {
 	if (!config.serviceBusEnabled) {
 		return false;
 	}

--- a/appeals/api/src/server/endpoints/integrations/integrations.controller.js
+++ b/appeals/api/src/server/endpoints/integrations/integrations.controller.js
@@ -19,7 +19,6 @@ import stringTokenReplacement from '#utils/string-token-replacement.js';
 /** @typedef {import('pins-data-model').Schemas.AppealHASCase} AppealHASCase */
 /** @typedef {import('pins-data-model').Schemas.AppellantSubmissionCommand} AppellantSubmissionCommand */
 /** @typedef {import('pins-data-model').Schemas.LPAQuestionnaireCommand} LPAQuestionnaireCommand */
-/** @typedef {import('#config/../openapi-types.js').AddDocumentsRequest} AddDocumentsRequest */
 
 /**
  * @param {{body: AppellantSubmissionCommand}} req

--- a/appeals/api/src/server/endpoints/integrations/integrations.mappers/address.mapper.js
+++ b/appeals/api/src/server/endpoints/integrations/integrations.mappers/address.mapper.js
@@ -1,6 +1,11 @@
-// @ts-nocheck
-// TODO: schemas (PINS data model)
+/** @typedef {import('@pins/appeals.api').Schema.Appeal} Appeal */
+/** @typedef {import('@pins/appeals.api').Schema.NeighbouringSite} NeighbouringSite */
 
+/**
+ *
+ * @param {*} casedata
+ * @returns
+ */
 export const mapAddressIn = (casedata) => {
 	return {
 		addressLine1: casedata.siteAddressLine1,
@@ -11,6 +16,11 @@ export const mapAddressIn = (casedata) => {
 	};
 };
 
+/**
+ *
+ * @param {*} casedata
+ * @returns
+ */
 export const mapNeighbouringAddressIn = (casedata) => {
 	return {
 		addressLine1: casedata.neighbouringSiteAddressLine1,
@@ -21,12 +31,66 @@ export const mapNeighbouringAddressIn = (casedata) => {
 	};
 };
 
+/**
+ *
+ * @param {Appeal} appeal
+ * @returns
+ */
 export const mapAddressOut = (appeal) => {
 	return {
-		siteAddressLine1: appeal.address.addressLine1,
-		siteAddressLine2: appeal.address.addressLine2 || '',
-		siteAddressCounty: appeal.address.addressCounty || '',
-		siteAddressPostcode: appeal.address.postcode,
-		siteAddressTown: appeal.address.addressTown || ''
+		siteAddressLine1: appeal.address?.addressLine1,
+		siteAddressLine2: appeal.address?.addressLine2 || '',
+		siteAddressCounty: appeal.address?.addressCounty || '',
+		siteAddressPostcode: appeal.address?.postcode,
+		siteAddressTown: appeal.address?.addressTown || ''
+	};
+};
+
+/**
+ *
+ * @param {NeighbouringSite[]} sites
+ * @returns
+ */
+export const mapNeighbouringAddressOut = (sites) => {
+	if (!sites || sites.length === 0) {
+		return null;
+	}
+
+	return sites.map((site) => {
+		return {
+			addressLine1: site.address?.addressLine1,
+			addressLine2: site.address?.addressLine2,
+			addressCounty: site.address?.addressCounty,
+			postcode: site.address?.postcode,
+			addressTown: site.address?.addressTown
+		};
+	});
+};
+
+/**
+ *
+ * @param {Appeal} appeal
+ * @returns
+ */
+export const mapSiteAccessDetailsOut = (appeal) => {
+	return {
+		siteAccessDetails: [
+			appeal?.appellantCase?.siteAccessDetails,
+			appeal?.lpaQuestionnaire?.siteAccessDetails
+		].filter((item) => item && item !== null)
+	};
+};
+
+/**
+ *
+ * @param {Appeal} appeal
+ * @returns
+ */
+export const mapSiteSafetyDetailsOut = (appeal) => {
+	return {
+		siteSafetyDetails: [
+			appeal?.appellantCase?.siteSafetyDetails,
+			appeal?.lpaQuestionnaire?.siteSafetyDetails
+		].filter((item) => item && item !== null)
 	};
 };

--- a/appeals/api/src/server/endpoints/integrations/integrations.mappers/appeal-allocation.mapper.js
+++ b/appeals/api/src/server/endpoints/integrations/integrations.mappers/appeal-allocation.mapper.js
@@ -1,10 +1,21 @@
-// @ts-nocheck
+/** @typedef {import('@pins/appeals.api').Schema.AppealAllocation} AppealAllocation */
+/** @typedef {import('@pins/appeals.api').Schema.AppealSpecialism} AppealSpecialism */
 
+/**
+ *
+ * @param {AppealAllocation | null | undefined} allocation
+ * @param {AppealSpecialism[]} specialisms
+ * @returns
+ */
 export const mapAppealAllocationOut = (allocation, specialisms) =>
 	allocation
 		? {
-				level: allocation.level,
-				band: allocation.band,
-				specialism: specialisms?.map((s) => s.specialism?.name) || []
+				allocationLevel: allocation.level,
+				allocationBand: allocation.band,
+				caseSpecialisms: specialisms?.map((s) => s.specialism?.name) || []
 		  }
-		: null;
+		: {
+				allocationLevel: null,
+				allocationBand: null,
+				caseSpecialisms: null
+		  };

--- a/appeals/api/src/server/endpoints/integrations/integrations.mappers/appeal-type.mapper.js
+++ b/appeals/api/src/server/endpoints/integrations/integrations.mappers/appeal-type.mapper.js
@@ -1,6 +1,11 @@
-// @ts-nocheck
 import { APPEAL_TYPE_SHORTHAND_HAS } from '#endpoints/constants.js';
 
+/** @typedef {import('@pins/appeals.api').Schema.AppealType} AppealType */
+/**
+ *
+ * @param {string} appealType
+ * @returns
+ */
 export const mapAppealTypeIn = (appealType) => {
 	switch (appealType) {
 		case APPEAL_TYPE_SHORTHAND_HAS:
@@ -9,4 +14,9 @@ export const mapAppealTypeIn = (appealType) => {
 	}
 };
 
-export const mapAppealTypeOut = (appealType) => appealType;
+/**
+ *
+ * @param {AppealType | null | undefined} appealType
+ * @returns
+ */
+export const mapAppealTypeOut = (appealType) => appealType?.key || null;

--- a/appeals/api/src/server/endpoints/integrations/integrations.mappers/appellant-case.mapper.js
+++ b/appeals/api/src/server/endpoints/integrations/integrations.mappers/appellant-case.mapper.js
@@ -6,7 +6,7 @@ import { mapDate } from './date.mapper.js';
 /**
  *
  * @param {Pick<AppellantSubmissionCommand, 'casedata'>} command
- * @returns {*}
+ * @returns
  */
 export const mapAppellantCaseIn = (command) => {
 	const casedata = command.casedata;
@@ -44,10 +44,11 @@ export const mapAppellantCaseIn = (command) => {
 		floorSpaceSquareMetres: casedata.floorSpaceSquareMetres,
 		ownsAllLand: casedata.ownsAllLand,
 		ownsSomeLand: casedata.ownsSomeLand,
-		hasAdvertisedAppeal: casedata.hasAdvertisedAppeal,
+		hasAdvertisedAppeal: casedata.advertisedAppeal,
 		appellantCostsAppliedFor: casedata.appellantCostsAppliedFor,
 		originalDevelopmentDescription: casedata.originalDevelopmentDescription,
 		changedDevelopmentDescription: casedata.changedDevelopmentDescription,
+		ownersInformed: casedata.ownersInformed,
 		...(knowsAllOwners && { knowsAllOwners }),
 		...(knowsOtherOwners && { knowsOtherOwners })
 	};
@@ -57,28 +58,36 @@ export const mapAppellantCaseIn = (command) => {
 
 /**
  *
- * @param {AppellantCase} casedata
- * @returns {*}
+ * @param {AppellantCase | null | undefined} casedata
+ * @returns
  */
 export const mapAppellantCaseOut = (casedata) => {
+	if (!casedata) {
+		return {};
+	}
+
 	const data = {
 		applicationDate: mapDate(casedata.applicationDate),
 		applicationDecision: casedata.applicationDecision,
 		applicationDecisionDate: mapDate(casedata.applicationDecisionDate),
 		caseSubmittedDate: mapDate(casedata.caseSubmittedDate),
 		caseSubmissionDueDate: mapDate(casedata.caseSubmissionDueDate),
-		siteAccessDetails: [casedata.siteAccessDetails],
-		siteSafetyDetails: [casedata.siteSafetyDetails],
-		siteAreaSquareMetres: casedata.siteAreaSquareMetres,
-		floorSpaceSquareMetres: casedata.floorSpaceSquareMetres,
-		ownsAllLand: casedata.ownsAllLand,
-		ownsSomeLand: casedata.ownsSomeLand,
-		hasAdvertisedAppeal: casedata.hasAdvertisedAppeal,
-		appellantCostsAppliedFor: casedata.appellantCostsAppliedFor,
-		originalDevelopmentDescription: casedata.originalDevelopmentDescription,
-		changedDevelopmentDescription: casedata.changedDevelopmentDescription,
-		knowsAllOwners: casedata.knowsAllOwners?.key,
-		knowsOtherOwners: casedata.knowsOtherOwners?.key
+		siteAreaSquareMetres: casedata.siteAreaSquareMetres
+			? Number(casedata.siteAreaSquareMetres)
+			: null,
+		floorSpaceSquareMetres: casedata.floorSpaceSquareMetres
+			? Number(casedata.floorSpaceSquareMetres)
+			: null,
+		ownsAllLand: casedata.ownsAllLand || null,
+		ownsSomeLand: casedata.ownsSomeLand || null,
+		advertisedAppeal: casedata.hasAdvertisedAppeal || null,
+		appellantCostsAppliedFor: casedata.appellantCostsAppliedFor || null,
+		originalDevelopmentDescription: casedata.originalDevelopmentDescription || null,
+		changedDevelopmentDescription: casedata.changedDevelopmentDescription || null,
+		knowsAllOwners: casedata.knowsAllOwners?.name || null,
+		knowsOtherOwners: casedata.knowsOtherOwners?.name || null,
+		ownersInformed: casedata.ownersInformed || null,
+		enforcementNotice: casedata.enforcementNotice || null
 	};
 
 	return data;

--- a/appeals/api/src/server/endpoints/integrations/integrations.mappers/casedata.mapper.js
+++ b/appeals/api/src/server/endpoints/integrations/integrations.mappers/casedata.mapper.js
@@ -1,9 +1,190 @@
 // @ts-nocheck
-// TODO: schemas (PINS data model)
-// TODO: mapping for case involvement
+
+import {
+	STATE_TARGET_CLOSED,
+	STATE_TARGET_COMPLETE,
+	STATE_TARGET_ISSUE_DETERMINATION,
+	STATE_TARGET_LPA_QUESTIONNAIRE_DUE,
+	STATE_TARGET_READY_TO_START,
+	STATE_TARGET_TRANSFERRED,
+	STATE_TARGET_WITHDRAWN
+} from '#endpoints/constants.js';
+import { STATUSES } from '@pins/appeals/constants/state.js';
+import formatValidationOutcomeResponse from '#utils/format-validation-outcome-response.js';
+import { mapDate } from './date.mapper.js';
+
+/** @typedef {import('@pins/appeals.api').Schema.Appeal} Appeal */
+/** @typedef {import('@pins/appeals.api').Schema.AppealStatus} AppealStatus */
 
 export const mapCaseDataOut = (data) => {
 	return {
 		...data
+	};
+};
+
+/**
+ *
+ * @param {Appeal} appeal
+ */
+export const mapAppealDatesOut = (appeal) => {
+	const dates = {
+		caseCreatedDate: mapDate(appeal.caseCreatedDate),
+		caseUpdatedDate: mapDate(appeal.caseUpdatedDate),
+		caseValidDate: mapDate(appeal.caseValidDate),
+		caseValidationDate: findStatusDate(appeal.appealStatus, STATE_TARGET_READY_TO_START),
+		caseExtensionDate: mapDate(appeal.caseExtensionDate),
+		caseStartedDate: mapDate(appeal.caseStartedDate),
+		casePublishedDate: findStatusDate(appeal.appealStatus, STATE_TARGET_READY_TO_START),
+		lpaQuestionnaireDueDate: mapDate(appeal.appealTimetable?.lpaQuestionnaireDueDate),
+		lpaQuestionnairePublishedDate: findStatusDate(
+			appeal.appealStatus,
+			STATE_TARGET_ISSUE_DETERMINATION
+		),
+		lpaQuestionnaireValidationOutcomeDate: findStatusDate(
+			appeal.appealStatus,
+			STATE_TARGET_ISSUE_DETERMINATION
+		),
+		caseWithdrawnDate: findStatusDate(appeal.appealStatus, STATE_TARGET_WITHDRAWN),
+		caseTransferredDate: findStatusDate(appeal.appealStatus, STATE_TARGET_TRANSFERRED),
+		transferredCaseClosedDate: findStatusDate(appeal.appealStatus, STATE_TARGET_CLOSED),
+		caseDecisionOutcomeDate: mapDate(appeal.inspectorDecision?.caseDecisionOutcomeDate),
+		caseDecisionPublishedDate: null,
+		caseCompletedDate: findStatusDate(appeal.appealStatus, STATE_TARGET_COMPLETE)
+	};
+
+	return dates;
+};
+
+/**
+ *
+ * @param {AppealStatus[]} appealStatuses
+ * @param {string} status
+ */
+const findStatusDate = (appealStatuses, status) => {
+	const appealStatus = appealStatuses.find((state) => state.status === status);
+	if (appealStatus) {
+		return appealStatus.createdAt?.toISOString();
+	}
+
+	return null;
+};
+
+/**
+ *
+ * @param {Appeal} appeal
+ */
+export const mapAppealStatusOut = (appeal) => {
+	const status = appeal.appealStatus.find((status) => status.valid === true).status;
+	if (status === STATE_TARGET_LPA_QUESTIONNAIRE_DUE) {
+		return STATUSES.LPA_QUESTIONNAIRE;
+	}
+	return status;
+};
+
+/**
+ *
+ * @param {Appeal} appeal
+ */
+export const mapAppealValidationOut = (appeal) => {
+	const validation = formatValidationOutcomeResponse(
+		appeal.appellantCase?.appellantCaseValidationOutcome?.name || '',
+		appeal.appellantCase?.appellantCaseIncompleteReasonsSelected,
+		appeal.appellantCase?.appellantCaseInvalidReasonsSelected
+	);
+
+	const incompleteDetails = [];
+	const invalidDetails = [];
+
+	if (validation?.incompleteReasons?.length) {
+		for (const incompleteReason of validation.incompleteReasons) {
+			if (incompleteReason.text.length) {
+				incompleteReason.text.map((text) =>
+					incompleteDetails.push(`${incompleteReason.name.name}: ${text}`)
+				);
+			} else {
+				incompleteDetails.push(incompleteReason.name.name);
+			}
+		}
+	}
+	if (validation?.invalidReasons?.length) {
+		for (const invalidReason of validation.invalidReasons) {
+			if (invalidReason.text.length) {
+				invalidReason.text.map((text) =>
+					invalidDetails.push(`${invalidReason.name.name}: ${text}`)
+				);
+			} else {
+				invalidDetails.push(invalidReason.name.name);
+			}
+		}
+	}
+
+	return {
+		caseValidationOutcome: validation?.outcome?.toLowerCase() || null,
+		caseValidationInvalidDetails: invalidDetails.length > 0 ? invalidDetails : null,
+		caseValidationIncompleteDetails: incompleteDetails.length > 0 ? incompleteDetails : null
+	};
+};
+
+/**
+ *
+ * @param {Appeal} appeal
+ */
+export const mapQuestionnaireValidationOut = (appeal) => {
+	const validation = formatValidationOutcomeResponse(
+		appeal.lpaQuestionnaire?.lpaQuestionnaireValidationOutcome?.name || '',
+		appeal.lpaQuestionnaire?.lpaQuestionnaireIncompleteReasonsSelected
+	);
+
+	const incompleteDetails = [];
+
+	if (validation?.incompleteReasons?.length) {
+		for (const incompleteReason of validation.incompleteReasons) {
+			if (incompleteReason.text.length) {
+				incompleteReason.text.map((text) =>
+					incompleteDetails.push(`${incompleteReason.name.name}: ${text}`)
+				);
+			} else {
+				incompleteDetails.push(incompleteReason.name.name);
+			}
+		}
+	}
+
+	return {
+		lpaQuestionnaireValidationOutcome: validation?.outcome?.toLowerCase() || null,
+		lpaQuestionnaireValidationDetails: incompleteDetails.length > 0 ? incompleteDetails : null
+	};
+};
+
+/**
+ *
+ * @param {Appeal} appeal
+ */
+export const mapAppealRelationships = (appeal) => {
+	const { linkedAppeals, relatedAppeals } = appeal;
+
+	let linkedCaseStatus = null;
+	let leadCaseReference = null;
+	if (linkedAppeals && linkedAppeals.length) {
+		const lead = linkedAppeals.find((_) => _.parentId === appeal.id);
+		if (lead) {
+			linkedCaseStatus = 'lead';
+			leadCaseReference = appeal.reference;
+		} else {
+			const child = linkedAppeals.find((_) => _.childId === appeal.id);
+			if (child) {
+				linkedCaseStatus = 'child';
+				leadCaseReference = child.parentRef;
+			}
+		}
+	}
+
+	const nearbyCaseReferences = relatedAppeals.map((a) =>
+		a.parentRef === appeal.reference ? a.childRef : a.parentRef
+	);
+
+	return {
+		linkedCaseStatus,
+		leadCaseReference,
+		nearbyCaseReferences
 	};
 };

--- a/appeals/api/src/server/endpoints/integrations/integrations.mappers/lpa.mapper.js
+++ b/appeals/api/src/server/endpoints/integrations/integrations.mappers/lpa.mapper.js
@@ -1,15 +1,23 @@
-// @ts-nocheck
-// TODO: schemas (PINS data model)
-// TODO: add local data model for LPA
+/** @typedef {import('@pins/appeals.api').Schema.Appeal} Appeal */
 
+/**
+ *
+ * @param {*} casedata
+ * @returns
+ */
 export const mapLpaIn = (casedata) => {
 	return {
 		lpaCode: casedata.lpaCode
 	};
 };
 
+/**
+ *
+ * @param {Appeal} appeal
+ * @returns
+ */
 export const mapLpaOut = (appeal) => {
 	return {
-		lpaCode: appeal.lpa.lpaCode
+		lpaCode: appeal.lpa?.lpaCode
 	};
 };

--- a/appeals/api/src/server/endpoints/integrations/integrations.mappers/questionnaire.mapper.js
+++ b/appeals/api/src/server/endpoints/integrations/integrations.mappers/questionnaire.mapper.js
@@ -1,6 +1,8 @@
 /** @typedef {import('pins-data-model').Schemas.LPAQuestionnaireCommand} LPAQuestionnaireCommand */
 /** @typedef {import('@pins/appeals.api').Schema.LPAQuestionnaire} LPAQuestionnaire */
 
+import { mapDate } from './date.mapper.js';
+
 /**
  *
  * @param {Pick<LPAQuestionnaireCommand, 'casedata'>} command
@@ -67,23 +69,24 @@ export const mapQuestionnaireIn = (command) => {
 
 /**
  *
- * @param {LPAQuestionnaire} casedata
- * @returns {*}
+ * @param {LPAQuestionnaire | null | undefined} casedata
+ * @returns
  */
 export const mapQuestionnaireOut = (casedata) => {
 	return {
-		lpaQuestionnaireSubmittedDate: casedata.lpaQuestionnaireSubmittedDate,
-		lpaStatement: casedata.lpaStatement,
-		siteAccessDetails: [casedata.siteAccessDetails],
-		siteSafetyDetails: [casedata.siteSafetyDetails],
-		isCorrectAppealType: casedata.isCorrectAppealType,
-		isGreenBelt: casedata.siteWithinGreenBelt,
-		inConservationArea: casedata.inConservationArea,
-		newConditionDetails: casedata.newConditionDetails,
-		notificationMethod: casedata.lpaNotificationMethods.map(
-			(method) => method.lpaNotificationMethod.key
-		),
-		lpaCostsAppliedFor: casedata.lpaCostsAppliedFor,
-		listedBuildingDetails: casedata.listedBuildingDetails.map((entry) => entry.listEntry)
+		lpaQuestionnaireSubmittedDate: mapDate(casedata?.lpaQuestionnaireSubmittedDate),
+		lpaQuestionnaireCreatedDate: mapDate(casedata?.lpaqCreatedDate),
+		lpaStatement: casedata?.lpaStatement || null,
+		isCorrectAppealType: casedata?.isCorrectAppealType || null,
+		isGreenBelt: casedata?.siteWithinGreenBelt || null,
+		inConservationArea: casedata?.inConservationArea || null,
+		newConditionDetails: casedata?.newConditionDetails || null,
+		notificationMethod: casedata?.lpaNotificationMethods
+			? casedata?.lpaNotificationMethods.map((method) => method.lpaNotificationMethod.key)
+			: null,
+		lpaCostsAppliedFor: casedata?.lpaCostsAppliedFor || null,
+		listedBuildingDetails: casedata?.listedBuildingDetails
+			? casedata?.listedBuildingDetails.map((entry) => entry.listEntry)
+			: null
 	};
 };

--- a/appeals/api/src/server/endpoints/integrations/integrations.middleware.js
+++ b/appeals/api/src/server/endpoints/integrations/integrations.middleware.js
@@ -57,7 +57,7 @@ export const validateLpaQuestionnaire = async (req, res, next) => {
 		});
 	}
 
-	const appealExists = await findAppealByReference(body?.questionnaire?.caseReference);
+	const appealExists = await findAppealByReference(body?.casedata?.caseReference);
 	if (!appealExists) {
 		pino.error(
 			`Error associating LPA submission to an existing appeal with reference '${body?.questionnaire?.caseReference}'`

--- a/appeals/api/src/server/endpoints/invalid-appeal-decision/invalid-appeal-decision.service.js
+++ b/appeals/api/src/server/endpoints/invalid-appeal-decision/invalid-appeal-decision.service.js
@@ -44,12 +44,12 @@ export const publishInvalidDecision = async (
 			: 'Address not available';
 		const emailVariables = {
 			appeal_reference_number: appeal.reference,
-			lpa_reference: appeal.applicationReference,
+			lpa_reference: appeal.applicationReference || '',
 			site_address: siteAddress,
 			reasons: invalidDecisionReason
 		};
 
-		if (!recipientEmail) {
+		if (!recipientEmail || !appeal.lpa?.email) {
 			throw new Error(ERROR_NO_RECIPIENT_EMAIL);
 		}
 		try {

--- a/appeals/api/src/server/endpoints/link-appeals/__tests__/link-appeal.test.js
+++ b/appeals/api/src/server/endpoints/link-appeals/__tests__/link-appeal.test.js
@@ -106,9 +106,10 @@ describe('appeal linked appeals routes', () => {
 
 			test('returns 400 when an internal appeal is already a parent', async () => {
 				// @ts-ignore
-				databaseConnector.appeal.findUnique.mockResolvedValueOnce(householdAppeal);
-				// @ts-ignore
-				databaseConnector.appealRelationship.findMany.mockResolvedValueOnce(linkedAppeals);
+				databaseConnector.appeal.findUnique.mockResolvedValueOnce({
+					...householdAppeal,
+					childAppeals: linkedAppeals
+				});
 
 				const response = await request
 					.post(`/appeals/${householdAppeal.id}/link-appeal`)

--- a/appeals/api/src/server/endpoints/lpa-questionnaires/lpa-questionnaires.formatter.js
+++ b/appeals/api/src/server/endpoints/lpa-questionnaires/lpa-questionnaires.formatter.js
@@ -55,8 +55,11 @@ const formatLpaQuestionnaire = (appeal, folders = null) => {
 				isConservationArea: lpaQuestionnaire.inConservationArea,
 				siteWithinGreenBelt: lpaQuestionnaire.siteWithinGreenBelt,
 				isCorrectAppealType: lpaQuestionnaire.isCorrectAppealType,
-				submittedAt: lpaQuestionnaire.lpaQuestionnaireSubmittedDate,
-				receivedAt: lpaQuestionnaire.lpaqCreatedDate,
+				submittedAt:
+					lpaQuestionnaire.lpaQuestionnaireSubmittedDate &&
+					lpaQuestionnaire.lpaQuestionnaireSubmittedDate?.toISOString(),
+				receivedAt:
+					lpaQuestionnaire.lpaqCreatedDate && lpaQuestionnaire.lpaqCreatedDate.toISOString(),
 				costsAppliedFor: lpaQuestionnaire.lpaCostsAppliedFor,
 				lpaStatement: lpaQuestionnaire.lpaStatement,
 				extraConditions: lpaQuestionnaire.newConditionDetails,

--- a/appeals/api/src/server/endpoints/site-visits/__tests__/site-visits.test.js
+++ b/appeals/api/src/server/endpoints/site-visits/__tests__/site-visits.test.js
@@ -2231,19 +2231,6 @@ describe('site visit routes', () => {
 				// eslint-disable-next-line no-undef
 				expect(mockSendEmail).not.toHaveBeenCalled();
 			});
-
-			test('does not throw an error if given an empty body', async () => {
-				// @ts-ignore
-				databaseConnector.appeal.update.mockResolvedValue(householdAppeal);
-
-				const response = await request
-					.patch(`/appeals/${householdAppeal.id}`)
-					.send({})
-					.set('azureAdUserId', azureAdUserId);
-
-				expect(response.status).toEqual(200);
-				expect(response.body).toEqual({});
-			});
 		});
 	});
 

--- a/appeals/api/src/server/state/transition-state.js
+++ b/appeals/api/src/server/state/transition-state.js
@@ -12,7 +12,7 @@ import { AUDIT_TRAIL_PROGRESSED_TO_STATUS } from '#endpoints/constants.js';
 
 /**
  * @param {number} appealId
- * @param {AppealType | null} appealType
+ * @param {AppealType | null | undefined} appealType
  * @param {string} azureAdUserId
  * @param {AppealStatus[]} currentState
  * @param {string} trigger

--- a/appeals/api/src/server/tests/appeals/expectation.js
+++ b/appeals/api/src/server/tests/appeals/expectation.js
@@ -1,5 +1,5 @@
-import formatValidationOutcomeResponse from '#utils/format-validation-outcome-response.js';
 import { formatAppellantCase } from '#endpoints/appellant-cases/appellant-cases.formatter.js';
+import { formatLpaQuestionnaire } from '#endpoints/lpa-questionnaires/lpa-questionnaires.formatter.js';
 
 /** @typedef {import('@pins/appeals.api').Schema.Appeal} Appeal */
 /** @typedef {import('@pins/appeals.api').Appeals.SingleLPAQuestionnaireResponse} SingleLPAQuestionnaireResponse */
@@ -10,37 +10,7 @@ import { formatAppellantCase } from '#endpoints/appellant-cases/appellant-cases.
  * @returns {SingleLPAQuestionnaireResponse}
  */
 export const baseExpectedLPAQuestionnaireResponse = (appeal) => ({
-	healthAndSafetyDetails: appeal.lpaQuestionnaire?.siteSafetyDetails,
-	doesSiteHaveHealthAndSafetyIssues: appeal.lpaQuestionnaire?.siteSafetyDetails !== null,
-	inspectorAccessDetails: appeal.lpaQuestionnaire?.siteAccessDetails,
-	doesSiteRequireInspectorAccess: appeal.lpaQuestionnaire?.siteAccessDetails !== null,
-	isConservationArea: appeal.lpaQuestionnaire?.inConservationArea,
-	siteWithinGreenBelt: appeal.lpaQuestionnaire?.siteWithinGreenBelt,
-	isCorrectAppealType: appeal.lpaQuestionnaire?.isCorrectAppealType,
-	submittedAt: appeal.lpaQuestionnaire?.lpaQuestionnaireSubmittedDate || null, //new
-	// @ts-ignore
-	receivedAt: appeal.lpaQuestionnaire?.lpaqCreatedDate,
-	procedureType: appeal.procedureType?.name,
-	costsAppliedFor: appeal.lpaQuestionnaire?.lpaCostsAppliedFor, //new
-	lpaStatement: appeal.lpaQuestionnaire?.lpaStatement, //new
-	extraConditions: appeal.lpaQuestionnaire?.newConditionDetails, //check
-	hasExtraConditions: appeal.lpaQuestionnaire?.newConditionDetails !== null,
-	listedBuildingDetails: appeal.lpaQuestionnaire?.listedBuildingDetails
-		? [
-				{
-					listEntry: appeal.lpaQuestionnaire?.listedBuildingDetails[1].listEntry
-				}
-		  ]
-		: null,
-	appealId: appeal.id,
-	appealReference: appeal.reference,
-	appealSite: {
-		addressLine1: '96 The Avenue',
-		addressLine2: 'Leftfield',
-		county: 'Kent',
-		postCode: 'MD21 5XY',
-		town: 'Maidstone'
-	},
+	...formatLpaQuestionnaire(appeal),
 	documents: {
 		// @ts-ignore
 		whoNotified: {},
@@ -52,18 +22,7 @@ export const baseExpectedLPAQuestionnaireResponse = (appeal) => ({
 		otherPartyRepresentations: {},
 		// @ts-ignore
 		planningOfficerReport: {}
-	},
-
-	localPlanningDepartment: appeal.lpa?.name,
-	lpaNotificationMethods: appeal.lpaQuestionnaire?.lpaNotificationMethods?.map(
-		({ lpaNotificationMethod: { name } }) => ({ name })
-	),
-	lpaQuestionnaireId: appeal.lpaQuestionnaire?.id || 1,
-	validation: formatValidationOutcomeResponse(
-		// @ts-ignore
-		appeal.lpaQuestionnaire?.lpaQuestionnaireValidationOutcome?.name,
-		appeal.lpaQuestionnaire?.lpaQuestionnaireIncompleteReasonsSelected
-	)
+	}
 });
 
 /**

--- a/appeals/api/src/server/tests/appeals/mocks.js
+++ b/appeals/api/src/server/tests/appeals/mocks.js
@@ -56,6 +56,7 @@ export const auditTrails = [
 ];
 
 export const householdAppeal = {
+	caseCreatedDate: new Date('2024-03-25T23:59:59.999Z'),
 	id: 1,
 	reference: '1345264',
 	procedureType: {
@@ -94,7 +95,6 @@ export const householdAppeal = {
 		phoneNumber: '09876 543 210',
 		organisationName: 'Smith Inc.'
 	},
-	caseCreatedDate: new Date(2022, 4, 18),
 	address: {
 		addressLine1: '96 The Avenue',
 		addressLine2: 'Leftfield',
@@ -114,35 +114,29 @@ export const householdAppeal = {
 		id: 1,
 		appellantCaseIncompleteReasonsSelected: [],
 		appellantCaseValidationOutcome: null,
-		applicantFirstName: 'Fiona',
-		applicantSurname: 'Burgess',
-		areAllOwnersKnown: true,
+		appellantCostsAppliedFor: null,
+		applicationDate: new Date(2022, 2, 18),
+		applicationDecision: 'refused',
+		applicationDecisionDate: new Date(2022, 2, 18),
+		caseSubmissionDueDate: new Date(2022, 2, 18),
+		caseSubmittedDate: new Date(2022, 2, 18),
+		changedDevelopmentDescription: false,
+		enforcementNotice: null,
+		floorSpaceSquareMetres: null,
 		hasAdvertisedAppeal: true,
-		hasAttemptedToIdentifyOwners: true,
-		hasHealthAndSafetyIssues: true,
-		hasNewSupportingDocuments: false,
-		hasOtherTenants: null,
-		hasToldOwners: true,
-		hasToldTenants: null,
+		knowsAllOwners: null,
+		knowsOtherOwners: null,
+		originalDevelopmentDescription: 'A test description',
+		ownersInformed: true,
+		ownsAllLand: true,
+		ownsSomeLand: true,
 		siteAccessDetails: 'There is no mobile reception at the site',
-		siteSafetyDetails: 'Small dog big character',
-		isAgriculturalHolding: null,
-		isAgriculturalHoldingTenant: null,
-		isAppellantNamedOnApplication: false,
-		isSiteFullyOwned: false,
-		isSitePartiallyOwned: true,
-		isSiteVisibleFromPublicRoad: false,
-		doesSiteRequireInspectorAccess: true,
-		knowledgeOfOtherLandowners: {
-			name: 'Some'
-		},
-		visibilityRestrictions: 'The site is behind a tall hedge'
+		siteSafetyDetails: 'Small dog big character'
 	},
 	caseOfficer: {
 		id: 1,
 		azureAdUserId: 'a8973f33-4d2e-486b-87b0-d068343ad9eb'
 	},
-	caseExtensionDate: '2023-08-10T01:00:00.000Z',
 	inspector: {
 		id: 2,
 		azureAdUserId: 'e8f89175-d02c-4a60-870e-dc954d5b530a'
@@ -150,7 +144,7 @@ export const householdAppeal = {
 	siteVisit: {
 		id: 1,
 		appealId: 1,
-		visitDate: '2022-03-31T01:00:00.000Z',
+		visitDate: new Date('2022-03-31T01:00:00.000Z'),
 		visitEndTime: '03:00',
 		visitStartTime: '01:00',
 		siteVisitType: {
@@ -158,8 +152,8 @@ export const householdAppeal = {
 			name: 'Access required'
 		}
 	},
-	linkedAppeals: [],
-	otherAppeals: [],
+	parentAppeals: [],
+	childAppeals: [],
 	lpaQuestionnaire: {
 		id: 1,
 		appealId: 1,
@@ -188,8 +182,8 @@ export const householdAppeal = {
 				}
 			}
 		],
-		lpaqCreatedDate: '2022-05-17T23:00:00.000Z',
-		lpaQuestionnaireSubmittedDate: '2023-05-24T10:34:09.286Z'
+		lpaqCreatedDate: new Date(2024, 5, 24),
+		lpaQuestionnaireSubmittedDate: new Date(2024, 5, 24)
 	}
 };
 
@@ -232,7 +226,7 @@ export const householdAppealAppellantCaseIncomplete = {
 		...incompleteAppellantCaseOutcome
 	},
 	id: 3,
-	caseExtensionDate: '2099-07-14T01:00:00.000Z'
+	caseExtensionDate: new Date(2099, 6, 14)
 };
 
 export const householdAppealAppellantCaseInvalid = {
@@ -294,7 +288,7 @@ export const linkedAppeals = [
 		parentId: householdAppeal.id,
 		parentRef: householdAppeal.reference,
 		childRef: '76215416',
-		linkingDate: '2024-01-01',
+		linkingDate: new Date(2024, 1, 1),
 		appealType: householdAppeal.appealType,
 		relationshipId: 1,
 		type: 'linked',

--- a/appeals/api/src/server/utils/format-address.js
+++ b/appeals/api/src/server/utils/format-address.js
@@ -1,21 +1,21 @@
 /** @typedef {import('@pins/appeals.api').Schema.Address} Address */
 
 /**
- * @param {Address | null} [address]
+ * @param {Address | null | undefined} [address]
  * @returns {{
- *   addressLine1?: string,
+ *   addressLine1: string,
  *   addressLine2?: string,
  *   town?: string,
  *   county?: string,
- *   postCode?: string | null
+ *   postCode: string
  * }}
  */
 const formatAddress = (address) => ({
-	...(address?.addressLine1 && { addressLine1: address.addressLine1 }),
+	addressLine1: address?.addressLine1 || '',
 	...(address?.addressLine2 && { addressLine2: address.addressLine2 }),
 	...(address?.addressTown && { town: address.addressTown }),
 	...(address?.addressCounty && { county: address.addressCounty }),
-	postCode: address?.postcode
+	postCode: address?.postcode || ''
 });
 
 export default formatAddress;

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
 				"joi": "^17.7.0",
 				"node-cache": "^5.1.2",
 				"nodemon": "3.0.3",
-				"pins-data-model": "github:Planning-Inspectorate/data-model#1.5.1"
+				"pins-data-model": "github:Planning-Inspectorate/data-model#1.6.2"
 			},
 			"devDependencies": {
 				"@commitlint/cli": "17.0.1",
@@ -76,7 +76,7 @@
 				"pino": "^8.1.0",
 				"pino-http": "^8.1.0",
 				"pino-pretty": "^8.1.0",
-				"pins-data-model": "github:Planning-Inspectorate/data-model#1.5.1",
+				"pins-data-model": "github:Planning-Inspectorate/data-model#1.6.2",
 				"rhea": "3.0.1",
 				"swagger-ui-express": "^5.0.1",
 				"xstate": "4.32.1"
@@ -20686,8 +20686,8 @@
 			"license": "MIT"
 		},
 		"node_modules/pins-data-model": {
-			"version": "1.5.1",
-			"resolved": "git+ssh://git@github.com/Planning-Inspectorate/data-model.git#42bada8587fd5963f3ebb9e0269b2aecc19c2092",
+			"version": "1.6.2",
+			"resolved": "git+ssh://git@github.com/Planning-Inspectorate/data-model.git#d162f6e649afdf03efbc8701b9f8d7a7a0eaa57b",
 			"integrity": "sha512-xk2gyAS0kAzFkiOWmo2pKvKAkQno2nER/buABJbmyVgIBsBGNSb7gQ91TmZOyn4aNEI90Q4Gxcq5w9q4+RyMpw==",
 			"license": "MIT",
 			"dependencies": {
@@ -29934,7 +29934,7 @@
 				"pino": "^8.1.0",
 				"pino-http": "^8.1.0",
 				"pino-pretty": "^8.1.0",
-				"pins-data-model": "github:Planning-Inspectorate/data-model#1.5.1",
+				"pins-data-model": "github:Planning-Inspectorate/data-model#1.6.2",
 				"prisma": "4.16.1",
 				"rhea": "3.0.1",
 				"rimraf": "^3.0.2",
@@ -41137,9 +41137,9 @@
 			"version": "4.0.0"
 		},
 		"pins-data-model": {
-			"version": "git+ssh://git@github.com/Planning-Inspectorate/data-model.git#42bada8587fd5963f3ebb9e0269b2aecc19c2092",
+			"version": "git+ssh://git@github.com/Planning-Inspectorate/data-model.git#d162f6e649afdf03efbc8701b9f8d7a7a0eaa57b",
 			"integrity": "sha512-xk2gyAS0kAzFkiOWmo2pKvKAkQno2nER/buABJbmyVgIBsBGNSb7gQ91TmZOyn4aNEI90Q4Gxcq5w9q4+RyMpw==",
-			"from": "pins-data-model@github:Planning-Inspectorate/data-model#1.5.1",
+			"from": "pins-data-model@github:Planning-Inspectorate/data-model#1.6.2",
 			"requires": {
 				"jsonc-parser": "^3.2.0"
 			}

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
 		"joi": "^17.7.0",
 		"node-cache": "^5.1.2",
 		"nodemon": "3.0.3",
-		"pins-data-model": "github:Planning-Inspectorate/data-model#1.5.1"
+		"pins-data-model": "github:Planning-Inspectorate/data-model#1.6.2"
 	},
 	"devDependencies": {
 		"@commitlint/cli": "17.0.1",


### PR DESCRIPTION
Appeal broadcast

When an appeal is saved in the back-office, its data is broadcasted to the network in the [data model HAS](https://github.com/Planning-Inspectorate/data-model/blob/main/schemas/appeal-has.schema.json) format.

- Refactors database for data model alignment and performance improvements
- Adds missing fields
- Aligns mocks

## Issue ticket number and link

[ASI-17](https://pins-ds.atlassian.net/browse/ASI-17)

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [ ] I have performed a self-review of my own code
- [ ] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [ ] I have referenced the ticket number above
- [ ] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
