### PR TITLE
fix(web): get all entra group members, not just direct members

### DIFF
--- a/appeals/web/src/server/appeals/appeal-details/assign-user/__tests__/assign-user.test.js
+++ b/appeals/web/src/server/appeals/appeal-details/assign-user/__tests__/assign-user.test.js
@@ -3,7 +3,6 @@ import supertest from 'supertest';
 import { jest } from '@jest/globals';
 import { parseHtml } from '@pins/platform';
 import { createTestEnvironment } from '#testing/index.js';
-import config from '#environment/config.js';
 import usersService from '#appeals/appeal-users/users-service.js';
 import { activeDirectoryUsersData } from '#testing/app/fixtures/referencedata.js';
 
@@ -19,12 +18,6 @@ describe('assign-user', () => {
 		usersService.getUsersByRole = jest.fn().mockResolvedValue(activeDirectoryUsersData);
 		// @ts-ignore
 		usersService.getUserByRoleAndId = jest.fn().mockResolvedValue(activeDirectoryUsersData[0]);
-
-		nock('https://graph.microsoft.com/')
-			.get(
-				`/v1.0/groups/${config.referenceData.appeals.caseOfficerGroupId}/members?$select=id,displayName,userPrincipalName`
-			)
-			.reply(200, activeDirectoryUsersData);
 	});
 	afterEach(teardown);
 

--- a/appeals/web/src/server/appeals/appeal-users/users-service.js
+++ b/appeals/web/src/server/appeals/appeal-users/users-service.js
@@ -104,7 +104,9 @@ const fetchRolesAndUsersFromGraph = async (roleName, session) => {
 		const data = [];
 		let gotAllPages = false;
 		let numberOfPagesReturned = 0;
-		let url = `groups/${roleName}/members?$select=id,displayName,givenName,surname,userPrincipalName`;
+		// use the transitive members API to fetch all members of a group, even if that membership is inherited from another group
+		// https://learn.microsoft.com/en-us/graph/api/group-list-transitivemembers?view=graph-rest-1.0&tabs=http
+		let url = `groups/${roleName}/transitiveMembers?$select=id,displayName,givenName,surname,userPrincipalName`;
 
 		while (!gotAllPages) {
 			const page = await getData(url, {


### PR DESCRIPTION
## Describe your changes

Currently trying to assign a user when they are not a direct member of the relevant Entra group doesn't work - they aren't found. This was noticed in Training where most members are from an inherited group.

To fix this, we use the transitive members API.

## Issue ticket number and link

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [ ] I have performed a self-review of my own code
- [ ] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [ ] I have referenced the ticket number above
- [ ] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
