### PR TITLE
fix(api): fixed mispelled field

### DIFF
--- a/appeals/api/src/server/repositories/integrations.repository.js
+++ b/appeals/api/src/server/repositories/integrations.repository.js
@@ -134,7 +134,7 @@ const setAppealRelationships = async (tx, appealId, caseReference, relatedRefere
 						parentId: appealId,
 						childId: foundAppeal?.id || null,
 						externalSource: foundAppeal?.reference ? false : true,
-						externaAppealType: null
+						externalAppealType: null
 					};
 
 					return item;


### PR DESCRIPTION
## Describe your changes

The DB field `externalType` on `appealRelationship` was misspelled in the integration routine importing cases.

## Issue ticket number and link

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [ ] I have performed a self-review of my own code
- [ ] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [ ] I have referenced the ticket number above
- [ ] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
