### PR TITLE
fix(web): fix status-dependent action link copy and URLs on personal list

### DIFF
--- a/appeals/web/src/server/appeals/appeal-details/__tests__/appeal-details.test.js
+++ b/appeals/web/src/server/appeals/appeal-details/__tests__/appeal-details.test.js
@@ -1578,7 +1578,7 @@ describe('appeal-details', () => {
 					'assign_case_officer',
 					'validation',
 					'ready_to_start',
-					'lpa_questionnaire_due',
+					'lpa_questionnaire',
 					'statement_review',
 					'final_comment_review',
 					'invalid',

--- a/appeals/web/src/server/appeals/appeal-details/audit/audit.service.js
+++ b/appeals/web/src/server/appeals/appeal-details/audit/audit.service.js
@@ -119,7 +119,7 @@ const tryMapStatus = async (log) => {
 		'progressed to <strong class="govuk-tag govuk-tag--turquoise single-line govuk-!-margin-bottom-4">Ready to start</strong>'
 	);
 	result = result.replace(
-		'progressed to lpa_questionnaire_due',
+		'progressed to lpa_questionnaire',
 		'progressed to <strong class="govuk-tag govuk-tag--yellow single-line govuk-!-margin-bottom-4">LPA questionnaire</strong>'
 	);
 	result = result.replace(

--- a/appeals/web/src/server/appeals/national-list/__tests__/__snapshots__/national-list.test.js.snap
+++ b/appeals/web/src/server/appeals/national-list/__tests__/__snapshots__/national-list.test.js.snap
@@ -37,7 +37,7 @@ exports[`national-list GET / should render national list - 10 pages - all page i
                             <option value="all">All</option>
                             <option value="assign_case_officer">Assign case officer</option>
                             <option value="ready_to_start">Ready to start</option>
-                            <option value="lpa_questionnaire_due">LPA questionnaire</option>
+                            <option value="lpa_questionnaire">LPA questionnaire</option>
                             <option value="issue_determination">Issue decision</option>
                             <option value="complete">Complete</option>
                         </select>
@@ -170,7 +170,7 @@ exports[`national-list GET / should render national list - 15 pages - pagination
                             <option value="all">All</option>
                             <option value="assign_case_officer">Assign case officer</option>
                             <option value="ready_to_start">Ready to start</option>
-                            <option value="lpa_questionnaire_due">LPA questionnaire</option>
+                            <option value="lpa_questionnaire">LPA questionnaire</option>
                             <option value="issue_determination">Issue decision</option>
                             <option value="complete">Complete</option>
                         </select>
@@ -283,7 +283,7 @@ exports[`national-list GET / should render national list - no pagination 1`] = `
                             <option value="all">All</option>
                             <option value="assign_case_officer">Assign case officer</option>
                             <option value="ready_to_start">Ready to start</option>
-                            <option value="lpa_questionnaire_due">LPA questionnaire</option>
+                            <option value="lpa_questionnaire">LPA questionnaire</option>
                             <option value="issue_determination">Issue decision</option>
                             <option value="complete">Complete</option>
                         </select>
@@ -382,7 +382,7 @@ exports[`national-list GET / should render national list - no search term - filt
                             <option value="all">All</option>
                             <option value="assign_case_officer">Assign case officer</option>
                             <option value="ready_to_start">Ready to start</option>
-                            <option value="lpa_questionnaire_due" selected>LPA questionnaire</option>
+                            <option value="lpa_questionnaire" selected>LPA questionnaire</option>
                             <option value="issue_determination">Issue decision</option>
                             <option value="complete">Complete</option>
                         </select>
@@ -473,7 +473,7 @@ exports[`national-list GET / should render national list - search term - filter 
                             <option value="all">All</option>
                             <option value="assign_case_officer">Assign case officer</option>
                             <option value="ready_to_start">Ready to start</option>
-                            <option value="lpa_questionnaire_due" selected>LPA questionnaire</option>
+                            <option value="lpa_questionnaire" selected>LPA questionnaire</option>
                             <option value="issue_determination">Issue decision</option>
                             <option value="complete">Complete</option>
                         </select>
@@ -564,7 +564,7 @@ exports[`national-list GET / should render national list - search term - no resu
                             <option value="all">All</option>
                             <option value="assign_case_officer">Assign case officer</option>
                             <option value="ready_to_start">Ready to start</option>
-                            <option value="lpa_questionnaire_due">LPA questionnaire</option>
+                            <option value="lpa_questionnaire">LPA questionnaire</option>
                             <option value="issue_determination">Issue decision</option>
                             <option value="complete">Complete</option>
                         </select>
@@ -632,7 +632,7 @@ exports[`national-list GET / should render national list - search term 1`] = `
                             <option value="all">All</option>
                             <option value="assign_case_officer">Assign case officer</option>
                             <option value="ready_to_start">Ready to start</option>
-                            <option value="lpa_questionnaire_due">LPA questionnaire</option>
+                            <option value="lpa_questionnaire">LPA questionnaire</option>
                             <option value="issue_determination">Issue decision</option>
                             <option value="complete">Complete</option>
                         </select>
@@ -728,7 +728,7 @@ exports[`national-list GET / should render the header with navigation containing
                             <option value="all">All</option>
                             <option value="assign_case_officer">Assign case officer</option>
                             <option value="ready_to_start">Ready to start</option>
-                            <option value="lpa_questionnaire_due">LPA questionnaire</option>
+                            <option value="lpa_questionnaire">LPA questionnaire</option>
                             <option value="issue_determination">Issue decision</option>
                             <option value="complete">Complete</option>
                         </select>

--- a/appeals/web/src/server/appeals/national-list/__tests__/national-list.test.js
+++ b/appeals/web/src/server/appeals/national-list/__tests__/national-list.test.js
@@ -10,7 +10,7 @@ const baseUrl = '/appeals-service/all-cases';
 const statuses = [
 	'assign_case_officer',
 	'ready_to_start',
-	'lpa_questionnaire_due',
+	'lpa_questionnaire',
 	'issue_determination',
 	'complete'
 ];
@@ -44,7 +44,7 @@ describe('national-list', () => {
 			expect(unprettifiedElement.innerHTML).toContain('<option value="all"');
 			expect(unprettifiedElement.innerHTML).toContain('<option value="assign_case_officer"');
 			expect(unprettifiedElement.innerHTML).toContain('<option value="ready_to_start"');
-			expect(unprettifiedElement.innerHTML).toContain('<option value="lpa_questionnaire_due"');
+			expect(unprettifiedElement.innerHTML).toContain('<option value="lpa_questionnaire"');
 			expect(unprettifiedElement.innerHTML).toContain('<option value="issue_determination"');
 			expect(unprettifiedElement.innerHTML).toContain('<option value="complete"');
 			expect(unprettifiedElement.innerHTML).toContain('Filter by inspector status</label>');
@@ -158,7 +158,7 @@ describe('national-list', () => {
 
 		it('should render national list - search term - filter applied', async () => {
 			nock('http://test/')
-				.get('/appeals?pageNumber=1&pageSize=30&searchTerm=BS7%208LQ&status=lpa_questionnaire_due')
+				.get('/appeals?pageNumber=1&pageSize=30&searchTerm=BS7%208LQ&status=lpa_questionnaire')
 				.reply(200, {
 					itemCount: 1,
 					items: [appealsNationalList.items[0]],
@@ -169,7 +169,7 @@ describe('national-list', () => {
 				});
 
 			const response = await request.get(
-				`${baseUrl}?searchTerm=BS7%208LQ&appealStatusFilter=lpa_questionnaire_due`
+				`${baseUrl}?searchTerm=BS7%208LQ&appealStatusFilter=lpa_questionnaire`
 			);
 			const element = parseHtml(response.text);
 
@@ -185,16 +185,14 @@ describe('national-list', () => {
 			expect(unprettifiedElement.innerHTML).toContain(
 				'<select class="govuk-select" id="" name="appealStatusFilter"'
 			);
-			expect(unprettifiedElement.innerHTML).toContain(
-				'<option value="lpa_questionnaire_due" selected'
-			);
+			expect(unprettifiedElement.innerHTML).toContain('<option value="lpa_questionnaire" selected');
 			expect(unprettifiedElement.innerHTML).toContain('Apply</button>');
 			expect(unprettifiedElement.innerHTML).toContain('Clear filter</a>');
 		});
 
 		it('should render national list - no search term - filter applied', async () => {
 			nock('http://test/')
-				.get('/appeals?pageNumber=1&pageSize=30&status=lpa_questionnaire_due')
+				.get('/appeals?pageNumber=1&pageSize=30&status=lpa_questionnaire')
 				.reply(200, {
 					itemCount: 1,
 					items: [appealsNationalList.items[0]],
@@ -204,7 +202,7 @@ describe('national-list', () => {
 					pageSize: 30
 				});
 
-			const response = await request.get(`${baseUrl}?appealStatusFilter=lpa_questionnaire_due`);
+			const response = await request.get(`${baseUrl}?appealStatusFilter=lpa_questionnaire`);
 			const element = parseHtml(response.text);
 
 			expect(element.innerHTML).toMatchSnapshot();
@@ -217,9 +215,7 @@ describe('national-list', () => {
 			expect(unprettifiedElement.innerHTML).toContain(
 				'<select class="govuk-select" id="" name="appealStatusFilter"'
 			);
-			expect(unprettifiedElement.innerHTML).toContain(
-				'<option value="lpa_questionnaire_due" selected'
-			);
+			expect(unprettifiedElement.innerHTML).toContain('<option value="lpa_questionnaire" selected');
 			expect(unprettifiedElement.innerHTML).toContain('Apply</button>');
 			expect(unprettifiedElement.innerHTML).toContain('Clear filter</a>');
 		});

--- a/appeals/web/src/server/appeals/personal-list/__tests__/__snapshots__/personal-list.test.js.snap
+++ b/appeals/web/src/server/appeals/personal-list/__tests__/__snapshots__/personal-list.test.js.snap
@@ -18,7 +18,7 @@ exports[`personal-list GET / should render a child status tag in the lead or chi
                     name="appealStatusFilter">
                         <option value="all">All</option>
                         <option value="ready_to_start">Ready to start</option>
-                        <option value="lpa_questionnaire_due">LPA questionnaire</option>
+                        <option value="lpa_questionnaire">LPA questionnaire</option>
                         <option value="issue_determination">Issue decision</option>
                     </select>
                 </div>
@@ -45,7 +45,7 @@ exports[`personal-list GET / should render a child status tag in the lead or chi
                 </td>
                 <td class="govuk-table__cell"><strong class="govuk-tag govuk-tag--grey single-line">Lead</strong>
                 </td>
-                <td class="govuk-table__cell">LPA Questionnaire Overdue</td>
+                <td class="govuk-table__cell">LPA questionnaire overdue</td>
                 <td class="govuk-table__cell">8 April 2022</td>
                 <td class="govuk-table__cell"><strong class="govuk-tag govuk-tag--yellow single-line">LPA questionnaire</strong>
                 </td>
@@ -127,7 +127,7 @@ exports[`personal-list GET / should render a lead status tag in the lead or chil
                     name="appealStatusFilter">
                         <option value="all">All</option>
                         <option value="ready_to_start">Ready to start</option>
-                        <option value="lpa_questionnaire_due">LPA questionnaire</option>
+                        <option value="lpa_questionnaire">LPA questionnaire</option>
                         <option value="issue_determination">Issue decision</option>
                     </select>
                 </div>
@@ -154,7 +154,7 @@ exports[`personal-list GET / should render a lead status tag in the lead or chil
                 </td>
                 <td class="govuk-table__cell"><strong class="govuk-tag govuk-tag--grey single-line">Lead</strong>
                 </td>
-                <td class="govuk-table__cell">LPA Questionnaire Overdue</td>
+                <td class="govuk-table__cell">LPA questionnaire overdue</td>
                 <td class="govuk-table__cell">8 April 2022</td>
                 <td class="govuk-table__cell"><strong class="govuk-tag govuk-tag--yellow single-line">LPA questionnaire</strong>
                 </td>
@@ -247,7 +247,7 @@ exports[`personal-list GET / should render an empty cell in the lead or child co
                     name="appealStatusFilter">
                         <option value="all">All</option>
                         <option value="ready_to_start">Ready to start</option>
-                        <option value="lpa_questionnaire_due">LPA questionnaire</option>
+                        <option value="lpa_questionnaire">LPA questionnaire</option>
                         <option value="issue_determination">Issue decision</option>
                     </select>
                 </div>
@@ -274,7 +274,7 @@ exports[`personal-list GET / should render an empty cell in the lead or child co
                 </td>
                 <td class="govuk-table__cell"><strong class="govuk-tag govuk-tag--grey single-line">Lead</strong>
                 </td>
-                <td class="govuk-table__cell">LPA Questionnaire Overdue</td>
+                <td class="govuk-table__cell">LPA questionnaire overdue</td>
                 <td class="govuk-table__cell">8 April 2022</td>
                 <td class="govuk-table__cell"><strong class="govuk-tag govuk-tag--yellow single-line">LPA questionnaire</strong>
                 </td>
@@ -356,7 +356,7 @@ exports[`personal-list GET / should render the first page of the personal list w
                     name="appealStatusFilter">
                         <option value="all">All</option>
                         <option value="ready_to_start">Ready to start</option>
-                        <option value="lpa_questionnaire_due">LPA questionnaire</option>
+                        <option value="lpa_questionnaire">LPA questionnaire</option>
                         <option value="issue_determination">Issue decision</option>
                     </select>
                 </div>
@@ -383,7 +383,7 @@ exports[`personal-list GET / should render the first page of the personal list w
                 </td>
                 <td class="govuk-table__cell"><strong class="govuk-tag govuk-tag--grey single-line">Lead</strong>
                 </td>
-                <td class="govuk-table__cell">LPA Questionnaire Overdue</td>
+                <td class="govuk-table__cell">LPA questionnaire overdue</td>
                 <td class="govuk-table__cell">8 April 2022</td>
                 <td class="govuk-table__cell"><strong class="govuk-tag govuk-tag--yellow single-line">LPA questionnaire</strong>
                 </td>
@@ -605,7 +605,7 @@ exports[`personal-list GET / should render the second page of the personal list 
                     name="appealStatusFilter">
                         <option value="all">All</option>
                         <option value="ready_to_start">Ready to start</option>
-                        <option value="lpa_questionnaire_due" selected>LPA questionnaire</option>
+                        <option value="lpa_questionnaire" selected>LPA questionnaire</option>
                         <option value="issue_determination">Issue decision</option>
                     </select>
                 </div>
@@ -640,14 +640,14 @@ exports[`personal-list GET / should render the second page of the personal list 
         </tbody>
     </table>
     <nav class="govuk-pagination" role="navigation" aria-label="results">
-        <div class="govuk-pagination__prev"><a class="govuk-link govuk-pagination__link" href="/appeals-service/personal-list?pageSize=1&amp;pageNumber=1&amp;appealStatusFilter=lpa_questionnaire_due"
+        <div class="govuk-pagination__prev"><a class="govuk-link govuk-pagination__link" href="/appeals-service/personal-list?pageSize=1&amp;pageNumber=1&amp;appealStatusFilter=lpa_questionnaire"
             rel="prev"><svg class="govuk-pagination__icon govuk-pagination__icon--prev" xmlns="http://www.w3.org/2000/svg" height="13" width="15" aria-hidden="true" focusable="false" viewBox="0 0 15 13"><path d="m6.5938-0.0078125-6.7266 6.7266 6.7441 6.4062 1.377-1.449-4.1856-3.9768h12.896v-2h-12.984l4.2931-4.293-1.414-1.414z"></path></svg><span class="govuk-pagination__link-title">Previous</span></a>
         </div>
         <ul class="govuk-pagination__list">
-            <li class="govuk-pagination__item"><a class="govuk-link govuk-pagination__link" href="/appeals-service/personal-list?pageSize=1&amp;pageNumber=1&amp;appealStatusFilter=lpa_questionnaire_due"
+            <li class="govuk-pagination__item"><a class="govuk-link govuk-pagination__link" href="/appeals-service/personal-list?pageSize=1&amp;pageNumber=1&amp;appealStatusFilter=lpa_questionnaire"
                 aria-label="Page 1"> 1</a>
             </li>
-            <li class="govuk-pagination__item govuk-pagination__item--current"><a class="govuk-link govuk-pagination__link" href="/appeals-service/personal-list?pageSize=1&amp;pageNumber=2&amp;appealStatusFilter=lpa_questionnaire_due"
+            <li class="govuk-pagination__item govuk-pagination__item--current"><a class="govuk-link govuk-pagination__link" href="/appeals-service/personal-list?pageSize=1&amp;pageNumber=2&amp;appealStatusFilter=lpa_questionnaire"
                 aria-label="Page 2" aria-current="page"> 2</a>
             </li>
         </ul>
@@ -673,7 +673,7 @@ exports[`personal-list GET / should render the second page of the personal list 
                     name="appealStatusFilter">
                         <option value="all">All</option>
                         <option value="ready_to_start">Ready to start</option>
-                        <option value="lpa_questionnaire_due">LPA questionnaire</option>
+                        <option value="lpa_questionnaire">LPA questionnaire</option>
                         <option value="issue_determination">Issue decision</option>
                     </select>
                 </div>

--- a/appeals/web/src/server/appeals/personal-list/__tests__/personal-list.test.js
+++ b/appeals/web/src/server/appeals/personal-list/__tests__/personal-list.test.js
@@ -35,7 +35,7 @@ describe('personal-list', () => {
 			expect(unprettifiedElement.innerHTML).toContain('Show cases with status</label>');
 			expect(unprettifiedElement.innerHTML).toContain('<option value="all"');
 			expect(unprettifiedElement.innerHTML).toContain('<option value="ready_to_start"');
-			expect(unprettifiedElement.innerHTML).toContain('option value="lpa_questionnaire_due"');
+			expect(unprettifiedElement.innerHTML).toContain('option value="lpa_questionnaire"');
 			expect(unprettifiedElement.innerHTML).toContain('<option value="issue_determination"');
 			expect(unprettifiedElement.innerHTML).toContain('Apply</button>');
 			expect(unprettifiedElement.innerHTML).toContain('Clear filter</a>');
@@ -73,7 +73,7 @@ describe('personal-list', () => {
 			expect(unprettifiedElement.innerHTML).toContain('Show cases with status</label>');
 			expect(unprettifiedElement.innerHTML).toContain('<option value="all"');
 			expect(unprettifiedElement.innerHTML).toContain('<option value="ready_to_start"');
-			expect(unprettifiedElement.innerHTML).toContain('option value="lpa_questionnaire_due"');
+			expect(unprettifiedElement.innerHTML).toContain('option value="lpa_questionnaire"');
 			expect(unprettifiedElement.innerHTML).toContain('<option value="issue_determination"');
 			expect(unprettifiedElement.innerHTML).toContain('Apply</button>');
 			expect(unprettifiedElement.innerHTML).toContain('Clear filter</a>');
@@ -96,11 +96,11 @@ describe('personal-list', () => {
 
 		it('should render the second page of the personal list with applied filter, the expected content and pagination', async () => {
 			nock('http://test/')
-				.get('/appeals/my-appeals?pageNumber=2&pageSize=1&status=lpa_questionnaire_due')
+				.get('/appeals/my-appeals?pageNumber=2&pageSize=1&status=lpa_questionnaire')
 				.reply(200, assignedAppealsPage3);
 
 			const response = await request.get(
-				`${baseUrl}${'?pageNumber=2&pageSize=1&appealStatusFilter=lpa_questionnaire_due'}`
+				`${baseUrl}${'?pageNumber=2&pageSize=1&appealStatusFilter=lpa_questionnaire'}`
 			);
 			const element = parseHtml(response.text);
 
@@ -113,9 +113,7 @@ describe('personal-list', () => {
 			expect(unprettifiedElement.innerHTML).toContain('Show cases with status</label>');
 			expect(unprettifiedElement.innerHTML).toContain('<option value="all"');
 			expect(unprettifiedElement.innerHTML).toContain('<option value="ready_to_start"');
-			expect(unprettifiedElement.innerHTML).toContain(
-				'option value="lpa_questionnaire_due" selected'
-			);
+			expect(unprettifiedElement.innerHTML).toContain('option value="lpa_questionnaire" selected');
 			expect(unprettifiedElement.innerHTML).toContain('<option value="issue_determination"');
 			expect(unprettifiedElement.innerHTML).toContain('Apply</button>');
 			expect(unprettifiedElement.innerHTML).toContain('Clear filter</a>');
@@ -246,10 +244,10 @@ describe('mapAppealStatusToActionRequiredHtml', () => {
 		);
 	});
 
-	it('should return "Awaiting appellant update" link for review_appellant_case status with incomplete appellant case', () => {
+	it('should return "Awaiting appellant update" link for validation status with incomplete appellant case', () => {
 		const result = mapAppealStatusToActionRequiredHtml(
 			appealId,
-			'review_appellant_case',
+			'validation',
 			lpaQuestionnaireId,
 			'Incomplete',
 			'',
@@ -261,10 +259,10 @@ describe('mapAppealStatusToActionRequiredHtml', () => {
 		);
 	});
 
-	it('should return "Awaiting appellant update" text for review_appellant_case status with incomplete appellant case and isInspector true', () => {
+	it('should return "Awaiting appellant update" text for validation status with incomplete appellant case and isInspector true', () => {
 		const result = mapAppealStatusToActionRequiredHtml(
 			appealId,
-			'review_appellant_case',
+			'validation',
 			lpaQuestionnaireId,
 			'Incomplete',
 			'',
@@ -274,23 +272,23 @@ describe('mapAppealStatusToActionRequiredHtml', () => {
 		expect(result).toEqual('Awaiting appellant update');
 	});
 
-	it('should return "Awaiting LPA Questionnaire" for lpa_questionnaire_due status with no LPA Questionnaire ID', () => {
+	it('should return "Awaiting LPA questionnaire" for lpa_questionnaire status with no LPA questionnaire ID', () => {
 		const result = mapAppealStatusToActionRequiredHtml(
 			appealId,
-			'lpa_questionnaire_due',
+			'lpa_questionnaire',
 			null,
 			'',
 			'',
 			'',
 			false
 		);
-		expect(result).toEqual('Awaiting LPA Questionnaire');
+		expect(result).toEqual('Awaiting LPA questionnaire');
 	});
 
-	it('should return "Awaiting LPA update" link for lpa_questionnaire_due status with incomplete LPA Questionnaire', () => {
+	it('should return "Awaiting LPA update" link for lpa_questionnaire status with incomplete LPA questionnaire', () => {
 		const result = mapAppealStatusToActionRequiredHtml(
 			appealId,
-			'lpa_questionnaire_due',
+			'lpa_questionnaire',
 			lpaQuestionnaireId,
 			'',
 			'Incomplete',
@@ -302,10 +300,10 @@ describe('mapAppealStatusToActionRequiredHtml', () => {
 		);
 	});
 
-	it('should return "Awaiting LPA update" text for lpa_questionnaire_due status with incomplete LPA Questionnaire and isInspector true', () => {
+	it('should return "Awaiting LPA update" text for lpa_questionnaire status with incomplete LPA questionnaire and isInspector true', () => {
 		const result = mapAppealStatusToActionRequiredHtml(
 			appealId,
-			'lpa_questionnaire_due',
+			'lpa_questionnaire',
 			lpaQuestionnaireId,
 			'',
 			'Incomplete',
@@ -315,10 +313,10 @@ describe('mapAppealStatusToActionRequiredHtml', () => {
 		expect(result).toEqual('Awaiting LPA update');
 	});
 
-	it('should return "Review LPA Questionnaire" for lpa_questionnaire_due status with LPA Questionnaire', () => {
+	it('should return "Review LPA questionnaire" for lpa_questionnaire status with LPA questionnaire', () => {
 		const result = mapAppealStatusToActionRequiredHtml(
 			appealId,
-			'lpa_questionnaire_due',
+			'lpa_questionnaire',
 			lpaQuestionnaireId,
 			'',
 			'',
@@ -326,34 +324,34 @@ describe('mapAppealStatusToActionRequiredHtml', () => {
 			false
 		);
 		expect(result).toEqual(
-			`<a class="govuk-link" href="/appeals-service/appeal-details/${appealId}/lpa-questionnaire/${lpaQuestionnaireId}">Review LPA Questionnaire</a>`
+			`<a class="govuk-link" href="/appeals-service/appeal-details/${appealId}/lpa-questionnaire/${lpaQuestionnaireId}">Review LPA questionnaire</a>`
 		);
 	});
 
-	it('should return "Review LPA Questionnaire" for lpa_questionnaire_due status with LPA Questionnaire and isInspector true', () => {
+	it('should return "Review LPA questionnaire" for lpa_questionnaire status with LPA questionnaire and isInspector true', () => {
 		const result = mapAppealStatusToActionRequiredHtml(
 			appealId,
-			'lpa_questionnaire_due',
+			'lpa_questionnaire',
 			lpaQuestionnaireId,
 			'',
 			'',
 			'',
 			true
 		);
-		expect(result).toEqual('Review LPA Questionnaire');
+		expect(result).toEqual('Review LPA questionnaire');
 	});
 
-	it('should return "LPA Questionnaire Overdue" for lpa_questionnaire_due status with LPA Questionnaire overdue', () => {
+	it('should return "LPA questionnaire overdue" for lpa_questionnaire status with LPA questionnaire overdue', () => {
 		const result = mapAppealStatusToActionRequiredHtml(
 			appealId,
-			'lpa_questionnaire_due',
+			'lpa_questionnaire',
 			null,
 			'',
 			'',
 			'2024-01-01',
 			false
 		);
-		expect(result).toEqual('LPA Questionnaire Overdue');
+		expect(result).toEqual('LPA questionnaire overdue');
 	});
 
 	it('should return "Issue decision" link for issue_determination status', () => {
@@ -386,7 +384,7 @@ describe('mapAppealStatusToActionRequiredHtml', () => {
 		);
 	});
 
-	it('should return "View appellant case" link for any other status', () => {
+	it('should return "View case" link for any other status', () => {
 		const result = mapAppealStatusToActionRequiredHtml(
 			appealId,
 			'some_other_status',
@@ -397,7 +395,7 @@ describe('mapAppealStatusToActionRequiredHtml', () => {
 			false
 		);
 		expect(result).toEqual(
-			`<a class="govuk-link" href="/appeals-service/appeal-details/${appealId}">View appellant case</a>`
+			`<a class="govuk-link" href="/appeals-service/appeal-details/${appealId}">View case</a>`
 		);
 	});
 });

--- a/appeals/web/src/server/appeals/personal-list/personal-list.mapper.js
+++ b/appeals/web/src/server/appeals/personal-list/personal-list.mapper.js
@@ -7,6 +7,7 @@ import { numberToAccessibleDigitLabel } from '#lib/accessibility.js';
 import * as authSession from '../../app/auth/auth-session.service.js';
 import { appealStatusToStatusTag } from '#lib/nunjucks-filters/status-tag.js';
 import { capitalizeFirstLetter } from '#lib/string-utilities.js';
+import { STATUSES } from '@pins/appeals/constants/state.js';
 
 /** @typedef {import('@pins/appeals').AppealList} AppealList */
 /** @typedef {import('@pins/appeals').Pagination} Pagination */
@@ -248,8 +249,8 @@ export function mapAppealStatusToActionRequiredHtml(
 	const appealDueDate = new Date(dueDate);
 
 	switch (appealStatus) {
-		case 'ready_to_start':
-		case 'review_appellant_case':
+		case STATUSES.READY_TO_START:
+		case STATUSES.VALIDATION:
 			if (appellantCaseStatus == 'Incomplete') {
 				if (isInspector) {
 					return 'Awaiting appellant update';
@@ -257,9 +258,10 @@ export function mapAppealStatusToActionRequiredHtml(
 				return `<a class="govuk-link" href="/appeals-service/appeal-details/${appealId}/appellant-case">Awaiting appellant update</a>`;
 			}
 			return `<a class="govuk-link" href="/appeals-service/appeal-details/${appealId}/appellant-case">Review appellant case</a>`;
-		case 'lpa_questionnaire_due':
+		case STATUSES.LPA_QUESTIONNAIRE:
+		case 'lpa_questionnaire_due': // TODO: remove once status value updates are complete
 			if (currentDate > appealDueDate) {
-				return 'LPA Questionnaire Overdue';
+				return 'LPA questionnaire overdue';
 			}
 			if (lpaQuestionnaireStatus == 'Incomplete') {
 				if (isInspector) {
@@ -269,16 +271,16 @@ export function mapAppealStatusToActionRequiredHtml(
 			}
 			if (lpaQuestionnaireId) {
 				if (isInspector) {
-					return 'Review LPA Questionnaire';
+					return 'Review LPA questionnaire';
 				}
-				return `<a class="govuk-link" href="/appeals-service/appeal-details/${appealId}/lpa-questionnaire/${lpaQuestionnaireId}">Review LPA Questionnaire</a>`;
+				return `<a class="govuk-link" href="/appeals-service/appeal-details/${appealId}/lpa-questionnaire/${lpaQuestionnaireId}">Review LPA questionnaire</a>`;
 			}
-			return 'Awaiting LPA Questionnaire';
-		case 'issue_determination':
+			return 'Awaiting LPA questionnaire';
+		case STATUSES.ISSUE_DETERMINATION:
 			return `<a class="govuk-link" href="/appeals-service/appeal-details/${appealId}/issue-decision/decision">Issue decision</a>`;
-		case 'awaiting_transfer':
+		case STATUSES.AWAITING_TRANSFER:
 			return `<a class="govuk-link" href="/appeals-service/appeal-details/${appealId}/change-appeal-type/add-horizon-reference">Update Horizon reference</a>`;
 		default:
-			return `<a class="govuk-link" href="/appeals-service/appeal-details/${appealId}">View appellant case</a>`;
+			return `<a class="govuk-link" href="/appeals-service/appeal-details/${appealId}">View case</a>`;
 	}
 }

--- a/appeals/web/src/server/lib/nunjucks-filters/status-tag.js
+++ b/appeals/web/src/server/lib/nunjucks-filters/status-tag.js
@@ -10,7 +10,7 @@ export function appealStatusToStatusTag(appealStatus) {
 	return capitalizeFirstLetter(
 		appealStatus
 			.replace('issue_determination', 'issue_decision')
-			.replace('lpa_questionnaire_due', 'lpa_questionnaire')
+			.replace('lpa_questionnaire_due', 'lpa_questionnaire') // TODO: remove once status value updates are complete
 			.replace('lpa_', 'LPA_')
 			.replace('lpaq_', 'LPAQ_')
 			.replaceAll('_', ' ')

--- a/appeals/web/src/server/views/appeals/components/status-tag.njk
+++ b/appeals/web/src/server/views/appeals/components/status-tag.njk
@@ -9,7 +9,9 @@
 	{%- switch (status | string | lower) -%}
 		{%- case 'ready_to_start' -%}
 			{%- set statusTagColor = 'turquoise' -%}
-		{%- case 'lpa_questionnaire_due' -%}
+		{%- case 'lpa_questionnaire' -%}
+			{%- set statusTagColor = 'yellow' -%}
+		{%- case 'lpa_questionnaire_due' -%} {# TODO: remove once status value updates are complete #}
 			{%- set statusTagColor = 'yellow' -%}
 		{%- case 'validation' -%}
 			{%- set statusTagColor = 'orange' -%}

--- a/appeals/web/testing/app/fixtures/referencedata.js
+++ b/appeals/web/testing/app/fixtures/referencedata.js
@@ -25,7 +25,7 @@ export const appealsNationalList = {
 				town: 'West Hill',
 				postCode: 'BS48 1PN'
 			},
-			appealStatus: 'lpa_questionnaire_due',
+			appealStatus: 'lpa_questionnaire',
 			appealType: 'Householder',
 			createdAt: '2023-04-17T09:49:22.021Z',
 			localPlanningDepartment: 'Wiltshire Council',
@@ -57,7 +57,7 @@ export const appealsNationalList = {
 	statuses: [
 		'assign_case_officer',
 		'ready_to_start',
-		'lpa_questionnaire_due',
+		'lpa_questionnaire',
 		'issue_determination',
 		'complete'
 	],
@@ -1709,7 +1709,7 @@ export const assignedAppealsPage1 = {
 				county: 'Wandsworth',
 				postCode: 'SW4 7UL'
 			},
-			appealStatus: 'lpa_questionnaire_due',
+			appealStatus: 'lpa_questionnaire',
 			appealType: 'Householder',
 			createdAt: '2024-01-02T11:43:21.830Z',
 			localPlanningDepartment: 'Maidstone Borough Council',
@@ -1792,7 +1792,7 @@ export const assignedAppealsPage1 = {
 			isChildAppeal: false
 		}
 	],
-	statuses: ['ready_to_start', 'lpa_questionnaire_due', 'issue_determination'],
+	statuses: ['ready_to_start', 'lpa_questionnaire', 'issue_determination'],
 	page: 1,
 	pageCount: 2,
 	pageSize: 5
@@ -1865,7 +1865,7 @@ export const assignedAppealsPage2 = {
 			dueDate: '2024-01-07T11:43:21.298Z'
 		}
 	],
-	statuses: ['ready_to_start', 'lpa_questionnaire_due', 'issue_determination'],
+	statuses: ['ready_to_start', 'lpa_questionnaire', 'issue_determination'],
 	page: 2,
 	pageCount: 2,
 	pageSize: 5
@@ -1890,7 +1890,7 @@ export const assignedAppealsPage3 = {
 			dueDate: '2024-01-07T11:43:21.226Z'
 		}
 	],
-	statuses: ['ready_to_start', 'lpa_questionnaire_due', 'issue_determination'],
+	statuses: ['ready_to_start', 'lpa_questionnaire', 'issue_determination'],
 	page: 2,
 	pageCount: 2,
 	pageSize: 1


### PR DESCRIPTION
## Describe your changes

Fix status-dependent action link copy and URLs on personal list, plus some additional changes:
- changed default action for personal list from ‘View appellant case’ to ‘View case’ (URL not changed as it was already linking to case details page, not appellant case)
- amended all personal list actions copy casing to `Sentence case` instead of `Title Case` as requested by content designer
- updated status tag template to account for `lpa_questionnaire_due` status having changed to `lpa_questionnaire`
- update personal list `mapAppealStatusToActionRequiredHtml` function to use STATUSES values from shared constants file, to avoid future regressions if state names change
- update unit tests in WEB to update `lpa_questionnaire_due` status value to `lpa_questionnaire`

## Issue ticket number and link

BOAT-1390

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [ ] I have performed a self-review of my own code
- [ ] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [ ] I have referenced the ticket number above
- [ ] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
