### PR TITLE
fix(functions): don't wrap HTTPErrors to enable logging response body

### DIFF
--- a/appeals/functions/casedata-import/appellant-case/back-office-api-client.js
+++ b/appeals/functions/casedata-import/appellant-case/back-office-api-client.js
@@ -6,17 +6,11 @@ import config from './config.js';
  * @returns {Promise<{reference: string | null}>}
  */
 async function post(submission) {
-	try {
-		const result = await got
-			.post(`https://${config.API_HOST}/appeals/case-submission`, {
-				json: submission
-			})
-			.json();
-
-		return result;
-	} catch (err) {
-		throw new Error(`post case submission failed with error: ${err}`);
-	}
+	return await got
+		.post(`https://${config.API_HOST}/appeals/case-submission`, {
+			json: submission
+		})
+		.json();
 }
 
 export default {

--- a/appeals/functions/casedata-import/appellant-case/index.js
+++ b/appeals/functions/casedata-import/appellant-case/index.js
@@ -35,7 +35,10 @@ export default async function (context, msg) {
 		context.log.info(`Appeal created: ${caseReference}`);
 	} catch (e) {
 		if (e instanceof HTTPError) {
-			context.log.error('Error creating appeal', e.message, e.response?.body);
+			context.log.error('Error creating appeal', {
+				message: e.message,
+				body: e.response?.body
+			});
 		} else {
 			context.log.error('Error creating appeal', e);
 		}

--- a/appeals/functions/casedata-import/questionnaire/back-office-api-client.js
+++ b/appeals/functions/casedata-import/questionnaire/back-office-api-client.js
@@ -6,17 +6,11 @@ import config from './config.js';
  * @returns {Promise<{reference: string | null}>}
  */
 async function post(submission) {
-	try {
-		const result = await got
-			.post(`https://${config.API_HOST}/appeals/lpaq-submission`, {
-				json: submission
-			})
-			.json();
-
-		return result;
-	} catch (err) {
-		throw new Error(`post questionnaire submission failed with error: ${err}`);
-	}
+	return await got
+		.post(`https://${config.API_HOST}/appeals/lpaq-submission`, {
+			json: submission
+		})
+		.json();
 }
 
 export default {

--- a/appeals/functions/casedata-import/questionnaire/index.js
+++ b/appeals/functions/casedata-import/questionnaire/index.js
@@ -35,7 +35,10 @@ export default async function (context, msg) {
 		context.log.info(`LPA questionnaire created for appeal: ${caseReference}`);
 	} catch (e) {
 		if (e instanceof HTTPError) {
-			context.log.error('Error creating LPA questionnaire', e.message, e.response?.body);
+			context.log.error('Error creating LPA questionnaire', {
+				message: e.message,
+				body: e.response?.body
+			});
 		} else {
 			context.log.error('Error creating LPA questionnaire', e);
 		}

--- a/appeals/functions/document-processing/malware-detection/back-office-api-client.js
+++ b/appeals/functions/document-processing/malware-detection/back-office-api-client.js
@@ -7,31 +7,27 @@ import config from './config.js';
  * @returns {Promise<{id: string | null}>}
  */
 async function patch(info, status, context) {
-	try {
-		const payload = {
-			documents: [
-				{
-					id: info.id,
-					version: Number(info.version),
-					virusCheckStatus: status
-				}
-			]
-		};
+	const payload = {
+		documents: [
+			{
+				id: info.id,
+				version: Number(info.version),
+				virusCheckStatus: status
+			}
+		]
+	};
 
-		context.log.info(`Patching document: ${JSON.stringify(payload)}`);
+	context.log.info(`Patching document: ${JSON.stringify(payload)}`);
 
-		const systemUserId = '00000000-0000-0000-0000-000000000000';
-		const result = await got
-			.patch(`https://${config.API_HOST}/appeals/documents/avcheck`, {
-				json: payload,
-				headers: { azureAdUserId: systemUserId }
-			})
-			.json();
+	const systemUserId = '00000000-0000-0000-0000-000000000000';
+	const result = await got
+		.patch(`https://${config.API_HOST}/appeals/documents/avcheck`, {
+			json: payload,
+			headers: { azureAdUserId: systemUserId }
+		})
+		.json();
 
-		return result.documents[0];
-	} catch (err) {
-		throw new Error(`patching document AV scan failed with error: ${err}`);
-	}
+	return result.documents[0];
 }
 
 export default {

--- a/appeals/functions/document-processing/malware-detection/index.js
+++ b/appeals/functions/document-processing/malware-detection/index.js
@@ -22,7 +22,10 @@ export default async function (context, msg) {
 		context.log.info(`Document scan report for document: ${id}`);
 	} catch (e) {
 		if (e instanceof HTTPError) {
-			context.log.error('Error reporting AV scan', e.message, e.response?.body);
+			context.log.error('Error reporting AV scan', {
+				message: e.message,
+				body: e.response?.body
+			});
 		} else {
 			context.log.error('Error reporting AV scan', e);
 		}

--- a/appeals/functions/user-import/employee/back-office-api-client.js
+++ b/appeals/functions/user-import/employee/back-office-api-client.js
@@ -6,17 +6,11 @@ import config from './config.js';
  * @returns {Promise<{id: string | null}>}
  */
 async function post(submission) {
-	try {
-		const result = await got
-			.post(`https://${config.API_HOST}/appeals/employee-import`, {
-				json: submission
-			})
-			.json();
-
-		return result;
-	} catch (err) {
-		throw new Error(`post employee submission failed with error: ${err}`);
-	}
+	return await got
+		.post(`https://${config.API_HOST}/appeals/employee-import`, {
+			json: submission
+		})
+		.json();
 }
 
 export default {

--- a/appeals/functions/user-import/employee/index.js
+++ b/appeals/functions/user-import/employee/index.js
@@ -35,7 +35,10 @@ export default async function (context, msg) {
 		context.log.info(`Employee created: ${id}`);
 	} catch (e) {
 		if (e instanceof HTTPError) {
-			context.log.error('Error creating employee', e.message, e.response?.body);
+			context.log.error('Error creating employee', {
+				message: e.message,
+				body: e.response?.body
+			});
 		} else {
 			context.log.error('Error creating employee', e);
 		}

--- a/appeals/functions/user-import/service-user/back-office-api-client.js
+++ b/appeals/functions/user-import/service-user/back-office-api-client.js
@@ -6,17 +6,11 @@ import config from './config.js';
  * @returns {Promise<{id: string | null}>}
  */
 async function post(submission) {
-	try {
-		const result = await got
-			.post(`https://${config.API_HOST}/appeals/service-user-import`, {
-				json: submission
-			})
-			.json();
-
-		return result;
-	} catch (err) {
-		throw new Error(`post service-user submission failed with error: ${err}`);
-	}
+	return await got
+		.post(`https://${config.API_HOST}/appeals/service-user-import`, {
+			json: submission
+		})
+		.json();
 }
 
 export default {

--- a/appeals/functions/user-import/service-user/index.js
+++ b/appeals/functions/user-import/service-user/index.js
@@ -35,7 +35,10 @@ export default async function (context, msg) {
 		context.log.info(`Service user created: ${id}`);
 	} catch (e) {
 		if (e instanceof HTTPError) {
-			context.log.error('Error creating service user', e.message, e.response?.body);
+			context.log.error('Error creating service user', {
+				message: e.message,
+				body: e.response?.body
+			});
 		} else {
 			context.log.error('Error creating service user', e);
 		}


### PR DESCRIPTION
## Describe your changes

Tested from the branch, the try/catch was not returning the `HTTPError` so the response body was not logged.

## Issue ticket number and link

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [ ] I have performed a self-review of my own code
- [ ] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [ ] I have referenced the ticket number above
- [ ] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
