### PR TITLE
fix(api): broadcast appeal data when change pages are used

### DIFF
--- a/appeals/api/src/server/endpoints/appellant-cases/appellant-cases.controller.js
+++ b/appeals/api/src/server/endpoints/appellant-cases/appellant-cases.controller.js
@@ -6,6 +6,7 @@ import logger from '#utils/logger.js';
 import { formatAppellantCase } from './appellant-cases.formatter.js';
 import { updateAppellantCaseValidationOutcome } from './appellant-cases.service.js';
 import { formatAddressSingleLine } from '#endpoints/addresses/addresses.formatter.js';
+import { broadcasters } from '#endpoints/integrations/integrations.broadcasters.js';
 
 /** @typedef {import('express').Request} Request */
 /** @typedef {import('express').Response} Response */
@@ -92,6 +93,8 @@ const updateAppellantCaseById = async (req, res) => {
 					applicationDate,
 					applicationDecisionDate
 			  });
+
+		await broadcasters.broadcastAppeal(appeal.id);
 	} catch (error) {
 		if (error) {
 			logger.error(error);

--- a/appeals/api/src/server/endpoints/appellant-cases/appellant-cases.service.js
+++ b/appeals/api/src/server/endpoints/appellant-cases/appellant-cases.service.js
@@ -3,7 +3,6 @@ import {
 	isOutcomeInvalid,
 	isOutcomeValid
 } from '#utils/check-validation-outcome.js';
-import { broadcasters } from '#endpoints/integrations/integrations.broadcasters.js';
 
 import {
 	AUDIT_TRAIL_SUBMISSION_INCOMPLETE,
@@ -154,8 +153,6 @@ const updateAppellantCaseValidationOutcome = async (
 			}
 		}
 	}
-
-	await broadcasters.broadcastAppeal(appealId);
 };
 
 export { checkAppellantCaseExists, updateAppellantCaseValidationOutcome };

--- a/appeals/api/src/server/endpoints/lpa-questionnaires/lpa-questionnaires.controller.js
+++ b/appeals/api/src/server/endpoints/lpa-questionnaires/lpa-questionnaires.controller.js
@@ -6,6 +6,7 @@ import { updateLPAQuestionnaireValidationOutcome } from './lpa-questionnaires.se
 import lpaQuestionnaireRepository from '#repositories/lpa-questionnaire.repository.js';
 import logger from '#utils/logger.js';
 import { formatAddressSingleLine } from '#endpoints/addresses/addresses.formatter.js';
+import { broadcasters } from '#endpoints/integrations/integrations.broadcasters.js';
 
 /** @typedef {import('express').Request} Request */
 /** @typedef {import('express').Response} Response */
@@ -75,6 +76,8 @@ const updateLPAQuestionnaireById = async (req, res) => {
 					isConservationArea,
 					isCorrectAppealType
 			  });
+
+		await broadcasters.broadcastAppeal(appeal.id);
 	} catch (error) {
 		if (error) {
 			logger.error(error);

--- a/appeals/api/src/server/endpoints/lpa-questionnaires/lpa-questionnaires.service.js
+++ b/appeals/api/src/server/endpoints/lpa-questionnaires/lpa-questionnaires.service.js
@@ -1,6 +1,5 @@
 import lpaQuestionnaireRepository from '#repositories/lpa-questionnaire.repository.js';
 import appealRepository from '#repositories/appeal.repository.js';
-import { broadcasters } from '#endpoints/integrations/integrations.broadcasters.js';
 import { recalculateDateIfNotBusinessDay } from '#utils/business-days.js';
 import { isOutcomeComplete, isOutcomeIncomplete } from '#utils/check-validation-outcome.js';
 import transitionState from '#state/transition-state.js';
@@ -129,8 +128,6 @@ const updateLPAQuestionnaireValidationOutcome = async (
 			}
 		}
 	}
-
-	await broadcasters.broadcastAppeal(appealId);
 
 	return timetable?.lpaQuestionnaireDueDate;
 };


### PR DESCRIPTION
Moves the execution of the appeal broadcaster, so every PATCH to appeal, appellant case or lpa questionnaire will result in an updated appeal message.

## Issue ticket number and link

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [ ] I have performed a self-review of my own code
- [ ] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [ ] I have referenced the ticket number above
- [ ] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
