### PR TITLE
feat(appeals): infra settings for horizon timeouts

### DIFF
--- a/infrastructure/app-api.tf
+++ b/infrastructure/app-api.tf
@@ -46,12 +46,13 @@ module "app_api" {
     DATABASE_URL  = local.key_vault_refs["sql-app-connection-string"]
 
     # integrations
-    GOV_NOTIFY_API_KEY   = local.key_vault_refs["appeals-bo-gov-notify-api-key"]
-    MOCK_HORIZON         = var.apps_config.integrations.horizon_mock
-    SERVICE_BUS_ENABLED  = var.apps_config.integrations.service_bus_broadcast_enabled
-    SERVICE_BUS_HOSTNAME = local.service_bus_hostname
-    SRV_HORIZON_URL      = var.apps_config.integrations.horizon_api_url
-    TEST_MAILBOX         = local.key_vault_refs["appeals-bo-test-mailbox"]
+    GOV_NOTIFY_API_KEY    = local.key_vault_refs["appeals-bo-gov-notify-api-key"]
+    MOCK_HORIZON          = var.apps_config.integrations.horizon_mock
+    SERVICE_BUS_ENABLED   = var.apps_config.integrations.service_bus_broadcast_enabled
+    SERVICE_BUS_HOSTNAME  = local.service_bus_hostname
+    SRV_HORIZON_URL       = var.apps_config.integrations.horizon_api_url
+    TIMEOUT_LIMIT_HORIZON = var.apps_config.integrations.horizon_timeout
+    TEST_MAILBOX          = local.key_vault_refs["appeals-bo-test-mailbox"]
 
     # notify templates
     GOV_NOTIFY_APPEAL_CONFIRMED_ID                                             = var.apps_config.integrations.notify_template_ids.appeal_confirmed_id

--- a/infrastructure/environments/dev.tfvars
+++ b/infrastructure/environments/dev.tfvars
@@ -21,6 +21,7 @@ apps_config = {
     horizon_api_url               = "http://10.0.7.4:8000" # required by config validation, even if mocked
     horizon_mock                  = true
     horizon_web_url               = ""
+    horizon_timeout               = 500
     service_bus_broadcast_enabled = true
     notify_template_ids = {
       appeal_confirmed_id                                             = "783f94cc-1d6d-4153-8ad7-9070e449a57c"

--- a/infrastructure/environments/prod.tfvars
+++ b/infrastructure/environments/prod.tfvars
@@ -21,6 +21,7 @@ apps_config = {
     horizon_api_url               = "http://10.224.161.68:8000"
     horizon_mock                  = false
     horizon_web_url               = "https://horizonweb.planninginspectorate.gov.uk/otcs/llisapi.dll?func=ll&objId="
+    horizon_timeout               = 500
     service_bus_broadcast_enabled = false
     notify_template_ids = {
       appeal_confirmed_id                                             = "783f94cc-1d6d-4153-8ad7-9070e449a57c"

--- a/infrastructure/environments/test.tfvars
+++ b/infrastructure/environments/test.tfvars
@@ -21,6 +21,7 @@ apps_config = {
     horizon_api_url               = "http://10.0.7.4:8000"
     horizon_mock                  = false
     horizon_web_url               = "https://horizontest.planninginspectorate.gov.uk/otcs/llisapi.dll?func=ll&objId="
+    horizon_timeout               = 500
     service_bus_broadcast_enabled = true
     notify_template_ids = {
       appeal_confirmed_id                                             = "783f94cc-1d6d-4153-8ad7-9070e449a57c"

--- a/infrastructure/environments/training.tfvars
+++ b/infrastructure/environments/training.tfvars
@@ -21,6 +21,7 @@ apps_config = {
     horizon_api_url               = "http://10.0.7.4:8000"
     horizon_mock                  = false
     horizon_web_url               = "https://horizontest.planninginspectorate.gov.uk/otcs/llisapi.dll?func=ll&objId="
+    horizon_timeout               = 500
     service_bus_broadcast_enabled = true
     notify_template_ids = {
       appeal_confirmed_id                                             = "783f94cc-1d6d-4153-8ad7-9070e449a57c"


### PR DESCRIPTION
Infrastructure changes to go with https://github.com/Planning-Inspectorate/appeals-back-office/pull/300

Adds a TIMEOUT_LIMIT_HORIZON setting to all environments

## Issue ticket number and link

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [ ] I have performed a self-review of my own code
- [ ] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [ ] I have referenced the ticket number above
- [ ] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
