### PR TITLE
fix(appeals): updated folder names for new notify rows

### DIFF
--- a/appeals/api/src/server/endpoints/appeals.d.ts
+++ b/appeals/api/src/server/endpoints/appeals.d.ts
@@ -234,9 +234,9 @@ interface SingleLPAQuestionnaireResponse {
 	procedureType?: string;
 	documents: {
 		whoNotified?: FolderInfo | null;
-		siteNotice?: FolderInfo | null;
-		lettersToNeighbours?: FolderInfo | null;
-		pressAdvert?: FolderInfo | null;
+		whoNotifiedSiteNotice?: FolderInfo | null;
+		whoNotifiedLetterToNeighbours?: FolderInfo | null;
+		whoNotifiedPressAdvert?: FolderInfo | null;
 		conservationMap?: FolderInfo | null;
 		lpaCaseCorrespondence?: FolderInfo | null;
 		otherPartyRepresentations?: FolderInfo | null;

--- a/appeals/web/src/server/appeals/appeal-details/appeal-details.types.d.ts
+++ b/appeals/web/src/server/appeals/appeal-details/appeal-details.types.d.ts
@@ -140,7 +140,7 @@ export type LpaQuestionnaireFullAppealEnvironmentalImpact = {
 	// No -> No more questions
 	// Yes or environmentalStatementComplete: Yes
 	responsesForEnvironmentalStatement?: AppealDocument;
-	siteNotice?: AppealDocument;
+	whoNotifiedSiteNotice?: AppealDocument;
 	// ScheduleType 2
 	developmentDescription?: DevelopmentDescription;
 	affectSensitiveArea?: {
@@ -153,9 +153,9 @@ export type LpaQuestionnaireFullAppealEnvironmentalImpact = {
 
 export type LpaQuestionnaireFullAppealNotifyingPeople = {
 	notificationMethod: NotificationMethodOptions;
-	siteNotice?: AppealDocument;
-	letterSentToNeighbours?: AppealDocument;
-	pressAdvert?: AppealDocument;
+	whoNotifiedSiteNotice?: AppealDocument;
+	whoNotifiedLetterToNeighbours?: AppealDocument;
+	whoNotifiedPressAdvert?: AppealDocument;
 };
 
 export type LpaQuestionnaireFullAppealConsultationResponses = {
@@ -287,9 +287,9 @@ export interface SingleLPAQuestionnaireResponse {
 	developmentDescription?: string | null;
 	documents: {
 		whoNotified: FolderInfo | {};
-		siteNotice?: FolderInfo | null;
-		lettersToNeighbours?: FolderInfo | null;
-		pressAdvert?: FolderInfo | null;
+		whoNotifiedSiteNotice?: FolderInfo | null;
+		whoNotifiedLetterToNeighbours?: FolderInfo | null;
+		whoNotifiedPressAdvert?: FolderInfo | null;
 		conservationMap: FolderInfo | {};
 		lpaCaseCorrespondence: FolderInfo | {};
 		otherPartyRepresentations: FolderInfo | {};

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/lpa-questionnaire.controller.js
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/lpa-questionnaire.controller.js
@@ -253,13 +253,13 @@ export const getAddDocuments = async (request, response) => {
 	let uploadPageHeadingText = '';
 
 	switch (documentType) {
-		case 'siteNotice':
+		case 'whoNotifiedSiteNotice':
 			uploadPageHeadingText = `Upload site notice`;
 			break;
-		case 'lettersToNeighbours':
+		case 'whoNotifiedLetterToNeighbours':
 			uploadPageHeadingText = `Upload letter or email notification`;
 			break;
-		case 'pressAdvert':
+		case 'whoNotifiedPressAdvert':
 			uploadPageHeadingText = `Upload press advert notification`;
 			break;
 		default:
@@ -302,7 +302,11 @@ export const getAddDocumentDetails = async (request, response) => {
 	}
 
 	const documentType = currentFolder.path.split('/')[1];
-	const notificationDocumentTypes = ['siteNotice', 'lettersToNeighbours', 'pressAdvert'];
+	const notificationDocumentTypes = [
+		'whoNotifiedSiteNotice',
+		'whoNotifiedLetterToNeighbours',
+		'whoNotifiedPressAdvert'
+	];
 	const uploadPageHeadingText = notificationDocumentTypes.includes(documentType)
 		? 'Notification documents'
 		: '';

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/lpa-questionnaire.controller.js
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/lpa-questionnaire.controller.js
@@ -8,6 +8,7 @@ import {
 } from './lpa-questionnaire.mapper.js';
 import logger from '#lib/logger.js';
 import { objectContainsAllKeys } from '#lib/object-utilities.js';
+import { APPEAL_DOCUMENT_TYPE } from 'pins-data-model';
 import {
 	renderDocumentUpload,
 	renderDocumentDetails,
@@ -253,13 +254,13 @@ export const getAddDocuments = async (request, response) => {
 	let uploadPageHeadingText = '';
 
 	switch (documentType) {
-		case 'whoNotifiedSiteNotice':
+		case `${APPEAL_DOCUMENT_TYPE.WHO_NOTIFIED_SITE_NOTICE}`:
 			uploadPageHeadingText = `Upload site notice`;
 			break;
-		case 'whoNotifiedLetterToNeighbours':
+		case `${APPEAL_DOCUMENT_TYPE.WHO_NOTIFIED_LETTER_TO_NEIGHBOURS}`:
 			uploadPageHeadingText = `Upload letter or email notification`;
 			break;
-		case 'whoNotifiedPressAdvert':
+		case `${APPEAL_DOCUMENT_TYPE.WHO_NOTIFIED_PRESS_ADVERT}`:
 			uploadPageHeadingText = `Upload press advert notification`;
 			break;
 		default:
@@ -303,9 +304,9 @@ export const getAddDocumentDetails = async (request, response) => {
 
 	const documentType = currentFolder.path.split('/')[1];
 	const notificationDocumentTypes = [
-		'whoNotifiedSiteNotice',
-		'whoNotifiedLetterToNeighbours',
-		'whoNotifiedPressAdvert'
+		`${APPEAL_DOCUMENT_TYPE.WHO_NOTIFIED_SITE_NOTICE}`,
+		`${APPEAL_DOCUMENT_TYPE.WHO_NOTIFIED_LETTER_TO_NEIGHBOURS}`,
+		`${APPEAL_DOCUMENT_TYPE.WHO_NOTIFIED_PRESS_ADVERT}`
 	];
 	const uploadPageHeadingText = notificationDocumentTypes.includes(documentType)
 		? 'Notification documents'

--- a/appeals/web/src/server/lib/mappers/lpaQuestionnaire.mapper.js
+++ b/appeals/web/src/server/lib/mappers/lpaQuestionnaire.mapper.js
@@ -222,14 +222,14 @@ export function initialiseAndMapLPAQData(
 				},
 				value: displayPageFormatter.formatDocumentValues(
 					lpaQuestionnaireData.appealId,
-					isFolderInfo(lpaQuestionnaireData.documents.siteNotice)
-						? lpaQuestionnaireData.documents.siteNotice.documents || []
+					isFolderInfo(lpaQuestionnaireData.documents.whoNotifiedSiteNotice)
+						? lpaQuestionnaireData.documents.whoNotifiedSiteNotice.documents || []
 						: []
 				),
 				actions: {
 					items: [
-						...((isFolderInfo(lpaQuestionnaireData.documents.siteNotice)
-							? lpaQuestionnaireData.documents.siteNotice.documents || []
+						...((isFolderInfo(lpaQuestionnaireData.documents.whoNotifiedSiteNotice)
+							? lpaQuestionnaireData.documents.whoNotifiedSiteNotice.documents || []
 							: []
 						).length
 							? [
@@ -239,8 +239,8 @@ export function initialiseAndMapLPAQData(
 										href: mapDocumentManageUrl(
 											lpaQuestionnaireData.appealId,
 											lpaQuestionnaireData.lpaQuestionnaireId,
-											isFolderInfo(lpaQuestionnaireData.documents.siteNotice)
-												? lpaQuestionnaireData.documents.siteNotice.folderId
+											isFolderInfo(lpaQuestionnaireData.documents.whoNotifiedSiteNotice)
+												? lpaQuestionnaireData.documents.whoNotifiedSiteNotice.folderId
 												: undefined
 										),
 										attributes: { 'lpaQuestionnaireData-cy': 'manage-site-notice' }
@@ -252,7 +252,7 @@ export function initialiseAndMapLPAQData(
 							visuallyHiddenText: 'Site notice',
 							href: displayPageFormatter.formatDocumentActionLink(
 								lpaQuestionnaireData.appealId,
-								lpaQuestionnaireData.documents.siteNotice,
+								lpaQuestionnaireData.documents.whoNotifiedSiteNotice,
 								buildDocumentUploadUrlTemplate(lpaQuestionnaireData.lpaQuestionnaireId)
 							),
 							attributes: { 'lpaQuestionnaireData-cy': 'add-site-notice' }
@@ -273,14 +273,14 @@ export function initialiseAndMapLPAQData(
 				},
 				value: displayPageFormatter.formatDocumentValues(
 					lpaQuestionnaireData.appealId,
-					isFolderInfo(lpaQuestionnaireData.documents.lettersToNeighbours)
-						? lpaQuestionnaireData.documents.lettersToNeighbours.documents || []
+					isFolderInfo(lpaQuestionnaireData.documents.whoNotifiedLetterToNeighbours)
+						? lpaQuestionnaireData.documents.whoNotifiedLetterToNeighbours.documents || []
 						: []
 				),
 				actions: {
 					items: [
-						...((isFolderInfo(lpaQuestionnaireData.documents.lettersToNeighbours)
-							? lpaQuestionnaireData.documents.lettersToNeighbours.documents || []
+						...((isFolderInfo(lpaQuestionnaireData.documents.whoNotifiedLetterToNeighbours)
+							? lpaQuestionnaireData.documents.whoNotifiedLetterToNeighbours.documents || []
 							: []
 						).length
 							? [
@@ -290,8 +290,8 @@ export function initialiseAndMapLPAQData(
 										href: mapDocumentManageUrl(
 											lpaQuestionnaireData.appealId,
 											lpaQuestionnaireData.lpaQuestionnaireId,
-											isFolderInfo(lpaQuestionnaireData.documents.lettersToNeighbours)
-												? lpaQuestionnaireData.documents.lettersToNeighbours.folderId
+											isFolderInfo(lpaQuestionnaireData.documents.whoNotifiedLetterToNeighbours)
+												? lpaQuestionnaireData.documents.whoNotifiedLetterToNeighbours.folderId
 												: undefined
 										),
 										attributes: { 'lpaQuestionnaireData-cy': 'manage-letter-or-email-notification' }
@@ -303,7 +303,7 @@ export function initialiseAndMapLPAQData(
 							visuallyHiddenText: 'Letter or email notification',
 							href: displayPageFormatter.formatDocumentActionLink(
 								lpaQuestionnaireData.appealId,
-								lpaQuestionnaireData.documents.lettersToNeighbours,
+								lpaQuestionnaireData.documents.whoNotifiedLetterToNeighbours,
 								buildDocumentUploadUrlTemplate(lpaQuestionnaireData.lpaQuestionnaireId)
 							),
 							attributes: { 'lpaQuestionnaireData-cy': 'add-letter-or-email-notification' }
@@ -324,14 +324,14 @@ export function initialiseAndMapLPAQData(
 				},
 				value: displayPageFormatter.formatDocumentValues(
 					lpaQuestionnaireData.appealId,
-					isFolderInfo(lpaQuestionnaireData.documents.pressAdvert)
-						? lpaQuestionnaireData.documents.pressAdvert.documents || []
+					isFolderInfo(lpaQuestionnaireData.documents.whoNotifiedPressAdvert)
+						? lpaQuestionnaireData.documents.whoNotifiedPressAdvert.documents || []
 						: []
 				),
 				actions: {
 					items: [
-						...((isFolderInfo(lpaQuestionnaireData.documents.pressAdvert)
-							? lpaQuestionnaireData.documents.pressAdvert.documents || []
+						...((isFolderInfo(lpaQuestionnaireData.documents.whoNotifiedPressAdvert)
+							? lpaQuestionnaireData.documents.whoNotifiedPressAdvert.documents || []
 							: []
 						).length
 							? [
@@ -341,8 +341,8 @@ export function initialiseAndMapLPAQData(
 										href: mapDocumentManageUrl(
 											lpaQuestionnaireData.appealId,
 											lpaQuestionnaireData.lpaQuestionnaireId,
-											isFolderInfo(lpaQuestionnaireData.documents.pressAdvert)
-												? lpaQuestionnaireData.documents.pressAdvert.folderId
+											isFolderInfo(lpaQuestionnaireData.documents.whoNotifiedPressAdvert)
+												? lpaQuestionnaireData.documents.whoNotifiedPressAdvert.folderId
 												: undefined
 										),
 										attributes: { 'lpaQuestionnaireData-cy': 'manage-press-advert-notification' }
@@ -354,7 +354,7 @@ export function initialiseAndMapLPAQData(
 							visuallyHiddenText: 'Press advert notification',
 							href: displayPageFormatter.formatDocumentActionLink(
 								lpaQuestionnaireData.appealId,
-								lpaQuestionnaireData.documents.pressAdvert,
+								lpaQuestionnaireData.documents.whoNotifiedPressAdvert,
 								buildDocumentUploadUrlTemplate(lpaQuestionnaireData.lpaQuestionnaireId)
 							),
 							attributes: { 'lpaQuestionnaireData-cy': 'add-press-advert-notification' }


### PR DESCRIPTION
## Describe your changes

Document types fix:
- siteNotice -> whoNotifiedSiteNotice
- lettersToNeighbours -> whoNotifiedLetterToNeighbours
- pressAdvert -> whoNotifiedPressAdvert

## Issue ticket number and link

[A2-315 Creation of three new rows/folders for HAS LPAQ](https://pins-ds.atlassian.net.mcas.ms/browse/A2-315)

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
