### PR TITLE
fix(web): add validation for linkable appeal reference length on linked and related appeals flows

### DIFF
--- a/appeals/web/src/server/appeals/appeal-details/__tests__/appeal-details.test.js
+++ b/appeals/web/src/server/appeals/appeal-details/__tests__/appeal-details.test.js
@@ -239,7 +239,7 @@ describe('appeal-details', () => {
 			});
 
 			it('should render a "This appeal is now the lead for appeal" success notification banner when the appeal was successfully linked as the lead of a back-office appeal', async () => {
-				const appealReference = '12345';
+				const appealReference = '1234567';
 
 				nock.cleanAll();
 				nock('http://test/')
@@ -275,7 +275,7 @@ describe('appeal-details', () => {
 			});
 
 			it('should render a success notification banner with appropriate content if the appeal was just linked as the child of a back-office appeal', async () => {
-				const appealReference = '12345';
+				const appealReference = '1234567';
 
 				nock.cleanAll();
 				nock('http://test/')
@@ -315,7 +315,7 @@ describe('appeal-details', () => {
 			});
 
 			it('should render a success notification banner with appropriate content if the appeal was just linked as the lead of a legacy (Horizon) appeal', async () => {
-				const appealReference = '12345';
+				const appealReference = '1234567';
 
 				nock.cleanAll();
 				nock('http://test/')
@@ -355,7 +355,7 @@ describe('appeal-details', () => {
 			});
 
 			it('should render a success notification banner with appropriate content if the appeal was just linked as the child of a legacy (Horizon) appeal', async () => {
-				const appealReference = '12345';
+				const appealReference = '1234567';
 
 				nock.cleanAll();
 				nock('http://test/')

--- a/appeals/web/src/server/appeals/appeal-details/manage-linked-appeals/__tests__/__snapshots__/manage-linked-appeals.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/manage-linked-appeals/__tests__/__snapshots__/manage-linked-appeals.test.js.snap
@@ -1161,6 +1161,72 @@ exports[`linked-appeals POST /linked-appeals/add should re-render the add linked
 </main>"
 `;
 
+exports[`linked-appeals POST /linked-appeals/add should re-render the add linked appeal reference page with the expected error message if the provided appeal reference is greater than 7 digits 1`] = `
+"<main class="govuk-main-wrapper " id="main-content" role="main">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <div class="govuk-error-summary" data-module="govuk-error-summary">
+                <div role="alert">
+                    <h2 class="govuk-error-summary__title"> There is a problem</h2>
+                    <div class="govuk-error-summary__body">
+                        <ul class="govuk-list govuk-error-summary__list">
+                            <li><a href="#appeal-reference">Appeal reference must be 7 digits</a>
+                            </li>
+                        </ul>
+                    </div>
+                </div>
+            </div>
+            <div class="govuk-grid-row">
+                <div class="govuk-grid-column-full"><span class="govuk-caption-l govuk-!-margin-bottom-3">Appeal 351062</span>
+                    <h1                     class="govuk-heading-l govuk-!-margin-bottom-3">What is the appeal reference?</h1>
+                </div>
+            </div>
+            <form method="POST" novalidate="novalidate">
+                <div class="govuk-form-group">
+                    <label class="govuk-label govuk-visually-hidden" for="appeal-reference">Appeal reference</label>
+                    <input class="govuk-input govuk-input govuk-input--width-10"
+                    id="appeal-reference" name="appeal-reference" type="text">
+                </div>
+                <button type="submit" class="govuk-button" data-module="govuk-button">Continue</button>
+            </form>
+        </div>
+    </div>
+</main>"
+`;
+
+exports[`linked-appeals POST /linked-appeals/add should re-render the add linked appeal reference page with the expected error message if the provided appeal reference is less than 7 digits 1`] = `
+"<main class="govuk-main-wrapper " id="main-content" role="main">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <div class="govuk-error-summary" data-module="govuk-error-summary">
+                <div role="alert">
+                    <h2 class="govuk-error-summary__title"> There is a problem</h2>
+                    <div class="govuk-error-summary__body">
+                        <ul class="govuk-list govuk-error-summary__list">
+                            <li><a href="#appeal-reference">Appeal reference must be 7 digits</a>
+                            </li>
+                        </ul>
+                    </div>
+                </div>
+            </div>
+            <div class="govuk-grid-row">
+                <div class="govuk-grid-column-full"><span class="govuk-caption-l govuk-!-margin-bottom-3">Appeal 351062</span>
+                    <h1                     class="govuk-heading-l govuk-!-margin-bottom-3">What is the appeal reference?</h1>
+                </div>
+            </div>
+            <form method="POST" novalidate="novalidate">
+                <div class="govuk-form-group">
+                    <label class="govuk-label govuk-visually-hidden" for="appeal-reference">Appeal reference</label>
+                    <input class="govuk-input govuk-input govuk-input--width-10"
+                    id="appeal-reference" name="appeal-reference" type="text">
+                </div>
+                <button type="submit" class="govuk-button" data-module="govuk-button">Continue</button>
+            </form>
+        </div>
+    </div>
+</main>"
+`;
+
 exports[`linked-appeals POST /linked-appeals/add should re-render the add linked appeal reference page with the expected error message if the reference was provided but no matching appeal was found 1`] = `
 "<main class="govuk-main-wrapper " id="main-content" role="main">
     <div class="govuk-grid-row">

--- a/appeals/web/src/server/appeals/appeal-details/manage-linked-appeals/__tests__/manage-linked-appeals.test.js
+++ b/appeals/web/src/server/appeals/appeal-details/manage-linked-appeals/__tests__/manage-linked-appeals.test.js
@@ -58,6 +58,8 @@ const childAppealDataWithLinkedAppeals = {
 		}
 	]
 };
+const testValidLinkableAppealReference = '1234567';
+const testInvalidLinkableAppealReference = '7654321';
 
 describe('linked-appeals', () => {
 	beforeEach(() => {
@@ -111,7 +113,7 @@ describe('linked-appeals', () => {
 			nock.cleanAll();
 			nock('http://test/').get('/appeals/1').reply(200, appealData);
 			nock('http://test/')
-				.get('/appeals/linkable-appeal/123')
+				.get(`/appeals/linkable-appeal/${testValidLinkableAppealReference}`)
 				.reply(200, linkableAppealSummaryBackOffice);
 
 			const response = await request.post(`${baseUrl}/1${linkedAppealsPath}/add`).send({
@@ -131,13 +133,63 @@ describe('linked-appeals', () => {
 			expect(errorSummaryHtml).toContain('Enter an appeal reference</a>');
 		});
 
+		it('should re-render the add linked appeal reference page with the expected error message if the provided appeal reference is less than 7 digits', async () => {
+			nock.cleanAll();
+			nock('http://test/').get('/appeals/1').reply(200, appealData);
+			nock('http://test/')
+				.get(`/appeals/linkable-appeal/${testValidLinkableAppealReference}`)
+				.reply(200, linkableAppealSummaryBackOffice);
+
+			const response = await request.post(`${baseUrl}/1${linkedAppealsPath}/add`).send({
+				'appeal-reference': '123456'
+			});
+			const element = parseHtml(response.text);
+
+			expect(element.innerHTML).toMatchSnapshot();
+			expect(element.innerHTML).toContain('What is the appeal reference?</h1>');
+
+			const errorSummaryHtml = parseHtml(response.text, {
+				rootElement: '.govuk-error-summary',
+				skipPrettyPrint: true
+			}).innerHTML;
+
+			expect(errorSummaryHtml).toContain('There is a problem</h2>');
+			expect(errorSummaryHtml).toContain('Appeal reference must be 7 digits</a>');
+		});
+
+		it('should re-render the add linked appeal reference page with the expected error message if the provided appeal reference is greater than 7 digits', async () => {
+			nock.cleanAll();
+			nock('http://test/').get('/appeals/1').reply(200, appealData);
+			nock('http://test/')
+				.get(`/appeals/linkable-appeal/${testValidLinkableAppealReference}`)
+				.reply(200, linkableAppealSummaryBackOffice);
+
+			const response = await request.post(`${baseUrl}/1${linkedAppealsPath}/add`).send({
+				'appeal-reference': '12345678'
+			});
+			const element = parseHtml(response.text);
+
+			expect(element.innerHTML).toMatchSnapshot();
+			expect(element.innerHTML).toContain('What is the appeal reference?</h1>');
+
+			const errorSummaryHtml = parseHtml(response.text, {
+				rootElement: '.govuk-error-summary',
+				skipPrettyPrint: true
+			}).innerHTML;
+
+			expect(errorSummaryHtml).toContain('There is a problem</h2>');
+			expect(errorSummaryHtml).toContain('Appeal reference must be 7 digits</a>');
+		});
+
 		it('should re-render the add linked appeal reference page with the expected error message if the reference was provided but no matching appeal was found', async () => {
 			nock.cleanAll();
 			nock('http://test/').get('/appeals/1').reply(200, appealData);
-			nock('http://test/').get('/appeals/linkable-appeal/123').reply(404);
+			nock('http://test/')
+				.get(`/appeals/linkable-appeal/${testInvalidLinkableAppealReference}`)
+				.reply(404);
 
 			const response = await request.post(`${baseUrl}/1${linkedAppealsPath}/add`).send({
-				'appeal-reference': '123'
+				'appeal-reference': testInvalidLinkableAppealReference
 			});
 			const element = parseHtml(response.text);
 
@@ -158,11 +210,11 @@ describe('linked-appeals', () => {
 			nock.cleanAll();
 			nock('http://test/').get('/appeals/1').reply(200, appealData);
 			nock('http://test/')
-				.get('/appeals/linkable-appeal/123')
+				.get(`/appeals/linkable-appeal/${testValidLinkableAppealReference}`)
 				.reply(200, linkableAppealSummaryBackOffice);
 
 			const response = await request.post(`${baseUrl}/1${linkedAppealsPath}/add`).send({
-				'appeal-reference': '123'
+				'appeal-reference': testValidLinkableAppealReference
 			});
 
 			expect(response.statusCode).toBe(302);
@@ -184,13 +236,13 @@ describe('linked-appeals', () => {
 					appealReference: linkableAppealSummaryBackOffice.appealReference
 				});
 			nock('http://test/')
-				.get('/appeals/linkable-appeal/123')
+				.get(`/appeals/linkable-appeal/${testValidLinkableAppealReference}`)
 				.reply(200, linkableAppealSummaryBackOffice);
 
 			const addLinkedAppealReferenceResponse = await request
 				.post(`${baseUrl}/1${linkedAppealsPath}/add`)
 				.send({
-					'appeal-reference': '123'
+					'appeal-reference': testValidLinkableAppealReference
 				});
 
 			expect(addLinkedAppealReferenceResponse.statusCode).toBe(302);
@@ -241,7 +293,7 @@ describe('linked-appeals', () => {
 			nock.cleanAll();
 			nock('http://test/').get('/appeals/1').reply(200, appealData).persist();
 			nock('http://test/')
-				.get('/appeals/linkable-appeal/123')
+				.get(`/appeals/linkable-appeal/${testValidLinkableAppealReference}`)
 				.reply(200, {
 					...linkableAppealSummaryBackOffice,
 					appealId: appealData.appealId,
@@ -251,7 +303,7 @@ describe('linked-appeals', () => {
 			const addLinkedAppealReferenceResponse = await request
 				.post(`${baseUrl}/1${linkedAppealsPath}/add`)
 				.send({
-					'appeal-reference': '123'
+					'appeal-reference': testValidLinkableAppealReference
 				});
 
 			expect(addLinkedAppealReferenceResponse.statusCode).toBe(302);
@@ -303,13 +355,13 @@ describe('linked-appeals', () => {
 					appealReference: linkableAppealSummaryBackOffice.appealReference
 				});
 			nock('http://test/')
-				.get('/appeals/linkable-appeal/123')
+				.get(`/appeals/linkable-appeal/${testValidLinkableAppealReference}`)
 				.reply(200, linkableAppealSummaryBackOffice);
 
 			const addLinkedAppealReferenceResponse = await request
 				.post(`${baseUrl}/1${linkedAppealsPath}/add`)
 				.send({
-					'appeal-reference': '123'
+					'appeal-reference': testValidLinkableAppealReference
 				});
 
 			expect(addLinkedAppealReferenceResponse.statusCode).toBe(302);
@@ -359,13 +411,13 @@ describe('linked-appeals', () => {
 				})
 				.persist();
 			nock('http://test/')
-				.get('/appeals/linkable-appeal/123')
+				.get(`/appeals/linkable-appeal/${testValidLinkableAppealReference}`)
 				.reply(200, linkableAppealSummaryBackOffice);
 
 			const addLinkedAppealReferenceResponse = await request
 				.post(`${baseUrl}/1${linkedAppealsPath}/add`)
 				.send({
-					'appeal-reference': '123'
+					'appeal-reference': testValidLinkableAppealReference
 				});
 
 			expect(addLinkedAppealReferenceResponse.statusCode).toBe(302);
@@ -415,13 +467,13 @@ describe('linked-appeals', () => {
 				})
 				.persist();
 			nock('http://test/')
-				.get('/appeals/linkable-appeal/123')
+				.get(`/appeals/linkable-appeal/${testValidLinkableAppealReference}`)
 				.reply(200, linkableAppealSummaryBackOffice);
 
 			const addLinkedAppealReferenceResponse = await request
 				.post(`${baseUrl}/1${linkedAppealsPath}/add`)
 				.send({
-					'appeal-reference': '123'
+					'appeal-reference': testValidLinkableAppealReference
 				});
 
 			expect(addLinkedAppealReferenceResponse.statusCode).toBe(302);
@@ -470,13 +522,13 @@ describe('linked-appeals', () => {
 				})
 				.persist();
 			nock('http://test/')
-				.get('/appeals/linkable-appeal/123')
+				.get(`/appeals/linkable-appeal/${testValidLinkableAppealReference}`)
 				.reply(200, linkableAppealSummaryBackOffice);
 
 			const addLinkedAppealReferenceResponse = await request
 				.post(`${baseUrl}/1${linkedAppealsPath}/add`)
 				.send({
-					'appeal-reference': '123'
+					'appeal-reference': testValidLinkableAppealReference
 				});
 
 			expect(addLinkedAppealReferenceResponse.statusCode).toBe(302);
@@ -526,13 +578,13 @@ describe('linked-appeals', () => {
 				})
 				.persist();
 			nock('http://test/')
-				.get('/appeals/linkable-appeal/123')
+				.get(`/appeals/linkable-appeal/${testValidLinkableAppealReference}`)
 				.reply(200, linkableAppealSummaryBackOffice);
 
 			const addLinkedAppealReferenceResponse = await request
 				.post(`${baseUrl}/1${linkedAppealsPath}/add`)
 				.send({
-					'appeal-reference': '123'
+					'appeal-reference': testValidLinkableAppealReference
 				});
 
 			expect(addLinkedAppealReferenceResponse.statusCode).toBe(302);
@@ -582,13 +634,13 @@ describe('linked-appeals', () => {
 				})
 				.persist();
 			nock('http://test/')
-				.get('/appeals/linkable-appeal/123')
+				.get(`/appeals/linkable-appeal/${testValidLinkableAppealReference}`)
 				.reply(200, linkableAppealSummaryBackOffice);
 
 			const addLinkedAppealReferenceResponse = await request
 				.post(`${baseUrl}/1${linkedAppealsPath}/add`)
 				.send({
-					'appeal-reference': '123'
+					'appeal-reference': testValidLinkableAppealReference
 				});
 
 			expect(addLinkedAppealReferenceResponse.statusCode).toBe(302);
@@ -640,13 +692,13 @@ describe('linked-appeals', () => {
 				})
 				.persist();
 			nock('http://test/')
-				.get('/appeals/linkable-appeal/123')
+				.get(`/appeals/linkable-appeal/${testValidLinkableAppealReference}`)
 				.reply(200, linkableAppealSummaryBackOffice);
 
 			const addLinkedAppealReferenceResponse = await request
 				.post(`${baseUrl}/1${linkedAppealsPath}/add`)
 				.send({
-					'appeal-reference': '123'
+					'appeal-reference': testValidLinkableAppealReference
 				});
 
 			expect(addLinkedAppealReferenceResponse.statusCode).toBe(302);
@@ -698,13 +750,13 @@ describe('linked-appeals', () => {
 				})
 				.persist();
 			nock('http://test/')
-				.get('/appeals/linkable-appeal/123')
+				.get(`/appeals/linkable-appeal/${testValidLinkableAppealReference}`)
 				.reply(200, linkableAppealSummaryBackOffice);
 
 			const addLinkedAppealReferenceResponse = await request
 				.post(`${baseUrl}/1${linkedAppealsPath}/add`)
 				.send({
-					'appeal-reference': '123'
+					'appeal-reference': testValidLinkableAppealReference
 				});
 
 			expect(addLinkedAppealReferenceResponse.statusCode).toBe(302);
@@ -762,13 +814,13 @@ describe('linked-appeals', () => {
 				})
 				.persist();
 			nock('http://test/')
-				.get('/appeals/linkable-appeal/123')
+				.get(`/appeals/linkable-appeal/${testValidLinkableAppealReference}`)
 				.reply(200, linkableAppealSummaryBackOffice);
 
 			const addLinkedAppealReferenceResponse = await request
 				.post(`${baseUrl}/1${linkedAppealsPath}/add`)
 				.send({
-					'appeal-reference': '123'
+					'appeal-reference': testValidLinkableAppealReference
 				});
 
 			expect(addLinkedAppealReferenceResponse.statusCode).toBe(302);
@@ -820,13 +872,13 @@ describe('linked-appeals', () => {
 				})
 				.persist();
 			nock('http://test/')
-				.get('/appeals/linkable-appeal/123')
+				.get(`/appeals/linkable-appeal/${testValidLinkableAppealReference}`)
 				.reply(200, linkableAppealSummaryBackOffice);
 
 			const addLinkedAppealReferenceResponse = await request
 				.post(`${baseUrl}/1${linkedAppealsPath}/add`)
 				.send({
-					'appeal-reference': '123'
+					'appeal-reference': testValidLinkableAppealReference
 				});
 
 			expect(addLinkedAppealReferenceResponse.statusCode).toBe(302);
@@ -880,13 +932,13 @@ describe('linked-appeals', () => {
 				})
 				.persist();
 			nock('http://test/')
-				.get('/appeals/linkable-appeal/123')
+				.get(`/appeals/linkable-appeal/${testValidLinkableAppealReference}`)
 				.reply(200, linkableAppealSummaryBackOffice);
 
 			const addLinkedAppealReferenceResponse = await request
 				.post(`${baseUrl}/1${linkedAppealsPath}/add`)
 				.send({
-					'appeal-reference': '123'
+					'appeal-reference': testValidLinkableAppealReference
 				});
 
 			expect(addLinkedAppealReferenceResponse.statusCode).toBe(302);
@@ -937,13 +989,13 @@ describe('linked-appeals', () => {
 				})
 				.persist();
 			nock('http://test/')
-				.get('/appeals/linkable-appeal/123')
+				.get(`/appeals/linkable-appeal/${testValidLinkableAppealReference}`)
 				.reply(200, linkableAppealSummaryBackOffice);
 
 			const addLinkedAppealReferenceResponse = await request
 				.post(`${baseUrl}/1${linkedAppealsPath}/add`)
 				.send({
-					'appeal-reference': '123'
+					'appeal-reference': testValidLinkableAppealReference
 				});
 
 			expect(addLinkedAppealReferenceResponse.statusCode).toBe(302);
@@ -986,14 +1038,14 @@ describe('linked-appeals', () => {
 				})
 				.persist();
 			nock('http://test/')
-				.get('/appeals/linkable-appeal/123')
+				.get(`/appeals/linkable-appeal/${testValidLinkableAppealReference}`)
 				.reply(200, linkableAppealSummaryBackOffice);
 			nock('http://test/').post('/appeals/1/link-appeal').reply(200, {});
 
 			const addLinkedAppealReferenceResponse = await request
 				.post(`${baseUrl}/1${linkedAppealsPath}/add`)
 				.send({
-					'appeal-reference': '123'
+					'appeal-reference': testValidLinkableAppealReference
 				});
 
 			expect(addLinkedAppealReferenceResponse.statusCode).toBe(302);
@@ -1034,14 +1086,14 @@ describe('linked-appeals', () => {
 				})
 				.persist();
 			nock('http://test/')
-				.get('/appeals/linkable-appeal/123')
+				.get(`/appeals/linkable-appeal/${testValidLinkableAppealReference}`)
 				.reply(200, linkableAppealSummaryBackOffice);
 			nock('http://test/').post('/appeals/1/link-appeal').reply(200, {});
 
 			const addLinkedAppealReferenceResponse = await request
 				.post(`${baseUrl}/1${linkedAppealsPath}/add`)
 				.send({
-					'appeal-reference': '123'
+					'appeal-reference': testValidLinkableAppealReference
 				});
 
 			expect(addLinkedAppealReferenceResponse.statusCode).toBe(302);
@@ -1082,14 +1134,14 @@ describe('linked-appeals', () => {
 				})
 				.persist();
 			nock('http://test/')
-				.get('/appeals/linkable-appeal/123')
+				.get(`/appeals/linkable-appeal/${testValidLinkableAppealReference}`)
 				.reply(200, linkableAppealSummaryHorizon);
 			nock('http://test/').post('/appeals/1/link-legacy-appeal').reply(200, {});
 
 			const addLinkedAppealReferenceResponse = await request
 				.post(`${baseUrl}/1${linkedAppealsPath}/add`)
 				.send({
-					'appeal-reference': '123'
+					'appeal-reference': testValidLinkableAppealReference
 				});
 
 			expect(addLinkedAppealReferenceResponse.statusCode).toBe(302);
@@ -1130,14 +1182,14 @@ describe('linked-appeals', () => {
 				})
 				.persist();
 			nock('http://test/')
-				.get('/appeals/linkable-appeal/123')
+				.get(`/appeals/linkable-appeal/${testValidLinkableAppealReference}`)
 				.reply(200, linkableAppealSummaryHorizon);
 			nock('http://test/').post('/appeals/1/link-legacy-appeal').reply(200, {});
 
 			const addLinkedAppealReferenceResponse = await request
 				.post(`${baseUrl}/1${linkedAppealsPath}/add`)
 				.send({
-					'appeal-reference': '123'
+					'appeal-reference': testValidLinkableAppealReference
 				});
 
 			expect(addLinkedAppealReferenceResponse.statusCode).toBe(302);

--- a/appeals/web/src/server/appeals/appeal-details/manage-linked-appeals/manage-linked-appeals.validators.js
+++ b/appeals/web/src/server/appeals/appeal-details/manage-linked-appeals/manage-linked-appeals.validators.js
@@ -9,6 +9,9 @@ export const validateAddLinkedAppealReference = createValidator(
 		.notEmpty()
 		.withMessage('Enter an appeal reference')
 		.bail()
+		.isLength({ min: 7, max: 7 })
+		.withMessage('Appeal reference must be 7 digits')
+		.bail()
 		.custom(async (reference, { req }) => {
 			try {
 				const linkableAppealSummary = await getLinkableAppealByReference(

--- a/appeals/web/src/server/appeals/appeal-details/other-appeals/__tests__/__snapshots__/other-appeals.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/other-appeals/__tests__/__snapshots__/other-appeals.test.js.snap
@@ -233,7 +233,7 @@ exports[`other-appeals POST /other-appeals/add should re-render the "What is the
     <form method="POST">
         <div class="govuk-form-group">
             <input class="govuk-input govuk-input--width-10" id="addOtherAppealsReference"
-            name="addOtherAppealsReference" type="text" value="1">
+            name="addOtherAppealsReference" type="text" value="7654321">
         </div>
         <button type="submit" class="govuk-button govuk-button" data-module="govuk-button"
         id="filters-submit">Continue</button>
@@ -267,6 +267,72 @@ exports[`other-appeals POST /other-appeals/add should re-render the "What is the
         <div class="govuk-form-group">
             <input class="govuk-input govuk-input--width-10" id="addOtherAppealsReference"
             name="addOtherAppealsReference" type="text">
+        </div>
+        <button type="submit" class="govuk-button govuk-button" data-module="govuk-button"
+        id="filters-submit">Continue</button>
+    </form>
+</main>"
+`;
+
+exports[`other-appeals POST /other-appeals/add should re-render the "What is the appeal reference?" page with the expected error, if the provided appeal reference is greater than 7 digits 1`] = `
+"<main class="govuk-main-wrapper " id="main-content" role="main">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <div class="govuk-error-summary" data-module="govuk-error-summary">
+                <div role="alert">
+                    <h2 class="govuk-error-summary__title"> There is a problem</h2>
+                    <div class="govuk-error-summary__body">
+                        <ul class="govuk-list govuk-error-summary__list">
+                            <li><a href="#addOtherAppealsReference">Appeal reference must be 7 digits</a>
+                            </li>
+                        </ul>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full"><span class="govuk-caption-l govuk-!-margin-bottom-3">Appeal APP/Q9999/D/21/351062</span>
+            <h1             class="govuk-heading-xl govuk-!-margin-bottom-3">What is the appeal reference?</h1>
+        </div>
+    </div>
+    <form method="POST">
+        <div class="govuk-form-group">
+            <input class="govuk-input govuk-input--width-10" id="addOtherAppealsReference"
+            name="addOtherAppealsReference" type="text" value="12345678">
+        </div>
+        <button type="submit" class="govuk-button govuk-button" data-module="govuk-button"
+        id="filters-submit">Continue</button>
+    </form>
+</main>"
+`;
+
+exports[`other-appeals POST /other-appeals/add should re-render the "What is the appeal reference?" page with the expected error, if the provided appeal reference is less than 7 digits 1`] = `
+"<main class="govuk-main-wrapper " id="main-content" role="main">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <div class="govuk-error-summary" data-module="govuk-error-summary">
+                <div role="alert">
+                    <h2 class="govuk-error-summary__title"> There is a problem</h2>
+                    <div class="govuk-error-summary__body">
+                        <ul class="govuk-list govuk-error-summary__list">
+                            <li><a href="#addOtherAppealsReference">Appeal reference must be 7 digits</a>
+                            </li>
+                        </ul>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full"><span class="govuk-caption-l govuk-!-margin-bottom-3">Appeal APP/Q9999/D/21/351062</span>
+            <h1             class="govuk-heading-xl govuk-!-margin-bottom-3">What is the appeal reference?</h1>
+        </div>
+    </div>
+    <form method="POST">
+        <div class="govuk-form-group">
+            <input class="govuk-input govuk-input--width-10" id="addOtherAppealsReference"
+            name="addOtherAppealsReference" type="text" value="123456">
         </div>
         <button type="submit" class="govuk-button govuk-button" data-module="govuk-button"
         id="filters-submit">Continue</button>

--- a/appeals/web/src/server/appeals/appeal-details/other-appeals/other-appeals.validators.js
+++ b/appeals/web/src/server/appeals/appeal-details/other-appeals/other-appeals.validators.js
@@ -8,6 +8,9 @@ export const validateAddOtherAppealsReference = createValidator(
 		.trim()
 		.notEmpty()
 		.withMessage('Enter an appeal reference')
+		.isLength({ min: 7, max: 7 })
+		.withMessage('Appeal reference must be 7 digits')
+		.bail()
 		.custom(async (reference, { req }) => {
 			try {
 				const linkableAppealSummary = await getLinkableAppealSummaryFromReference(


### PR DESCRIPTION
## Describe your changes

add validation for linkable appeal reference length on linked and related appeals flows. Fixes bugs relating to user entering appeal references fewer or greater than 7 digits in length.

## Issue ticket number and link

A2-402

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [ ] I have performed a self-review of my own code
- [ ] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [ ] I have referenced the ticket number above
- [ ] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
