### PR TITLE
fix(web): security logs update reverted (partially)

### DIFF
--- a/appeals/web/src/server/appeals/appeal-documents/appeal-documents.controller.js
+++ b/appeals/web/src/server/appeals/appeal-documents/appeal-documents.controller.js
@@ -725,7 +725,6 @@ export const postDeleteDocument = async (
 	if (
 		!isInternalUrl(returnUrl, request) ||
 		!isInternalUrl(cancelUrl, request) ||
-		!isInternalUrl(cancelUrlProcessed, request) ||
 		!isInternalUrl(uploadNewDocumentUrl, request)
 	) {
 		return response.status(400).render('errorPageTemplate', {
@@ -734,11 +733,7 @@ export const postDeleteDocument = async (
 	}
 
 	if (body['delete-file-answer'] === 'no') {
-		const cancelUrlProcessedSafe = new URL(
-			cancelUrlProcessed,
-			`${request.protocol}://${request.headers.host}`
-		);
-		return response.redirect(cancelUrlProcessedSafe.toString());
+		return response.redirect(cancelUrlProcessed);
 	} else if (body['delete-file-answer'] === 'yes') {
 		await deleteDocument(apiClient, appealId, documentId, versionId);
 		addNotificationBannerToSession(
@@ -746,9 +741,7 @@ export const postDeleteDocument = async (
 			'documentDeleted',
 			Number.parseInt(appealId, 10)
 		);
-
-		const returnUrlSafe = new URL(returnUrl, `${request.protocol}://${request.headers.host}`);
-		return response.redirect(returnUrlSafe.toString());
+		return response.redirect(returnUrl);
 	} else if (body['delete-file-answer'] === 'yes-and-upload-another-document') {
 		const fileVersionsInfo = await getFileVersionsInfo(request.apiClient, appealId, documentId);
 
@@ -758,12 +751,7 @@ export const postDeleteDocument = async (
 
 			if (deletingOnlyVersion) {
 				await deleteDocument(apiClient, appealId, documentId, versionId);
-
-				const uploadNewDocumentUrlProcessedSafe = new URL(
-					uploadNewDocumentUrlProcessed,
-					`${request.protocol}://${request.headers.host}`
-				);
-				return response.redirect(uploadNewDocumentUrlProcessedSafe.toString());
+				return response.redirect(uploadNewDocumentUrlProcessed);
 			} else {
 				return response.status(500).render('app/500.njk');
 			}


### PR DESCRIPTION
## Describe your changes

Redirects are failing on appeal documents on DEV and TEST only.
It seems to coincide with a recent PR addressing security logs and looks consistent with where it's failing.
https://github.com/Planning-Inspectorate/appeals-back-office/pull/307

This reverts a small part of that code update.

## Issue ticket number and link

[A2-616 WEB/API - cannot remove documents from manage file page ](https://pins-ds.atlassian.net.mcas.ms/browse/A2-616)

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
