### PR TITLE
feat(api): audit trails for appellant case and lpaq

### DIFF
--- a/appeals/api/src/server/endpoints/addresses/addresses.controller.js
+++ b/appeals/api/src/server/endpoints/addresses/addresses.controller.js
@@ -1,7 +1,8 @@
 import logger from '#utils/logger.js';
-import { ERROR_FAILED_TO_SAVE_DATA } from '../constants.js';
+import { AUDIT_TRAIL_ADDRESS_UPDATED, ERROR_FAILED_TO_SAVE_DATA } from '../constants.js';
 import { formatAddress } from './addresses.formatter.js';
 import addressRepository from '#repositories/address.repository.js';
+import { createAuditTrail } from '#endpoints/audit-trails/audit-trails.service.js';
 
 /** @typedef {import('express').Request} Request */
 /** @typedef {import('express').Response} Response */
@@ -26,7 +27,7 @@ const getAddressById = async (req, res) => {
 const updateAddressById = async (req, res) => {
 	const {
 		body: { addressLine1, addressLine2, country, county, postcode, town },
-		params: { addressId }
+		params: { appealId, addressId }
 	} = req;
 
 	const updateAddress = {
@@ -46,6 +47,12 @@ const updateAddressById = async (req, res) => {
 			return res.status(500).send({ errors: { body: ERROR_FAILED_TO_SAVE_DATA } });
 		}
 	}
+
+	await createAuditTrail({
+		appealId: parseInt(appealId),
+		azureAdUserId: req.get('azureAdUserId'),
+		details: AUDIT_TRAIL_ADDRESS_UPDATED
+	});
 
 	return res.send(updateAddress);
 };

--- a/appeals/api/src/server/endpoints/appellant-cases/appellant-cases.controller.js
+++ b/appeals/api/src/server/endpoints/appellant-cases/appellant-cases.controller.js
@@ -1,12 +1,14 @@
 import { getFoldersForAppeal } from '#endpoints/documents/documents.service.js';
-import { ERROR_FAILED_TO_SAVE_DATA } from '#endpoints/constants.js';
+import * as CONSTANTS from '#endpoints/constants.js';
 import { APPEAL_CASE_STAGE } from 'pins-data-model';
 import appellantCaseRepository from '#repositories/appellant-case.repository.js';
 import logger from '#utils/logger.js';
 import { formatAppellantCase } from './appellant-cases.formatter.js';
 import { updateAppellantCaseValidationOutcome } from './appellant-cases.service.js';
 import { formatAddressSingleLine } from '#endpoints/addresses/addresses.formatter.js';
+import { createAuditTrail } from '#endpoints/audit-trails/audit-trails.service.js';
 import { broadcasters } from '#endpoints/integrations/integrations.broadcasters.js';
+import { camelToScreamingSnake } from '#utils/string-utils.js';
 
 /** @typedef {import('express').Request} Request */
 /** @typedef {import('express').Response} Response */
@@ -106,11 +108,31 @@ const updateAppellantCaseById = async (req, res) => {
 					applicationDecision
 			  });
 
+		const updatedProperties = Object.keys(body).filter((key) => body[key] !== undefined);
+		let auditTrailDetail = CONSTANTS.AUDIT_TRAIL_APPELLANT_CASE_UPDATED;
+
+		if (updatedProperties.length === 1) {
+			const updatedProperty = updatedProperties[0];
+			const constantKey = `AUDIT_TRAIL_${camelToScreamingSnake(updatedProperty)}_UPDATED`;
+			// @ts-ignore
+			auditTrailDetail = CONSTANTS[constantKey] || auditTrailDetail;
+		} else if (updatedProperties.length > 1) {
+			if (updatedProperties.includes('ownsSomeLand') && updatedProperties.includes('ownsAllLand')) {
+				auditTrailDetail = CONSTANTS.AUDIT_TRAIL_SITE_OWNERSHIP_UPDATED;
+			}
+		}
+
+		await createAuditTrail({
+			appealId: appeal.id,
+			azureAdUserId: req.get('azureAdUserId'),
+			details: auditTrailDetail
+		});
+
 		await broadcasters.broadcastAppeal(appeal.id);
 	} catch (error) {
 		if (error) {
 			logger.error(error);
-			return res.status(500).send({ errors: { body: ERROR_FAILED_TO_SAVE_DATA } });
+			return res.status(500).send({ errors: { body: CONSTANTS.ERROR_FAILED_TO_SAVE_DATA } });
 		}
 	}
 

--- a/appeals/api/src/server/endpoints/constants.js
+++ b/appeals/api/src/server/endpoints/constants.js
@@ -45,11 +45,31 @@ export const AUDIT_TRAIL_APPEAL_LINK_ADDED = 'A linked appeal was added';
 export const AUDIT_TRAIL_APPEAL_LINK_REMOVED = 'A linked appeal was removed';
 export const AUDIT_TRAIL_APPEAL_RELATION_ADDED = 'A related appeal was added';
 export const AUDIT_TRAIL_APPEAL_RELATION_REMOVED = 'A related appeal was removed';
-export const AUDIT_TRAIL_ADDRESS_ADDED = 'A neighbouring address was added';
-export const AUDIT_TRAIL_ADDRESS_UPDATED = 'A neighbouring address was updated';
-export const AUDIT_TRAIL_ADDRESS_REMOVED = 'A neighbouring address was removed';
+export const AUDIT_TRAIL_NEIGHBOURING_ADDRESS_ADDED = 'A neighbouring address was added';
+export const AUDIT_TRAIL_NEIGHBOURING_ADDRESS_UPDATED = 'A neighbouring address was updated';
+export const AUDIT_TRAIL_NEIGHBOURING_ADDRESS_REMOVED = 'A neighbouring address was removed';
 export const AUDIT_TRAIL_SYSTEM_UUID = '00000000-0000-0000-0000-000000000000';
 export const AUDIT_TRAIL_SERVICE_USER_UPDATED = 'The {replacement0}’s details were updated';
+export const AUDIT_TRAIL_ADDRESS_UPDATED = 'Site address updated';
+export const AUDIT_TRAIL_APPELLANT_CASE_UPDATED = 'Appellant case updated';
+export const AUDIT_TRAIL_SITE_AREA_SQUARE_METRES_UPDATED = 'Site area updated';
+export const AUDIT_TRAIL_IS_GREEN_BELT_UPDATED = 'Green belt status updated';
+export const AUDIT_TRAIL_SITE_OWNERSHIP_UPDATED = 'Site ownership updated';
+export const AUDIT_TRAIL_KNOWS_OTHER_OWNERS_UPDATED = 'Owners known updated';
+export const AUDIT_TRAIL_SITE_ACCESS_DETAILS_UPDATED = 'Inspector access (appellant) updated';
+export const AUDIT_TRAIL_SITE_SAFETY_DETAILS_UPDATED =
+	'Site health and safety risks (appellant answer) updated';
+export const AUDIT_TRAIL_APPLICATION_DATE_UPDATED = 'Date application submitted updated';
+export const AUDIT_TRAIL_DEVELOPMENT_DESCRIPTION_UPDATED =
+	'Original development description has been updated';
+export const AUDIT_TRAIL_APPLICATION_DECISION_DATE_UPDATED = 'Application decision date updated';
+export const AUDIT_TRAIL_LPAQ_UPDATED = 'LPA questionnaire updated';
+export const AUDIT_TRAIL_LPAQ_IS_CORRECT_APPEAL_TYPE_UPDATED =
+	'Correct appeal type (LPA response) has been updated';
+export const AUDIT_TRAIL_LPAQ_IS_GREEN_BELT_UPDATED = 'Green belt status updated';
+export const AUDIT_TRAIL_LPAQ_SITE_ACCESS_DETAILS_UPDATED = 'Inspector access (lpa) updated';
+export const AUDIT_TRAIL_LPAQ_SITE_SAFETY_DETAILS_UPDATED =
+	'Site health and safety risks (LPA answer) updated';
 
 export const BANK_HOLIDAY_FEED_DIVISION_ENGLAND = 'england-and-wales';
 

--- a/appeals/api/src/server/endpoints/neighbouring-sites/neighbouring-sites.controller.js
+++ b/appeals/api/src/server/endpoints/neighbouring-sites/neighbouring-sites.controller.js
@@ -3,9 +3,9 @@ import neighbouringSitesRepository from '#repositories/neighbouring-sites.reposi
 import { createAuditTrail } from '#endpoints/audit-trails/audit-trails.service.js';
 import { broadcasters } from '#endpoints/integrations/integrations.broadcasters.js';
 import {
-	AUDIT_TRAIL_ADDRESS_ADDED,
-	AUDIT_TRAIL_ADDRESS_UPDATED,
-	AUDIT_TRAIL_ADDRESS_REMOVED
+	AUDIT_TRAIL_NEIGHBOURING_ADDRESS_ADDED,
+	AUDIT_TRAIL_NEIGHBOURING_ADDRESS_UPDATED,
+	AUDIT_TRAIL_NEIGHBOURING_ADDRESS_REMOVED
 } from '#endpoints/constants.js';
 import formatAddress from '#utils/format-address.js';
 
@@ -33,7 +33,7 @@ export const addNeighbouringSite = async (req, res) => {
 		await createAuditTrail({
 			appealId: appeal.id,
 			azureAdUserId: req.get('azureAdUserId'),
-			details: AUDIT_TRAIL_ADDRESS_ADDED
+			details: AUDIT_TRAIL_NEIGHBOURING_ADDRESS_ADDED
 		});
 
 		await broadcasters.broadcastAppeal(appeal.id);
@@ -71,7 +71,7 @@ export const updateNeighbouringSite = async (req, res) => {
 	await createAuditTrail({
 		appealId: appeal.id,
 		azureAdUserId: req.get('azureAdUserId'),
-		details: AUDIT_TRAIL_ADDRESS_UPDATED
+		details: AUDIT_TRAIL_NEIGHBOURING_ADDRESS_UPDATED
 	});
 
 	await broadcasters.broadcastAppeal(appeal.id);
@@ -98,7 +98,7 @@ export const removeNeighbouringSite = async (req, res) => {
 	await createAuditTrail({
 		appealId: appeal.id,
 		azureAdUserId: req.get('azureAdUserId'),
-		details: AUDIT_TRAIL_ADDRESS_REMOVED
+		details: AUDIT_TRAIL_NEIGHBOURING_ADDRESS_REMOVED
 	});
 
 	await broadcasters.broadcastAppeal(appeal.id);

--- a/appeals/api/src/server/tests/appeals/mocks.js
+++ b/appeals/api/src/server/tests/appeals/mocks.js
@@ -131,7 +131,8 @@ export const householdAppeal = {
 		ownsAllLand: true,
 		ownsSomeLand: true,
 		siteAccessDetails: 'There is no mobile reception at the site',
-		siteSafetyDetails: 'Small dog big character'
+		siteSafetyDetails: 'Small dog big character',
+		siteAreaSquareMetres: '100'
 	},
 	caseOfficer: {
 		id: 1,

--- a/appeals/api/src/server/utils/__tests__/string-utils.test.js
+++ b/appeals/api/src/server/utils/__tests__/string-utils.test.js
@@ -1,4 +1,4 @@
-import { toCamelCase } from '#utils/string-utils.js';
+import { toCamelCase, camelToScreamingSnake } from '#utils/string-utils.js';
 
 describe('toCamelCase', () => {
 	test('converts a single word to lowercase', () => {
@@ -24,5 +24,33 @@ describe('toCamelCase', () => {
 
 	test('handles empty strings', () => {
 		expect(toCamelCase('')).toBe('');
+	});
+});
+
+describe('camelToScreamingSnake', () => {
+	test('converts camelCase to SCREAMING_SNAKE_CASE', () => {
+		expect(camelToScreamingSnake('helloWorld')).toBe('HELLO_WORLD');
+		expect(camelToScreamingSnake('accessRequired')).toBe('ACCESS_REQUIRED');
+		expect(camelToScreamingSnake('applicantFirstName')).toBe('APPLICANT_FIRST_NAME');
+		expect(camelToScreamingSnake('siteAccessDetails')).toBe('SITE_ACCESS_DETAILS');
+	});
+
+	test('handles strings with mixed case correctly', () => {
+		expect(camelToScreamingSnake('hElLoWoRLd')).toBe('H_EL_LO_WO_R_LD');
+		expect(camelToScreamingSnake('AccessRequired')).toBe('ACCESS_REQUIRED');
+	});
+
+	test('handles strings with single word correctly', () => {
+		expect(camelToScreamingSnake('hello')).toBe('HELLO');
+		expect(camelToScreamingSnake('WORLD')).toBe('WORLD');
+	});
+
+	test('handles strings with no uppercase letters', () => {
+		expect(camelToScreamingSnake('helloworld')).toBe('HELLOWORLD');
+		expect(camelToScreamingSnake('accessrequired')).toBe('ACCESSREQUIRED');
+	});
+
+	test('handles empty strings correctly', () => {
+		expect(camelToScreamingSnake('')).toBe('');
 	});
 });

--- a/appeals/api/src/server/utils/__tests__/string-utils.test.js
+++ b/appeals/api/src/server/utils/__tests__/string-utils.test.js
@@ -50,6 +50,11 @@ describe('camelToScreamingSnake', () => {
 		expect(camelToScreamingSnake('accessrequired')).toBe('ACCESSREQUIRED');
 	});
 
+	test('removes spaces and then converts to SCREAMING_SNAKE_CASE', () => {
+		expect(camelToScreamingSnake('hello world')).toBe('HELLOWORLD');
+		expect(camelToScreamingSnake('Multiple   Spaces   Here')).toBe('MULTIPLE_SPACES_HERE');
+	});
+
 	test('handles empty strings correctly', () => {
 		expect(camelToScreamingSnake('')).toBe('');
 	});

--- a/appeals/api/src/server/utils/string-utils.js
+++ b/appeals/api/src/server/utils/string-utils.js
@@ -13,3 +13,19 @@ const toCamelCase = (str) => {
 };
 
 export { toCamelCase };
+
+/**
+ * Converts a string from camelCase to SCREAMING_SNAKE format.
+ * @param {string} str - The string to convert.
+ * @returns {string} - The SCREAMING_SNAKE formatted string.
+ */
+
+const camelToScreamingSnake = (str) => {
+	return str
+		.replace(/([a-z])([A-Z])/g, '$1_$2') // Lowercase to Uppercase transitions
+		.replace(/([A-Z]+)([A-Z][a-z])/g, '$1_$2') // Uppercase sequence followed by lowercase
+		.replace(/([A-Z])([A-Z][a-z])/g, '$1_$2') // Uppercase sequence followed by lowercase (catch-all)
+		.toUpperCase(); // Convert the entire string to uppercase
+};
+
+export { camelToScreamingSnake };

--- a/appeals/api/src/server/utils/string-utils.js
+++ b/appeals/api/src/server/utils/string-utils.js
@@ -22,6 +22,7 @@ export { toCamelCase };
 
 const camelToScreamingSnake = (str) => {
 	return str
+		.replace(/\s+/g, '') // Remove all spaces
 		.replace(/([a-z])([A-Z])/g, '$1_$2') // Lowercase to Uppercase transitions
 		.replace(/([A-Z]+)([A-Z][a-z])/g, '$1_$2') // Uppercase sequence followed by lowercase
 		.replace(/([A-Z])([A-Z][a-z])/g, '$1_$2') // Uppercase sequence followed by lowercase (catch-all)


### PR DESCRIPTION
## Describe your changes

Applies `createAuditTrail` where missing for appellant case and LPAQ change rows.
Adds a `camelToScreamingSnake` string util

## Issue ticket number and link

[A2-647](https://pins-ds.atlassian.net.mcas.ms/browse/A2-647)

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [x] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [x] I have included unit tests to cover any testable code changes


[A2-647]: https://pins-ds.atlassian.net/browse/A2-647?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ