### PR TITLE
Enable s78 data, based on flag

### DIFF
--- a/appeals/api/.env.test
+++ b/appeals/api/.env.test
@@ -26,3 +26,4 @@ BO_BLOB_STORAGE_ACCOUNT=https://127.0.0.1:10000/
 SWAGGER_JSON_DIR=./src/server/openapi.json
 SRV_HORIZON_URL=http://horizontest
 MOCK_HORIZON=false
+FEATURE_FLAG_S78_WRITTEN=true

--- a/appeals/api/src/database/seed/data-test.js
+++ b/appeals/api/src/database/seed/data-test.js
@@ -15,6 +15,7 @@ import { localPlanningDepartmentList } from './LPAs/dev.js';
 import { calculateTimetable } from '#utils/business-days.js';
 import {
 	APPEAL_TYPE_SHORTHAND_HAS,
+	APPEAL_TYPE_SHORTHAND_FPA,
 	CASE_RELATIONSHIP_LINKED,
 	CASE_RELATIONSHIP_RELATED
 } from '#endpoints/constants.js';
@@ -23,6 +24,7 @@ import neighbouringSitesRepository from '#repositories/neighbouring-sites.reposi
 import { createAppealReference } from '#utils/appeal-reference.js';
 import { FOLDERS } from '@pins/appeals/constants/documents.js';
 import { APPEAL_CASE_STATUS } from 'pins-data-model';
+import { isAppealTypeEnabled } from '#utils/feature-flags-appeal-types.js';
 
 /** @typedef {import('@pins/appeals.api').Appeals.AppealSite} AppealSite */
 
@@ -243,6 +245,27 @@ const newAppeals = [
 	})
 ];
 
+const newS78Appeals = [
+	appealFactory({ typeShorthand: APPEAL_TYPE_SHORTHAND_FPA, assignCaseOfficer: false }),
+	appealFactory({
+		typeShorthand: APPEAL_TYPE_SHORTHAND_FPA,
+		assignCaseOfficer: false,
+		agent: false
+	}),
+	appealFactory({ typeShorthand: APPEAL_TYPE_SHORTHAND_FPA, assignCaseOfficer: false }),
+	appealFactory({
+		typeShorthand: APPEAL_TYPE_SHORTHAND_FPA,
+		siteAddressList: addressListForTrainers,
+		assignCaseOfficer: false
+	}),
+	appealFactory({
+		typeShorthand: APPEAL_TYPE_SHORTHAND_FPA,
+		status: { status: APPEAL_CASE_STATUS.VALIDATION, createdAt: getDateTwoWeeksAgo() },
+		assignCaseOfficer: true,
+		agent: false
+	})
+];
+
 const appealsLpaQuestionnaireDue = [
 	appealFactory({
 		typeShorthand: APPEAL_TYPE_SHORTHAND_HAS,
@@ -373,6 +396,7 @@ const appealsLpaQuestionnaireDue = [
 		assignCaseOfficer: true
 	})
 ];
+
 const appealsReadyToStart = [
 	appealFactory({
 		typeShorthand: APPEAL_TYPE_SHORTHAND_HAS,
@@ -437,6 +461,10 @@ const appealsReadyToStart = [
 ];
 
 const appealsData = [...appealsReadyToStart, ...newAppeals, ...appealsLpaQuestionnaireDue];
+if (isAppealTypeEnabled(APPEAL_TYPE_SHORTHAND_FPA)) {
+	console.log('pushing s78');
+	appealsData.push(...newS78Appeals);
+}
 
 /**
  * @param {import('#db-client').PrismaClient} databaseConnector

--- a/appeals/api/src/database/seed/data-test.js
+++ b/appeals/api/src/database/seed/data-test.js
@@ -462,7 +462,7 @@ const appealsReadyToStart = [
 
 const appealsData = [...appealsReadyToStart, ...newAppeals, ...appealsLpaQuestionnaireDue];
 if (isAppealTypeEnabled(APPEAL_TYPE_SHORTHAND_FPA)) {
-	console.log('pushing s78');
+	console.log('Adding s78 cases');
 	appealsData.push(...newS78Appeals);
 }
 

--- a/appeals/api/src/server/config/config.js
+++ b/appeals/api/src/server/config/config.js
@@ -28,13 +28,8 @@ const { value, error } = schema.validate({
 		levelStdOut: environment.LOG_LEVEL_STDOUT || 'debug'
 	},
 	cwd: url.fileURLToPath(new URL('..', import.meta.url)),
-	// flag name convention: featureFlag[ jira number ][ferature shoret description]
-	// set Feature Flag default val here [default: false] - will be overwritted by values cming from the .env file
 	featureFlags: {
-		featureFlagBoas1TestFeature: !environment.FEATURE_FLAG_BOAS_1_TEST_FEATURE
-			? false
-			: environment.FEATURE_FLAG_BOAS_1_TEST_FEATURE === 'true',
-		featureFlagS78Written: environment.FEATURE_FLAG_S78_WRITTEN === 'false'
+		featureFlagS78Written: environment.FEATURE_FLAG_S78_WRITTEN === 'true'
 	},
 	serviceBusEnabled: environment.SERVICE_BUS_ENABLED && environment.SERVICE_BUS_ENABLED === 'true',
 	govNotify: {

--- a/appeals/api/src/server/endpoints/appeals/__tests__/appeals.test.js
+++ b/appeals/api/src/server/endpoints/appeals/__tests__/appeals.test.js
@@ -27,6 +27,7 @@ import stringTokenReplacement from '#utils/string-token-replacement.js';
 import { getIdsOfReferencedAppeals, mapAppealToDueDate } from '../appeals.formatter.js';
 import { mapAppealStatuses } from '../appeals.controller.js';
 import { APPEAL_CASE_STATUS } from 'pins-data-model';
+import { getEnabledAppealTypes } from '#utils/feature-flags-appeal-types.js';
 
 const { databaseConnector } = await import('#utils/database-connector.js');
 
@@ -167,6 +168,9 @@ describe('appeals list routes', () => {
 				expect(databaseConnector.appeal.findMany).toHaveBeenCalledWith(
 					expect.objectContaining({
 						where: {
+							appealType: {
+								key: { in: getEnabledAppealTypes() }
+							},
 							OR: [
 								{
 									reference: {
@@ -234,6 +238,9 @@ describe('appeals list routes', () => {
 				expect(databaseConnector.appeal.findMany).toHaveBeenCalledWith(
 					expect.objectContaining({
 						where: {
+							appealType: {
+								key: { in: getEnabledAppealTypes() }
+							},
 							OR: [
 								{
 									reference: {
@@ -301,6 +308,9 @@ describe('appeals list routes', () => {
 				expect(databaseConnector.appeal.findMany).toHaveBeenCalledWith(
 					expect.objectContaining({
 						where: {
+							appealType: {
+								key: { in: getEnabledAppealTypes() }
+							},
 							OR: [
 								{
 									reference: {
@@ -368,6 +378,9 @@ describe('appeals list routes', () => {
 				expect(databaseConnector.appeal.findMany).toHaveBeenCalledWith(
 					expect.objectContaining({
 						where: {
+							appealType: {
+								key: { in: getEnabledAppealTypes() }
+							},
 							appealStatus: {
 								some: {
 									status: 'assign_case_officer',
@@ -422,6 +435,9 @@ describe('appeals list routes', () => {
 				expect(databaseConnector.appeal.findMany).toHaveBeenCalledWith(
 					expect.objectContaining({
 						where: {
+							appealType: {
+								key: { in: getEnabledAppealTypes() }
+							},
 							appealStatus: {
 								some: {
 									valid: true
@@ -478,6 +494,9 @@ describe('appeals list routes', () => {
 				expect(databaseConnector.appeal.findMany).toHaveBeenCalledWith(
 					expect.objectContaining({
 						where: {
+							appealType: {
+								key: { in: getEnabledAppealTypes() }
+							},
 							appealStatus: {
 								some: {
 									valid: true

--- a/appeals/api/src/server/endpoints/integrations/integrations.middleware.js
+++ b/appeals/api/src/server/endpoints/integrations/integrations.middleware.js
@@ -7,7 +7,7 @@ import {
 	ERROR_INVALID_LPAQ_DATA,
 	ERROR_INVALID_DOCUMENT_DATA
 } from '#endpoints/constants.js';
-import { APPEAL_CASE_TYPE } from 'pins-data-model';
+import { getEnabledAppealTypes } from '#utils/feature-flags-appeal-types.js';
 
 /**
  * @type {import("express").RequestHandler}
@@ -41,7 +41,7 @@ export const validateAppellantCase = async (req, res, next) => {
  */
 export const validateCaseType = async (req, res, next) => {
 	const { body } = req;
-	const validCaseTypes = [APPEAL_CASE_TYPE.D];
+	const validCaseTypes = getEnabledAppealTypes();
 
 	const caseType = body.casedata?.caseType;
 	if (validCaseTypes.indexOf(caseType) === -1) {

--- a/appeals/api/src/server/middleware/check-appeal-exists-and-add-to-request.js
+++ b/appeals/api/src/server/middleware/check-appeal-exists-and-add-to-request.js
@@ -1,5 +1,6 @@
 import { ERROR_NOT_FOUND } from '#endpoints/constants.js';
 import appealRepository from '#repositories/appeal.repository.js';
+import { isAppealTypeEnabled } from '#utils/feature-flags-appeal-types.js';
 
 /** @typedef {import('express').Request} Request */
 /** @typedef {import('express').Response} Response */
@@ -17,7 +18,9 @@ export const checkAppealExistsByIdAndAddToRequest = async (req, res, next) => {
 	} = req;
 	const appeal = await appealRepository.getAppealById(Number(appealId));
 
-	if (!appeal) {
+	console.log('S78 enabled', isAppealTypeEnabled(appeal?.appealType?.key || ''));
+
+	if (!appeal || !isAppealTypeEnabled(appeal.appealType?.key || '')) {
 		return res.status(404).send({ errors: { appealId: ERROR_NOT_FOUND } });
 	}
 
@@ -37,7 +40,7 @@ export const checkAppealExistsByCaseReferenceAndAddToRequest = async (req, res, 
 	} = req;
 	const appeal = await appealRepository.getAppealByAppealReference(caseReference);
 
-	if (!appeal) {
+	if (!appeal || !isAppealTypeEnabled(appeal.appealType?.key || '')) {
 		return res.status(404).send({ errors: { caseReference: ERROR_NOT_FOUND } });
 	}
 

--- a/appeals/api/src/server/middleware/check-appeal-exists-and-add-to-request.js
+++ b/appeals/api/src/server/middleware/check-appeal-exists-and-add-to-request.js
@@ -18,8 +18,6 @@ export const checkAppealExistsByIdAndAddToRequest = async (req, res, next) => {
 	} = req;
 	const appeal = await appealRepository.getAppealById(Number(appealId));
 
-	console.log('S78 enabled', isAppealTypeEnabled(appeal?.appealType?.key || ''));
-
 	if (!appeal || !isAppealTypeEnabled(appeal.appealType?.key || '')) {
 		return res.status(404).send({ errors: { appealId: ERROR_NOT_FOUND } });
 	}

--- a/appeals/api/src/server/repositories/appeal-lists.repository.js
+++ b/appeals/api/src/server/repositories/appeal-lists.repository.js
@@ -1,6 +1,7 @@
 import { getSkipValue } from '#utils/database-pagination.js';
 import { databaseConnector } from '#utils/database-connector.js';
 import { APPEAL_CASE_STATUS } from 'pins-data-model';
+import { getEnabledAppealTypes } from '#utils/feature-flags-appeal-types.js';
 
 /** @typedef {import('@pins/appeals.api').Schema.Appeal} Appeal */
 /** @typedef {import('@pins/appeals.api').Schema.InspectorDecision} InspectorDecision */
@@ -25,6 +26,9 @@ const getAllAppeals = (pageNumber, pageSize, searchTerm, status, hasInspector) =
 				valid: true,
 				...(status !== 'undefined' && { status })
 			}
+		},
+		appealType: {
+			key: { in: getEnabledAppealTypes() }
 		},
 		...(searchTerm !== 'undefined' && {
 			OR: [
@@ -91,6 +95,7 @@ const getUserAppeals = (userId, pageNumber, pageSize, status) => {
 				some: { valid: true, status }
 			}
 		}),
+		appealType: { key: { in: getEnabledAppealTypes() } },
 		OR: [
 			{ inspector: { azureAdUserId: { equals: userId } } },
 			{ caseOfficer: { azureAdUserId: { equals: userId } } }

--- a/appeals/api/src/server/utils/feature-flags-appeal-types.js
+++ b/appeals/api/src/server/utils/feature-flags-appeal-types.js
@@ -1,0 +1,30 @@
+import { APPEAL_CASE_TYPE } from 'pins-data-model';
+import { isFeatureActive } from './feature-flags.js';
+import { FEATURE_FLAG_NAMES } from '@pins/appeals/constants/common.js';
+
+/**
+ *
+ * @param {string} type
+ * @returns
+ */
+export const isAppealTypeEnabled = (type) => {
+	switch (type) {
+		case APPEAL_CASE_TYPE.D: {
+			return true;
+		}
+		case APPEAL_CASE_TYPE.W: {
+			return isFeatureActive(FEATURE_FLAG_NAMES.SECTION_78);
+		}
+	}
+
+	return false;
+};
+
+export const getEnabledAppealTypes = () => {
+	const enabledAppeals = [APPEAL_CASE_TYPE.D];
+	if (isAppealTypeEnabled(APPEAL_CASE_TYPE.W)) {
+		enabledAppeals.push(APPEAL_CASE_TYPE.W);
+	}
+
+	return enabledAppeals;
+};

--- a/appeals/web/.env.test
+++ b/appeals/web/.env.test
@@ -79,9 +79,6 @@ DISABLE_REDIS=true
 DATABASE_URL="sqlserver://"
 PORT=0
 
-# FEATURE FLAGS  ####################################################################
-# flag name convention: FEATURE_FLAG_[ jira number ]_[ferature shoret description]
-FEATURE_FLAG_BOAS_1_TEST_FEATURE="true"
 
 AZURE_BLOB_STORE_HOST=https://127.0.0.1:10000/devstoreaccount1
 AZURE_BLOB_DEFAULT_CONTAINER=document-service-uploads

--- a/appeals/web/environment/config.js
+++ b/appeals/web/environment/config.js
@@ -50,7 +50,6 @@ export function loadConfig() {
 		AZURE_BLOB_DEFAULT_CONTAINER,
 		AZURE_BLOB_EMULATOR_SAS_HOST,
 		AZURE_BLOB_USE_EMULATOR,
-		FEATURE_FLAG_BOAS_1_TEST_FEATURE,
 		FEATURE_FLAG_S78_WRITTEN,
 		HORIZON_APPEAL_BASE_URL,
 		HTTP_PORT = 8080,
@@ -113,8 +112,7 @@ export function loadConfig() {
 		// flag name convention: featureFlag[ jira number ][feature short description]
 		// set Feature Flag default val here [default: false] - will be overwritted by values coming from the .env file
 		featureFlags: {
-			featureFlagBoas1TestFeature: FEATURE_FLAG_BOAS_1_TEST_FEATURE === 'true',
-			featureFlagS78Written: FEATURE_FLAG_S78_WRITTEN === 'false'
+			featureFlagS78Written: FEATURE_FLAG_S78_WRITTEN === 'true'
 		}
 	};
 


### PR DESCRIPTION
Adds logic depending on the value of FEATURE_FLAG_S78_WRITTEN env variable, in order to:
- Import S78 appeals
- Add S78 seed data
- Display S78 appeals in lists
- Access S78 appeal details

## Issue ticket number and link
General unblocking, but here's the epic: https://pins-ds.atlassian.net/browse/A2-730

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [ ] I have performed a self-review of my own code
- [ ] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [ ] I have referenced the ticket number above
- [ ] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
