### PR TITLE
feat(api): keep training data when running db seed

### DIFF
--- a/appeals/api/src/database/seed/seed-training.js
+++ b/appeals/api/src/database/seed/seed-training.js
@@ -2,7 +2,6 @@ import { databaseConnector } from '../../server/utils/database-connector.js';
 import { seedStaticData } from './data-static.js';
 import { seedLPAs } from './seed-lpas.js';
 import { localPlanningDepartmentList } from './LPAs/training.js';
-import { deleteAllRecords } from './seed-clear.js';
 
 /**
  * Seed the training database with the required static data
@@ -12,7 +11,6 @@ import { deleteAllRecords } from './seed-clear.js';
  */
 const seedTraining = async () => {
 	try {
-		await deleteAllRecords(databaseConnector);
 		await seedStaticData(databaseConnector);
 		await seedLPAs(databaseConnector, localPlanningDepartmentList);
 	} catch (error) {


### PR DESCRIPTION
Modifies the DB seed to case data is not deleted from the TRAINING env

## Issue ticket number and link

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [ ] I have performed a self-review of my own code
- [ ] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [ ] I have referenced the ticket number above
- [ ] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
