### PR TITLE
feat(appeals): add planning obligation boolean and status rows to s78 appellant case

### DIFF
--- a/appeals/api/src/database/seed/data-samples.js
+++ b/appeals/api/src/database/seed/data-samples.js
@@ -10,7 +10,7 @@ import {
 /**
  * @returns {boolean}
  */
-const randomBool = () => Math.random() < 0.5;
+export const randomBool = () => Math.random() < 0.5;
 
 /**
  * @typedef {import('@pins/appeals.api').Schema.LPAQuestionnaire} LPAQuestionnaire
@@ -275,7 +275,9 @@ export const appellantCaseList = {
 		hasAdvertisedAppeal: false,
 		originalDevelopmentDescription: 'lorem ipsum',
 		changedDevelopmentDescription: false,
-		isGreenBelt: randomBool()
+		isGreenBelt: randomBool(),
+		planningObligation: true,
+		statusPlanningObligation: null
 	}
 };
 

--- a/appeals/api/src/database/seed/data-test.js
+++ b/appeals/api/src/database/seed/data-test.js
@@ -24,6 +24,7 @@ import neighbouringSitesRepository from '#repositories/neighbouring-sites.reposi
 import { createAppealReference } from '#utils/appeal-reference.js';
 import { FOLDERS } from '@pins/appeals/constants/documents.js';
 import { APPEAL_CASE_STATUS } from 'pins-data-model';
+import { randomBool } from './data-samples.js';
 import { APPEAL_REPRESENTATION_TYPE } from '@pins/appeals/constants/common.js';
 
 /** @typedef {import('@pins/appeals.api').Appeals.AppealSite} AppealSite */
@@ -772,6 +773,13 @@ export async function seedTestData(databaseConnector) {
 				? appellantCaseValidationOutcomes[2]
 				: null;
 
+		const planningObligation = randomBool();
+		const statusPlanningObligation = planningObligation
+			? randomBool()
+				? 'finalised'
+				: 'not_started' // TODO (A2-173): replace with data model constants once those are available
+			: null;
+
 		await databaseConnector.appellantCase.update({
 			where: { id: appellantCase.id },
 			data: {
@@ -779,7 +787,9 @@ export async function seedTestData(databaseConnector) {
 				knowsOtherOwnersId: knowledgeOfOtherLandowners[0].id,
 				...(validationOutcome && {
 					appellantCaseValidationOutcomeId: validationOutcome.validationOutcomeId
-				})
+				}),
+				planningObligation,
+				statusPlanningObligation
 			}
 		});
 

--- a/appeals/api/src/server/endpoints/appeals.d.ts
+++ b/appeals/api/src/server/endpoints/appeals.d.ts
@@ -178,6 +178,10 @@ interface SingleAppellantCaseResponse {
 	};
 	validation: ValidationOutcomeResponse | null;
 	isGreenBelt?: boolean | null;
+	planningObligation?: {
+		hasObligation: boolean | null;
+		status: string | null;
+	};
 }
 
 interface UpdateAppellantCaseRequest {
@@ -207,6 +211,8 @@ interface UpdateAppellantCaseRequest {
 	isSitePartiallyOwned?: boolean;
 	isSiteVisibleFromPublicRoad?: boolean;
 	visibilityRestrictions?: string;
+	planningObligation?: boolean | null;
+	statusPlanningObligation?: string | null;
 }
 
 interface UpdateAppellantCaseValidationOutcome {

--- a/appeals/api/src/server/endpoints/appellant-cases/appellant-cases.controller.js
+++ b/appeals/api/src/server/endpoints/appellant-cases/appellant-cases.controller.js
@@ -51,7 +51,9 @@ const updateAppellantCaseById = async (req, res) => {
 			applicationDecisionDate,
 			developmentDescription,
 			isGreenBelt,
-			applicationDecision
+			applicationDecision,
+			planningObligation,
+			statusPlanningObligation
 		},
 		params,
 		validationOutcome
@@ -109,7 +111,9 @@ const updateAppellantCaseById = async (req, res) => {
 						typeof developmentDescription?.details !== typeof undefined
 							? developmentDescription?.details
 							: undefined,
-					applicationDecision
+					applicationDecision,
+					planningObligation,
+					statusPlanningObligation
 			  });
 
 		const updatedProperties = Object.keys(body).filter((key) => body[key] !== undefined);

--- a/appeals/api/src/server/endpoints/appellant-cases/appellant-cases.formatter.js
+++ b/appeals/api/src/server/endpoints/appellant-cases/appellant-cases.formatter.js
@@ -75,7 +75,11 @@ const formatAppellantCase = (appeal, folders = null) => {
 			applicationDecision: appellantCase.applicationDecision || null,
 			appellantCostsAppliedFor: appellantCase.appellantCostsAppliedFor,
 			...formatFoldersAndDocuments(folders),
-			isGreenBelt: appellantCase.isGreenBelt
+			isGreenBelt: appellantCase.isGreenBelt,
+			planningObligation: {
+				hasObligation: appellantCase.planningObligation,
+				status: appellantCase.statusPlanningObligation
+			}
 		};
 	}
 };

--- a/appeals/api/src/server/openapi-types.ts
+++ b/appeals/api/src/server/openapi-types.ts
@@ -803,6 +803,14 @@ export interface SingleAppellantCaseResponse {
 	};
 	/** @example true */
 	isGreenBelt?: boolean;
+	planningObligation?: {
+		/** @example true */
+		hasObligation?: boolean;
+		/** @example "Finalised" */
+		status?: string;
+	};
+	/** @example "finalised" */
+	statusPlanningObligation?: string;
 	documents?: {
 		appealStatement?: {
 			/** @example 4562 */
@@ -867,12 +875,6 @@ export interface SingleAppellantCaseResponse {
 	isAppellantNamedOnApplication?: boolean;
 	/** @example "Wiltshire Council" */
 	localPlanningDepartment?: string;
-	planningObligation?: {
-		/** @example true */
-		hasObligation?: boolean;
-		/** @example "Finalised" */
-		status?: string;
-	};
 	/** @example "written" */
 	procedureType?: string;
 	siteOwnership?: {

--- a/appeals/api/src/server/openapi.json
+++ b/appeals/api/src/server/openapi.json
@@ -5315,6 +5315,23 @@
 						"type": "boolean",
 						"example": true
 					},
+					"planningObligation": {
+						"type": "object",
+						"properties": {
+							"hasObligation": {
+								"type": "boolean",
+								"example": true
+							},
+							"status": {
+								"type": "string",
+								"example": "Finalised"
+							}
+						}
+					},
+					"statusPlanningObligation": {
+						"type": "string",
+						"example": "finalised"
+					},
 					"documents": {
 						"type": "object",
 						"properties": {
@@ -5458,19 +5475,6 @@
 					"localPlanningDepartment": {
 						"type": "string",
 						"example": "Wiltshire Council"
-					},
-					"planningObligation": {
-						"type": "object",
-						"properties": {
-							"hasObligation": {
-								"type": "boolean",
-								"example": true
-							},
-							"status": {
-								"type": "string",
-								"example": "Finalised"
-							}
-						}
 					},
 					"procedureType": {
 						"type": "string",

--- a/appeals/web/src/server/appeals/appeal-details/appellant-case/__tests__/__snapshots__/appellant-case.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/appellant-case/__tests__/__snapshots__/appellant-case.test.js.snap
@@ -530,6 +530,30 @@ exports[`appellant-case GET /appellant-case should render a "LPA application ref
 </main>"
 `;
 
+exports[`appellant-case GET /appellant-case should render a "Planning obligation in support updated" notification banner when the planning obligation response is changed 1`] = `
+"<div class="govuk-notification-banner govuk-notification-banner--success"
+role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
+    <div class="govuk-notification-banner__header">
+        <h3 class="govuk-notification-banner__title" id="govuk-notification-banner-title"> Success</h3>
+    </div>
+    <div class="govuk-notification-banner__content">
+        <p class="govuk-notification-banner__heading">Planning obligation in support updated</p>
+    </div>
+</div>"
+`;
+
+exports[`appellant-case GET /appellant-case should render a "Planning obligation status updated" notification banner when the planning obligation status is changed 1`] = `
+"<div class="govuk-notification-banner govuk-notification-banner--success"
+role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
+    <div class="govuk-notification-banner__header">
+        <h3 class="govuk-notification-banner__title" id="govuk-notification-banner-title"> Success</h3>
+    </div>
+    <div class="govuk-notification-banner__content">
+        <p class="govuk-notification-banner__heading">Planning obligation status updated</p>
+    </div>
+</div>"
+`;
+
 exports[`appellant-case GET /appellant-case should render a "Site area updated" success notification banner when the site area is updated 1`] = `
 "<main class="govuk-main-wrapper " id="main-content" role="main">
     <div class="govuk-grid-row">
@@ -2069,6 +2093,16 @@ exports[`appellant-case GET /appellant-case should render the appellant case pag
                     <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/appellant-case/other-appeals/add"
                         data-cy="add-related-appeals"> Add<span class="govuk-visually-hidden"> Related appeals</span></a>
                     </dd>
+                </div>
+                <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Planning obligation in support</dt>
+                    <dd                     class="govuk-summary-list__value">Yes</dd>
+                        <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/appellant-case/planning-obligation/change"> Change<span class="govuk-visually-hidden"> Planning obligation in support</span></a>
+                        </dd>
+                </div>
+                <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Planning obligation status</dt>
+                    <dd                     class="govuk-summary-list__value">Finalised</dd>
+                        <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/appellant-case/planning-obligation/status/change"> Change<span class="govuk-visually-hidden"> Planning obligation status</span></a>
+                        </dd>
                 </div>
                 <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Applied for award of appeal costs</dt>
                     <dd                     class="govuk-summary-list__value"></dd>

--- a/appeals/web/src/server/appeals/appeal-details/appellant-case/__tests__/appellant-case.test.js
+++ b/appeals/web/src/server/appeals/appeal-details/appellant-case/__tests__/appellant-case.test.js
@@ -121,6 +121,8 @@ describe('appellant-case', () => {
 			expect(unprettifiedElement.innerHTML).toContain(
 				'Supporting documents submitted with statement</dt>'
 			);
+			expect(unprettifiedElement.innerHTML).toContain('Planning obligation in support</dt>');
+			expect(unprettifiedElement.innerHTML).toContain('Planning obligation status</dt>');
 			expect(unprettifiedElement.innerHTML).toContain('Planning obligation</dt>');
 		});
 
@@ -531,6 +533,50 @@ describe('appellant-case', () => {
 			expect(unprettifiedNotificationBannerHTML).toContain('Other</span>');
 			expect(unprettifiedNotificationBannerHTML).toContain('test reason 2</li>');
 			expect(unprettifiedNotificationBannerHTML).toContain('test reason 3</li>');
+		});
+
+		it('should render a "Planning obligation in support updated" notification banner when the planning obligation response is changed', async () => {
+			const appealId = appealData.appealId.toString();
+			const appellantCaseUrl = `/appeals-service/appeal-details/${appealId}/appellant-case`;
+
+			nock('http://test/')
+				.patch(`/appeals/${appealId}/appellant-cases/${appealData.appellantCaseId}`)
+				.reply(200, {});
+
+			await request.post(`${appellantCaseUrl}/planning-obligation/change`).send({
+				planningObligationRadio: 'yes'
+			});
+
+			const response = await request.get(`${baseUrl}/1${appellantCasePagePath}`);
+			const notificationBannerElementHTML = parseHtml(response.text, {
+				rootElement: notificationBannerElement
+			}).innerHTML;
+
+			expect(notificationBannerElementHTML).toMatchSnapshot();
+			expect(notificationBannerElementHTML).toContain('Success</h3>');
+			expect(notificationBannerElementHTML).toContain('Planning obligation in support updated');
+		});
+
+		it('should render a "Planning obligation status updated" notification banner when the planning obligation status is changed', async () => {
+			const appealId = appealData.appealId.toString();
+			const appellantCaseUrl = `/appeals-service/appeal-details/${appealId}/appellant-case`;
+
+			nock('http://test/')
+				.patch(`/appeals/${appealId}/appellant-cases/${appealData.appellantCaseId}`)
+				.reply(200, {});
+
+			await request.post(`${appellantCaseUrl}/planning-obligation/status/change`).send({
+				planningObligationStatusRadio: 'finalised'
+			});
+
+			const response = await request.get(`${baseUrl}/1${appellantCasePagePath}`);
+			const notificationBannerElementHTML = parseHtml(response.text, {
+				rootElement: notificationBannerElement
+			}).innerHTML;
+
+			expect(notificationBannerElementHTML).toMatchSnapshot();
+			expect(notificationBannerElementHTML).toContain('Success</h3>');
+			expect(notificationBannerElementHTML).toContain('Planning obligation status updated');
 		});
 	});
 

--- a/appeals/web/src/server/appeals/appeal-details/appellant-case/appellant-case.router.js
+++ b/appeals/web/src/server/appeals/appeal-details/appellant-case/appellant-case.router.js
@@ -22,6 +22,7 @@ import safetyRisksRouter from '../safety-risks/safety-risks.router.js';
 import siteAddressRouter from './address/address.router.js';
 import siteOwnershipRouter from './site-ownership/site-ownership.router.js';
 import ownersKnownRouter from './owners-known/owners-known.router.js';
+import planningObligationRouter from './planning-obligation/planning-obligation.router.js';
 import otherAppealsRouter from '../other-appeals/other-appeals.router.js';
 import siteAreaRouter from './site-area/site-area.router.js';
 import applicationSubmissionDateRouter from './application-submission-date/application-submission-date.router.js';
@@ -93,6 +94,12 @@ router.use(
 	validateAppeal,
 	assertUserHasPermission(permissionNames.updateCase),
 	ownersKnownRouter
+);
+router.use(
+	'/planning-obligation',
+	validateAppeal,
+	assertUserHasPermission(permissionNames.updateCase),
+	planningObligationRouter
 );
 router.use(
 	'/other-appeals',

--- a/appeals/web/src/server/appeals/appeal-details/appellant-case/planning-obligation/__tests__/__snapshots__/planning-obligation.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/appellant-case/planning-obligation/__tests__/__snapshots__/planning-obligation.test.js.snap
@@ -1,0 +1,172 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`planning-obligation GET /change should render the change planning obligation in support page with "no" radio option checked if planningObligation.hasObligation is false 1`] = `
+"<main class="govuk-main-wrapper " id="main-content" role="main">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <div class="govuk-grid-row">
+                <div class="govuk-grid-column-full"><span class="govuk-caption-l govuk-!-margin-bottom-3">Appeal 351062</span>
+                    <h1                     class="govuk-heading-l govuk-!-margin-bottom-3">Change planning obligation in support</h1>
+                </div>
+            </div>
+            <form method="POST" novalidate="novalidate">
+                <div class="govuk-form-group">
+                    <div class="govuk-radios" data-module="govuk-radios">
+                        <div class="govuk-radios__item">
+                            <input class="govuk-radios__input" id="planningObligationRadio" name="planningObligationRadio"
+                            type="radio" value="no" checked>
+                            <label class="govuk-label govuk-radios__label" for="planningObligationRadio">No</label>
+                        </div>
+                        <div class="govuk-radios__item">
+                            <input class="govuk-radios__input" id="planningObligationRadio-2" name="planningObligationRadio"
+                            type="radio" value="yes">
+                            <label class="govuk-label govuk-radios__label" for="planningObligationRadio-2">Yes</label>
+                        </div>
+                    </div>
+                </div>
+                <button type="submit" class="govuk-button" data-module="govuk-button">Continue</button>
+            </form>
+        </div>
+    </div>
+</main>"
+`;
+
+exports[`planning-obligation GET /change should render the change planning obligation in support page with "yes" radio option checked if planningObligation.hasObligation is true 1`] = `
+"<main class="govuk-main-wrapper " id="main-content" role="main">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <div class="govuk-grid-row">
+                <div class="govuk-grid-column-full"><span class="govuk-caption-l govuk-!-margin-bottom-3">Appeal 351062</span>
+                    <h1                     class="govuk-heading-l govuk-!-margin-bottom-3">Change planning obligation in support</h1>
+                </div>
+            </div>
+            <form method="POST" novalidate="novalidate">
+                <div class="govuk-form-group">
+                    <div class="govuk-radios" data-module="govuk-radios">
+                        <div class="govuk-radios__item">
+                            <input class="govuk-radios__input" id="planningObligationRadio" name="planningObligationRadio"
+                            type="radio" value="no">
+                            <label class="govuk-label govuk-radios__label" for="planningObligationRadio">No</label>
+                        </div>
+                        <div class="govuk-radios__item">
+                            <input class="govuk-radios__input" id="planningObligationRadio-2" name="planningObligationRadio"
+                            type="radio" value="yes" checked>
+                            <label class="govuk-label govuk-radios__label" for="planningObligationRadio-2">Yes</label>
+                        </div>
+                    </div>
+                </div>
+                <button type="submit" class="govuk-button" data-module="govuk-button">Continue</button>
+            </form>
+        </div>
+    </div>
+</main>"
+`;
+
+exports[`planning-obligation GET /status/change should render the change planning obligation status page with "Finalised" radio option checked if planningObligation.status is "finalised" 1`] = `
+"<main class="govuk-main-wrapper " id="main-content" role="main">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <div class="govuk-grid-row">
+                <div class="govuk-grid-column-full"><span class="govuk-caption-l govuk-!-margin-bottom-3">Appeal 351062</span>
+                    <h1                     class="govuk-heading-l govuk-!-margin-bottom-3">Change planning obligation status</h1>
+                </div>
+            </div>
+            <form method="POST" novalidate="novalidate">
+                <div class="govuk-form-group">
+                    <div class="govuk-radios" data-module="govuk-radios">
+                        <div class="govuk-radios__item">
+                            <input class="govuk-radios__input" id="planningObligationStatusRadio"
+                            name="planningObligationStatusRadio" type="radio" value="not_started">
+                            <label class="govuk-label govuk-radios__label" for="planningObligationStatusRadio">Not yet started</label>
+                        </div>
+                        <div class="govuk-radios__item">
+                            <input class="govuk-radios__input" id="planningObligationStatusRadio-2"
+                            name="planningObligationStatusRadio" type="radio" value="finalised" checked>
+                            <label class="govuk-label govuk-radios__label" for="planningObligationStatusRadio-2">Finalised</label>
+                        </div>
+                        <div class="govuk-radios__item">
+                            <input class="govuk-radios__input" id="planningObligationStatusRadio-3"
+                            name="planningObligationStatusRadio" type="radio" value="not-applicable">
+                            <label class="govuk-label govuk-radios__label" for="planningObligationStatusRadio-3">Not applicable</label>
+                        </div>
+                    </div>
+                </div>
+                <button type="submit" class="govuk-button" data-module="govuk-button">Continue</button>
+            </form>
+        </div>
+    </div>
+</main>"
+`;
+
+exports[`planning-obligation GET /status/change should render the change planning obligation status page with "Not applicable" radio option checked if planningObligation.status is null 1`] = `
+"<main class="govuk-main-wrapper " id="main-content" role="main">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <div class="govuk-grid-row">
+                <div class="govuk-grid-column-full"><span class="govuk-caption-l govuk-!-margin-bottom-3">Appeal 351062</span>
+                    <h1                     class="govuk-heading-l govuk-!-margin-bottom-3">Change planning obligation status</h1>
+                </div>
+            </div>
+            <form method="POST" novalidate="novalidate">
+                <div class="govuk-form-group">
+                    <div class="govuk-radios" data-module="govuk-radios">
+                        <div class="govuk-radios__item">
+                            <input class="govuk-radios__input" id="planningObligationStatusRadio"
+                            name="planningObligationStatusRadio" type="radio" value="not_started">
+                            <label class="govuk-label govuk-radios__label" for="planningObligationStatusRadio">Not yet started</label>
+                        </div>
+                        <div class="govuk-radios__item">
+                            <input class="govuk-radios__input" id="planningObligationStatusRadio-2"
+                            name="planningObligationStatusRadio" type="radio" value="finalised">
+                            <label class="govuk-label govuk-radios__label" for="planningObligationStatusRadio-2">Finalised</label>
+                        </div>
+                        <div class="govuk-radios__item">
+                            <input class="govuk-radios__input" id="planningObligationStatusRadio-3"
+                            name="planningObligationStatusRadio" type="radio" value="not-applicable"
+                            checked>
+                            <label class="govuk-label govuk-radios__label" for="planningObligationStatusRadio-3">Not applicable</label>
+                        </div>
+                    </div>
+                </div>
+                <button type="submit" class="govuk-button" data-module="govuk-button">Continue</button>
+            </form>
+        </div>
+    </div>
+</main>"
+`;
+
+exports[`planning-obligation GET /status/change should render the change planning obligation status page with "Not yet started" radio option checked if planningObligation.status is "not_started" 1`] = `
+"<main class="govuk-main-wrapper " id="main-content" role="main">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <div class="govuk-grid-row">
+                <div class="govuk-grid-column-full"><span class="govuk-caption-l govuk-!-margin-bottom-3">Appeal 351062</span>
+                    <h1                     class="govuk-heading-l govuk-!-margin-bottom-3">Change planning obligation status</h1>
+                </div>
+            </div>
+            <form method="POST" novalidate="novalidate">
+                <div class="govuk-form-group">
+                    <div class="govuk-radios" data-module="govuk-radios">
+                        <div class="govuk-radios__item">
+                            <input class="govuk-radios__input" id="planningObligationStatusRadio"
+                            name="planningObligationStatusRadio" type="radio" value="not_started" checked>
+                            <label class="govuk-label govuk-radios__label" for="planningObligationStatusRadio">Not yet started</label>
+                        </div>
+                        <div class="govuk-radios__item">
+                            <input class="govuk-radios__input" id="planningObligationStatusRadio-2"
+                            name="planningObligationStatusRadio" type="radio" value="finalised">
+                            <label class="govuk-label govuk-radios__label" for="planningObligationStatusRadio-2">Finalised</label>
+                        </div>
+                        <div class="govuk-radios__item">
+                            <input class="govuk-radios__input" id="planningObligationStatusRadio-3"
+                            name="planningObligationStatusRadio" type="radio" value="not-applicable">
+                            <label class="govuk-label govuk-radios__label" for="planningObligationStatusRadio-3">Not applicable</label>
+                        </div>
+                    </div>
+                </div>
+                <button type="submit" class="govuk-button" data-module="govuk-button">Continue</button>
+            </form>
+        </div>
+    </div>
+</main>"
+`;

--- a/appeals/web/src/server/appeals/appeal-details/appellant-case/planning-obligation/__tests__/planning-obligation.test.js
+++ b/appeals/web/src/server/appeals/appeal-details/appellant-case/planning-obligation/__tests__/planning-obligation.test.js
@@ -1,0 +1,235 @@
+// @ts-nocheck
+import { parseHtml } from '@pins/platform';
+import supertest from 'supertest';
+import { appealData, appellantCaseDataNotValidated } from '#testing/app/fixtures/referencedata.js';
+import { createTestEnvironment } from '#testing/index.js';
+import nock from 'nock';
+
+const { app, installMockApi, teardown } = createTestEnvironment();
+const request = supertest(app);
+const baseUrl = '/appeals-service/appeal-details';
+
+describe('planning-obligation', () => {
+	beforeEach(installMockApi);
+	afterEach(teardown);
+
+	describe('GET /change', () => {
+		it('should render the change planning obligation in support page with "no" radio option checked if planningObligation.hasObligation is false', async () => {
+			nock('http://test/')
+				.get(`/appeals/1/appellant-cases/${appealData.appellantCaseId}`)
+				.reply(200, {
+					...appellantCaseDataNotValidated,
+					planningObligation: {
+						...appellantCaseDataNotValidated.planningObligation,
+						hasObligation: false
+					}
+				});
+
+			const response = await request.get(`${baseUrl}/1/appellant-case/planning-obligation/change`);
+			const element = parseHtml(response.text);
+
+			expect(element.innerHTML).toMatchSnapshot();
+
+			const unprettifiedElement = parseHtml(response.text, { skipPrettyPrint: true });
+
+			expect(unprettifiedElement.innerHTML).toContain('Change planning obligation in support</h1>');
+			expect(unprettifiedElement.innerHTML).toContain(
+				'name="planningObligationRadio" type="radio" value="no" checked>'
+			);
+			expect(unprettifiedElement.innerHTML).toContain(
+				'name="planningObligationRadio" type="radio" value="yes">'
+			);
+			expect(unprettifiedElement.innerHTML).toContain('Continue</button>');
+		});
+
+		it('should render the change planning obligation in support page with "yes" radio option checked if planningObligation.hasObligation is true', async () => {
+			nock('http://test/')
+				.get(`/appeals/1/appellant-cases/${appealData.appellantCaseId}`)
+				.reply(200, {
+					...appellantCaseDataNotValidated,
+					planningObligation: {
+						...appellantCaseDataNotValidated.planningObligation,
+						hasObligation: true
+					}
+				});
+
+			const response = await request.get(`${baseUrl}/1/appellant-case/planning-obligation/change`);
+			const element = parseHtml(response.text);
+
+			expect(element.innerHTML).toMatchSnapshot();
+
+			const unprettifiedElement = parseHtml(response.text, { skipPrettyPrint: true });
+
+			expect(unprettifiedElement.innerHTML).toContain('Change planning obligation in support</h1>');
+			expect(unprettifiedElement.innerHTML).toContain(
+				'name="planningObligationRadio" type="radio" value="no">'
+			);
+			expect(unprettifiedElement.innerHTML).toContain(
+				'name="planningObligationRadio" type="radio" value="yes" checked>'
+			);
+			expect(unprettifiedElement.innerHTML).toContain('Continue</button>');
+		});
+	});
+
+	describe('POST /change', () => {
+		const validValues = ['Yes', 'No'];
+
+		for (const validValue of validValues) {
+			it(`should call appellant cases PATCH endpoint and redirect to the appellant case page if "${validValue}" is selected`, async () => {
+				const mockAppellantCasesPatchEndpoint = nock('http://test/')
+					.patch(`/appeals/1/appellant-cases/${appealData.appellantCaseId}`)
+					.reply(200, {});
+
+				const response = await request
+					.post(`${baseUrl}/1/appellant-case/planning-obligation/change`)
+					.send({
+						planningObligationRadio: validValue.toLowerCase()
+					});
+
+				expect(mockAppellantCasesPatchEndpoint.isDone()).toBe(true);
+				expect(response.statusCode).toBe(302);
+				expect(response.text).toBe(
+					'Found. Redirecting to /appeals-service/appeal-details/1/appellant-case'
+				);
+			});
+		}
+	});
+
+	describe('GET /status/change', () => {
+		it('should render the change planning obligation status page with "Not yet started" radio option checked if planningObligation.status is "not_started"', async () => {
+			nock('http://test/')
+				.get(`/appeals/1/appellant-cases/${appealData.appellantCaseId}`)
+				.reply(200, {
+					...appellantCaseDataNotValidated,
+					planningObligation: {
+						...appellantCaseDataNotValidated.planningObligation,
+						status: 'not_started'
+					}
+				});
+
+			const response = await request.get(
+				`${baseUrl}/1/appellant-case/planning-obligation/status/change`
+			);
+			const element = parseHtml(response.text);
+
+			expect(element.innerHTML).toMatchSnapshot();
+
+			const unprettifiedElement = parseHtml(response.text, { skipPrettyPrint: true });
+
+			expect(unprettifiedElement.innerHTML).toContain('Change planning obligation status</h1>');
+			expect(unprettifiedElement.innerHTML).toContain(
+				'name="planningObligationStatusRadio" type="radio" value="not_started" checked>'
+			);
+			expect(unprettifiedElement.innerHTML).toContain(
+				'name="planningObligationStatusRadio" type="radio" value="finalised">'
+			);
+			expect(unprettifiedElement.innerHTML).toContain(
+				'name="planningObligationStatusRadio" type="radio" value="not-applicable">'
+			);
+			expect(unprettifiedElement.innerHTML).toContain('Continue</button>');
+		});
+
+		it('should render the change planning obligation status page with "Finalised" radio option checked if planningObligation.status is "finalised"', async () => {
+			nock('http://test/')
+				.get(`/appeals/1/appellant-cases/${appealData.appellantCaseId}`)
+				.reply(200, {
+					...appellantCaseDataNotValidated,
+					planningObligation: {
+						...appellantCaseDataNotValidated.planningObligation,
+						status: 'finalised'
+					}
+				});
+
+			const response = await request.get(
+				`${baseUrl}/1/appellant-case/planning-obligation/status/change`
+			);
+			const element = parseHtml(response.text);
+
+			expect(element.innerHTML).toMatchSnapshot();
+
+			const unprettifiedElement = parseHtml(response.text, { skipPrettyPrint: true });
+
+			expect(unprettifiedElement.innerHTML).toContain('Change planning obligation status</h1>');
+			expect(unprettifiedElement.innerHTML).toContain(
+				'name="planningObligationStatusRadio" type="radio" value="not_started">'
+			);
+			expect(unprettifiedElement.innerHTML).toContain(
+				'name="planningObligationStatusRadio" type="radio" value="finalised" checked>'
+			);
+			expect(unprettifiedElement.innerHTML).toContain(
+				'name="planningObligationStatusRadio" type="radio" value="not-applicable">'
+			);
+			expect(unprettifiedElement.innerHTML).toContain('Continue</button>');
+		});
+
+		it('should render the change planning obligation status page with "Not applicable" radio option checked if planningObligation.status is null', async () => {
+			nock('http://test/')
+				.get(`/appeals/1/appellant-cases/${appealData.appellantCaseId}`)
+				.reply(200, {
+					...appellantCaseDataNotValidated,
+					planningObligation: {
+						...appellantCaseDataNotValidated.planningObligation,
+						status: null
+					}
+				});
+
+			const response = await request.get(
+				`${baseUrl}/1/appellant-case/planning-obligation/status/change`
+			);
+			const element = parseHtml(response.text);
+
+			expect(element.innerHTML).toMatchSnapshot();
+
+			const unprettifiedElement = parseHtml(response.text, { skipPrettyPrint: true });
+
+			expect(unprettifiedElement.innerHTML).toContain('Change planning obligation status</h1>');
+			expect(unprettifiedElement.innerHTML).toContain(
+				'name="planningObligationStatusRadio" type="radio" value="not_started">'
+			);
+			expect(unprettifiedElement.innerHTML).toContain(
+				'name="planningObligationStatusRadio" type="radio" value="finalised">'
+			);
+			expect(unprettifiedElement.innerHTML).toContain(
+				'name="planningObligationStatusRadio" type="radio" value="not-applicable" checked>'
+			);
+			expect(unprettifiedElement.innerHTML).toContain('Continue</button>');
+		});
+	});
+
+	describe('POST /status/change', () => {
+		const validInputs = [
+			{
+				label: 'Not yet started',
+				value: 'not_started'
+			},
+			{
+				label: 'Finalised',
+				value: 'finalised'
+			},
+			{
+				label: 'Not applicable',
+				value: null
+			}
+		];
+
+		for (const validInput of validInputs) {
+			it(`should call appellant cases PATCH endpoint and redirect to the appellant case page if "${validInput.label}" is selected`, async () => {
+				const mockAppellantCasesPatchEndpoint = nock('http://test/')
+					.patch(`/appeals/1/appellant-cases/${appealData.appellantCaseId}`)
+					.reply(200, {});
+
+				const response = await request
+					.post(`${baseUrl}/1/appellant-case/planning-obligation/status/change`)
+					.send({
+						planningObligationRadio: validInput.value
+					});
+
+				expect(mockAppellantCasesPatchEndpoint.isDone()).toBe(true);
+				expect(response.statusCode).toBe(302);
+				expect(response.text).toBe(
+					'Found. Redirecting to /appeals-service/appeal-details/1/appellant-case'
+				);
+			});
+		}
+	});
+});

--- a/appeals/web/src/server/appeals/appeal-details/appellant-case/planning-obligation/planning-obligation.controller.js
+++ b/appeals/web/src/server/appeals/appeal-details/appellant-case/planning-obligation/planning-obligation.controller.js
@@ -1,0 +1,197 @@
+import logger from '#lib/logger.js';
+import { addNotificationBannerToSession } from '#lib/session-utilities.js';
+import { HTTPError } from 'got';
+import { getAppellantCaseFromAppealId } from '../appellant-case.service.js';
+import {
+	changePlanningObligationPage,
+	changePlanningObligationStatusPage
+} from './planning-obligation.mapper.js';
+import {
+	changePlanningObligation,
+	changePlanningObligationStatus
+} from './planning-obligation.service.js';
+
+/**
+ * @param {import('@pins/express/types/express.js').Request} request
+ * @param {import('@pins/express/types/express.js').RenderedResponse<any, any, Number>} response
+ */
+export const getChangePlanningObligation = async (request, response) => {
+	return renderChangePlanningObligation(request, response);
+};
+
+/**
+ * @param {import('@pins/express/types/express.js').Request} request
+ * @param {import('@pins/express/types/express.js').RenderedResponse<any, any, Number>} response
+ */
+const renderChangePlanningObligation = async (request, response) => {
+	try {
+		const { errors, currentAppeal } = request;
+
+		const appellantCaseData = await getAppellantCaseFromAppealId(
+			request.apiClient,
+			currentAppeal.appealId,
+			currentAppeal.appellantCaseId
+		);
+
+		const mappedPageContents = changePlanningObligationPage(
+			currentAppeal,
+			appellantCaseData,
+			request.session.planningObligation
+		);
+
+		return response.status(200).render('patterns/change-page.pattern.njk', {
+			pageContent: mappedPageContents,
+			errors
+		});
+	} catch (error) {
+		logger.error(error);
+
+		if (error instanceof HTTPError && error.response.statusCode === 404) {
+			return response.status(404).render('app/404.njk');
+		} else {
+			return response.status(500).render('app/500.njk');
+		}
+	}
+};
+
+/**
+ * @param {import('@pins/express/types/express.js').Request} request
+ * @param {import('@pins/express/types/express.js').RenderedResponse<any, any, Number>} response
+ */
+export const postChangePlanningObligation = async (request, response) => {
+	if (request.errors) {
+		return renderChangePlanningObligation(request, response);
+	}
+
+	const {
+		params: { appealId },
+		currentAppeal
+	} = request;
+
+	request.session.planningObligation = {
+		radio: request.body['planningObligationRadio'] === 'yes'
+	};
+
+	const appellantCaseId = currentAppeal.appellantCaseId;
+
+	try {
+		await changePlanningObligation(
+			request.apiClient,
+			appealId,
+			appellantCaseId,
+			request.session.planningObligation.radio
+		);
+
+		addNotificationBannerToSession(
+			request.session,
+			'changePage',
+			appealId,
+			undefined,
+			'Planning obligation in support updated'
+		);
+
+		delete request.session.planningObligation;
+
+		return response.redirect(
+			`/appeals-service/appeal-details/${currentAppeal.appealId}/appellant-case`
+		);
+	} catch (error) {
+		logger.error(error);
+	}
+
+	return response.status(500).render('app/500.njk');
+};
+
+/**
+ * @param {import('@pins/express/types/express.js').Request} request
+ * @param {import('@pins/express/types/express.js').RenderedResponse<any, any, Number>} response
+ */
+export const getChangePlanningObligationStatus = async (request, response) => {
+	return renderChangePlanningObligationStatus(request, response);
+};
+
+/**
+ * @param {import('@pins/express/types/express.js').Request} request
+ * @param {import('@pins/express/types/express.js').RenderedResponse<any, any, Number>} response
+ */
+const renderChangePlanningObligationStatus = async (request, response) => {
+	try {
+		const { errors, currentAppeal } = request;
+
+		const appellantCaseData = await getAppellantCaseFromAppealId(
+			request.apiClient,
+			currentAppeal.appealId,
+			currentAppeal.appellantCaseId
+		);
+
+		const mappedPageContents = changePlanningObligationStatusPage(
+			currentAppeal,
+			appellantCaseData,
+			request.session.planningObligationStatus
+		);
+
+		return response.status(200).render('patterns/change-page.pattern.njk', {
+			pageContent: mappedPageContents,
+			errors
+		});
+	} catch (error) {
+		logger.error(error);
+
+		if (error instanceof HTTPError && error.response.statusCode === 404) {
+			return response.status(404).render('app/404.njk');
+		} else {
+			return response.status(500).render('app/500.njk');
+		}
+	}
+};
+
+/**
+ * @param {import('@pins/express/types/express.js').Request} request
+ * @param {import('@pins/express/types/express.js').RenderedResponse<any, any, Number>} response
+ */
+export const postChangePlanningObligationStatus = async (request, response) => {
+	if (request.errors) {
+		return renderChangePlanningObligationStatus(request, response);
+	}
+
+	const {
+		params: { appealId },
+		currentAppeal
+	} = request;
+
+	request.session.planningObligationStatus = {
+		radio:
+			request.body['planningObligationStatusRadio'] === 'not-applicable'
+				? null
+				: request.body['planningObligationStatusRadio']
+	};
+
+	const appellantCaseId = currentAppeal.appellantCaseId;
+
+	try {
+		await changePlanningObligationStatus(
+			request.apiClient,
+			appealId,
+			appellantCaseId,
+			request.session.planningObligationStatus.radio
+		);
+
+		addNotificationBannerToSession(
+			request.session,
+			'changePage',
+			appealId,
+			undefined,
+			'Planning obligation status updated'
+		);
+
+		delete request.session.planningObligationStatus;
+
+		return response.redirect(
+			`/appeals-service/appeal-details/${currentAppeal.appealId}/appellant-case`
+		);
+	} catch (error) {
+		logger.error(error);
+	}
+
+	return response.status(500).render('app/500.njk');
+};

--- a/appeals/web/src/server/appeals/appeal-details/appellant-case/planning-obligation/planning-obligation.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/appellant-case/planning-obligation/planning-obligation.mapper.js
@@ -1,0 +1,121 @@
+/**
+ * @typedef {import('../../appeal-details.types.js').WebAppeal} Appeal
+ */
+import { appealShortReference } from '#lib/appeals-formatter.js';
+
+/**
+ * @param {Appeal} appealData
+ * @param {import('@pins/appeals.api').Appeals.SingleAppellantCaseResponse} appellantCaseData
+ * @param {{radio: boolean}} storedSessionData
+ * @returns {PageContent}
+ */
+export const changePlanningObligationPage = (appealData, appellantCaseData, storedSessionData) => {
+	const shortAppealReference = appealShortReference(appealData.appealReference);
+
+	let planningObligation = appellantCaseData.planningObligation?.hasObligation;
+
+	if (storedSessionData?.radio) {
+		planningObligation = storedSessionData.radio;
+	}
+
+	/** @type {PageContent} */
+	const pageContent = {
+		title: 'Change planning obligation in support',
+		backLinkUrl: `/appeals-service/appeal-details/${appealData.appealId}/appellant-case`,
+		preHeading: `Appeal ${shortAppealReference}`,
+		heading: 'Change planning obligation in support',
+		pageComponents: [
+			{
+				type: 'radios',
+				parameters: {
+					name: 'planningObligationRadio',
+					id: 'planning-obligation-radio',
+					fieldSet: {
+						legend: {
+							text: 'Is there a planning obligation to support the appeal?',
+							isPageHeading: false,
+							classes: 'govuk-fieldset__legend--l'
+						}
+					},
+					items: [
+						{
+							value: 'no',
+							text: 'No',
+							checked: !planningObligation
+						},
+						{
+							value: 'yes',
+							text: 'Yes',
+							checked: !!planningObligation
+						}
+					]
+				}
+			}
+		]
+	};
+
+	return pageContent;
+};
+
+/**
+ * @param {Appeal} appealData
+ * @param {import('@pins/appeals.api').Appeals.SingleAppellantCaseResponse} appellantCaseData
+ * @param {{radio: string}} storedSessionData
+ * @returns {PageContent}
+ */
+export const changePlanningObligationStatusPage = (
+	appealData,
+	appellantCaseData,
+	storedSessionData
+) => {
+	const shortAppealReference = appealShortReference(appealData.appealReference);
+
+	let planningObligationStatus = appellantCaseData.planningObligation?.status;
+
+	if (storedSessionData?.radio) {
+		planningObligationStatus = storedSessionData.radio === null ? null : storedSessionData.radio;
+	}
+
+	/** @type {PageContent} */
+	const pageContent = {
+		title: 'Change planning obligation status',
+		backLinkUrl: `/appeals-service/appeal-details/${appealData.appealId}/appellant-case`,
+		preHeading: `Appeal ${shortAppealReference}`,
+		heading: 'Change planning obligation status',
+		pageComponents: [
+			{
+				type: 'radios',
+				parameters: {
+					name: 'planningObligationStatusRadio',
+					id: 'planning-obligation-status-radio',
+					fieldSet: {
+						legend: {
+							text: 'What is the status of the planning obligation?',
+							isPageHeading: false,
+							classes: 'govuk-fieldset__legend--l'
+						}
+					},
+					items: [
+						{
+							value: 'not_started',
+							text: 'Not yet started',
+							checked: planningObligationStatus === 'not_started'
+						},
+						{
+							value: 'finalised',
+							text: 'Finalised',
+							checked: planningObligationStatus === 'finalised'
+						},
+						{
+							value: 'not-applicable',
+							text: 'Not applicable',
+							checked: planningObligationStatus === null
+						}
+					]
+				}
+			}
+		]
+	};
+
+	return pageContent;
+};

--- a/appeals/web/src/server/appeals/appeal-details/appellant-case/planning-obligation/planning-obligation.router.js
+++ b/appeals/web/src/server/appeals/appeal-details/appellant-case/planning-obligation/planning-obligation.router.js
@@ -1,0 +1,18 @@
+import { Router as createRouter } from 'express';
+import { asyncHandler } from '@pins/express';
+import * as controllers from './planning-obligation.controller.js';
+import { validateAppeal } from '../../appeal-details.middleware.js';
+
+const router = createRouter({ mergeParams: true });
+
+router
+	.route('/change')
+	.get(validateAppeal, asyncHandler(controllers.getChangePlanningObligation))
+	.post(validateAppeal, asyncHandler(controllers.postChangePlanningObligation));
+
+router
+	.route('/status/change')
+	.get(validateAppeal, asyncHandler(controllers.getChangePlanningObligationStatus))
+	.post(validateAppeal, asyncHandler(controllers.postChangePlanningObligationStatus));
+
+export default router;

--- a/appeals/web/src/server/appeals/appeal-details/appellant-case/planning-obligation/planning-obligation.service.js
+++ b/appeals/web/src/server/appeals/appeal-details/appellant-case/planning-obligation/planning-obligation.service.js
@@ -1,0 +1,39 @@
+/**
+ * @param {import('got').Got} apiClient
+ * @param {string} appealId
+ * @param {string} appellantCaseId
+ * @param {boolean} updatedPlanningObligation
+ * @returns {Promise<{}>}
+ */
+export function changePlanningObligation(
+	apiClient,
+	appealId,
+	appellantCaseId,
+	updatedPlanningObligation
+) {
+	return apiClient.patch(`appeals/${appealId}/appellant-cases/${appellantCaseId}`, {
+		json: {
+			planningObligation: updatedPlanningObligation
+		}
+	});
+}
+
+/**
+ * @param {import('got').Got} apiClient
+ * @param {string} appealId
+ * @param {string} appellantCaseId
+ * @param {string|null} updatedPlanningObligationStatus
+ * @returns {Promise<{}>}
+ */
+export function changePlanningObligationStatus(
+	apiClient,
+	appealId,
+	appellantCaseId,
+	updatedPlanningObligationStatus
+) {
+	return apiClient.patch(`appeals/${appealId}/appellant-cases/${appellantCaseId}`, {
+		json: {
+			statusPlanningObligation: updatedPlanningObligationStatus
+		}
+	});
+}

--- a/appeals/web/src/server/lib/display-page-formatter.js
+++ b/appeals/web/src/server/lib/display-page-formatter.js
@@ -362,3 +362,18 @@ export function generateHorizonAppealUrl(appealId) {
 		? `${config.horizonAppealBaseUrl}${appealId}`
 		: '';
 }
+
+/**
+ * @param {string|null|undefined} planningObligationStatus
+ * @returns {string}
+ */
+export const formatPlanningObligationStatus = (planningObligationStatus) => {
+	switch (planningObligationStatus) {
+		case 'not_started': // TODO (A2-173): replace with data model constants once those are available
+			return 'Not yet started';
+		case 'finalised': // TODO (A2-173): replace with data model constants once those are available
+			return 'Finalised';
+		default:
+			return 'Not applicable';
+	}
+};

--- a/appeals/web/src/server/lib/mappers/appellant-case/appeal-type-fpa.mapper.js
+++ b/appeals/web/src/server/lib/mappers/appellant-case/appeal-type-fpa.mapper.js
@@ -88,6 +88,8 @@ export function generateFPAComponents(appealDetails, appellantCaseData, mappedAp
 					removeSummaryListActions(mappedAppellantCaseData.appealType.display.summaryListItem),
 					mappedAppellantCaseData.appealStatement.display.summaryListItem,
 					mappedAppellantCaseData.relatedAppeals.display.summaryListItem,
+					mappedAppellantCaseData.planningObligationInSupport.display.summaryListItem,
+					mappedAppellantCaseData.statusPlanningObligation.display.summaryListItem,
 					mappedAppellantCaseData.appellantCostsApplication.display.summaryListItem,
 					mappedAppellantCaseData.costsDocument.display.summaryListItem,
 					mappedAppellantCaseData.planningObligation.display.summaryListItem

--- a/appeals/web/src/server/lib/mappers/appellantCase.mapper.js
+++ b/appeals/web/src/server/lib/mappers/appellantCase.mapper.js
@@ -1003,6 +1003,56 @@ export function initialiseAndMapData(appellantCaseData, appealDetails, currentRo
 		}
 	};
 
+	/** @type {Instructions} */
+	mappedData.planningObligationInSupport = {
+		id: 'planning-obligation-in-support',
+		display: {
+			summaryListItem: {
+				key: {
+					text: 'Planning obligation in support'
+				},
+				value: {
+					text: convertFromBooleanToYesNo(appellantCaseData.planningObligation?.hasObligation) || ''
+				},
+				actions: {
+					items: [
+						mapActionComponent(permissionNames.updateCase, session, {
+							text: 'Change',
+							visuallyHiddenText: 'Planning obligation in support',
+							href: `${currentRoute}/planning-obligation/change`
+						})
+					]
+				}
+			}
+		}
+	};
+
+	/** @type {Instructions} */
+	mappedData.statusPlanningObligation = {
+		id: 'planning-obligation-status',
+		display: {
+			summaryListItem: {
+				key: {
+					text: 'Planning obligation status'
+				},
+				value: {
+					text: displayPageFormatter.formatPlanningObligationStatus(
+						appellantCaseData.planningObligation?.status
+					)
+				},
+				actions: {
+					items: [
+						mapActionComponent(permissionNames.updateCase, session, {
+							text: 'Change',
+							visuallyHiddenText: 'Planning obligation status',
+							href: `${currentRoute}/planning-obligation/status/change`
+						})
+					]
+				}
+			}
+		}
+	};
+
 	mappedData.appellantCostsApplication = {
 		id: 'appellant-costs-application',
 		display: {

--- a/appeals/web/testing/app/fixtures/referencedata.js
+++ b/appeals/web/testing/app/fixtures/referencedata.js
@@ -382,6 +382,10 @@ export const appellantCaseDataNotValidated = {
 	visibility: {
 		details: null,
 		isVisible: true
+	},
+	planningObligation: {
+		hasObligation: true,
+		status: 'finalised'
 	}
 };
 


### PR DESCRIPTION
## Describe your changes

add planning obligation boolean and status rows to s78 appellant case

## Issue ticket number and link

A2-173

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [ ] I have performed a self-review of my own code
- [ ] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [ ] I have referenced the ticket number above
- [ ] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
