### PR TITLE
fix(web): add text between end of expanded text and close button in show more component

### DIFF
--- a/appeals/web/src/client/components/show-more/show-more.js
+++ b/appeals/web/src/client/components/show-more/show-more.js
@@ -35,7 +35,8 @@ const toggleExpanded = (componentInstance) => {
 	toggleButton.setAttribute('aria-expanded', `${componentInstance.state.expanded}`);
 
 	if (componentInstance.state.expanded) {
-		textContainer.textContent = componentInstance.elements.root.getAttribute(ATTRIBUTES.fullText);
+		const fullText = componentInstance.elements.root.getAttribute(ATTRIBUTES.fullText);
+		textContainer.textContent = `${fullText} `;
 		toggleButtonTextContainer.textContent = DEFAULT_OPTIONS.toggleButtonTextExpanded;
 	} else {
 		textContainer.textContent = getPreviewFromFullText(


### PR DESCRIPTION
## Describe your changes

add text between end of expanded text and close button in show more component

## Issue ticket number and link

A2-872

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [ ] I have performed a self-review of my own code
- [ ] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [ ] I have referenced the ticket number above
- [ ] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
