### PR TITLE
refactor(web): pass empty string to addNotificationBannerToSession instead of undefined (html param)

### DIFF
--- a/appeals/web/src/server/appeals/appeal-details/appellant-case/agricultural-holding/agricultural-holding.controller.js
+++ b/appeals/web/src/server/appeals/appeal-details/appellant-case/agricultural-holding/agricultural-holding.controller.js
@@ -88,7 +88,7 @@ export const postChangePartOfAgriculturalHolding = async (request, response) => 
 			request.session,
 			'changePage',
 			appealId,
-			undefined,
+			'',
 			'Part of agricultural holding updated'
 		);
 
@@ -179,7 +179,7 @@ export const postChangeTenantOfAgriculturalHolding = async (request, response) =
 			request.session,
 			'changePage',
 			appealId,
-			undefined,
+			'',
 			'Tenant of agricultural holding updated'
 		);
 
@@ -270,7 +270,7 @@ export const postChangeOtherTenantsOfAgriculturalHolding = async (request, respo
 			request.session,
 			'changePage',
 			appealId,
-			undefined,
+			'',
 			'Other tenants of agricultural holding updated'
 		);
 

--- a/appeals/web/src/server/appeals/appeal-details/appellant-case/appeal-costs-application/appeal-costs-application.controller.js
+++ b/appeals/web/src/server/appeals/appeal-details/appellant-case/appeal-costs-application/appeal-costs-application.controller.js
@@ -91,7 +91,7 @@ export const postChangeAppealCostsApplication = async (request, response) => {
 			session,
 			'changePage',
 			appealId,
-			undefined,
+			'',
 			'Appeal costs applied for updated'
 		);
 

--- a/appeals/web/src/server/appeals/appeal-details/appellant-case/application-decision-date/application-decision-date.controller.js
+++ b/appeals/web/src/server/appeals/appeal-details/appellant-case/application-decision-date/application-decision-date.controller.js
@@ -87,7 +87,7 @@ export const postChangeApplicationHasDecisionDate = async (request, response) =>
 				request.session,
 				'changePage',
 				appealId,
-				undefined,
+				'',
 				'Application decision date removed'
 			);
 
@@ -196,7 +196,7 @@ export const postChangeApplicationSetDecisionDate = async (request, response) =>
 			request.session,
 			'changePage',
 			appealId,
-			undefined,
+			'',
 			'Application decision date updated'
 		);
 

--- a/appeals/web/src/server/appeals/appeal-details/appellant-case/application-outcome/application-outcome.controller.js
+++ b/appeals/web/src/server/appeals/appeal-details/appellant-case/application-outcome/application-outcome.controller.js
@@ -69,7 +69,7 @@ export const postChangeApplicationOutcome = async (request, response) => {
 			request.session,
 			'changePage',
 			appealId,
-			undefined,
+			'',
 			'Application outcome has been updated'
 		);
 

--- a/appeals/web/src/server/appeals/appeal-details/appellant-case/application-submission-date/application-submission-date.controller.js
+++ b/appeals/web/src/server/appeals/appeal-details/appellant-case/application-submission-date/application-submission-date.controller.js
@@ -107,7 +107,7 @@ export const postChangeApplicationSubmissionDate = async (request, response) => 
 			request.session,
 			'changePage',
 			appealId,
-			undefined,
+			'',
 			'Date application submitted updated'
 		);
 

--- a/appeals/web/src/server/appeals/appeal-details/appellant-case/development-description/development-description.controller.js
+++ b/appeals/web/src/server/appeals/appeal-details/appellant-case/development-description/development-description.controller.js
@@ -60,7 +60,7 @@ export const postChangeDevelopmentDescription = async (request, response) => {
 			request.session,
 			'changePage',
 			appealId,
-			undefined,
+			'',
 			'Original development description has been updated'
 		);
 		delete request.session.developmentDescription;

--- a/appeals/web/src/server/appeals/appeal-details/appellant-case/owners-known/owners-known.controller.js
+++ b/appeals/web/src/server/appeals/appeal-details/appellant-case/owners-known/owners-known.controller.js
@@ -83,7 +83,7 @@ export const postChangeOwnersKnown = async (request, response) => {
 			request.session,
 			'changePage',
 			appealId,
-			undefined,
+			'',
 			'Owners known updated'
 		);
 

--- a/appeals/web/src/server/appeals/appeal-details/appellant-case/planning-obligation/planning-obligation.controller.js
+++ b/appeals/web/src/server/appeals/appeal-details/appellant-case/planning-obligation/planning-obligation.controller.js
@@ -86,7 +86,7 @@ export const postChangePlanningObligation = async (request, response) => {
 			request.session,
 			'changePage',
 			appealId,
-			undefined,
+			'',
 			'Planning obligation in support updated'
 		);
 
@@ -180,7 +180,7 @@ export const postChangePlanningObligationStatus = async (request, response) => {
 			request.session,
 			'changePage',
 			appealId,
-			undefined,
+			'',
 			'Planning obligation status updated'
 		);
 

--- a/appeals/web/src/server/appeals/appeal-details/appellant-case/site-area/site-area.controller.js
+++ b/appeals/web/src/server/appeals/appeal-details/appellant-case/site-area/site-area.controller.js
@@ -75,7 +75,7 @@ export const postChangeSiteArea = async (request, response) => {
 			request.session,
 			'changePage',
 			appealId,
-			undefined,
+			'',
 			'Site area updated'
 		);
 

--- a/appeals/web/src/server/appeals/appeal-details/appellant-case/site-ownership/site-ownership.controller.js
+++ b/appeals/web/src/server/appeals/appeal-details/appellant-case/site-ownership/site-ownership.controller.js
@@ -82,7 +82,7 @@ export const postChangeSiteOwnership = async (request, response) => {
 			request.session,
 			'changePage',
 			appealId,
-			undefined,
+			'',
 			'Site ownership updated'
 		);
 

--- a/appeals/web/src/server/appeals/appeal-details/green-belt/green-belt.controller.js
+++ b/appeals/web/src/server/appeals/appeal-details/green-belt/green-belt.controller.js
@@ -106,7 +106,7 @@ export const postGreenBelt = async (request, response) => {
 			session,
 			'changePage',
 			appealId,
-			undefined,
+			'',
 			'Green belt status updated'
 		);
 

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/affected-listed-buildings/affected-listed-buildings.controller.js
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/affected-listed-buildings/affected-listed-buildings.controller.js
@@ -127,7 +127,7 @@ export const postAddAffectedListedBuildingCheckAndConfirm = async (request, resp
 			request.session,
 			'changePage',
 			appealId,
-			undefined,
+			'',
 			'Listed building added'
 		);
 
@@ -237,7 +237,7 @@ export const postRemoveAffectedListedBuilding = async (request, response) => {
 			request.session,
 			'changePage',
 			appealId,
-			undefined,
+			'',
 			'Listed building removed'
 		);
 
@@ -367,7 +367,7 @@ export const postChangeAffectedListedBuildingCheckAndConfirm = async (request, r
 			request.session,
 			'changePage',
 			appealId,
-			undefined,
+			'',
 			'Listed building updated'
 		);
 


### PR DESCRIPTION
## Describe your changes

Calls to addNotificationBannerToSession were previously passing `undefined` as the `html` parameter in situations where the parameter was not required. This PR changes these instances to pass empty strings instead.

## Issue ticket number and link

A2-846

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [ ] I have performed a self-review of my own code
- [ ] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [ ] I have referenced the ticket number above
- [ ] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
