### PR TITLE
fix(web): fix late entry tags appearing on manage pages for folders other than additional documents

### DIFF
--- a/appeals/web/src/server/appeals/appeal-details/appellant-case/__tests__/__snapshots__/appellant-case.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/appellant-case/__tests__/__snapshots__/appellant-case.test.js.snap
@@ -3533,7 +3533,7 @@ exports[`appellant-case GET /appellant-case/manage-documents/:folderId/ should r
 </main>"
 `;
 
-exports[`appellant-case GET /appellant-case/manage-documents/:folderId/ should render the manage documents listing page with one document item for each document present in the folder, with late entry status tags in the date received column for documents marked as late entry, if the folderId is valid 1`] = `
+exports[`appellant-case GET /appellant-case/manage-documents/:folderId/ should render the manage documents listing page with one document item for each document present in the folder, if the folderId is valid 1`] = `
 "<main class="govuk-main-wrapper " id="main-content" role="main">
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">
@@ -3604,11 +3604,7 @@ exports[`appellant-case GET /appellant-case/manage-documents/:folderId/ should r
                     <div class="govuk-!-margin-bottom-4"><strong class="govuk-tag govuk-tag--yellow single-line">Virus scanning</strong>
                     </div>
                 </td>
-                <td class="govuk-table__cell">
-                    <div>2 March 2024</div>
-                    <div class="govuk-!-margin-top-3"><strong class="govuk-tag govuk-tag--pink single-line">Late entry</strong>
-                    </div>
-                </td>
+                <td class="govuk-table__cell">2 March 2024</td>
                 <td class="govuk-table__cell">Unredacted</td>
                 <td class="govuk-table__cell"><a href="/appeals-service/appeal-details/1/appellant-case/manage-documents/2864/47d8f073-c837-4f07-9161-c1a5626eba56"
                     class="govuk-link">Edit <span class="govuk-visually-hidden">sample-20s-documentFolderInfo.mp4</span></a>
@@ -3638,11 +3634,7 @@ exports[`appellant-case GET /appellant-case/manage-documents/:folderId/ should r
                         <dd>JPEG, 59 KB</dd>
                     </dl>
                 </td>
-                <td class="govuk-table__cell">
-                    <div>3 April 2025</div>
-                    <div class="govuk-!-margin-top-3"><strong class="govuk-tag govuk-tag--pink single-line">Late entry</strong>
-                    </div>
-                </td>
+                <td class="govuk-table__cell">3 April 2025</td>
                 <td class="govuk-table__cell">Unredacted</td>
                 <td class="govuk-table__cell"><a href="/appeals-service/appeal-details/1/appellant-case/manage-documents/2864/97260151-4334-407f-a76a-0b5666cbcfa7"
                     class="govuk-link">View and edit <span class="govuk-visually-hidden">ph1-documentFolderInfo.jpeg</span></a>

--- a/appeals/web/src/server/appeals/appeal-details/appellant-case/__tests__/appellant-case.test.js
+++ b/appeals/web/src/server/appeals/appeal-details/appellant-case/__tests__/appellant-case.test.js
@@ -4495,7 +4495,7 @@ describe('appellant-case', () => {
 			expect(unprettifiedElement.innerHTML).toContain('Page not found</h1>');
 		});
 
-		it('should render the manage documents listing page with one document item for each document present in the folder, with late entry status tags in the date received column for documents marked as late entry, if the folderId is valid', async () => {
+		it('should render the manage documents listing page with one document item for each document present in the folder, if the folderId is valid', async () => {
 			nock('http://test/').get('/appeals/1/document-folders/1').reply(200, documentFolderInfo);
 
 			const response = await request.get(

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/__tests__/__snapshots__/lpa-questionnaire.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/__tests__/__snapshots__/lpa-questionnaire.test.js.snap
@@ -2059,7 +2059,7 @@ exports[`LPA Questionnaire review GET /lpa-questionnaire/1/manage-documents/:fol
 </main>"
 `;
 
-exports[`LPA Questionnaire review GET /lpa-questionnaire/1/manage-documents/:folderId/ should render the manage documents listing page with one document item for each document present in the folder, with late entry status tags in the date received column for documents marked as late entry, if the folderId is valid 1`] = `
+exports[`LPA Questionnaire review GET /lpa-questionnaire/1/manage-documents/:folderId/ should render the manage documents listing page with one document item for each document present in the folder, if the folderId is valid 1`] = `
 "<main class="govuk-main-wrapper " id="main-content" role="main">
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">
@@ -2130,11 +2130,7 @@ exports[`LPA Questionnaire review GET /lpa-questionnaire/1/manage-documents/:fol
                     <div class="govuk-!-margin-bottom-4"><strong class="govuk-tag govuk-tag--yellow single-line">Virus scanning</strong>
                     </div>
                 </td>
-                <td class="govuk-table__cell">
-                    <div>2 March 2024</div>
-                    <div class="govuk-!-margin-top-3"><strong class="govuk-tag govuk-tag--pink single-line">Late entry</strong>
-                    </div>
-                </td>
+                <td class="govuk-table__cell">2 March 2024</td>
                 <td class="govuk-table__cell">Unredacted</td>
                 <td class="govuk-table__cell"><a href="/appeals-service/appeal-details/1/lpa-questionnaire/2/manage-documents/2864/47d8f073-c837-4f07-9161-c1a5626eba56"
                     class="govuk-link">Edit <span class="govuk-visually-hidden">sample-20s-documentFolderInfo.mp4</span></a>
@@ -2164,11 +2160,7 @@ exports[`LPA Questionnaire review GET /lpa-questionnaire/1/manage-documents/:fol
                         <dd>JPEG, 59 KB</dd>
                     </dl>
                 </td>
-                <td class="govuk-table__cell">
-                    <div>3 April 2025</div>
-                    <div class="govuk-!-margin-top-3"><strong class="govuk-tag govuk-tag--pink single-line">Late entry</strong>
-                    </div>
-                </td>
+                <td class="govuk-table__cell">3 April 2025</td>
                 <td class="govuk-table__cell">Unredacted</td>
                 <td class="govuk-table__cell"><a href="/appeals-service/appeal-details/1/lpa-questionnaire/2/manage-documents/2864/97260151-4334-407f-a76a-0b5666cbcfa7"
                     class="govuk-link">View and edit <span class="govuk-visually-hidden">ph1-documentFolderInfo.jpeg</span></a>

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/__tests__/lpa-questionnaire.test.js
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/__tests__/lpa-questionnaire.test.js
@@ -2740,7 +2740,7 @@ describe('LPA Questionnaire review', () => {
 			expect(unprettifiedElement.innerHTML).toContain('Page not found</h1>');
 		});
 
-		it('should render the manage documents listing page with one document item for each document present in the folder, with late entry status tags in the date received column for documents marked as late entry, if the folderId is valid', async () => {
+		it('should render the manage documents listing page with one document item for each document present in the folder, if the folderId is valid', async () => {
 			nock('http://test/').get('/appeals/1/document-folders/1').reply(200, documentFolderInfo);
 
 			const response = await request.get(`${baseUrl}/manage-documents/1/`);

--- a/appeals/web/src/server/appeals/appeal-documents/appeal-documents.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-documents/appeal-documents.mapper.js
@@ -789,7 +789,7 @@ export function manageFolderPage(
 					},
 					rows: (folder?.documents || []).map((document) => [
 						mapFolderDocumentInformationHtmlProperty(folder, document),
-						document?.latestDocumentVersion?.isLateEntry
+						folderIsAdditionalDocuments(folder.path) && document?.latestDocumentVersion?.isLateEntry
 							? {
 									html: '',
 									pageComponents: [
@@ -1079,43 +1079,44 @@ export async function manageDocumentPage(
 				},
 				{
 					key: { text: 'Date received' },
-					value: latestVersion?.isLateEntry
-						? {
-								html: '',
-								pageComponents: [
-									{
-										type: 'html',
-										parameters: {
-											html: '',
-											pageComponents: [
-												{
-													wrapperHtml: {
-														opening: '<div class="govuk-!-margin-bottom-2">',
-														closing: '</div>'
+					value:
+						folderIsAdditionalDocuments(folder.path) && latestVersion?.isLateEntry
+							? {
+									html: '',
+									pageComponents: [
+										{
+											type: 'html',
+											parameters: {
+												html: '',
+												pageComponents: [
+													{
+														wrapperHtml: {
+															opening: '<div class="govuk-!-margin-bottom-2">',
+															closing: '</div>'
+														},
+														type: 'html',
+														parameters: {
+															html: dateToDisplayDate(latestVersion?.dateReceived)
+														}
 													},
-													type: 'html',
-													parameters: {
-														html: dateToDisplayDate(latestVersion?.dateReceived)
+													{
+														wrapperHtml: {
+															opening: '<div class="govuk-!-margin-bottom-1">',
+															closing: '</div>'
+														},
+														type: 'status-tag',
+														parameters: {
+															status: 'late_entry'
+														}
 													}
-												},
-												{
-													wrapperHtml: {
-														opening: '<div class="govuk-!-margin-bottom-1">',
-														closing: '</div>'
-													},
-													type: 'status-tag',
-													parameters: {
-														status: 'late_entry'
-													}
-												}
-											]
+												]
+											}
 										}
-									}
-								]
-						  }
-						: {
-								text: dateToDisplayDate(latestVersion?.dateReceived)
-						  },
+									]
+							  }
+							: {
+									text: dateToDisplayDate(latestVersion?.dateReceived)
+							  },
 					actions: {
 						items: [
 							{


### PR DESCRIPTION
## Describe your changes

fix late entry tags appearing on manage pages for folders other than additional documents

## Issue ticket number and link

A2-886

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [ ] I have performed a self-review of my own code
- [ ] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [ ] I have referenced the ticket number above
- [ ] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
