### PR TITLE
feat(web): Remove "Yes, and upload another document" option from delete document version journey

### DIFF
--- a/appeals/web/src/server/appeals/appeal-details/appellant-case/__tests__/__snapshots__/appellant-case.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/appellant-case/__tests__/__snapshots__/appellant-case.test.js.snap
@@ -4436,13 +4436,8 @@ exports[`appellant-case GET /appellant-case/manage-documents/:folderId/:document
                         </div>
                         <div class="govuk-radios__item">
                             <input class="govuk-radios__input" id="delete-file-answer-2" name="delete-file-answer"
-                            type="radio" value="yes-and-upload-another-document">
-                            <label class="govuk-label govuk-radios__label" for="delete-file-answer-2">Yes, and upload another document</label>
-                        </div>
-                        <div class="govuk-radios__item">
-                            <input class="govuk-radios__input" id="delete-file-answer-3" name="delete-file-answer"
                             type="radio" value="no">
-                            <label class="govuk-label govuk-radios__label" for="delete-file-answer-3">No</label>
+                            <label class="govuk-label govuk-radios__label" for="delete-file-answer-2">No</label>
                         </div>
                     </div>
                 </div>

--- a/appeals/web/src/server/appeals/appeal-details/appellant-case/__tests__/appellant-case.test.js
+++ b/appeals/web/src/server/appeals/appeal-details/appellant-case/__tests__/appellant-case.test.js
@@ -4787,9 +4787,6 @@ describe('appellant-case', () => {
 				'name="delete-file-answer" type="radio" value="yes">'
 			);
 			expect(unprettifiedElement.innerHTML).toContain(
-				'name="delete-file-answer" type="radio" value="yes-and-upload-another-document">'
-			);
-			expect(unprettifiedElement.innerHTML).toContain(
 				'name="delete-file-answer" type="radio" value="no">'
 			);
 		});
@@ -4820,9 +4817,6 @@ describe('appellant-case', () => {
 			);
 			expect(unprettifiedElement.innerHTML).toContain(
 				'name="delete-file-answer" type="radio" value="no">'
-			);
-			expect(unprettifiedElement.innerHTML).not.toContain(
-				'name="delete-file-answer" type="radio" value="yes-and-upload-another-document">'
 			);
 			expect(unprettifiedElement.innerHTML).not.toContain(
 				'<strong class="govuk-warning-text__text"><span class="govuk-warning-text__assistive">Warning</span> Removing the only version of a document will delete the document from the case</strong>'

--- a/appeals/web/src/server/appeals/appeal-details/costs/__tests__/__snapshots__/costs.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/costs/__tests__/__snapshots__/costs.test.js.snap
@@ -3361,13 +3361,8 @@ exports[`costs application, withdrawal and correspondence GET /costs/:costsCateg
                         </div>
                         <div class="govuk-radios__item">
                             <input class="govuk-radios__input" id="delete-file-answer-2" name="delete-file-answer"
-                            type="radio" value="yes-and-upload-another-document">
-                            <label class="govuk-label govuk-radios__label" for="delete-file-answer-2">Yes, and upload another document</label>
-                        </div>
-                        <div class="govuk-radios__item">
-                            <input class="govuk-radios__input" id="delete-file-answer-3" name="delete-file-answer"
                             type="radio" value="no">
-                            <label class="govuk-label govuk-radios__label" for="delete-file-answer-3">No</label>
+                            <label class="govuk-label govuk-radios__label" for="delete-file-answer-2">No</label>
                         </div>
                     </div>
                 </div>
@@ -3410,13 +3405,8 @@ exports[`costs application, withdrawal and correspondence GET /costs/:costsCateg
                         </div>
                         <div class="govuk-radios__item">
                             <input class="govuk-radios__input" id="delete-file-answer-2" name="delete-file-answer"
-                            type="radio" value="yes-and-upload-another-document">
-                            <label class="govuk-label govuk-radios__label" for="delete-file-answer-2">Yes, and upload another document</label>
-                        </div>
-                        <div class="govuk-radios__item">
-                            <input class="govuk-radios__input" id="delete-file-answer-3" name="delete-file-answer"
                             type="radio" value="no">
-                            <label class="govuk-label govuk-radios__label" for="delete-file-answer-3">No</label>
+                            <label class="govuk-label govuk-radios__label" for="delete-file-answer-2">No</label>
                         </div>
                     </div>
                 </div>
@@ -3459,13 +3449,8 @@ exports[`costs application, withdrawal and correspondence GET /costs/:costsCateg
                         </div>
                         <div class="govuk-radios__item">
                             <input class="govuk-radios__input" id="delete-file-answer-2" name="delete-file-answer"
-                            type="radio" value="yes-and-upload-another-document">
-                            <label class="govuk-label govuk-radios__label" for="delete-file-answer-2">Yes, and upload another document</label>
-                        </div>
-                        <div class="govuk-radios__item">
-                            <input class="govuk-radios__input" id="delete-file-answer-3" name="delete-file-answer"
                             type="radio" value="no">
-                            <label class="govuk-label govuk-radios__label" for="delete-file-answer-3">No</label>
+                            <label class="govuk-label govuk-radios__label" for="delete-file-answer-2">No</label>
                         </div>
                     </div>
                 </div>
@@ -3508,13 +3493,8 @@ exports[`costs application, withdrawal and correspondence GET /costs/:costsCateg
                         </div>
                         <div class="govuk-radios__item">
                             <input class="govuk-radios__input" id="delete-file-answer-2" name="delete-file-answer"
-                            type="radio" value="yes-and-upload-another-document">
-                            <label class="govuk-label govuk-radios__label" for="delete-file-answer-2">Yes, and upload another document</label>
-                        </div>
-                        <div class="govuk-radios__item">
-                            <input class="govuk-radios__input" id="delete-file-answer-3" name="delete-file-answer"
                             type="radio" value="no">
-                            <label class="govuk-label govuk-radios__label" for="delete-file-answer-3">No</label>
+                            <label class="govuk-label govuk-radios__label" for="delete-file-answer-2">No</label>
                         </div>
                     </div>
                 </div>
@@ -3557,13 +3537,8 @@ exports[`costs application, withdrawal and correspondence GET /costs/:costsCateg
                         </div>
                         <div class="govuk-radios__item">
                             <input class="govuk-radios__input" id="delete-file-answer-2" name="delete-file-answer"
-                            type="radio" value="yes-and-upload-another-document">
-                            <label class="govuk-label govuk-radios__label" for="delete-file-answer-2">Yes, and upload another document</label>
-                        </div>
-                        <div class="govuk-radios__item">
-                            <input class="govuk-radios__input" id="delete-file-answer-3" name="delete-file-answer"
                             type="radio" value="no">
-                            <label class="govuk-label govuk-radios__label" for="delete-file-answer-3">No</label>
+                            <label class="govuk-label govuk-radios__label" for="delete-file-answer-2">No</label>
                         </div>
                     </div>
                 </div>
@@ -3606,13 +3581,8 @@ exports[`costs application, withdrawal and correspondence GET /costs/:costsCateg
                         </div>
                         <div class="govuk-radios__item">
                             <input class="govuk-radios__input" id="delete-file-answer-2" name="delete-file-answer"
-                            type="radio" value="yes-and-upload-another-document">
-                            <label class="govuk-label govuk-radios__label" for="delete-file-answer-2">Yes, and upload another document</label>
-                        </div>
-                        <div class="govuk-radios__item">
-                            <input class="govuk-radios__input" id="delete-file-answer-3" name="delete-file-answer"
                             type="radio" value="no">
-                            <label class="govuk-label govuk-radios__label" for="delete-file-answer-3">No</label>
+                            <label class="govuk-label govuk-radios__label" for="delete-file-answer-2">No</label>
                         </div>
                     </div>
                 </div>
@@ -4268,13 +4238,8 @@ exports[`costs application, withdrawal and correspondence POST /costs/:costsCate
                         </div>
                         <div class="govuk-radios__item">
                             <input class="govuk-radios__input" id="delete-file-answer-2" name="delete-file-answer"
-                            type="radio" value="yes-and-upload-another-document">
-                            <label class="govuk-label govuk-radios__label" for="delete-file-answer-2">Yes, and upload another document</label>
-                        </div>
-                        <div class="govuk-radios__item">
-                            <input class="govuk-radios__input" id="delete-file-answer-3" name="delete-file-answer"
                             type="radio" value="no">
-                            <label class="govuk-label govuk-radios__label" for="delete-file-answer-3">No</label>
+                            <label class="govuk-label govuk-radios__label" for="delete-file-answer-2">No</label>
                         </div>
                     </div>
                 </div>
@@ -4332,13 +4297,8 @@ exports[`costs application, withdrawal and correspondence POST /costs/:costsCate
                         </div>
                         <div class="govuk-radios__item">
                             <input class="govuk-radios__input" id="delete-file-answer-2" name="delete-file-answer"
-                            type="radio" value="yes-and-upload-another-document">
-                            <label class="govuk-label govuk-radios__label" for="delete-file-answer-2">Yes, and upload another document</label>
-                        </div>
-                        <div class="govuk-radios__item">
-                            <input class="govuk-radios__input" id="delete-file-answer-3" name="delete-file-answer"
                             type="radio" value="no">
-                            <label class="govuk-label govuk-radios__label" for="delete-file-answer-3">No</label>
+                            <label class="govuk-label govuk-radios__label" for="delete-file-answer-2">No</label>
                         </div>
                     </div>
                 </div>
@@ -4396,13 +4356,8 @@ exports[`costs application, withdrawal and correspondence POST /costs/:costsCate
                         </div>
                         <div class="govuk-radios__item">
                             <input class="govuk-radios__input" id="delete-file-answer-2" name="delete-file-answer"
-                            type="radio" value="yes-and-upload-another-document">
-                            <label class="govuk-label govuk-radios__label" for="delete-file-answer-2">Yes, and upload another document</label>
-                        </div>
-                        <div class="govuk-radios__item">
-                            <input class="govuk-radios__input" id="delete-file-answer-3" name="delete-file-answer"
                             type="radio" value="no">
-                            <label class="govuk-label govuk-radios__label" for="delete-file-answer-3">No</label>
+                            <label class="govuk-label govuk-radios__label" for="delete-file-answer-2">No</label>
                         </div>
                     </div>
                 </div>
@@ -4460,13 +4415,8 @@ exports[`costs application, withdrawal and correspondence POST /costs/:costsCate
                         </div>
                         <div class="govuk-radios__item">
                             <input class="govuk-radios__input" id="delete-file-answer-2" name="delete-file-answer"
-                            type="radio" value="yes-and-upload-another-document">
-                            <label class="govuk-label govuk-radios__label" for="delete-file-answer-2">Yes, and upload another document</label>
-                        </div>
-                        <div class="govuk-radios__item">
-                            <input class="govuk-radios__input" id="delete-file-answer-3" name="delete-file-answer"
                             type="radio" value="no">
-                            <label class="govuk-label govuk-radios__label" for="delete-file-answer-3">No</label>
+                            <label class="govuk-label govuk-radios__label" for="delete-file-answer-2">No</label>
                         </div>
                     </div>
                 </div>
@@ -4524,13 +4474,8 @@ exports[`costs application, withdrawal and correspondence POST /costs/:costsCate
                         </div>
                         <div class="govuk-radios__item">
                             <input class="govuk-radios__input" id="delete-file-answer-2" name="delete-file-answer"
-                            type="radio" value="yes-and-upload-another-document">
-                            <label class="govuk-label govuk-radios__label" for="delete-file-answer-2">Yes, and upload another document</label>
-                        </div>
-                        <div class="govuk-radios__item">
-                            <input class="govuk-radios__input" id="delete-file-answer-3" name="delete-file-answer"
                             type="radio" value="no">
-                            <label class="govuk-label govuk-radios__label" for="delete-file-answer-3">No</label>
+                            <label class="govuk-label govuk-radios__label" for="delete-file-answer-2">No</label>
                         </div>
                     </div>
                 </div>
@@ -4588,13 +4533,8 @@ exports[`costs application, withdrawal and correspondence POST /costs/:costsCate
                         </div>
                         <div class="govuk-radios__item">
                             <input class="govuk-radios__input" id="delete-file-answer-2" name="delete-file-answer"
-                            type="radio" value="yes-and-upload-another-document">
-                            <label class="govuk-label govuk-radios__label" for="delete-file-answer-2">Yes, and upload another document</label>
-                        </div>
-                        <div class="govuk-radios__item">
-                            <input class="govuk-radios__input" id="delete-file-answer-3" name="delete-file-answer"
                             type="radio" value="no">
-                            <label class="govuk-label govuk-radios__label" for="delete-file-answer-3">No</label>
+                            <label class="govuk-label govuk-radios__label" for="delete-file-answer-2">No</label>
                         </div>
                     </div>
                 </div>
@@ -5534,13 +5474,8 @@ exports[`costs decision GET /costs/decision/manage-documents/:folderId/:document
                         </div>
                         <div class="govuk-radios__item">
                             <input class="govuk-radios__input" id="delete-file-answer-2" name="delete-file-answer"
-                            type="radio" value="yes-and-upload-another-document">
-                            <label class="govuk-label govuk-radios__label" for="delete-file-answer-2">Yes, and upload another document</label>
-                        </div>
-                        <div class="govuk-radios__item">
-                            <input class="govuk-radios__input" id="delete-file-answer-3" name="delete-file-answer"
                             type="radio" value="no">
-                            <label class="govuk-label govuk-radios__label" for="delete-file-answer-3">No</label>
+                            <label class="govuk-label govuk-radios__label" for="delete-file-answer-2">No</label>
                         </div>
                     </div>
                 </div>
@@ -5738,13 +5673,8 @@ exports[`costs decision POST /costs/decision/manage-documents/:folderId/:documen
                         </div>
                         <div class="govuk-radios__item">
                             <input class="govuk-radios__input" id="delete-file-answer-2" name="delete-file-answer"
-                            type="radio" value="yes-and-upload-another-document">
-                            <label class="govuk-label govuk-radios__label" for="delete-file-answer-2">Yes, and upload another document</label>
-                        </div>
-                        <div class="govuk-radios__item">
-                            <input class="govuk-radios__input" id="delete-file-answer-3" name="delete-file-answer"
                             type="radio" value="no">
-                            <label class="govuk-label govuk-radios__label" for="delete-file-answer-3">No</label>
+                            <label class="govuk-label govuk-radios__label" for="delete-file-answer-2">No</label>
                         </div>
                     </div>
                 </div>

--- a/appeals/web/src/server/appeals/appeal-details/costs/__tests__/costs.test.js
+++ b/appeals/web/src/server/appeals/appeal-details/costs/__tests__/costs.test.js
@@ -1389,9 +1389,6 @@ describe('costs', () => {
 							'name="delete-file-answer" type="radio" value="yes"'
 						);
 						expect(radiosElement.innerHTML).toContain(
-							'name="delete-file-answer" type="radio" value="yes-and-upload-another-document"'
-						);
-						expect(radiosElement.innerHTML).toContain(
 							'name="delete-file-answer" type="radio" value="no"'
 						);
 					});
@@ -1428,9 +1425,6 @@ describe('costs', () => {
 						);
 						expect(radiosElement.innerHTML).toContain(
 							'name="delete-file-answer" type="radio" value="no"'
-						);
-						expect(radiosElement.innerHTML).not.toContain(
-							'name="delete-file-answer" type="radio" value="yes-and-upload-another-document"'
 						);
 					});
 				}
@@ -1520,52 +1514,6 @@ describe('costs', () => {
 						expect(response.statusCode).toBe(302);
 						expect(response.text).toContain('Found. Redirecting to ');
 						expect(response.text).toContain('/appeals-service/appeal-details/1');
-					});
-
-					it(`should render a 500 page, if answer "yes, and upload another document" was provided, and there is more than one version of the document (${costsCategory} ${costsDocumentType})`, async () => {
-						const multipleVersionsDocument = cloneDeep(documentFileVersionsInfo);
-						multipleVersionsDocument.allVersions.push({
-							...multipleVersionsDocument.allVersions[0],
-							version: 2
-						});
-
-						nock('http://test/')
-							.get('/appeals/1/documents/1/versions')
-							.reply(200, multipleVersionsDocument);
-
-						const response = await request
-							.post(
-								`${baseUrl}/1/costs/${costsCategory}/${costsDocumentType}/manage-documents/${costsFolder.folderId}/1/1/delete`
-							)
-							.send({
-								'delete-file-answer': 'yes-and-upload-another-document'
-							});
-
-						const unprettifiedElement = parseHtml(response.text, { skipPrettyPrint: true });
-
-						expect(unprettifiedElement.innerHTML).toContain(
-							'Sorry, there is a problem with the service</h1>'
-						);
-					});
-
-					it(`should send an API request to delete the document, and redirect to the upload new document version page, if answer "yes, and upload another document" was provided, and there is only one version of the document (${costsCategory} ${costsDocumentType})`, async () => {
-						nock('http://test/')
-							.get('/appeals/1/documents/1/versions')
-							.reply(200, documentFileVersionsInfo);
-
-						const response = await request
-							.post(
-								`${baseUrl}/1/costs/${costsCategory}/${costsDocumentType}/manage-documents/${costsFolder.folderId}/1/1/delete`
-							)
-							.send({
-								'delete-file-answer': 'yes-and-upload-another-document'
-							});
-
-						expect(response.statusCode).toBe(302);
-						expect(response.text).toContain('Found. Redirecting to ');
-						expect(response.text).toContain(
-							`/appeals-service/appeal-details/1/costs/${costsCategory}/${costsDocumentType}/upload-documents/${costsFolder.folderId}`
-						);
 					});
 				}
 			}
@@ -2652,9 +2600,6 @@ describe('costs', () => {
 					'name="delete-file-answer" type="radio" value="yes"'
 				);
 				expect(radiosElement.innerHTML).toContain(
-					'name="delete-file-answer" type="radio" value="yes-and-upload-another-document"'
-				);
-				expect(radiosElement.innerHTML).toContain(
 					'name="delete-file-answer" type="radio" value="no"'
 				);
 			});
@@ -2691,9 +2636,6 @@ describe('costs', () => {
 				);
 				expect(radiosElement.innerHTML).toContain(
 					'name="delete-file-answer" type="radio" value="no"'
-				);
-				expect(radiosElement.innerHTML).not.toContain(
-					'name="delete-file-answer" type="radio" value="yes-and-upload-another-document"'
 				);
 			});
 		});
@@ -2772,48 +2714,6 @@ describe('costs', () => {
 				expect(response.statusCode).toBe(302);
 				expect(response.text).toContain('Found. Redirecting to ');
 				expect(response.text).toContain('/appeals-service/appeal-details/1');
-			});
-
-			it(`should render a 500 page, if answer "yes, and upload another document" was provided, and there is more than one version of the document`, async () => {
-				const multipleVersionsDocument = cloneDeep(documentFileVersionsInfo);
-				multipleVersionsDocument.allVersions.push({
-					...multipleVersionsDocument.allVersions[0],
-					version: 2
-				});
-
-				nock('http://test/')
-					.get('/appeals/1/documents/1/versions')
-					.reply(200, multipleVersionsDocument);
-
-				const response = await request
-					.post(`${baseUrl}/1/costs/decision/manage-documents/${costsFolder?.folderId}/1/1/delete`)
-					.send({
-						'delete-file-answer': 'yes-and-upload-another-document'
-					});
-
-				const unprettifiedElement = parseHtml(response.text, { skipPrettyPrint: true });
-
-				expect(unprettifiedElement.innerHTML).toContain(
-					'Sorry, there is a problem with the service</h1>'
-				);
-			});
-
-			it(`should send an API request to delete the document, and redirect to the upload new document version page, if answer "yes, and upload another document" was provided, and there is only one version of the document`, async () => {
-				nock('http://test/')
-					.get('/appeals/1/documents/1/versions')
-					.reply(200, documentFileVersionsInfo);
-
-				const response = await request
-					.post(`${baseUrl}/1/costs/decision/manage-documents/${costsFolder?.folderId}/1/1/delete`)
-					.send({
-						'delete-file-answer': 'yes-and-upload-another-document'
-					});
-
-				expect(response.statusCode).toBe(302);
-				expect(response.text).toContain('Found. Redirecting to ');
-				expect(response.text).toContain(
-					`/appeals-service/appeal-details/1/costs/decision/upload-documents/${costsFolder?.folderId}`
-				);
 			});
 		});
 	});

--- a/appeals/web/src/server/appeals/appeal-details/internal-correspondence/__tests__/__snapshots__/internal-correspondence.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/internal-correspondence/__tests__/__snapshots__/internal-correspondence.test.js.snap
@@ -1297,13 +1297,8 @@ exports[`internal correspondence GET /internal-correspondence/:correspondenceCat
                         </div>
                         <div class="govuk-radios__item">
                             <input class="govuk-radios__input" id="delete-file-answer-2" name="delete-file-answer"
-                            type="radio" value="yes-and-upload-another-document">
-                            <label class="govuk-label govuk-radios__label" for="delete-file-answer-2">Yes, and upload another document</label>
-                        </div>
-                        <div class="govuk-radios__item">
-                            <input class="govuk-radios__input" id="delete-file-answer-3" name="delete-file-answer"
                             type="radio" value="no">
-                            <label class="govuk-label govuk-radios__label" for="delete-file-answer-3">No</label>
+                            <label class="govuk-label govuk-radios__label" for="delete-file-answer-2">No</label>
                         </div>
                     </div>
                 </div>
@@ -1346,13 +1341,8 @@ exports[`internal correspondence GET /internal-correspondence/:correspondenceCat
                         </div>
                         <div class="govuk-radios__item">
                             <input class="govuk-radios__input" id="delete-file-answer-2" name="delete-file-answer"
-                            type="radio" value="yes-and-upload-another-document">
-                            <label class="govuk-label govuk-radios__label" for="delete-file-answer-2">Yes, and upload another document</label>
-                        </div>
-                        <div class="govuk-radios__item">
-                            <input class="govuk-radios__input" id="delete-file-answer-3" name="delete-file-answer"
                             type="radio" value="no">
-                            <label class="govuk-label govuk-radios__label" for="delete-file-answer-3">No</label>
+                            <label class="govuk-label govuk-radios__label" for="delete-file-answer-2">No</label>
                         </div>
                     </div>
                 </div>
@@ -1610,13 +1600,8 @@ exports[`internal correspondence POST /internal-correspondence/:correspondenceCa
                         </div>
                         <div class="govuk-radios__item">
                             <input class="govuk-radios__input" id="delete-file-answer-2" name="delete-file-answer"
-                            type="radio" value="yes-and-upload-another-document">
-                            <label class="govuk-label govuk-radios__label" for="delete-file-answer-2">Yes, and upload another document</label>
-                        </div>
-                        <div class="govuk-radios__item">
-                            <input class="govuk-radios__input" id="delete-file-answer-3" name="delete-file-answer"
                             type="radio" value="no">
-                            <label class="govuk-label govuk-radios__label" for="delete-file-answer-3">No</label>
+                            <label class="govuk-label govuk-radios__label" for="delete-file-answer-2">No</label>
                         </div>
                     </div>
                 </div>
@@ -1674,13 +1659,8 @@ exports[`internal correspondence POST /internal-correspondence/:correspondenceCa
                         </div>
                         <div class="govuk-radios__item">
                             <input class="govuk-radios__input" id="delete-file-answer-2" name="delete-file-answer"
-                            type="radio" value="yes-and-upload-another-document">
-                            <label class="govuk-label govuk-radios__label" for="delete-file-answer-2">Yes, and upload another document</label>
-                        </div>
-                        <div class="govuk-radios__item">
-                            <input class="govuk-radios__input" id="delete-file-answer-3" name="delete-file-answer"
                             type="radio" value="no">
-                            <label class="govuk-label govuk-radios__label" for="delete-file-answer-3">No</label>
+                            <label class="govuk-label govuk-radios__label" for="delete-file-answer-2">No</label>
                         </div>
                     </div>
                 </div>

--- a/appeals/web/src/server/appeals/appeal-details/internal-correspondence/__tests__/internal-correspondence.test.js
+++ b/appeals/web/src/server/appeals/appeal-details/internal-correspondence/__tests__/internal-correspondence.test.js
@@ -2010,9 +2010,6 @@ describe('internal correspondence', () => {
 					'name="delete-file-answer" type="radio" value="yes"'
 				);
 				expect(radiosElement.innerHTML).toContain(
-					'name="delete-file-answer" type="radio" value="yes-and-upload-another-document"'
-				);
-				expect(radiosElement.innerHTML).toContain(
 					'name="delete-file-answer" type="radio" value="no"'
 				);
 			});
@@ -2049,9 +2046,6 @@ describe('internal correspondence', () => {
 				);
 				expect(radiosElement.innerHTML).toContain(
 					'name="delete-file-answer" type="radio" value="no"'
-				);
-				expect(radiosElement.innerHTML).not.toContain(
-					'name="delete-file-answer" type="radio" value="yes-and-upload-another-document"'
 				);
 			});
 		}
@@ -2156,52 +2150,6 @@ describe('internal correspondence', () => {
 				expect(response.statusCode).toBe(302);
 				expect(response.text).toContain('Found. Redirecting to ');
 				expect(response.text).toContain('/appeals-service/appeal-details/1');
-			});
-
-			it(`should render a 500 page, if answer "yes, and upload another document" was provided, and there is more than one version of the document`, async () => {
-				const multipleVersionsDocument = cloneDeep(documentFileVersionsInfo);
-				multipleVersionsDocument.allVersions.push({
-					...multipleVersionsDocument.allVersions[0],
-					version: 2
-				});
-
-				nock('http://test/')
-					.get('/appeals/1/documents/1/versions')
-					.reply(200, multipleVersionsDocument);
-
-				const response = await request
-					.post(
-						`${baseUrl}/1/internal-correspondence/${correspondenceCategory}/manage-documents/${folder.folderId}/1/1/delete`
-					)
-					.send({
-						'delete-file-answer': 'yes-and-upload-another-document'
-					});
-
-				const unprettifiedElement = parseHtml(response.text, { skipPrettyPrint: true });
-
-				expect(unprettifiedElement.innerHTML).toContain(
-					'Sorry, there is a problem with the service</h1>'
-				);
-			});
-
-			it(`should send an API request to delete the document, and redirect to the upload new document page, if answer "yes, and upload another document" was provided, and there is only one version of the document`, async () => {
-				nock('http://test/')
-					.get('/appeals/1/documents/1/versions')
-					.reply(200, documentFileVersionsInfo);
-
-				const response = await request
-					.post(
-						`${baseUrl}/1/internal-correspondence/${correspondenceCategory}/manage-documents/${folder.folderId}/1/1/delete`
-					)
-					.send({
-						'delete-file-answer': 'yes-and-upload-another-document'
-					});
-
-				expect(response.statusCode).toBe(302);
-				expect(response.text).toContain('Found. Redirecting to ');
-				expect(response.text).toContain(
-					`/appeals-service/appeal-details/1/internal-correspondence/${correspondenceCategory}/upload-documents/${folder.folderId}`
-				);
 			});
 		}
 	});

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/__tests__/__snapshots__/lpa-questionnaire.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/__tests__/__snapshots__/lpa-questionnaire.test.js.snap
@@ -2957,13 +2957,8 @@ exports[`LPA Questionnaire review GET /lpa-questionnaire/1/manage-documents/:fol
                         </div>
                         <div class="govuk-radios__item">
                             <input class="govuk-radios__input" id="delete-file-answer-2" name="delete-file-answer"
-                            type="radio" value="yes-and-upload-another-document">
-                            <label class="govuk-label govuk-radios__label" for="delete-file-answer-2">Yes, and upload another document</label>
-                        </div>
-                        <div class="govuk-radios__item">
-                            <input class="govuk-radios__input" id="delete-file-answer-3" name="delete-file-answer"
                             type="radio" value="no">
-                            <label class="govuk-label govuk-radios__label" for="delete-file-answer-3">No</label>
+                            <label class="govuk-label govuk-radios__label" for="delete-file-answer-2">No</label>
                         </div>
                     </div>
                 </div>

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/__tests__/lpa-questionnaire.test.js
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/__tests__/lpa-questionnaire.test.js
@@ -3009,9 +3009,6 @@ describe('LPA Questionnaire review', () => {
 				'name="delete-file-answer" type="radio" value="yes">'
 			);
 			expect(unprettifiedElement.innerHTML).toContain(
-				'name="delete-file-answer" type="radio" value="yes-and-upload-another-document">'
-			);
-			expect(unprettifiedElement.innerHTML).toContain(
 				'name="delete-file-answer" type="radio" value="no">'
 			);
 		});
@@ -3040,9 +3037,6 @@ describe('LPA Questionnaire review', () => {
 			);
 			expect(unprettifiedElement.innerHTML).toContain(
 				'name="delete-file-answer" type="radio" value="no">'
-			);
-			expect(unprettifiedElement.innerHTML).not.toContain(
-				'name="delete-file-answer" type="radio" value="yes-and-upload-another-document">'
 			);
 			expect(unprettifiedElement.innerHTML).not.toContain(
 				'<strong class="govuk-warning-text__text"><span class="govuk-warning-text__assistive">Warning</span> Removing the only version of a document will delete the document from the case</strong>'

--- a/appeals/web/src/server/appeals/appeal-documents/appeal-documents.controller.js
+++ b/appeals/web/src/server/appeals/appeal-documents/appeal-documents.controller.js
@@ -766,20 +766,6 @@ export const postDeleteDocument = async (
 			Number.parseInt(appealId, 10)
 		);
 		return response.redirect(returnUrl);
-	} else if (body['delete-file-answer'] === 'yes-and-upload-another-document') {
-		const fileVersionsInfo = await getFileVersionsInfo(request.apiClient, appealId, documentId);
-
-		if (fileVersionsInfo?.allVersions) {
-			const deletingOnlyVersion =
-				fileVersionsInfo?.allVersions?.filter((version) => version.isDeleted === false).length < 2;
-
-			if (deletingOnlyVersion) {
-				await deleteDocument(apiClient, appealId, documentId, versionId);
-				return response.redirect(uploadNewDocumentUrlProcessed);
-			} else {
-				return response.status(500).render('app/500.njk');
-			}
-		}
 	}
 
 	return response.status(500).render('app/500.njk');

--- a/appeals/web/src/server/appeals/appeal-documents/appeal-documents.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-documents/appeal-documents.mapper.js
@@ -1313,13 +1313,6 @@ export async function deleteDocumentPage(
 		}
 	];
 
-	if (totalDocumentVersions === 1) {
-		radioEntries.push({
-			text: 'Yes, and upload another document',
-			value: 'yes-and-upload-another-document'
-		});
-	}
-
 	radioEntries.push({
 		text: 'No',
 		value: 'no'


### PR DESCRIPTION
# Describe your changes

Remove "Yes, and upload another document" option from delete document version journey

## Issue ticket number and link

A2-901

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [ ] I have performed a self-review of my own code
- [ ] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [ ] I have referenced the ticket number above
- [ ] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
