### PR TITLE
fix(api): ensure broadcast document selects the correct document by guid

### DIFF
--- a/appeals/api/src/server/endpoints/integrations/integrations.broadcasters/documents.js
+++ b/appeals/api/src/server/endpoints/integrations/integrations.broadcasters/documents.js
@@ -22,7 +22,7 @@ export const broadcastDocument = async (documentId, version, updateType) => {
 	if (!config.serviceBusEnabled) {
 		return false;
 	}
-	const document = await databaseConnector.document.findFirst({
+	const document = await databaseConnector.document.findUnique({
 		where: { guid: documentId },
 		include: {
 			case: {

--- a/appeals/api/src/server/endpoints/integrations/integrations.controller.js
+++ b/appeals/api/src/server/endpoints/integrations/integrations.controller.js
@@ -60,12 +60,12 @@ export const postAppealSubmission = async (req, res) => {
 	await integrationService.importDocuments(documents, documentVersions);
 
 	for (const document of documentVersions) {
-		await broadcasters.broadcastDocument(document.guid, 1, EventType.Create);
+		await broadcasters.broadcastDocument(document.documentGuid, 1, EventType.Create);
 
 		const auditTrail = await createAuditTrail({
 			appealId: id,
 			azureAdUserId: AUDIT_TRAIL_SYSTEM_UUID,
-			details: stringTokenReplacement(AUDIT_TRAIL_DOCUMENT_IMPORTED, [document.fileName])
+			details: stringTokenReplacement(AUDIT_TRAIL_DOCUMENT_IMPORTED, [document.fileName || ''])
 		});
 
 		if (auditTrail) {
@@ -106,12 +106,12 @@ export const postLpaqSubmission = async (req, res) => {
 	await integrationService.importDocuments(documents, documentVersions);
 
 	for (const document of documentVersions) {
-		await broadcasters.broadcastDocument(document.guid, 1, EventType.Create);
+		await broadcasters.broadcastDocument(document.documentGuid, 1, EventType.Create);
 
 		const auditTrail = await createAuditTrail({
 			appealId: id,
 			azureAdUserId: AUDIT_TRAIL_SYSTEM_UUID,
-			details: stringTokenReplacement(AUDIT_TRAIL_DOCUMENT_IMPORTED, [document.fileName])
+			details: stringTokenReplacement(AUDIT_TRAIL_DOCUMENT_IMPORTED, [document.fileName || ''])
 		});
 
 		if (auditTrail) {


### PR DESCRIPTION
## Describe your changes

A2-946

Correct the types for document broadcast, and use the `documentGuid` property of the document version for broadcast.

## Issue ticket number and link

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [ ] I have performed a self-review of my own code
- [ ] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [ ] I have referenced the ticket number above
- [ ] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
