### PR TITLE
fix(api): broadcast no redaction required for decision letter

### DIFF
--- a/appeals/api/setup-tests.js
+++ b/appeals/api/setup-tests.js
@@ -10,6 +10,7 @@ const mockAppealRelationshipRemove = jest.fn().mockResolvedValue({});
 const mockAppealRelationshipFindMany = jest.fn().mockResolvedValue({});
 const mockAppealDecision = jest.fn().mockResolvedValue({});
 const mockAppealFindUnique = jest.fn().mockResolvedValue({});
+const mockAppealCreate = jest.fn().mockResolvedValue({});
 const mocklPAQuestionnaireCreate = jest.fn().mockResolvedValue({});
 const mocklPAQuestionnaireUpdate = jest.fn().mockResolvedValue({});
 const mockAppealStatusUpdateMany = jest.fn().mockResolvedValue({});
@@ -32,6 +33,7 @@ const mockDocumentFindMany = jest.fn().mockResolvedValue({});
 const mockDocumentCount = jest.fn().mockResolvedValue({});
 const mockDocumentFindFirst = jest.fn().mockResolvedValue({});
 const mockDocumentDelete = jest.fn().mockResolvedValue({});
+const mockDocumentCreateMany = jest.fn().mockResolvedValue({});
 const mockDocumentVersionCreate = jest.fn().mockResolvedValue({});
 const mockDocumentMetdataFindFirst = jest.fn().mockResolvedValue({});
 const mockDocumentMetdataFindUnique = jest.fn().mockResolvedValue({});
@@ -108,7 +110,8 @@ class MockPrismaClient {
 			findUnique: mockAppealFindUnique,
 			update: mockAppealUpdate,
 			findMany: mockAppealFindMany,
-			count: mockAppealCount
+			count: mockAppealCount,
+			create: mockAppealCreate
 		};
 	}
 
@@ -156,7 +159,8 @@ class MockPrismaClient {
 			findUnique: mockDocumentFindUnique,
 			findMany: mockDocumentFindMany,
 			update: mockDocumentUpdate,
-			upsert: mockDocumentUpsert
+			upsert: mockDocumentUpsert,
+			createMany: mockDocumentCreateMany
 		};
 	}
 

--- a/appeals/api/src/server/endpoints/integrations/__tests__/integrations.test.js
+++ b/appeals/api/src/server/endpoints/integrations/__tests__/integrations.test.js
@@ -32,7 +32,7 @@ describe('/appeals/case-submission', () => {
 			});
 		});
 
-		test('invalid appellant case payload: no LPA', async () => {
+		test('POST invalid appellant case payload: no LPA', async () => {
 			const { lpaCode, ...invalidPayload } = validAppellantCase.casedata;
 			const payload = { casedata: { ...invalidPayload }, users: [], documents: [] };
 			const response = await request.post('/appeals/case-submission').send(payload);
@@ -47,7 +47,7 @@ describe('/appeals/case-submission', () => {
 			});
 		});
 
-		test('invalid appellant case payload: no appeal type', async () => {
+		test('POST invalid appellant case payload: no appeal type', async () => {
 			const { caseType, ...invalidPayload } = validAppellantCase.casedata;
 			const payload = { casedata: { ...invalidPayload }, users: [], documents: [] };
 			const response = await request.post('/appeals/case-submission').send(payload);
@@ -62,7 +62,7 @@ describe('/appeals/case-submission', () => {
 			});
 		});
 
-		test('invalid appellant case payload: unsupported appeal type', async () => {
+		test('POST invalid appellant case payload: unsupported appeal type', async () => {
 			// eslint-disable-next-line no-unused-vars
 			const { caseType, ...validPayload } = validAppellantCase.casedata;
 			const payload = {
@@ -85,7 +85,7 @@ describe('/appeals/case-submission', () => {
 			});
 		});
 
-		test('invalid appellant case payload: no application reference', async () => {
+		test('POST invalid appellant case payload: no application reference', async () => {
 			const { applicationReference, ...invalidPayload } = validAppellantCase.casedata;
 			const payload = { casedata: { ...invalidPayload }, users: [], documents: [] };
 			const response = await request.post('/appeals/case-submission').send(payload);
@@ -98,6 +98,194 @@ describe('/appeals/case-submission', () => {
 					integration: ERROR_INVALID_APPELLANT_CASE_DATA
 				}
 			});
+		});
+
+		test('POST valid appellant case payload and create appeal', async () => {
+			// @ts-ignore
+			databaseConnector.appeal.create.mockResolvedValue({});
+
+			const payload = validAppellantCase;
+			await request.post('/appeals/case-submission').send(payload);
+
+			expect(databaseConnector.appeal.create).toHaveBeenCalledWith({
+				data: {
+					reference: expect.any(String),
+					submissionId: expect.any(String),
+					appealType: {
+						connect: {
+							key: 'D'
+						}
+					},
+					appellant: {
+						create: {
+							organisationName: 'A company',
+							salutation: 'Mr',
+							firstName: 'Testy',
+							lastName: 'McTest',
+							email: 'test@test.com',
+							webAddress: undefined,
+							phoneNumber: '0123456789',
+							otherPhoneNumber: undefined,
+							faxNumber: undefined
+						}
+					},
+					agent: {
+						create: undefined
+					},
+					lpa: {
+						connect: {
+							lpaCode: 'Q9999'
+						}
+					},
+					applicationReference: '123',
+					address: {
+						create: {
+							addressLine1: 'Somewhere',
+							addressLine2: 'Somewhere St',
+							addressCounty: 'Somewhere',
+							postcode: 'SOM3 W3R',
+							addressTown: 'Somewhereville'
+						}
+					},
+					appellantCase: {
+						create: {
+							applicationDate: '2024-01-01T00:00:00.000Z',
+							applicationDecision: 'refused',
+							applicationDecisionDate: '2024-01-01T00:00:00.000Z',
+							caseSubmittedDate: '2024-03-25T23:59:59.999Z',
+							caseSubmissionDueDate: '2024-03-25T23:59:59.999Z',
+							siteAccessDetails: 'Come and see',
+							siteSafetyDetails: "It's dangerous",
+							siteAreaSquareMetres: 22,
+							floorSpaceSquareMetres: 22,
+							ownsAllLand: true,
+							ownsSomeLand: true,
+							hasAdvertisedAppeal: true,
+							appellantCostsAppliedFor: false,
+							originalDevelopmentDescription: 'A test description',
+							changedDevelopmentDescription: false,
+							ownersInformed: true,
+							knowsAllOwners: {
+								connect: {
+									key: 'Some'
+								}
+							},
+							knowsOtherOwners: {
+								connect: {
+									key: 'Some'
+								}
+							},
+							isGreenBelt: false,
+							appellantProcedurePreference: undefined,
+							appellantProcedurePreferenceDetails: undefined,
+							appellantProcedurePreferenceDuration: undefined,
+							inquiryHowManyWitnesses: undefined
+						}
+					},
+					neighbouringSites: {
+						create: []
+					},
+					folders: {
+						create: [
+							{
+								path: 'appellant-case/appellantStatement'
+							},
+							{
+								path: 'appellant-case/originalApplicationForm'
+							},
+							{
+								path: 'appellant-case/applicationDecisionLetter'
+							},
+							{
+								path: 'appellant-case/changedDescription'
+							},
+							{
+								path: 'appellant-case/appellantCaseWithdrawalLetter'
+							},
+							{
+								path: 'appellant-case/appellantCaseCorrespondence'
+							},
+							{
+								path: 'appellant-case/designAccessStatement'
+							},
+							{
+								path: 'appellant-case/plansDrawings'
+							},
+							{
+								path: 'appellant-case/newPlansDrawings'
+							},
+							{
+								path: 'appellant-case/planningObligation'
+							},
+							{
+								path: 'appellant-case/ownershipCertificate'
+							},
+							{
+								path: 'appellant-case/otherNewDocuments'
+							},
+							{
+								path: 'lpa-questionnaire/whoNotified'
+							},
+							{
+								path: 'lpa-questionnaire/whoNotifiedSiteNotice'
+							},
+							{
+								path: 'lpa-questionnaire/whoNotifiedLetterToNeighbours'
+							},
+							{
+								path: 'lpa-questionnaire/whoNotifiedPressAdvert'
+							},
+							{
+								path: 'lpa-questionnaire/conservationMap'
+							},
+							{
+								path: 'lpa-questionnaire/otherPartyRepresentations'
+							},
+							{
+								path: 'lpa-questionnaire/planningOfficerReport'
+							},
+							{
+								path: 'lpa-questionnaire/lpaCaseCorrespondence'
+							},
+							{
+								path: 'costs/appellantCostsApplication'
+							},
+							{
+								path: 'costs/appellantCostsWithdrawal'
+							},
+							{
+								path: 'costs/appellantCostsCorrespondence'
+							},
+							{
+								path: 'costs/lpaCostsApplication'
+							},
+							{
+								path: 'costs/lpaCostsWithdrawal'
+							},
+							{
+								path: 'costs/lpaCostsCorrespondence'
+							},
+							{
+								path: 'costs/costsDecisionLetter'
+							},
+							{
+								path: 'internal/crossTeamCorrespondence'
+							},
+							{
+								path: 'internal/inspectorCorrespondence'
+							},
+							{
+								path: 'internal/uncategorised'
+							},
+							{
+								path: 'appeal-decision/caseDecisionLetter'
+							}
+						]
+					}
+				}
+			});
+			expect(databaseConnector.appeal.update).toHaveBeenCalled();
+			expect(databaseConnector.documentRedactionStatus.findMany).toHaveBeenCalled();
 		});
 	});
 });

--- a/appeals/api/src/server/endpoints/integrations/integrations.mappers/document.mapper.js
+++ b/appeals/api/src/server/endpoints/integrations/integrations.mappers/document.mapper.js
@@ -2,7 +2,12 @@ import config from '#config/config.js';
 import { randomUUID } from 'node:crypto';
 import { mapDate } from './date.mapper.js';
 import { ODW_SYSTEM_ID } from '@pins/appeals/constants/common.js';
-import { APPEAL_ORIGIN, APPEAL_CASE_STAGE } from 'pins-data-model';
+import {
+	APPEAL_ORIGIN,
+	APPEAL_CASE_STAGE,
+	APPEAL_DOCUMENT_TYPE,
+	APPEAL_REDACTED_STATUS
+} from 'pins-data-model';
 import { getAvScanStatus } from '#endpoints/documents/documents.service.js';
 
 /** @typedef {import('@pins/appeals.api').Schema.Document} Document */
@@ -57,7 +62,8 @@ export const mapDocumentOut = (data) => {
 	const isPublished = mapPublishingStatus(documentInput.latestDocumentVersion);
 	const virusCheckStatus = mapVirusCheckStatus(documentInput.latestDocumentVersion);
 	const redactedStatus = mapRedactionStatus(
-		documentInput.latestDocumentVersion.redactionStatus || null
+		documentInput.latestDocumentVersion.redactionStatus || null,
+		documentInput.latestDocumentVersion.documentType || null
 	);
 
 	const doc = {
@@ -116,10 +122,15 @@ const mapPublishingStatus = (documentVersion) => {
 /**
  *
  * @param {DocumentRedactionStatus | null} status
+ * @param {string | null} documentType
  * @returns
  */
-const mapRedactionStatus = (status) => {
-	return status?.key || null;
+const mapRedactionStatus = (status, documentType) => {
+	if (documentType === APPEAL_DOCUMENT_TYPE.CASE_DECISION_LETTER) {
+		return APPEAL_REDACTED_STATUS.NO_REDACTION_REQUIRED;
+	}
+
+	return status?.key || APPEAL_REDACTED_STATUS.NOT_REDACTED;
 };
 
 /**


### PR DESCRIPTION
When broadcasting document data, use an exception for `caseDecisionLetter` document types, forcing them to be broadcasted with `redactedStatus: no_redaction_required`.

## Issue ticket number and link

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [ ] I have performed a self-review of my own code
- [ ] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [ ] I have referenced the ticket number above
- [ ] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
