### PR TITLE
feat(web): add notification banner for unreviewed ip comments

### DIFF
--- a/appeals/web/src/server/appeals/appeal-details/__tests__/__snapshots__/appeal-details.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/__tests__/__snapshots__/appeal-details.test.js.snap
@@ -406,6 +406,21 @@ role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govu
 </div>"
 `;
 
+exports[`appeal-details GET /:appealId Notification banners should render an important notification banner when the appeal has unreviewed IP comments 1`] = `
+"<div class="govuk-notification-banner" role="region" aria-labelledby="govuk-notification-banner-title"
+data-module="govuk-notification-banner">
+    <div class="govuk-notification-banner__header">
+        <h3 class="govuk-notification-banner__title" id="govuk-notification-banner-title"> Important</h3>
+    </div>
+    <div class="govuk-notification-banner__content">
+        <p class="govuk-notification-banner__heading">Review comments</p>
+        <p><a class="govuk-notification-banner__link" href="/appeals-service/appeal-details/2/interested-party-comments"
+            data-cy="banner-review-ip-comments">Review</a>
+        </p>
+    </div>
+</div>"
+`;
+
 exports[`appeal-details GET /:appealId should not render action links to the manage linked appeals page or the add linked appeal page in the linked appeals row, if the appeal is linked as a child of an external lead appeal 1`] = `
 "<main class="govuk-main-wrapper " id="main-content" role="main">
     <div class="govuk-grid-row">

--- a/appeals/web/src/server/appeals/appeal-details/appeal-details.controller.js
+++ b/appeals/web/src/server/appeals/appeal-details/appeal-details.controller.js
@@ -1,4 +1,6 @@
 import { appealDetailsPage } from './appeal-details.mapper.js';
+import { getInterestedPartyComments } from './interested-party-comments/interested-party-comments.service.js';
+import { APPEAL_REPRESENTATION_STATUS, APPEAL_TYPE } from '@pins/appeals/constants/common.js';
 
 /**
  *
@@ -10,12 +12,23 @@ export const viewAppealDetails = async (request, response) => {
 	const session = request.session;
 	try {
 		if (appealDetails) {
+			let unreviewedIPComments;
+
+			if (appealDetails.appealType === APPEAL_TYPE.W) {
+				unreviewedIPComments = await getInterestedPartyComments(
+					request.apiClient,
+					appealDetails.appealId,
+					APPEAL_REPRESENTATION_STATUS.AWAITING_REVIEW
+				);
+			}
+
 			const currentUrl = request.originalUrl;
 			const mappedPageContent = await appealDetailsPage(
 				appealDetails,
 				currentUrl,
 				session,
-				request
+				request,
+				unreviewedIPComments && unreviewedIPComments.length > 0
 			);
 
 			return response.status(200).render('patterns/display-page.pattern.njk', {

--- a/appeals/web/src/server/appeals/appeal-details/interested-party-comments/interested-party-comments.service.js
+++ b/appeals/web/src/server/appeals/appeal-details/interested-party-comments/interested-party-comments.service.js
@@ -1,0 +1,27 @@
+import { paginationDefaultSettings } from '#appeals/appeal.constants.js';
+
+/**
+ * Fetch paginated appeal comments based on appeal ID and status.
+ *
+ * @param {import('got').Got} apiClient
+ * @param {string} appealId
+ * @param {string|undefined} statusFilter
+ * @param {number} pageNumber
+ * @param {number} pageSize
+ * @returns {Promise<any>}
+ */
+export const getInterestedPartyComments = (
+	apiClient,
+	appealId,
+	statusFilter = 'all',
+	pageNumber = paginationDefaultSettings.firstPageNumber,
+	pageSize = paginationDefaultSettings.pageSize
+) => {
+	let url = `appeals/${appealId}/reps/comments?pageNumber=${pageNumber}&pageSize=${pageSize}`;
+
+	if (statusFilter && statusFilter !== 'all') {
+		url += `&status=${encodeURIComponent(statusFilter)}`;
+	}
+
+	return apiClient.get(url).json();
+};

--- a/appeals/web/src/server/lib/mappers/notification-banners.mapper.js
+++ b/appeals/web/src/server/lib/mappers/notification-banners.mapper.js
@@ -170,6 +170,10 @@ export const notificationBannerDefinitions = {
 	changePage: {
 		type: 'success',
 		pages: ['appealDetails', 'appellantCase', 'lpaQuestionnaire']
+	},
+	interestedPartyCommentsAwaitingReview: {
+		pages: ['appealDetails'],
+		persist: true
 	}
 };
 

--- a/appeals/web/testing/app/fixtures/referencedata.js
+++ b/appeals/web/testing/app/fixtures/referencedata.js
@@ -2268,6 +2268,42 @@ export const lpaNotificationMethodsData = [
 	}
 ];
 
+export const interestedPartyCommentsAwaitingReview = [
+	{
+		id: 6383,
+		origin: 'citizen',
+		author: 'Roger Simmons',
+		status: 'awaiting_review',
+		originalRepresentation: 'Some autogen text 9',
+		redactedRepresentation: '',
+		created: '2024-09-13T12:04:55.565Z',
+		notes: '',
+		attachments: []
+	},
+	{
+		id: 6382,
+		origin: 'citizen',
+		author: 'Fiona Burgess',
+		status: 'awaiting_review',
+		originalRepresentation: 'Some autogen text 8',
+		redactedRepresentation: '',
+		created: '2024-09-13T12:04:55.555Z',
+		notes: '',
+		attachments: []
+	},
+	{
+		id: 6381,
+		origin: 'citizen',
+		author: 'Elaine Madsen',
+		status: 'awaiting_review',
+		originalRepresentation: 'Some autogen text 7',
+		redactedRepresentation: '',
+		created: '2024-09-13T12:04:55.545Z',
+		notes: '',
+		attachments: []
+	}
+];
+
 export const baseSession = {
 	id: '',
 	cookie: { originalMaxAge: 1 },


### PR DESCRIPTION
## Describe your changes

add notification banner to case details page for full planning / s78 appeals in 'statements' status which have unreviewed IP comments

## Issue ticket number and link

A2-587

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [ ] I have performed a self-review of my own code
- [ ] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [ ] I have referenced the ticket number above
- [ ] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
