### PR TITLE
fix(api): integration test coverage

### DIFF
--- a/appeals/api/jest.config.js
+++ b/appeals/api/jest.config.js
@@ -8,13 +8,6 @@ export default {
 			functions: 65,
 			lines: 70,
 			statements: 70
-		},
-		// to improve and increase the coverage thresholds
-		'./src/server/endpoints/integrations': {
-			branches: 5.85,
-			functions: 10.86,
-			lines: 26.05,
-			statements: 25.51
 		}
 	}
 };

--- a/appeals/api/setup-tests.js
+++ b/appeals/api/setup-tests.js
@@ -8,6 +8,7 @@ const mockRepUpdateById = jest.fn().mockResolvedValue({});
 const mockAppealRelationshipAdd = jest.fn().mockResolvedValue({});
 const mockAppealRelationshipRemove = jest.fn().mockResolvedValue({});
 const mockAppealRelationshipFindMany = jest.fn().mockResolvedValue({});
+const mockAppealRelationshipCreateMany = jest.fn().mockResolvedValue({});
 const mockAppealDecision = jest.fn().mockResolvedValue({});
 const mockAppealFindUnique = jest.fn().mockResolvedValue({});
 const mockAppealCreate = jest.fn().mockResolvedValue({});
@@ -35,6 +36,8 @@ const mockDocumentFindFirst = jest.fn().mockResolvedValue({});
 const mockDocumentDelete = jest.fn().mockResolvedValue({});
 const mockDocumentCreateMany = jest.fn().mockResolvedValue({});
 const mockDocumentVersionCreate = jest.fn().mockResolvedValue({});
+const mockDocumentVersionCreateMany = jest.fn().mockResolvedValue({});
+const mockDocumentVersionFindMany = jest.fn().mockResolvedValue({});
 const mockDocumentMetdataFindFirst = jest.fn().mockResolvedValue({});
 const mockDocumentMetdataFindUnique = jest.fn().mockResolvedValue({});
 const mockDocumentMetdataUpsert = jest.fn().mockResolvedValue({});
@@ -119,7 +122,8 @@ class MockPrismaClient {
 		return {
 			findMany: mockAppealRelationshipFindMany,
 			delete: mockAppealRelationshipRemove,
-			create: mockAppealRelationshipAdd
+			create: mockAppealRelationshipAdd,
+			createMany: mockAppealRelationshipCreateMany
 		};
 	}
 
@@ -167,6 +171,8 @@ class MockPrismaClient {
 	get documentVersion() {
 		return {
 			create: mockDocumentVersionCreate,
+			createMany: mockDocumentVersionCreateMany,
+			findMany: mockDocumentVersionFindMany,
 			findFirst: mockDocumentMetdataFindFirst,
 			findUnique: mockDocumentMetdataFindUnique,
 			upsert: mockDocumentMetdataUpsert,

--- a/appeals/api/src/server/endpoints/documents/documents.service.js
+++ b/appeals/api/src/server/endpoints/documents/documents.service.js
@@ -319,7 +319,7 @@ export const getDocumentRedactionStatusIds = async () => {
 /**
  *
  * @param {DocumentVersion} documentVersion
- * @returns
+ * @returns {string}
  */
 export const getAvScanStatus = (documentVersion) => {
 	return documentVersion.virusCheckStatus || APPEAL_VIRUS_CHECK_STATUS.NOT_SCANNED;

--- a/appeals/api/src/server/endpoints/integrations/integrations.controller.js
+++ b/appeals/api/src/server/endpoints/integrations/integrations.controller.js
@@ -91,8 +91,11 @@ export const postLpaqSubmission = async (req, res) => {
 		relatedReferences
 	);
 
+	if (!casedata.appeal) {
+		return res.status(404);
+	}
+
 	const { documentVersions } = casedata;
-	// @ts-ignore
 	const { id, reference } = casedata.appeal;
 
 	await createAuditTrail({

--- a/appeals/api/src/server/endpoints/integrations/integrations.mappers.js
+++ b/appeals/api/src/server/endpoints/integrations/integrations.mappers.js
@@ -33,12 +33,12 @@ import { APPEAL_CASE_STAGE, SERVICE_USER_TYPE } from 'pins-data-model';
 import { FOLDERS } from '@pins/appeals/constants/documents.js';
 import { mapSiteVisitOut } from './integrations.mappers/site-visit.mapper.js';
 
-/** @typedef {import('pins-data-model').Schemas.AppellantSubmissionCommand} AppellantSubmissionCommand */
-/** @typedef {import('pins-data-model').Schemas.LPAQuestionnaireCommand} LPAQuestionnaireCommand */
 /** @typedef {import('@pins/appeals.api').Schema.Appeal} Appeal */
 /** @typedef {import('@pins/appeals.api').Schema.ServiceUser} ServiceUser */
 /** @typedef {import('@pins/appeals.api').Schema.Document} Document */
 /** @typedef {import('@pins/appeals.api').Schema.SiteVisit} SiteVisit */
+/** @typedef {import('pins-data-model').Schemas.AppellantSubmissionCommand} AppellantSubmissionCommand */
+/** @typedef {import('pins-data-model').Schemas.LPAQuestionnaireCommand} LPAQuestionnaireCommand */
 /** @typedef {import('pins-data-model').Schemas.AppealHASCase} AppealHASCase */
 /** @typedef {import('pins-data-model').Schemas.ServiceUser} AppealServiceUser */
 /** @typedef {import('pins-data-model').Schemas.AppealDocument} AppealDocument */
@@ -74,7 +74,7 @@ const mappers = {
 
 /**
  * @param {AppellantSubmissionCommand} data
- * @returns {{ appeal: import('#db-client').Prisma.AppealCreateInput, documents: *[], relatedReferences: string[] }}
+ * @returns {{ appeal: import('#db-client').Prisma.AppealCreateInput, documents: import('#db-client').Prisma.DocumentVersionCreateInput[], relatedReferences: string[] }}
  */
 const mapAppealSubmission = (data) => {
 	const { casedata, documents, users } = data;
@@ -127,7 +127,7 @@ const mapAppealSubmission = (data) => {
 /**
  *
  * @param {LPAQuestionnaireCommand} data
- * @returns {{ questionnaire: import('#db-client').Prisma.LPAQuestionnaireCreateInput, documents: *[], relatedReferences: string[], caseReference: string }}
+ * @returns {{ questionnaire: import('#db-client').Prisma.LPAQuestionnaireCreateInput, documents: import('#db-client').Prisma.DocumentVersionCreateInput[], relatedReferences: string[], caseReference: string }}
  */
 const mapQuestionnaireSubmission = (data) => {
 	const { casedata, documents } = data;
@@ -205,7 +205,7 @@ const mapAppeal = (appeal) => {
 /**
  *
  * @param {Document} doc
- * @returns
+ * @returns {AppealDocument | null}
  */
 const mapDocument = (doc) => {
 	return mappers.mapDocumentOut(doc);

--- a/appeals/api/src/server/endpoints/integrations/integrations.mappers/appellant-case.mapper.js
+++ b/appeals/api/src/server/endpoints/integrations/integrations.mappers/appellant-case.mapper.js
@@ -6,7 +6,7 @@ import { mapDate } from './date.mapper.js';
 /**
  *
  * @param {Pick<AppellantSubmissionCommand, 'casedata'>} command
- * @returns
+ * @returns {Omit<import('#db-client').Prisma.AppellantCaseCreateInput, 'appeal'>}
  */
 export const mapAppellantCaseIn = (command) => {
 	const casedata = command.casedata;
@@ -58,6 +58,7 @@ export const mapAppellantCaseIn = (command) => {
 		inquiryHowManyWitnesses: casedata.inquiryHowManyWitnesses
 	};
 
+	// @ts-ignore
 	return data;
 };
 

--- a/appeals/api/src/server/tests/integrations/mocks.js
+++ b/appeals/api/src/server/tests/integrations/mocks.js
@@ -113,3 +113,194 @@ export const validLpaQuestionnaire = {
 		}
 	]
 };
+
+export const appealIngestionInput = {
+	appealType: {
+		connect: {
+			key: 'D'
+		}
+	},
+	appellant: {
+		create: {
+			organisationName: 'A company',
+			salutation: 'Mr',
+			firstName: 'Testy',
+			lastName: 'McTest',
+			email: 'test@test.com',
+			webAddress: undefined,
+			phoneNumber: '0123456789',
+			otherPhoneNumber: undefined,
+			faxNumber: undefined
+		}
+	},
+	agent: {
+		create: undefined
+	},
+	lpa: {
+		connect: {
+			lpaCode: 'Q9999'
+		}
+	},
+	applicationReference: '123',
+	address: {
+		create: {
+			addressLine1: 'Somewhere',
+			addressLine2: 'Somewhere St',
+			addressCounty: 'Somewhere',
+			postcode: 'SOM3 W3R',
+			addressTown: 'Somewhereville'
+		}
+	},
+	appellantCase: {
+		create: {
+			applicationDate: '2024-01-01T00:00:00.000Z',
+			applicationDecision: 'refused',
+			applicationDecisionDate: '2024-01-01T00:00:00.000Z',
+			caseSubmittedDate: '2024-03-25T23:59:59.999Z',
+			caseSubmissionDueDate: '2024-03-25T23:59:59.999Z',
+			siteAccessDetails: 'Come and see',
+			siteSafetyDetails: "It's dangerous",
+			siteAreaSquareMetres: 22,
+			floorSpaceSquareMetres: 22,
+			ownsAllLand: true,
+			ownsSomeLand: true,
+			hasAdvertisedAppeal: true,
+			appellantCostsAppliedFor: false,
+			originalDevelopmentDescription: 'A test description',
+			changedDevelopmentDescription: false,
+			ownersInformed: true,
+			knowsAllOwners: {
+				connect: {
+					key: 'Some'
+				}
+			},
+			knowsOtherOwners: {
+				connect: {
+					key: 'Some'
+				}
+			},
+			isGreenBelt: false,
+			appellantProcedurePreference: undefined,
+			appellantProcedurePreferenceDetails: undefined,
+			appellantProcedurePreferenceDuration: undefined,
+			inquiryHowManyWitnesses: undefined
+		}
+	},
+	neighbouringSites: {
+		create: []
+	},
+	folders: {
+		create: [
+			{
+				path: 'appellant-case/appellantStatement'
+			},
+			{
+				path: 'appellant-case/originalApplicationForm'
+			},
+			{
+				path: 'appellant-case/applicationDecisionLetter'
+			},
+			{
+				path: 'appellant-case/changedDescription'
+			},
+			{
+				path: 'appellant-case/appellantCaseWithdrawalLetter'
+			},
+			{
+				path: 'appellant-case/appellantCaseCorrespondence'
+			},
+			{
+				path: 'appellant-case/designAccessStatement'
+			},
+			{
+				path: 'appellant-case/plansDrawings'
+			},
+			{
+				path: 'appellant-case/newPlansDrawings'
+			},
+			{
+				path: 'appellant-case/planningObligation'
+			},
+			{
+				path: 'appellant-case/ownershipCertificate'
+			},
+			{
+				path: 'appellant-case/otherNewDocuments'
+			},
+			{
+				path: 'lpa-questionnaire/whoNotified'
+			},
+			{
+				path: 'lpa-questionnaire/whoNotifiedSiteNotice'
+			},
+			{
+				path: 'lpa-questionnaire/whoNotifiedLetterToNeighbours'
+			},
+			{
+				path: 'lpa-questionnaire/whoNotifiedPressAdvert'
+			},
+			{
+				path: 'lpa-questionnaire/conservationMap'
+			},
+			{
+				path: 'lpa-questionnaire/otherPartyRepresentations'
+			},
+			{
+				path: 'lpa-questionnaire/planningOfficerReport'
+			},
+			{
+				path: 'lpa-questionnaire/lpaCaseCorrespondence'
+			},
+			{
+				path: 'costs/appellantCostsApplication'
+			},
+			{
+				path: 'costs/appellantCostsWithdrawal'
+			},
+			{
+				path: 'costs/appellantCostsCorrespondence'
+			},
+			{
+				path: 'costs/lpaCostsApplication'
+			},
+			{
+				path: 'costs/lpaCostsWithdrawal'
+			},
+			{
+				path: 'costs/lpaCostsCorrespondence'
+			},
+			{
+				path: 'costs/costsDecisionLetter'
+			},
+			{
+				path: 'internal/crossTeamCorrespondence'
+			},
+			{
+				path: 'internal/inspectorCorrespondence'
+			},
+			{
+				path: 'internal/uncategorised'
+			},
+			{
+				path: 'appeal-decision/caseDecisionLetter'
+			}
+		]
+	}
+};
+
+export const docIngestionInput = {
+	documentType: 'appellantCostsApplication',
+	documentURI:
+		'https://pinsstdocsdevukw001.blob.core.windows.net/uploads/055c2c5a-a540-4cd6-a51a-5cfd2ddc16bf/788b8a15-d392-4986-ac23-57be2f824f9c/--12345678---chrishprofilepic.jpeg',
+	mime: 'image/jpeg',
+	originalFilename: 'oimg.jpg',
+	size: 10293,
+	fileName: 'img1.jpg',
+	blobStorageContainer: 'document-service-uploads',
+	blobStoragePath: 'a2c9f873-448e-4dfe-9a19-8239d59a8a88/v1/img1.jpg',
+	stage: 'appellant-case',
+	documentGuid: 'a2c9f873-448e-4dfe-9a19-8239d59a8a88',
+	description: 'Document 001 imported',
+	lastModified: '2024-09-12T14:12:20.552Z',
+	dateCreated: '2024-03-01T13:48:35.847Z'
+};


### PR DESCRIPTION
Increase test coverage on integration code.
Removes custom coverage thresholds for integration.
Uses `originalFilename` when displaying imported documents.

## Issue ticket number and link
[A2-976](https://pins-ds.atlassian.net/browse/A2-976)
[A2-778](https://pins-ds.atlassian.net/browse/A2-778)

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Other (please explain in the description section above)

## Checklist before requesting a review

- [ ] I have performed a self-review of my own code
- [ ] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [ ] I have referenced the ticket number above
- [ ] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes


[A2-976]: https://pins-ds.atlassian.net/browse/A2-976?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[A2-778]: https://pins-ds.atlassian.net/browse/A2-778?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ