### PR TITLE
fix(web): fix single-file upload component add file button not hiding when file is selected

### DIFF
--- a/appeals/web/src/client/components/file-uploader/_client-actions.js
+++ b/appeals/web/src/client/components/file-uploader/_client-actions.js
@@ -196,11 +196,15 @@ const clientActions = (container) => {
 	};
 
 	const updateUploadControlsVisibility = () => {
-		if (!dropZone) {
-			return;
+		const displayStyle = allowSingleFileOnly() && globalDataTransfer.files.length > 0 ? 'none' : '';
+
+		if (uploadRow) {
+			uploadRow.style.display = displayStyle;
 		}
 
-		dropZone.hidden = allowSingleFileOnly() && globalDataTransfer.files.length > 0;
+		if (dropZone) {
+			dropZone.style.display = displayStyle;
+		}
 	};
 
 	/**

--- a/appeals/web/src/server/appeals/appeal-details/appellant-case/__tests__/__snapshots__/appellant-case.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/appellant-case/__tests__/__snapshots__/appellant-case.test.js.snap
@@ -2558,7 +2558,7 @@ exports[`appellant-case GET /appellant-case/add-documents/:folderId/ should rend
                     <label for="upload-file-1">Choose a single file to upload.</label><span>The file must be smaller than 1 GB.</span><span>The file must be PDF, DOC, DOCX, PPT, PPTX, XLS, XLSX, JPG, JPEG, MPEG, MP3, MP4, MOV, PNG, TIF, 	or TIFF.</span>
                     <div                     class="middle-errors-hook"></div>
             </div>
-            <div class="pins-file-upload__upload display--flex">
+            <div class="pins-file-upload__upload">
                 <input class="display--none" id="upload-file-1" accept=".pdf,application/pdf,.doc,application/msword,.docx,application/vnd.openxmlformats-officedocument.wordprocessingml.document,.ppt,application/vnd.ms-powerpoint,.pptx,application/vnd.openxmlformats-officedocument.presentationml.presentation,.xls,application/vnd.ms-excel,.xlsx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,.jpg,image/jpeg,.jpeg,image/jpeg,.mpeg,video/mpeg,.mp3,audio/mpeg,.mp4,video/mp4,.mov,video/quicktime,.png,image/png,.tif,image/tiff,.tiff,image/tiff,"
                 type="file" name="files" value="Choose file" aria-controls="file-list-1">
                 <button type='button' class="pins-file-upload__button govuk-button">Choose file</button><span role="status" aria-live="assertive" class='govuk-body pins-file-upload__counter'> No file chosen</span>
@@ -2595,7 +2595,7 @@ exports[`appellant-case GET /appellant-case/add-documents/:folderId/ should rend
                     <label for="upload-file-1">Choose a single file to upload.</label><span>The file must be smaller than 1 GB.</span><span>The file must be PDF, DOC, DOCX, PPT, PPTX, XLS, XLSX, JPG, JPEG, MPEG, MP3, MP4, MOV, PNG, TIF, 	or TIFF.</span>
                     <div                     class="middle-errors-hook"></div>
             </div>
-            <div class="pins-file-upload__upload display--flex">
+            <div class="pins-file-upload__upload">
                 <input class="display--none" id="upload-file-1" accept=".pdf,application/pdf,.doc,application/msword,.docx,application/vnd.openxmlformats-officedocument.wordprocessingml.document,.ppt,application/vnd.ms-powerpoint,.pptx,application/vnd.openxmlformats-officedocument.presentationml.presentation,.xls,application/vnd.ms-excel,.xlsx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,.jpg,image/jpeg,.jpeg,image/jpeg,.mpeg,video/mpeg,.mp3,audio/mpeg,.mp4,video/mp4,.mov,video/quicktime,.png,image/png,.tif,image/tiff,.tiff,image/tiff,"
                 type="file" name="files" value="Choose file" aria-controls="file-list-1">
                 <button type='button' class="pins-file-upload__button govuk-button">Choose file</button><span role="status" aria-live="assertive" class='govuk-body pins-file-upload__counter'> No file chosen</span>
@@ -2647,7 +2647,7 @@ exports[`appellant-case GET /appellant-case/add-documents/:folderId/ should rend
                     <label for="upload-file-1">Choose a single file to upload.</label><span>The file must be smaller than 1 GB.</span><span>The file must be PDF, DOC, DOCX, PPT, PPTX, XLS, XLSX, JPG, JPEG, MPEG, MP3, MP4, MOV, PNG, TIF, 	or TIFF.</span>
                     <div                     class="middle-errors-hook"></div>
             </div>
-            <div class="pins-file-upload__upload display--flex">
+            <div class="pins-file-upload__upload">
                 <input class="display--none" id="upload-file-1" accept=".pdf,application/pdf,.doc,application/msword,.docx,application/vnd.openxmlformats-officedocument.wordprocessingml.document,.ppt,application/vnd.ms-powerpoint,.pptx,application/vnd.openxmlformats-officedocument.presentationml.presentation,.xls,application/vnd.ms-excel,.xlsx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,.jpg,image/jpeg,.jpeg,image/jpeg,.mpeg,video/mpeg,.mp3,audio/mpeg,.mp4,video/mp4,.mov,video/quicktime,.png,image/png,.tif,image/tiff,.tiff,image/tiff,"
                 type="file" name="files" value="Choose file" aria-controls="file-list-1">
                 <button type='button' class="pins-file-upload__button govuk-button">Choose file</button><span role="status" aria-live="assertive" class='govuk-body pins-file-upload__counter'> No file chosen</span>
@@ -2699,7 +2699,7 @@ exports[`appellant-case GET /appellant-case/add-documents/:folderId/ should rend
                     <label for="upload-file-1">Choose a single file to upload.</label><span>The file must be smaller than 1 GB.</span><span>The file must be PDF, DOC, DOCX, PPT, PPTX, XLS, XLSX, JPG, JPEG, MPEG, MP3, MP4, MOV, PNG, TIF, 	or TIFF.</span>
                     <div                     class="middle-errors-hook"></div>
             </div>
-            <div class="pins-file-upload__upload display--flex">
+            <div class="pins-file-upload__upload">
                 <input class="display--none" id="upload-file-1" accept=".pdf,application/pdf,.doc,application/msword,.docx,application/vnd.openxmlformats-officedocument.wordprocessingml.document,.ppt,application/vnd.ms-powerpoint,.pptx,application/vnd.openxmlformats-officedocument.presentationml.presentation,.xls,application/vnd.ms-excel,.xlsx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,.jpg,image/jpeg,.jpeg,image/jpeg,.mpeg,video/mpeg,.mp3,audio/mpeg,.mp4,video/mp4,.mov,video/quicktime,.png,image/png,.tif,image/tiff,.tiff,image/tiff,"
                 type="file" name="files" value="Choose file" aria-controls="file-list-1">
                 <button type='button' class="pins-file-upload__button govuk-button">Choose file</button><span role="status" aria-live="assertive" class='govuk-body pins-file-upload__counter'> No file chosen</span>
@@ -2766,7 +2766,7 @@ exports[`appellant-case GET /appellant-case/add-documents/:folderId/ should rend
                     <label for="upload-file-1">Choose a single file to upload.</label><span>The file must be smaller than 1 GB.</span><span>The file must be PDF, DOC, DOCX, PPT, PPTX, XLS, XLSX, JPG, JPEG, MPEG, MP3, MP4, MOV, PNG, TIF, 	or TIFF.</span>
                     <div                     class="middle-errors-hook"></div>
             </div>
-            <div class="pins-file-upload__upload display--flex">
+            <div class="pins-file-upload__upload">
                 <input class="display--none" id="upload-file-1" accept=".pdf,application/pdf,.doc,application/msword,.docx,application/vnd.openxmlformats-officedocument.wordprocessingml.document,.ppt,application/vnd.ms-powerpoint,.pptx,application/vnd.openxmlformats-officedocument.presentationml.presentation,.xls,application/vnd.ms-excel,.xlsx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,.jpg,image/jpeg,.jpeg,image/jpeg,.mpeg,video/mpeg,.mp3,audio/mpeg,.mp4,video/mp4,.mov,video/quicktime,.png,image/png,.tif,image/tiff,.tiff,image/tiff,"
                 type="file" name="files" value="Choose file" aria-controls="file-list-1">
                 <button type='button' class="pins-file-upload__button govuk-button">Choose file</button><span role="status" aria-live="assertive" class='govuk-body pins-file-upload__counter'> No file chosen</span>
@@ -2804,7 +2804,7 @@ exports[`appellant-case GET /appellant-case/add-documents/:folderId/:documentId 
                     <label for="upload-file-1">Choose a single file to upload.</label><span>The file must be smaller than 1 GB.</span><span>The file must be PDF, DOC, DOCX, PPT, PPTX, XLS, XLSX, JPG, JPEG, MPEG, MP3, MP4, MOV, PNG, TIF, 	or TIFF.</span>
                     <div                     class="middle-errors-hook"></div>
             </div>
-            <div class="pins-file-upload__upload display--flex">
+            <div class="pins-file-upload__upload">
                 <input class="display--none" id="upload-file-1" accept=".pdf,application/pdf,.doc,application/msword,.docx,application/vnd.openxmlformats-officedocument.wordprocessingml.document,.ppt,application/vnd.ms-powerpoint,.pptx,application/vnd.openxmlformats-officedocument.presentationml.presentation,.xls,application/vnd.ms-excel,.xlsx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,.jpg,image/jpeg,.jpeg,image/jpeg,.mpeg,video/mpeg,.mp3,audio/mpeg,.mp4,video/mp4,.mov,video/quicktime,.png,image/png,.tif,image/tiff,.tiff,image/tiff,"
                 type="file" name="files" value="Choose file" aria-controls="file-list-1">
                 <button type='button' class="pins-file-upload__button govuk-button">Choose file</button><span role="status" aria-live="assertive" class='govuk-body pins-file-upload__counter'> No file chosen</span>
@@ -2842,7 +2842,7 @@ exports[`appellant-case GET /appellant-case/add-documents/:folderId/:documentId 
                     <label for="upload-file-1">Choose a single file to upload.</label><span>The file must be smaller than 1 GB.</span><span>The file must be PDF, DOC, DOCX, PPT, PPTX, XLS, XLSX, JPG, JPEG, MPEG, MP3, MP4, MOV, PNG, TIF, 	or TIFF.</span>
                     <div                     class="middle-errors-hook"></div>
             </div>
-            <div class="pins-file-upload__upload display--flex">
+            <div class="pins-file-upload__upload">
                 <input class="display--none" id="upload-file-1" accept=".pdf,application/pdf,.doc,application/msword,.docx,application/vnd.openxmlformats-officedocument.wordprocessingml.document,.ppt,application/vnd.ms-powerpoint,.pptx,application/vnd.openxmlformats-officedocument.presentationml.presentation,.xls,application/vnd.ms-excel,.xlsx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,.jpg,image/jpeg,.jpeg,image/jpeg,.mpeg,video/mpeg,.mp3,audio/mpeg,.mp4,video/mp4,.mov,video/quicktime,.png,image/png,.tif,image/tiff,.tiff,image/tiff,"
                 type="file" name="files" value="Choose file" aria-controls="file-list-1">
                 <button type='button' class="pins-file-upload__button govuk-button">Choose file</button><span role="status" aria-live="assertive" class='govuk-body pins-file-upload__counter'> No file chosen</span>
@@ -2895,7 +2895,7 @@ exports[`appellant-case GET /appellant-case/add-documents/:folderId/:documentId 
                     <label for="upload-file-1">Choose a single file to upload.</label><span>The file must be smaller than 1 GB.</span><span>The file must be PDF, DOC, DOCX, PPT, PPTX, XLS, XLSX, JPG, JPEG, MPEG, MP3, MP4, MOV, PNG, TIF, 	or TIFF.</span>
                     <div                     class="middle-errors-hook"></div>
             </div>
-            <div class="pins-file-upload__upload display--flex">
+            <div class="pins-file-upload__upload">
                 <input class="display--none" id="upload-file-1" accept=".pdf,application/pdf,.doc,application/msword,.docx,application/vnd.openxmlformats-officedocument.wordprocessingml.document,.ppt,application/vnd.ms-powerpoint,.pptx,application/vnd.openxmlformats-officedocument.presentationml.presentation,.xls,application/vnd.ms-excel,.xlsx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,.jpg,image/jpeg,.jpeg,image/jpeg,.mpeg,video/mpeg,.mp3,audio/mpeg,.mp4,video/mp4,.mov,video/quicktime,.png,image/png,.tif,image/tiff,.tiff,image/tiff,"
                 type="file" name="files" value="Choose file" aria-controls="file-list-1">
                 <button type='button' class="pins-file-upload__button govuk-button">Choose file</button><span role="status" aria-live="assertive" class='govuk-body pins-file-upload__counter'> No file chosen</span>
@@ -2948,7 +2948,7 @@ exports[`appellant-case GET /appellant-case/add-documents/:folderId/:documentId 
                     <label for="upload-file-1">Choose a single file to upload.</label><span>The file must be smaller than 1 GB.</span><span>The file must be PDF, DOC, DOCX, PPT, PPTX, XLS, XLSX, JPG, JPEG, MPEG, MP3, MP4, MOV, PNG, TIF, 	or TIFF.</span>
                     <div                     class="middle-errors-hook"></div>
             </div>
-            <div class="pins-file-upload__upload display--flex">
+            <div class="pins-file-upload__upload">
                 <input class="display--none" id="upload-file-1" accept=".pdf,application/pdf,.doc,application/msword,.docx,application/vnd.openxmlformats-officedocument.wordprocessingml.document,.ppt,application/vnd.ms-powerpoint,.pptx,application/vnd.openxmlformats-officedocument.presentationml.presentation,.xls,application/vnd.ms-excel,.xlsx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,.jpg,image/jpeg,.jpeg,image/jpeg,.mpeg,video/mpeg,.mp3,audio/mpeg,.mp4,video/mp4,.mov,video/quicktime,.png,image/png,.tif,image/tiff,.tiff,image/tiff,"
                 type="file" name="files" value="Choose file" aria-controls="file-list-1">
                 <button type='button' class="pins-file-upload__button govuk-button">Choose file</button><span role="status" aria-live="assertive" class='govuk-body pins-file-upload__counter'> No file chosen</span>
@@ -3016,7 +3016,7 @@ exports[`appellant-case GET /appellant-case/add-documents/:folderId/:documentId 
                     <label for="upload-file-1">Choose a single file to upload.</label><span>The file must be smaller than 1 GB.</span><span>The file must be PDF, DOC, DOCX, PPT, PPTX, XLS, XLSX, JPG, JPEG, MPEG, MP3, MP4, MOV, PNG, TIF, 	or TIFF.</span>
                     <div                     class="middle-errors-hook"></div>
             </div>
-            <div class="pins-file-upload__upload display--flex">
+            <div class="pins-file-upload__upload">
                 <input class="display--none" id="upload-file-1" accept=".pdf,application/pdf,.doc,application/msword,.docx,application/vnd.openxmlformats-officedocument.wordprocessingml.document,.ppt,application/vnd.ms-powerpoint,.pptx,application/vnd.openxmlformats-officedocument.presentationml.presentation,.xls,application/vnd.ms-excel,.xlsx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,.jpg,image/jpeg,.jpeg,image/jpeg,.mpeg,video/mpeg,.mp3,audio/mpeg,.mp4,video/mp4,.mov,video/quicktime,.png,image/png,.tif,image/tiff,.tiff,image/tiff,"
                 type="file" name="files" value="Choose file" aria-controls="file-list-1">
                 <button type='button' class="pins-file-upload__button govuk-button">Choose file</button><span role="status" aria-live="assertive" class='govuk-body pins-file-upload__counter'> No file chosen</span>

--- a/appeals/web/src/server/appeals/appeal-details/costs/__tests__/__snapshots__/costs.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/costs/__tests__/__snapshots__/costs.test.js.snap
@@ -3610,7 +3610,7 @@ exports[`costs application, withdrawal and correspondence GET /costs/:costsCateg
                     <label for="upload-file-1">Choose a single file to upload.</label><span>The file must be smaller than 1 GB.</span><span>The file must be PDF, DOC, DOCX, PPT, PPTX, XLS, XLSX, JPG, JPEG, MPEG, MP3, MP4, MOV, PNG, TIF, 	or TIFF.</span>
                     <div                     class="middle-errors-hook"></div>
             </div>
-            <div class="pins-file-upload__upload display--flex">
+            <div class="pins-file-upload__upload">
                 <input class="display--none" id="upload-file-1" accept=".pdf,application/pdf,.doc,application/msword,.docx,application/vnd.openxmlformats-officedocument.wordprocessingml.document,.ppt,application/vnd.ms-powerpoint,.pptx,application/vnd.openxmlformats-officedocument.presentationml.presentation,.xls,application/vnd.ms-excel,.xlsx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,.jpg,image/jpeg,.jpeg,image/jpeg,.mpeg,video/mpeg,.mp3,audio/mpeg,.mp4,video/mp4,.mov,video/quicktime,.png,image/png,.tif,image/tiff,.tiff,image/tiff,"
                 type="file" name="files" value="Choose file" aria-controls="file-list-1">
                 <button type='button' class="pins-file-upload__button govuk-button">Choose file</button><span role="status" aria-live="assertive" class='govuk-body pins-file-upload__counter'> No file chosen</span>
@@ -3647,7 +3647,7 @@ exports[`costs application, withdrawal and correspondence GET /costs/:costsCateg
                     <label for="upload-file-1">Choose a single file to upload.</label><span>The file must be smaller than 1 GB.</span><span>The file must be PDF, DOC, DOCX, PPT, PPTX, XLS, XLSX, JPG, JPEG, MPEG, MP3, MP4, MOV, PNG, TIF, 	or TIFF.</span>
                     <div                     class="middle-errors-hook"></div>
             </div>
-            <div class="pins-file-upload__upload display--flex">
+            <div class="pins-file-upload__upload">
                 <input class="display--none" id="upload-file-1" accept=".pdf,application/pdf,.doc,application/msword,.docx,application/vnd.openxmlformats-officedocument.wordprocessingml.document,.ppt,application/vnd.ms-powerpoint,.pptx,application/vnd.openxmlformats-officedocument.presentationml.presentation,.xls,application/vnd.ms-excel,.xlsx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,.jpg,image/jpeg,.jpeg,image/jpeg,.mpeg,video/mpeg,.mp3,audio/mpeg,.mp4,video/mp4,.mov,video/quicktime,.png,image/png,.tif,image/tiff,.tiff,image/tiff,"
                 type="file" name="files" value="Choose file" aria-controls="file-list-1">
                 <button type='button' class="pins-file-upload__button govuk-button">Choose file</button><span role="status" aria-live="assertive" class='govuk-body pins-file-upload__counter'> No file chosen</span>
@@ -3684,7 +3684,7 @@ exports[`costs application, withdrawal and correspondence GET /costs/:costsCateg
                     <label for="upload-file-1">Choose a single file to upload.</label><span>The file must be smaller than 1 GB.</span><span>The file must be PDF, DOC, DOCX, PPT, PPTX, XLS, XLSX, JPG, JPEG, MPEG, MP3, MP4, MOV, PNG, TIF, 	or TIFF.</span>
                     <div                     class="middle-errors-hook"></div>
             </div>
-            <div class="pins-file-upload__upload display--flex">
+            <div class="pins-file-upload__upload">
                 <input class="display--none" id="upload-file-1" accept=".pdf,application/pdf,.doc,application/msword,.docx,application/vnd.openxmlformats-officedocument.wordprocessingml.document,.ppt,application/vnd.ms-powerpoint,.pptx,application/vnd.openxmlformats-officedocument.presentationml.presentation,.xls,application/vnd.ms-excel,.xlsx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,.jpg,image/jpeg,.jpeg,image/jpeg,.mpeg,video/mpeg,.mp3,audio/mpeg,.mp4,video/mp4,.mov,video/quicktime,.png,image/png,.tif,image/tiff,.tiff,image/tiff,"
                 type="file" name="files" value="Choose file" aria-controls="file-list-1">
                 <button type='button' class="pins-file-upload__button govuk-button">Choose file</button><span role="status" aria-live="assertive" class='govuk-body pins-file-upload__counter'> No file chosen</span>
@@ -3720,7 +3720,7 @@ exports[`costs application, withdrawal and correspondence GET /costs/:costsCateg
                     <label for="upload-file-1">Choose a single file to upload.</label><span>The file must be smaller than 1 GB.</span><span>The file must be PDF, DOC, DOCX, PPT, PPTX, XLS, XLSX, JPG, JPEG, MPEG, MP3, MP4, MOV, PNG, TIF, 	or TIFF.</span>
                     <div                     class="middle-errors-hook"></div>
             </div>
-            <div class="pins-file-upload__upload display--flex">
+            <div class="pins-file-upload__upload">
                 <input class="display--none" id="upload-file-1" accept=".pdf,application/pdf,.doc,application/msword,.docx,application/vnd.openxmlformats-officedocument.wordprocessingml.document,.ppt,application/vnd.ms-powerpoint,.pptx,application/vnd.openxmlformats-officedocument.presentationml.presentation,.xls,application/vnd.ms-excel,.xlsx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,.jpg,image/jpeg,.jpeg,image/jpeg,.mpeg,video/mpeg,.mp3,audio/mpeg,.mp4,video/mp4,.mov,video/quicktime,.png,image/png,.tif,image/tiff,.tiff,image/tiff,"
                 type="file" name="files" value="Choose file" aria-controls="file-list-1">
                 <button type='button' class="pins-file-upload__button govuk-button">Choose file</button><span role="status" aria-live="assertive" class='govuk-body pins-file-upload__counter'> No file chosen</span>
@@ -3757,7 +3757,7 @@ exports[`costs application, withdrawal and correspondence GET /costs/:costsCateg
                     <label for="upload-file-1">Choose a single file to upload.</label><span>The file must be smaller than 1 GB.</span><span>The file must be PDF, DOC, DOCX, PPT, PPTX, XLS, XLSX, JPG, JPEG, MPEG, MP3, MP4, MOV, PNG, TIF, 	or TIFF.</span>
                     <div                     class="middle-errors-hook"></div>
             </div>
-            <div class="pins-file-upload__upload display--flex">
+            <div class="pins-file-upload__upload">
                 <input class="display--none" id="upload-file-1" accept=".pdf,application/pdf,.doc,application/msword,.docx,application/vnd.openxmlformats-officedocument.wordprocessingml.document,.ppt,application/vnd.ms-powerpoint,.pptx,application/vnd.openxmlformats-officedocument.presentationml.presentation,.xls,application/vnd.ms-excel,.xlsx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,.jpg,image/jpeg,.jpeg,image/jpeg,.mpeg,video/mpeg,.mp3,audio/mpeg,.mp4,video/mp4,.mov,video/quicktime,.png,image/png,.tif,image/tiff,.tiff,image/tiff,"
                 type="file" name="files" value="Choose file" aria-controls="file-list-1">
                 <button type='button' class="pins-file-upload__button govuk-button">Choose file</button><span role="status" aria-live="assertive" class='govuk-body pins-file-upload__counter'> No file chosen</span>
@@ -3793,7 +3793,7 @@ exports[`costs application, withdrawal and correspondence GET /costs/:costsCateg
                     <label for="upload-file-1">Choose a single file to upload.</label><span>The file must be smaller than 1 GB.</span><span>The file must be PDF, DOC, DOCX, PPT, PPTX, XLS, XLSX, JPG, JPEG, MPEG, MP3, MP4, MOV, PNG, TIF, 	or TIFF.</span>
                     <div                     class="middle-errors-hook"></div>
             </div>
-            <div class="pins-file-upload__upload display--flex">
+            <div class="pins-file-upload__upload">
                 <input class="display--none" id="upload-file-1" accept=".pdf,application/pdf,.doc,application/msword,.docx,application/vnd.openxmlformats-officedocument.wordprocessingml.document,.ppt,application/vnd.ms-powerpoint,.pptx,application/vnd.openxmlformats-officedocument.presentationml.presentation,.xls,application/vnd.ms-excel,.xlsx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,.jpg,image/jpeg,.jpeg,image/jpeg,.mpeg,video/mpeg,.mp3,audio/mpeg,.mp4,video/mp4,.mov,video/quicktime,.png,image/png,.tif,image/tiff,.tiff,image/tiff,"
                 type="file" name="files" value="Choose file" aria-controls="file-list-1">
                 <button type='button' class="pins-file-upload__button govuk-button">Choose file</button><span role="status" aria-live="assertive" class='govuk-body pins-file-upload__counter'> No file chosen</span>
@@ -3831,7 +3831,7 @@ exports[`costs application, withdrawal and correspondence GET /costs/:costsCateg
                     <label for="upload-file-1">Choose a single file to upload.</label><span>The file must be smaller than 1 GB.</span><span>The file must be PDF, DOC, DOCX, PPT, PPTX, XLS, XLSX, JPG, JPEG, MPEG, MP3, MP4, MOV, PNG, TIF, 	or TIFF.</span>
                     <div                     class="middle-errors-hook"></div>
             </div>
-            <div class="pins-file-upload__upload display--flex">
+            <div class="pins-file-upload__upload">
                 <input class="display--none" id="upload-file-1" accept=".pdf,application/pdf,.doc,application/msword,.docx,application/vnd.openxmlformats-officedocument.wordprocessingml.document,.ppt,application/vnd.ms-powerpoint,.pptx,application/vnd.openxmlformats-officedocument.presentationml.presentation,.xls,application/vnd.ms-excel,.xlsx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,.jpg,image/jpeg,.jpeg,image/jpeg,.mpeg,video/mpeg,.mp3,audio/mpeg,.mp4,video/mp4,.mov,video/quicktime,.png,image/png,.tif,image/tiff,.tiff,image/tiff,"
                 type="file" name="files" value="Choose file" aria-controls="file-list-1">
                 <button type='button' class="pins-file-upload__button govuk-button">Choose file</button><span role="status" aria-live="assertive" class='govuk-body pins-file-upload__counter'> No file chosen</span>
@@ -3869,7 +3869,7 @@ exports[`costs application, withdrawal and correspondence GET /costs/:costsCateg
                     <label for="upload-file-1">Choose a single file to upload.</label><span>The file must be smaller than 1 GB.</span><span>The file must be PDF, DOC, DOCX, PPT, PPTX, XLS, XLSX, JPG, JPEG, MPEG, MP3, MP4, MOV, PNG, TIF, 	or TIFF.</span>
                     <div                     class="middle-errors-hook"></div>
             </div>
-            <div class="pins-file-upload__upload display--flex">
+            <div class="pins-file-upload__upload">
                 <input class="display--none" id="upload-file-1" accept=".pdf,application/pdf,.doc,application/msword,.docx,application/vnd.openxmlformats-officedocument.wordprocessingml.document,.ppt,application/vnd.ms-powerpoint,.pptx,application/vnd.openxmlformats-officedocument.presentationml.presentation,.xls,application/vnd.ms-excel,.xlsx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,.jpg,image/jpeg,.jpeg,image/jpeg,.mpeg,video/mpeg,.mp3,audio/mpeg,.mp4,video/mp4,.mov,video/quicktime,.png,image/png,.tif,image/tiff,.tiff,image/tiff,"
                 type="file" name="files" value="Choose file" aria-controls="file-list-1">
                 <button type='button' class="pins-file-upload__button govuk-button">Choose file</button><span role="status" aria-live="assertive" class='govuk-body pins-file-upload__counter'> No file chosen</span>
@@ -3907,7 +3907,7 @@ exports[`costs application, withdrawal and correspondence GET /costs/:costsCateg
                     <label for="upload-file-1">Choose a single file to upload.</label><span>The file must be smaller than 1 GB.</span><span>The file must be PDF, DOC, DOCX, PPT, PPTX, XLS, XLSX, JPG, JPEG, MPEG, MP3, MP4, MOV, PNG, TIF, 	or TIFF.</span>
                     <div                     class="middle-errors-hook"></div>
             </div>
-            <div class="pins-file-upload__upload display--flex">
+            <div class="pins-file-upload__upload">
                 <input class="display--none" id="upload-file-1" accept=".pdf,application/pdf,.doc,application/msword,.docx,application/vnd.openxmlformats-officedocument.wordprocessingml.document,.ppt,application/vnd.ms-powerpoint,.pptx,application/vnd.openxmlformats-officedocument.presentationml.presentation,.xls,application/vnd.ms-excel,.xlsx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,.jpg,image/jpeg,.jpeg,image/jpeg,.mpeg,video/mpeg,.mp3,audio/mpeg,.mp4,video/mp4,.mov,video/quicktime,.png,image/png,.tif,image/tiff,.tiff,image/tiff,"
                 type="file" name="files" value="Choose file" aria-controls="file-list-1">
                 <button type='button' class="pins-file-upload__button govuk-button">Choose file</button><span role="status" aria-live="assertive" class='govuk-body pins-file-upload__counter'> No file chosen</span>
@@ -3945,7 +3945,7 @@ exports[`costs application, withdrawal and correspondence GET /costs/:costsCateg
                     <label for="upload-file-1">Choose a single file to upload.</label><span>The file must be smaller than 1 GB.</span><span>The file must be PDF, DOC, DOCX, PPT, PPTX, XLS, XLSX, JPG, JPEG, MPEG, MP3, MP4, MOV, PNG, TIF, 	or TIFF.</span>
                     <div                     class="middle-errors-hook"></div>
             </div>
-            <div class="pins-file-upload__upload display--flex">
+            <div class="pins-file-upload__upload">
                 <input class="display--none" id="upload-file-1" accept=".pdf,application/pdf,.doc,application/msword,.docx,application/vnd.openxmlformats-officedocument.wordprocessingml.document,.ppt,application/vnd.ms-powerpoint,.pptx,application/vnd.openxmlformats-officedocument.presentationml.presentation,.xls,application/vnd.ms-excel,.xlsx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,.jpg,image/jpeg,.jpeg,image/jpeg,.mpeg,video/mpeg,.mp3,audio/mpeg,.mp4,video/mp4,.mov,video/quicktime,.png,image/png,.tif,image/tiff,.tiff,image/tiff,"
                 type="file" name="files" value="Choose file" aria-controls="file-list-1">
                 <button type='button' class="pins-file-upload__button govuk-button">Choose file</button><span role="status" aria-live="assertive" class='govuk-body pins-file-upload__counter'> No file chosen</span>
@@ -3983,7 +3983,7 @@ exports[`costs application, withdrawal and correspondence GET /costs/:costsCateg
                     <label for="upload-file-1">Choose a single file to upload.</label><span>The file must be smaller than 1 GB.</span><span>The file must be PDF, DOC, DOCX, PPT, PPTX, XLS, XLSX, JPG, JPEG, MPEG, MP3, MP4, MOV, PNG, TIF, 	or TIFF.</span>
                     <div                     class="middle-errors-hook"></div>
             </div>
-            <div class="pins-file-upload__upload display--flex">
+            <div class="pins-file-upload__upload">
                 <input class="display--none" id="upload-file-1" accept=".pdf,application/pdf,.doc,application/msword,.docx,application/vnd.openxmlformats-officedocument.wordprocessingml.document,.ppt,application/vnd.ms-powerpoint,.pptx,application/vnd.openxmlformats-officedocument.presentationml.presentation,.xls,application/vnd.ms-excel,.xlsx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,.jpg,image/jpeg,.jpeg,image/jpeg,.mpeg,video/mpeg,.mp3,audio/mpeg,.mp4,video/mp4,.mov,video/quicktime,.png,image/png,.tif,image/tiff,.tiff,image/tiff,"
                 type="file" name="files" value="Choose file" aria-controls="file-list-1">
                 <button type='button' class="pins-file-upload__button govuk-button">Choose file</button><span role="status" aria-live="assertive" class='govuk-body pins-file-upload__counter'> No file chosen</span>
@@ -4021,7 +4021,7 @@ exports[`costs application, withdrawal and correspondence GET /costs/:costsCateg
                     <label for="upload-file-1">Choose a single file to upload.</label><span>The file must be smaller than 1 GB.</span><span>The file must be PDF, DOC, DOCX, PPT, PPTX, XLS, XLSX, JPG, JPEG, MPEG, MP3, MP4, MOV, PNG, TIF, 	or TIFF.</span>
                     <div                     class="middle-errors-hook"></div>
             </div>
-            <div class="pins-file-upload__upload display--flex">
+            <div class="pins-file-upload__upload">
                 <input class="display--none" id="upload-file-1" accept=".pdf,application/pdf,.doc,application/msword,.docx,application/vnd.openxmlformats-officedocument.wordprocessingml.document,.ppt,application/vnd.ms-powerpoint,.pptx,application/vnd.openxmlformats-officedocument.presentationml.presentation,.xls,application/vnd.ms-excel,.xlsx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,.jpg,image/jpeg,.jpeg,image/jpeg,.mpeg,video/mpeg,.mp3,audio/mpeg,.mp4,video/mp4,.mov,video/quicktime,.png,image/png,.tif,image/tiff,.tiff,image/tiff,"
                 type="file" name="files" value="Choose file" aria-controls="file-list-1">
                 <button type='button' class="pins-file-upload__button govuk-button">Choose file</button><span role="status" aria-live="assertive" class='govuk-body pins-file-upload__counter'> No file chosen</span>
@@ -5466,7 +5466,7 @@ exports[`costs decision GET /costs/decision/upload-documents/:folderId should re
                     <label for="upload-file-1">Choose a single file to upload.</label><span>The file must be smaller than 1 GB.</span><span>The file must be PDF, DOC, DOCX, PPT, PPTX, XLS, XLSX, JPG, JPEG, MPEG, MP3, MP4, MOV, PNG, TIF, 	or TIFF.</span>
                     <div                     class="middle-errors-hook"></div>
             </div>
-            <div class="pins-file-upload__upload display--flex">
+            <div class="pins-file-upload__upload">
                 <input class="display--none" id="upload-file-1" accept=".pdf,application/pdf,.doc,application/msword,.docx,application/vnd.openxmlformats-officedocument.wordprocessingml.document,.ppt,application/vnd.ms-powerpoint,.pptx,application/vnd.openxmlformats-officedocument.presentationml.presentation,.xls,application/vnd.ms-excel,.xlsx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,.jpg,image/jpeg,.jpeg,image/jpeg,.mpeg,video/mpeg,.mp3,audio/mpeg,.mp4,video/mp4,.mov,video/quicktime,.png,image/png,.tif,image/tiff,.tiff,image/tiff,"
                 type="file" name="files" value="Choose file" aria-controls="file-list-1">
                 <button type='button' class="pins-file-upload__button govuk-button">Choose file</button><span role="status" aria-live="assertive" class='govuk-body pins-file-upload__counter'> No file chosen</span>
@@ -5504,7 +5504,7 @@ exports[`costs decision GET /costs/decision/upload-documents/:folderId/:document
                     <label for="upload-file-1">Choose a single file to upload.</label><span>The file must be smaller than 1 GB.</span><span>The file must be PDF, DOC, DOCX, PPT, PPTX, XLS, XLSX, JPG, JPEG, MPEG, MP3, MP4, MOV, PNG, TIF, 	or TIFF.</span>
                     <div                     class="middle-errors-hook"></div>
             </div>
-            <div class="pins-file-upload__upload display--flex">
+            <div class="pins-file-upload__upload">
                 <input class="display--none" id="upload-file-1" accept=".pdf,application/pdf,.doc,application/msword,.docx,application/vnd.openxmlformats-officedocument.wordprocessingml.document,.ppt,application/vnd.ms-powerpoint,.pptx,application/vnd.openxmlformats-officedocument.presentationml.presentation,.xls,application/vnd.ms-excel,.xlsx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,.jpg,image/jpeg,.jpeg,image/jpeg,.mpeg,video/mpeg,.mp3,audio/mpeg,.mp4,video/mp4,.mov,video/quicktime,.png,image/png,.tif,image/tiff,.tiff,image/tiff,"
                 type="file" name="files" value="Choose file" aria-controls="file-list-1">
                 <button type='button' class="pins-file-upload__button govuk-button">Choose file</button><span role="status" aria-live="assertive" class='govuk-body pins-file-upload__counter'> No file chosen</span>

--- a/appeals/web/src/server/appeals/appeal-details/internal-correspondence/__tests__/__snapshots__/internal-correspondence.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/internal-correspondence/__tests__/__snapshots__/internal-correspondence.test.js.snap
@@ -1370,7 +1370,7 @@ exports[`internal correspondence GET /internal-correspondence/:correspondenceCat
                     <label for="upload-file-1">Choose a single file to upload.</label><span>The file must be smaller than 1 GB.</span><span>The file must be PDF, DOC, DOCX, PPT, PPTX, XLS, XLSX, JPG, JPEG, MPEG, MP3, MP4, MOV, PNG, TIF, 	or TIFF.</span>
                     <div                     class="middle-errors-hook"></div>
             </div>
-            <div class="pins-file-upload__upload display--flex">
+            <div class="pins-file-upload__upload">
                 <input class="display--none" id="upload-file-1" accept=".pdf,application/pdf,.doc,application/msword,.docx,application/vnd.openxmlformats-officedocument.wordprocessingml.document,.ppt,application/vnd.ms-powerpoint,.pptx,application/vnd.openxmlformats-officedocument.presentationml.presentation,.xls,application/vnd.ms-excel,.xlsx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,.jpg,image/jpeg,.jpeg,image/jpeg,.mpeg,video/mpeg,.mp3,audio/mpeg,.mp4,video/mp4,.mov,video/quicktime,.png,image/png,.tif,image/tiff,.tiff,image/tiff,"
                 type="file" name="files" value="Choose file" aria-controls="file-list-1">
                 <button type='button' class="pins-file-upload__button govuk-button">Choose file</button><span role="status" aria-live="assertive" class='govuk-body pins-file-upload__counter'> No file chosen</span>
@@ -1407,7 +1407,7 @@ exports[`internal correspondence GET /internal-correspondence/:correspondenceCat
                     <label for="upload-file-1">Choose a single file to upload.</label><span>The file must be smaller than 1 GB.</span><span>The file must be PDF, DOC, DOCX, PPT, PPTX, XLS, XLSX, JPG, JPEG, MPEG, MP3, MP4, MOV, PNG, TIF, 	or TIFF.</span>
                     <div                     class="middle-errors-hook"></div>
             </div>
-            <div class="pins-file-upload__upload display--flex">
+            <div class="pins-file-upload__upload">
                 <input class="display--none" id="upload-file-1" accept=".pdf,application/pdf,.doc,application/msword,.docx,application/vnd.openxmlformats-officedocument.wordprocessingml.document,.ppt,application/vnd.ms-powerpoint,.pptx,application/vnd.openxmlformats-officedocument.presentationml.presentation,.xls,application/vnd.ms-excel,.xlsx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,.jpg,image/jpeg,.jpeg,image/jpeg,.mpeg,video/mpeg,.mp3,audio/mpeg,.mp4,video/mp4,.mov,video/quicktime,.png,image/png,.tif,image/tiff,.tiff,image/tiff,"
                 type="file" name="files" value="Choose file" aria-controls="file-list-1">
                 <button type='button' class="pins-file-upload__button govuk-button">Choose file</button><span role="status" aria-live="assertive" class='govuk-body pins-file-upload__counter'> No file chosen</span>
@@ -1445,7 +1445,7 @@ exports[`internal correspondence GET /internal-correspondence/:correspondenceCat
                     <label for="upload-file-1">Choose a single file to upload.</label><span>The file must be smaller than 1 GB.</span><span>The file must be PDF, DOC, DOCX, PPT, PPTX, XLS, XLSX, JPG, JPEG, MPEG, MP3, MP4, MOV, PNG, TIF, 	or TIFF.</span>
                     <div                     class="middle-errors-hook"></div>
             </div>
-            <div class="pins-file-upload__upload display--flex">
+            <div class="pins-file-upload__upload">
                 <input class="display--none" id="upload-file-1" accept=".pdf,application/pdf,.doc,application/msword,.docx,application/vnd.openxmlformats-officedocument.wordprocessingml.document,.ppt,application/vnd.ms-powerpoint,.pptx,application/vnd.openxmlformats-officedocument.presentationml.presentation,.xls,application/vnd.ms-excel,.xlsx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,.jpg,image/jpeg,.jpeg,image/jpeg,.mpeg,video/mpeg,.mp3,audio/mpeg,.mp4,video/mp4,.mov,video/quicktime,.png,image/png,.tif,image/tiff,.tiff,image/tiff,"
                 type="file" name="files" value="Choose file" aria-controls="file-list-1">
                 <button type='button' class="pins-file-upload__button govuk-button">Choose file</button><span role="status" aria-live="assertive" class='govuk-body pins-file-upload__counter'> No file chosen</span>
@@ -1483,7 +1483,7 @@ exports[`internal correspondence GET /internal-correspondence/:correspondenceCat
                     <label for="upload-file-1">Choose a single file to upload.</label><span>The file must be smaller than 1 GB.</span><span>The file must be PDF, DOC, DOCX, PPT, PPTX, XLS, XLSX, JPG, JPEG, MPEG, MP3, MP4, MOV, PNG, TIF, 	or TIFF.</span>
                     <div                     class="middle-errors-hook"></div>
             </div>
-            <div class="pins-file-upload__upload display--flex">
+            <div class="pins-file-upload__upload">
                 <input class="display--none" id="upload-file-1" accept=".pdf,application/pdf,.doc,application/msword,.docx,application/vnd.openxmlformats-officedocument.wordprocessingml.document,.ppt,application/vnd.ms-powerpoint,.pptx,application/vnd.openxmlformats-officedocument.presentationml.presentation,.xls,application/vnd.ms-excel,.xlsx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,.jpg,image/jpeg,.jpeg,image/jpeg,.mpeg,video/mpeg,.mp3,audio/mpeg,.mp4,video/mp4,.mov,video/quicktime,.png,image/png,.tif,image/tiff,.tiff,image/tiff,"
                 type="file" name="files" value="Choose file" aria-controls="file-list-1">
                 <button type='button' class="pins-file-upload__button govuk-button">Choose file</button><span role="status" aria-live="assertive" class='govuk-body pins-file-upload__counter'> No file chosen</span>

--- a/appeals/web/src/server/appeals/appeal-details/issue-decision/__tests__/__snapshots__/issue-decision.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/issue-decision/__tests__/__snapshots__/issue-decision.test.js.snap
@@ -174,7 +174,7 @@ exports[`issue-decision GET /decision-letter-upload should render the decision l
                     <label for="upload-file-1">Choose a single file to upload.</label><span>The file must be smaller than 1 GB.</span><span>The file must be PDF, DOC, DOCX, PPT, PPTX, XLS, XLSX, JPG, JPEG, MPEG, MP3, MP4, MOV, PNG, TIF, 	or TIFF.</span>
                     <div                     class="middle-errors-hook"></div>
             </div>
-            <div class="pins-file-upload__upload display--flex">
+            <div class="pins-file-upload__upload">
                 <input class="display--none" id="upload-file-1" accept=".pdf,application/pdf,.doc,application/msword,.docx,application/vnd.openxmlformats-officedocument.wordprocessingml.document,.ppt,application/vnd.ms-powerpoint,.pptx,application/vnd.openxmlformats-officedocument.presentationml.presentation,.xls,application/vnd.ms-excel,.xlsx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,.jpg,image/jpeg,.jpeg,image/jpeg,.mpeg,video/mpeg,.mp3,audio/mpeg,.mp4,video/mp4,.mov,video/quicktime,.png,image/png,.tif,image/tiff,.tiff,image/tiff,"
                 type="file" name="files" value="Choose file" aria-controls="file-list-1">
                 <button type='button' class="pins-file-upload__button govuk-button">Choose file</button><span role="status" aria-live="assertive" class='govuk-body pins-file-upload__counter'> No file chosen</span>

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/__tests__/__snapshots__/lpa-questionnaire.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/__tests__/__snapshots__/lpa-questionnaire.test.js.snap
@@ -1649,7 +1649,7 @@ exports[`LPA Questionnaire review GET /lpa-questionnaire/1/add-documents/:folder
                     <label for="upload-file-1">Choose a single file to upload.</label><span>The file must be smaller than 1 GB.</span><span>The file must be PDF, DOC, DOCX, PPT, PPTX, XLS, XLSX, JPG, JPEG, MPEG, MP3, MP4, MOV, PNG, TIF, 	or TIFF.</span>
                     <div                     class="middle-errors-hook"></div>
             </div>
-            <div class="pins-file-upload__upload display--flex">
+            <div class="pins-file-upload__upload">
                 <input class="display--none" id="upload-file-1" accept=".pdf,application/pdf,.doc,application/msword,.docx,application/vnd.openxmlformats-officedocument.wordprocessingml.document,.ppt,application/vnd.ms-powerpoint,.pptx,application/vnd.openxmlformats-officedocument.presentationml.presentation,.xls,application/vnd.ms-excel,.xlsx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,.jpg,image/jpeg,.jpeg,image/jpeg,.mpeg,video/mpeg,.mp3,audio/mpeg,.mp4,video/mp4,.mov,video/quicktime,.png,image/png,.tif,image/tiff,.tiff,image/tiff,"
                 type="file" name="files" value="Choose file" aria-controls="file-list-1">
                 <button type='button' class="pins-file-upload__button govuk-button">Choose file</button><span role="status" aria-live="assertive" class='govuk-body pins-file-upload__counter'> No file chosen</span>
@@ -1686,7 +1686,7 @@ exports[`LPA Questionnaire review GET /lpa-questionnaire/1/add-documents/:folder
                     <label for="upload-file-1">Choose a single file to upload.</label><span>The file must be smaller than 1 GB.</span><span>The file must be PDF, DOC, DOCX, PPT, PPTX, XLS, XLSX, JPG, JPEG, MPEG, MP3, MP4, MOV, PNG, TIF, 	or TIFF.</span>
                     <div                     class="middle-errors-hook"></div>
             </div>
-            <div class="pins-file-upload__upload display--flex">
+            <div class="pins-file-upload__upload">
                 <input class="display--none" id="upload-file-1" accept=".pdf,application/pdf,.doc,application/msword,.docx,application/vnd.openxmlformats-officedocument.wordprocessingml.document,.ppt,application/vnd.ms-powerpoint,.pptx,application/vnd.openxmlformats-officedocument.presentationml.presentation,.xls,application/vnd.ms-excel,.xlsx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,.jpg,image/jpeg,.jpeg,image/jpeg,.mpeg,video/mpeg,.mp3,audio/mpeg,.mp4,video/mp4,.mov,video/quicktime,.png,image/png,.tif,image/tiff,.tiff,image/tiff,"
                 type="file" name="files" value="Choose file" aria-controls="file-list-1">
                 <button type='button' class="pins-file-upload__button govuk-button">Choose file</button><span role="status" aria-live="assertive" class='govuk-body pins-file-upload__counter'> No file chosen</span>
@@ -1738,7 +1738,7 @@ exports[`LPA Questionnaire review GET /lpa-questionnaire/1/add-documents/:folder
                     <label for="upload-file-1">Choose a single file to upload.</label><span>The file must be smaller than 1 GB.</span><span>The file must be PDF, DOC, DOCX, PPT, PPTX, XLS, XLSX, JPG, JPEG, MPEG, MP3, MP4, MOV, PNG, TIF, 	or TIFF.</span>
                     <div                     class="middle-errors-hook"></div>
             </div>
-            <div class="pins-file-upload__upload display--flex">
+            <div class="pins-file-upload__upload">
                 <input class="display--none" id="upload-file-1" accept=".pdf,application/pdf,.doc,application/msword,.docx,application/vnd.openxmlformats-officedocument.wordprocessingml.document,.ppt,application/vnd.ms-powerpoint,.pptx,application/vnd.openxmlformats-officedocument.presentationml.presentation,.xls,application/vnd.ms-excel,.xlsx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,.jpg,image/jpeg,.jpeg,image/jpeg,.mpeg,video/mpeg,.mp3,audio/mpeg,.mp4,video/mp4,.mov,video/quicktime,.png,image/png,.tif,image/tiff,.tiff,image/tiff,"
                 type="file" name="files" value="Choose file" aria-controls="file-list-1">
                 <button type='button' class="pins-file-upload__button govuk-button">Choose file</button><span role="status" aria-live="assertive" class='govuk-body pins-file-upload__counter'> No file chosen</span>
@@ -1805,7 +1805,7 @@ exports[`LPA Questionnaire review GET /lpa-questionnaire/1/add-documents/:folder
                     <label for="upload-file-1">Choose a single file to upload.</label><span>The file must be smaller than 1 GB.</span><span>The file must be PDF, DOC, DOCX, PPT, PPTX, XLS, XLSX, JPG, JPEG, MPEG, MP3, MP4, MOV, PNG, TIF, 	or TIFF.</span>
                     <div                     class="middle-errors-hook"></div>
             </div>
-            <div class="pins-file-upload__upload display--flex">
+            <div class="pins-file-upload__upload">
                 <input class="display--none" id="upload-file-1" accept=".pdf,application/pdf,.doc,application/msword,.docx,application/vnd.openxmlformats-officedocument.wordprocessingml.document,.ppt,application/vnd.ms-powerpoint,.pptx,application/vnd.openxmlformats-officedocument.presentationml.presentation,.xls,application/vnd.ms-excel,.xlsx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,.jpg,image/jpeg,.jpeg,image/jpeg,.mpeg,video/mpeg,.mp3,audio/mpeg,.mp4,video/mp4,.mov,video/quicktime,.png,image/png,.tif,image/tiff,.tiff,image/tiff,"
                 type="file" name="files" value="Choose file" aria-controls="file-list-1">
                 <button type='button' class="pins-file-upload__button govuk-button">Choose file</button><span role="status" aria-live="assertive" class='govuk-body pins-file-upload__counter'> No file chosen</span>
@@ -1843,7 +1843,7 @@ exports[`LPA Questionnaire review GET /lpa-questionnaire/1/add-documents/:folder
                     <label for="upload-file-1">Choose a single file to upload.</label><span>The file must be smaller than 1 GB.</span><span>The file must be PDF, DOC, DOCX, PPT, PPTX, XLS, XLSX, JPG, JPEG, MPEG, MP3, MP4, MOV, PNG, TIF, 	or TIFF.</span>
                     <div                     class="middle-errors-hook"></div>
             </div>
-            <div class="pins-file-upload__upload display--flex">
+            <div class="pins-file-upload__upload">
                 <input class="display--none" id="upload-file-1" accept=".pdf,application/pdf,.doc,application/msword,.docx,application/vnd.openxmlformats-officedocument.wordprocessingml.document,.ppt,application/vnd.ms-powerpoint,.pptx,application/vnd.openxmlformats-officedocument.presentationml.presentation,.xls,application/vnd.ms-excel,.xlsx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,.jpg,image/jpeg,.jpeg,image/jpeg,.mpeg,video/mpeg,.mp3,audio/mpeg,.mp4,video/mp4,.mov,video/quicktime,.png,image/png,.tif,image/tiff,.tiff,image/tiff,"
                 type="file" name="files" value="Choose file" aria-controls="file-list-1">
                 <button type='button' class="pins-file-upload__button govuk-button">Choose file</button><span role="status" aria-live="assertive" class='govuk-body pins-file-upload__counter'> No file chosen</span>
@@ -1881,7 +1881,7 @@ exports[`LPA Questionnaire review GET /lpa-questionnaire/1/add-documents/:folder
                     <label for="upload-file-1">Choose a single file to upload.</label><span>The file must be smaller than 1 GB.</span><span>The file must be PDF, DOC, DOCX, PPT, PPTX, XLS, XLSX, JPG, JPEG, MPEG, MP3, MP4, MOV, PNG, TIF, 	or TIFF.</span>
                     <div                     class="middle-errors-hook"></div>
             </div>
-            <div class="pins-file-upload__upload display--flex">
+            <div class="pins-file-upload__upload">
                 <input class="display--none" id="upload-file-1" accept=".pdf,application/pdf,.doc,application/msword,.docx,application/vnd.openxmlformats-officedocument.wordprocessingml.document,.ppt,application/vnd.ms-powerpoint,.pptx,application/vnd.openxmlformats-officedocument.presentationml.presentation,.xls,application/vnd.ms-excel,.xlsx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,.jpg,image/jpeg,.jpeg,image/jpeg,.mpeg,video/mpeg,.mp3,audio/mpeg,.mp4,video/mp4,.mov,video/quicktime,.png,image/png,.tif,image/tiff,.tiff,image/tiff,"
                 type="file" name="files" value="Choose file" aria-controls="file-list-1">
                 <button type='button' class="pins-file-upload__button govuk-button">Choose file</button><span role="status" aria-live="assertive" class='govuk-body pins-file-upload__counter'> No file chosen</span>
@@ -1934,7 +1934,7 @@ exports[`LPA Questionnaire review GET /lpa-questionnaire/1/add-documents/:folder
                     <label for="upload-file-1">Choose a single file to upload.</label><span>The file must be smaller than 1 GB.</span><span>The file must be PDF, DOC, DOCX, PPT, PPTX, XLS, XLSX, JPG, JPEG, MPEG, MP3, MP4, MOV, PNG, TIF, 	or TIFF.</span>
                     <div                     class="middle-errors-hook"></div>
             </div>
-            <div class="pins-file-upload__upload display--flex">
+            <div class="pins-file-upload__upload">
                 <input class="display--none" id="upload-file-1" accept=".pdf,application/pdf,.doc,application/msword,.docx,application/vnd.openxmlformats-officedocument.wordprocessingml.document,.ppt,application/vnd.ms-powerpoint,.pptx,application/vnd.openxmlformats-officedocument.presentationml.presentation,.xls,application/vnd.ms-excel,.xlsx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,.jpg,image/jpeg,.jpeg,image/jpeg,.mpeg,video/mpeg,.mp3,audio/mpeg,.mp4,video/mp4,.mov,video/quicktime,.png,image/png,.tif,image/tiff,.tiff,image/tiff,"
                 type="file" name="files" value="Choose file" aria-controls="file-list-1">
                 <button type='button' class="pins-file-upload__button govuk-button">Choose file</button><span role="status" aria-live="assertive" class='govuk-body pins-file-upload__counter'> No file chosen</span>
@@ -2002,7 +2002,7 @@ exports[`LPA Questionnaire review GET /lpa-questionnaire/1/add-documents/:folder
                     <label for="upload-file-1">Choose a single file to upload.</label><span>The file must be smaller than 1 GB.</span><span>The file must be PDF, DOC, DOCX, PPT, PPTX, XLS, XLSX, JPG, JPEG, MPEG, MP3, MP4, MOV, PNG, TIF, 	or TIFF.</span>
                     <div                     class="middle-errors-hook"></div>
             </div>
-            <div class="pins-file-upload__upload display--flex">
+            <div class="pins-file-upload__upload">
                 <input class="display--none" id="upload-file-1" accept=".pdf,application/pdf,.doc,application/msword,.docx,application/vnd.openxmlformats-officedocument.wordprocessingml.document,.ppt,application/vnd.ms-powerpoint,.pptx,application/vnd.openxmlformats-officedocument.presentationml.presentation,.xls,application/vnd.ms-excel,.xlsx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,.jpg,image/jpeg,.jpeg,image/jpeg,.mpeg,video/mpeg,.mp3,audio/mpeg,.mp4,video/mp4,.mov,video/quicktime,.png,image/png,.tif,image/tiff,.tiff,image/tiff,"
                 type="file" name="files" value="Choose file" aria-controls="file-list-1">
                 <button type='button' class="pins-file-upload__button govuk-button">Choose file</button><span role="status" aria-live="assertive" class='govuk-body pins-file-upload__counter'> No file chosen</span>

--- a/appeals/web/src/server/appeals/appeal-details/withdrawal/__tests__/__snapshots__/withdrawal.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/withdrawal/__tests__/__snapshots__/withdrawal.test.js.snap
@@ -53,7 +53,7 @@ exports[`withdrawal GET /start should render the withdrawal request upload page 
                     <label for="upload-file-1">Choose a single file to upload.</label><span>The file must be smaller than 1 GB.</span><span>The file must be PDF, DOC, DOCX, PPT, PPTX, XLS, XLSX, JPG, JPEG, MPEG, MP3, MP4, MOV, PNG, TIF, 	or TIFF.</span>
                     <div                     class="middle-errors-hook"></div>
             </div>
-            <div class="pins-file-upload__upload display--flex">
+            <div class="pins-file-upload__upload">
                 <input class="display--none" id="upload-file-1" accept=".pdf,application/pdf,.doc,application/msword,.docx,application/vnd.openxmlformats-officedocument.wordprocessingml.document,.ppt,application/vnd.ms-powerpoint,.pptx,application/vnd.openxmlformats-officedocument.presentationml.presentation,.xls,application/vnd.ms-excel,.xlsx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,.jpg,image/jpeg,.jpeg,image/jpeg,.mpeg,video/mpeg,.mp3,audio/mpeg,.mp4,video/mp4,.mov,video/quicktime,.png,image/png,.tif,image/tiff,.tiff,image/tiff,"
                 type="file" name="files" value="Choose file" aria-controls="file-list-1">
                 <button type='button' class="pins-file-upload__button govuk-button">Choose file</button><span role="status" aria-live="assertive" class='govuk-body pins-file-upload__counter'> No file chosen</span>

--- a/appeals/web/src/server/appeals/appeal-documents/__tests__/__snapshots__/appeal-documents.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-documents/__tests__/__snapshots__/appeal-documents.test.js.snap
@@ -16,7 +16,7 @@ exports[`documents upload should render upload form if appeal ID and folder ID a
                     <label for="upload-file-1">Choose a single file to upload.</label><span>The file must be smaller than 1 GB.</span><span>The file must be PDF, DOC, DOCX, PPT, PPTX, XLS, XLSX, JPG, JPEG, MPEG, MP3, MP4, MOV, PNG, TIF, 	or TIFF.</span>
                     <div                     class="middle-errors-hook"></div>
             </div>
-            <div class="pins-file-upload__upload display--flex">
+            <div class="pins-file-upload__upload">
                 <input class="display--none" id="upload-file-1" accept=".pdf,application/pdf,.doc,application/msword,.docx,application/vnd.openxmlformats-officedocument.wordprocessingml.document,.ppt,application/vnd.ms-powerpoint,.pptx,application/vnd.openxmlformats-officedocument.presentationml.presentation,.xls,application/vnd.ms-excel,.xlsx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,.jpg,image/jpeg,.jpeg,image/jpeg,.mpeg,video/mpeg,.mp3,audio/mpeg,.mp4,video/mp4,.mov,video/quicktime,.png,image/png,.tif,image/tiff,.tiff,image/tiff,"
                 type="file" name="files" value="Choose file" aria-controls="file-list-1">
                 <button type='button' class="pins-file-upload__button govuk-button">Choose file</button><span role="status" aria-live="assertive" class='govuk-body pins-file-upload__counter'> No file chosen</span>
@@ -54,7 +54,7 @@ exports[`documents upload should render upload form if appeal ID, folder ID and 
                     <label for="upload-file-1">Choose a single file to upload.</label><span>The file must be smaller than 1 GB.</span><span>The file must be PDF, DOC, DOCX, PPT, PPTX, XLS, XLSX, JPG, JPEG, MPEG, MP3, MP4, MOV, PNG, TIF, 	or TIFF.</span>
                     <div                     class="middle-errors-hook"></div>
             </div>
-            <div class="pins-file-upload__upload display--flex">
+            <div class="pins-file-upload__upload">
                 <input class="display--none" id="upload-file-1" accept=".pdf,application/pdf,.doc,application/msword,.docx,application/vnd.openxmlformats-officedocument.wordprocessingml.document,.ppt,application/vnd.ms-powerpoint,.pptx,application/vnd.openxmlformats-officedocument.presentationml.presentation,.xls,application/vnd.ms-excel,.xlsx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,.jpg,image/jpeg,.jpeg,image/jpeg,.mpeg,video/mpeg,.mp3,audio/mpeg,.mp4,video/mp4,.mov,video/quicktime,.png,image/png,.tif,image/tiff,.tiff,image/tiff,"
                 type="file" name="files" value="Choose file" aria-controls="file-list-1">
                 <button type='button' class="pins-file-upload__button govuk-button">Choose file</button><span role="status" aria-live="assertive" class='govuk-body pins-file-upload__counter'> No file chosen</span>

--- a/appeals/web/src/server/views/app/components/file-uploader.component.njk
+++ b/appeals/web/src/server/views/app/components/file-uploader.component.njk
@@ -41,7 +41,7 @@
 					{{ extensionsHtml(params) }}
 					<div class="middle-errors-hook"></div>
 				</div>
-				<div class="pins-file-upload__upload display--flex">
+				<div class="pins-file-upload__upload">
 					<input class="display--none"
 						   id="upload-file-{{ params.formId }}"
 						   accept="{% for value in params.allowedTypes %}{{ value|MIME }}{% endfor %}"

--- a/appeals/web/src/styles/7-components/file-upload.scss
+++ b/appeals/web/src/styles/7-components/file-upload.scss
@@ -77,6 +77,7 @@
   }
 
   &__upload {
+	display: flex;
 	padding: 20px 0 30px;
   }
 }


### PR DESCRIPTION
## Describe your changes

fix single-file upload component add file button not hiding when file is selected

## Issue ticket number and link

A2-1091

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [ ] I have performed a self-review of my own code
- [ ] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [ ] I have referenced the ticket number above
- [ ] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
