### PR TITLE
fix(web): decode document key in doc download

### DIFF
--- a/appeals/web/src/server/app/components/file-downloader.component.js
+++ b/appeals/web/src/server/app/components/file-downloader.component.js
@@ -51,11 +51,12 @@ export const getDocumentDownload = async ({ apiClient, params, session }, respon
 
 	// Document URIs are persisted with a prepended slash, but this slash is treated as part of the key by blob storage so we need to remove it
 	const documentKey = blobStoragePath.startsWith('/') ? blobStoragePath.slice(1) : blobStoragePath;
+	const decodedKey = decodeURIComponent(documentKey);
 	const fileName = `${documentKey}`.split(/\/+/).pop();
 
 	const blobProperties = await blobStorageClient.getBlobProperties(
 		blobStorageContainer,
-		documentKey
+		decodedKey
 	);
 	if (!blobProperties) {
 		return response.status(404);
@@ -67,7 +68,7 @@ export const getDocumentDownload = async ({ apiClient, params, session }, respon
 		response.setHeader('content-disposition', `attachment; filename=${fileName}`);
 	}
 
-	const blobStream = await blobStorageClient.downloadStream(blobStorageContainer, documentKey);
+	const blobStream = await blobStorageClient.downloadStream(blobStorageContainer, decodedKey);
 
 	if (!blobStream?.readableStreamBody) {
 		throw new Error(`Document ${documentKey} missing stream body`);
@@ -172,11 +173,12 @@ export const getDocumentDownloadByVersion = async ({ apiClient, params, session 
 
 	// Document URIs are persisted with a prepended slash, but this slash is treated as part of the key by blob storage so we need to remove it
 	const documentKey = blobStoragePath.startsWith('/') ? blobStoragePath.slice(1) : blobStoragePath;
+	const decodedKey = decodeURIComponent(documentKey);
 	const fileName = `${documentKey}`.split(/\/+/).pop();
 
 	const blobProperties = await blobStorageClient.getBlobProperties(
 		blobStorageContainer,
-		documentKey
+		decodedKey
 	);
 	if (!blobProperties) {
 		return response.status(404);
@@ -188,7 +190,7 @@ export const getDocumentDownloadByVersion = async ({ apiClient, params, session 
 		response.setHeader('content-disposition', `attachment; filename=${fileName}`);
 	}
 
-	const blobStream = await blobStorageClient.downloadStream(blobStorageContainer, documentKey);
+	const blobStream = await blobStorageClient.downloadStream(blobStorageContainer, decodedKey);
 
 	if (!blobStream?.readableStreamBody) {
 		throw new Error(`Document ${documentKey} missing stream body`);


### PR DESCRIPTION
Fixes downloading document encoded in storage: uses `decodeURIComponent` to decode the storage path and allow finding the blob.

## Issue ticket number and link

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [ ] I have performed a self-review of my own code
- [ ] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [ ] I have referenced the ticket number above
- [ ] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
