### PR TITLE
fix(appeals): decoding of blob path when copying blobs

### DIFF
--- a/appeals/api/src/server/endpoints/integrations/__tests__/documents-import.test.js
+++ b/appeals/api/src/server/endpoints/integrations/__tests__/documents-import.test.js
@@ -1,0 +1,40 @@
+import { mapBlobPath } from '#endpoints/documents/documents.mapper.js';
+import { randomUUID } from 'node:crypto';
+
+describe('document import', () => {
+	describe('mapping/encoding', () => {
+		const tests = [
+			{
+				it: 'success strings with spaces',
+				input: 'document name with space.pdf'
+			},
+			{
+				it: 'success strings with encoding',
+				input: 'space and enc Q%20-%20Press%20advert.pdf'
+			},
+			{
+				it: 'success strings with uncommon chars',
+				input: 'document name with numbers10 &chars `.pdf'
+			}
+		];
+
+		const containerName = 'files';
+
+		for (const { it, input } of tests) {
+			test(`${it}`, async () => {
+				const guid = randomUUID();
+				const ref = randomUUID();
+				const blobStoragePath = mapBlobPath(guid, ref, input);
+				const destinationUrl = `https://test.com/${containerName}/${blobStoragePath}`;
+
+				const destinationComponents = destinationUrl.split(`/${containerName}/`);
+				if (destinationComponents.length !== 2) {
+					throw new Error(`Destination URL format unexpected : ${destinationUrl}`);
+				}
+				const blobPath = destinationComponents[1];
+
+				expect(blobStoragePath).toEqual(blobPath);
+			});
+		}
+	});
+});

--- a/appeals/functions/document-processing/document-move/blob.js
+++ b/appeals/functions/document-processing/document-move/blob.js
@@ -9,7 +9,11 @@ const storageClient = BlobStorageClient.fromUrl(config.BO_BLOB_STORAGE_ACCOUNT);
  * @param {string} destinationUrl
  */
 export const copyBlob = async (sourceUrl, destinationUrl) => {
-	const blobPath = new URL(destinationUrl).pathname.replace(`/${config.BO_BLOB_CONTAINER}/`, '');
+	const destinationComponents = destinationUrl.split(`/${config.BO_BLOB_CONTAINER}/`);
+	if (destinationComponents.length !== 2) {
+		throw new Error(`Destination URL format unexpected : ${destinationUrl}`);
+	}
+	const blobPath = destinationComponents[1];
 	const blobClient = storageClient.getBlobClient(config.BO_BLOB_CONTAINER, blobPath);
 	if (!blobClient) {
 		throw new Error(`Could not get a blob reference to ${blobPath}`);

--- a/appeals/web/src/server/app/components/file-downloader.component.js
+++ b/appeals/web/src/server/app/components/file-downloader.component.js
@@ -51,12 +51,11 @@ export const getDocumentDownload = async ({ apiClient, params, session }, respon
 
 	// Document URIs are persisted with a prepended slash, but this slash is treated as part of the key by blob storage so we need to remove it
 	const documentKey = blobStoragePath.startsWith('/') ? blobStoragePath.slice(1) : blobStoragePath;
-	const decodedKey = decodeURIComponent(documentKey);
 	const fileName = `${documentKey}`.split(/\/+/).pop();
 
 	const blobProperties = await blobStorageClient.getBlobProperties(
 		blobStorageContainer,
-		decodedKey
+		documentKey
 	);
 	if (!blobProperties) {
 		return response.status(404);
@@ -68,7 +67,7 @@ export const getDocumentDownload = async ({ apiClient, params, session }, respon
 		response.setHeader('content-disposition', `attachment; filename=${fileName}`);
 	}
 
-	const blobStream = await blobStorageClient.downloadStream(blobStorageContainer, decodedKey);
+	const blobStream = await blobStorageClient.downloadStream(blobStorageContainer, documentKey);
 
 	if (!blobStream?.readableStreamBody) {
 		throw new Error(`Document ${documentKey} missing stream body`);
@@ -173,12 +172,11 @@ export const getDocumentDownloadByVersion = async ({ apiClient, params, session 
 
 	// Document URIs are persisted with a prepended slash, but this slash is treated as part of the key by blob storage so we need to remove it
 	const documentKey = blobStoragePath.startsWith('/') ? blobStoragePath.slice(1) : blobStoragePath;
-	const decodedKey = decodeURIComponent(documentKey);
 	const fileName = `${documentKey}`.split(/\/+/).pop();
 
 	const blobProperties = await blobStorageClient.getBlobProperties(
 		blobStorageContainer,
-		decodedKey
+		documentKey
 	);
 	if (!blobProperties) {
 		return response.status(404);
@@ -190,7 +188,7 @@ export const getDocumentDownloadByVersion = async ({ apiClient, params, session 
 		response.setHeader('content-disposition', `attachment; filename=${fileName}`);
 	}
 
-	const blobStream = await blobStorageClient.downloadStream(blobStorageContainer, decodedKey);
+	const blobStream = await blobStorageClient.downloadStream(blobStorageContainer, documentKey);
 
 	if (!blobStream?.readableStreamBody) {
 		throw new Error(`Document ${documentKey} missing stream body`);


### PR DESCRIPTION
When importing blobs from front office, documents with spaces where encoded when trying to validate the document URI.

## Issue ticket number and link

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [ ] I have performed a self-review of my own code
- [ ] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [ ] I have referenced the ticket number above
- [ ] I have provided a description of the ticket
- [x] I have included unit tests to cover any testable code changes
