### PR TITLE
fix(api): server-side checks on uploaded blobs

### DIFF
--- a/appeals/api/setup-tests.js
+++ b/appeals/api/setup-tests.js
@@ -3,6 +3,7 @@ import { jest } from '@jest/globals';
 import config from '#config/config.js';
 import { NODE_ENV_PRODUCTION } from '#endpoints/constants.js';
 
+const mockValidateBlob = jest.fn().mockResolvedValue(true);
 const mockRepGetById = jest.fn().mockResolvedValue({});
 const mockRepUpdateById = jest.fn().mockResolvedValue({});
 const mockAppealRelationshipAdd = jest.fn().mockResolvedValue({});
@@ -451,6 +452,12 @@ jest.unstable_mockModule('notifications-node-client', () => ({
 		sendEmail = mockSendEmail;
 	}
 }));
+
+jest.unstable_mockModule('./src/server/utils/blobValidation', () => {
+	return {
+		validateBlobContents: mockValidateBlob
+	};
+});
 
 jest.unstable_mockModule('./src/server/config/config.js', () => ({
 	default: {

--- a/appeals/api/src/server/config/config.js
+++ b/appeals/api/src/server/config/config.js
@@ -16,6 +16,8 @@ const { value, error } = schema.validate({
 	DATABASE_URL: environment.DATABASE_URL,
 	BO_BLOB_STORAGE_ACCOUNT: environment.BO_BLOB_STORAGE_ACCOUNT,
 	BO_BLOB_CONTAINER: environment.BO_BLOB_CONTAINER,
+	blobEmulatorSasUrl: environment.AZURE_BLOB_EMULATOR_SAS_HOST,
+	useBlobEmulator: environment.AZURE_BLOB_USE_EMULATOR || false,
 	defaultApiVersion: environment.DEFAULT_API_VERSION || '1',
 	serviceBusOptions: {
 		hostname: environment.SERVICE_BUS_HOSTNAME

--- a/appeals/api/src/server/config/schema.js
+++ b/appeals/api/src/server/config/schema.js
@@ -9,6 +9,8 @@ export default joi
 		DATABASE_URL: joi.string(),
 		BO_BLOB_STORAGE_ACCOUNT: joi.string(),
 		BO_BLOB_CONTAINER: joi.string(),
+		blobEmulatorSasUrl: joi.string().optional(),
+		useBlobEmulator: joi.boolean(),
 		defaultApiVersion: joi.string(),
 		serviceBusOptions: joi.object({
 			hostname: joi.string().optional()

--- a/appeals/api/src/server/endpoints/appeal-timetables/appeal-timetables.service.js
+++ b/appeals/api/src/server/endpoints/appeal-timetables/appeal-timetables.service.js
@@ -16,7 +16,7 @@ import transitionState from '#state/transition-state.js';
 import formatDate from '#utils/date-formatter.js';
 import config from '#config/config.js';
 import { createAuditTrail } from '#endpoints/audit-trails/audit-trails.service.js';
-import { PROCEDURE_TYPE_MAP } from '@pins/appeals/constants/documents.js';
+import { PROCEDURE_TYPE_MAP } from '@pins/appeals/constants/common.js';
 import { APPEAL_CASE_STATUS } from 'pins-data-model';
 
 /** @typedef {import('@pins/appeals.api').Schema.Appeal} Appeal */

--- a/appeals/api/src/server/utils/blobValidation.js
+++ b/appeals/api/src/server/utils/blobValidation.js
@@ -1,0 +1,72 @@
+import { BlobStorageClient } from '@pins/blob-storage-client';
+import { BlobServiceClient } from '@azure/storage-blob';
+import config from '#config/config.js';
+import { VALID_MIME_TYPES } from '@pins/appeals/constants/documents.js';
+
+/**
+ * @param {string} appealReference
+ * @param {string[]} storagePaths
+ * @returns {Promise<boolean>}
+ */
+export const validateBlobContents = async (appealReference, storagePaths) => {
+	const storageClient = config.useBlobEmulator
+		? new BlobStorageClient(new BlobServiceClient(config.blobEmulatorSasUrl))
+		: BlobStorageClient.fromUrl(config.BO_BLOB_STORAGE_ACCOUNT);
+
+	for (const path of storagePaths) {
+		if (!validateBlobPath(appealReference, path)) {
+			return false;
+		}
+
+		const blobClient = storageClient.getBlobClient(config.BO_BLOB_CONTAINER, path);
+		if (!blobClient) {
+			return false;
+		}
+
+		const blobProperties = await blobClient.getProperties();
+		const mime = blobProperties.contentType || '';
+		const header = await blobClient.downloadToBuffer(0, 8);
+		const uint8Array = new Uint8Array(header);
+		const isValidSignature = validateMimeType(uint8Array, mime);
+
+		return isValidSignature;
+	}
+
+	return true;
+};
+
+/**
+ *
+ * @param {Uint8Array} uint8Array
+ * @param {string} mime
+ * @returns {boolean}
+ */
+const validateMimeType = (uint8Array, mime) => {
+	let bytes = [];
+	for (let i = 0; i < 8; i++) {
+		bytes.push(uint8Array[i].toString(16).padStart(2, '0'));
+	}
+
+	const result = bytes.join('').toUpperCase();
+	const match = VALID_MIME_TYPES[mime];
+	if (match) {
+		const offset = match.offset ?? 0;
+		return match.hexSignature
+			.split(',')
+			.some((/** @type {string} */ magicNumber) =>
+				result.substring(offset).startsWith(magicNumber.trim())
+			);
+	}
+
+	return false;
+};
+
+/**
+ *
+ * @param {string} appealReference
+ * @param {string} path
+ * @param {Number|undefined} version
+ * @returns {boolean}
+ */
+const validateBlobPath = (appealReference, path, version = 1) =>
+	path.startsWith(`appeal/${appealReference}`) && path.indexOf(`/v${version}/`) > 0;

--- a/infrastructure/document-storage.tf
+++ b/infrastructure/document-storage.tf
@@ -166,3 +166,9 @@ resource "azurerm_role_assignment" "legal_documents_access" {
   role_definition_name = "Storage Blob Data Reader"
   principal_id         = var.apps_config.auth.group_ids.legal
 }
+
+resource "azurerm_role_assignment" "api_document_validation" {
+  scope                = azurerm_storage_container.appeal_documents.resource_manager_id
+  role_definition_name = "Storage Blob Data Reader"
+  principal_id         = module.app_api.principal_id
+}

--- a/packages/appeals/constants/common.js
+++ b/packages/appeals/constants/common.js
@@ -3,15 +3,15 @@ export const ODW_APPELLANT_SVCUSR = 'Appellant';
 export const ODW_AGENT_SVCUSR = 'Agent';
 export const APPEAL_START_RANGE = 6000000;
 
-export const EVENT_TYPE = {
+export const EVENT_TYPE = Object.freeze({
 	SITE_VISIT: 'siteVisit'
-};
+});
 
-export const FEATURE_FLAG_NAMES = {
+export const FEATURE_FLAG_NAMES = Object.freeze({
 	SECTION_78: 'featureFlagS78Written'
-};
+});
 
-export const APPEAL_TYPE = {
+export const APPEAL_TYPE = Object.freeze({
 	D: 'Householder',
 	W: 'Planning appeal',
 	C: 'Enforcement notice appeal',
@@ -25,21 +25,28 @@ export const APPEAL_TYPE = {
 	X: 'Lawful development certificate appeal',
 	Y: 'Planned listed building and conservation area appeal',
 	Z: 'Commercial (CAS) appeal'
-};
+});
+
+/** @type {Object<string, string>} */
+export const PROCEDURE_TYPE_MAP = Object.freeze({
+	written: 'a written procedure',
+	hearing: 'a hearing',
+	inquiry: 'an inquiry'
+});
 
 //TODO: remove when available in appeal-representation.schema
-export const APPEAL_REPRESENTATION_TYPE = {
+export const APPEAL_REPRESENTATION_TYPE = Object.freeze({
 	STATEMENT: 'statement',
 	COMMENT: 'comment',
 	FINAL_COMMENT: 'final_comment'
-};
+});
 
 //TODO: remove when available in appeal-representation.schema - here just for reference
 // eslint-disable-next-line no-unused-vars
-export const APPEAL_REPRESENTATION_STATUS = {
+export const APPEAL_REPRESENTATION_STATUS = Object.freeze({
 	AWAITING_REVIEW: 'awaiting_review',
 	VALID: 'valid',
 	INVALID: 'invalid',
 	PUBLISHED: 'published',
 	WITHDRAWN: 'withdrawn'
-};
+});

--- a/packages/appeals/constants/documents.js
+++ b/packages/appeals/constants/documents.js
@@ -35,9 +35,28 @@ export const FOLDERS = [
 	`${APPEAL_CASE_STAGE.APPEAL_DECISION}/${APPEAL_DOCUMENT_TYPE.CASE_DECISION_LETTER}`
 ];
 
-/** @type {Object<string, string>} */
-export const PROCEDURE_TYPE_MAP = {
-	written: 'a written procedure',
-	hearing: 'a hearing',
-	inquiry: 'an inquiry'
-};
+export const VALID_MIME_TYPES = Object.freeze({
+	'application/pdf': { hexSignature: '255044462D', extensions: ['pdf'] },
+	'application/msword': { hexSignature: 'D0CF11E0', extensions: ['doc'] },
+	'application/vnd.openxmlformats-officedocument.wordprocessingml.document': {
+		hexSignature: '504B03041400',
+		extensions: ['docx']
+	},
+	'application/vnd.ms-powerpoint': { hexSignature: 'D0CF11E0', extensions: ['ppt'] },
+	'application/vnd.openxmlformats-officedocument.presentationml.presentation': {
+		hexSignature: 'D0CF11E0',
+		extensions: ['pptx']
+	},
+	'application/vnd.ms-excel': { hexSignature: 'D0CF11E0', extensions: ['xls'] },
+	'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet': {
+		hexSignature: '504B03041400',
+		extensions: ['xlsx']
+	},
+	'image/jpeg': { hexSignature: 'FFD8FFE0', extensions: ['jpg', 'jpeg'] },
+	'video/mpeg': { hexSignature: '000001B3, 000001BA', extensions: ['mpeg'] },
+	'audio/mpeg': { hexSignature: 'FFFB, 494433', extensions: ['mp3'] },
+	'video/mp4': { hexSignature: '66747970', offset: 8, extensions: ['mp4'] },
+	'video/quicktime': { hexSignature: '0000001466747970', extensions: ['mov'] },
+	'image/png': { hexSignature: '89504E47', extensions: ['png'] },
+	'image/tiff': { hexSignature: '4D4D002A, 49492A00', extensions: ['tif', 'tiff'] }
+});


### PR DESCRIPTION
This is a remedy to the PEN test report, client-side upload vulnerabilities.

## Describe your changes

Before writing document records to the database, an extra validation check will:
- Download the first bytes from blob storage
- Calculate the `magic number` signature of the file, to ensure the content type is allowed
- Validates the documentURI

## Issue ticket number and link

[A2-848](https://pins-ds.atlassian.net/browse/A2-848)

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Other (please explain in the description section above)

## Checklist before requesting a review

- [ ] I have performed a self-review of my own code
- [ ] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [ ] I have referenced the ticket number above
- [ ] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes


[A2-848]: https://pins-ds.atlassian.net/browse/A2-848?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ