### PR TITLE
fix(web): add visually hidden content to review IP comments link in notification banner

### DIFF
--- a/appeals/web/src/server/appeals/appeal-details/__tests__/__snapshots__/appeal-details.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/__tests__/__snapshots__/appeal-details.test.js.snap
@@ -415,7 +415,7 @@ data-module="govuk-notification-banner">
     <div class="govuk-notification-banner__content">
         <p class="govuk-notification-banner__heading">Review comments</p>
         <p><a class="govuk-notification-banner__link" href="/appeals-service/appeal-details/2/interested-party-comments"
-            data-cy="banner-review-ip-comments">Review</a>
+            data-cy="banner-review-ip-comments">Review <span class="govuk-visually-hidden">interested party comments</span></a>
         </p>
     </div>
 </div>"

--- a/appeals/web/src/server/appeals/appeal-details/__tests__/appeal-details.test.js
+++ b/appeals/web/src/server/appeals/appeal-details/__tests__/appeal-details.test.js
@@ -999,7 +999,7 @@ describe('appeal-details', () => {
 					'<p class="govuk-notification-banner__heading">Review comments</p>'
 				);
 				expect(unprettifiedElementHtml).toContain(
-					'<p><a class="govuk-notification-banner__link" href="/appeals-service/appeal-details/2/interested-party-comments" data-cy="banner-review-ip-comments">Review</a></p>'
+					'<p><a class="govuk-notification-banner__link" href="/appeals-service/appeal-details/2/interested-party-comments" data-cy="banner-review-ip-comments">Review <span class="govuk-visually-hidden">interested party comments</span></a></p>'
 				);
 			});
 		});

--- a/appeals/web/src/server/appeals/appeal-details/appeal-details.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/appeal-details.mapper.js
@@ -265,7 +265,7 @@ function mapStatusDependentNotifications(
 	ipCommentsAwaitingReview = false
 ) {
 	switch (appealDetails.appealStatus) {
-		case 'assign_case_officer':
+		case APPEAL_CASE_STATUS.ASSIGN_CASE_OFFICER:
 			addNotificationBannerToSession(
 				session,
 				'assignCaseOfficer',
@@ -273,7 +273,7 @@ function mapStatusDependentNotifications(
 				`<p class="govuk-notification-banner__heading">Appeal ready to be assigned to case officer</p><p><a class="govuk-notification-banner__link" href="/appeals-service/appeal-details/${appealDetails.appealId}/assign-user/case-officer" data-cy="banner-assign-case-officer">Assign case officer</a></p>`
 			);
 			break;
-		case 'issue_determination':
+		case APPEAL_CASE_STATUS.ISSUE_DETERMINATION:
 			addNotificationBannerToSession(
 				session,
 				'readyForDecision',
@@ -283,7 +283,7 @@ function mapStatusDependentNotifications(
 				)}">Issue decision</a></p>`
 			);
 			break;
-		case 'ready_to_start':
+		case APPEAL_CASE_STATUS.READY_TO_START:
 			addNotificationBannerToSession(
 				session,
 				'appealValidAndReadyToStart',
@@ -293,7 +293,7 @@ function mapStatusDependentNotifications(
 				)}">Start case</a></p>`
 			);
 			break;
-		case 'awaiting_transfer':
+		case APPEAL_CASE_STATUS.AWAITING_TRANSFER:
 			addNotificationBannerToSession(
 				session,
 				'appealAwaitingTransfer',
@@ -308,7 +308,7 @@ function mapStatusDependentNotifications(
 					session,
 					'interestedPartyCommentsAwaitingReview',
 					appealDetails.appealId,
-					`<p class="govuk-notification-banner__heading">Review comments</p><p><a class="govuk-notification-banner__link" href="/appeals-service/appeal-details/${appealDetails.appealId}/interested-party-comments" data-cy="banner-review-ip-comments">Review</a></p>`
+					`<p class="govuk-notification-banner__heading">Review comments</p><p><a class="govuk-notification-banner__link" href="/appeals-service/appeal-details/${appealDetails.appealId}/interested-party-comments" data-cy="banner-review-ip-comments">Review <span class="govuk-visually-hidden">interested party comments</span></a></p>`
 				);
 			}
 			break;


### PR DESCRIPTION
## Describe your changes

Add visually hidden content to review IP comments link in notification banner. Also includes a small refactoring improvement to `mapStatusDependentNotifications` (replace hardcoded appeal status strings with constants)

## Issue ticket number and link

A2-587

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [ ] I have performed a self-review of my own code
- [ ] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [ ] I have referenced the ticket number above
- [ ] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
