### PR TITLE
fix(api): ensures start date is set to beginning of day UTC

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,8 +5,7 @@
 		"program": "node_modules/jest/bin/jest.js",
 		"args": ["--testTimeout=300000"],
 		"env": {
-			"NODE_OPTIONS": "--experimental-vm-modules",
-			"TZ": "UTC"
+			"NODE_OPTIONS": "--experimental-vm-modules"
 		}
 	},
 	"jestrunner.jestCommand": "node --experimental-vm-modules node_modules/jest/bin/jest.js"

--- a/appeals/api/src/server/endpoints/appeal-timetables/appeal-timetables.service.js
+++ b/appeals/api/src/server/endpoints/appeal-timetables/appeal-timetables.service.js
@@ -69,8 +69,11 @@ const startCase = async (appeal, startDate, notifyClient, siteAddress, azureAdUs
 			DAYTIME_HOUR,
 			DAYTIME_MINUTE
 		).toISOString();
+
 		const startedAt = await recalculateDateIfNotBusinessDay(processedStartDate);
 		const timetable = await calculateTimetable(appealType.key, startedAt);
+
+		const startDateWithTimeCorrection = setTimeInTimeZone(processedStartDate, 0, 0);
 
 		const appellantTemplate = appeal.caseStartedDate
 			? config.govNotify.template.appealStartDateChange.appellant
@@ -83,7 +86,9 @@ const startCase = async (appeal, startDate, notifyClient, siteAddress, azureAdUs
 		if (timetable) {
 			await Promise.all([
 				appealTimetableRepository.upsertAppealTimetableById(appeal.id, timetable),
-				appealRepository.updateAppealById(appeal.id, { caseStartedDate: startedAt.toISOString() })
+				appealRepository.updateAppealById(appeal.id, {
+					caseStartedDate: startDateWithTimeCorrection.toISOString()
+				})
 			]);
 
 			await createAuditTrail({


### PR DESCRIPTION
Quick fix from dates refactoring, ensures that start date is set back to start of the day after business days calc

## Issue ticket number and link

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [ ] I have performed a self-review of my own code
- [ ] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [ ] I have referenced the ticket number above
- [ ] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
