### PR TITLE
feat(api): updates schemas to include new doc types

### DIFF
--- a/appeals/api/package.json
+++ b/appeals/api/package.json
@@ -69,7 +69,7 @@
     "rhea": "3.0.1",
     "swagger-ui-express": "^5.0.1",
     "xstate": "4.32.1",
-    "pins-data-model": "github:Planning-Inspectorate/data-model#1.8.3"
+    "pins-data-model": "github:Planning-Inspectorate/data-model#1.9.1"
   },
   "devDependencies": {
     "@types/express": "^4.17.13",

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
 				"joi": "^17.7.0",
 				"node-cache": "^5.1.2",
 				"nodemon": "3.0.3",
-				"pins-data-model": "github:Planning-Inspectorate/data-model#1.8.3"
+				"pins-data-model": "github:Planning-Inspectorate/data-model#1.9.1"
 			},
 			"devDependencies": {
 				"@commitlint/cli": "17.0.1",
@@ -77,7 +77,7 @@
 				"pino": "^8.1.0",
 				"pino-http": "^8.1.0",
 				"pino-pretty": "^8.1.0",
-				"pins-data-model": "github:Planning-Inspectorate/data-model#1.8.3",
+				"pins-data-model": "github:Planning-Inspectorate/data-model#1.9.1",
 				"rhea": "3.0.1",
 				"swagger-ui-express": "^5.0.1",
 				"xstate": "4.32.1"
@@ -20585,8 +20585,8 @@
 			"license": "MIT"
 		},
 		"node_modules/pins-data-model": {
-			"version": "1.8.3",
-			"resolved": "git+ssh://git@github.com/Planning-Inspectorate/data-model.git#fa77246549c5bcdf5a2fa6d27e2e1b302844b420",
+			"version": "1.9.1",
+			"resolved": "git+ssh://git@github.com/Planning-Inspectorate/data-model.git#1e3d230f7bf2308e1e7328e9160f658e1c98937c",
 			"integrity": "sha512-xk2gyAS0kAzFkiOWmo2pKvKAkQno2nER/buABJbmyVgIBsBGNSb7gQ91TmZOyn4aNEI90Q4Gxcq5w9q4+RyMpw==",
 			"license": "MIT",
 			"dependencies": {
@@ -29928,7 +29928,7 @@
 				"pino": "^8.1.0",
 				"pino-http": "^8.1.0",
 				"pino-pretty": "^8.1.0",
-				"pins-data-model": "github:Planning-Inspectorate/data-model#1.8.3",
+				"pins-data-model": "github:Planning-Inspectorate/data-model#1.9.1",
 				"prisma": "4.16.1",
 				"rhea": "3.0.1",
 				"rimraf": "^3.0.2",
@@ -41006,9 +41006,9 @@
 			"version": "4.0.0"
 		},
 		"pins-data-model": {
-			"version": "git+ssh://git@github.com/Planning-Inspectorate/data-model.git#fa77246549c5bcdf5a2fa6d27e2e1b302844b420",
+			"version": "git+ssh://git@github.com/Planning-Inspectorate/data-model.git#1e3d230f7bf2308e1e7328e9160f658e1c98937c",
 			"integrity": "sha512-xk2gyAS0kAzFkiOWmo2pKvKAkQno2nER/buABJbmyVgIBsBGNSb7gQ91TmZOyn4aNEI90Q4Gxcq5w9q4+RyMpw==",
-			"from": "pins-data-model@github:Planning-Inspectorate/data-model#1.8.3",
+			"from": "pins-data-model@github:Planning-Inspectorate/data-model#1.9.1",
 			"requires": {
 				"jsonc-parser": "^3.2.0"
 			}

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
 		"joi": "^17.7.0",
 		"node-cache": "^5.1.2",
 		"nodemon": "3.0.3",
-		"pins-data-model": "github:Planning-Inspectorate/data-model#1.8.3"
+		"pins-data-model": "github:Planning-Inspectorate/data-model#1.9.1"
 	},
 	"devDependencies": {
 		"@commitlint/cli": "17.0.1",


### PR DESCRIPTION
Uses an upgraded data model schema (v1.9.1) to support new document types for HAS.

## Issue ticket number and link

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [ ] I have performed a self-review of my own code
- [ ] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [ ] I have referenced the ticket number above
- [ ] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
