### PR TITLE
fix(web): binding of inspector data A2-1240

### DIFF
--- a/appeals/web/src/server/lib/mappers/appeal/appeal.mapper.js
+++ b/appeals/web/src/server/lib/mappers/appeal/appeal.mapper.js
@@ -76,7 +76,7 @@ export async function initialiseAndMapAppealData(
 
 	const inspectorUser = appealDetails.inspector
 		? await usersService.getUserByRoleAndId(
-				config.referenceData.appeals.caseOfficerGroupId,
+				config.referenceData.appeals.inspectorGroupId,
 				session,
 				appealDetails.inspector
 		  )


### PR DESCRIPTION
Small bug, was trying to load inspector details from the wrong group.

## Issue ticket number and link

[A2-1240](https://pins-ds.atlassian.net/browse/A2-1240)

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [ ] I have performed a self-review of my own code
- [ ] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [ ] I have referenced the ticket number above
- [ ] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes


[A2-1240]: https://pins-ds.atlassian.net/browse/A2-1240?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ