### PR TITLE
fix(web): ready for validation and ready for LPAQ review banners added

### DIFF
--- a/appeals/web/src/server/appeals/appeal-details/__tests__/__snapshots__/appeal-details.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/__tests__/__snapshots__/appeal-details.test.js.snap
@@ -68,6 +68,20 @@ exports[`appeal-details GET /:appealId Appeal decision should render a row in th
 
 exports[`appeal-details GET /:appealId Appeal decision should render a row in the case overview accordion with with "Issue" action link to the issue decision start page, if the appeal status is "issue_determination" 1`] = `"<div class="govuk-summary-list__row appeal-decision"><dt class="govuk-summary-list__key"> Decision</dt><dd class="govuk-summary-list__value"> Not yet issued</dd><dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/issue-decision/decision"> Issue<span class="govuk-visually-hidden"> decision</span></a></dd></div>"`;
 
+exports[`appeal-details GET /:appealId Notification banners should render a "Appeal ready for validation" important notification banner with a link to validate the appeal when the appeal status is "validation" 1`] = `
+"<div class="govuk-notification-banner" role="region" aria-labelledby="govuk-notification-banner-title"
+data-module="govuk-notification-banner">
+    <div class="govuk-notification-banner__header">
+        <h3 class="govuk-notification-banner__title" id="govuk-notification-banner-title"> Important</h3>
+    </div>
+    <div class="govuk-notification-banner__content">
+        <p class="govuk-notification-banner__heading">Appeal ready for validation</p>
+        <p><a class="govuk-notification-banner__link" data-cy="validate-appeal" href="/appeals-service/appeal-details/2/appellant-case">Validate <span class="govuk-visually-hidden">appeal</span></a>
+        </p>
+    </div>
+</div>"
+`;
+
 exports[`appeal-details GET /:appealId Notification banners should render a "Appeal ready to be assigned to case officer" important notification banner with a link to assign case officer when status is "Assign case officer" 1`] = `
 "<div class="govuk-notification-banner" role="region" aria-labelledby="govuk-notification-banner-title"
 data-module="govuk-notification-banner">
@@ -101,6 +115,21 @@ exports[`appeal-details GET /:appealId Notification banners should render a "Hor
 "<div class="govuk-inset-text govuk-!-margin-top-0">
     <p class="govuk-body">This appeal needed to change to a (C) Enforcement notice appeal</p>
     <p     class="govuk-body">It has been transferred to Horizon with the reference 12345</p>
+</div>"
+`;
+
+exports[`appeal-details GET /:appealId Notification banners should render a "LPA questionnaire ready for review" notification banner with a link to review the questionnaire when the appeal status is "lpa_questionnaire" and the appeal has an LPA questionnaire ID 1`] = `
+"<div class="govuk-notification-banner" role="region" aria-labelledby="govuk-notification-banner-title"
+data-module="govuk-notification-banner">
+    <div class="govuk-notification-banner__header">
+        <h3 class="govuk-notification-banner__title" id="govuk-notification-banner-title"> Important</h3>
+    </div>
+    <div class="govuk-notification-banner__content">
+        <p class="govuk-notification-banner__heading">LPA questionnaire ready for review</p>
+        <p><a class="govuk-notification-banner__link" data-cy="review-lpa-questionnaire"
+            href="/appeals-service/appeal-details/2/lpa-questionnaire/123">Review <span class="govuk-visually-hidden">LPA questionnaire</span></a>
+        </p>
+    </div>
 </div>"
 `;
 
@@ -3360,6 +3389,21 @@ exports[`appeal-details GET /:appealId should render an action link to the add l
 exports[`appeal-details GET /:appealId should render the appellant case status as "Incomplete" if the appellant case validation status is incomplete, and the due date is in the future 1`] = `
 "<main class="govuk-main-wrapper " id="main-content" role="main">
     <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <div class="govuk-notification-banner" role="region" aria-labelledby="govuk-notification-banner-title"
+            data-module="govuk-notification-banner">
+                <div class="govuk-notification-banner__header">
+                    <h3 class="govuk-notification-banner__title" id="govuk-notification-banner-title"> Important</h3>
+                </div>
+                <div class="govuk-notification-banner__content">
+                    <p class="govuk-notification-banner__heading">Appeal ready for validation</p>
+                    <p><a class="govuk-notification-banner__link" data-cy="validate-appeal" href="/appeals-service/appeal-details/1/appellant-case">Validate <span class="govuk-visually-hidden">appeal</span></a>
+                    </p>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
         <div class="govuk-grid-column-full"><span class="govuk-caption-l govuk-!-margin-bottom-3">Appeal 351062</span>
             <h1             class="govuk-heading-xl govuk-!-margin-bottom-3">Case details</h1>
         </div>
@@ -3772,6 +3816,21 @@ exports[`appeal-details GET /:appealId should render the appellant case status a
 exports[`appeal-details GET /:appealId should render the appellant case status as "Incomplete" if the appellant case validation status is incomplete, and the due date is today 1`] = `
 "<main class="govuk-main-wrapper " id="main-content" role="main">
     <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <div class="govuk-notification-banner" role="region" aria-labelledby="govuk-notification-banner-title"
+            data-module="govuk-notification-banner">
+                <div class="govuk-notification-banner__header">
+                    <h3 class="govuk-notification-banner__title" id="govuk-notification-banner-title"> Important</h3>
+                </div>
+                <div class="govuk-notification-banner__content">
+                    <p class="govuk-notification-banner__heading">Appeal ready for validation</p>
+                    <p><a class="govuk-notification-banner__link" data-cy="validate-appeal" href="/appeals-service/appeal-details/1/appellant-case">Validate <span class="govuk-visually-hidden">appeal</span></a>
+                    </p>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
         <div class="govuk-grid-column-full"><span class="govuk-caption-l govuk-!-margin-bottom-3">Appeal 351062</span>
             <h1             class="govuk-heading-xl govuk-!-margin-bottom-3">Case details</h1>
         </div>
@@ -4183,6 +4242,21 @@ exports[`appeal-details GET /:appealId should render the appellant case status a
 
 exports[`appeal-details GET /:appealId should render the appellant case status as "Overdue" if the appellant case validation status is incomplete, and the due date is in the past 1`] = `
 "<main class="govuk-main-wrapper " id="main-content" role="main">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <div class="govuk-notification-banner" role="region" aria-labelledby="govuk-notification-banner-title"
+            data-module="govuk-notification-banner">
+                <div class="govuk-notification-banner__header">
+                    <h3 class="govuk-notification-banner__title" id="govuk-notification-banner-title"> Important</h3>
+                </div>
+                <div class="govuk-notification-banner__content">
+                    <p class="govuk-notification-banner__heading">Appeal ready for validation</p>
+                    <p><a class="govuk-notification-banner__link" data-cy="validate-appeal" href="/appeals-service/appeal-details/1/appellant-case">Validate <span class="govuk-visually-hidden">appeal</span></a>
+                    </p>
+                </div>
+            </div>
+        </div>
+    </div>
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-full"><span class="govuk-caption-l govuk-!-margin-bottom-3">Appeal 351062</span>
             <h1             class="govuk-heading-xl govuk-!-margin-bottom-3">Case details</h1>

--- a/appeals/web/src/server/appeals/appeal-details/__tests__/__snapshots__/appeal-details.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/__tests__/__snapshots__/appeal-details.test.js.snap
@@ -118,7 +118,7 @@ exports[`appeal-details GET /:appealId Notification banners should render a "Hor
 </div>"
 `;
 
-exports[`appeal-details GET /:appealId Notification banners should render a "LPA questionnaire ready for review" notification banner with a link to review the questionnaire when the appeal status is "lpa_questionnaire" and the appeal has an LPA questionnaire ID 1`] = `
+exports[`appeal-details GET /:appealId Notification banners should render a "LPA questionnaire ready for review" important notification banner with a link to review the questionnaire when the appeal status is "lpa_questionnaire" and the appeal has an LPA questionnaire ID 1`] = `
 "<div class="govuk-notification-banner" role="region" aria-labelledby="govuk-notification-banner-title"
 data-module="govuk-notification-banner">
     <div class="govuk-notification-banner__header">

--- a/appeals/web/src/server/appeals/appeal-details/__tests__/appeal-details.test.js
+++ b/appeals/web/src/server/appeals/appeal-details/__tests__/appeal-details.test.js
@@ -1002,6 +1002,81 @@ describe('appeal-details', () => {
 					'<p><a class="govuk-notification-banner__link" href="/appeals-service/appeal-details/2/interested-party-comments" data-cy="banner-review-ip-comments">Review <span class="govuk-visually-hidden">interested party comments</span></a></p>'
 				);
 			});
+
+			it('should render a "Appeal ready for validation" important notification banner with a link to validate the appeal when the appeal status is "validation"', async () => {
+				const appealId = 2;
+
+				nock('http://test/')
+					.get(`/appeals/${appealId}`)
+					.reply(200, { ...appealData, appealId, appealStatus: 'validation' });
+
+				const response = await request.get(`${baseUrl}/${appealId}`);
+
+				expect(response.statusCode).toBe(200);
+				const notificationBannerElementHTML = parseHtml(response.text, {
+					rootElement: '.govuk-notification-banner'
+				}).innerHTML;
+				expect(notificationBannerElementHTML).toMatchSnapshot();
+				expect(notificationBannerElementHTML).toContain('Important</h3>');
+				expect(notificationBannerElementHTML).toContain('Appeal ready for validation</p>');
+				expect(notificationBannerElementHTML).toContain(
+					`href="/appeals-service/appeal-details/${appealId}/appellant-case"`
+				);
+				expect(notificationBannerElementHTML).toContain('data-cy="validate-appeal"');
+				expect(notificationBannerElementHTML).toContain(
+					'Validate <span class="govuk-visually-hidden">appeal</span></a>'
+				);
+			});
+
+			it('should render a "LPA questionnaire ready for review" important notification banner with a link to review the questionnaire when the appeal status is "lpa_questionnaire" and the appeal has an LPA questionnaire ID', async () => {
+				const appealId = 2;
+				const lpaQuestionnaireId = 123;
+
+				nock('http://test/')
+					.get(`/appeals/${appealId}`)
+					.reply(200, {
+						...appealData,
+						appealId,
+						appealStatus: 'lpa_questionnaire',
+						lpaQuestionnaireId
+					});
+
+				const response = await request.get(`${baseUrl}/${appealId}`);
+
+				expect(response.statusCode).toBe(200);
+				const notificationBannerElementHTML = parseHtml(response.text, {
+					rootElement: '.govuk-notification-banner'
+				}).innerHTML;
+				expect(notificationBannerElementHTML).toMatchSnapshot();
+				expect(notificationBannerElementHTML).toContain('Important</h3>');
+				expect(notificationBannerElementHTML).toContain('LPA questionnaire ready for review</p>');
+				expect(notificationBannerElementHTML).toContain(
+					`href="/appeals-service/appeal-details/${appealId}/lpa-questionnaire/${lpaQuestionnaireId}"`
+				);
+				expect(notificationBannerElementHTML).toContain('data-cy="review-lpa-questionnaire"');
+				expect(notificationBannerElementHTML).toContain(
+					'Review <span class="govuk-visually-hidden">LPA questionnaire</span></a>'
+				);
+			});
+
+			it('should not render a "LPA questionnaire ready for review" important notification banner when the appeal status is "lpa_questionnaire" but the appeal does not have an LPA questionnaire ID', async () => {
+				const appealId = 2;
+
+				nock('http://test/')
+					.get(`/appeals/${appealId}`)
+					.reply(200, {
+						...appealData,
+						appealId,
+						appealStatus: 'lpa_questionnaire',
+						lpaQuestionnaireId: null
+					});
+
+				const response = await request.get(`${baseUrl}/${appealId}`);
+
+				expect(response.statusCode).toBe(200);
+				const notificationBannerElement = response.text.includes('govuk-notification-banner');
+				expect(notificationBannerElement).toBe(false);
+			});
 		});
 
 		it('should render the received appeal details for a valid appealId with no linked/other appeals', async () => {

--- a/appeals/web/src/server/appeals/appeal-details/appeal-details.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/appeal-details.mapper.js
@@ -249,6 +249,24 @@ function mapStatusDependentNotifications(
 				`<p class="govuk-notification-banner__heading">Appeal ready to be assigned to case officer</p><p><a class="govuk-notification-banner__link" href="/appeals-service/appeal-details/${appealDetails.appealId}/assign-user/case-officer" data-cy="banner-assign-case-officer">Assign case officer</a></p>`
 			);
 			break;
+		case APPEAL_CASE_STATUS.VALIDATION:
+			addNotificationBannerToSession(
+				session,
+				'readyForValidation',
+				appealDetails.appealId,
+				`<p class="govuk-notification-banner__heading">Appeal ready for validation</p><p><a class="govuk-notification-banner__link" data-cy="validate-appeal" href="/appeals-service/appeal-details/${appealDetails.appealId}/appellant-case">Validate <span class="govuk-visually-hidden">appeal</span></a></p>`
+			);
+			break;
+		case APPEAL_CASE_STATUS.LPA_QUESTIONNAIRE:
+			if (appealDetails.lpaQuestionnaireId) {
+				addNotificationBannerToSession(
+					session,
+					'readyForLpaQuestionnaireReview',
+					appealDetails.appealId,
+					`<p class="govuk-notification-banner__heading">LPA questionnaire ready for review</p><p><a class="govuk-notification-banner__link" data-cy="review-lpa-questionnaire" href="/appeals-service/appeal-details/${appealDetails.appealId}/lpa-questionnaire/${appealDetails.lpaQuestionnaireId}">Review <span class="govuk-visually-hidden">LPA questionnaire</span></a></p>`
+				);
+			}
+			break;
 		case APPEAL_CASE_STATUS.ISSUE_DETERMINATION:
 			addNotificationBannerToSession(
 				session,

--- a/appeals/web/src/server/lib/mappers/notification-banners.mapper.js
+++ b/appeals/web/src/server/lib/mappers/notification-banners.mapper.js
@@ -73,6 +73,12 @@ export const notificationBannerDefinitions = {
 	readyForDecision: {
 		pages: ['appealDetails']
 	},
+	readyForValidation: {
+		pages: ['appealDetails']
+	},
+	readyForLpaQuestionnaireReview: {
+		pages: ['appealDetails']
+	},
 	lpaQuestionnaireNotValid: {
 		pages: ['lpaQuestionnaire'],
 		persist: true


### PR DESCRIPTION
## Describe your changes

Two important notification banners added to Appeal details

- 'Ready for validation' when the case status is 'validation'
- 'LPA questionnaire ready for review' when the status is 'lpa_questionnaire' and it has an LPAQ id

## Issue ticket number and link

[A2-397 WEB - Missing banners -  Appeal ready for validation & LPA is ready to review](https://pins-ds.atlassian.net.mcas.ms/browse/A2-397)

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [x] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [x] I have included unit tests to cover any testable code changes
