### PR TITLE
feat(web): add custom date field label copy for costs decision document flows

### DIFF
--- a/appeals/web/package.json
+++ b/appeals/web/package.json
@@ -20,6 +20,7 @@
     "sass": "node ./scripts/rollup/compile-css.js",
     "start": "node ./src/server/server.js",
     "test": "cross-env NODE_ENV=test NODE_OPTIONS=\"--experimental-vm-modules --max-old-space-size=8192\" npx jest --detectOpenHandles --forceExit --coverage",
+		"test:fast": "cross-env NODE_ENV=test NODE_OPTIONS=\"--experimental-vm-modules --max-old-space-size=8192\" npx jest",
     "test:cov": "cross-env NODE_ENV=test NODE_OPTIONS=--experimental-vm-modules npx jest --coverage",
     "tscheck": "npx tsc -p jsconfig.json --maxNodeModuleJsDepth 0",
     "watch:rollup": "chokidar \"src/client/**/*.js\" --silent -c \"npm run rollup\"",

--- a/appeals/web/src/server/appeals/appeal-details/appellant-case/appellant-case.controller.js
+++ b/appeals/web/src/server/appeals/appeal-details/appellant-case/appellant-case.controller.js
@@ -267,13 +267,15 @@ export const getAddDocumentDetails = async (request, response) => {
 
 	const headingTextOverride = getPageHeadingTextOverrideForFolder(currentFolder);
 
-	await renderDocumentDetails(
+	await renderDocumentDetails({
 		request,
 		response,
-		`/appeals-service/appeal-details/${request.params.appealId}/appellant-case/add-documents/{{folderId}}`,
-		getValidationOutcomeFromAppellantCase(appellantCaseDetails) === 'valid',
-		headingTextOverride && capitalize(headingTextOverride)
-	);
+		backLinkUrl: `/appeals-service/appeal-details/${request.params.appealId}/appellant-case/add-documents/{{folderId}}`,
+		isLateEntry: getValidationOutcomeFromAppellantCase(appellantCaseDetails) === 'valid',
+		...(headingTextOverride && {
+			pageHeadingTextOverride: capitalize(headingTextOverride)
+		})
+	});
 };
 
 /** @type {import('@pins/express').RequestHandler<Response>} */
@@ -377,24 +379,26 @@ export const getManageFolder = async (request, response) => {
 
 	const headingTextOverride = getPageHeadingTextOverrideForFolder(currentFolder);
 
-	await renderManageFolder(
+	await renderManageFolder({
 		request,
 		response,
-		`/appeals-service/appeal-details/${request.params.appealId}/appellant-case/`,
-		`/appeals-service/appeal-details/${request.params.appealId}/appellant-case/manage-documents/{{folderId}}/{{documentId}}`,
-		headingTextOverride && capitalize(headingTextOverride)
-	);
+		backLinkUrl: `/appeals-service/appeal-details/${request.params.appealId}/appellant-case/`,
+		viewAndEditUrl: `/appeals-service/appeal-details/${request.params.appealId}/appellant-case/manage-documents/{{folderId}}/{{documentId}}`,
+		...(headingTextOverride && {
+			pageHeadingTextOverride: capitalize(headingTextOverride)
+		})
+	});
 };
 
 /** @type {import('@pins/express').RequestHandler<Response>} */
 export const getManageDocument = async (request, response) => {
-	await renderManageDocument(
+	await renderManageDocument({
 		request,
 		response,
-		`/appeals-service/appeal-details/${request.params.appealId}/appellant-case/manage-documents/{{folderId}}`,
-		`/appeals-service/appeal-details/${request.params.appealId}/appellant-case/add-documents/{{folderId}}/{{documentId}}`,
-		`/appeals-service/appeal-details/${request.params.appealId}/appellant-case/manage-documents/{{folderId}}/{{documentId}}/{{versionId}}/delete`
-	);
+		backLinkUrl: `/appeals-service/appeal-details/${request.params.appealId}/appellant-case/manage-documents/{{folderId}}`,
+		uploadUpdatedDocumentUrl: `/appeals-service/appeal-details/${request.params.appealId}/appellant-case/add-documents/{{folderId}}/{{documentId}}`,
+		removeDocumentUrl: `/appeals-service/appeal-details/${request.params.appealId}/appellant-case/manage-documents/{{folderId}}/{{documentId}}/{{versionId}}/delete`
+	});
 };
 
 /** @type {import('@pins/express').RequestHandler<Response>} */
@@ -458,14 +462,16 @@ export const getAddDocumentVersionDetails = async (request, response) => {
 
 	const headingTextOverride = getPageHeadingTextOverrideForFolder(currentFolder);
 
-	await renderDocumentDetails(
+	await renderDocumentDetails({
 		request,
 		response,
-		`/appeals-service/appeal-details/${request.params.appealId}/appellant-case/add-documents/${request.params.folderId}/${request.params.documentId}`,
-		getValidationOutcomeFromAppellantCase(appellantCaseDetails) === 'valid',
-		headingTextOverride && `Updated ${headingTextOverride} document`,
-		documentId
-	);
+		backLinkUrl: `/appeals-service/appeal-details/${request.params.appealId}/appellant-case/add-documents/${request.params.folderId}/${request.params.documentId}`,
+		isLateEntry: getValidationOutcomeFromAppellantCase(appellantCaseDetails) === 'valid',
+		documentId,
+		...(headingTextOverride && {
+			pageHeadingTextOverride: `Updated ${headingTextOverride} document`
+		})
+	});
 };
 
 /** @type {import('@pins/express').RequestHandler<Response>} */

--- a/appeals/web/src/server/appeals/appeal-details/costs/__tests__/__snapshots__/costs.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/costs/__tests__/__snapshots__/costs.test.js.snap
@@ -882,7 +882,7 @@ exports[`costs application, withdrawal and correspondence GET /costs/:costsCateg
         </div>
     </div>
     <div class="govuk-grid-row">
-        <div class="govuk-grid-column-full"><span class="govuk-caption-l govuk-!-margin-bottom-3">Manage decision document</span>
+        <div class="govuk-grid-column-full"><span class="govuk-caption-l govuk-!-margin-bottom-3">Manage document</span>
             <h1             class="govuk-heading-l">test-pdf-documentFileVersionsInfo.pdf</h1>
         </div>
     </div>
@@ -986,7 +986,7 @@ exports[`costs application, withdrawal and correspondence GET /costs/:costsCateg
         </div>
     </div>
     <div class="govuk-grid-row">
-        <div class="govuk-grid-column-full"><span class="govuk-caption-l govuk-!-margin-bottom-3">Manage decision document</span>
+        <div class="govuk-grid-column-full"><span class="govuk-caption-l govuk-!-margin-bottom-3">Manage document</span>
             <h1             class="govuk-heading-l">test-pdf-documentFileVersionsInfo.pdf</h1>
         </div>
     </div>
@@ -1090,7 +1090,7 @@ exports[`costs application, withdrawal and correspondence GET /costs/:costsCateg
         </div>
     </div>
     <div class="govuk-grid-row">
-        <div class="govuk-grid-column-full"><span class="govuk-caption-l govuk-!-margin-bottom-3">Manage decision document</span>
+        <div class="govuk-grid-column-full"><span class="govuk-caption-l govuk-!-margin-bottom-3">Manage document</span>
             <h1             class="govuk-heading-l">test-pdf-documentFileVersionsInfo.pdf</h1>
         </div>
     </div>
@@ -1194,7 +1194,7 @@ exports[`costs application, withdrawal and correspondence GET /costs/:costsCateg
         </div>
     </div>
     <div class="govuk-grid-row">
-        <div class="govuk-grid-column-full"><span class="govuk-caption-l govuk-!-margin-bottom-3">Manage decision document</span>
+        <div class="govuk-grid-column-full"><span class="govuk-caption-l govuk-!-margin-bottom-3">Manage document</span>
             <h1             class="govuk-heading-l">test-pdf-documentFileVersionsInfo.pdf</h1>
         </div>
     </div>
@@ -1298,7 +1298,7 @@ exports[`costs application, withdrawal and correspondence GET /costs/:costsCateg
         </div>
     </div>
     <div class="govuk-grid-row">
-        <div class="govuk-grid-column-full"><span class="govuk-caption-l govuk-!-margin-bottom-3">Manage decision document</span>
+        <div class="govuk-grid-column-full"><span class="govuk-caption-l govuk-!-margin-bottom-3">Manage document</span>
             <h1             class="govuk-heading-l">test-pdf-documentFileVersionsInfo.pdf</h1>
         </div>
     </div>
@@ -1402,7 +1402,7 @@ exports[`costs application, withdrawal and correspondence GET /costs/:costsCateg
         </div>
     </div>
     <div class="govuk-grid-row">
-        <div class="govuk-grid-column-full"><span class="govuk-caption-l govuk-!-margin-bottom-3">Manage decision document</span>
+        <div class="govuk-grid-column-full"><span class="govuk-caption-l govuk-!-margin-bottom-3">Manage document</span>
             <h1             class="govuk-heading-l">test-pdf-documentFileVersionsInfo.pdf</h1>
         </div>
     </div>
@@ -1504,7 +1504,7 @@ exports[`costs application, withdrawal and correspondence GET /costs/:costsCateg
         </div>
     </div>
     <div class="govuk-grid-row">
-        <div class="govuk-grid-column-full"><span class="govuk-caption-l govuk-!-margin-bottom-3">Manage decision document</span>
+        <div class="govuk-grid-column-full"><span class="govuk-caption-l govuk-!-margin-bottom-3">Manage document</span>
             <h1             class="govuk-heading-l">test-pdf-documentFileVersionsInfo.pdf</h1>
         </div>
     </div>
@@ -1595,7 +1595,7 @@ exports[`costs application, withdrawal and correspondence GET /costs/:costsCateg
         </div>
     </div>
     <div class="govuk-grid-row">
-        <div class="govuk-grid-column-full"><span class="govuk-caption-l govuk-!-margin-bottom-3">Manage decision document</span>
+        <div class="govuk-grid-column-full"><span class="govuk-caption-l govuk-!-margin-bottom-3">Manage document</span>
             <h1             class="govuk-heading-l">test-pdf-documentFileVersionsInfo.pdf</h1>
         </div>
     </div>
@@ -1686,7 +1686,7 @@ exports[`costs application, withdrawal and correspondence GET /costs/:costsCateg
         </div>
     </div>
     <div class="govuk-grid-row">
-        <div class="govuk-grid-column-full"><span class="govuk-caption-l govuk-!-margin-bottom-3">Manage decision document</span>
+        <div class="govuk-grid-column-full"><span class="govuk-caption-l govuk-!-margin-bottom-3">Manage document</span>
             <h1             class="govuk-heading-l">test-pdf-documentFileVersionsInfo.pdf</h1>
         </div>
     </div>
@@ -1777,7 +1777,7 @@ exports[`costs application, withdrawal and correspondence GET /costs/:costsCateg
         </div>
     </div>
     <div class="govuk-grid-row">
-        <div class="govuk-grid-column-full"><span class="govuk-caption-l govuk-!-margin-bottom-3">Manage decision document</span>
+        <div class="govuk-grid-column-full"><span class="govuk-caption-l govuk-!-margin-bottom-3">Manage document</span>
             <h1             class="govuk-heading-l">test-pdf-documentFileVersionsInfo.pdf</h1>
         </div>
     </div>
@@ -1868,7 +1868,7 @@ exports[`costs application, withdrawal and correspondence GET /costs/:costsCateg
         </div>
     </div>
     <div class="govuk-grid-row">
-        <div class="govuk-grid-column-full"><span class="govuk-caption-l govuk-!-margin-bottom-3">Manage decision document</span>
+        <div class="govuk-grid-column-full"><span class="govuk-caption-l govuk-!-margin-bottom-3">Manage document</span>
             <h1             class="govuk-heading-l">test-pdf-documentFileVersionsInfo.pdf</h1>
         </div>
     </div>
@@ -1959,7 +1959,7 @@ exports[`costs application, withdrawal and correspondence GET /costs/:costsCateg
         </div>
     </div>
     <div class="govuk-grid-row">
-        <div class="govuk-grid-column-full"><span class="govuk-caption-l govuk-!-margin-bottom-3">Manage decision document</span>
+        <div class="govuk-grid-column-full"><span class="govuk-caption-l govuk-!-margin-bottom-3">Manage document</span>
             <h1             class="govuk-heading-l">test-pdf-documentFileVersionsInfo.pdf</h1>
         </div>
     </div>
@@ -2037,7 +2037,7 @@ exports[`costs application, withdrawal and correspondence GET /costs/:costsCateg
 exports[`costs application, withdrawal and correspondence GET /costs/:costsCategory/:costsDocumentType/manage-documents/:folderId/:documentId should render the manage individual document page with the expected content if the folderId and documentId are both valid and the document virus check status is "scanned" (appellant application) 1`] = `
 "<main class="govuk-main-wrapper " id="main-content" role="main">
     <div class="govuk-grid-row">
-        <div class="govuk-grid-column-full"><span class="govuk-caption-l govuk-!-margin-bottom-3">Manage decision document</span>
+        <div class="govuk-grid-column-full"><span class="govuk-caption-l govuk-!-margin-bottom-3">Manage document</span>
             <h1             class="govuk-heading-l">test-pdf-documentFileVersionsInfo.pdf</h1>
         </div>
     </div>
@@ -2122,7 +2122,7 @@ exports[`costs application, withdrawal and correspondence GET /costs/:costsCateg
 exports[`costs application, withdrawal and correspondence GET /costs/:costsCategory/:costsDocumentType/manage-documents/:folderId/:documentId should render the manage individual document page with the expected content if the folderId and documentId are both valid and the document virus check status is "scanned" (appellant correspondence) 1`] = `
 "<main class="govuk-main-wrapper " id="main-content" role="main">
     <div class="govuk-grid-row">
-        <div class="govuk-grid-column-full"><span class="govuk-caption-l govuk-!-margin-bottom-3">Manage decision document</span>
+        <div class="govuk-grid-column-full"><span class="govuk-caption-l govuk-!-margin-bottom-3">Manage document</span>
             <h1             class="govuk-heading-l">test-pdf-documentFileVersionsInfo.pdf</h1>
         </div>
     </div>
@@ -2207,7 +2207,7 @@ exports[`costs application, withdrawal and correspondence GET /costs/:costsCateg
 exports[`costs application, withdrawal and correspondence GET /costs/:costsCategory/:costsDocumentType/manage-documents/:folderId/:documentId should render the manage individual document page with the expected content if the folderId and documentId are both valid and the document virus check status is "scanned" (appellant withdrawal) 1`] = `
 "<main class="govuk-main-wrapper " id="main-content" role="main">
     <div class="govuk-grid-row">
-        <div class="govuk-grid-column-full"><span class="govuk-caption-l govuk-!-margin-bottom-3">Manage decision document</span>
+        <div class="govuk-grid-column-full"><span class="govuk-caption-l govuk-!-margin-bottom-3">Manage document</span>
             <h1             class="govuk-heading-l">test-pdf-documentFileVersionsInfo.pdf</h1>
         </div>
     </div>
@@ -2292,7 +2292,7 @@ exports[`costs application, withdrawal and correspondence GET /costs/:costsCateg
 exports[`costs application, withdrawal and correspondence GET /costs/:costsCategory/:costsDocumentType/manage-documents/:folderId/:documentId should render the manage individual document page with the expected content if the folderId and documentId are both valid and the document virus check status is "scanned" (lpa application) 1`] = `
 "<main class="govuk-main-wrapper " id="main-content" role="main">
     <div class="govuk-grid-row">
-        <div class="govuk-grid-column-full"><span class="govuk-caption-l govuk-!-margin-bottom-3">Manage decision document</span>
+        <div class="govuk-grid-column-full"><span class="govuk-caption-l govuk-!-margin-bottom-3">Manage document</span>
             <h1             class="govuk-heading-l">test-pdf-documentFileVersionsInfo.pdf</h1>
         </div>
     </div>
@@ -2377,7 +2377,7 @@ exports[`costs application, withdrawal and correspondence GET /costs/:costsCateg
 exports[`costs application, withdrawal and correspondence GET /costs/:costsCategory/:costsDocumentType/manage-documents/:folderId/:documentId should render the manage individual document page with the expected content if the folderId and documentId are both valid and the document virus check status is "scanned" (lpa correspondence) 1`] = `
 "<main class="govuk-main-wrapper " id="main-content" role="main">
     <div class="govuk-grid-row">
-        <div class="govuk-grid-column-full"><span class="govuk-caption-l govuk-!-margin-bottom-3">Manage decision document</span>
+        <div class="govuk-grid-column-full"><span class="govuk-caption-l govuk-!-margin-bottom-3">Manage document</span>
             <h1             class="govuk-heading-l">test-pdf-documentFileVersionsInfo.pdf</h1>
         </div>
     </div>
@@ -2462,7 +2462,7 @@ exports[`costs application, withdrawal and correspondence GET /costs/:costsCateg
 exports[`costs application, withdrawal and correspondence GET /costs/:costsCategory/:costsDocumentType/manage-documents/:folderId/:documentId should render the manage individual document page with the expected content if the folderId and documentId are both valid and the document virus check status is "scanned" (lpa withdrawal) 1`] = `
 "<main class="govuk-main-wrapper " id="main-content" role="main">
     <div class="govuk-grid-row">
-        <div class="govuk-grid-column-full"><span class="govuk-caption-l govuk-!-margin-bottom-3">Manage decision document</span>
+        <div class="govuk-grid-column-full"><span class="govuk-caption-l govuk-!-margin-bottom-3">Manage document</span>
             <h1             class="govuk-heading-l">test-pdf-documentFileVersionsInfo.pdf</h1>
         </div>
     </div>
@@ -2560,7 +2560,7 @@ exports[`costs application, withdrawal and correspondence GET /costs/:costsCateg
         </div>
     </div>
     <div class="govuk-grid-row">
-        <div class="govuk-grid-column-full"><span class="govuk-caption-l govuk-!-margin-bottom-3">Manage decision document</span>
+        <div class="govuk-grid-column-full"><span class="govuk-caption-l govuk-!-margin-bottom-3">Manage document</span>
             <h1             class="govuk-heading-l">test-pdf-documentFileVersionsInfo.pdf</h1>
         </div>
     </div>
@@ -2651,7 +2651,7 @@ exports[`costs application, withdrawal and correspondence GET /costs/:costsCateg
         </div>
     </div>
     <div class="govuk-grid-row">
-        <div class="govuk-grid-column-full"><span class="govuk-caption-l govuk-!-margin-bottom-3">Manage decision document</span>
+        <div class="govuk-grid-column-full"><span class="govuk-caption-l govuk-!-margin-bottom-3">Manage document</span>
             <h1             class="govuk-heading-l">test-pdf-documentFileVersionsInfo.pdf</h1>
         </div>
     </div>
@@ -2742,7 +2742,7 @@ exports[`costs application, withdrawal and correspondence GET /costs/:costsCateg
         </div>
     </div>
     <div class="govuk-grid-row">
-        <div class="govuk-grid-column-full"><span class="govuk-caption-l govuk-!-margin-bottom-3">Manage decision document</span>
+        <div class="govuk-grid-column-full"><span class="govuk-caption-l govuk-!-margin-bottom-3">Manage document</span>
             <h1             class="govuk-heading-l">test-pdf-documentFileVersionsInfo.pdf</h1>
         </div>
     </div>
@@ -2833,7 +2833,7 @@ exports[`costs application, withdrawal and correspondence GET /costs/:costsCateg
         </div>
     </div>
     <div class="govuk-grid-row">
-        <div class="govuk-grid-column-full"><span class="govuk-caption-l govuk-!-margin-bottom-3">Manage decision document</span>
+        <div class="govuk-grid-column-full"><span class="govuk-caption-l govuk-!-margin-bottom-3">Manage document</span>
             <h1             class="govuk-heading-l">test-pdf-documentFileVersionsInfo.pdf</h1>
         </div>
     </div>
@@ -2924,7 +2924,7 @@ exports[`costs application, withdrawal and correspondence GET /costs/:costsCateg
         </div>
     </div>
     <div class="govuk-grid-row">
-        <div class="govuk-grid-column-full"><span class="govuk-caption-l govuk-!-margin-bottom-3">Manage decision document</span>
+        <div class="govuk-grid-column-full"><span class="govuk-caption-l govuk-!-margin-bottom-3">Manage document</span>
             <h1             class="govuk-heading-l">test-pdf-documentFileVersionsInfo.pdf</h1>
         </div>
     </div>
@@ -3015,7 +3015,7 @@ exports[`costs application, withdrawal and correspondence GET /costs/:costsCateg
         </div>
     </div>
     <div class="govuk-grid-row">
-        <div class="govuk-grid-column-full"><span class="govuk-caption-l govuk-!-margin-bottom-3">Manage decision document</span>
+        <div class="govuk-grid-column-full"><span class="govuk-caption-l govuk-!-margin-bottom-3">Manage document</span>
             <h1             class="govuk-heading-l">test-pdf-documentFileVersionsInfo.pdf</h1>
         </div>
     </div>
@@ -4904,6 +4904,34 @@ exports[`costs decision GET /costs/decision/check-and-confirm/:folderId should r
 </main>"
 `;
 
+exports[`costs decision GET /costs/decision/check-and-confirm/:folderId/:documentId should render a 404 error page if the documentId is not valid 1`] = `
+"<main class="govuk-main-wrapper " id="main-content" role="main">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <h1 class="govuk-heading-xl">Page not found</h1>
+            <p class="govuk-body">If you typed the web address, check it is correct.</p>
+            <p class="govuk-body">If you pasted the web address, check you copied the entire address.</p>
+            <p             class="govuk-body"><a href="https://has-appeal.herokuapp.com/help/contact" class="govuk-link">Contact the Planning Inspectorate Customer Support</a> if
+                the problem persists</p>
+        </div>
+    </div>
+</main>"
+`;
+
+exports[`costs decision GET /costs/decision/check-and-confirm/:folderId/:documentId should render a 404 error page if the folderId is not valid 1`] = `
+"<main class="govuk-main-wrapper " id="main-content" role="main">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <h1 class="govuk-heading-xl">Page not found</h1>
+            <p class="govuk-body">If you typed the web address, check it is correct.</p>
+            <p class="govuk-body">If you pasted the web address, check you copied the entire address.</p>
+            <p             class="govuk-body"><a href="https://has-appeal.herokuapp.com/help/contact" class="govuk-link">Contact the Planning Inspectorate Customer Support</a> if
+                the problem persists</p>
+        </div>
+    </div>
+</main>"
+`;
+
 exports[`costs decision GET /costs/decision/manage-documents/:folderId should render a 404 error page if the folderId is not valid 1`] = `
 "<main class="govuk-main-wrapper " id="main-content" role="main">
     <div class="govuk-grid-row">
@@ -4929,7 +4957,7 @@ exports[`costs decision GET /costs/decision/manage-documents/:folderId should re
         <thead class="govuk-table__head">
             <tr class="govuk-table__row">
                 <th scope="col" class="govuk-table__header">Name</th>
-                <th scope="col" class="govuk-table__header">Date received</th>
+                <th scope="col" class="govuk-table__header">Decision date</th>
                 <th scope="col" class="govuk-table__header">Redaction status</th>
                 <th scope="col" class="govuk-table__header">Actions</th>
             </tr>
@@ -5032,7 +5060,7 @@ exports[`costs decision GET /costs/decision/manage-documents/:folderId/:document
                 <div class="govuk-summary-list__row govuk-summary-list__row--no-actions"><dt class="govuk-summary-list__key"> Version</dt>
                     <dd class="govuk-summary-list__value">1</dd>
                 </div>
-                <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Date received</dt>
+                <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Decision date</dt>
                     <dd class="govuk-summary-list__value">1 February 2023</dd>
                     <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/costs/decision/change-document-details/7/1"> Change<span class="govuk-visually-hidden"> test-pdf-documentFileVersionsInfo.pdf date received</span></a>
                     </dd>
@@ -5134,7 +5162,7 @@ exports[`costs decision GET /costs/decision/manage-documents/:folderId/:document
                 <div class="govuk-summary-list__row govuk-summary-list__row--no-actions"><dt class="govuk-summary-list__key"> Version</dt>
                     <dd class="govuk-summary-list__value">1</dd>
                 </div>
-                <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Date received</dt>
+                <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Decision date</dt>
                     <dd class="govuk-summary-list__value">1 February 2023</dd>
                     <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/costs/decision/change-document-details/7/1"> Change<span class="govuk-visually-hidden"> test-pdf-documentFileVersionsInfo.pdf date received</span></a>
                     </dd>
@@ -5210,7 +5238,7 @@ exports[`costs decision GET /costs/decision/manage-documents/:folderId/:document
                 <div class="govuk-summary-list__row govuk-summary-list__row--no-actions"><dt class="govuk-summary-list__key"> Version</dt>
                     <dd class="govuk-summary-list__value">1</dd>
                 </div>
-                <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Date received</dt>
+                <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Decision date</dt>
                     <dd class="govuk-summary-list__value">1 February 2023</dd>
                     <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/costs/decision/change-document-details/7/1"> Change<span class="govuk-visually-hidden"> test-pdf-documentFileVersionsInfo.pdf date received</span></a>
                     </dd>
@@ -5310,7 +5338,7 @@ exports[`costs decision GET /costs/decision/manage-documents/:folderId/:document
                 <div class="govuk-summary-list__row govuk-summary-list__row--no-actions"><dt class="govuk-summary-list__key"> Version</dt>
                     <dd class="govuk-summary-list__value">1</dd>
                 </div>
-                <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Date received</dt>
+                <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Decision date</dt>
                     <dd class="govuk-summary-list__value">1 February 2023</dd>
                     <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/costs/decision/change-document-details/7/1"> Change<span class="govuk-visually-hidden"> test-pdf-documentFileVersionsInfo.pdf date received</span></a>
                     </dd>
@@ -5526,6 +5554,20 @@ exports[`costs decision GET /costs/decision/upload-documents/:folderId/:document
 `;
 
 exports[`costs decision POST /costs/decision/check-and-confirm/:folderId should render a 404 error page if the folderId is not valid 1`] = `
+"<main class="govuk-main-wrapper " id="main-content" role="main">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <h1 class="govuk-heading-xl">Page not found</h1>
+            <p class="govuk-body">If you typed the web address, check it is correct.</p>
+            <p class="govuk-body">If you pasted the web address, check you copied the entire address.</p>
+            <p             class="govuk-body"><a href="https://has-appeal.herokuapp.com/help/contact" class="govuk-link">Contact the Planning Inspectorate Customer Support</a> if
+                the problem persists</p>
+        </div>
+    </div>
+</main>"
+`;
+
+exports[`costs decision POST /costs/decision/check-and-confirm/:folderId/:documentId should render a 404 error page if the folderId is not valid 1`] = `
 "<main class="govuk-main-wrapper " id="main-content" role="main">
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">

--- a/appeals/web/src/server/appeals/appeal-details/costs/__tests__/costs.test.js
+++ b/appeals/web/src/server/appeals/appeal-details/costs/__tests__/costs.test.js
@@ -1705,7 +1705,7 @@ describe('costs', () => {
 				expect(unprettifiedElement.innerHTML).toContain('Add document details</span><h1');
 				expect(unprettifiedElement.innerHTML).toContain(`Costs decision document</h1>`);
 				expect(unprettifiedElement.innerHTML).toContain('test-document.txt</h2>');
-				expect(unprettifiedElement.innerHTML).toContain('Date received</legend>');
+				expect(unprettifiedElement.innerHTML).toContain('Decision date</legend>');
 				expect(unprettifiedElement.innerHTML).toContain('Redaction status</legend>');
 			});
 
@@ -1995,7 +1995,7 @@ describe('costs', () => {
 				expect(unprettifiedElement.innerHTML).toContain('Add document details</span><h1');
 				expect(unprettifiedElement.innerHTML).toContain(`Costs decision document</h1>`);
 				expect(unprettifiedElement.innerHTML).toContain('test-document.txt</h2>');
-				expect(unprettifiedElement.innerHTML).toContain('Date received</legend>');
+				expect(unprettifiedElement.innerHTML).toContain('Decision date</legend>');
 				expect(unprettifiedElement.innerHTML).toContain('Redaction status</legend>');
 			});
 
@@ -2265,10 +2265,6 @@ describe('costs', () => {
 			});
 
 			it('should render a 404 error page if the folderId is not valid', async () => {
-				nock('http://test/')
-					.get('/appeals/1/documents/1/versions')
-					.reply(200, documentFileVersionsInfo);
-
 				expect(addDocumentsResponse.statusCode).toBe(302);
 
 				const response = await request.get(`${baseUrl}/1/costs/decision/check-and-confirm/99`);
@@ -2283,10 +2279,6 @@ describe('costs', () => {
 			});
 
 			it('should render the check and confirm costs decision page if the folderId is valid', async () => {
-				nock('http://test/')
-					.get('/appeals/1/documents/1/versions')
-					.reply(200, documentFileVersionsInfo);
-
 				expect(addDocumentsResponse.statusCode).toBe(302);
 
 				const response = await request.get(
@@ -2364,6 +2356,145 @@ describe('costs', () => {
 				const mockDocumentsEndpoint = nock('http://test/').post('/appeals/1/documents').reply(200);
 				const response = await request
 					.post(`${baseUrl}/1/costs/decision/check-and-confirm/3`)
+					.send({
+						confirm: 'yes'
+					});
+
+				expect(mockDocumentsEndpoint.isDone()).toBe(true);
+				expect(response.statusCode).toBe(302);
+				expect(response.text).toEqual(`Found. Redirecting to /appeals-service/appeal-details/1`);
+			});
+		});
+
+		describe('GET /costs/decision/check-and-confirm/:folderId/:documentId', () => {
+			/**
+			 * @type {import("superagent").Response}
+			 */
+			let addDocumentsResponse;
+
+			const costsDecisionFolder = appealData.costs.decisionFolder;
+
+			beforeEach(async () => {
+				addDocumentsResponse = await request
+					.post(`${baseUrl}/1/costs/decision/upload-documents/${costsDecisionFolder?.folderId}/1`)
+					.send({
+						'upload-info': fileUploadInfo
+					});
+			});
+
+			it('should render a 404 error page if the folderId is not valid', async () => {
+				expect(addDocumentsResponse.statusCode).toBe(302);
+
+				const response = await request.get(`${baseUrl}/1/costs/decision/check-and-confirm/99/1`);
+
+				const element = parseHtml(response.text);
+
+				expect(element.innerHTML).toMatchSnapshot();
+
+				const unprettifiedElement = parseHtml(response.text, { skipPrettyPrint: true });
+
+				expect(unprettifiedElement.innerHTML).toContain('Page not found</h1>');
+			});
+
+			it('should render a 404 error page if the documentId is not valid', async () => {
+				expect(addDocumentsResponse.statusCode).toBe(302);
+
+				const response = await request.get(`${baseUrl}/1/costs/decision/check-and-confirm/1/99`);
+
+				const element = parseHtml(response.text);
+
+				expect(element.innerHTML).toMatchSnapshot();
+
+				const unprettifiedElement = parseHtml(response.text, { skipPrettyPrint: true });
+
+				expect(unprettifiedElement.innerHTML).toContain('Page not found</h1>');
+			});
+
+			it('should render the check and confirm costs decision page if the folderId and documentId are both valid', async () => {
+				expect(addDocumentsResponse.statusCode).toBe(302);
+
+				const response = await request.get(
+					`${baseUrl}/1/costs/decision/check-and-confirm/${costsDecisionFolder?.folderId}/1`
+				);
+
+				const unprettifiedElement = parseHtml(response.text, { skipPrettyPrint: true });
+
+				expect(unprettifiedElement.innerHTML).toContain('Check your answers</h1>');
+				expect(unprettifiedElement.innerHTML).toContain('Updated costs decision</dt>');
+				expect(unprettifiedElement.innerHTML).toContain(
+					'<a class="govuk-link" href="/documents/APP/Q9999/D/21/351062/download-uncommitted/1/ph0-documentFileInfo.jpeg/2" target="_blank">test-document.txt</a>'
+				);
+				expect(unprettifiedElement.innerHTML).toContain('Decision date</dt>');
+				expect(unprettifiedElement.innerHTML).toContain(
+					'Warning</span> You must email the relevant parties to inform them of the decision.'
+				);
+				expect(unprettifiedElement.innerHTML).toContain(
+					'name="confirm" type="checkbox" value="yes">'
+				);
+				expect(unprettifiedElement.innerHTML).toContain(
+					'for="confirm"> I will email the relevant parties'
+				);
+			});
+		});
+
+		describe('POST /costs/decision/check-and-confirm/:folderId/:documentId', () => {
+			/**
+			 * @type {import("superagent").Response}
+			 */
+			let addDocumentsResponse;
+
+			const costsDecisionFolder = appealData.costs.decisionFolder;
+
+			beforeEach(async () => {
+				addDocumentsResponse = await request
+					.post(`${baseUrl}/1/costs/decision/upload-documents/${costsDecisionFolder?.folderId}`)
+					.send({
+						'upload-info': fileUploadInfo
+					});
+			});
+
+			it('should render a 404 error page if the folderId is not valid', async () => {
+				expect(addDocumentsResponse.statusCode).toBe(302);
+
+				const response = await request
+					.post(`${baseUrl}/1/costs/decision/check-and-confirm/99/1`)
+					.send({
+						confirm: 'yes'
+					});
+
+				const element = parseHtml(response.text);
+
+				expect(element.innerHTML).toMatchSnapshot();
+
+				const unprettifiedElement = parseHtml(response.text, { skipPrettyPrint: true });
+
+				expect(unprettifiedElement.innerHTML).toContain('Page not found</h1>');
+			});
+
+			it('should re-render the check and confirm costs decision page with the expected error message if confirmation was not provided', async () => {
+				expect(addDocumentsResponse.statusCode).toBe(302);
+
+				const response = await request
+					.post(`${baseUrl}/1/costs/decision/check-and-confirm/${costsDecisionFolder?.folderId}/1`)
+					.send({});
+
+				const unprettifiedElement = parseHtml(response.text, { skipPrettyPrint: true });
+
+				expect(unprettifiedElement.innerHTML).toContain('Check your answers</h1>');
+				expect(unprettifiedElement.innerHTML).toContain('There is a problem</h2>');
+				expect(unprettifiedElement.innerHTML).toContain(
+					'Select that you will email the relevant parties</a></li>'
+				);
+			});
+
+			it('should redirect to the case details page if confirmation was provided', async () => {
+				expect(addDocumentsResponse.statusCode).toBe(302);
+
+				const mockDocumentsEndpoint = nock('http://test/')
+					.post('/appeals/1/documents/1')
+					.reply(200);
+				const response = await request
+					.post(`${baseUrl}/1/costs/decision/check-and-confirm/${costsDecisionFolder?.folderId}/1`)
 					.send({
 						confirm: 'yes'
 					});

--- a/appeals/web/src/server/appeals/appeal-details/costs/costs.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/costs/costs.mapper.js
@@ -8,6 +8,8 @@ import { addDocumentsCheckAndConfirmPage } from '#appeals/appeal-documents/appea
  * @param {import('#appeals/appeal-documents/appeal-documents.types').FileUploadInfoItem[]} uncommittedFiles
  * @param {import('@pins/appeals.api').Schema.DocumentRedactionStatus[]} redactionStatuses
  * @param {string} [documentId]
+ * @param {number} [documentVersion]
+ * @param {string} [documentFileName]
  * @returns {PageContent}
  */
 export function decisionCheckAndConfirmPage(
@@ -15,25 +17,28 @@ export function decisionCheckAndConfirmPage(
 	decisionDocumentFolder,
 	uncommittedFiles,
 	redactionStatuses,
-	documentId
+	documentId,
+	documentVersion,
+	documentFileName
 ) {
 	const shortAppealReference = appealShortReference(appealDetails.appealReference);
 	const addDocumentDetailsPageUrl = `/appeals-service/appeal-details/${appealDetails.appealId}/costs/decision/add-document-details/${decisionDocumentFolder.folderId}`;
 
 	/** @type {PageContent} */
-	const pageContent = addDocumentsCheckAndConfirmPage(
-		addDocumentDetailsPageUrl,
-		`/appeals-service/appeal-details/${appealDetails.appealId}/costs/decision/upload-documents/${decisionDocumentFolder.folderId}`,
-		addDocumentDetailsPageUrl,
-		addDocumentDetailsPageUrl,
-		appealDetails.appealReference,
+	const pageContent = addDocumentsCheckAndConfirmPage({
+		backLinkUrl: addDocumentDetailsPageUrl,
+		changeFileLinkUrl: `/appeals-service/appeal-details/${appealDetails.appealId}/costs/decision/upload-documents/${decisionDocumentFolder.folderId}`,
+		changeDateLinkUrl: addDocumentDetailsPageUrl,
+		changeRedactionStatusLinkUrl: addDocumentDetailsPageUrl,
+		appealReference: appealDetails.appealReference,
 		uncommittedFiles,
 		redactionStatuses,
-		undefined,
-		undefined,
-		`Check your answers - ${shortAppealReference}`,
-		documentId ? 'Updated costs decision' : 'Costs decision'
-	);
+		titleTextOverride: `Check your answers - ${shortAppealReference}`,
+		summaryListNameLabelOverride: documentId ? 'Updated costs decision' : 'Costs decision',
+		summaryListDateLabelOverride: 'Decision date',
+		documentVersion,
+		documentFileName
+	});
 
 	pageContent.pageComponents?.push(
 		{

--- a/appeals/web/src/server/appeals/appeal-details/costs/costs.router.js
+++ b/appeals/web/src/server/appeals/appeal-details/costs/costs.router.js
@@ -133,7 +133,10 @@ router
 	);
 
 router
-	.route('/decision/check-and-confirm/:folderId')
+	.route([
+		'/decision/check-and-confirm/:folderId',
+		'/decision/check-and-confirm/:folderId/:documentId'
+	])
 	.get(validateCaseFolderId, asyncHandler(controller.getDecisionCheckAndConfirm))
 	.post(
 		validateCaseFolderId,

--- a/appeals/web/src/server/appeals/appeal-details/internal-correspondence/internal-correspondence.controller.js
+++ b/appeals/web/src/server/appeals/appeal-details/internal-correspondence/internal-correspondence.controller.js
@@ -117,17 +117,17 @@ export const getAddDocumentDetails = async (request, response) => {
 		return response.status(404).render('app/404.njk');
 	}
 
-	await renderDocumentDetails(
+	await renderDocumentDetails({
 		request,
 		response,
-		`/appeals-service/appeal-details/${
+		backLinkUrl: `/appeals-service/appeal-details/${
 			currentAppeal.appealId
 		}/internal-correspondence/${correspondenceCategory}/upload-documents/${
 			currentFolder?.folderId
 		}${documentId ? `/${documentId}` : ''}`,
-		false,
-		`${capitalize(correspondenceCategory)} correspondence`
-	);
+		pageHeadingTextOverride: `${capitalize(correspondenceCategory)} correspondence`,
+		documentId
+	});
 };
 
 /** @type {import('@pins/express').RequestHandler<Response>} */
@@ -275,13 +275,13 @@ export const getManageFolder = async (request, response) => {
 		return response.status(404).render('app/404.njk');
 	}
 
-	await renderManageFolder(
+	await renderManageFolder({
 		request,
 		response,
-		`/appeals-service/appeal-details/${currentAppeal.appealId}`,
-		`/appeals-service/appeal-details/${currentAppeal.appealId}/internal-correspondence/${correspondenceCategory}/manage-documents/${currentFolder.folderId}/{{documentId}}`,
-		`${capitalize(correspondenceCategory)} correspondence documents`
-	);
+		backLinkUrl: `/appeals-service/appeal-details/${currentAppeal.appealId}`,
+		viewAndEditUrl: `/appeals-service/appeal-details/${currentAppeal.appealId}/internal-correspondence/${correspondenceCategory}/manage-documents/${currentFolder.folderId}/{{documentId}}`,
+		pageHeadingTextOverride: `${capitalize(correspondenceCategory)} correspondence documents`
+	});
 };
 
 /** @type {import('@pins/express').RequestHandler<Response>}  */
@@ -296,13 +296,13 @@ export const getManageDocument = async (request, response) => {
 		return response.status(404).render('app/404.njk');
 	}
 
-	await renderManageDocument(
+	await renderManageDocument({
 		request,
 		response,
-		`/appeals-service/appeal-details/${currentAppeal.appealId}/internal-correspondence/${correspondenceCategory}/manage-documents/${currentFolder.folderId}`,
-		`/appeals-service/appeal-details/${currentAppeal.appealId}/internal-correspondence/${correspondenceCategory}/upload-documents/${currentFolder?.folderId}/{{documentId}}`,
-		`/appeals-service/appeal-details/${currentAppeal.appealId}/internal-correspondence/${correspondenceCategory}/manage-documents/${currentFolder.folderId}/{{documentId}}/{{versionId}}/delete`
-	);
+		backLinkUrl: `/appeals-service/appeal-details/${currentAppeal.appealId}/internal-correspondence/${correspondenceCategory}/manage-documents/${currentFolder.folderId}`,
+		uploadUpdatedDocumentUrl: `/appeals-service/appeal-details/${currentAppeal.appealId}/internal-correspondence/${correspondenceCategory}/upload-documents/${currentFolder?.folderId}/{{documentId}}`,
+		removeDocumentUrl: `/appeals-service/appeal-details/${currentAppeal.appealId}/internal-correspondence/${correspondenceCategory}/manage-documents/${currentFolder.folderId}/{{documentId}}/{{versionId}}/delete`
+	});
 };
 
 /** @type {import('@pins/express').RequestHandler<Response>} */

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/lpa-questionnaire.controller.js
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/lpa-questionnaire.controller.js
@@ -322,13 +322,13 @@ export const getAddDocumentDetails = async (request, response) => {
 		? 'Notification documents'
 		: '';
 
-	await renderDocumentDetails(
+	await renderDocumentDetails({
 		request,
 		response,
-		`/appeals-service/appeal-details/${request.params.appealId}/lpa-questionnaire/${request.params.lpaQuestionnaireId}/add-documents/{{folderId}}`,
-		getValidationOutcomeFromLpaQuestionnaire(lpaQuestionnaireDetails) === 'complete',
+		backLinkUrl: `/appeals-service/appeal-details/${request.params.appealId}/lpa-questionnaire/${request.params.lpaQuestionnaireId}/add-documents/{{folderId}}`,
+		isLateEntry: getValidationOutcomeFromLpaQuestionnaire(lpaQuestionnaireDetails) === 'complete',
 		pageHeadingTextOverride
-	);
+	});
 };
 
 /** @type {import('@pins/express').RequestHandler<Response>} */
@@ -447,24 +447,24 @@ export const getManageFolder = async (request, response) => {
 			break;
 	}
 
-	await renderManageFolder(
+	await renderManageFolder({
 		request,
 		response,
-		`/appeals-service/appeal-details/${request.params.appealId}/lpa-questionnaire/${request.params.lpaQuestionnaireId}/`,
-		`/appeals-service/appeal-details/${request.params.appealId}/lpa-questionnaire/${request.params.lpaQuestionnaireId}/manage-documents/{{folderId}}/{{documentId}}`,
-		managePageHeadingText
-	);
+		backLinkUrl: `/appeals-service/appeal-details/${request.params.appealId}/lpa-questionnaire/${request.params.lpaQuestionnaireId}/`,
+		viewAndEditUrl: `/appeals-service/appeal-details/${request.params.appealId}/lpa-questionnaire/${request.params.lpaQuestionnaireId}/manage-documents/{{folderId}}/{{documentId}}`,
+		pageHeadingTextOverride: managePageHeadingText
+	});
 };
 
 /** @type {import('@pins/express').RequestHandler<Response>} */
 export const getManageDocument = async (request, response) => {
-	await renderManageDocument(
+	await renderManageDocument({
 		request,
 		response,
-		`/appeals-service/appeal-details/${request.params.appealId}/lpa-questionnaire/${request.params.lpaQuestionnaireId}/manage-documents/{{folderId}}`,
-		`/appeals-service/appeal-details/${request.params.appealId}/lpa-questionnaire/${request.params.lpaQuestionnaireId}/add-documents/{{folderId}}/{{documentId}}`,
-		`/appeals-service/appeal-details/${request.params.appealId}/lpa-questionnaire/${request.params.lpaQuestionnaireId}/manage-documents/{{folderId}}/{{documentId}}/{{versionId}}/delete`
-	);
+		backLinkUrl: `/appeals-service/appeal-details/${request.params.appealId}/lpa-questionnaire/${request.params.lpaQuestionnaireId}/manage-documents/{{folderId}}`,
+		uploadUpdatedDocumentUrl: `/appeals-service/appeal-details/${request.params.appealId}/lpa-questionnaire/${request.params.lpaQuestionnaireId}/add-documents/{{folderId}}/{{documentId}}`,
+		removeDocumentUrl: `/appeals-service/appeal-details/${request.params.appealId}/lpa-questionnaire/${request.params.lpaQuestionnaireId}/manage-documents/{{folderId}}/{{documentId}}/{{versionId}}/delete`
+	});
 };
 
 /** @type {import('@pins/express').RequestHandler<Response>} */
@@ -525,14 +525,13 @@ export const getAddDocumentVersionDetails = async (request, response) => {
 		return response.status(404).render('app/404.njk');
 	}
 
-	await renderDocumentDetails(
+	await renderDocumentDetails({
 		request,
 		response,
-		`/appeals-service/appeal-details/${request.params.appealId}/lpa-questionnaire/${request.params.lpaQuestionnaireId}/add-documents/${request.params.folderId}/${request.params.documentId}`,
-		getValidationOutcomeFromLpaQuestionnaire(lpaQuestionnaireDetails) === 'complete',
-		undefined,
+		backLinkUrl: `/appeals-service/appeal-details/${request.params.appealId}/lpa-questionnaire/${request.params.lpaQuestionnaireId}/add-documents/${request.params.folderId}/${request.params.documentId}`,
+		isLateEntry: getValidationOutcomeFromLpaQuestionnaire(lpaQuestionnaireDetails) === 'complete',
 		documentId
-	);
+	});
 };
 
 /** @type {import('@pins/express').RequestHandler<Response>} */

--- a/appeals/web/src/server/appeals/appeal-documents/appeal-documents.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-documents/appeal-documents.mapper.js
@@ -295,24 +295,27 @@ function mapManageFolderPageHeading(folderPath) {
 }
 
 /**
- * @param {string} backLinkUrl
- * @param {FolderInfo} folder
- * @param {FileUploadInfoItem[]} uncommittedFiles
- * @param {Object<string, any>} bodyItems
- * @param {RedactionStatus[]} redactionStatuses
- * @param {string} [pageHeadingTextOverride]
- * @param {string} [documentId]
+ * @param {Object} params
+ * @param {string} params.backLinkUrl
+ * @param {FolderInfo} params.folder
+ * @param {FileUploadInfoItem[]} params.uncommittedFiles
+ * @param {Object<string, any>} params.bodyItems
+ * @param {RedactionStatus[]} params.redactionStatuses
+ * @param {string} [params.pageHeadingTextOverride]
+ * @param {string} [params.dateLabelTextOverride]
+ * @param {string} [params.documentId]
  * @returns {PageContent}
  */
-export function addDocumentDetailsPage(
+export function addDocumentDetailsPage({
 	backLinkUrl,
 	folder,
 	uncommittedFiles,
 	bodyItems,
 	redactionStatuses,
 	pageHeadingTextOverride,
+	dateLabelTextOverride,
 	documentId
-) {
+}) {
 	/** @type {PageContent} */
 	const pageContent = {
 		title: pageHeadingTextOverride || 'Add document details',
@@ -321,13 +324,14 @@ export function addDocumentDetailsPage(
 		preHeading: 'Add document details',
 		heading: pageHeadingTextOverride || mapAddDocumentDetailsPageHeading(folder.path, documentId),
 		pageComponents: uncommittedFiles.flatMap((uncommittedFile, index) => {
-			return mapFileUploadInfoItemToDocumentDetailsPageComponents(
+			return mapFileUploadInfoItemToDocumentDetailsPageComponents({
 				uncommittedFiles,
 				uncommittedFile,
 				bodyItems,
 				index,
-				redactionStatuses
-			);
+				redactionStatuses,
+				dateLabelTextOverride
+			});
 		})
 	};
 
@@ -335,20 +339,23 @@ export function addDocumentDetailsPage(
 }
 
 /**
- * @param {FileUploadInfoItem[]} uncommittedFiles
- * @param {FileUploadInfoItem} uncommittedFile
- * @param {Object<string, any>} bodyItems
- * @param {number} index
- * @param {RedactionStatus[]} redactionStatuses
+ * @param {Object} params
+ * @param {FileUploadInfoItem[]} params.uncommittedFiles
+ * @param {FileUploadInfoItem} params.uncommittedFile
+ * @param {Object<string, any>} params.bodyItems
+ * @param {number} params.index
+ * @param {RedactionStatus[]} params.redactionStatuses
+ * @param {string} [params.dateLabelTextOverride]
  * @returns {PageComponent[]}
  */
-function mapFileUploadInfoItemToDocumentDetailsPageComponents(
+function mapFileUploadInfoItemToDocumentDetailsPageComponents({
 	uncommittedFiles,
 	uncommittedFile,
 	bodyItems,
 	index,
-	redactionStatuses
-) {
+	redactionStatuses,
+	dateLabelTextOverride
+}) {
 	const receivedDateDayMonthYear = dateISOStringToDayMonthYearHourMinute(
 		uncommittedFile.receivedDate
 	);
@@ -380,7 +387,7 @@ function mapFileUploadInfoItemToDocumentDetailsPageComponents(
 				namePrefix: `items[${index}][receivedDate]`,
 				fieldset: {
 					legend: {
-						text: 'Date received'
+						text: dateLabelTextOverride || 'Date received'
 					}
 				},
 				items: [
@@ -580,20 +587,22 @@ function mapDocumentDetailsItemToDocumentDetailsPageComponents(item, redactionSt
 }
 
 /**
- * @param {string} backLinkUrl
- * @param {string} changeFileLinkUrl
- * @param {string} changeDateLinkUrl
- * @param {string} changeRedactionStatusLinkUrl
- * @param {string} appealReference
- * @param {FileUploadInfoItem[]} uncommittedFiles
- * @param {RedactionStatus[]} redactionStatuses
- * @param {number} [documentVersion] current version being uploaded (if uploading a new version of an existing document)
- * @param {string} [documentFileName] filename of existing document, not new version being uploaded (if uploading a new version of an existing document)
- * @param {string} [titleTextOverride]
- * @param {string} [summaryListNameLabelOverride]
+ * @param {Object} params
+ * @param {string} params.backLinkUrl
+ * @param {string} params.changeFileLinkUrl
+ * @param {string} params.changeDateLinkUrl
+ * @param {string} params.changeRedactionStatusLinkUrl
+ * @param {string} params.appealReference
+ * @param {FileUploadInfoItem[]} params.uncommittedFiles
+ * @param {RedactionStatus[]} params.redactionStatuses
+ * @param {number} [params.documentVersion] current version being uploaded (if uploading a new version of an existing document)
+ * @param {string} [params.documentFileName] filename of existing document, not new version being uploaded (if uploading a new version of an existing document)
+ * @param {string} [params.titleTextOverride]
+ * @param {string} [params.summaryListNameLabelOverride]
+ * @param {string} [params.summaryListDateLabelOverride]
  * @returns {PageContent}
  */
-export function addDocumentsCheckAndConfirmPage(
+export function addDocumentsCheckAndConfirmPage({
 	backLinkUrl,
 	changeFileLinkUrl,
 	changeDateLinkUrl,
@@ -604,8 +613,9 @@ export function addDocumentsCheckAndConfirmPage(
 	documentVersion,
 	documentFileName,
 	titleTextOverride,
-	summaryListNameLabelOverride
-) {
+	summaryListNameLabelOverride,
+	summaryListDateLabelOverride
+}) {
 	/** @type {PageContent} */
 	const pageContent = {
 		title: titleTextOverride || 'Check your answers',
@@ -656,7 +666,7 @@ export function addDocumentsCheckAndConfirmPage(
 					},
 					{
 						key: {
-							text: 'Date received'
+							text: summaryListDateLabelOverride || 'Date received'
 						},
 						value: {
 							text: dateISOStringToDisplayDate(uncommittedFile.receivedDate)
@@ -790,22 +800,23 @@ export function mapFolderDocumentActionsHtmlProperty(folder, document, viewAndEd
 }
 
 /**
- * @param {string} backLinkUrl
- * @param {string} viewAndEditUrl
- * @param {FolderInfo} folder - API type needs to be updated (should be Folder, but there are worse problems with that type)
- * @param {RedactionStatus[]} redactionStatuses
- * @param {import('@pins/express/types/express.js').Request} request
- * @param {string} [pageHeadingTextOverride]
+ * @param {Object} params
+ * @param {string} params.backLinkUrl
+ * @param {string} params.viewAndEditUrl
+ * @param {FolderInfo} params.folder - API type needs to be updated (should be Folder, but there are worse problems with that type)
+ * @param {import('@pins/express/types/express.js').Request} params.request
+ * @param {string} [params.pageHeadingTextOverride]
+ * @param {string} [params.dateColumnLabelTextOverride]
  * @returns {PageContent}
  */
-export function manageFolderPage(
+export function manageFolderPage({
 	backLinkUrl,
 	viewAndEditUrl,
 	folder,
-	redactionStatuses,
 	request,
-	pageHeadingTextOverride
-) {
+	pageHeadingTextOverride,
+	dateColumnLabelTextOverride
+}) {
 	if (getDocumentsForVirusStatus(folder, APPEAL_VIRUS_CHECK_STATUS.NOT_SCANNED).length > 0) {
 		addNotificationBannerToSession(
 			request.session,
@@ -861,7 +872,7 @@ export function manageFolderPage(
 							text: 'Name'
 						},
 						{
-							text: 'Date received'
+							text: dateColumnLabelTextOverride || 'Date received'
 						},
 						{
 							text: 'Redaction status'
@@ -1077,17 +1088,19 @@ function mapDocumentNameHtmlProperty(document, documentVersion) {
 }
 
 /**
- * @param {string|number} appealId
- * @param {string} backLinkUrl
- * @param {string} uploadUpdatedDocumentUrl
- * @param {string} removeDocumentUrl
- * @param {DocumentInfo} document
- * @param {FolderInfo} folder
- * @param {import('@pins/express/types/express.js').Request} request
- * @param {string} [pageTitleTextOverride]
+ * @param {Object} params
+ * @param {string|number} params.appealId
+ * @param {string} params.backLinkUrl
+ * @param {string} params.uploadUpdatedDocumentUrl
+ * @param {string} params.removeDocumentUrl
+ * @param {DocumentInfo} params.document
+ * @param {FolderInfo} params.folder
+ * @param {import('@pins/express/types/express.js').Request} params.request
+ * @param {string} [params.pageTitleTextOverride]
+ * @param {string} [params.dateRowLabelTextOverride]
  * @returns {Promise<PageContent>}
  */
-export async function manageDocumentPage(
+export async function manageDocumentPage({
 	appealId,
 	backLinkUrl,
 	uploadUpdatedDocumentUrl,
@@ -1095,8 +1108,9 @@ export async function manageDocumentPage(
 	document,
 	folder,
 	request,
-	pageTitleTextOverride
-) {
+	pageTitleTextOverride,
+	dateRowLabelTextOverride
+}) {
 	const changeDetailsUrl = request.originalUrl.replace(
 		'manage-documents',
 		'change-document-details'
@@ -1166,7 +1180,7 @@ export async function manageDocumentPage(
 					}
 				},
 				{
-					key: { text: 'Date received' },
+					key: { text: dateRowLabelTextOverride || 'Date received' },
 					value:
 						folderIsAdditionalDocuments(folder.path) && latestVersion?.isLateEntry
 							? {


### PR DESCRIPTION
## Describe your changes

Add custom date field label copy for costs decision document flows. Includes supporting refactoring of some shared document functions to accept a params object, which has several advantages. Also fixes the costs decision upload new version flow to use the correct check and confirm screen (was previously using the same screen as other costs flows, which doesn't include the confirmation checkbox).

## Issue ticket number and link

A2-844

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [ ] I have performed a self-review of my own code
- [ ] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [ ] I have referenced the ticket number above
- [ ] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
