### PR TITLE
refactor(web): use addressInputs lib function in Add IP Comment form

### DIFF
--- a/appeals/web/src/server/appeals/appeal-details/interested-party-comments/add-ip-comment/__tests__/__snapshots__/add-ip-comment.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/interested-party-comments/add-ip-comment/__tests__/__snapshots__/add-ip-comment.test.js.snap
@@ -52,18 +52,19 @@ exports[`add-ip-comment GET /add/ip-address should match the snapshot 1`] = `
                     name="addressLine2" type="text">
                 </div>
                 <div class="govuk-form-group">
-                    <label class="govuk-label" for="town">Town or city</label>
-                    <input class="govuk-input" id="town" name="town" type="text">
+                    <label class="govuk-label" for="address-town">Town or city</label>
+                    <input class="govuk-input govuk-input govuk-input--width-20"
+                    id="address-town" name="town" type="text">
                 </div>
                 <div class="govuk-form-group">
-                    <label class="govuk-label" for="county">County (optional)</label>
-                    <input class="govuk-input" id="county" name="county"
-                    type="text">
+                    <label class="govuk-label" for="address-county">County (optional)</label>
+                    <input class="govuk-input govuk-input govuk-input--width-20"
+                    id="address-county" name="county" type="text">
                 </div>
                 <div class="govuk-form-group">
-                    <label class="govuk-label" for="postCode">Postcode</label>
-                    <input class="govuk-input" id="postCode" name="postCode"
-                    type="text">
+                    <label class="govuk-label" for="address-postcode">Postcode</label>
+                    <input class="govuk-input govuk-input govuk-input--width-10"
+                    id="address-postcode" name="postCode" type="text">
                 </div>
                 <button type="submit" data-prevent-double-click="true" class="govuk-button"
                 data-module="govuk-button">Continue</button>

--- a/appeals/web/src/server/appeals/appeal-details/interested-party-comments/add-ip-comment/__tests__/add-ip-comment.test.js
+++ b/appeals/web/src/server/appeals/appeal-details/interested-party-comments/add-ip-comment/__tests__/add-ip-comment.test.js
@@ -129,15 +129,15 @@ describe('add-ip-comment', () => {
 		});
 
 		it('should render a Town or city field', () => {
-			expect(pageHtml.querySelector('input#town')).not.toBeNull();
+			expect(pageHtml.querySelector('input#address-town')).not.toBeNull();
 		});
 
 		it('should render a County field', () => {
-			expect(pageHtml.querySelector('input#county')).not.toBeNull();
+			expect(pageHtml.querySelector('input#address-county')).not.toBeNull();
 		});
 
 		it('should render a Postcode field', () => {
-			expect(pageHtml.querySelector('input#postCode')).not.toBeNull();
+			expect(pageHtml.querySelector('input#address-postcode')).not.toBeNull();
 		});
 	});
 

--- a/appeals/web/src/server/appeals/appeal-details/interested-party-comments/add-ip-comment/add-ip-comment.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/interested-party-comments/add-ip-comment/add-ip-comment.mapper.js
@@ -1,13 +1,11 @@
 import { appealShortReference } from '#lib/appeals-formatter.js';
 import {
-	errorAddressLine1,
 	errorAddressProvidedRadio,
 	errorEmail,
 	errorFirstName,
-	errorLastName,
-	errorPostcode,
-	errorTown
+	errorLastName
 } from '#lib/error-handlers/change-screen-error-handlers.js';
+import { addressInputs } from '#lib/page-components/address.js';
 
 /** @typedef {import("../../appeal-details.types.js").WebAppeal} Appeal */
 
@@ -104,83 +102,14 @@ export const checkAddressPage = (appealDetails, errors) => ({
 
 /**
  * @param {Appeal} appealDetails
- * @param {{ addressLine1: string, addressLine2: string, town: string, county: string, postCode: string }} values
+ * @param {{ addressLine1: string, addressLine2: string, town: string, county: string, postCode: string }} address
  * @param {import('@pins/express').ValidationErrors | undefined} errors
  * @returns {PageContent}
  * */
-export const ipAddressPage = (appealDetails, values, errors) => ({
+export const ipAddressPage = (appealDetails, address, errors) => ({
 	title: "Interested party's address",
 	backLinkUrl: `/appeals-service/appeal-details/${appealDetails.appealId}/interested-party-comments/add/check-address`,
 	preHeading: `Appeal ${appealShortReference(appealDetails.appealReference)}`,
 	heading: "Interested party's address",
-	pageComponents: [
-		{
-			type: 'input',
-			parameters: {
-				id: 'address-line-1',
-				name: 'addressLine1',
-				type: 'text',
-				label: {
-					isPageHeading: false,
-					text: 'Address line 1'
-				},
-				value: values.addressLine1,
-				errorMessage: errorAddressLine1(errors)
-			}
-		},
-		{
-			type: 'input',
-			parameters: {
-				id: 'address-line-2',
-				name: 'addressLine2',
-				type: 'text',
-				label: {
-					isPageHeading: false,
-					text: 'Address line 2 (optional)'
-				},
-				value: values.addressLine2
-			}
-		},
-		{
-			type: 'input',
-			parameters: {
-				id: 'town',
-				name: 'town',
-				type: 'text',
-				label: {
-					isPageHeading: false,
-					text: 'Town or city'
-				},
-				value: values.town,
-				errorMessage: errorTown(errors)
-			}
-		},
-		{
-			type: 'input',
-			parameters: {
-				id: 'county',
-				name: 'county',
-				type: 'text',
-				label: {
-					isPageHeading: false,
-					text: 'County (optional)'
-				},
-				value: values.county
-			}
-		},
-		{
-			type: 'input',
-			parameters: {
-				id: 'postCode',
-				name: 'postCode',
-				type: 'text',
-				label: {
-					isPageHeading: false,
-					text: 'Postcode'
-				},
-				value: values.postCode,
-				errorMessage: errorPostcode(errors)
-			}
-		}
-	]
+	pageComponents: addressInputs({ address, errors })
 });


### PR DESCRIPTION
## Describe your changes

Previously missed that there is a lib function for creating the full set of address inputs. This PR just replaces the duplicated instance in interested-party-comments with the `addressInputs` function.

## Issue ticket number and link

[A2-600](https://pins-ds.atlassian.net/browse/A2-600)

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [x] I have included unit tests to cover any testable code changes


[A2-600]: https://pins-ds.atlassian.net/browse/A2-600?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ