### PR TITLE
Feature/a2 1087 valid

### DIFF
--- a/appeals/api/src/database/migrations/20241009085620_nullable_ip_comment/migration.sql
+++ b/appeals/api/src/database/migrations/20241009085620_nullable_ip_comment/migration.sql
@@ -1,0 +1,19 @@
+BEGIN TRY
+
+BEGIN TRAN;
+
+-- AlterTable
+ALTER TABLE [dbo].[Representation] ALTER COLUMN [originalRepresentation] NVARCHAR(1000) NULL;
+
+COMMIT TRAN;
+
+END TRY
+BEGIN CATCH
+
+IF @@TRANCOUNT > 0
+BEGIN
+    ROLLBACK TRAN;
+END;
+THROW
+
+END CATCH

--- a/appeals/api/src/database/schema.prisma
+++ b/appeals/api/src/database/schema.prisma
@@ -665,7 +665,7 @@ model Representation {
   representationType     String
   dateCreated            DateTime                   @default(now())
   dateLastUpdated        DateTime                   @default(now())
-  originalRepresentation String
+  originalRepresentation String?
   redactedRepresentation String?
   represented            ServiceUser?               @relation("represented", fields: [representedId], references: [id], onDelete: NoAction, onUpdate: NoAction)
   representedId          Int?

--- a/appeals/web/src/server/appeals/appeal-details/interested-party-comments/interested-party-comments.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/interested-party-comments/interested-party-comments.mapper.js
@@ -84,8 +84,15 @@ export function viewInterestedPartyCommentPage(appealDetails, comment) {
 			return null;
 		}
 
-		const items = comment.attachments.map((a) => `<li>${a.documentVersion.document.name}</li>`);
-		return `<ul class="govuk-list govuk-list--bullet">${items.join('')}</ul>`;
+		const items = comment.attachments.map(
+			(a) => `
+      <li>
+        <a href="#">${a.documentVersion.document.name}</a>
+      </li>
+    `
+		);
+
+		return `<ul class="govuk-list">${items.join('')}</ul>`;
 	})();
 
 	const hasAddress =
@@ -93,15 +100,7 @@ export function viewInterestedPartyCommentPage(appealDetails, comment) {
 		comment.represented.address.addressLine1 &&
 		comment.represented.address.postCode;
 
-	const commentText = (() => {
-		if (comment.originalRepresentation) {
-			return comment.originalRepresentation;
-		}
-
-		if (comment.attachments?.length > 0) {
-			return 'Added as document';
-		}
-	})();
+	const commentIsDocument = !comment.originalRepresentation && comment.attachments?.length > 0;
 
 	/** @type {PageComponent} */
 	const commentSummaryList = {
@@ -147,14 +146,18 @@ export function viewInterestedPartyCommentPage(appealDetails, comment) {
 				},
 				{
 					key: { text: comment.redactedRepresentation ? 'Original comment' : 'Comment' },
-					value: { text: commentText },
+					value: {
+						text: commentIsDocument ? 'Added as a document' : comment.originalRepresentation
+					},
 					actions: {
-						items: [
-							{
-								text: 'Redact',
-								href: '#'
-							}
-						]
+						items: commentIsDocument
+							? []
+							: [
+									{
+										text: 'Redact',
+										href: '#'
+									}
+							  ]
 					}
 				},
 				...(comment.redactedRepresentation


### PR DESCRIPTION
## Describe your changes

* feat(web): render list of comment's supporting documents as links
* fix(web): correct 'Added as a document' copy on interested party page
* feat(api): change Representation.originalRepresentation to be nullable
This is required as in some cases the comment is uploaded as a document,
and there is no text comment provided.
* feat(web): hide Redact link if comment was added as a document

Tested locally.

## Issue ticket number and link

[A2-1087](https://pins-ds.atlassian.net/browse/A2-1087)

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes


[A2-1087]: https://pins-ds.atlassian.net/browse/A2-1087?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ