### PR TITLE
refactor(web): userHasEditPermission -> editable

### DIFF
--- a/appeals/web/src/server/lib/mappers/appeal/submappers/agent.mapper.js
+++ b/appeals/web/src/server/lib/mappers/appeal/submappers/agent.mapper.js
@@ -10,6 +10,6 @@ export const mapAgent = ({ appealDetails, currentRoute, userHasUpdateCasePermiss
 			html: appealDetails.agent ? formatServiceUserAsHtmlList(appealDetails.agent) : 'No agent'
 		},
 		link: `${currentRoute}/service-user/change/agent`,
-		userHasEditPermission: 'agent' in appealDetails && userHasUpdateCasePermission,
+		editable: 'agent' in appealDetails && userHasUpdateCasePermission,
 		classes: 'appeal-agent'
 	});

--- a/appeals/web/src/server/lib/mappers/appeal/submappers/allocation-details.mapper.js
+++ b/appeals/web/src/server/lib/mappers/appeal/submappers/allocation-details.mapper.js
@@ -13,7 +13,7 @@ export const mapAllocationDetails = ({
 			html: mapDetailsHtml(appealDetails.allocationDetails)
 		},
 		link: `${currentRoute}/allocation-details/allocation-level`,
-		userHasEditPermission: userHasUpdateCasePermission,
+		editable: userHasUpdateCasePermission,
 		classes: 'appeal-allocation-details',
 		actionText: appealDetails.allocationDetails ? 'Change' : 'Add'
 	});

--- a/appeals/web/src/server/lib/mappers/appeal/submappers/appeal-type.mapper.js
+++ b/appeals/web/src/server/lib/mappers/appeal/submappers/appeal-type.mapper.js
@@ -7,6 +7,6 @@ export const mapAppealType = ({ appealDetails, currentRoute, userHasUpdateCasePe
 		text: 'Appeal type',
 		value: appealDetails.appealType || 'No appeal type',
 		link: `${currentRoute}/change-appeal-type/appeal-type`,
-		userHasEditPermission: userHasUpdateCasePermission,
+		editable: userHasUpdateCasePermission,
 		classes: 'appeal-appeal-type'
 	});

--- a/appeals/web/src/server/lib/mappers/appeal/submappers/appellant-health-and-safety.mapper.js
+++ b/appeals/web/src/server/lib/mappers/appeal/submappers/appellant-health-and-safety.mapper.js
@@ -13,6 +13,6 @@ export const mapAppellantHealthAndSafety = ({
 		valueDetails: appealDetails.healthAndSafety.appellantCase.details,
 		defaultText: 'No answer provided',
 		link: `${currentRoute}/safety-risks/change/appellant`,
-		userHasEditPermission: userHasUpdateCasePermission,
+		editable: userHasUpdateCasePermission,
 		classes: 'appeal-appellant-health-and-safety'
 	});

--- a/appeals/web/src/server/lib/mappers/appeal/submappers/appellant-inspector-access.mapper.js
+++ b/appeals/web/src/server/lib/mappers/appeal/submappers/appellant-inspector-access.mapper.js
@@ -13,6 +13,6 @@ export const mapAppellantInspectorAccess = ({
 		valueDetails: appealDetails.inspectorAccess.appellantCase.details,
 		defaultText: 'No answer provided',
 		link: `${currentRoute}/inspector-access/change/appellant`,
-		userHasEditPermission: userHasUpdateCasePermission,
+		editable: userHasUpdateCasePermission,
 		classes: 'appeal-appellant-inspector-access'
 	});

--- a/appeals/web/src/server/lib/mappers/appeal/submappers/appellant.mapper.js
+++ b/appeals/web/src/server/lib/mappers/appeal/submappers/appellant.mapper.js
@@ -12,6 +12,6 @@ export const mapAppellant = ({ appealDetails, currentRoute, userHasUpdateCasePer
 				: 'No appellant'
 		},
 		link: `${currentRoute}/service-user/change/appellant`,
-		userHasEditPermission: userHasUpdateCasePermission,
+		editable: userHasUpdateCasePermission,
 		classes: 'appeal-appellant'
 	});

--- a/appeals/web/src/server/lib/mappers/appeal/submappers/case-officer.mapper.js
+++ b/appeals/web/src/server/lib/mappers/appeal/submappers/case-officer.mapper.js
@@ -24,7 +24,7 @@ import { textSummaryListItem } from '#lib/mappers/components/text.js';
 			html: caseOfficerRowValue
 		},
 		link: `${currentRoute}/assign-user/case-officer`,
-		userHasEditPermission: userHasUpdateCasePermission,
+		editable: userHasUpdateCasePermission,
 		classes: 'appeal-case-officer',
 		actionText: appealDetails.caseOfficer ? 'Change' : 'Assign'
 	});

--- a/appeals/web/src/server/lib/mappers/appeal/submappers/case-procedure.mapper.js
+++ b/appeals/web/src/server/lib/mappers/appeal/submappers/case-procedure.mapper.js
@@ -7,6 +7,6 @@ export const mapCaseProcedure = ({ appealDetails, currentRoute, userHasUpdateCas
 		text: 'Case procedure',
 		value: appealDetails.procedureType || `No case procedure`,
 		link: `${currentRoute}/change-appeal-details/case-procedure`,
-		userHasEditPermission: userHasUpdateCasePermission,
+		editable: userHasUpdateCasePermission,
 		classes: 'appeal-case-procedure'
 	});

--- a/appeals/web/src/server/lib/mappers/appeal/submappers/complete-date.mapper.js
+++ b/appeals/web/src/server/lib/mappers/appeal/submappers/complete-date.mapper.js
@@ -10,7 +10,7 @@ export const mapCompleteDate = ({ appealDetails, currentRoute, userHasUpdateCase
 			dateISOStringToDisplayDate(appealDetails.appealTimetable?.completeDate) ||
 			'Due date not yet set',
 		link: `${currentRoute}/change-appeal-details/complete-date`,
-		userHasEditPermission: userHasUpdateCasePermission,
+		editable: userHasUpdateCasePermission,
 		classes: 'appeal-complete-date',
 		actionText: appealDetails.appealTimetable?.completeDate ? 'Change' : 'Schedule'
 	});

--- a/appeals/web/src/server/lib/mappers/appeal/submappers/decision.mapper.js
+++ b/appeals/web/src/server/lib/mappers/appeal/submappers/decision.mapper.js
@@ -14,7 +14,7 @@ export const mapDecision = ({ appealDetails, userHasUpdateCasePermission }) => {
 		text: 'Decision',
 		value: appealDetails.decision?.outcome || 'Not yet issued',
 		link: generateIssueDecisionUrl(appealDetails.appealId),
-		userHasEditPermission: userHasUpdateCasePermission && canIssueDecision,
+		editable: userHasUpdateCasePermission && canIssueDecision,
 		actionText: 'Issue',
 		classes: 'appeal-decision'
 	});

--- a/appeals/web/src/server/lib/mappers/appeal/submappers/final-comment-review-due-date.mapper.js
+++ b/appeals/web/src/server/lib/mappers/appeal/submappers/final-comment-review-due-date.mapper.js
@@ -14,7 +14,7 @@ export const mapFinalCommentReviewDueDate = ({
 			dateISOStringToDisplayDate(appealDetails.appealTimetable?.finalCommentReviewDate) ||
 			'Due date not yet set',
 		link: `${currentRoute}/appeal-timetables/final-comment-review`,
-		userHasEditPermission: userHasUpdateCasePermission,
+		editable: userHasUpdateCasePermission,
 		classes: 'appeal-final-comment-review-due-date',
 		actionText: appealDetails.appealTimetable?.finalCommentReviewDate ? 'Change' : 'Schedule'
 	});

--- a/appeals/web/src/server/lib/mappers/appeal/submappers/inspector.mapper.js
+++ b/appeals/web/src/server/lib/mappers/appeal/submappers/inspector.mapper.js
@@ -25,7 +25,7 @@ import { textSummaryListItem } from '#lib/mappers/components/text.js';
 			html: inspectorRowValue
 		},
 		link: `${currentRoute}/assign-user/inspector`,
-		userHasEditPermission: userHasUpdateCasePermission,
+		editable: userHasUpdateCasePermission,
 		classes: 'appeal-inspector',
 		actionText: appealDetails.inspector ? 'Change' : 'Assign'
 	});

--- a/appeals/web/src/server/lib/mappers/appeal/submappers/ip-comments-due-date.mapper.js
+++ b/appeals/web/src/server/lib/mappers/appeal/submappers/ip-comments-due-date.mapper.js
@@ -13,6 +13,6 @@ export const mapIpCommentsDueDate = ({
 		// @ts-ignore
 		value: dateISOStringToDisplayDate(appealDetails.appealTimetable?.ipCommentsDueDate) || '',
 		link: `${currentRoute}/appellant-case/valid/date`,
-		userHasEditPermission: userHasUpdateCasePermission,
+		editable: userHasUpdateCasePermission,
 		classes: 'appeal-ip-comments-due-date'
 	});

--- a/appeals/web/src/server/lib/mappers/appeal/submappers/issue-determination-date.mapper.js
+++ b/appeals/web/src/server/lib/mappers/appeal/submappers/issue-determination-date.mapper.js
@@ -14,7 +14,7 @@ export const mapIssueDeterminationDate = ({
 			dateISOStringToDisplayDate(appealDetails.appealTimetable?.issueDeterminationDate) ||
 			'Due date not yet set',
 		link: `${currentRoute}/appeal-timetables/issue-determination`,
-		userHasEditPermission: userHasUpdateCasePermission,
+		editable: userHasUpdateCasePermission,
 		actionText: appealDetails.appealTimetable?.issueDeterminationDate ? 'Change' : 'Schedule',
 		classes: 'appeal-issue-determination'
 	});

--- a/appeals/web/src/server/lib/mappers/appeal/submappers/local-planning-authority.mapper.js
+++ b/appeals/web/src/server/lib/mappers/appeal/submappers/local-planning-authority.mapper.js
@@ -11,6 +11,6 @@ export const mapLocalPlanningAuthority = ({
 		text: 'Local planning authority (LPA)',
 		value: appealDetails.localPlanningDepartment,
 		link: `${currentRoute}/change-appeal-details/local-planning-authority`,
-		userHasEditPermission: userHasUpdateCasePermission,
+		editable: userHasUpdateCasePermission,
 		classes: 'appeal-local-planning-authority'
 	});

--- a/appeals/web/src/server/lib/mappers/appeal/submappers/lpa-final-comment-due-date.mapper.js
+++ b/appeals/web/src/server/lib/mappers/appeal/submappers/lpa-final-comment-due-date.mapper.js
@@ -13,6 +13,6 @@ export const mapLpaFinalCommentDueDate = ({
 		// @ts-ignore
 		value: dateISOStringToDisplayDate(appealDetails.appealTimetable?.lpaFinalCommentDueDate) || '',
 		link: `${currentRoute}/lpa-case/valid/date`,
-		userHasEditPermission: Boolean(userHasUpdateCasePermission && appealDetails.validAt),
+		editable: Boolean(userHasUpdateCasePermission && appealDetails.validAt),
 		classes: 'appeal-lpa-final-comment-due-date'
 	});

--- a/appeals/web/src/server/lib/mappers/appeal/submappers/lpa-health-and-safety.mapper.js
+++ b/appeals/web/src/server/lib/mappers/appeal/submappers/lpa-health-and-safety.mapper.js
@@ -14,7 +14,7 @@ export const mapLpaHealthAndSafety = ({
 		valueDetails: appealDetails.healthAndSafety.lpaQuestionnaire?.details,
 		defaultText: 'No answer provided',
 		link: `${currentRoute}/safety-risks/change/lpa`,
-		userHasEditPermission:
+		editable:
 			userHasUpdateCasePermission &&
 			shouldDisplayChangeLinksForLPAQStatus(
 				appealDetails.documentationSummary?.lpaQuestionnaire?.status

--- a/appeals/web/src/server/lib/mappers/appeal/submappers/lpa-inspector-access.mapper.js
+++ b/appeals/web/src/server/lib/mappers/appeal/submappers/lpa-inspector-access.mapper.js
@@ -14,7 +14,7 @@ export const mapLpaInspectorAccess = ({
 		valueDetails: appealDetails.inspectorAccess.lpaQuestionnaire.details,
 		defaultText: '',
 		link: `${currentRoute}/inspector-access/change/lpa`,
-		userHasEditPermission:
+		editable:
 			userHasUpdateCasePermission &&
 			shouldDisplayChangeLinksForLPAQStatus(
 				appealDetails.documentationSummary?.lpaQuestionnaire?.status

--- a/appeals/web/src/server/lib/mappers/appeal/submappers/lpa-questionnaire-due-date.mapper.js
+++ b/appeals/web/src/server/lib/mappers/appeal/submappers/lpa-questionnaire-due-date.mapper.js
@@ -14,6 +14,6 @@ export const mapLpaQuestionnaireDueDate = ({
 			dateISOStringToDisplayDate(appealDetails.appealTimetable?.lpaQuestionnaireDueDate) ||
 			'Due date not yet set',
 		link: `${currentRoute}/appeal-timetables/lpa-questionnaire`,
-		userHasEditPermission: userHasUpdateCasePermission,
+		editable: userHasUpdateCasePermission,
 		classes: 'appeal-lpa-questionnaire-due-date'
 	});

--- a/appeals/web/src/server/lib/mappers/appeal/submappers/lpa-reference.mapper.js
+++ b/appeals/web/src/server/lib/mappers/appeal/submappers/lpa-reference.mapper.js
@@ -8,6 +8,6 @@ export const mapLpaReference = ({ appealDetails, currentRoute, userHasUpdateCase
 		value:
 			appealDetails.planningApplicationReference || 'No LPA application reference for this appeal',
 		link: `${currentRoute}/lpa-reference/change`,
-		userHasEditPermission: userHasUpdateCasePermission,
+		editable: userHasUpdateCasePermission,
 		classes: 'appeal-lpa-reference'
 	});

--- a/appeals/web/src/server/lib/mappers/appeal/submappers/lpa-statement-due-date.mapper.js
+++ b/appeals/web/src/server/lib/mappers/appeal/submappers/lpa-statement-due-date.mapper.js
@@ -13,6 +13,6 @@ export const mapLpaStatementDueDate = ({
 		// @ts-ignore
 		value: dateISOStringToDisplayDate(appealDetails.appealTimetable?.lpaStatementDueDate) || '',
 		link: `${currentRoute}/appellant-case/valid/date`,
-		userHasEditPermission: Boolean(userHasUpdateCasePermission && appealDetails.validAt),
+		editable: Boolean(userHasUpdateCasePermission && appealDetails.validAt),
 		classes: 'appeal-lpa-statement-due-date'
 	});

--- a/appeals/web/src/server/lib/mappers/appeal/submappers/neighboring-site-is-affected.mapper.js
+++ b/appeals/web/src/server/lib/mappers/appeal/submappers/neighboring-site-is-affected.mapper.js
@@ -13,7 +13,7 @@ export const mapNeighboringSiteIsAffected = ({
 		value: appealDetails.isAffectingNeighbouringSites,
 		defaultText: 'No answer provided',
 		link: `${currentRoute}/neighbouring-sites/change/affected`,
-		userHasEditPermission:
+		editable:
 			userHasUpdateCasePermission &&
 			shouldDisplayChangeLinksForLPAQStatus(
 				appealDetails.documentationSummary?.lpaQuestionnaire?.status

--- a/appeals/web/src/server/lib/mappers/appeal/submappers/site-address.mapper.js
+++ b/appeals/web/src/server/lib/mappers/appeal/submappers/site-address.mapper.js
@@ -8,6 +8,6 @@ export const mapSiteAddress = ({ appealDetails, currentRoute, userHasUpdateCaseP
 		text: 'Site address',
 		value: appealSiteToAddressString(appealDetails.appealSite),
 		link: `${currentRoute}/change-appeal-details/site-address`,
-		userHasEditPermission: userHasUpdateCasePermission,
+		editable: userHasUpdateCasePermission,
 		classes: 'appeal-site-address'
 	});

--- a/appeals/web/src/server/lib/mappers/appeal/submappers/site-visit-date.mapper.js
+++ b/appeals/web/src/server/lib/mappers/appeal/submappers/site-visit-date.mapper.js
@@ -20,7 +20,7 @@ export const mapSiteVisitDate = ({ appealDetails, currentRoute, userHasUpdateCas
 		value: { html: value },
 		link: `${currentRoute}/site-visit/${hasVisit ? 'manage' : 'schedule'}-visit`,
 		actionText: hasVisit ? 'Change' : 'Arrange',
-		userHasEditPermission: userHasUpdateCasePermission,
+		editable: userHasUpdateCasePermission,
 		classes: 'appeal-site-visit'
 	});
 };

--- a/appeals/web/src/server/lib/mappers/appeal/submappers/statement-review-due-date.mapper.js
+++ b/appeals/web/src/server/lib/mappers/appeal/submappers/statement-review-due-date.mapper.js
@@ -14,7 +14,7 @@ export const mapStatementReviewDueDate = ({
 			dateISOStringToDisplayDate(appealDetails.appealTimetable?.statementReviewDate) ||
 			'Due date not yet set',
 		link: `${currentRoute}/appeal-timetables/statement-review`,
-		userHasEditPermission: userHasUpdateCasePermission,
+		editable: userHasUpdateCasePermission,
 		classes: 'appeal-statement-review-due-date',
 		actionText: appealDetails.appealTimetable?.statementReviewDate ? 'Change' : 'Schedule'
 	});

--- a/appeals/web/src/server/lib/mappers/appeal/submappers/valid-at.mapper.js
+++ b/appeals/web/src/server/lib/mappers/appeal/submappers/valid-at.mapper.js
@@ -8,6 +8,6 @@ export const mapValidAt = ({ appealDetails, currentRoute, userHasUpdateCasePermi
 		text: 'Valid date',
 		value: dateISOStringToDisplayDate(appealDetails.validAt) || '',
 		link: `${currentRoute}/appellant-case/valid/date`,
-		userHasEditPermission: Boolean(appealDetails.validAt && userHasUpdateCasePermission),
+		editable: Boolean(appealDetails.validAt && userHasUpdateCasePermission),
 		classes: 'appeal-valid-date'
 	});

--- a/appeals/web/src/server/lib/mappers/appeal/submappers/visit-type.mapper.js
+++ b/appeals/web/src/server/lib/mappers/appeal/submappers/visit-type.mapper.js
@@ -9,6 +9,6 @@ export const mapVisitType = ({ appealDetails, currentRoute, userHasUpdateCasePer
 		link: `${currentRoute}/site-visit/${
 			appealDetails.siteVisit?.visitType ? 'visit-booked' : 'schedule-visit'
 		}`,
-		userHasEditPermission: userHasUpdateCasePermission,
+		editable: userHasUpdateCasePermission,
 		classes: 'appeal-visit-type'
 	});

--- a/appeals/web/src/server/lib/mappers/appellantCase.mapper.js
+++ b/appeals/web/src/server/lib/mappers/appellantCase.mapper.js
@@ -49,7 +49,7 @@ export function initialiseAndMapData(appellantCaseData, appealDetails, currentRo
 			text,
 			appealId: appellantCaseData.appealId,
 			folderInfo,
-			userHasEditPermission: userHasPermission(permissionNames.updateCase, session),
+			editable: userHasPermission(permissionNames.updateCase, session),
 			uploadUrlTemplate: documentUploadUrlTemplate,
 			manageUrl: mapDocumentManageUrl(appellantCaseData.appealId, folderInfo?.folderId),
 			cypressDataName
@@ -69,7 +69,7 @@ export function initialiseAndMapData(appellantCaseData, appealDetails, currentRo
 				: 'No appellant'
 		},
 		link: `${currentRoute}/service-user/change/appellant`,
-		userHasEditPermission: userHasUpdateCase,
+		editable: userHasUpdateCase,
 		classes: 'appeal-appellant',
 		cypressDataName: 'appellant'
 	});
@@ -81,7 +81,7 @@ export function initialiseAndMapData(appellantCaseData, appealDetails, currentRo
 			html: appealDetails.agent ? formatServiceUserAsHtmlList(appealDetails.agent) : 'No agent'
 		},
 		link: `${currentRoute}/service-user/change/agent`,
-		userHasEditPermission: userHasUpdateCase,
+		editable: userHasUpdateCase,
 		classes: 'appeal-agent'
 	});
 
@@ -90,7 +90,7 @@ export function initialiseAndMapData(appellantCaseData, appealDetails, currentRo
 		text: 'LPA application reference',
 		value: appellantCaseData.planningApplicationReference,
 		link: `${currentRoute}/lpa-reference/change`,
-		userHasEditPermission: userHasUpdateCase
+		editable: userHasUpdateCase
 	});
 
 	mappedData.siteAddress = textSummaryListItem({
@@ -98,7 +98,7 @@ export function initialiseAndMapData(appellantCaseData, appealDetails, currentRo
 		text: 'Site address',
 		value: appealSiteToAddressString(appellantCaseData.appealSite),
 		link: `${currentRoute}/site-address/change/${appealDetails.appealSite.addressId}`,
-		userHasEditPermission: userHasUpdateCase
+		editable: userHasUpdateCase
 	});
 
 	mappedData.siteArea = textSummaryListItem({
@@ -108,7 +108,7 @@ export function initialiseAndMapData(appellantCaseData, appealDetails, currentRo
 			? `${appellantCaseData.siteAreaSquareMetres} m²`
 			: '',
 		link: `${currentRoute}/site-area/change`,
-		userHasEditPermission: userHasUpdateCase
+		editable: userHasUpdateCase
 	});
 
 	mappedData.inGreenBelt = booleanSummaryListItem({
@@ -117,7 +117,7 @@ export function initialiseAndMapData(appellantCaseData, appealDetails, currentRo
 		value: appellantCaseData.isGreenBelt,
 		defaultText: '',
 		link: `${currentRoute}/green-belt/change/appellant`,
-		userHasEditPermission: userHasUpdateCase
+		editable: userHasUpdateCase
 	});
 
 	mappedData.applicationDecisionDate = textSummaryListItem({
@@ -125,7 +125,7 @@ export function initialiseAndMapData(appellantCaseData, appealDetails, currentRo
 		text: 'Decision date',
 		value: dateISOStringToDisplayDate(appellantCaseData.applicationDecisionDate),
 		link: `${currentRoute}/application-decision-date/change`,
-		userHasEditPermission: userHasUpdateCase
+		editable: userHasUpdateCase
 	});
 
 	mappedData.applicationDate = textSummaryListItem({
@@ -133,7 +133,7 @@ export function initialiseAndMapData(appellantCaseData, appealDetails, currentRo
 		text: 'Application submitted',
 		value: dateISOStringToDisplayDate(appellantCaseData.applicationDate),
 		link: `${currentRoute}/application-date/change`,
-		userHasEditPermission: userHasUpdateCase
+		editable: userHasUpdateCase
 	});
 
 	mappedData.developmentDescription = textSummaryListItem({
@@ -141,7 +141,7 @@ export function initialiseAndMapData(appellantCaseData, appealDetails, currentRo
 		text: 'Original Development description',
 		value: appellantCaseData.developmentDescription?.details || 'Not provided',
 		link: `${currentRoute}/development-description/change`,
-		userHasEditPermission: userHasUpdateCase,
+		editable: userHasUpdateCase,
 		withShowMore: true
 	});
 
@@ -150,7 +150,7 @@ export function initialiseAndMapData(appellantCaseData, appealDetails, currentRo
 		text: 'LPA changed the development description',
 		value: appellantCaseData.developmentDescription?.isChanged,
 		link: `${currentRoute}/lpa-changed-description/change`,
-		userHasEditPermission: userHasUpdateCase
+		editable: userHasUpdateCase
 	});
 
 	mappedData.applicationDecision = textSummaryListItem({
@@ -161,7 +161,7 @@ export function initialiseAndMapData(appellantCaseData, appealDetails, currentRo
 				? 'Not received'
 				: capitalize(appellantCaseData.applicationDecision ?? ''),
 		link: `${currentRoute}/application-outcome/change`,
-		userHasEditPermission: userHasUpdateCase
+		editable: userHasUpdateCase
 	});
 
 	//TODO: update with new document type
@@ -177,7 +177,7 @@ export function initialiseAndMapData(appellantCaseData, appealDetails, currentRo
 		text: 'Local planning authority (LPA)',
 		value: appellantCaseData.localPlanningDepartment,
 		link: `${currentRoute}/change-appeal-details/local-planning-authority`,
-		userHasEditPermission: userHasUpdateCase
+		editable: userHasUpdateCase
 	});
 
 	/**
@@ -203,7 +203,7 @@ export function initialiseAndMapData(appellantCaseData, appealDetails, currentRo
 			appellantCaseData.siteOwnership.ownsSomeLand
 		),
 		link: `${currentRoute}/site-ownership/change`,
-		userHasEditPermission: userHasUpdateCase
+		editable: userHasUpdateCase
 	});
 
 	mappedData.ownersKnown = textSummaryListItem({
@@ -211,7 +211,7 @@ export function initialiseAndMapData(appellantCaseData, appealDetails, currentRo
 		text: 'Owners known',
 		value: mapOwnersKnownLabelText(appellantCaseData.siteOwnership.knowsOtherLandowners),
 		link: `${currentRoute}/owners-known/change`,
-		userHasEditPermission: userHasUpdateCase
+		editable: userHasUpdateCase
 	});
 
 	mappedData.appealType = textSummaryListItem({
@@ -219,7 +219,7 @@ export function initialiseAndMapData(appellantCaseData, appealDetails, currentRo
 		text: 'Appeal type',
 		value: appealDetails.appealType,
 		link: `${currentRoute}/#`,
-		userHasEditPermission: userHasUpdateCase
+		editable: userHasUpdateCase
 	});
 
 	mappedData.advertisedAppeal = booleanSummaryListItem({
@@ -229,7 +229,7 @@ export function initialiseAndMapData(appellantCaseData, appealDetails, currentRo
 		defaultText: '',
 		link: `${currentRoute}/change-appeal-details/advertised-appeal`,
 		addCyAttribute: true,
-		userHasEditPermission: userHasUpdateCase
+		editable: userHasUpdateCase
 	});
 
 	mappedData.inspectorAccess = booleanWithDetailsSummaryListItem({
@@ -239,7 +239,7 @@ export function initialiseAndMapData(appellantCaseData, appealDetails, currentRo
 		valueDetails: appealDetails.inspectorAccess.appellantCase.details,
 		defaultText: 'No answer provided',
 		link: `${currentRoute}/inspector-access/change/appellant`,
-		userHasEditPermission: userHasUpdateCase,
+		editable: userHasUpdateCase,
 		classes: 'appellantcase-inspector-access',
 		addCyAttribute: true
 	});
@@ -251,7 +251,7 @@ export function initialiseAndMapData(appellantCaseData, appealDetails, currentRo
 		valueDetails: appealDetails.healthAndSafety.appellantCase.details,
 		defaultText: 'No answer provided',
 		link: `${currentRoute}/safety-risks/change/appellant`,
-		userHasEditPermission: userHasUpdateCase,
+		editable: userHasUpdateCase,
 		addCyAttribute: true
 	});
 
@@ -292,7 +292,7 @@ export function initialiseAndMapData(appellantCaseData, appealDetails, currentRo
 		defaultText: '',
 		link: `${currentRoute}/ownership-certificate/change`,
 		addCyAttribute: true,
-		userHasEditPermission: userHasUpdateCase
+		editable: userHasUpdateCase
 	});
 
 	mappedData.ownershipCertificate = documentInstruction({
@@ -468,7 +468,7 @@ export function initialiseAndMapData(appellantCaseData, appealDetails, currentRo
 		value: appellantCaseData.planningObligation?.hasObligation,
 		defaultText: '',
 		link: `${currentRoute}/planning-obligation/change`,
-		userHasEditPermission: userHasUpdateCase
+		editable: userHasUpdateCase
 	});
 
 	mappedData.statusPlanningObligation = textSummaryListItem({
@@ -478,7 +478,7 @@ export function initialiseAndMapData(appellantCaseData, appealDetails, currentRo
 			appellantCaseData.planningObligation?.status
 		),
 		link: `${currentRoute}/planning-obligation/status/change`,
-		userHasEditPermission: userHasUpdateCase
+		editable: userHasUpdateCase
 	});
 
 	mappedData.partOfAgriculturalHolding = booleanSummaryListItem({
@@ -487,7 +487,7 @@ export function initialiseAndMapData(appellantCaseData, appealDetails, currentRo
 		value: appellantCaseData.agriculturalHolding.isPartOfAgriculturalHolding,
 		defaultText: '',
 		link: `${currentRoute}/agricultural-holding/change`,
-		userHasEditPermission: userHasUpdateCase
+		editable: userHasUpdateCase
 	});
 
 	mappedData.tenantOfAgriculturalHolding = booleanSummaryListItem({
@@ -496,7 +496,7 @@ export function initialiseAndMapData(appellantCaseData, appealDetails, currentRo
 		value: appellantCaseData.agriculturalHolding.isTenant,
 		defaultText: '',
 		link: `${currentRoute}/agricultural-holding/tenant/change`,
-		userHasEditPermission: userHasUpdateCase
+		editable: userHasUpdateCase
 	});
 
 	mappedData.otherTenantsOfAgriculturalHolding = booleanSummaryListItem({
@@ -505,7 +505,7 @@ export function initialiseAndMapData(appellantCaseData, appealDetails, currentRo
 		value: appellantCaseData.agriculturalHolding.hasOtherTenants,
 		defaultText: '',
 		link: `${currentRoute}/agricultural-holding/other-tenants/change`,
-		userHasEditPermission: userHasUpdateCase
+		editable: userHasUpdateCase
 	});
 
 	mappedData.appellantCostsApplication = booleanSummaryListItem({
@@ -513,7 +513,7 @@ export function initialiseAndMapData(appellantCaseData, appealDetails, currentRo
 		text: 'Applied for award of appeal costs',
 		value: appellantCaseData.appellantCostsAppliedFor,
 		link: `${currentRoute}/appeal-costs-application/change`,
-		userHasEditPermission: userHasUpdateCase
+		editable: userHasUpdateCase
 	});
 
 	mappedData.costsDocument = documentInstruction({

--- a/appeals/web/src/server/lib/mappers/components/boolean.js
+++ b/appeals/web/src/server/lib/mappers/components/boolean.js
@@ -10,7 +10,7 @@ import { buildHtmSpan } from '#lib/nunjucks-template-builders/tag-builders.js';
  * @param {string} [options.defaultText]
  * @param {string} options.link
  * @param {boolean} [options.addCyAttribute]
- * @param {boolean} options.userHasEditPermission
+ * @param {boolean} options.editable
  * @param {string} [options.classes]
  * @returns {Instructions}
  */
@@ -21,12 +21,12 @@ export function booleanSummaryListItem({
 	defaultText,
 	link,
 	addCyAttribute,
-	userHasEditPermission,
+	editable,
 	classes
 }) {
 	/** @type {ActionItemProperties[]} */
 	const actions = [];
-	if (userHasEditPermission) {
+	if (editable) {
 		actions.push({
 			text: 'Change',
 			visuallyHiddenText: text,
@@ -59,7 +59,7 @@ export function booleanSummaryListItem({
  * @param {string} [options.defaultText]
  * @param {string} options.link
  * @param {boolean} [options.addCyAttribute]
- * @param {boolean} options.userHasEditPermission
+ * @param {boolean} options.editable
  * @param {string} [options.classes]
  * @returns {Instructions}
  */
@@ -71,12 +71,12 @@ export function booleanWithDetailsSummaryListItem({
 	defaultText,
 	link,
 	addCyAttribute,
-	userHasEditPermission,
+	editable,
 	classes
 }) {
 	/** @type {ActionItemProperties[]} */
 	const actions = [];
-	if (userHasEditPermission) {
+	if (editable) {
 		actions.push({
 			text: 'Change',
 			visuallyHiddenText: text,

--- a/appeals/web/src/server/lib/mappers/components/document.js
+++ b/appeals/web/src/server/lib/mappers/components/document.js
@@ -9,7 +9,7 @@ import { formatDocumentActionLink, formatDocumentValues } from '#lib/display-pag
  * @param {string} options.text
  * @param {number} options.appealId
  * @param {import('@pins/appeals.api').Appeals.FolderInfo|null|undefined} options.folderInfo
- * @param {boolean} options.userHasEditPermission
+ * @param {boolean} options.editable
  * @param {string} options.manageUrl
  * @param {string} options.uploadUrlTemplate
  * @param {string} [options.cypressDataName]
@@ -20,7 +20,7 @@ export function documentSummaryListItem({
 	text,
 	appealId,
 	folderInfo,
-	userHasEditPermission,
+	editable,
 	manageUrl,
 	uploadUrlTemplate,
 	cypressDataName = id
@@ -28,7 +28,7 @@ export function documentSummaryListItem({
 	const documents = (isFolderInfo(folderInfo) && folderInfo.documents) || [];
 	/** @type {ActionItemProperties[]} */
 	const actions = [];
-	if (userHasEditPermission) {
+	if (editable) {
 		if (documents.length) {
 			actions.push({
 				text: 'Manage',

--- a/appeals/web/src/server/lib/mappers/components/text.js
+++ b/appeals/web/src/server/lib/mappers/components/text.js
@@ -8,7 +8,7 @@ import { SHOW_MORE_MAXIMUM_CHARACTERS_BEFORE_HIDING } from '#lib/constants.js';
  * @param {string} options.text
  * @param {string|HtmlProperty|null} [options.value]
  * @param {string} options.link
- * @param {boolean} options.userHasEditPermission
+ * @param {boolean} options.editable
  * @param {boolean} [options.withShowMore]
  * @param {string} [options.classes]
  * @param {string} [options.actionText]
@@ -20,7 +20,7 @@ export function textSummaryListItem({
 	text,
 	value,
 	link,
-	userHasEditPermission,
+	editable,
 	withShowMore,
 	classes,
 	actionText = 'Change',
@@ -53,7 +53,7 @@ export function textSummaryListItem({
 	}
 	/** @type {ActionItemProperties[]} */
 	const actions = [];
-	if (userHasEditPermission) {
+	if (editable) {
 		actions.push({
 			text: actionText,
 			visuallyHiddenText: text,

--- a/appeals/web/src/server/lib/mappers/lpaQuestionnaire.mapper.js
+++ b/appeals/web/src/server/lib/mappers/lpaQuestionnaire.mapper.js
@@ -50,7 +50,7 @@ export function initialiseAndMapLPAQData(
 			text,
 			appealId: lpaQuestionnaireData.appealId,
 			folderInfo,
-			userHasEditPermission: userHasPermission(permissionNames.updateCase, session),
+			editable: userHasPermission(permissionNames.updateCase, session),
 			uploadUrlTemplate: buildDocumentUploadUrlTemplate(lpaQuestionnaireData.lpaQuestionnaireId),
 			manageUrl: mapDocumentManageUrl(
 				lpaQuestionnaireData.appealId,
@@ -115,7 +115,7 @@ export function initialiseAndMapLPAQData(
 		defaultText: '',
 		addCyAttribute: true,
 		link: `${currentRoute}/is-correct-appeal-type/change`,
-		userHasEditPermission: userHasUpdateCase
+		editable: userHasUpdateCase
 	});
 
 	mappedData.lpaq.conservationAreaMap = documentInstruction({
@@ -132,7 +132,7 @@ export function initialiseAndMapLPAQData(
 		defaultText: '',
 		addCyAttribute: true,
 		link: `${currentRoute}/green-belt/change/lpa`,
-		userHasEditPermission: userHasUpdateCase
+		editable: userHasUpdateCase
 	});
 
 	mappedData.lpaq.notifyingParties = documentInstruction({
@@ -170,7 +170,7 @@ export function initialiseAndMapLPAQData(
 			)
 		},
 		link: `${currentRoute}/notification-methods/change`,
-		userHasEditPermission: userHasUpdateCase
+		editable: userHasUpdateCase
 	});
 
 	mappedData.lpaq.representations = documentInstruction({
@@ -204,7 +204,7 @@ export function initialiseAndMapLPAQData(
 		valueDetails: lpaQuestionnaireData.inspectorAccessDetails,
 		defaultText: 'No answer provided',
 		link: `${currentRoute}/inspector-access/change/lpa`,
-		userHasEditPermission: userHasUpdateCase,
+		editable: userHasUpdateCase,
 		addCyAttribute: true
 	});
 
@@ -215,7 +215,7 @@ export function initialiseAndMapLPAQData(
 		valueDetails: lpaQuestionnaireData.healthAndSafetyDetails,
 		defaultText: 'No answer provided',
 		link: `${currentRoute}/safety-risks/change/lpa`,
-		userHasEditPermission: userHasUpdateCase,
+		editable: userHasUpdateCase,
 		addCyAttribute: true,
 		classes: 'lpa-health-and-safety'
 	});
@@ -269,7 +269,7 @@ export function initialiseAndMapLPAQData(
 		valueDetails: lpaQuestionnaireData.extraConditions,
 		defaultText: '',
 		link: `${currentRoute}/extra-conditions/change`,
-		userHasEditPermission: userHasUpdateCase
+		editable: userHasUpdateCase
 	});
 
 	/** @type {Instructions} */


### PR DESCRIPTION
## Describe your changes

A better name for the `userHasEditPermission` parameter -> `editable`, since this is used to hide actions if the appeal isn't in the appropriate state and other reasons.

## Issue ticket number and link

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [ ] I have performed a self-review of my own code
- [ ] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [ ] I have referenced the ticket number above
- [ ] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
