### PR TITLE
fix(web): fix add document notification banners not displaying on appellant case and lpaq pages

### DIFF
--- a/appeals/web/src/server/appeals/appeal-details/appellant-case/__tests__/appellant-case.test.js
+++ b/appeals/web/src/server/appeals/appeal-details/appellant-case/__tests__/appellant-case.test.js
@@ -4329,6 +4329,34 @@ describe('appellant-case', () => {
 			);
 			expect(mockDocumentsEndpoint.isDone()).toBe(true);
 		});
+
+		it('should display a "document added" notification banner on the appellant case page after a document was uploaded', async () => {
+			nock('http://test/').post('/appeals/1/documents').reply(200);
+
+			const addDocumentsResponse = await request
+				.post(`${baseUrl}/1${appellantCasePagePath}/add-documents/1`)
+				.send({
+					'upload-info': fileUploadInfo
+				});
+
+			expect(addDocumentsResponse.statusCode).toBe(302);
+
+			const checkYourAnswersResponse = await request
+				.post(`${baseUrl}/1${appellantCasePagePath}/add-documents/1/check-your-answers`)
+				.send({});
+
+			expect(checkYourAnswersResponse.statusCode).toBe(302);
+
+			const response = await request.get(`${baseUrl}/1${appellantCasePagePath}`);
+
+			const unprettifiedElement = parseHtml(response.text, {
+				rootElement: notificationBannerElement,
+				skipPrettyPrint: true
+			});
+
+			expect(unprettifiedElement.innerHTML).toContain('Success</h3>');
+			expect(unprettifiedElement.innerHTML).toContain('Document added</p>');
+		});
 	});
 
 	describe('GET /appellant-case/add-documents/:folderId/:documentId/check-your-answers', () => {

--- a/appeals/web/src/server/appeals/appeal-details/appellant-case/appellant-case.controller.js
+++ b/appeals/web/src/server/appeals/appeal-details/appellant-case/appellant-case.controller.js
@@ -24,6 +24,7 @@ import {
 	renderManageFolder
 } from '../../appeal-documents/appeal-documents.controller.js';
 import { capitalize } from 'lodash-es';
+import { addNotificationBannerToSession } from '#lib/session-utilities.js';
 
 /**
  *
@@ -329,7 +330,10 @@ export const postAddDocumentsCheckAndConfirm = async (request, response) => {
 		await postUploadDocumentsCheckAndConfirm(
 			request,
 			response,
-			`/appeals-service/appeal-details/${currentAppeal.appealId}/appellant-case`
+			`/appeals-service/appeal-details/${currentAppeal.appealId}/appellant-case`,
+			() => {
+				addNotificationBannerToSession(request.session, 'documentAdded', currentAppeal.appealId);
+			}
 		);
 	} catch (error) {
 		logger.error(

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/lpa-questionnaire.controller.js
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/lpa-questionnaire.controller.js
@@ -24,6 +24,7 @@ import {
 	postChangeDocumentDetails,
 	postDeleteDocument
 } from '../../appeal-documents/appeal-documents.controller.js';
+import { addNotificationBannerToSession } from '#lib/session-utilities.js';
 
 /**
  * @param {import('@pins/express/types/express.js').Request} request
@@ -382,7 +383,10 @@ export const postAddDocumentsCheckAndConfirm = async (request, response) => {
 		await postUploadDocumentsCheckAndConfirm(
 			request,
 			response,
-			`/appeals-service/appeal-details/${currentAppeal.appealId}/lpa-questionnaire/${request.params.lpaQuestionnaireId}`
+			`/appeals-service/appeal-details/${currentAppeal.appealId}/lpa-questionnaire/${request.params.lpaQuestionnaireId}`,
+			() => {
+				addNotificationBannerToSession(request.session, 'documentAdded', currentAppeal.appealId);
+			}
 		);
 	} catch (error) {
 		logger.error(


### PR DESCRIPTION
## Describe your changes

fix add document notification banners not displaying on appellant case and lpaq pages

## Issue ticket number and link

A2-1232

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [ ] I have performed a self-review of my own code
- [ ] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [ ] I have referenced the ticket number above
- [ ] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
