### PR TITLE
Feature/a2 588 copy

### DIFF
--- a/appeals/api/setup-tests.js
+++ b/appeals/api/setup-tests.js
@@ -6,6 +6,7 @@ import { NODE_ENV_PRODUCTION } from '#endpoints/constants.js';
 const mockValidateBlob = jest.fn().mockResolvedValue(true);
 const mockRepGetById = jest.fn().mockResolvedValue({});
 const mockRepUpdateById = jest.fn().mockResolvedValue({});
+const mockRepGroupBy = jest.fn().mockResolvedValue([]);
 const mockAppealRelationshipAdd = jest.fn().mockResolvedValue({});
 const mockAppealRelationshipRemove = jest.fn().mockResolvedValue({});
 const mockAppealRelationshipFindMany = jest.fn().mockResolvedValue({});
@@ -98,7 +99,8 @@ class MockPrismaClient {
 	get representation() {
 		return {
 			update: mockRepUpdateById,
-			findUnique: mockRepGetById
+			findUnique: mockRepGetById,
+			groupBy: mockRepGroupBy
 		};
 	}
 

--- a/appeals/api/src/server/endpoints/appeals.d.ts
+++ b/appeals/api/src/server/endpoints/appeals.d.ts
@@ -452,6 +452,7 @@ interface AppealListResponse {
 	dueDate: Date | undefined | null;
 	isParentAppeal: boolean | null;
 	isChildAppeal: boolean | null;
+  commentCounts: Record<string, number>;
 }
 
 interface DocumentationSummary {

--- a/appeals/api/src/server/endpoints/appeals/__tests__/appeals.test.js
+++ b/appeals/api/src/server/endpoints/appeals/__tests__/appeals.test.js
@@ -77,7 +77,8 @@ describe('appeals list routes', () => {
 							lpaQuestionnaireStatus: '',
 							dueDate: null,
 							isParentAppeal: false,
-							isChildAppeal: false
+							isChildAppeal: false,
+							commentCounts: {}
 						},
 						{
 							appealId: fullPlanningAppeal.id,
@@ -97,7 +98,8 @@ describe('appeals list routes', () => {
 							lpaQuestionnaireStatus: '',
 							dueDate: null,
 							isParentAppeal: false,
-							isChildAppeal: false
+							isChildAppeal: false,
+							commentCounts: {}
 						}
 					],
 					page: 1,
@@ -145,7 +147,8 @@ describe('appeals list routes', () => {
 							lpaQuestionnaireStatus: '',
 							dueDate: null,
 							isParentAppeal: false,
-							isChildAppeal: false
+							isChildAppeal: false,
+							commentCounts: {}
 						}
 					],
 					page: 2,
@@ -215,7 +218,8 @@ describe('appeals list routes', () => {
 							lpaQuestionnaireStatus: '',
 							dueDate: null,
 							isParentAppeal: false,
-							isChildAppeal: false
+							isChildAppeal: false,
+							commentCounts: {}
 						}
 					],
 					page: 1,
@@ -285,7 +289,8 @@ describe('appeals list routes', () => {
 							lpaQuestionnaireStatus: '',
 							dueDate: null,
 							isParentAppeal: false,
-							isChildAppeal: false
+							isChildAppeal: false,
+							commentCounts: {}
 						}
 					],
 					page: 1,
@@ -355,7 +360,8 @@ describe('appeals list routes', () => {
 							lpaQuestionnaireStatus: '',
 							dueDate: null,
 							isParentAppeal: false,
-							isChildAppeal: false
+							isChildAppeal: false,
+							commentCounts: {}
 						}
 					],
 					page: 1,
@@ -412,7 +418,8 @@ describe('appeals list routes', () => {
 							lpaQuestionnaireStatus: '',
 							dueDate: null,
 							isParentAppeal: false,
-							isChildAppeal: false
+							isChildAppeal: false,
+							commentCounts: {}
 						}
 					],
 					page: 1,
@@ -471,7 +478,8 @@ describe('appeals list routes', () => {
 							lpaQuestionnaireStatus: '',
 							dueDate: null,
 							isParentAppeal: false,
-							isChildAppeal: false
+							isChildAppeal: false,
+							commentCounts: {}
 						}
 					],
 					page: 1,
@@ -528,7 +536,8 @@ describe('appeals list routes', () => {
 							lpaQuestionnaireStatus: '',
 							dueDate: null,
 							isParentAppeal: false,
-							isChildAppeal: false
+							isChildAppeal: false,
+							commentCounts: {}
 						}
 					],
 					page: 1,

--- a/appeals/api/src/server/endpoints/appeals/appeals.controller.js
+++ b/appeals/api/src/server/endpoints/appeals/appeals.controller.js
@@ -8,6 +8,7 @@ import { getAvScanStatus } from '#endpoints/documents/documents.service.js';
 import logger from '#utils/logger.js';
 import appealRepository from '#repositories/appeal.repository.js';
 import appealListRepository from '#repositories/appeal-lists.repository.js';
+import { countAppealRepresentationsByStatus } from '#repositories/representation.repository.js';
 import stringTokenReplacement from '#utils/string-token-replacement.js';
 import {
 	AUDIT_TRAIL_ASSIGNED_CASE_OFFICER,
@@ -59,9 +60,12 @@ const getAppeals = async (req, res) => {
 	const formattedAppeals = await Promise.all(
 		appeals.map(async (appeal) => {
 			const linkedAppeals = await appealRepository.getLinkedAppeals(appeal.reference);
+			const commentCounts = await countAppealRepresentationsByStatus(appeal.id, 'comment');
+
 			return formatAppeals(
 				appeal,
-				linkedAppeals.filter((linkedAppeal) => linkedAppeal.type === 'linked')
+				linkedAppeals.filter((linkedAppeal) => linkedAppeal.type === 'linked'),
+				commentCounts
 			);
 		})
 	);
@@ -101,9 +105,12 @@ const getMyAppeals = async (req, res) => {
 		const formattedAppeals = await Promise.all(
 			appeals.map(async (appeal) => {
 				const linkedAppeals = await appealRepository.getLinkedAppeals(appeal.reference);
+				const commentCounts = await countAppealRepresentationsByStatus(appeal.id, 'comment');
+
 				return formatMyAppeals(
 					appeal,
-					linkedAppeals.filter((linkedAppeal) => linkedAppeal.type === 'linked')
+					linkedAppeals.filter((linkedAppeal) => linkedAppeal.type === 'linked'),
+					commentCounts
 				);
 			})
 		);

--- a/appeals/api/src/server/endpoints/appeals/appeals.formatter.js
+++ b/appeals/api/src/server/endpoints/appeals/appeals.formatter.js
@@ -28,9 +28,10 @@ const approxStageCompletion = {
 /**
  * @param {Appeal} appeal
  * @param {AppealRelationship[]} linkedAppeals
+ * @param {Record<string, number>} commentCounts
  * @returns {AppealListResponse}}
  */
-const formatAppeals = (appeal, linkedAppeals) => ({
+const formatAppeals = (appeal, linkedAppeals, commentCounts) => ({
 	appealId: appeal.id,
 	appealReference: appeal.reference,
 	appealSite: formatAddress(appeal.address),
@@ -42,15 +43,17 @@ const formatAppeals = (appeal, linkedAppeals) => ({
 	lpaQuestionnaireStatus: '',
 	dueDate: null,
 	isParentAppeal: linkedAppeals.filter((link) => link.parentRef === appeal.reference).length > 0,
-	isChildAppeal: linkedAppeals.filter((link) => link.childRef === appeal.reference).length > 0
+	isChildAppeal: linkedAppeals.filter((link) => link.childRef === appeal.reference).length > 0,
+  commentCounts
 });
 
 /**
  * @param {Appeal} appeal
  * @param {AppealRelationship[]} linkedAppeals
+ * @param {Record<string, number>} commentCounts
  * @returns {AppealListResponse}}
  */
-const formatMyAppeals = (appeal, linkedAppeals) => ({
+const formatMyAppeals = (appeal, linkedAppeals, commentCounts) => ({
 	appealId: appeal.id,
 	appealReference: appeal.reference,
 	appealSite: formatAddress(appeal.address),
@@ -83,7 +86,8 @@ const formatMyAppeals = (appeal, linkedAppeals) => ({
 		appeal.caseExtensionDate
 	),
 	isParentAppeal: linkedAppeals.filter((link) => link.parentRef === appeal.reference).length > 0,
-	isChildAppeal: linkedAppeals.filter((link) => link.childRef === appeal.reference).length > 0
+	isChildAppeal: linkedAppeals.filter((link) => link.childRef === appeal.reference).length > 0,
+  commentCounts
 });
 
 /**
@@ -101,6 +105,8 @@ const formatAppeal = (
 	decisionInfo = null,
 	referencedAppeals = null
 ) => {
+  // TODO: This if statement shouldn't be needed because appeal is non-optional
+  // Need to make sure removing it doesn't break anything though
 	if (appeal) {
 		const decisionFolder = formatFolder(
 			rootFolders.find(

--- a/appeals/api/src/server/repositories/representation.repository.js
+++ b/appeals/api/src/server/repositories/representation.repository.js
@@ -137,3 +137,27 @@ export const updateRepresentationById = (id, redactedRepresentation, status, not
 		}
 	});
 };
+
+/**
+ * @param {number} appealId
+ * @param {string} [representationType]
+ * @returns {Promise<Record<string, number>>}
+ * */
+export const countAppealRepresentationsByStatus = async (appealId, representationType) => {
+	const statusCounts = await databaseConnector.representation.groupBy({
+		by: ['status'],
+		where: {
+			appealId,
+			representationType
+		},
+		_count: true
+	});
+
+	return statusCounts.reduce(
+		(acc, item) => ({
+			...acc,
+			[item.status]: item._count
+		}),
+		{}
+	);
+};

--- a/appeals/web/src/server/appeals/personal-list/__tests__/personal-list.test.js
+++ b/appeals/web/src/server/appeals/personal-list/__tests__/personal-list.test.js
@@ -233,6 +233,7 @@ describe('mapAppealStatusToActionRequiredHtml', () => {
 		const result = mapAppealStatusToActionRequiredHtml(
 			appealId,
 			'validation',
+			false,
 			lpaQuestionnaireId,
 			'',
 			'',
@@ -248,6 +249,7 @@ describe('mapAppealStatusToActionRequiredHtml', () => {
 		const result = mapAppealStatusToActionRequiredHtml(
 			appealId,
 			'validation',
+			false,
 			lpaQuestionnaireId,
 			'Incomplete',
 			'',
@@ -263,6 +265,7 @@ describe('mapAppealStatusToActionRequiredHtml', () => {
 		const result = mapAppealStatusToActionRequiredHtml(
 			appealId,
 			'validation',
+			false,
 			lpaQuestionnaireId,
 			'Incomplete',
 			'',
@@ -276,6 +279,7 @@ describe('mapAppealStatusToActionRequiredHtml', () => {
 		const result = mapAppealStatusToActionRequiredHtml(
 			appealId,
 			'ready_to_start',
+			false,
 			lpaQuestionnaireId,
 			'',
 			'',
@@ -291,6 +295,7 @@ describe('mapAppealStatusToActionRequiredHtml', () => {
 		const result = mapAppealStatusToActionRequiredHtml(
 			appealId,
 			'ready_to_start',
+			false,
 			lpaQuestionnaireId,
 			'',
 			'',
@@ -304,6 +309,7 @@ describe('mapAppealStatusToActionRequiredHtml', () => {
 		const result = mapAppealStatusToActionRequiredHtml(
 			appealId,
 			'lpa_questionnaire',
+			false,
 			null,
 			'',
 			'',
@@ -317,6 +323,7 @@ describe('mapAppealStatusToActionRequiredHtml', () => {
 		const result = mapAppealStatusToActionRequiredHtml(
 			appealId,
 			'lpa_questionnaire',
+			false,
 			lpaQuestionnaireId,
 			'',
 			'Incomplete',
@@ -332,6 +339,7 @@ describe('mapAppealStatusToActionRequiredHtml', () => {
 		const result = mapAppealStatusToActionRequiredHtml(
 			appealId,
 			'lpa_questionnaire',
+			false,
 			lpaQuestionnaireId,
 			'',
 			'Incomplete',
@@ -345,6 +353,7 @@ describe('mapAppealStatusToActionRequiredHtml', () => {
 		const result = mapAppealStatusToActionRequiredHtml(
 			appealId,
 			'lpa_questionnaire',
+			false,
 			lpaQuestionnaireId,
 			'',
 			'',
@@ -360,6 +369,7 @@ describe('mapAppealStatusToActionRequiredHtml', () => {
 		const result = mapAppealStatusToActionRequiredHtml(
 			appealId,
 			'lpa_questionnaire',
+			false,
 			lpaQuestionnaireId,
 			'',
 			'',
@@ -373,6 +383,7 @@ describe('mapAppealStatusToActionRequiredHtml', () => {
 		const result = mapAppealStatusToActionRequiredHtml(
 			appealId,
 			'lpa_questionnaire',
+			false,
 			null,
 			'',
 			'',
@@ -386,6 +397,7 @@ describe('mapAppealStatusToActionRequiredHtml', () => {
 		const result = mapAppealStatusToActionRequiredHtml(
 			appealId,
 			'issue_determination',
+			false,
 			null,
 			'',
 			'',
@@ -401,6 +413,7 @@ describe('mapAppealStatusToActionRequiredHtml', () => {
 		const result = mapAppealStatusToActionRequiredHtml(
 			appealId,
 			'awaiting_transfer',
+			false,
 			null,
 			'',
 			'',
@@ -416,6 +429,7 @@ describe('mapAppealStatusToActionRequiredHtml', () => {
 		const result = mapAppealStatusToActionRequiredHtml(
 			appealId,
 			'some_other_status',
+			false,
 			null,
 			'',
 			'',

--- a/packages/appeals/types/appeal.d.ts
+++ b/packages/appeals/types/appeal.d.ts
@@ -22,6 +22,7 @@ export interface AppealSummary {
 	documentationSummary: DocumentationSummary;
 	isParentAppeal: boolean;
 	isChildAppeal: boolean;
+	commentCounts?: Record<string, number>;
 }
 
 export interface AppealList {


### PR DESCRIPTION
## Describe your changes

* feat(api): return comment counts for each status in Appeal response
* test(api): update tests to expect commentCounts property in response
* chore(api): add a TODO comment for a redundant if-statement
* refactor(web): use ternary operator to check isCaseOfficer
Just a minor improvement to readability by reducing nesting.
* feat(web): implement logic for Action required tab for statements


### Explanation for the `groupBy` query

The ACs for this ticket require us to check whether each appeal has any comments in `awaiting_review` state. I spent some time trying to figure out the best way to do this. We're fetching a list of stubs for the appeals which could be quite long, so we ideally want to avoid having to make a separate API call for every item. It would be better if the API just returned the information as part of the request for the appeals list.

On the other hand, including every representation for every appeal in the list could potentially add a huge amount of redundant data to the response. I decided the best way would be to do an aggregate query to just count the number of comments in each state. Then in the `web` code we can just check if there are more than 0 `awaiting_review` representations.

I didn't want to abstract this code too much before we know if it's necessary, but I've tried not to make it too specific. E.g. you can pass the representation type to the new repository method so it works for more than just comments.

## Issue ticket number and link

[A2-588](https://pins-ds.atlassian.net/browse/A2-588)

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes


[A2-588]: https://pins-ds.atlassian.net/browse/A2-588?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ