### PR TITLE
fix(web): permissions for inspectors on case details

### DIFF
--- a/appeals/web/src/server/appeals/appeal-details/appeal-details.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/appeal-details.mapper.js
@@ -15,12 +15,13 @@ import { APPEAL_CASE_STATUS } from 'pins-data-model';
 import { APPEAL_TYPE, FEATURE_FLAG_NAMES } from '@pins/appeals/constants/common.js';
 import { isFeatureActive } from '#common/feature-flags.js';
 import { addNotificationBannerToSession } from '#lib/session-utilities.js';
-import config from '#environment/config.js';
 import {
 	generateIssueDecisionUrl,
 	generateStartTimetableUrl
 } from './issue-decision/issue-decision.mapper.js';
 import { dateISOStringToDisplayDate, getTodaysISOString } from '#lib/dates.js';
+import { userHasPermission } from '#lib/mappers/permissions.mapper.js';
+import { permissionNames } from '#environment/permissions.js';
 
 export const pageHeading = 'Case details';
 
@@ -561,9 +562,7 @@ function generateAccordion(appealDetails, mappedData, session, ipCommentsAwaitin
 		ipCommentsAwaitingReview
 	);
 
-	if (
-		!session.account.idTokenClaims.groups.includes(config.referenceData.appeals.caseOfficerGroupId)
-	) {
+	if (!userHasPermission(permissionNames.viewCaseDetails, session)) {
 		removeAccordionComponentsActions(accordionComponents);
 	}
 


### PR DESCRIPTION
The appeal detail mapper was fixing some of the action links to case officers only.
Now, it uses the correct permission set.

## Issue ticket number and link

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [ ] I have performed a self-review of my own code
- [ ] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [ ] I have referenced the ticket number above
- [ ] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
