### PR TITLE
fix(appeals): inspector perms reset A2-1279

### DIFF
--- a/appeals/web/environment/permissions.js
+++ b/appeals/web/environment/permissions.js
@@ -26,9 +26,9 @@ export const calculatePermissions = (currentUserGroups) => {
 		viewCaseList: !isPads,
 		viewCaseDetails: !isPads,
 		viewAssignedCaseDetails: isPads,
-		updateStage: isCaseOfficer,
-		updateCase: isCaseOfficer,
-		setStageOutcome: isCaseOfficer,
+		updateStage: isCaseOfficer || isInspector,
+		updateCase: isCaseOfficer || isInspector,
+		setStageOutcome: isCaseOfficer || isInspector,
 		setCaseOutcome: isCaseOfficer || isInspector,
 		setEvents: isCaseOfficer || isInspector
 	};

--- a/appeals/web/src/server/app/auth/auth.router.js
+++ b/appeals/web/src/server/app/auth/auth.router.js
@@ -29,7 +29,7 @@ const allowedGroups = config.referenceData.appeals;
 router
 	.route('/auth/get-access-token')
 	.get(
-		assertGroupAccess(allowedGroups.caseOfficerGroupId),
+		assertGroupAccess(allowedGroups.caseOfficerGroupId, allowedGroups.inspectorGroupId),
 		addApiClientToRequest,
 		asyncHandler(getAccessToken)
 	);

--- a/appeals/web/src/server/appeals/appeal-details/appellant-case/appellant-case.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/appellant-case/appellant-case.mapper.js
@@ -170,7 +170,10 @@ export async function appellantCasePage(appellantCaseData, appealDetails, curren
 	};
 
 	if (
-		!session.account.idTokenClaims.groups.includes(config.referenceData.appeals.caseOfficerGroupId)
+		!session.account.idTokenClaims.groups.includes(
+			config.referenceData.appeals.caseOfficerGroupId,
+			config.referenceData.appeals.inspectorGroupId
+		)
 	) {
 		pageContent.pageComponents?.forEach((component) => {
 			if ('rows' in component.parameters && Array.isArray(component.parameters.rows)) {
@@ -397,7 +400,10 @@ export function checkAndConfirmPage(
 	};
 
 	if (
-		!session.account.idTokenClaims.groups.includes(config.referenceData.appeals.caseOfficerGroupId)
+		!session.account.idTokenClaims.groups.includes(
+			config.referenceData.appeals.caseOfficerGroupId,
+			config.referenceData.appeals.inspectorGroupId
+		)
 	) {
 		pageContent.pageComponents?.forEach((component) => {
 			if ('rows' in component.parameters && Array.isArray(component.parameters.rows)) {

--- a/appeals/web/src/server/appeals/appeal-details/appellant-case/appellant-case.router.js
+++ b/appeals/web/src/server/appeals/appeal-details/appellant-case/appellant-case.router.js
@@ -184,7 +184,10 @@ router
 		validateAppeal,
 		assertUserHasPermission(permissionNames.updateCase),
 		validators.validateReviewOutcome,
-		assertGroupAccess(config.referenceData.appeals.caseOfficerGroupId),
+		assertGroupAccess(
+			config.referenceData.appeals.caseOfficerGroupId,
+			config.referenceData.appeals.inspectorGroupId
+		),
 		asyncHandler(controller.postAppellantCase)
 	);
 
@@ -198,7 +201,10 @@ router
 	.post(
 		validateAppeal,
 		assertUserHasPermission(permissionNames.updateCase),
-		assertGroupAccess(config.referenceData.appeals.caseOfficerGroupId),
+		assertGroupAccess(
+			config.referenceData.appeals.caseOfficerGroupId,
+			config.referenceData.appeals.inspectorGroupId
+		),
 		asyncHandler(controller.postCheckAndConfirm)
 	);
 
@@ -266,7 +272,10 @@ router
 		documentsValidators.validateDocumentDetailsReceivedDateValid,
 		documentsValidators.validateDocumentDetailsReceivedDateIsNotFutureDate,
 		documentsValidators.validateDocumentDetailsRedactionStatuses,
-		assertGroupAccess(config.referenceData.appeals.caseOfficerGroupId),
+		assertGroupAccess(
+			config.referenceData.appeals.caseOfficerGroupId,
+			config.referenceData.appeals.inspectorGroupId
+		),
 		asyncHandler(controller.postAddDocumentDetails)
 	);
 
@@ -287,7 +296,10 @@ router
 		documentsValidators.validateDocumentDetailsReceivedDateValid,
 		documentsValidators.validateDocumentDetailsReceivedDateIsNotFutureDate,
 		documentsValidators.validateDocumentDetailsRedactionStatuses,
-		assertGroupAccess(config.referenceData.appeals.caseOfficerGroupId),
+		assertGroupAccess(
+			config.referenceData.appeals.caseOfficerGroupId,
+			config.referenceData.appeals.inspectorGroupId
+		),
 		asyncHandler(controller.postDocumentVersionDetails)
 	);
 
@@ -326,7 +338,10 @@ router
 		documentsValidators.validateDocumentDetailsReceivedDateValid,
 		documentsValidators.validateDocumentDetailsReceivedDateIsNotFutureDate,
 		documentsValidators.validateDocumentDetailsRedactionStatuses,
-		assertGroupAccess(config.referenceData.appeals.caseOfficerGroupId),
+		assertGroupAccess(
+			config.referenceData.appeals.caseOfficerGroupId,
+			config.referenceData.appeals.inspectorGroupId
+		),
 		asyncHandler(controller.postChangeDocumentVersionDetails)
 	);
 

--- a/appeals/web/src/server/appeals/appeal-details/assign-user/assign-user.router.js
+++ b/appeals/web/src/server/appeals/appeal-details/assign-user/assign-user.router.js
@@ -11,7 +11,10 @@ assignUserRouter
 	.route('/case-officer')
 	.get(asyncHandler(controller.getAssignCaseOfficer))
 	.post(
-		assertGroupAccess(config.referenceData.appeals.caseOfficerGroupId),
+		assertGroupAccess(
+			config.referenceData.appeals.caseOfficerGroupId,
+			config.referenceData.appeals.inspectorGroupId
+		),
 		validators.validateSearchTerm,
 		asyncHandler(controller.postAssignCaseOfficer)
 	);
@@ -20,7 +23,10 @@ assignUserRouter
 	.route('/inspector')
 	.get(asyncHandler(controller.getAssignInspector))
 	.post(
-		assertGroupAccess(config.referenceData.appeals.caseOfficerGroupId),
+		assertGroupAccess(
+			config.referenceData.appeals.caseOfficerGroupId,
+			config.referenceData.appeals.inspectorGroupId
+		),
 		validators.validateSearchTerm,
 		asyncHandler(controller.postAssignInspector)
 	);
@@ -29,7 +35,10 @@ assignUserRouter
 	.route('/case-officer/:assigneeId/confirm')
 	.get(asyncHandler(controller.getAssignCaseOfficerCheckAndConfirm))
 	.post(
-		assertGroupAccess(config.referenceData.appeals.caseOfficerGroupId),
+		assertGroupAccess(
+			config.referenceData.appeals.caseOfficerGroupId,
+			config.referenceData.appeals.inspectorGroupId
+		),
 		validators.validatePostConfirmation(),
 		asyncHandler(controller.postAssignCaseOfficerCheckAndConfirm)
 	);
@@ -38,7 +47,10 @@ assignUserRouter
 	.route('/inspector/:assigneeId/confirm')
 	.get(asyncHandler(controller.getAssignInspectorCheckAndConfirm))
 	.post(
-		assertGroupAccess(config.referenceData.appeals.caseOfficerGroupId),
+		assertGroupAccess(
+			config.referenceData.appeals.caseOfficerGroupId,
+			config.referenceData.appeals.inspectorGroupId
+		),
 		validators.validatePostConfirmation(false, true),
 		asyncHandler(controller.postAssignInspectorCheckAndConfirm)
 	);
@@ -49,7 +61,10 @@ unassignUserRouter
 	.route('/inspector/:assigneeId/confirm')
 	.get(asyncHandler(controller.getUnassignInspectorCheckAndConfirm))
 	.post(
-		assertGroupAccess(config.referenceData.appeals.caseOfficerGroupId),
+		assertGroupAccess(
+			config.referenceData.appeals.caseOfficerGroupId,
+			config.referenceData.appeals.inspectorGroupId
+		),
 		validators.validatePostConfirmation(true, true),
 		asyncHandler(controller.postUnassignInspectorCheckAndConfirm)
 	);
@@ -60,7 +75,10 @@ assignNewUserRouter
 	.route('/case-officer')
 	.get(asyncHandler(controller.getAssignNewCaseOfficer))
 	.post(
-		assertGroupAccess(config.referenceData.appeals.caseOfficerGroupId),
+		assertGroupAccess(
+			config.referenceData.appeals.caseOfficerGroupId,
+			config.referenceData.appeals.inspectorGroupId
+		),
 		validators.validateNewUserPostConfirmation(),
 		asyncHandler(controller.postAssignNewCaseOfficer)
 	);
@@ -69,7 +87,10 @@ assignNewUserRouter
 	.route('/inspector')
 	.get(asyncHandler(controller.getAssignNewInspector))
 	.post(
-		assertGroupAccess(config.referenceData.appeals.caseOfficerGroupId),
+		assertGroupAccess(
+			config.referenceData.appeals.caseOfficerGroupId,
+			config.referenceData.appeals.inspectorGroupId
+		),
 		validators.validateNewUserPostConfirmation(true),
 		asyncHandler(controller.postAssignNewInspector)
 	);

--- a/appeals/web/src/server/appeals/appeal-details/costs/costs.router.js
+++ b/appeals/web/src/server/appeals/appeal-details/costs/costs.router.js
@@ -47,7 +47,10 @@ router
 		documentsValidators.validateDocumentDetailsReceivedDateValid,
 		documentsValidators.validateDocumentDetailsReceivedDateIsNotFutureDate,
 		documentsValidators.validateDocumentDetailsRedactionStatuses,
-		assertGroupAccess(config.referenceData.appeals.caseOfficerGroupId),
+		assertGroupAccess(
+			config.referenceData.appeals.caseOfficerGroupId,
+			config.referenceData.appeals.inspectorGroupId
+		),
 		asyncHandler(controller.postAddDocumentDetails)
 	);
 
@@ -128,7 +131,10 @@ router
 		documentsValidators.validateDocumentDetailsReceivedDateValid,
 		documentsValidators.validateDocumentDetailsReceivedDateIsNotFutureDate,
 		documentsValidators.validateDocumentDetailsRedactionStatuses,
-		assertGroupAccess(config.referenceData.appeals.caseOfficerGroupId),
+		assertGroupAccess(
+			config.referenceData.appeals.caseOfficerGroupId,
+			config.referenceData.appeals.inspectorGroupId
+		),
 		asyncHandler(controller.postChangeDocumentVersionDetails)
 	);
 

--- a/appeals/web/src/server/appeals/appeal-details/internal-correspondence/internal-correspondence.router.js
+++ b/appeals/web/src/server/appeals/appeal-details/internal-correspondence/internal-correspondence.router.js
@@ -38,7 +38,10 @@ router
 		documentsValidators.validateDocumentDetailsReceivedDateValid,
 		documentsValidators.validateDocumentDetailsReceivedDateIsNotFutureDate,
 		documentsValidators.validateDocumentDetailsRedactionStatuses,
-		assertGroupAccess(config.referenceData.appeals.caseOfficerGroupId),
+		assertGroupAccess(
+			config.referenceData.appeals.caseOfficerGroupId,
+			config.referenceData.appeals.inspectorGroupId
+		),
 		asyncHandler(controller.postAddDocumentDetails)
 	);
 
@@ -93,7 +96,10 @@ router
 		documentsValidators.validateDocumentDetailsReceivedDateValid,
 		documentsValidators.validateDocumentDetailsReceivedDateIsNotFutureDate,
 		documentsValidators.validateDocumentDetailsRedactionStatuses,
-		assertGroupAccess(config.referenceData.appeals.caseOfficerGroupId),
+		assertGroupAccess(
+			config.referenceData.appeals.caseOfficerGroupId,
+			config.referenceData.appeals.inspectorGroupId
+		),
 		asyncHandler(controller.postChangeDocumentVersionDetails)
 	);
 

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/lpa-questionnaire.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/lpa-questionnaire.mapper.js
@@ -186,7 +186,10 @@ export async function lpaQuestionnairePage(lpaqDetails, appealDetails, currentRo
 	};
 
 	if (
-		!session.account.idTokenClaims.groups.includes(config.referenceData.appeals.caseOfficerGroupId)
+		!session.account.idTokenClaims.groups.includes(
+			config.referenceData.appeals.caseOfficerGroupId,
+			config.referenceData.appeals.inspectorGroupId
+		)
 	) {
 		pageContent.pageComponents?.forEach((component) => {
 			if ('rows' in component.parameters && Array.isArray(component.parameters.rows)) {
@@ -404,7 +407,10 @@ export function checkAndConfirmPage(
 	};
 
 	if (
-		!session.account.idTokenClaims.groups.includes(config.referenceData.appeals.caseOfficerGroupId)
+		!session.account.idTokenClaims.groups.includes(
+			config.referenceData.appeals.caseOfficerGroupId,
+			config.referenceData.appeals.inspectorGroupId
+		)
 	) {
 		pageContent.pageComponents?.forEach((component) => {
 			if ('rows' in component.parameters && Array.isArray(component.parameters.rows)) {

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/lpa-questionnaire.router.js
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/lpa-questionnaire.router.js
@@ -105,7 +105,10 @@ router
 		validateAppeal,
 		assertUserHasPermission(permissionNames.updateCase),
 		validators.validateReviewOutcome,
-		assertGroupAccess(config.referenceData.appeals.caseOfficerGroupId),
+		assertGroupAccess(
+			config.referenceData.appeals.caseOfficerGroupId,
+			config.referenceData.appeals.inspectorGroupId
+		),
 		asyncHandler(controller.postLpaQuestionnaire)
 	);
 router
@@ -118,7 +121,10 @@ router
 	.post(
 		validateAppeal,
 		assertUserHasPermission(permissionNames.updateCase),
-		assertGroupAccess(config.referenceData.appeals.caseOfficerGroupId),
+		assertGroupAccess(
+			config.referenceData.appeals.caseOfficerGroupId,
+			config.referenceData.appeals.inspectorGroupId
+		),
 		asyncHandler(controller.postCheckAndConfirm)
 	);
 
@@ -195,7 +201,10 @@ router
 		documentsValidators.validateDocumentDetailsReceivedDateValid,
 		documentsValidators.validateDocumentDetailsReceivedDateIsNotFutureDate,
 		documentsValidators.validateDocumentDetailsRedactionStatuses,
-		assertGroupAccess(config.referenceData.appeals.caseOfficerGroupId),
+		assertGroupAccess(
+			config.referenceData.appeals.caseOfficerGroupId,
+			config.referenceData.appeals.inspectorGroupId
+		),
 		asyncHandler(controller.postAddDocumentDetails)
 	);
 
@@ -216,7 +225,10 @@ router
 		documentsValidators.validateDocumentDetailsReceivedDateValid,
 		documentsValidators.validateDocumentDetailsReceivedDateIsNotFutureDate,
 		documentsValidators.validateDocumentDetailsRedactionStatuses,
-		assertGroupAccess(config.referenceData.appeals.caseOfficerGroupId),
+		assertGroupAccess(
+			config.referenceData.appeals.caseOfficerGroupId,
+			config.referenceData.appeals.inspectorGroupId
+		),
 		asyncHandler(controller.postDocumentVersionDetails)
 	);
 
@@ -262,7 +274,10 @@ router
 		documentsValidators.validateDocumentDetailsReceivedDateValid,
 		documentsValidators.validateDocumentDetailsReceivedDateIsNotFutureDate,
 		documentsValidators.validateDocumentDetailsRedactionStatuses,
-		assertGroupAccess(config.referenceData.appeals.caseOfficerGroupId),
+		assertGroupAccess(
+			config.referenceData.appeals.caseOfficerGroupId,
+			config.referenceData.appeals.inspectorGroupId
+		),
 		asyncHandler(controller.postChangeDocumentVersionDetails)
 	);
 

--- a/appeals/web/src/server/appeals/appeal-details/site-visit/site-visit.router.js
+++ b/appeals/web/src/server/appeals/appeal-details/site-visit/site-visit.router.js
@@ -11,7 +11,10 @@ router
 	.route('/schedule-visit')
 	.get(asyncHandler(controller.getScheduleSiteVisit))
 	.post(
-		assertGroupAccess(config.referenceData.appeals.caseOfficerGroupId),
+		assertGroupAccess(
+			config.referenceData.appeals.caseOfficerGroupId,
+			config.referenceData.appeals.inspectorGroupId
+		),
 		validators.validateSiteVisitType,
 		validators.validateVisitDateFields,
 		validators.validateVisitDateValid,
@@ -26,7 +29,10 @@ router
 	.route('/manage-visit')
 	.get(asyncHandler(controller.getManageSiteVisit))
 	.post(
-		assertGroupAccess(config.referenceData.appeals.caseOfficerGroupId),
+		assertGroupAccess(
+			config.referenceData.appeals.caseOfficerGroupId,
+			config.referenceData.appeals.inspectorGroupId
+		),
 		validators.validateSiteVisitType,
 		validators.validateVisitDateFields,
 		validators.validateVisitDateValid,
@@ -45,7 +51,10 @@ router
 	.route('/set-visit-type')
 	.get(asyncHandler(controller.getSetVisitType))
 	.post(
-		assertGroupAccess(config.referenceData.appeals.caseOfficerGroupId),
+		assertGroupAccess(
+			config.referenceData.appeals.caseOfficerGroupId,
+			config.referenceData.appeals.inspectorGroupId
+		),
 		validators.validateSiteVisitType,
 		asyncHandler(controller.postSetVisitType)
 	);

--- a/appeals/web/src/server/appeals/personal-list/personal-list.mapper.js
+++ b/appeals/web/src/server/appeals/personal-list/personal-list.mapper.js
@@ -209,7 +209,10 @@ export function personalListPage(
 	}
 
 	if (
-		!session.account.idTokenClaims.groups.includes(config.referenceData.appeals.caseOfficerGroupId)
+		!session.account.idTokenClaims.groups.includes(
+			config.referenceData.appeals.caseOfficerGroupId,
+			config.referenceData.appeals.inspectorGroupId
+		)
 	) {
 		pageContent.pageComponents?.forEach((component) => {
 			if (


### PR DESCRIPTION
Aligns permissions between inspectors and case officers

## Issue ticket number and link

A2-1279

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [ ] I have performed a self-review of my own code
- [ ] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [ ] I have referenced the ticket number above
- [ ] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
