### PR TITLE
fix(appeals): handle case notes empty string without 500 error

### DIFF
--- a/appeals/api/src/database/seed/seed-clear.js
+++ b/appeals/api/src/database/seed/seed-clear.js
@@ -13,6 +13,7 @@ export async function deleteAllRecords(databaseConnector) {
 	const deleteAudits = databaseConnector.auditTrail.deleteMany();
 	const deleteFolders = databaseConnector.folder.deleteMany();
 	const deleteAppeals = databaseConnector.appeal.deleteMany();
+	const deleteCaseNotes = databaseConnector.caseNote.deleteMany();
 	const deleteUsers = databaseConnector.user.deleteMany();
 	const deleteAddresses = databaseConnector.address.deleteMany();
 	const deleteAppellantCase = databaseConnector.appellantCase.deleteMany();
@@ -83,6 +84,7 @@ export async function deleteAllRecords(databaseConnector) {
 		deleteRepsAttachments,
 		deleteReps,
 		deleteAudits,
+		deleteCaseNotes,
 		deleteUsers,
 		deleteAppealAllocationLevels,
 		deleteAppealSpecialisms,

--- a/appeals/web/src/server/appeals/appeal-details/__tests__/appeal-details.test.js
+++ b/appeals/web/src/server/appeals/appeal-details/__tests__/appeal-details.test.js
@@ -1164,6 +1164,34 @@ describe('appeal-details', () => {
 				expect(element).toContain('3 case notes');
 				expect(element).toContain('This is a new comment</p>');
 			});
+			it('should not submit and  re-render case details with an error if the string is empty', async () => {
+				nock.cleanAll();
+				const appealId = appealData.appealId.toString();
+				const caseNotesResponse = [...caseNotes];
+				const comment = '';
+				nock('http://test/').get(`/appeals/${appealId}`).reply(200, appealData).persist();
+				nock('http://test/')
+					.get(`/appeals/${appealId}/case-notes`)
+					.reply(200, caseNotesResponse)
+					.persist();
+
+				const submitRequest = nock('http://test/')
+					.post(`/appeals/${appealId}/case-notes`)
+					.reply(200, {});
+				await request.get(`${baseUrl}/${appealId}`);
+
+				const response = await request.post(`${baseUrl}/${appealId}`).send({ comment: comment });
+				expect(response.statusCode).toBe(200);
+
+				const pageElements = parseHtml(response.text, { skipPrettyPrint: true }).innerHTML;
+				const element = parseHtml(response.text, {
+					skipPrettyPrint: true,
+					rootElement: '.govuk-details'
+				}).innerHTML;
+				expect(pageElements).toContain('error-summary');
+				expect(element).toContain('2 case notes');
+				expect(submitRequest.isDone()).toBe(false);
+			});
 			it('should redirect to 500 page if it fails to post', async () => {
 				nock.cleanAll();
 				const appealId = appealData.appealId;

--- a/appeals/web/src/server/appeals/appeal-details/appeal-details.controller.js
+++ b/appeals/web/src/server/appeals/appeal-details/appeal-details.controller.js
@@ -11,6 +11,7 @@ import { APPEAL_REPRESENTATION_STATUS, APPEAL_TYPE } from '@pins/appeals/constan
 export const viewAppealDetails = async (request, response) => {
 	const appealDetails = request.currentAppeal;
 	const session = request.session;
+	const { errors } = request;
 	try {
 		if (appealDetails) {
 			let unreviewedIPComments;
@@ -38,7 +39,8 @@ export const viewAppealDetails = async (request, response) => {
 			);
 
 			return response.status(200).render('patterns/display-page.pattern.njk', {
-				pageContent: mappedPageContent
+				pageContent: mappedPageContent,
+				errors
 			});
 		} else {
 			return response.status(404).render('app/404.njk');

--- a/appeals/web/src/server/appeals/appeal-details/appeal-details.router.js
+++ b/appeals/web/src/server/appeals/appeal-details/appeal-details.router.js
@@ -45,7 +45,7 @@ router
 		),
 		asyncHandler(controller.viewAppealDetails)
 	)
-	.post(validateCaseNoteEntry, asyncHandler(postCaseNote));
+	.post(validateAppeal, validateCaseNoteEntry, asyncHandler(postCaseNote));
 
 router.use(
 	'/:appealId/start-case',

--- a/appeals/web/src/server/appeals/appeal-details/case-notes/case-notes.controller.js
+++ b/appeals/web/src/server/appeals/appeal-details/case-notes/case-notes.controller.js
@@ -1,5 +1,6 @@
 import { getOriginPathname } from '#lib/url-utilities.js';
 import { postAppealCaseNote } from './case-notes.service.js';
+import { viewAppealDetails } from '#appeals/appeal-details/appeal-details.controller.js';
 
 /**
  *
@@ -7,6 +8,9 @@ import { postAppealCaseNote } from './case-notes.service.js';
  * @param {import('@pins/express/types/express.js').RenderedResponse<any, any, Number>} response
  */
 export const postCaseNote = async (request, response) => {
+	if (request.errors) {
+		return viewAppealDetails(request, response);
+	}
 	const { appealId } = request.params;
 	const comment = request.body['comment'];
 	const currentUrl = getOriginPathname(request);


### PR DESCRIPTION
## Describe your changes

<!--
    Please include a summary of the change along with any relevant context.
    List any dependencies that are required for this change.
-->

## Issue ticket number and link
Empty case note submission now gives error message instead of 500 error page
## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [x] I have made corresponding changes to the documentation
- [x] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [x] I have included unit tests to cover any testable code changes
