### PR TITLE
feat(appeals): add s78 lpaq rows for environmental impact assessment boolean fields

### DIFF
--- a/appeals/api/src/database/seed/data-samples.js
+++ b/appeals/api/src/database/seed/data-samples.js
@@ -187,34 +187,45 @@ export const addressListForTrainers = addressesList.map((address) => ({
 
 /**
  * An array of objects representing LPA questionnaire lists.
- * @type {Object<string, import('#db-client').Prisma.LPAQuestionnaireCreateWithoutAppealInput>}
+ * @param {string} appealTypeShorthand
+ * @returns {import('#db-client').Prisma.LPAQuestionnaireCreateWithoutAppealInput | undefined}
  */
-export const lpaQuestionnaireList = {
-	[APPEAL_TYPE_SHORTHAND_HAS]: {
-		siteSafetyDetails: 'There may be no mobile reception at the site',
-		siteAccessDetails: 'There is a tall hedge around the site which obstructs the view of the site',
-		inConservationArea: true,
-		isCorrectAppealType: true,
-		lpaStatement: null,
-		newConditionDetails: null,
-		lpaCostsAppliedFor: false,
-		lpaqCreatedDate: new Date(2023, 4, 9),
-		lpaQuestionnaireSubmittedDate: new Date(2023, 4, 9),
-		isGreenBelt: randomBool()
-	},
-	[APPEAL_TYPE_SHORTHAND_FPA]: {
-		siteSafetyDetails: 'There may be no mobile reception at the site',
-		siteAccessDetails: 'There is a tall hedge around the site which obstructs the view of the site',
-		inConservationArea: true,
-		isCorrectAppealType: true,
-		lpaStatement: null,
-		newConditionDetails: null,
-		lpaCostsAppliedFor: false,
-		lpaqCreatedDate: new Date(2023, 4, 9),
-		lpaQuestionnaireSubmittedDate: new Date(2023, 4, 9),
-		isGreenBelt: randomBool()
+export function createLPAQuestionnaireForAppealType(appealTypeShorthand) {
+	switch (appealTypeShorthand) {
+		case APPEAL_TYPE_SHORTHAND_HAS:
+			return {
+				siteSafetyDetails: 'There may be no mobile reception at the site',
+				siteAccessDetails:
+					'There is a tall hedge around the site which obstructs the view of the site',
+				inConservationArea: true,
+				isCorrectAppealType: true,
+				lpaStatement: null,
+				newConditionDetails: null,
+				lpaCostsAppliedFor: false,
+				lpaqCreatedDate: new Date(2023, 4, 9),
+				lpaQuestionnaireSubmittedDate: new Date(2023, 4, 9),
+				isGreenBelt: randomBool()
+			};
+		case APPEAL_TYPE_SHORTHAND_FPA:
+			return {
+				siteSafetyDetails: 'There may be no mobile reception at the site',
+				siteAccessDetails:
+					'There is a tall hedge around the site which obstructs the view of the site',
+				inConservationArea: true,
+				isCorrectAppealType: true,
+				lpaStatement: null,
+				newConditionDetails: null,
+				lpaCostsAppliedFor: false,
+				lpaqCreatedDate: new Date(2023, 4, 9),
+				lpaQuestionnaireSubmittedDate: new Date(2023, 4, 9),
+				isGreenBelt: randomBool(),
+				eiaColumnTwoThreshold: randomBool(),
+				eiaRequiresEnvironmentalStatement: randomBool()
+			};
+		default:
+			return;
 	}
-};
+}
 
 /**
  * Sample incomplete review questionnaire data.

--- a/appeals/api/src/database/seed/data-test.js
+++ b/appeals/api/src/database/seed/data-test.js
@@ -9,7 +9,7 @@ import {
 	getRandomisedAppellantCaseCreateInput,
 	appellantsList,
 	agentsList,
-	lpaQuestionnaireList
+	createLPAQuestionnaireForAppealType
 } from './data-samples.js';
 import { localPlanningDepartmentList } from './LPAs/dev.js';
 import { calculateTimetable } from '#utils/business-days.js';
@@ -125,7 +125,9 @@ const appealFactory = ({
 				}
 			}
 		}),
-		...(lpaQuestionnaire && { lpaQuestionnaire: { create: lpaQuestionnaireList[typeShorthand] } })
+		...(lpaQuestionnaire && {
+			lpaQuestionnaire: { create: createLPAQuestionnaireForAppealType(typeShorthand) }
+		})
 	};
 
 	return appeal;
@@ -262,12 +264,14 @@ const newS78Appeals = [
 	appealFactory({
 		typeShorthand: APPEAL_TYPE_SHORTHAND_FPA,
 		status: { status: APPEAL_CASE_STATUS.VALIDATION, createdAt: getDateTwoWeeksAgo() },
+		lpaQuestionnaire: true,
 		assignCaseOfficer: true,
 		agent: false
 	}),
 	appealFactory({
 		typeShorthand: APPEAL_TYPE_SHORTHAND_FPA,
 		status: { status: APPEAL_CASE_STATUS.VALIDATION, createdAt: getDateTwoWeeksAgo() },
+		lpaQuestionnaire: true,
 		assignCaseOfficer: true,
 		agent: false
 	}),

--- a/appeals/api/src/server/endpoints/appeals.d.ts
+++ b/appeals/api/src/server/endpoints/appeals.d.ts
@@ -310,6 +310,8 @@ interface SingleLPAQuestionnaireResponse {
 	extraConditions?: string | null;
 	hasExtraConditions?: boolean | null;
 	affectsScheduledMonument?: boolean | null;
+	eiaColumnTwoThreshold?: boolean | null;
+	eiaRequiresEnvironmentalStatement?: boolean | null;
 }
 
 interface UpdateLPAQuestionnaireRequest {
@@ -326,6 +328,8 @@ interface UpdateLPAQuestionnaireRequest {
 	validationOutcomeId?: number;
 	lpaNotificationMethods?: LPANotificationMethodsSelectedUncheckedUpdateManyWithoutLpaQuestionnaireNestedInput;
 	isAffectingNeighbouringSites?: boolean;
+	eiaColumnTwoThreshold?: boolean;
+	eiaRequiresEnvironmentalStatement?: boolean;
 }
 
 interface UpdateLPAQuestionnaireValidationOutcomeParams {

--- a/appeals/api/src/server/endpoints/lpa-questionnaires/lpa-questionnaires.controller.js
+++ b/appeals/api/src/server/endpoints/lpa-questionnaires/lpa-questionnaires.controller.js
@@ -45,7 +45,9 @@ const updateLPAQuestionnaireById = async (req, res) => {
 			isCorrectAppealType,
 			isGreenBelt,
 			lpaNotificationMethods,
-			isAffectingNeighbouringSites
+			isAffectingNeighbouringSites,
+			eiaColumnTwoThreshold,
+			eiaRequiresEnvironmentalStatement
 		},
 		params,
 		validationOutcome
@@ -80,7 +82,9 @@ const updateLPAQuestionnaireById = async (req, res) => {
 					isConservationArea,
 					isCorrectAppealType,
 					lpaNotificationMethods,
-					isAffectingNeighbouringSites
+					isAffectingNeighbouringSites,
+					eiaColumnTwoThreshold,
+					eiaRequiresEnvironmentalStatement
 			  });
 
 		const updatedProperties = Object.keys(body).filter((key) => body[key] !== undefined);

--- a/appeals/api/src/server/endpoints/lpa-questionnaires/lpa-questionnaires.formatter.js
+++ b/appeals/api/src/server/endpoints/lpa-questionnaires/lpa-questionnaires.formatter.js
@@ -65,7 +65,9 @@ const formatLpaQuestionnaire = (appeal, folders = null) => {
 			lpaStatement: lpaQuestionnaire.lpaStatement,
 			extraConditions: lpaQuestionnaire.newConditionDetails,
 			hasExtraConditions: lpaQuestionnaire.newConditionDetails !== null,
-			affectsSheduledMonument: lpaQuestionnaire.affectsScheduledMonument
+			affectsSheduledMonument: lpaQuestionnaire.affectsScheduledMonument,
+			eiaColumnTwoThreshold: lpaQuestionnaire.eiaColumnTwoThreshold,
+			eiaRequiresEnvironmentalStatement: lpaQuestionnaire.eiaRequiresEnvironmentalStatement
 		};
 	} else {
 		return {};

--- a/appeals/api/src/server/repositories/lpa-questionnaire.repository.js
+++ b/appeals/api/src/server/repositories/lpa-questionnaire.repository.js
@@ -34,7 +34,9 @@ const updateLPAQuestionnaireById = (id, data) => {
 				inConservationArea: data.isConservationArea,
 				isCorrectAppealType: data.isCorrectAppealType,
 				lpaNotificationMethods: processNotificationMethods(id, data, transaction),
-				isAffectingNeighbouringSites: data.isAffectingNeighbouringSites
+				isAffectingNeighbouringSites: data.isAffectingNeighbouringSites,
+				eiaColumnTwoThreshold: data.eiaColumnTwoThreshold,
+				eiaRequiresEnvironmentalStatement: data.eiaRequiresEnvironmentalStatement
 			}
 		})
 	);

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/__tests__/__snapshots__/lpa-questionnaire.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/__tests__/__snapshots__/lpa-questionnaire.test.js.snap
@@ -78,7 +78,15 @@ exports[`LPA Questionnaire review GET / should render review outcome form fields
     </div>
     <div class="govuk-summary-card">
         <div class="govuk-summary-card__title-wrapper">
-            <h2 class="govuk-summary-card__title">2. Notifying relevant parties of the application</h2>
+            <h2 class="govuk-summary-card__title">2. Environmental impact assessment</h2>
+        </div>
+        <div class="govuk-summary-card__content">
+            <dl class="govuk-summary-list"></dl>
+        </div>
+    </div>
+    <div class="govuk-summary-card">
+        <div class="govuk-summary-card__title-wrapper">
+            <h2 class="govuk-summary-card__title">3. Notifying relevant parties of the application</h2>
         </div>
         <div class="govuk-summary-card__content">
             <dl class="govuk-summary-list">
@@ -131,7 +139,7 @@ exports[`LPA Questionnaire review GET / should render review outcome form fields
     </div>
     <div class="govuk-summary-card">
         <div class="govuk-summary-card__title-wrapper">
-            <h2 class="govuk-summary-card__title">3. Consultation responses and representations</h2>
+            <h2 class="govuk-summary-card__title">4. Consultation responses and representations</h2>
         </div>
         <div class="govuk-summary-card__content">
             <dl class="govuk-summary-list">
@@ -158,7 +166,7 @@ exports[`LPA Questionnaire review GET / should render review outcome form fields
     </div>
     <div class="govuk-summary-card">
         <div class="govuk-summary-card__title-wrapper">
-            <h2 class="govuk-summary-card__title">4. Planning officer’s report and supplementary documents</h2>
+            <h2 class="govuk-summary-card__title">5. Planning officer’s report and supplementary documents</h2>
         </div>
         <div class="govuk-summary-card__content">
             <dl class="govuk-summary-list">
@@ -195,7 +203,7 @@ exports[`LPA Questionnaire review GET / should render review outcome form fields
     </div>
     <div class="govuk-summary-card">
         <div class="govuk-summary-card__title-wrapper">
-            <h2 class="govuk-summary-card__title">5. Site access</h2>
+            <h2 class="govuk-summary-card__title">6. Site access</h2>
         </div>
         <div class="govuk-summary-card__content">
             <dl class="govuk-summary-list">
@@ -236,7 +244,7 @@ exports[`LPA Questionnaire review GET / should render review outcome form fields
     </div>
     <div class="govuk-summary-card">
         <div class="govuk-summary-card__title-wrapper">
-            <h2 class="govuk-summary-card__title">6. Appeal process</h2>
+            <h2 class="govuk-summary-card__title">7. Appeal process</h2>
         </div>
         <div class="govuk-summary-card__content">
             <dl class="govuk-summary-list">
@@ -400,7 +408,15 @@ exports[`LPA Questionnaire review GET / should render the LPA Questionnaire page
     </div>
     <div class="govuk-summary-card">
         <div class="govuk-summary-card__title-wrapper">
-            <h2 class="govuk-summary-card__title">2. Notifying relevant parties of the application</h2>
+            <h2 class="govuk-summary-card__title">2. Environmental impact assessment</h2>
+        </div>
+        <div class="govuk-summary-card__content">
+            <dl class="govuk-summary-list"></dl>
+        </div>
+    </div>
+    <div class="govuk-summary-card">
+        <div class="govuk-summary-card__title-wrapper">
+            <h2 class="govuk-summary-card__title">3. Notifying relevant parties of the application</h2>
         </div>
         <div class="govuk-summary-card__content">
             <dl class="govuk-summary-list">
@@ -453,7 +469,7 @@ exports[`LPA Questionnaire review GET / should render the LPA Questionnaire page
     </div>
     <div class="govuk-summary-card">
         <div class="govuk-summary-card__title-wrapper">
-            <h2 class="govuk-summary-card__title">3. Consultation responses and representations</h2>
+            <h2 class="govuk-summary-card__title">4. Consultation responses and representations</h2>
         </div>
         <div class="govuk-summary-card__content">
             <dl class="govuk-summary-list">
@@ -480,7 +496,7 @@ exports[`LPA Questionnaire review GET / should render the LPA Questionnaire page
     </div>
     <div class="govuk-summary-card">
         <div class="govuk-summary-card__title-wrapper">
-            <h2 class="govuk-summary-card__title">4. Planning officer’s report and supplementary documents</h2>
+            <h2 class="govuk-summary-card__title">5. Planning officer’s report and supplementary documents</h2>
         </div>
         <div class="govuk-summary-card__content">
             <dl class="govuk-summary-list">
@@ -517,7 +533,7 @@ exports[`LPA Questionnaire review GET / should render the LPA Questionnaire page
     </div>
     <div class="govuk-summary-card">
         <div class="govuk-summary-card__title-wrapper">
-            <h2 class="govuk-summary-card__title">5. Site access</h2>
+            <h2 class="govuk-summary-card__title">6. Site access</h2>
         </div>
         <div class="govuk-summary-card__content">
             <dl class="govuk-summary-list">
@@ -558,7 +574,7 @@ exports[`LPA Questionnaire review GET / should render the LPA Questionnaire page
     </div>
     <div class="govuk-summary-card">
         <div class="govuk-summary-card__title-wrapper">
-            <h2 class="govuk-summary-card__title">6. Appeal process</h2>
+            <h2 class="govuk-summary-card__title">7. Appeal process</h2>
         </div>
         <div class="govuk-summary-card__content">
             <dl class="govuk-summary-list">
@@ -757,7 +773,15 @@ exports[`LPA Questionnaire review GET / with unchecked documents should render a
     </div>
     <div class="govuk-summary-card">
         <div class="govuk-summary-card__title-wrapper">
-            <h2 class="govuk-summary-card__title">2. Notifying relevant parties of the application</h2>
+            <h2 class="govuk-summary-card__title">2. Environmental impact assessment</h2>
+        </div>
+        <div class="govuk-summary-card__content">
+            <dl class="govuk-summary-list"></dl>
+        </div>
+    </div>
+    <div class="govuk-summary-card">
+        <div class="govuk-summary-card__title-wrapper">
+            <h2 class="govuk-summary-card__title">3. Notifying relevant parties of the application</h2>
         </div>
         <div class="govuk-summary-card__content">
             <dl class="govuk-summary-list">
@@ -810,7 +834,7 @@ exports[`LPA Questionnaire review GET / with unchecked documents should render a
     </div>
     <div class="govuk-summary-card">
         <div class="govuk-summary-card__title-wrapper">
-            <h2 class="govuk-summary-card__title">3. Consultation responses and representations</h2>
+            <h2 class="govuk-summary-card__title">4. Consultation responses and representations</h2>
         </div>
         <div class="govuk-summary-card__content">
             <dl class="govuk-summary-list">
@@ -837,7 +861,7 @@ exports[`LPA Questionnaire review GET / with unchecked documents should render a
     </div>
     <div class="govuk-summary-card">
         <div class="govuk-summary-card__title-wrapper">
-            <h2 class="govuk-summary-card__title">4. Planning officer’s report and supplementary documents</h2>
+            <h2 class="govuk-summary-card__title">5. Planning officer’s report and supplementary documents</h2>
         </div>
         <div class="govuk-summary-card__content">
             <dl class="govuk-summary-list">
@@ -874,7 +898,7 @@ exports[`LPA Questionnaire review GET / with unchecked documents should render a
     </div>
     <div class="govuk-summary-card">
         <div class="govuk-summary-card__title-wrapper">
-            <h2 class="govuk-summary-card__title">5. Site access</h2>
+            <h2 class="govuk-summary-card__title">6. Site access</h2>
         </div>
         <div class="govuk-summary-card__content">
             <dl class="govuk-summary-list">
@@ -915,7 +939,7 @@ exports[`LPA Questionnaire review GET / with unchecked documents should render a
     </div>
     <div class="govuk-summary-card">
         <div class="govuk-summary-card__title-wrapper">
-            <h2 class="govuk-summary-card__title">6. Appeal process</h2>
+            <h2 class="govuk-summary-card__title">7. Appeal process</h2>
         </div>
         <div class="govuk-summary-card__content">
             <dl class="govuk-summary-list">
@@ -1073,7 +1097,15 @@ exports[`LPA Questionnaire review GET / with unchecked documents should render a
     </div>
     <div class="govuk-summary-card">
         <div class="govuk-summary-card__title-wrapper">
-            <h2 class="govuk-summary-card__title">2. Notifying relevant parties of the application</h2>
+            <h2 class="govuk-summary-card__title">2. Environmental impact assessment</h2>
+        </div>
+        <div class="govuk-summary-card__content">
+            <dl class="govuk-summary-list"></dl>
+        </div>
+    </div>
+    <div class="govuk-summary-card">
+        <div class="govuk-summary-card__title-wrapper">
+            <h2 class="govuk-summary-card__title">3. Notifying relevant parties of the application</h2>
         </div>
         <div class="govuk-summary-card__content">
             <dl class="govuk-summary-list">
@@ -1126,7 +1158,7 @@ exports[`LPA Questionnaire review GET / with unchecked documents should render a
     </div>
     <div class="govuk-summary-card">
         <div class="govuk-summary-card__title-wrapper">
-            <h2 class="govuk-summary-card__title">3. Consultation responses and representations</h2>
+            <h2 class="govuk-summary-card__title">4. Consultation responses and representations</h2>
         </div>
         <div class="govuk-summary-card__content">
             <dl class="govuk-summary-list">
@@ -1153,7 +1185,7 @@ exports[`LPA Questionnaire review GET / with unchecked documents should render a
     </div>
     <div class="govuk-summary-card">
         <div class="govuk-summary-card__title-wrapper">
-            <h2 class="govuk-summary-card__title">4. Planning officer’s report and supplementary documents</h2>
+            <h2 class="govuk-summary-card__title">5. Planning officer’s report and supplementary documents</h2>
         </div>
         <div class="govuk-summary-card__content">
             <dl class="govuk-summary-list">
@@ -1190,7 +1222,7 @@ exports[`LPA Questionnaire review GET / with unchecked documents should render a
     </div>
     <div class="govuk-summary-card">
         <div class="govuk-summary-card__title-wrapper">
-            <h2 class="govuk-summary-card__title">5. Site access</h2>
+            <h2 class="govuk-summary-card__title">6. Site access</h2>
         </div>
         <div class="govuk-summary-card__content">
             <dl class="govuk-summary-list">
@@ -1231,7 +1263,7 @@ exports[`LPA Questionnaire review GET / with unchecked documents should render a
     </div>
     <div class="govuk-summary-card">
         <div class="govuk-summary-card__title-wrapper">
-            <h2 class="govuk-summary-card__title">6. Appeal process</h2>
+            <h2 class="govuk-summary-card__title">7. Appeal process</h2>
         </div>
         <div class="govuk-summary-card__content">
             <dl class="govuk-summary-list">
@@ -2976,6 +3008,18 @@ exports[`LPA Questionnaire review GET /lpa-questionnaire/1/manage-documents/:fol
 </main>"
 `;
 
+exports[`LPA Questionnaire review Notification banners should render a "Column 2 threshold criteria status changed" success notification banner when meets eia column two threshold is changed 1`] = `
+"<div class="govuk-notification-banner govuk-notification-banner--success"
+role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
+    <div class="govuk-notification-banner__header">
+        <h3 class="govuk-notification-banner__title" id="govuk-notification-banner-title"> Success</h3>
+    </div>
+    <div class="govuk-notification-banner__content">
+        <p class="govuk-notification-banner__heading">Column 2 threshold criteria status changed</p>
+    </div>
+</div>"
+`;
+
 exports[`LPA Questionnaire review Notification banners should render a "Inspector access (lpa) updated" success notification banner when the inspector access (lpa) is updated 1`] = `
 "<div class="govuk-notification-banner govuk-notification-banner--success"
 role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
@@ -3080,6 +3124,18 @@ role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govu
     </div>
     <div class="govuk-notification-banner__content">
         <p class="govuk-notification-banner__heading">Neighbouring site affected status updated</p>
+    </div>
+</div>"
+`;
+
+exports[`LPA Questionnaire review Notification banners should render an "Environmental statement status changed" success notification banner when meets eia requires environmental statement is changed 1`] = `
+"<div class="govuk-notification-banner govuk-notification-banner--success"
+role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
+    <div class="govuk-notification-banner__header">
+        <h3 class="govuk-notification-banner__title" id="govuk-notification-banner-title"> Success</h3>
+    </div>
+    <div class="govuk-notification-banner__content">
+        <p class="govuk-notification-banner__heading">Environmental statement status changed</p>
     </div>
 </div>"
 `;
@@ -3270,7 +3326,15 @@ exports[`LPA Questionnaire review POST / should render LPA Questionnaire review 
     </div>
     <div class="govuk-summary-card">
         <div class="govuk-summary-card__title-wrapper">
-            <h2 class="govuk-summary-card__title">2. Notifying relevant parties of the application</h2>
+            <h2 class="govuk-summary-card__title">2. Environmental impact assessment</h2>
+        </div>
+        <div class="govuk-summary-card__content">
+            <dl class="govuk-summary-list"></dl>
+        </div>
+    </div>
+    <div class="govuk-summary-card">
+        <div class="govuk-summary-card__title-wrapper">
+            <h2 class="govuk-summary-card__title">3. Notifying relevant parties of the application</h2>
         </div>
         <div class="govuk-summary-card__content">
             <dl class="govuk-summary-list">
@@ -3323,7 +3387,7 @@ exports[`LPA Questionnaire review POST / should render LPA Questionnaire review 
     </div>
     <div class="govuk-summary-card">
         <div class="govuk-summary-card__title-wrapper">
-            <h2 class="govuk-summary-card__title">3. Consultation responses and representations</h2>
+            <h2 class="govuk-summary-card__title">4. Consultation responses and representations</h2>
         </div>
         <div class="govuk-summary-card__content">
             <dl class="govuk-summary-list">
@@ -3350,7 +3414,7 @@ exports[`LPA Questionnaire review POST / should render LPA Questionnaire review 
     </div>
     <div class="govuk-summary-card">
         <div class="govuk-summary-card__title-wrapper">
-            <h2 class="govuk-summary-card__title">4. Planning officer’s report and supplementary documents</h2>
+            <h2 class="govuk-summary-card__title">5. Planning officer’s report and supplementary documents</h2>
         </div>
         <div class="govuk-summary-card__content">
             <dl class="govuk-summary-list">
@@ -3387,7 +3451,7 @@ exports[`LPA Questionnaire review POST / should render LPA Questionnaire review 
     </div>
     <div class="govuk-summary-card">
         <div class="govuk-summary-card__title-wrapper">
-            <h2 class="govuk-summary-card__title">5. Site access</h2>
+            <h2 class="govuk-summary-card__title">6. Site access</h2>
         </div>
         <div class="govuk-summary-card__content">
             <dl class="govuk-summary-list">
@@ -3428,7 +3492,7 @@ exports[`LPA Questionnaire review POST / should render LPA Questionnaire review 
     </div>
     <div class="govuk-summary-card">
         <div class="govuk-summary-card__title-wrapper">
-            <h2 class="govuk-summary-card__title">6. Appeal process</h2>
+            <h2 class="govuk-summary-card__title">7. Appeal process</h2>
         </div>
         <div class="govuk-summary-card__content">
             <dl class="govuk-summary-list">

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/__tests__/lpa-questionnaire.test.js
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/__tests__/lpa-questionnaire.test.js
@@ -339,6 +339,54 @@ describe('LPA Questionnaire review', () => {
 			expect(notificationBannerElementHTML).toContain('Success');
 			expect(notificationBannerElementHTML).toContain('Notification methods updated');
 		});
+
+		it('should render a "Column 2 threshold criteria status changed" success notification banner when meets eia column two threshold is changed', async () => {
+			nock('http://test/').get(`/appeals/1`).reply(200, appealData).persist();
+			nock('http://test/')
+				.get(`/appeals/1/lpa-questionnaires/2`)
+				.reply(200, lpaQuestionnaireDataNotValidated)
+				.persist();
+			nock('http://test/').patch(`/appeals/1/lpa-questionnaires/2`).reply(200, {});
+
+			await request
+				.post(`${baseUrl}/environmental-impact-assessment/column-two-threshold/change`)
+				.send({
+					eiaColumnTwoThreshold: 'yes'
+				});
+
+			const response = await request.get(`${baseUrl}`);
+
+			const notificationBannerElementHTML = parseHtml(response.text, {
+				rootElement: notificationBannerElement
+			}).innerHTML;
+			expect(notificationBannerElementHTML).toMatchSnapshot();
+			expect(notificationBannerElementHTML).toContain('Success');
+			expect(notificationBannerElementHTML).toContain('Column 2 threshold criteria status changed');
+		});
+
+		it('should render an "Environmental statement status changed" success notification banner when meets eia requires environmental statement is changed', async () => {
+			nock('http://test/').get(`/appeals/1`).reply(200, appealData).persist();
+			nock('http://test/')
+				.get(`/appeals/1/lpa-questionnaires/2`)
+				.reply(200, lpaQuestionnaireDataNotValidated)
+				.persist();
+			nock('http://test/').patch(`/appeals/1/lpa-questionnaires/2`).reply(200, {});
+
+			await request
+				.post(`${baseUrl}/environmental-impact-assessment/requires-environmental-statement/change`)
+				.send({
+					eiaRequiresEnvironmentalStatement: 'yes'
+				});
+
+			const response = await request.get(`${baseUrl}`);
+
+			const notificationBannerElementHTML = parseHtml(response.text, {
+				rootElement: notificationBannerElement
+			}).innerHTML;
+			expect(notificationBannerElementHTML).toMatchSnapshot();
+			expect(notificationBannerElementHTML).toContain('Success');
+			expect(notificationBannerElementHTML).toContain('Environmental statement status changed');
+		});
 	});
 
 	describe('GET /', () => {
@@ -353,13 +401,14 @@ describe('LPA Questionnaire review', () => {
 			expect(element.innerHTML).toMatchSnapshot();
 			expect(element.innerHTML).toContain('LPA questionnaire</h1>');
 			expect(element.innerHTML).toContain('1. Constraints, designations and other issues</h2>');
-			expect(element.innerHTML).toContain('2. Notifying relevant parties of the application</h2>');
-			expect(element.innerHTML).toContain('3. Consultation responses and representations</h2>');
+			expect(element.innerHTML).toContain('2. Environmental impact assessment</h2>');
+			expect(element.innerHTML).toContain('3. Notifying relevant parties of the application</h2>');
+			expect(element.innerHTML).toContain('4. Consultation responses and representations</h2>');
 			expect(element.innerHTML).toContain(
-				'4. Planning officer’s report and supplementary documents</h2>'
+				'5. Planning officer’s report and supplementary documents</h2>'
 			);
-			expect(element.innerHTML).toContain('5. Site access</h2>');
-			expect(element.innerHTML).toContain('6. Appeal process</h2>');
+			expect(element.innerHTML).toContain('6. Site access</h2>');
+			expect(element.innerHTML).toContain('7. Appeal process</h2>');
 			expect(element.innerHTML).toContain('Additional documents</h2>');
 		}, 10000);
 

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/environmental-impact-assessment/__tests__/__snapshots__/environmental-impact-assessment.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/environmental-impact-assessment/__tests__/__snapshots__/environmental-impact-assessment.test.js.snap
@@ -1,0 +1,129 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`environmental-impact-assessment GET /environmental-impact-assessment/column-two-threshold/change should render the change eia column two threshold page with "Does not meet or exceed" radio option checked if eiaColumnTwoThreshold is false 1`] = `
+"<main class="govuk-main-wrapper " id="main-content" role="main">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <div class="govuk-grid-row">
+                <div class="govuk-grid-column-full"><span class="govuk-caption-l govuk-!-margin-bottom-3">Appeal 351062</span>
+                    <h1                     class="govuk-heading-l govuk-!-margin-bottom-3">Change whether meets or exceeds column 2 threshold criteria</h1>
+                </div>
+            </div>
+            <form method="POST" novalidate="novalidate">
+                <div class="govuk-form-group">
+                    <div class="govuk-radios" data-module="govuk-radios">
+                        <div class="govuk-radios__item">
+                            <input class="govuk-radios__input" id="eiaColumnTwoThreshold" name="eiaColumnTwoThreshold"
+                            type="radio" value="yes">
+                            <label class="govuk-label govuk-radios__label" for="eiaColumnTwoThreshold">Meets or exceeds</label>
+                        </div>
+                        <div class="govuk-radios__item">
+                            <input class="govuk-radios__input" id="eiaColumnTwoThreshold-2" name="eiaColumnTwoThreshold"
+                            type="radio" value="no" checked>
+                            <label class="govuk-label govuk-radios__label" for="eiaColumnTwoThreshold-2">Does not meet or exceed</label>
+                        </div>
+                    </div>
+                </div>
+                <button type="submit" data-prevent-double-click="true" class="govuk-button"
+                data-module="govuk-button">Continue</button>
+            </form>
+        </div>
+    </div>
+</main>"
+`;
+
+exports[`environmental-impact-assessment GET /environmental-impact-assessment/column-two-threshold/change should render the change eia column two threshold page with "Meets or exceeds" radio option checked if eiaColumnTwoThreshold is true 1`] = `
+"<main class="govuk-main-wrapper " id="main-content" role="main">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <div class="govuk-grid-row">
+                <div class="govuk-grid-column-full"><span class="govuk-caption-l govuk-!-margin-bottom-3">Appeal 351062</span>
+                    <h1                     class="govuk-heading-l govuk-!-margin-bottom-3">Change whether meets or exceeds column 2 threshold criteria</h1>
+                </div>
+            </div>
+            <form method="POST" novalidate="novalidate">
+                <div class="govuk-form-group">
+                    <div class="govuk-radios" data-module="govuk-radios">
+                        <div class="govuk-radios__item">
+                            <input class="govuk-radios__input" id="eiaColumnTwoThreshold" name="eiaColumnTwoThreshold"
+                            type="radio" value="yes" checked>
+                            <label class="govuk-label govuk-radios__label" for="eiaColumnTwoThreshold">Meets or exceeds</label>
+                        </div>
+                        <div class="govuk-radios__item">
+                            <input class="govuk-radios__input" id="eiaColumnTwoThreshold-2" name="eiaColumnTwoThreshold"
+                            type="radio" value="no">
+                            <label class="govuk-label govuk-radios__label" for="eiaColumnTwoThreshold-2">Does not meet or exceed</label>
+                        </div>
+                    </div>
+                </div>
+                <button type="submit" data-prevent-double-click="true" class="govuk-button"
+                data-module="govuk-button">Continue</button>
+            </form>
+        </div>
+    </div>
+</main>"
+`;
+
+exports[`environmental-impact-assessment GET /environmental-impact-assessment/requires-environmental-statement/change should render the change eia requires environmental statement page with "Needed" radio option checked if eiaRequiresEnvironmentalStatement is true 1`] = `
+"<main class="govuk-main-wrapper " id="main-content" role="main">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <div class="govuk-grid-row">
+                <div class="govuk-grid-column-full"><span class="govuk-caption-l govuk-!-margin-bottom-3">Appeal 351062</span>
+                    <h1                     class="govuk-heading-l govuk-!-margin-bottom-3">Change opinion that environmental statement needed</h1>
+                </div>
+            </div>
+            <form method="POST" novalidate="novalidate">
+                <div class="govuk-form-group">
+                    <div class="govuk-radios" data-module="govuk-radios">
+                        <div class="govuk-radios__item">
+                            <input class="govuk-radios__input" id="eiaRequiresEnvironmentalStatement"
+                            name="eiaRequiresEnvironmentalStatement" type="radio" value="yes" checked>
+                            <label class="govuk-label govuk-radios__label" for="eiaRequiresEnvironmentalStatement">Needed</label>
+                        </div>
+                        <div class="govuk-radios__item">
+                            <input class="govuk-radios__input" id="eiaRequiresEnvironmentalStatement-2"
+                            name="eiaRequiresEnvironmentalStatement" type="radio" value="no">
+                            <label class="govuk-label govuk-radios__label" for="eiaRequiresEnvironmentalStatement-2">Not needed</label>
+                        </div>
+                    </div>
+                </div>
+                <button type="submit" data-prevent-double-click="true" class="govuk-button"
+                data-module="govuk-button">Continue</button>
+            </form>
+        </div>
+    </div>
+</main>"
+`;
+
+exports[`environmental-impact-assessment GET /environmental-impact-assessment/requires-environmental-statement/change should render the change eia requires environmental statement page with "Not needed" radio option checked if eiaRequiresEnvironmentalStatement is false 1`] = `
+"<main class="govuk-main-wrapper " id="main-content" role="main">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <div class="govuk-grid-row">
+                <div class="govuk-grid-column-full"><span class="govuk-caption-l govuk-!-margin-bottom-3">Appeal 351062</span>
+                    <h1                     class="govuk-heading-l govuk-!-margin-bottom-3">Change opinion that environmental statement needed</h1>
+                </div>
+            </div>
+            <form method="POST" novalidate="novalidate">
+                <div class="govuk-form-group">
+                    <div class="govuk-radios" data-module="govuk-radios">
+                        <div class="govuk-radios__item">
+                            <input class="govuk-radios__input" id="eiaRequiresEnvironmentalStatement"
+                            name="eiaRequiresEnvironmentalStatement" type="radio" value="yes">
+                            <label class="govuk-label govuk-radios__label" for="eiaRequiresEnvironmentalStatement">Needed</label>
+                        </div>
+                        <div class="govuk-radios__item">
+                            <input class="govuk-radios__input" id="eiaRequiresEnvironmentalStatement-2"
+                            name="eiaRequiresEnvironmentalStatement" type="radio" value="no" checked>
+                            <label class="govuk-label govuk-radios__label" for="eiaRequiresEnvironmentalStatement-2">Not needed</label>
+                        </div>
+                    </div>
+                </div>
+                <button type="submit" data-prevent-double-click="true" class="govuk-button"
+                data-module="govuk-button">Continue</button>
+            </form>
+        </div>
+    </div>
+</main>"
+`;

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/environmental-impact-assessment/__tests__/environmental-impact-assessment.test.js
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/environmental-impact-assessment/__tests__/environmental-impact-assessment.test.js
@@ -1,0 +1,214 @@
+// @ts-nocheck
+import { parseHtml } from '@pins/platform';
+import supertest from 'supertest';
+import {
+	appealData,
+	lpaQuestionnaireDataNotValidated
+} from '#testing/app/fixtures/referencedata.js';
+import { createTestEnvironment } from '#testing/index.js';
+import nock from 'nock';
+
+const { app, installMockApi, teardown } = createTestEnvironment();
+const request = supertest(app);
+const baseUrl = '/appeals-service/appeal-details';
+
+describe('environmental-impact-assessment', () => {
+	beforeEach(installMockApi);
+	afterEach(teardown);
+
+	describe('GET /environmental-impact-assessment/column-two-threshold/change', () => {
+		it('should render the change eia column two threshold page with "Meets or exceeds" radio option checked if eiaColumnTwoThreshold is true', async () => {
+			nock('http://test/')
+				.get(`/appeals/1/lpa-questionnaires/${appealData.lpaQuestionnaireId}`)
+				.reply(200, {
+					...lpaQuestionnaireDataNotValidated,
+					eiaColumnTwoThreshold: true
+				});
+
+			const response = await request.get(
+				`${baseUrl}/1/lpa-questionnaire/${appealData.lpaQuestionnaireId}/environmental-impact-assessment/column-two-threshold/change`
+			);
+			const element = parseHtml(response.text);
+
+			expect(element.innerHTML).toMatchSnapshot();
+
+			const unprettifiedElement = parseHtml(response.text, { skipPrettyPrint: true });
+
+			expect(unprettifiedElement.innerHTML).toContain(
+				'Change whether meets or exceeds column 2 threshold criteria</h1>'
+			);
+			expect(unprettifiedElement.innerHTML).toContain(
+				'name="eiaColumnTwoThreshold" type="radio" value="yes" checked>'
+			);
+			expect(unprettifiedElement.innerHTML).toContain(
+				'<label class="govuk-label govuk-radios__label" for="eiaColumnTwoThreshold"> Meets or exceeds</label>'
+			);
+			expect(unprettifiedElement.innerHTML).toContain(
+				'name="eiaColumnTwoThreshold" type="radio" value="no">'
+			);
+			expect(unprettifiedElement.innerHTML).toContain(
+				'<label class="govuk-label govuk-radios__label" for="eiaColumnTwoThreshold-2"> Does not meet or exceed</label>'
+			);
+			expect(unprettifiedElement.innerHTML).toContain('Continue</button>');
+		});
+
+		it('should render the change eia column two threshold page with "Does not meet or exceed" radio option checked if eiaColumnTwoThreshold is false', async () => {
+			nock('http://test/')
+				.get(`/appeals/1/lpa-questionnaires/${appealData.lpaQuestionnaireId}`)
+				.reply(200, {
+					...lpaQuestionnaireDataNotValidated,
+					eiaColumnTwoThreshold: false
+				});
+
+			const response = await request.get(
+				`${baseUrl}/1/lpa-questionnaire/${appealData.lpaQuestionnaireId}/environmental-impact-assessment/column-two-threshold/change`
+			);
+			const element = parseHtml(response.text);
+
+			expect(element.innerHTML).toMatchSnapshot();
+
+			const unprettifiedElement = parseHtml(response.text, { skipPrettyPrint: true });
+
+			expect(unprettifiedElement.innerHTML).toContain(
+				'Change whether meets or exceeds column 2 threshold criteria</h1>'
+			);
+			expect(unprettifiedElement.innerHTML).toContain(
+				'name="eiaColumnTwoThreshold" type="radio" value="yes">'
+			);
+			expect(unprettifiedElement.innerHTML).toContain(
+				'<label class="govuk-label govuk-radios__label" for="eiaColumnTwoThreshold"> Meets or exceeds</label>'
+			);
+			expect(unprettifiedElement.innerHTML).toContain(
+				'name="eiaColumnTwoThreshold" type="radio" value="no" checked>'
+			);
+			expect(unprettifiedElement.innerHTML).toContain(
+				'<label class="govuk-label govuk-radios__label" for="eiaColumnTwoThreshold-2"> Does not meet or exceed</label>'
+			);
+			expect(unprettifiedElement.innerHTML).toContain('Continue</button>');
+		});
+	});
+
+	describe('POST /environmental-impact-assessment/column-two-threshold/change', () => {
+		const validValues = ['yes', 'no'];
+
+		for (const validValue of validValues) {
+			it(`should call LPA questionnaires PATCH endpoint and redirect to the LPA questionnaire page if "${validValue}" is selected`, async () => {
+				const mockLPAQPatchEndpoint = nock('http://test/')
+					.patch(`/appeals/1/lpa-questionnaires/${appealData.lpaQuestionnaireId}`)
+					.reply(200, {});
+
+				const response = await request
+					.post(
+						`${baseUrl}/1/lpa-questionnaire/${appealData.lpaQuestionnaireId}/environmental-impact-assessment/column-two-threshold/change`
+					)
+					.send({
+						eiaColumnTwoThreshold: validValue
+					});
+
+				expect(mockLPAQPatchEndpoint.isDone()).toBe(true);
+				expect(response.statusCode).toBe(302);
+				expect(response.text).toBe(
+					`Found. Redirecting to /appeals-service/appeal-details/1/lpa-questionnaire/${appealData.lpaQuestionnaireId}`
+				);
+			});
+		}
+	});
+
+	describe('GET /environmental-impact-assessment/requires-environmental-statement/change', () => {
+		it('should render the change eia requires environmental statement page with "Needed" radio option checked if eiaRequiresEnvironmentalStatement is true', async () => {
+			nock('http://test/')
+				.get(`/appeals/1/lpa-questionnaires/${appealData.lpaQuestionnaireId}`)
+				.reply(200, {
+					...lpaQuestionnaireDataNotValidated,
+					eiaRequiresEnvironmentalStatement: true
+				});
+
+			const response = await request.get(
+				`${baseUrl}/1/lpa-questionnaire/${appealData.lpaQuestionnaireId}/environmental-impact-assessment/requires-environmental-statement/change`
+			);
+			const element = parseHtml(response.text);
+
+			expect(element.innerHTML).toMatchSnapshot();
+
+			const unprettifiedElement = parseHtml(response.text, { skipPrettyPrint: true });
+
+			expect(unprettifiedElement.innerHTML).toContain(
+				'Change opinion that environmental statement needed</h1>'
+			);
+			expect(unprettifiedElement.innerHTML).toContain(
+				'name="eiaRequiresEnvironmentalStatement" type="radio" value="yes" checked>'
+			);
+			expect(unprettifiedElement.innerHTML).toContain(
+				'<label class="govuk-label govuk-radios__label" for="eiaRequiresEnvironmentalStatement"> Needed</label>'
+			);
+			expect(unprettifiedElement.innerHTML).toContain(
+				'name="eiaRequiresEnvironmentalStatement" type="radio" value="no">'
+			);
+			expect(unprettifiedElement.innerHTML).toContain(
+				'<label class="govuk-label govuk-radios__label" for="eiaRequiresEnvironmentalStatement-2"> Not needed</label>'
+			);
+			expect(unprettifiedElement.innerHTML).toContain('Continue</button>');
+		});
+
+		it('should render the change eia requires environmental statement page with "Not needed" radio option checked if eiaRequiresEnvironmentalStatement is false', async () => {
+			nock('http://test/')
+				.get(`/appeals/1/lpa-questionnaires/${appealData.lpaQuestionnaireId}`)
+				.reply(200, {
+					...lpaQuestionnaireDataNotValidated,
+					eiaRequiresEnvironmentalStatement: false
+				});
+
+			const response = await request.get(
+				`${baseUrl}/1/lpa-questionnaire/${appealData.lpaQuestionnaireId}/environmental-impact-assessment/requires-environmental-statement/change`
+			);
+			const element = parseHtml(response.text);
+
+			expect(element.innerHTML).toMatchSnapshot();
+
+			const unprettifiedElement = parseHtml(response.text, { skipPrettyPrint: true });
+
+			expect(unprettifiedElement.innerHTML).toContain(
+				'Change opinion that environmental statement needed</h1>'
+			);
+			expect(unprettifiedElement.innerHTML).toContain(
+				'name="eiaRequiresEnvironmentalStatement" type="radio" value="yes">'
+			);
+			expect(unprettifiedElement.innerHTML).toContain(
+				'<label class="govuk-label govuk-radios__label" for="eiaRequiresEnvironmentalStatement"> Needed</label>'
+			);
+			expect(unprettifiedElement.innerHTML).toContain(
+				'name="eiaRequiresEnvironmentalStatement" type="radio" value="no" checked>'
+			);
+			expect(unprettifiedElement.innerHTML).toContain(
+				'<label class="govuk-label govuk-radios__label" for="eiaRequiresEnvironmentalStatement-2"> Not needed</label>'
+			);
+			expect(unprettifiedElement.innerHTML).toContain('Continue</button>');
+		});
+	});
+
+	describe('POST /environmental-impact-assessment/requires-environmental-statement/change', () => {
+		const validValues = ['yes', 'no'];
+
+		for (const validValue of validValues) {
+			it(`should call LPA questionnaires PATCH endpoint and redirect to the LPA questionnaire page if "${validValue}" is selected`, async () => {
+				const mockLPAQPatchEndpoint = nock('http://test/')
+					.patch(`/appeals/1/lpa-questionnaires/${appealData.lpaQuestionnaireId}`)
+					.reply(200, {});
+
+				const response = await request
+					.post(
+						`${baseUrl}/1/lpa-questionnaire/${appealData.lpaQuestionnaireId}/environmental-impact-assessment/requires-environmental-statement/change`
+					)
+					.send({
+						eiaRequiresEnvironmentalStatement: validValue
+					});
+
+				expect(mockLPAQPatchEndpoint.isDone()).toBe(true);
+				expect(response.statusCode).toBe(302);
+				expect(response.text).toBe(
+					`Found. Redirecting to /appeals-service/appeal-details/1/lpa-questionnaire/${appealData.lpaQuestionnaireId}`
+				);
+			});
+		}
+	});
+});

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/environmental-impact-assessment/environmental-impact-assessment.controller.js
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/environmental-impact-assessment/environmental-impact-assessment.controller.js
@@ -1,0 +1,162 @@
+import logger from '#lib/logger.js';
+import {
+	changeEiaColumnTwoThresholdPage,
+	changeEiaRequiresEnvironmentalStatementPage
+} from './environmental-impact-assessment.mapper.js';
+import {
+	changeEiaColumnTwoThreshold,
+	changeEiaRequiresEnvironmentalStatement
+} from './environmental-impact-assessment.service.js';
+import { getLpaQuestionnaireFromId } from '../lpa-questionnaire.service.js';
+import { addNotificationBannerToSession } from '#lib/session-utilities.js';
+
+/**
+ * @param {import('@pins/express/types/express.js').Request} request
+ * @param {import('@pins/express/types/express.js').RenderedResponse<any, any, Number>} response
+ */
+export const getChangeEiaColumnTwoThreshold = async (request, response) => {
+	return renderChangeEiaColumnTwoThreshold(request, response);
+};
+
+/**
+ * @param {import('@pins/express/types/express.js').Request} request
+ * @param {import('@pins/express/types/express.js').RenderedResponse<any, any, Number>} response
+ */
+const renderChangeEiaColumnTwoThreshold = async (request, response) => {
+	const {
+		errors,
+		apiClient,
+		params: { appealId, lpaQuestionnaireId }
+	} = request;
+
+	const lpaQuestionnaire = await getLpaQuestionnaireFromId(apiClient, appealId, lpaQuestionnaireId);
+
+	const mappedPageContents = changeEiaColumnTwoThresholdPage(
+		request.currentAppeal,
+		lpaQuestionnaire.eiaColumnTwoThreshold
+	);
+
+	return response.status(200).render('patterns/change-page.pattern.njk', {
+		pageContent: mappedPageContents,
+		errors
+	});
+};
+
+/**
+ * @param {import('@pins/express/types/express.js').Request} request
+ * @param {import('@pins/express/types/express.js').RenderedResponse<any, any, Number>} response
+ */
+export const postChangeEiaColumnTwoThreshold = async (request, response) => {
+	request.session.eiaColumnTwoThreshold = request.body['eiaColumnTwoThreshold'];
+
+	if (request.errors) {
+		return renderChangeEiaColumnTwoThreshold(request, response);
+	}
+
+	const {
+		params: { appealId, lpaQuestionnaireId },
+		apiClient
+	} = request;
+
+	try {
+		await changeEiaColumnTwoThreshold(
+			apiClient,
+			appealId,
+			lpaQuestionnaireId,
+			request.session.eiaColumnTwoThreshold
+		);
+
+		addNotificationBannerToSession(
+			request.session,
+			'changePage',
+			appealId,
+			'',
+			'Column 2 threshold criteria status changed'
+		);
+
+		delete request.session.eiaColumnTwoThreshold;
+
+		return response.redirect(
+			`/appeals-service/appeal-details/${appealId}/lpa-questionnaire/${lpaQuestionnaireId}`
+		);
+	} catch (error) {
+		logger.error(error);
+	}
+	return response.status(500).render('app/500.njk');
+};
+
+/**
+ * @param {import('@pins/express/types/express.js').Request} request
+ * @param {import('@pins/express/types/express.js').RenderedResponse<any, any, Number>} response
+ */
+export const getChangeEiaRequiresEnvironmentalStatement = async (request, response) => {
+	return renderChangeEiaRequiresEnvironmentalStatement(request, response);
+};
+
+/**
+ * @param {import('@pins/express/types/express.js').Request} request
+ * @param {import('@pins/express/types/express.js').RenderedResponse<any, any, Number>} response
+ */
+const renderChangeEiaRequiresEnvironmentalStatement = async (request, response) => {
+	const {
+		errors,
+		apiClient,
+		params: { appealId, lpaQuestionnaireId }
+	} = request;
+
+	const lpaQuestionnaire = await getLpaQuestionnaireFromId(apiClient, appealId, lpaQuestionnaireId);
+
+	const mappedPageContents = changeEiaRequiresEnvironmentalStatementPage(
+		request.currentAppeal,
+		lpaQuestionnaire.eiaRequiresEnvironmentalStatement
+	);
+
+	return response.status(200).render('patterns/change-page.pattern.njk', {
+		pageContent: mappedPageContents,
+		errors
+	});
+};
+
+/**
+ * @param {import('@pins/express/types/express.js').Request} request
+ * @param {import('@pins/express/types/express.js').RenderedResponse<any, any, Number>} response
+ */
+export const postChangeEiaRequiresEnvironmentalStatement = async (request, response) => {
+	request.session.eiaRequiresEnvironmentalStatement =
+		request.body['eiaRequiresEnvironmentalStatement'];
+
+	if (request.errors) {
+		return renderChangeEiaRequiresEnvironmentalStatement(request, response);
+	}
+
+	const {
+		params: { appealId, lpaQuestionnaireId },
+		apiClient
+	} = request;
+
+	try {
+		await changeEiaRequiresEnvironmentalStatement(
+			apiClient,
+			appealId,
+			lpaQuestionnaireId,
+			request.session.eiaRequiresEnvironmentalStatement
+		);
+
+		addNotificationBannerToSession(
+			request.session,
+			'changePage',
+			appealId,
+			'',
+			'Environmental statement status changed'
+		);
+
+		delete request.session.eiaRequiresEnvironmentalStatement;
+
+		return response.redirect(
+			`/appeals-service/appeal-details/${appealId}/lpa-questionnaire/${lpaQuestionnaireId}`
+		);
+	} catch (error) {
+		logger.error(error);
+	}
+	return response.status(500).render('app/500.njk');
+};

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/environmental-impact-assessment/environmental-impact-assessment.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/environmental-impact-assessment/environmental-impact-assessment.mapper.js
@@ -1,0 +1,61 @@
+import { appealShortReference } from '#lib/appeals-formatter.js';
+import { yesNoInput } from '#lib/mappers/components/radio.js';
+
+/**
+ * @typedef {import('../../appeal-details.types.js').WebAppeal} Appeal
+ * @typedef {import('../lpa-questionnaire.service.js').LpaQuestionnaire} LpaQuestionnaire
+ */
+
+/**
+ * @param {Appeal} appealData
+ * @param {boolean|null} [existingValue]
+ */
+export function changeEiaColumnTwoThresholdPage(appealData, existingValue) {
+	const shortAppealReference = appealShortReference(appealData.appealReference);
+
+	/** @type {PageContent} */
+	const pageContent = {
+		title: `Change whether meets or exceeds column 2 threshold criteria`,
+		backLinkUrl: `/appeals-service/appeal-details/${appealData.appealId}/lpa-questionnaire/${appealData.lpaQuestionnaireId}`,
+		preHeading: `Appeal ${shortAppealReference}`,
+		heading: `Change whether meets or exceeds column 2 threshold criteria`,
+		headingClasses: 'govuk-heading-l',
+		pageComponents: [
+			yesNoInput({
+				name: 'eiaColumnTwoThreshold',
+				value: existingValue,
+				customYesLabel: 'Meets or exceeds',
+				customNoLabel: 'Does not meet or exceed'
+			})
+		]
+	};
+
+	return pageContent;
+}
+
+/**
+ * @param {Appeal} appealData
+ * @param {boolean|null} [existingValue]
+ */
+export function changeEiaRequiresEnvironmentalStatementPage(appealData, existingValue) {
+	const shortAppealReference = appealShortReference(appealData.appealReference);
+
+	/** @type {PageContent} */
+	const pageContent = {
+		title: `Change opinion that environmental statement needed`,
+		backLinkUrl: `/appeals-service/appeal-details/${appealData.appealId}/lpa-questionnaire/${appealData.lpaQuestionnaireId}`,
+		preHeading: `Appeal ${shortAppealReference}`,
+		heading: `Change opinion that environmental statement needed`,
+		headingClasses: 'govuk-heading-l',
+		pageComponents: [
+			yesNoInput({
+				name: 'eiaRequiresEnvironmentalStatement',
+				value: existingValue,
+				customYesLabel: 'Needed',
+				customNoLabel: 'Not needed'
+			})
+		]
+	};
+
+	return pageContent;
+}

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/environmental-impact-assessment/environmental-impact-assessment.router.js
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/environmental-impact-assessment/environmental-impact-assessment.router.js
@@ -1,0 +1,17 @@
+import { asyncHandler } from '@pins/express';
+import { Router as createRouter } from 'express';
+import * as controllers from './environmental-impact-assessment.controller.js';
+
+const router = createRouter({ mergeParams: true });
+
+router
+	.route('/column-two-threshold/change')
+	.get(asyncHandler(controllers.getChangeEiaColumnTwoThreshold))
+	.post(asyncHandler(controllers.postChangeEiaColumnTwoThreshold));
+
+router
+	.route('/requires-environmental-statement/change')
+	.get(asyncHandler(controllers.getChangeEiaRequiresEnvironmentalStatement))
+	.post(asyncHandler(controllers.postChangeEiaRequiresEnvironmentalStatement));
+
+export default router;

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/environmental-impact-assessment/environmental-impact-assessment.service.js
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/environmental-impact-assessment/environmental-impact-assessment.service.js
@@ -1,0 +1,36 @@
+import { convertFromYesNoToBoolean } from '#lib/boolean-formatter.js';
+
+/**
+ * @param {import('got').Got} apiClient
+ * @param {string} appealId
+ * @param {string} lpaQuestionnaireId
+ * @param {string} updatedData
+ * @returns {Promise<{}>}
+ */
+export function changeEiaColumnTwoThreshold(apiClient, appealId, lpaQuestionnaireId, updatedData) {
+	return apiClient.patch(`appeals/${appealId}/lpa-questionnaires/${lpaQuestionnaireId}`, {
+		json: {
+			eiaColumnTwoThreshold: convertFromYesNoToBoolean(updatedData)
+		}
+	});
+}
+
+/**
+ * @param {import('got').Got} apiClient
+ * @param {string} appealId
+ * @param {string} lpaQuestionnaireId
+ * @param {string} updatedData
+ * @returns {Promise<{}>}
+ */
+export function changeEiaRequiresEnvironmentalStatement(
+	apiClient,
+	appealId,
+	lpaQuestionnaireId,
+	updatedData
+) {
+	return apiClient.patch(`appeals/${appealId}/lpa-questionnaires/${lpaQuestionnaireId}`, {
+		json: {
+			eiaRequiresEnvironmentalStatement: convertFromYesNoToBoolean(updatedData)
+		}
+	});
+}

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/lpa-questionnaire.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/lpa-questionnaire.mapper.js
@@ -735,7 +735,23 @@ const generateHASLpaQuestionnaireComponents = (mappedLPAQData, mappedAppealDetai
 		parameters: {
 			card: {
 				title: {
-					text: '2. Notifying relevant parties of the application'
+					text: '2. Environmental impact assessment'
+				}
+			},
+			rows: [
+				mappedLPAQData.lpaq?.eiaColumnTwoThreshold?.display.summaryListItem,
+				mappedLPAQData.lpaq?.eiaRequiresEnvironmentalStatement?.display.summaryListItem
+			].filter(isDefined)
+		}
+	});
+
+	pageComponents.push({
+		/** @type {'summary-list'} */
+		type: 'summary-list',
+		parameters: {
+			card: {
+				title: {
+					text: '3. Notifying relevant parties of the application'
 				}
 			},
 			rows: [
@@ -754,7 +770,7 @@ const generateHASLpaQuestionnaireComponents = (mappedLPAQData, mappedAppealDetai
 		parameters: {
 			card: {
 				title: {
-					text: '3. Consultation responses and representations'
+					text: '4. Consultation responses and representations'
 				}
 			},
 			rows: [mappedLPAQData.lpaq?.representations?.display.summaryListItem].filter(isDefined)
@@ -767,7 +783,7 @@ const generateHASLpaQuestionnaireComponents = (mappedLPAQData, mappedAppealDetai
 		parameters: {
 			card: {
 				title: {
-					text: '4. Planning officer’s report and supplementary documents'
+					text: '5. Planning officer’s report and supplementary documents'
 				}
 			},
 			rows: [
@@ -784,7 +800,7 @@ const generateHASLpaQuestionnaireComponents = (mappedLPAQData, mappedAppealDetai
 		parameters: {
 			card: {
 				title: {
-					text: '5. Site access'
+					text: '6. Site access'
 				}
 			},
 			rows: [
@@ -801,7 +817,7 @@ const generateHASLpaQuestionnaireComponents = (mappedLPAQData, mappedAppealDetai
 		parameters: {
 			card: {
 				title: {
-					text: '6. Appeal process'
+					text: '7. Appeal process'
 				}
 			},
 			rows: [

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/lpa-questionnaire.router.js
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/lpa-questionnaire.router.js
@@ -24,6 +24,7 @@ import greenBeltRouter from '../green-belt/green-belt.router.js';
 import extraConditionsRouter from './extra-conditions/extra-conditions.router.js';
 import notificationMethodsRouter from './notification-methods/notification-methods.router.js';
 import affectedListedBuildingsRouter from './affected-listed-buildings/affected-listed-buildings.router.js';
+import environmentalImpactAssessmentRouter from './environmental-impact-assessment/environmental-impact-assessment.router.js';
 
 const router = createRouter({ mergeParams: true });
 
@@ -96,6 +97,13 @@ router.use(
 	validateAppeal,
 	assertUserHasPermission(permissionNames.updateCase),
 	affectedListedBuildingsRouter
+);
+
+router.use(
+	'/:lpaQuestionnaireId/environmental-impact-assessment',
+	validateAppeal,
+	assertUserHasPermission(permissionNames.updateCase),
+	environmentalImpactAssessmentRouter
 );
 
 router

--- a/appeals/web/src/server/lib/mappers/components/radio.js
+++ b/appeals/web/src/server/lib/mappers/components/radio.js
@@ -9,13 +9,23 @@ import { kebabCase } from 'lodash-es';
  * @param {string|boolean|null} [params.value]
  * @param {string} [params.legendText]
  * @param {import('../global-mapper-formatter.js').ConditionalParams} [params.yesConditional]
+ * @param {string} [params.customYesLabel]
+ * @param {string} [params.customNoLabel]
  * @returns {PageComponent}
  */
-export function yesNoInput({ name, id, value, legendText, yesConditional }) {
+export function yesNoInput({
+	name,
+	id,
+	value,
+	legendText,
+	yesConditional,
+	customYesLabel,
+	customNoLabel
+}) {
 	/** @type {RadioItem} */
 	const yes = {
 		value: 'yes',
-		text: 'Yes',
+		text: customYesLabel || 'Yes',
 		checked: Boolean(value)
 	};
 	if (yesConditional) {
@@ -38,7 +48,7 @@ export function yesNoInput({ name, id, value, legendText, yesConditional }) {
 				yes,
 				{
 					value: 'no',
-					text: 'No',
+					text: customNoLabel || 'No',
 					// only show 'No' checked if value is defined
 					checked: typeof value !== 'undefined' && !value
 				}

--- a/appeals/web/src/server/lib/mappers/lpa-questionnaire/s78.js
+++ b/appeals/web/src/server/lib/mappers/lpa-questionnaire/s78.js
@@ -1,6 +1,9 @@
 import { submaps as hasSubmaps } from './has.js';
+import { mapEiaColumnTwoThreshold } from './submappers/map-eia-column-two-threshold.js';
+import { mapEiaRequiresEnvironmentalStatement } from './submappers/map-eia-requires-environmental-statement.js';
 
 export const submaps = {
-	...hasSubmaps
-	// Add new S78 submaps here
+	...hasSubmaps,
+	eiaColumnTwoThreshold: mapEiaColumnTwoThreshold,
+	eiaRequiresEnvironmentalStatement: mapEiaRequiresEnvironmentalStatement
 };

--- a/appeals/web/src/server/lib/mappers/lpa-questionnaire/submappers/map-eia-column-two-threshold.js
+++ b/appeals/web/src/server/lib/mappers/lpa-questionnaire/submappers/map-eia-column-two-threshold.js
@@ -1,0 +1,17 @@
+import { booleanSummaryListItem } from '#lib/mappers/components/boolean.js';
+
+/** @type {import("../lpa-questionnaire.mapper.js").SubMapper} */
+export const mapEiaColumnTwoThreshold = ({
+	lpaQuestionnaireData,
+	userHasUpdateCase,
+	currentRoute
+}) =>
+	booleanSummaryListItem({
+		id: 'eia-column-two-threshold',
+		text: 'Meets or exceeds column 2 threshold criteria',
+		value: lpaQuestionnaireData.eiaColumnTwoThreshold,
+		defaultText: '',
+		addCyAttribute: true,
+		link: `${currentRoute}/environmental-impact-assessment/column-two-threshold/change`,
+		editable: userHasUpdateCase
+	});

--- a/appeals/web/src/server/lib/mappers/lpa-questionnaire/submappers/map-eia-requires-environmental-statement.js
+++ b/appeals/web/src/server/lib/mappers/lpa-questionnaire/submappers/map-eia-requires-environmental-statement.js
@@ -1,0 +1,17 @@
+import { booleanSummaryListItem } from '#lib/mappers/components/boolean.js';
+
+/** @type {import("../lpa-questionnaire.mapper.js").SubMapper} */
+export const mapEiaRequiresEnvironmentalStatement = ({
+	lpaQuestionnaireData,
+	userHasUpdateCase,
+	currentRoute
+}) =>
+	booleanSummaryListItem({
+		id: 'eia-requires-environmental-statement',
+		text: 'Screening opinion says environmental statement needed',
+		value: lpaQuestionnaireData.eiaRequiresEnvironmentalStatement,
+		defaultText: '',
+		addCyAttribute: true,
+		link: `${currentRoute}/environmental-impact-assessment/requires-environmental-statement/change`,
+		editable: userHasUpdateCase
+	});


### PR DESCRIPTION
## Describe your changes

add s78 lpaq rows for environmental impact assessment boolean fields

## Issue ticket number and link

A2-1149

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [ ] I have performed a self-review of my own code
- [ ] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [ ] I have referenced the ticket number above
- [ ] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
