### PR TITLE
feat(web): global rollout of show more component

### DIFF
--- a/appeals/web/src/server/appeals/appeal-details/__tests__/appeal-details.test.js
+++ b/appeals/web/src/server/appeals/appeal-details/__tests__/appeal-details.test.js
@@ -21,7 +21,9 @@ import {
 	fileUploadInfo,
 	interestedPartyCommentsAwaitingReview,
 	caseNotes,
-	activeDirectoryUsersData
+	activeDirectoryUsersData,
+	text300Characters,
+	text301Characters
 } from '#testing/app/fixtures/referencedata.js';
 import { createTestEnvironment } from '#testing/index.js';
 import { capitalize } from 'lodash-es';
@@ -2186,6 +2188,220 @@ describe('appeal-details', () => {
 				expect(columnHtml).toContain(
 					'<li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/documents/2/download/448efec9-43d4-406a-92b7-1aecbdcd5e87/test-document.txt" target="_blank">View</a></li>'
 				);
+			});
+		});
+
+		describe('show more', () => {
+			describe('Inspection access (LPA answer)', () => {
+				it('should not render a "show more" component on the "Inspection access (LPA answer)" row if the associated value is less than or equal to 300 characters in length', async () => {
+					nock('http://test/')
+						.get('/appeals/2')
+						.reply(200, {
+							...appealData,
+							inspectorAccess: {
+								...appealData.inspectorAccess,
+								lpaQuestionnaire: {
+									isRequired: true,
+									details: text300Characters
+								}
+							}
+						});
+
+					const response = await request.get(`${baseUrl}/2`);
+					const unprettifiedElement = parseHtml(response.text, {
+						rootElement: '.appeal-lpa-inspector-access',
+						skipPrettyPrint: true
+					});
+
+					expect(unprettifiedElement.innerHTML).toContain(
+						`<dd class="govuk-summary-list__value"><span>Yes</span><br><span>${text300Characters}</span></dd>`
+					);
+					expect(unprettifiedElement.innerHTML).not.toContain('class="pins-show-more"');
+				});
+
+				it('should render a "show more" component with the expected HTML on the "Inspection access (LPA answer)" row if the associated value is over 300 characters in length', async () => {
+					nock('http://test/')
+						.get('/appeals/2')
+						.reply(200, {
+							...appealData,
+							inspectorAccess: {
+								...appealData.inspectorAccess,
+								lpaQuestionnaire: {
+									isRequired: true,
+									details: text301Characters
+								}
+							}
+						});
+
+					const response = await request.get(`${baseUrl}/2`);
+					const unprettifiedElement = parseHtml(response.text, {
+						rootElement: '.appeal-lpa-inspector-access',
+						skipPrettyPrint: true
+					});
+
+					expect(unprettifiedElement.innerHTML).toContain(
+						`<dd class="govuk-summary-list__value"><span>Yes</span><br><div class="pins-show-more" data-label="Inspection access details (LPA answer)">${text301Characters}</div></dd>`
+					);
+				});
+			});
+
+			describe('Inspection access (appellant answer)', () => {
+				it('should not render a "show more" component on the "Inspection access (appellant answer)" row if the associated value is less than or equal to 300 characters in length', async () => {
+					nock('http://test/')
+						.get('/appeals/2')
+						.reply(200, {
+							...appealData,
+							inspectorAccess: {
+								...appealData.inspectorAccess,
+								appellantCase: {
+									isRequired: true,
+									details: text300Characters
+								}
+							}
+						});
+
+					const response = await request.get(`${baseUrl}/2`);
+					const unprettifiedElement = parseHtml(response.text, {
+						rootElement: '.appeal-appellant-inspector-access',
+						skipPrettyPrint: true
+					});
+
+					expect(unprettifiedElement.innerHTML).toContain(
+						`<dd class="govuk-summary-list__value"><span>Yes</span><br><span>${text300Characters}</span></dd>`
+					);
+					expect(unprettifiedElement.innerHTML).not.toContain('class="pins-show-more"');
+				});
+
+				it('should render a "show more" component with the expected HTML on the "Inspection access (appellant answer)" row if the associated value is over 300 characters in length', async () => {
+					nock('http://test/')
+						.get('/appeals/2')
+						.reply(200, {
+							...appealData,
+							inspectorAccess: {
+								...appealData.inspectorAccess,
+								appellantCase: {
+									isRequired: true,
+									details: text301Characters
+								}
+							}
+						});
+
+					const response = await request.get(`${baseUrl}/2`);
+					const unprettifiedElement = parseHtml(response.text, {
+						rootElement: '.appeal-appellant-inspector-access',
+						skipPrettyPrint: true
+					});
+
+					expect(unprettifiedElement.innerHTML).toContain(
+						`<dd class="govuk-summary-list__value"><span>Yes</span><br><div class="pins-show-more" data-label="Inspection access details (appellant answer)">${text301Characters}</div></dd>`
+					);
+				});
+			});
+
+			describe('Potential safety risks (LPA answer)', () => {
+				it('should not render a "show more" component on the "Potential safety risks (LPA answer)" row if the associated value is less than or equal to 300 characters in length', async () => {
+					nock('http://test/')
+						.get('/appeals/2')
+						.reply(200, {
+							...appealData,
+							healthAndSafety: {
+								...appealData.healthAndSafety,
+								lpaQuestionnaire: {
+									hasIssues: true,
+									details: text300Characters
+								}
+							}
+						});
+
+					const response = await request.get(`${baseUrl}/2`);
+					const unprettifiedElement = parseHtml(response.text, {
+						rootElement: '.appeal-lpa-health-and-safety',
+						skipPrettyPrint: true
+					});
+
+					expect(unprettifiedElement.innerHTML).toContain(
+						`<dd class="govuk-summary-list__value"><span>Yes</span><br><span>${text300Characters}</span></dd>`
+					);
+					expect(unprettifiedElement.innerHTML).not.toContain('class="pins-show-more"');
+				});
+
+				it('should render a "show more" component with the expected HTML on the "Potential safety risks (LPA answer)" row if the associated value is over 300 characters in length', async () => {
+					nock('http://test/')
+						.get('/appeals/2')
+						.reply(200, {
+							...appealData,
+							healthAndSafety: {
+								...appealData.healthAndSafety,
+								lpaQuestionnaire: {
+									hasIssues: true,
+									details: text301Characters
+								}
+							}
+						});
+
+					const response = await request.get(`${baseUrl}/2`);
+					const unprettifiedElement = parseHtml(response.text, {
+						rootElement: '.appeal-lpa-health-and-safety',
+						skipPrettyPrint: true
+					});
+
+					expect(unprettifiedElement.innerHTML).toContain(
+						`<dd class="govuk-summary-list__value"><span>Yes</span><br><div class="pins-show-more" data-label="Potential safety risks details (LPA answer)">${text301Characters}</div></dd>`
+					);
+				});
+			});
+
+			describe('Potential safety risks (appellant answer)', () => {
+				it('should not render a "show more" component on the "Potential safety risks (appellant answer)" row if the associated value is less than or equal to 300 characters in length', async () => {
+					nock('http://test/')
+						.get('/appeals/2')
+						.reply(200, {
+							...appealData,
+							healthAndSafety: {
+								...appealData.healthAndSafety,
+								appellantCase: {
+									hasIssues: true,
+									details: text300Characters
+								}
+							}
+						});
+
+					const response = await request.get(`${baseUrl}/2`);
+					const unprettifiedElement = parseHtml(response.text, {
+						rootElement: '.appeal-appellant-health-and-safety',
+						skipPrettyPrint: true
+					});
+
+					expect(unprettifiedElement.innerHTML).toContain(
+						`<dd class="govuk-summary-list__value"><span>Yes</span><br><span>${text300Characters}</span></dd>`
+					);
+					expect(unprettifiedElement.innerHTML).not.toContain('class="pins-show-more"');
+				});
+
+				it('should render a "show more" component with the expected HTML on the "Potential safety risks (appellant answer)" row if the associated value is over 300 characters in length', async () => {
+					nock('http://test/')
+						.get('/appeals/2')
+						.reply(200, {
+							...appealData,
+							healthAndSafety: {
+								...appealData.healthAndSafety,
+								appellantCase: {
+									hasIssues: true,
+									details: text301Characters
+								}
+							}
+						});
+
+					const response = await request.get(`${baseUrl}/2`);
+					const unprettifiedElement = parseHtml(response.text, {
+						rootElement: '.appeal-appellant-health-and-safety',
+						skipPrettyPrint: true
+					});
+
+					expect(unprettifiedElement.innerHTML).toContain(
+						`<dd class="govuk-summary-list__value"><span>Yes</span><br><div class="pins-show-more" data-label="Potential safety risks details (appellant answer)">${text301Characters}</div></dd>`
+					);
+				});
 			});
 		});
 	});

--- a/appeals/web/src/server/appeals/appeal-details/appellant-case/__tests__/__snapshots__/appellant-case.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/appellant-case/__tests__/__snapshots__/appellant-case.test.js.snap
@@ -131,15 +131,14 @@ exports[`appellant-case GET /appellant-case should render a "Inspector access (a
                     </dd>
                 </div>
                 <div class="govuk-summary-list__row appellantcase-inspector-access"><dt class="govuk-summary-list__key"> Inspector access required</dt>
-                    <dd                     class="govuk-summary-list__value"><span>No</span>
+                    <dd                     class="govuk-summary-list__value"><span>No answer provided</span>
                         </dd>
                         <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/inspector-access/change/appellant"
                             data-cy="change-inspector-access"> Change<span class="govuk-visually-hidden"> Inspector access required</span></a>
                         </dd>
                 </div>
                 <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Potential safety risks</dt>
-                    <dd class="govuk-summary-list__value"><span>Yes</span>
-                        <br><span>Dogs on site</span>
+                    <dd class="govuk-summary-list__value"><span>No</span>
                     </dd>
                     <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/safety-risks/change/appellant"
                         data-cy="change-appellant-case-health-and-safety"> Change<span class="govuk-visually-hidden"> Potential safety risks</span></a>
@@ -391,15 +390,14 @@ exports[`appellant-case GET /appellant-case should render a "LPA application ref
                     </dd>
                 </div>
                 <div class="govuk-summary-list__row appellantcase-inspector-access"><dt class="govuk-summary-list__key"> Inspector access required</dt>
-                    <dd                     class="govuk-summary-list__value"><span>No</span>
+                    <dd                     class="govuk-summary-list__value"><span>No answer provided</span>
                         </dd>
                         <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/inspector-access/change/appellant"
                             data-cy="change-inspector-access"> Change<span class="govuk-visually-hidden"> Inspector access required</span></a>
                         </dd>
                 </div>
                 <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Potential safety risks</dt>
-                    <dd class="govuk-summary-list__value"><span>Yes</span>
-                        <br><span>Dogs on site</span>
+                    <dd class="govuk-summary-list__value"><span>No</span>
                     </dd>
                     <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/safety-risks/change/appellant"
                         data-cy="change-appellant-case-health-and-safety"> Change<span class="govuk-visually-hidden"> Potential safety risks</span></a>
@@ -687,15 +685,14 @@ exports[`appellant-case GET /appellant-case should render a "Site area updated" 
                     </dd>
                 </div>
                 <div class="govuk-summary-list__row appellantcase-inspector-access"><dt class="govuk-summary-list__key"> Inspector access required</dt>
-                    <dd                     class="govuk-summary-list__value"><span>No</span>
+                    <dd                     class="govuk-summary-list__value"><span>No answer provided</span>
                         </dd>
                         <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/inspector-access/change/appellant"
                             data-cy="change-inspector-access"> Change<span class="govuk-visually-hidden"> Inspector access required</span></a>
                         </dd>
                 </div>
                 <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Potential safety risks</dt>
-                    <dd class="govuk-summary-list__value"><span>Yes</span>
-                        <br><span>Dogs on site</span>
+                    <dd class="govuk-summary-list__value"><span>No</span>
                     </dd>
                     <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/safety-risks/change/appellant"
                         data-cy="change-appellant-case-health-and-safety"> Change<span class="govuk-visually-hidden"> Potential safety risks</span></a>
@@ -947,15 +944,14 @@ exports[`appellant-case GET /appellant-case should render a "Site health and saf
                     </dd>
                 </div>
                 <div class="govuk-summary-list__row appellantcase-inspector-access"><dt class="govuk-summary-list__key"> Inspector access required</dt>
-                    <dd                     class="govuk-summary-list__value"><span>No</span>
+                    <dd                     class="govuk-summary-list__value"><span>No answer provided</span>
                         </dd>
                         <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/inspector-access/change/appellant"
                             data-cy="change-inspector-access"> Change<span class="govuk-visually-hidden"> Inspector access required</span></a>
                         </dd>
                 </div>
                 <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Potential safety risks</dt>
-                    <dd class="govuk-summary-list__value"><span>Yes</span>
-                        <br><span>Dogs on site</span>
+                    <dd class="govuk-summary-list__value"><span>No</span>
                     </dd>
                     <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/safety-risks/change/appellant"
                         data-cy="change-appellant-case-health-and-safety"> Change<span class="govuk-visually-hidden"> Potential safety risks</span></a>
@@ -1207,15 +1203,14 @@ exports[`appellant-case GET /appellant-case should render a "Site updated" notif
                     </dd>
                 </div>
                 <div class="govuk-summary-list__row appellantcase-inspector-access"><dt class="govuk-summary-list__key"> Inspector access required</dt>
-                    <dd                     class="govuk-summary-list__value"><span>No</span>
+                    <dd                     class="govuk-summary-list__value"><span>No answer provided</span>
                         </dd>
                         <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/inspector-access/change/appellant"
                             data-cy="change-inspector-access"> Change<span class="govuk-visually-hidden"> Inspector access required</span></a>
                         </dd>
                 </div>
                 <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Potential safety risks</dt>
-                    <dd class="govuk-summary-list__value"><span>Yes</span>
-                        <br><span>Dogs on site</span>
+                    <dd class="govuk-summary-list__value"><span>No</span>
                     </dd>
                     <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/safety-risks/change/appellant"
                         data-cy="change-appellant-case-health-and-safety"> Change<span class="govuk-visually-hidden"> Potential safety risks</span></a>
@@ -1479,15 +1474,14 @@ exports[`appellant-case GET /appellant-case should render a success notification
                     </dd>
                 </div>
                 <div class="govuk-summary-list__row appellantcase-inspector-access"><dt class="govuk-summary-list__key"> Inspector access required</dt>
-                    <dd                     class="govuk-summary-list__value"><span>No</span>
+                    <dd                     class="govuk-summary-list__value"><span>No answer provided</span>
                         </dd>
                         <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/inspector-access/change/appellant"
                             data-cy="change-inspector-access"> Change<span class="govuk-visually-hidden"> Inspector access required</span></a>
                         </dd>
                 </div>
                 <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Potential safety risks</dt>
-                    <dd class="govuk-summary-list__value"><span>Yes</span>
-                        <br><span>Dogs on site</span>
+                    <dd class="govuk-summary-list__value"><span>No</span>
                     </dd>
                     <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/safety-risks/change/appellant"
                         data-cy="change-appellant-case-health-and-safety"> Change<span class="govuk-visually-hidden"> Potential safety risks</span></a>
@@ -1821,15 +1815,14 @@ exports[`appellant-case GET /appellant-case should render review outcome form fi
                     </dd>
                 </div>
                 <div class="govuk-summary-list__row appellantcase-inspector-access"><dt class="govuk-summary-list__key"> Inspector access required</dt>
-                    <dd                     class="govuk-summary-list__value"><span>No</span>
+                    <dd                     class="govuk-summary-list__value"><span>No answer provided</span>
                         </dd>
                         <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/appellant-case/inspector-access/change/appellant"
                             data-cy="change-inspector-access"> Change<span class="govuk-visually-hidden"> Inspector access required</span></a>
                         </dd>
                 </div>
                 <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Potential safety risks</dt>
-                    <dd class="govuk-summary-list__value"><span>Yes</span>
-                        <br><span>Dogs on site</span>
+                    <dd class="govuk-summary-list__value"><span>No</span>
                     </dd>
                     <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/appellant-case/safety-risks/change/appellant"
                         data-cy="change-appellant-case-health-and-safety"> Change<span class="govuk-visually-hidden"> Potential safety risks</span></a>
@@ -2101,15 +2094,14 @@ exports[`appellant-case GET /appellant-case should render the appellant case pag
                     </dd>
                 </div>
                 <div class="govuk-summary-list__row appellantcase-inspector-access"><dt class="govuk-summary-list__key"> Inspector access required</dt>
-                    <dd                     class="govuk-summary-list__value"><span>No</span>
+                    <dd                     class="govuk-summary-list__value"><span>No answer provided</span>
                         </dd>
                         <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/appellant-case/inspector-access/change/appellant"
                             data-cy="change-inspector-access"> Change<span class="govuk-visually-hidden"> Inspector access required</span></a>
                         </dd>
                 </div>
                 <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Potential safety risks</dt>
-                    <dd class="govuk-summary-list__value"><span>Yes</span>
-                        <br><span>Dogs on site</span>
+                    <dd class="govuk-summary-list__value"><span>No</span>
                     </dd>
                     <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/appellant-case/safety-risks/change/appellant"
                         data-cy="change-appellant-case-health-and-safety"> Change<span class="govuk-visually-hidden"> Potential safety risks</span></a>
@@ -2218,7 +2210,7 @@ exports[`appellant-case GET /appellant-case should render the appellant case pag
                 <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Reason for preference</dt>
                     <dd class="govuk-summary-list__value">Not applicable</dd>
                     <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/appellant-case/procedure-preference/details/change"
-                        data-cy="change-procedure-preference-details"> Change<span class="govuk-visually-hidden"> reason for preference</span></a>
+                        data-cy="change-procedure-preference-details"> Change<span class="govuk-visually-hidden"> Reason for preference</span></a>
                     </dd>
                 </div>
                 <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Expected length of procedure</dt>
@@ -2407,15 +2399,14 @@ exports[`appellant-case GET /appellant-case should render the appellant case pag
                     </dd>
                 </div>
                 <div class="govuk-summary-list__row appellantcase-inspector-access"><dt class="govuk-summary-list__key"> Inspector access required</dt>
-                    <dd                     class="govuk-summary-list__value"><span>No</span>
+                    <dd                     class="govuk-summary-list__value"><span>No answer provided</span>
                         </dd>
                         <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/inspector-access/change/appellant"
                             data-cy="change-inspector-access"> Change<span class="govuk-visually-hidden"> Inspector access required</span></a>
                         </dd>
                 </div>
                 <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Potential safety risks</dt>
-                    <dd class="govuk-summary-list__value"><span>Yes</span>
-                        <br><span>Dogs on site</span>
+                    <dd class="govuk-summary-list__value"><span>No</span>
                     </dd>
                     <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/safety-risks/change/appellant"
                         data-cy="change-appellant-case-health-and-safety"> Change<span class="govuk-visually-hidden"> Potential safety risks</span></a>
@@ -4678,15 +4669,14 @@ exports[`appellant-case POST /appellant-case should re-render the appellant case
                     </dd>
                 </div>
                 <div class="govuk-summary-list__row appellantcase-inspector-access"><dt class="govuk-summary-list__key"> Inspector access required</dt>
-                    <dd                     class="govuk-summary-list__value"><span>No</span>
+                    <dd                     class="govuk-summary-list__value"><span>No answer provided</span>
                         </dd>
                         <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/inspector-access/change/appellant"
                             data-cy="change-inspector-access"> Change<span class="govuk-visually-hidden"> Inspector access required</span></a>
                         </dd>
                 </div>
                 <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Potential safety risks</dt>
-                    <dd class="govuk-summary-list__value"><span>Yes</span>
-                        <br><span>Dogs on site</span>
+                    <dd class="govuk-summary-list__value"><span>No</span>
                     </dd>
                     <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/safety-risks/change/appellant"
                         data-cy="change-appellant-case-health-and-safety"> Change<span class="govuk-visually-hidden"> Potential safety risks</span></a>

--- a/appeals/web/src/server/appeals/appeal-details/appellant-case/__tests__/appellant-case.test.js
+++ b/appeals/web/src/server/appeals/appeal-details/appellant-case/__tests__/appellant-case.test.js
@@ -22,7 +22,9 @@ import {
 	appealData,
 	appealDataFullPlanning,
 	appellantCaseDataInvalidOutcome,
-	fileUploadInfo
+	fileUploadInfo,
+	text300Characters,
+	text301Characters
 } from '#testing/app/fixtures/referencedata.js';
 import { cloneDeep } from 'lodash-es';
 import { textInputCharacterLimits } from '#appeals/appeal.constants.js';
@@ -139,69 +141,6 @@ describe('appellant-case', () => {
 			expect(unprettifiedElement.innerHTML).toContain('Reason for preference</dt>');
 			expect(unprettifiedElement.innerHTML).toContain('Expected length of procedure</dt>');
 			expect(unprettifiedElement.innerHTML).toContain('Expected number of witnesses</dt>');
-		});
-
-		const text300Characters =
-			'Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cill';
-
-		it('should render a "show more" component with the expected HTML on a text row with a value over 300 characters in length', async () => {
-			const text301Characters = text300Characters + 'u';
-
-			nock('http://test/')
-				.get('/appeals/2')
-				.reply(200, {
-					...appealData,
-					appealId: 2
-				});
-			nock('http://test/')
-				.get('/appeals/2/appellant-cases/0')
-				.reply(200, {
-					...appellantCaseDataNotValidated,
-					developmentDescription: {
-						...appellantCaseDataNotValidated.developmentDescription,
-						details: text301Characters
-					}
-				});
-
-			const response = await request.get(`${baseUrl}/2${appellantCasePagePath}`);
-
-			const unprettifiedElement = parseHtml(response.text, {
-				rootElement: '#application-summary',
-				skipPrettyPrint: true
-			});
-
-			expect(unprettifiedElement.innerHTML).toContain(
-				'<div class="pins-show-more" data-label="Original Development description">Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillu</div>'
-			);
-		});
-
-		it('should not render a "show more" component on a text row with a value less than or equal to 300 characters in length', async () => {
-			nock('http://test/')
-				.get('/appeals/2')
-				.reply(200, {
-					...appealData,
-					appealId: 2
-				});
-			nock('http://test/')
-				.get('/appeals/2/appellant-cases/0')
-				.reply(200, {
-					...appellantCaseDataNotValidated,
-					developmentDescription: {
-						...appellantCaseDataNotValidated.developmentDescription,
-						details: text300Characters
-					}
-				});
-
-			const response = await request.get(`${baseUrl}/2${appellantCasePagePath}`);
-			const unprettifiedElement = parseHtml(response.text, {
-				rootElement: '#application-summary',
-				skipPrettyPrint: true
-			});
-
-			expect(unprettifiedElement.innerHTML).toContain(
-				`<dd class="govuk-summary-list__value"> ${text300Characters}</dd>`
-			);
-			expect(unprettifiedElement.innerHTML).not.toContain('class="pins-show-more"');
 		});
 
 		it('should render review outcome form fields and controls when the appeal is in "validation" status', async () => {
@@ -753,6 +692,242 @@ describe('appellant-case', () => {
 			expect(unprettifiedNotificationBannerElementHTML).toContain(
 				'Ownership certificate or land declaration submitted updated'
 			);
+		});
+
+		describe('show more', () => {
+			describe('inspector access required', () => {
+				it('should not render a "show more" component on the "inspector access required" row if the associated value is less than or equal to 300 characters in length', async () => {
+					nock('http://test/')
+						.get('/appeals/2')
+						.reply(200, {
+							...appealData,
+							appellantCaseId: 3
+						});
+					nock('http://test/')
+						.get('/appeals/1/appellant-cases/3')
+						.reply(200, {
+							...appellantCaseDataNotValidated,
+							siteAccessRequired: {
+								hasIssues: true,
+								details: text300Characters
+							}
+						});
+
+					const response = await request.get(`${baseUrl}/2${appellantCasePagePath}`);
+					const unprettifiedElement = parseHtml(response.text, {
+						rootElement: '#site-details',
+						skipPrettyPrint: true
+					});
+
+					expect(unprettifiedElement.innerHTML).toContain(
+						`<dd class="govuk-summary-list__value"><span>Yes</span><br><span>${text300Characters}</span></dd>`
+					);
+					expect(unprettifiedElement.innerHTML).not.toContain('class="pins-show-more"');
+				});
+
+				it('should render a "show more" component with the expected HTML on the "inspector access required" row if the associated value is over 300 characters in length', async () => {
+					nock('http://test/')
+						.get('/appeals/2')
+						.reply(200, {
+							...appealData,
+							appellantCaseId: 3
+						});
+					nock('http://test/')
+						.get('/appeals/1/appellant-cases/3')
+						.reply(200, {
+							...appellantCaseDataNotValidated,
+							siteAccessRequired: {
+								hasIssues: true,
+								details: text301Characters
+							}
+						});
+
+					const response = await request.get(`${baseUrl}/2${appellantCasePagePath}`);
+
+					const unprettifiedElement = parseHtml(response.text, {
+						rootElement: '#site-details',
+						skipPrettyPrint: true
+					});
+
+					expect(unprettifiedElement.innerHTML).toContain(
+						`<dd class="govuk-summary-list__value"><span>Yes</span><br><div class="pins-show-more" data-label="Inspector access details">${text301Characters}</div></dd>`
+					);
+				});
+			});
+
+			describe('potential safety risks', () => {
+				it('should not render a "show more" component on the "potential safety risks" row if the associated value is less than or equal to 300 characters in length', async () => {
+					nock('http://test/')
+						.get('/appeals/2')
+						.reply(200, {
+							...appealData,
+							appellantCaseId: 3
+						});
+					nock('http://test/')
+						.get('/appeals/1/appellant-cases/3')
+						.reply(200, {
+							...appellantCaseDataNotValidated,
+							healthAndSafety: {
+								hasIssues: true,
+								details: text300Characters
+							}
+						});
+
+					const response = await request.get(`${baseUrl}/2${appellantCasePagePath}`);
+					const unprettifiedElement = parseHtml(response.text, {
+						rootElement: '#site-details',
+						skipPrettyPrint: true
+					});
+
+					expect(unprettifiedElement.innerHTML).toContain(
+						`<dd class="govuk-summary-list__value"><span>Yes</span><br><span>${text300Characters}</span></dd>`
+					);
+					expect(unprettifiedElement.innerHTML).not.toContain('class="pins-show-more"');
+				});
+
+				it('should render a "show more" component with the expected HTML on the "potential safety risks" row if the associated value is over 300 characters in length', async () => {
+					nock('http://test/')
+						.get('/appeals/2')
+						.reply(200, {
+							...appealData,
+							appellantCaseId: 3
+						});
+					nock('http://test/')
+						.get('/appeals/1/appellant-cases/3')
+						.reply(200, {
+							...appellantCaseDataNotValidated,
+							healthAndSafety: {
+								hasIssues: true,
+								details: text301Characters
+							}
+						});
+
+					const response = await request.get(`${baseUrl}/2${appellantCasePagePath}`);
+
+					const unprettifiedElement = parseHtml(response.text, {
+						rootElement: '#site-details',
+						skipPrettyPrint: true
+					});
+
+					expect(unprettifiedElement.innerHTML).toContain(
+						`<dd class="govuk-summary-list__value"><span>Yes</span><br><div class="pins-show-more" data-label="Potential safety risks details">${text301Characters}</div></dd>`
+					);
+				});
+			});
+
+			describe('original development description', () => {
+				it('should not render a "show more" component on the "original development description" row if the associated value is less than or equal to 300 characters in length', async () => {
+					nock('http://test/')
+						.get('/appeals/2')
+						.reply(200, {
+							...appealData,
+							appellantCaseId: 3
+						});
+					nock('http://test/')
+						.get('/appeals/1/appellant-cases/3')
+						.reply(200, {
+							...appellantCaseDataNotValidated,
+							developmentDescription: {
+								details: text300Characters
+							}
+						});
+
+					const response = await request.get(`${baseUrl}/2${appellantCasePagePath}`);
+					const unprettifiedElement = parseHtml(response.text, {
+						rootElement: '#application-summary',
+						skipPrettyPrint: true
+					});
+
+					expect(unprettifiedElement.innerHTML).toContain(
+						`<dd class="govuk-summary-list__value"> ${text300Characters}</dd>`
+					);
+					expect(unprettifiedElement.innerHTML).not.toContain('class="pins-show-more"');
+				});
+
+				it('should render a "show more" component with the expected HTML on the "original development description" row if the associated value is over 300 characters in length', async () => {
+					nock('http://test/')
+						.get('/appeals/2')
+						.reply(200, {
+							...appealData,
+							appellantCaseId: 3
+						});
+					nock('http://test/')
+						.get('/appeals/1/appellant-cases/3')
+						.reply(200, {
+							...appellantCaseDataNotValidated,
+							developmentDescription: {
+								details: text301Characters
+							}
+						});
+
+					const response = await request.get(`${baseUrl}/2${appellantCasePagePath}`);
+
+					const unprettifiedElement = parseHtml(response.text, {
+						rootElement: '#application-summary',
+						skipPrettyPrint: true
+					});
+
+					expect(unprettifiedElement.innerHTML).toContain(
+						`<div class="pins-show-more" data-label="Original Development description details">${text301Characters}</div>`
+					);
+				});
+			});
+
+			describe('reason for preference', () => {
+				it('should not render a "show more" component on the "reason for preference" row if the associated value is less than or equal to 300 characters in length', async () => {
+					nock('http://test/')
+						.get('/appeals/2')
+						.reply(200, {
+							...appealData,
+							appealId: 2,
+							appealType: 'Planning appeal'
+						});
+					nock('http://test/')
+						.get('/appeals/2/appellant-cases/0')
+						.reply(200, {
+							...appellantCaseDataNotValidated,
+							appellantProcedurePreferenceDetails: text300Characters
+						});
+
+					const response = await request.get(`${baseUrl}/2${appellantCasePagePath}`);
+					const unprettifiedElement = parseHtml(response.text, {
+						rootElement: '#appeal-summary',
+						skipPrettyPrint: true
+					});
+
+					expect(unprettifiedElement.innerHTML).toContain(
+						`<dd class="govuk-summary-list__value"> ${text300Characters}</dd>`
+					);
+					expect(unprettifiedElement.innerHTML).not.toContain('class="pins-show-more"');
+				});
+
+				it('should render a "show more" component with the expected HTML on the "reason for preference" row if the associated value is over 300 characters in length', async () => {
+					nock('http://test/')
+						.get('/appeals/2')
+						.reply(200, {
+							...appealData,
+							appealId: 2,
+							appealType: 'Planning appeal'
+						});
+					nock('http://test/')
+						.get('/appeals/2/appellant-cases/0')
+						.reply(200, {
+							...appellantCaseDataNotValidated,
+							appellantProcedurePreferenceDetails: text301Characters
+						});
+
+					const response = await request.get(`${baseUrl}/2${appellantCasePagePath}`);
+
+					const unprettifiedElement = parseHtml(response.text, {
+						rootElement: '#appeal-summary',
+						skipPrettyPrint: true
+					});
+
+					expect(unprettifiedElement.innerHTML).toContain(
+						`<div class="pins-show-more" data-label="Reason for preference details">${text301Characters}</div>`
+					);
+				});
+			});
 		});
 	});
 

--- a/appeals/web/src/server/appeals/appeal-details/appellant-case/procedure-preference/__tests__/__snapshots__/procedure-preference.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/appellant-case/procedure-preference/__tests__/__snapshots__/procedure-preference.test.js.snap
@@ -97,15 +97,14 @@ exports[`procedure-preference GET /appellant-case should render a summary list r
                     </dd>
                 </div>
                 <div class="govuk-summary-list__row appellantcase-inspector-access"><dt class="govuk-summary-list__key"> Inspector access required</dt>
-                    <dd                     class="govuk-summary-list__value"><span>No</span>
+                    <dd                     class="govuk-summary-list__value"><span>No answer provided</span>
                         </dd>
                         <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/appellant-case/inspector-access/change/appellant"
                             data-cy="change-inspector-access"> Change<span class="govuk-visually-hidden"> Inspector access required</span></a>
                         </dd>
                 </div>
                 <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Potential safety risks</dt>
-                    <dd class="govuk-summary-list__value"><span>Yes</span>
-                        <br><span>Dogs on site</span>
+                    <dd class="govuk-summary-list__value"><span>No</span>
                     </dd>
                     <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/appellant-case/safety-risks/change/appellant"
                         data-cy="change-appellant-case-health-and-safety"> Change<span class="govuk-visually-hidden"> Potential safety risks</span></a>
@@ -214,7 +213,7 @@ exports[`procedure-preference GET /appellant-case should render a summary list r
                 <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Reason for preference</dt>
                     <dd class="govuk-summary-list__value">Not applicable</dd>
                     <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/appellant-case/procedure-preference/details/change"
-                        data-cy="change-procedure-preference-details"> Change<span class="govuk-visually-hidden"> reason for preference</span></a>
+                        data-cy="change-procedure-preference-details"> Change<span class="govuk-visually-hidden"> Reason for preference</span></a>
                     </dd>
                 </div>
                 <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Expected length of procedure</dt>
@@ -418,15 +417,14 @@ exports[`procedure-preference GET /appellant-case should render a summary list r
                     </dd>
                 </div>
                 <div class="govuk-summary-list__row appellantcase-inspector-access"><dt class="govuk-summary-list__key"> Inspector access required</dt>
-                    <dd                     class="govuk-summary-list__value"><span>No</span>
+                    <dd                     class="govuk-summary-list__value"><span>No answer provided</span>
                         </dd>
                         <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/appellant-case/inspector-access/change/appellant"
                             data-cy="change-inspector-access"> Change<span class="govuk-visually-hidden"> Inspector access required</span></a>
                         </dd>
                 </div>
                 <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Potential safety risks</dt>
-                    <dd class="govuk-summary-list__value"><span>Yes</span>
-                        <br><span>Dogs on site</span>
+                    <dd class="govuk-summary-list__value"><span>No</span>
                     </dd>
                     <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/appellant-case/safety-risks/change/appellant"
                         data-cy="change-appellant-case-health-and-safety"> Change<span class="govuk-visually-hidden"> Potential safety risks</span></a>
@@ -535,7 +533,7 @@ exports[`procedure-preference GET /appellant-case should render a summary list r
                 <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Reason for preference</dt>
                     <dd class="govuk-summary-list__value">Not applicable</dd>
                     <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/appellant-case/procedure-preference/details/change"
-                        data-cy="change-procedure-preference-details"> Change<span class="govuk-visually-hidden"> reason for preference</span></a>
+                        data-cy="change-procedure-preference-details"> Change<span class="govuk-visually-hidden"> Reason for preference</span></a>
                     </dd>
                 </div>
                 <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Expected length of procedure</dt>
@@ -739,15 +737,14 @@ exports[`procedure-preference GET /appellant-case should render a summary list r
                     </dd>
                 </div>
                 <div class="govuk-summary-list__row appellantcase-inspector-access"><dt class="govuk-summary-list__key"> Inspector access required</dt>
-                    <dd                     class="govuk-summary-list__value"><span>No</span>
+                    <dd                     class="govuk-summary-list__value"><span>No answer provided</span>
                         </dd>
                         <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/appellant-case/inspector-access/change/appellant"
                             data-cy="change-inspector-access"> Change<span class="govuk-visually-hidden"> Inspector access required</span></a>
                         </dd>
                 </div>
                 <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Potential safety risks</dt>
-                    <dd class="govuk-summary-list__value"><span>Yes</span>
-                        <br><span>Dogs on site</span>
+                    <dd class="govuk-summary-list__value"><span>No</span>
                     </dd>
                     <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/appellant-case/safety-risks/change/appellant"
                         data-cy="change-appellant-case-health-and-safety"> Change<span class="govuk-visually-hidden"> Potential safety risks</span></a>
@@ -856,7 +853,7 @@ exports[`procedure-preference GET /appellant-case should render a summary list r
                 <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Reason for preference</dt>
                     <dd class="govuk-summary-list__value">Not applicable</dd>
                     <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/appellant-case/procedure-preference/details/change"
-                        data-cy="change-procedure-preference-details"> Change<span class="govuk-visually-hidden"> reason for preference</span></a>
+                        data-cy="change-procedure-preference-details"> Change<span class="govuk-visually-hidden"> Reason for preference</span></a>
                     </dd>
                 </div>
                 <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Expected length of procedure</dt>
@@ -1060,15 +1057,14 @@ exports[`procedure-preference GET /appellant-case should render a summary list r
                     </dd>
                 </div>
                 <div class="govuk-summary-list__row appellantcase-inspector-access"><dt class="govuk-summary-list__key"> Inspector access required</dt>
-                    <dd                     class="govuk-summary-list__value"><span>No</span>
+                    <dd                     class="govuk-summary-list__value"><span>No answer provided</span>
                         </dd>
                         <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/appellant-case/inspector-access/change/appellant"
                             data-cy="change-inspector-access"> Change<span class="govuk-visually-hidden"> Inspector access required</span></a>
                         </dd>
                 </div>
                 <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Potential safety risks</dt>
-                    <dd class="govuk-summary-list__value"><span>Yes</span>
-                        <br><span>Dogs on site</span>
+                    <dd class="govuk-summary-list__value"><span>No</span>
                     </dd>
                     <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/appellant-case/safety-risks/change/appellant"
                         data-cy="change-appellant-case-health-and-safety"> Change<span class="govuk-visually-hidden"> Potential safety risks</span></a>
@@ -1177,7 +1173,7 @@ exports[`procedure-preference GET /appellant-case should render a summary list r
                 <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Reason for preference</dt>
                     <dd class="govuk-summary-list__value">Not applicable</dd>
                     <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/appellant-case/procedure-preference/details/change"
-                        data-cy="change-procedure-preference-details"> Change<span class="govuk-visually-hidden"> reason for preference</span></a>
+                        data-cy="change-procedure-preference-details"> Change<span class="govuk-visually-hidden"> Reason for preference</span></a>
                     </dd>
                 </div>
                 <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Expected length of procedure</dt>
@@ -1381,15 +1377,14 @@ exports[`procedure-preference GET /appellant-case should render a summary list r
                     </dd>
                 </div>
                 <div class="govuk-summary-list__row appellantcase-inspector-access"><dt class="govuk-summary-list__key"> Inspector access required</dt>
-                    <dd                     class="govuk-summary-list__value"><span>No</span>
+                    <dd                     class="govuk-summary-list__value"><span>No answer provided</span>
                         </dd>
                         <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/appellant-case/inspector-access/change/appellant"
                             data-cy="change-inspector-access"> Change<span class="govuk-visually-hidden"> Inspector access required</span></a>
                         </dd>
                 </div>
                 <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Potential safety risks</dt>
-                    <dd class="govuk-summary-list__value"><span>Yes</span>
-                        <br><span>Dogs on site</span>
+                    <dd class="govuk-summary-list__value"><span>No</span>
                     </dd>
                     <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/appellant-case/safety-risks/change/appellant"
                         data-cy="change-appellant-case-health-and-safety"> Change<span class="govuk-visually-hidden"> Potential safety risks</span></a>
@@ -1498,7 +1493,7 @@ exports[`procedure-preference GET /appellant-case should render a summary list r
                 <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Reason for preference</dt>
                     <dd class="govuk-summary-list__value">Not applicable</dd>
                     <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/appellant-case/procedure-preference/details/change"
-                        data-cy="change-procedure-preference-details"> Change<span class="govuk-visually-hidden"> reason for preference</span></a>
+                        data-cy="change-procedure-preference-details"> Change<span class="govuk-visually-hidden"> Reason for preference</span></a>
                     </dd>
                 </div>
                 <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Expected length of procedure</dt>
@@ -1702,15 +1697,14 @@ exports[`procedure-preference GET /appellant-case should render a summary list r
                     </dd>
                 </div>
                 <div class="govuk-summary-list__row appellantcase-inspector-access"><dt class="govuk-summary-list__key"> Inspector access required</dt>
-                    <dd                     class="govuk-summary-list__value"><span>No</span>
+                    <dd                     class="govuk-summary-list__value"><span>No answer provided</span>
                         </dd>
                         <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/appellant-case/inspector-access/change/appellant"
                             data-cy="change-inspector-access"> Change<span class="govuk-visually-hidden"> Inspector access required</span></a>
                         </dd>
                 </div>
                 <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Potential safety risks</dt>
-                    <dd class="govuk-summary-list__value"><span>Yes</span>
-                        <br><span>Dogs on site</span>
+                    <dd class="govuk-summary-list__value"><span>No</span>
                     </dd>
                     <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/appellant-case/safety-risks/change/appellant"
                         data-cy="change-appellant-case-health-and-safety"> Change<span class="govuk-visually-hidden"> Potential safety risks</span></a>
@@ -1819,7 +1813,7 @@ exports[`procedure-preference GET /appellant-case should render a summary list r
                 <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Reason for preference</dt>
                     <dd class="govuk-summary-list__value">Not applicable</dd>
                     <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/appellant-case/procedure-preference/details/change"
-                        data-cy="change-procedure-preference-details"> Change<span class="govuk-visually-hidden"> reason for preference</span></a>
+                        data-cy="change-procedure-preference-details"> Change<span class="govuk-visually-hidden"> Reason for preference</span></a>
                     </dd>
                 </div>
                 <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Expected length of procedure</dt>
@@ -2023,15 +2017,14 @@ exports[`procedure-preference GET /appellant-case should render a summary list r
                     </dd>
                 </div>
                 <div class="govuk-summary-list__row appellantcase-inspector-access"><dt class="govuk-summary-list__key"> Inspector access required</dt>
-                    <dd                     class="govuk-summary-list__value"><span>No</span>
+                    <dd                     class="govuk-summary-list__value"><span>No answer provided</span>
                         </dd>
                         <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/appellant-case/inspector-access/change/appellant"
                             data-cy="change-inspector-access"> Change<span class="govuk-visually-hidden"> Inspector access required</span></a>
                         </dd>
                 </div>
                 <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Potential safety risks</dt>
-                    <dd class="govuk-summary-list__value"><span>Yes</span>
-                        <br><span>Dogs on site</span>
+                    <dd class="govuk-summary-list__value"><span>No</span>
                     </dd>
                     <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/appellant-case/safety-risks/change/appellant"
                         data-cy="change-appellant-case-health-and-safety"> Change<span class="govuk-visually-hidden"> Potential safety risks</span></a>
@@ -2140,7 +2133,7 @@ exports[`procedure-preference GET /appellant-case should render a summary list r
                 <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Reason for preference</dt>
                     <dd class="govuk-summary-list__value">Not applicable</dd>
                     <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/appellant-case/procedure-preference/details/change"
-                        data-cy="change-procedure-preference-details"> Change<span class="govuk-visually-hidden"> reason for preference</span></a>
+                        data-cy="change-procedure-preference-details"> Change<span class="govuk-visually-hidden"> Reason for preference</span></a>
                     </dd>
                 </div>
                 <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Expected length of procedure</dt>
@@ -2344,15 +2337,14 @@ exports[`procedure-preference GET /appellant-case should render a summary list r
                     </dd>
                 </div>
                 <div class="govuk-summary-list__row appellantcase-inspector-access"><dt class="govuk-summary-list__key"> Inspector access required</dt>
-                    <dd                     class="govuk-summary-list__value"><span>No</span>
+                    <dd                     class="govuk-summary-list__value"><span>No answer provided</span>
                         </dd>
                         <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/appellant-case/inspector-access/change/appellant"
                             data-cy="change-inspector-access"> Change<span class="govuk-visually-hidden"> Inspector access required</span></a>
                         </dd>
                 </div>
                 <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Potential safety risks</dt>
-                    <dd class="govuk-summary-list__value"><span>Yes</span>
-                        <br><span>Dogs on site</span>
+                    <dd class="govuk-summary-list__value"><span>No</span>
                     </dd>
                     <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/appellant-case/safety-risks/change/appellant"
                         data-cy="change-appellant-case-health-and-safety"> Change<span class="govuk-visually-hidden"> Potential safety risks</span></a>
@@ -2461,7 +2453,7 @@ exports[`procedure-preference GET /appellant-case should render a summary list r
                 <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Reason for preference</dt>
                     <dd class="govuk-summary-list__value">Lorem ipsum</dd>
                     <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/appellant-case/procedure-preference/details/change"
-                        data-cy="change-procedure-preference-details"> Change<span class="govuk-visually-hidden"> reason for preference</span></a>
+                        data-cy="change-procedure-preference-details"> Change<span class="govuk-visually-hidden"> Reason for preference</span></a>
                     </dd>
                 </div>
                 <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Expected length of procedure</dt>

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/__tests__/__snapshots__/lpa-questionnaire.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/__tests__/__snapshots__/lpa-questionnaire.test.js.snap
@@ -81,7 +81,7 @@ exports[`LPA Questionnaire review GET / should render review outcome form fields
             <h2 class="govuk-summary-card__title">2. Notifying relevant parties of the application</h2>
         </div>
         <div class="govuk-summary-card__content">
-            <dl class="govuk-summary-list">
+            <dl class="govuk-summary-list" id="notifications-summary">
                 <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Who was notified</dt>
                     <dd class="govuk-summary-list__value">
                         <ul class="govuk-list">
@@ -134,7 +134,7 @@ exports[`LPA Questionnaire review GET / should render review outcome form fields
             <h2 class="govuk-summary-card__title">3. Consultation responses and representations</h2>
         </div>
         <div class="govuk-summary-card__content">
-            <dl class="govuk-summary-list">
+            <dl class="govuk-summary-list" id="representations-summary">
                 <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Representations from other parties documents</dt>
                     <dd                     class="govuk-summary-list__value">
                         <ul class="govuk-list">
@@ -161,7 +161,7 @@ exports[`LPA Questionnaire review GET / should render review outcome form fields
             <h2 class="govuk-summary-card__title">4. Planning officer’s report and supplementary documents</h2>
         </div>
         <div class="govuk-summary-card__content">
-            <dl class="govuk-summary-list">
+            <dl class="govuk-summary-list" id="supplementary-documents-summary">
                 <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Planning officer&#39;s report</dt>
                     <dd                     class="govuk-summary-list__value">
                         <ul class="govuk-list">
@@ -208,7 +208,7 @@ exports[`LPA Questionnaire review GET / should render review outcome form fields
             <h2 class="govuk-summary-card__title">5. Site access</h2>
         </div>
         <div class="govuk-summary-card__content">
-            <dl class="govuk-summary-list">
+            <dl class="govuk-summary-list" id="site-access-summary">
                 <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Site access required</dt>
                     <dd class="govuk-summary-list__value"><span>Yes</span>
                         <br><span>The entrance is at the back of the property</span>
@@ -249,7 +249,7 @@ exports[`LPA Questionnaire review GET / should render review outcome form fields
             <h2 class="govuk-summary-card__title">6. Appeal process</h2>
         </div>
         <div class="govuk-summary-card__content">
-            <dl class="govuk-summary-list">
+            <dl class="govuk-summary-list" id="appeal-process-summary">
                 <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Appeals near the site</dt>
                     <dd class="govuk-summary-list__value"><span>No appeals</span>
                     </dd>
@@ -413,7 +413,7 @@ exports[`LPA Questionnaire review GET / should render the LPA Questionnaire page
             <h2 class="govuk-summary-card__title">2. Notifying relevant parties of the application</h2>
         </div>
         <div class="govuk-summary-card__content">
-            <dl class="govuk-summary-list">
+            <dl class="govuk-summary-list" id="notifications-summary">
                 <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Who was notified</dt>
                     <dd class="govuk-summary-list__value">
                         <ul class="govuk-list">
@@ -466,7 +466,7 @@ exports[`LPA Questionnaire review GET / should render the LPA Questionnaire page
             <h2 class="govuk-summary-card__title">3. Consultation responses and representations</h2>
         </div>
         <div class="govuk-summary-card__content">
-            <dl class="govuk-summary-list">
+            <dl class="govuk-summary-list" id="representations-summary">
                 <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Representations from other parties documents</dt>
                     <dd                     class="govuk-summary-list__value">
                         <ul class="govuk-list">
@@ -493,7 +493,7 @@ exports[`LPA Questionnaire review GET / should render the LPA Questionnaire page
             <h2 class="govuk-summary-card__title">4. Planning officer’s report and supplementary documents</h2>
         </div>
         <div class="govuk-summary-card__content">
-            <dl class="govuk-summary-list">
+            <dl class="govuk-summary-list" id="supplementary-documents-summary">
                 <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Planning officer&#39;s report</dt>
                     <dd                     class="govuk-summary-list__value">
                         <ul class="govuk-list">
@@ -540,7 +540,7 @@ exports[`LPA Questionnaire review GET / should render the LPA Questionnaire page
             <h2 class="govuk-summary-card__title">5. Site access</h2>
         </div>
         <div class="govuk-summary-card__content">
-            <dl class="govuk-summary-list">
+            <dl class="govuk-summary-list" id="site-access-summary">
                 <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Site access required</dt>
                     <dd class="govuk-summary-list__value"><span>Yes</span>
                         <br><span>The entrance is at the back of the property</span>
@@ -581,7 +581,7 @@ exports[`LPA Questionnaire review GET / should render the LPA Questionnaire page
             <h2 class="govuk-summary-card__title">6. Appeal process</h2>
         </div>
         <div class="govuk-summary-card__content">
-            <dl class="govuk-summary-list">
+            <dl class="govuk-summary-list" id="appeal-process-summary">
                 <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Appeals near the site</dt>
                     <dd class="govuk-summary-list__value"><span>No appeals</span>
                     </dd>
@@ -780,7 +780,7 @@ exports[`LPA Questionnaire review GET / with unchecked documents should render a
             <h2 class="govuk-summary-card__title">2. Notifying relevant parties of the application</h2>
         </div>
         <div class="govuk-summary-card__content">
-            <dl class="govuk-summary-list">
+            <dl class="govuk-summary-list" id="notifications-summary">
                 <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Who was notified</dt>
                     <dd class="govuk-summary-list__value">
                         <ul class="govuk-list">
@@ -833,7 +833,7 @@ exports[`LPA Questionnaire review GET / with unchecked documents should render a
             <h2 class="govuk-summary-card__title">3. Consultation responses and representations</h2>
         </div>
         <div class="govuk-summary-card__content">
-            <dl class="govuk-summary-list">
+            <dl class="govuk-summary-list" id="representations-summary">
                 <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Representations from other parties documents</dt>
                     <dd                     class="govuk-summary-list__value">
                         <ul class="govuk-list">
@@ -860,7 +860,7 @@ exports[`LPA Questionnaire review GET / with unchecked documents should render a
             <h2 class="govuk-summary-card__title">4. Planning officer’s report and supplementary documents</h2>
         </div>
         <div class="govuk-summary-card__content">
-            <dl class="govuk-summary-list">
+            <dl class="govuk-summary-list" id="supplementary-documents-summary">
                 <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Planning officer&#39;s report</dt>
                     <dd                     class="govuk-summary-list__value">
                         <ul class="govuk-list">
@@ -907,7 +907,7 @@ exports[`LPA Questionnaire review GET / with unchecked documents should render a
             <h2 class="govuk-summary-card__title">5. Site access</h2>
         </div>
         <div class="govuk-summary-card__content">
-            <dl class="govuk-summary-list">
+            <dl class="govuk-summary-list" id="site-access-summary">
                 <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Site access required</dt>
                     <dd class="govuk-summary-list__value"><span>Yes</span>
                         <br><span>The entrance is at the back of the property</span>
@@ -948,7 +948,7 @@ exports[`LPA Questionnaire review GET / with unchecked documents should render a
             <h2 class="govuk-summary-card__title">6. Appeal process</h2>
         </div>
         <div class="govuk-summary-card__content">
-            <dl class="govuk-summary-list">
+            <dl class="govuk-summary-list" id="appeal-process-summary">
                 <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Appeals near the site</dt>
                     <dd class="govuk-summary-list__value"><span>No appeals</span>
                     </dd>
@@ -1106,7 +1106,7 @@ exports[`LPA Questionnaire review GET / with unchecked documents should render a
             <h2 class="govuk-summary-card__title">2. Notifying relevant parties of the application</h2>
         </div>
         <div class="govuk-summary-card__content">
-            <dl class="govuk-summary-list">
+            <dl class="govuk-summary-list" id="notifications-summary">
                 <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Who was notified</dt>
                     <dd class="govuk-summary-list__value">
                         <ul class="govuk-list">
@@ -1159,7 +1159,7 @@ exports[`LPA Questionnaire review GET / with unchecked documents should render a
             <h2 class="govuk-summary-card__title">3. Consultation responses and representations</h2>
         </div>
         <div class="govuk-summary-card__content">
-            <dl class="govuk-summary-list">
+            <dl class="govuk-summary-list" id="representations-summary">
                 <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Representations from other parties documents</dt>
                     <dd                     class="govuk-summary-list__value">
                         <ul class="govuk-list">
@@ -1186,7 +1186,7 @@ exports[`LPA Questionnaire review GET / with unchecked documents should render a
             <h2 class="govuk-summary-card__title">4. Planning officer’s report and supplementary documents</h2>
         </div>
         <div class="govuk-summary-card__content">
-            <dl class="govuk-summary-list">
+            <dl class="govuk-summary-list" id="supplementary-documents-summary">
                 <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Planning officer&#39;s report</dt>
                     <dd                     class="govuk-summary-list__value">
                         <ul class="govuk-list">
@@ -1233,7 +1233,7 @@ exports[`LPA Questionnaire review GET / with unchecked documents should render a
             <h2 class="govuk-summary-card__title">5. Site access</h2>
         </div>
         <div class="govuk-summary-card__content">
-            <dl class="govuk-summary-list">
+            <dl class="govuk-summary-list" id="site-access-summary">
                 <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Site access required</dt>
                     <dd class="govuk-summary-list__value"><span>Yes</span>
                         <br><span>The entrance is at the back of the property</span>
@@ -1274,7 +1274,7 @@ exports[`LPA Questionnaire review GET / with unchecked documents should render a
             <h2 class="govuk-summary-card__title">6. Appeal process</h2>
         </div>
         <div class="govuk-summary-card__content">
-            <dl class="govuk-summary-list">
+            <dl class="govuk-summary-list" id="appeal-process-summary">
                 <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Appeals near the site</dt>
                     <dd class="govuk-summary-list__value"><span>No appeals</span>
                     </dd>
@@ -3337,7 +3337,7 @@ exports[`LPA Questionnaire review POST / should render LPA Questionnaire review 
             <h2 class="govuk-summary-card__title">2. Notifying relevant parties of the application</h2>
         </div>
         <div class="govuk-summary-card__content">
-            <dl class="govuk-summary-list">
+            <dl class="govuk-summary-list" id="notifications-summary">
                 <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Who was notified</dt>
                     <dd class="govuk-summary-list__value">
                         <ul class="govuk-list">
@@ -3390,7 +3390,7 @@ exports[`LPA Questionnaire review POST / should render LPA Questionnaire review 
             <h2 class="govuk-summary-card__title">3. Consultation responses and representations</h2>
         </div>
         <div class="govuk-summary-card__content">
-            <dl class="govuk-summary-list">
+            <dl class="govuk-summary-list" id="representations-summary">
                 <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Representations from other parties documents</dt>
                     <dd                     class="govuk-summary-list__value">
                         <ul class="govuk-list">
@@ -3417,7 +3417,7 @@ exports[`LPA Questionnaire review POST / should render LPA Questionnaire review 
             <h2 class="govuk-summary-card__title">4. Planning officer’s report and supplementary documents</h2>
         </div>
         <div class="govuk-summary-card__content">
-            <dl class="govuk-summary-list">
+            <dl class="govuk-summary-list" id="supplementary-documents-summary">
                 <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Planning officer&#39;s report</dt>
                     <dd                     class="govuk-summary-list__value">
                         <ul class="govuk-list">
@@ -3464,7 +3464,7 @@ exports[`LPA Questionnaire review POST / should render LPA Questionnaire review 
             <h2 class="govuk-summary-card__title">5. Site access</h2>
         </div>
         <div class="govuk-summary-card__content">
-            <dl class="govuk-summary-list">
+            <dl class="govuk-summary-list" id="site-access-summary">
                 <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Site access required</dt>
                     <dd class="govuk-summary-list__value"><span>Yes</span>
                         <br><span>The entrance is at the back of the property</span>
@@ -3505,7 +3505,7 @@ exports[`LPA Questionnaire review POST / should render LPA Questionnaire review 
             <h2 class="govuk-summary-card__title">6. Appeal process</h2>
         </div>
         <div class="govuk-summary-card__content">
-            <dl class="govuk-summary-list">
+            <dl class="govuk-summary-list" id="appeal-process-summary">
                 <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Appeals near the site</dt>
                     <dd class="govuk-summary-list__value"><span>No appeals</span>
                     </dd>

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/__tests__/lpa-questionnaire.test.js
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/__tests__/lpa-questionnaire.test.js
@@ -21,7 +21,9 @@ import {
 	notCheckedDocumentFolderInfoDocuments,
 	lpaQuestionnaireData,
 	fileUploadInfo,
-	lpaNotificationMethodsData
+	lpaNotificationMethodsData,
+	text300Characters,
+	text301Characters
 } from '#testing/app/fixtures/referencedata.js';
 import { createTestEnvironment } from '#testing/index.js';
 import { textInputCharacterLimits } from '../../../appeal.constants.js';
@@ -478,6 +480,137 @@ describe('LPA Questionnaire review', () => {
 				expect(unprettifiedElement.innerHTML).not.toContain('Continue</button>');
 			}, 10000);
 		}
+
+		describe('show more', () => {
+			describe('site access required', () => {
+				it('should not render a "show more" component on the "site access required" row if the associated value is less than or equal to 300 characters in length', async () => {
+					nock('http://test/')
+						.get('/appeals/1/lpa-questionnaires/2')
+						.reply(200, {
+							...lpaQuestionnaireDataNotValidated,
+							doesSiteRequireInspectorAccess: true,
+							inspectorAccessDetails: text300Characters
+						});
+
+					const response = await request.get(baseUrl);
+					const unprettifiedElement = parseHtml(response.text, {
+						rootElement: '#site-access-summary',
+						skipPrettyPrint: true
+					});
+
+					expect(unprettifiedElement.innerHTML).toContain(
+						`<dd class="govuk-summary-list__value"><span>Yes</span><br><span>${text300Characters}</span></dd>`
+					);
+					expect(unprettifiedElement.innerHTML).not.toContain('class="pins-show-more"');
+				});
+
+				it('should render a "show more" component with the expected HTML on the "site access required" row if the associated value is over 300 characters in length', async () => {
+					nock('http://test/')
+						.get('/appeals/1/lpa-questionnaires/2')
+						.reply(200, {
+							...lpaQuestionnaireDataNotValidated,
+							doesSiteRequireInspectorAccess: true,
+							inspectorAccessDetails: text301Characters
+						});
+
+					const response = await request.get(baseUrl);
+					const unprettifiedElement = parseHtml(response.text, {
+						rootElement: '#site-access-summary',
+						skipPrettyPrint: true
+					});
+
+					expect(unprettifiedElement.innerHTML).toContain(
+						`<dd class="govuk-summary-list__value"><span>Yes</span><br><div class="pins-show-more" data-label="Site access required details">${text301Characters}</div></dd>`
+					);
+				});
+			});
+
+			describe('potential safety risks', () => {
+				it('should not render a "show more" component on the "potential safety risks" row if the associated value is less than or equal to 300 characters in length', async () => {
+					nock('http://test/')
+						.get('/appeals/1/lpa-questionnaires/2')
+						.reply(200, {
+							...lpaQuestionnaireDataNotValidated,
+							doesSiteHaveHealthAndSafetyIssues: true,
+							healthAndSafetyDetails: text300Characters
+						});
+
+					const response = await request.get(baseUrl);
+					const unprettifiedElement = parseHtml(response.text, {
+						rootElement: '#site-access-summary',
+						skipPrettyPrint: true
+					});
+
+					expect(unprettifiedElement.innerHTML).toContain(
+						`<dd class="govuk-summary-list__value"><span>Yes</span><br><span>${text300Characters}</span></dd>`
+					);
+					expect(unprettifiedElement.innerHTML).not.toContain('class="pins-show-more"');
+				});
+
+				it('should render a "show more" component with the expected HTML on the "potential safety risks" row if the associated value is over 300 characters in length', async () => {
+					nock('http://test/')
+						.get('/appeals/1/lpa-questionnaires/2')
+						.reply(200, {
+							...lpaQuestionnaireDataNotValidated,
+							doesSiteHaveHealthAndSafetyIssues: true,
+							healthAndSafetyDetails: text301Characters
+						});
+
+					const response = await request.get(baseUrl);
+					const unprettifiedElement = parseHtml(response.text, {
+						rootElement: '#site-access-summary',
+						skipPrettyPrint: true
+					});
+
+					expect(unprettifiedElement.innerHTML).toContain(
+						`<dd class="govuk-summary-list__value"><span>Yes</span><br><div class="pins-show-more" data-label="Potential safety risks details">${text301Characters}</div></dd>`
+					);
+				});
+			});
+
+			describe('extra conditions', () => {
+				it('should not render a "show more" component on the "extra conditions" row if the associated value is less than or equal to 300 characters in length', async () => {
+					nock('http://test/')
+						.get('/appeals/1/lpa-questionnaires/2')
+						.reply(200, {
+							...lpaQuestionnaireDataNotValidated,
+							hasExtraConditions: true,
+							extraConditions: text300Characters
+						});
+
+					const response = await request.get(baseUrl);
+					const unprettifiedElement = parseHtml(response.text, {
+						rootElement: '#appeal-process-summary',
+						skipPrettyPrint: true
+					});
+
+					expect(unprettifiedElement.innerHTML).toContain(
+						`<dd class="govuk-summary-list__value"><span>Yes</span><br><span>${text300Characters}</span></dd>`
+					);
+					expect(unprettifiedElement.innerHTML).not.toContain('class="pins-show-more"');
+				});
+
+				it('should render a "show more" component with the expected HTML on the "extra conditions" row if the associated value is over 300 characters in length', async () => {
+					nock('http://test/')
+						.get('/appeals/1/lpa-questionnaires/2')
+						.reply(200, {
+							...lpaQuestionnaireDataNotValidated,
+							hasExtraConditions: true,
+							extraConditions: text301Characters
+						});
+
+					const response = await request.get(baseUrl);
+					const unprettifiedElement = parseHtml(response.text, {
+						rootElement: '#appeal-process-summary',
+						skipPrettyPrint: true
+					});
+
+					expect(unprettifiedElement.innerHTML).toContain(
+						`<dd class="govuk-summary-list__value"><span>Yes</span><br><div class="pins-show-more" data-label="Extra conditions details">${text301Characters}</div></dd>`
+					);
+				});
+			});
+		});
 	});
 
 	describe('GET / with unchecked documents', () => {

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/lpa-questionnaire.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/lpa-questionnaire.mapper.js
@@ -737,6 +737,9 @@ const generateHASLpaQuestionnaireComponents = (mappedLPAQData, mappedAppealDetai
 					text: '2. Notifying relevant parties of the application'
 				}
 			},
+			attributes: {
+				id: 'notifications-summary'
+			},
 			rows: [
 				mappedLPAQData.lpaq?.notifyingParties?.display.summaryListItem,
 				mappedLPAQData.lpaq?.siteNotice?.display.summaryListItem,
@@ -756,6 +759,9 @@ const generateHASLpaQuestionnaireComponents = (mappedLPAQData, mappedAppealDetai
 					text: '3. Consultation responses and representations'
 				}
 			},
+			attributes: {
+				id: 'representations-summary'
+			},
 			rows: [mappedLPAQData.lpaq?.representations?.display.summaryListItem].filter(isDefined)
 		}
 	});
@@ -768,6 +774,9 @@ const generateHASLpaQuestionnaireComponents = (mappedLPAQData, mappedAppealDetai
 				title: {
 					text: '4. Planning officer’s report and supplementary documents'
 				}
+			},
+			attributes: {
+				id: 'supplementary-documents-summary'
 			},
 			rows: [
 				mappedLPAQData.lpaq?.officersReport?.display.summaryListItem,
@@ -788,6 +797,9 @@ const generateHASLpaQuestionnaireComponents = (mappedLPAQData, mappedAppealDetai
 					text: '5. Site access'
 				}
 			},
+			attributes: {
+				id: 'site-access-summary'
+			},
 			rows: [
 				mappedLPAQData.lpaq?.siteAccess?.display.summaryListItem,
 				mappedAppealDetails.appeal.lpaNeighbouringSites?.display.summaryListItem,
@@ -804,6 +816,9 @@ const generateHASLpaQuestionnaireComponents = (mappedLPAQData, mappedAppealDetai
 				title: {
 					text: '6. Appeal process'
 				}
+			},
+			attributes: {
+				id: 'appeal-process-summary'
 			},
 			rows: [
 				mappedLPAQData.lpaq?.otherAppeals?.display.summaryListItem,

--- a/appeals/web/src/server/lib/mappers/appeal/submappers/appellant-health-and-safety.mapper.js
+++ b/appeals/web/src/server/lib/mappers/appeal/submappers/appellant-health-and-safety.mapper.js
@@ -14,5 +14,7 @@ export const mapAppellantHealthAndSafety = ({
 		defaultText: 'No answer provided',
 		link: `${currentRoute}/safety-risks/change/appellant`,
 		editable: userHasUpdateCasePermission,
-		classes: 'appeal-appellant-health-and-safety'
+		classes: 'appeal-appellant-health-and-safety',
+		withShowMore: true,
+		showMoreLabelText: 'Potential safety risks details (appellant answer)'
 	});

--- a/appeals/web/src/server/lib/mappers/appeal/submappers/appellant-inspector-access.mapper.js
+++ b/appeals/web/src/server/lib/mappers/appeal/submappers/appellant-inspector-access.mapper.js
@@ -14,5 +14,7 @@ export const mapAppellantInspectorAccess = ({
 		defaultText: 'No answer provided',
 		link: `${currentRoute}/inspector-access/change/appellant`,
 		editable: userHasUpdateCasePermission,
-		classes: 'appeal-appellant-inspector-access'
+		classes: 'appeal-appellant-inspector-access',
+		withShowMore: true,
+		showMoreLabelText: 'Inspection access details (appellant answer)'
 	});

--- a/appeals/web/src/server/lib/mappers/appeal/submappers/lpa-health-and-safety.mapper.js
+++ b/appeals/web/src/server/lib/mappers/appeal/submappers/lpa-health-and-safety.mapper.js
@@ -19,5 +19,7 @@ export const mapLpaHealthAndSafety = ({
 			shouldDisplayChangeLinksForLPAQStatus(
 				appealDetails.documentationSummary?.lpaQuestionnaire?.status
 			),
-		classes: 'appeal-lpa-health-and-safety'
+		classes: 'appeal-lpa-health-and-safety',
+		withShowMore: true,
+		showMoreLabelText: 'Potential safety risks details (LPA answer)'
 	});

--- a/appeals/web/src/server/lib/mappers/appeal/submappers/lpa-inspector-access.mapper.js
+++ b/appeals/web/src/server/lib/mappers/appeal/submappers/lpa-inspector-access.mapper.js
@@ -19,5 +19,7 @@ export const mapLpaInspectorAccess = ({
 			shouldDisplayChangeLinksForLPAQStatus(
 				appealDetails.documentationSummary?.lpaQuestionnaire?.status
 			),
-		classes: 'appeal-lpa-inspector-access'
+		classes: 'appeal-lpa-inspector-access',
+		withShowMore: true,
+		showMoreLabelText: 'Inspection access details (LPA answer)'
 	});

--- a/appeals/web/src/server/lib/mappers/appellantCase.mapper.js
+++ b/appeals/web/src/server/lib/mappers/appellantCase.mapper.js
@@ -142,7 +142,8 @@ export function initialiseAndMapData(appellantCaseData, appealDetails, currentRo
 		value: appellantCaseData.developmentDescription?.details || 'Not provided',
 		link: `${currentRoute}/development-description/change`,
 		editable: userHasUpdateCase,
-		withShowMore: true
+		withShowMore: true,
+		showMoreLabelText: 'Original Development description details'
 	});
 
 	mappedData.changedDevelopmentDescription = booleanSummaryListItem({
@@ -243,24 +244,28 @@ export function initialiseAndMapData(appellantCaseData, appealDetails, currentRo
 	mappedData.inspectorAccess = booleanWithDetailsSummaryListItem({
 		id: 'inspector-access',
 		text: 'Inspector access required',
-		value: appealDetails.inspectorAccess.appellantCase.isRequired,
-		valueDetails: appealDetails.inspectorAccess.appellantCase.details,
+		value: appellantCaseData.siteAccessRequired?.hasIssues,
+		valueDetails: appellantCaseData.siteAccessRequired?.details,
 		defaultText: 'No answer provided',
 		link: `${currentRoute}/inspector-access/change/appellant`,
 		editable: userHasUpdateCase,
 		classes: 'appellantcase-inspector-access',
-		addCyAttribute: true
+		addCyAttribute: true,
+		withShowMore: true,
+		showMoreLabelText: 'Inspector access details'
 	});
 
 	mappedData.healthAndSafetyIssues = booleanWithDetailsSummaryListItem({
 		id: 'appellant-case-health-and-safety',
 		text: 'Potential safety risks',
-		value: appealDetails.healthAndSafety.appellantCase.hasIssues,
-		valueDetails: appealDetails.healthAndSafety.appellantCase.details,
+		value: appellantCaseData.healthAndSafety?.hasIssues,
+		valueDetails: appellantCaseData.healthAndSafety?.details,
 		defaultText: 'No answer provided',
 		link: `${currentRoute}/safety-risks/change/appellant`,
 		editable: userHasUpdateCase,
-		addCyAttribute: true
+		addCyAttribute: true,
+		withShowMore: true,
+		showMoreLabelText: 'Potential safety risks details'
 	});
 
 	mappedData.applicationForm = documentInstruction({
@@ -556,30 +561,15 @@ export function initialiseAndMapData(appellantCaseData, appealDetails, currentRo
 		}
 	};
 
-	/** @type {Instructions} */
-	mappedData.procedurePreferenceDetails = {
+	mappedData.procedurePreferenceDetails = textSummaryListItem({
 		id: 'procedure-preference-details',
-		display: {
-			summaryListItem: {
-				key: {
-					text: 'Reason for preference'
-				},
-				value: {
-					text: appellantCaseData.appellantProcedurePreferenceDetails || 'Not applicable'
-				},
-				actions: {
-					items: [
-						{
-							text: 'Change',
-							visuallyHiddenText: 'reason for preference',
-							href: `${currentRoute}/procedure-preference/details/change`,
-							attributes: { 'data-cy': 'change-procedure-preference-details' }
-						}
-					]
-				}
-			}
-		}
-	};
+		text: 'Reason for preference',
+		value: appellantCaseData.appellantProcedurePreferenceDetails || 'Not applicable',
+		link: `${currentRoute}/procedure-preference/details/change`,
+		editable: userHasUpdateCase,
+		withShowMore: true,
+		showMoreLabelText: 'Reason for preference details'
+	});
 
 	/** @type {Instructions} */
 	mappedData.procedurePreferenceDuration = {

--- a/appeals/web/src/server/lib/mappers/components/text.js
+++ b/appeals/web/src/server/lib/mappers/components/text.js
@@ -10,6 +10,7 @@ import { SHOW_MORE_MAXIMUM_CHARACTERS_BEFORE_HIDING } from '#lib/constants.js';
  * @param {string} options.link
  * @param {boolean} options.editable
  * @param {boolean} [options.withShowMore]
+ * @param {string} [options.showMoreLabelText]
  * @param {string} [options.classes]
  * @param {string} [options.actionText]
  * @param {string} [options.cypressDataName]
@@ -22,6 +23,7 @@ export function textSummaryListItem({
 	link,
 	editable,
 	withShowMore,
+	showMoreLabelText,
 	classes,
 	actionText = 'Change',
 	cypressDataName = actionText.toLowerCase() + '-' + id
@@ -45,7 +47,7 @@ export function textSummaryListItem({
 					type: 'show-more',
 					parameters: {
 						text: value,
-						labelText: text
+						labelText: showMoreLabelText || text
 					}
 				}
 			]

--- a/appeals/web/src/server/lib/mappers/lpa-questionnaire/has.js
+++ b/appeals/web/src/server/lib/mappers/lpa-questionnaire/has.js
@@ -16,7 +16,7 @@ import { mapPlansDrawings } from './submappers/map-plans-drawings.js';
 import { mapPressAdvert } from './submappers/map-press-advert.js';
 import { mapRepresentations } from './submappers/map-representations.js';
 import { mapReviewOutcome } from './submappers/map-review-outcome.js';
-import { mapSiteAccess } from './submappers/map-site-address.js';
+import { mapSiteAccess } from './submappers/map-site-access.js';
 import { mapSiteNotice } from './submappers/map-site-notice.js';
 import { mapSiteWithinGreenBelt } from './submappers/map-site-within-green-belt.js';
 import { mapSupplementaryPlanning } from './submappers/map-supplementary-planning.js';

--- a/appeals/web/src/server/lib/mappers/lpa-questionnaire/submappers/map-extra-conditions.js
+++ b/appeals/web/src/server/lib/mappers/lpa-questionnaire/submappers/map-extra-conditions.js
@@ -9,5 +9,7 @@ export const mapExtraConditions = ({ lpaQuestionnaireData, currentRoute, userHas
 		valueDetails: lpaQuestionnaireData.extraConditions,
 		defaultText: '',
 		link: `${currentRoute}/extra-conditions/change`,
-		editable: userHasUpdateCase
+		editable: userHasUpdateCase,
+		withShowMore: true,
+		showMoreLabelText: 'Extra conditions details'
 	});

--- a/appeals/web/src/server/lib/mappers/lpa-questionnaire/submappers/map-lpa-health-and-safety.js
+++ b/appeals/web/src/server/lib/mappers/lpa-questionnaire/submappers/map-lpa-health-and-safety.js
@@ -11,5 +11,7 @@ export const mapLpaHealthAndSafety = ({ lpaQuestionnaireData, currentRoute, user
 		link: `${currentRoute}/safety-risks/change/lpa`,
 		editable: userHasUpdateCase,
 		addCyAttribute: true,
-		classes: 'lpa-health-and-safety'
+		classes: 'lpa-health-and-safety',
+		withShowMore: true,
+		showMoreLabelText: 'Potential safety risks details'
 	});

--- a/appeals/web/src/server/lib/mappers/lpa-questionnaire/submappers/map-site-access.js
+++ b/appeals/web/src/server/lib/mappers/lpa-questionnaire/submappers/map-site-access.js
@@ -10,5 +10,7 @@ export const mapSiteAccess = ({ lpaQuestionnaireData, currentRoute, userHasUpdat
 		defaultText: 'No answer provided',
 		link: `${currentRoute}/inspector-access/change/lpa`,
 		editable: userHasUpdateCase,
-		addCyAttribute: true
+		addCyAttribute: true,
+		withShowMore: true,
+		showMoreLabelText: 'Site access required details'
 	});

--- a/appeals/web/testing/app/fixtures/referencedata.js
+++ b/appeals/web/testing/app/fixtures/referencedata.js
@@ -2452,3 +2452,8 @@ export const caseNotes = [
 		azureAdUserId: '923ac03b-9031-4cf4-8b17-348c274321f9'
 	}
 ];
+
+export const text300Characters =
+	'Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cill';
+
+export const text301Characters = text300Characters + 'u';


### PR DESCRIPTION
## Describe your changes

Global rollout of show more component. Also includes a fix to map appellant case inspector access from the appellant case data rather than the equivalent field on the appeal data (for consistency with the LPAQ mapper).

## Issue ticket number and link

A2-826

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [ ] I have performed a self-review of my own code
- [ ] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [ ] I have referenced the ticket number above
- [ ] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
