### PR TITLE
fix(appeals): align changed notification vars

### DIFF
--- a/appeals/api/src/server/endpoints/change-appeal-type/__tests__/change-appeal-type.test.js
+++ b/appeals/api/src/server/endpoints/change-appeal-type/__tests__/change-appeal-type.test.js
@@ -168,6 +168,7 @@ describe('appeal change type resubmit routes', () => {
 				{
 					emailReplyToId: null,
 					personalisation: {
+						existing_appeal_type: 'Householder',
 						appeal_reference_number: '1345264',
 						lpa_reference: '48269/APP/2021/1482',
 						appeal_type: 'type a',

--- a/appeals/api/src/server/endpoints/change-appeal-type/change-appeal-type.service.js
+++ b/appeals/api/src/server/endpoints/change-appeal-type/change-appeal-type.service.js
@@ -56,6 +56,7 @@ const changeAppealType = async (
 
 	const recipientEmail = appeal.agent?.email || appeal.appellant?.email;
 	const emailVariables = {
+		existing_appeal_type: appeal.appealType?.type || '',
 		appeal_reference_number: appeal.reference,
 		lpa_reference: appeal.applicationReference || '',
 		site_address: siteAddress,


### PR DESCRIPTION
Aligns the GovNotify notification variables to changes to templates: appeal type change and resubmit.

## Issue ticket number and link

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [ ] I have performed a self-review of my own code
- [ ] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [ ] I have referenced the ticket number above
- [ ] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
