### PR TITLE
fix(web): fix reference to appealId in add-ip-comment upload handler

### DIFF
--- a/appeals/web/src/server/appeals/appeal-details/interested-party-comments/add-ip-comment/add-ip-comment.controller.js
+++ b/appeals/web/src/server/appeals/appeal-details/interested-party-comments/add-ip-comment/add-ip-comment.controller.js
@@ -78,7 +78,7 @@ export async function renderUpload(request, response) {
 export async function postUpload(request, response) {
 	const { currentAppeal } = request;
 
-	request.currentFolder = await getAttachmentsFolder(request.apiClient, currentAppeal.id);
+	request.currentFolder = await getAttachmentsFolder(request.apiClient, currentAppeal.appealId);
 
 	await postDocumentUpload({
 		request,


### PR DESCRIPTION
## Describe your changes

The post upload handler is incorrectly referencing `currentAppeal.id`. This changes it to `currentAppeal.appealId`.

## Issue ticket number and link

[A2-604](https://pins-ds.atlassian.net/browse/A2-604)

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes


[A2-604]: https://pins-ds.atlassian.net/browse/A2-604?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ