### PR TITLE
feat(appeals): redaction status defaults A2-1161

### DIFF
--- a/appeals/api/src/server/endpoints/appeal-timetables/__tests__/appeal-timetables.test.js
+++ b/appeals/api/src/server/endpoints/appeal-timetables/__tests__/appeal-timetables.test.js
@@ -8,13 +8,11 @@ import {
 	ERROR_MUST_BE_CORRECT_UTC_DATE_FORMAT,
 	ERROR_MUST_BE_IN_FUTURE,
 	ERROR_MUST_NOT_HAVE_TIMETABLE_DATE,
-	ERROR_NOT_FOUND,
-	FRONT_OFFICE_URL
+	ERROR_NOT_FOUND
 } from '../../constants.js';
 import { azureAdUserId } from '#tests/shared/mocks.js';
 import { householdAppeal, fullPlanningAppeal } from '#tests/appeals/mocks.js';
 import stringTokenReplacement from '#utils/string-token-replacement.js';
-import config from '#config/config.js';
 import { add } from 'date-fns';
 import { recalculateDateIfNotBusinessDay, setTimeInTimeZone } from '#utils/business-days.js';
 import { DEADLINE_HOUR } from '@pins/appeals/constants/dates.js';
@@ -792,85 +790,6 @@ describe('appeal timetables routes', () => {
 						body: ERROR_FAILED_TO_SAVE_DATA
 					}
 				});
-			});
-		});
-	});
-
-	describe('/appeals/:appealId/appeal-timetables/', () => {
-		describe('POST', () => {
-			test('updates start date when a start date has previously been set', async () => {
-				// @ts-ignore
-				databaseConnector.appeal.findUnique.mockResolvedValue(houseAppealWithTimetable);
-				// @ts-ignore
-				databaseConnector.user.upsert.mockResolvedValue({
-					id: 1,
-					azureAdUserId
-				});
-
-				jest
-					.useFakeTimers({ doNotFake: ['performance'] })
-					.setSystemTime(new Date('2023-06-05T22:59:00Z'));
-
-				const response = await request
-					.post(`/appeals/${householdAppeal.id}/appeal-timetables`)
-					.send({})
-					.set('azureAdUserId', azureAdUserId);
-
-				expect(databaseConnector.appealTimetable.upsert).toHaveBeenCalledWith(
-					expect.objectContaining({
-						update: {
-							lpaQuestionnaireDueDate: new Date('2023-06-12T22:59:00.000Z')
-						}
-					})
-				);
-
-				// eslint-disable-next-line no-undef
-				expect(mockSendEmail).toHaveBeenCalledTimes(2);
-
-				// eslint-disable-next-line no-undef
-				expect(mockSendEmail).toHaveBeenCalledWith(
-					config.govNotify.template.appealStartDateChange.appellant.id,
-					'test@136s7.com',
-					{
-						emailReplyToId: null,
-						personalisation: {
-							appeal_reference_number: '1345264',
-							lpa_reference: '48269/APP/2021/1482',
-							site_address: '96 The Avenue, Leftfield, Maidstone, Kent, MD21 5XY, United Kingdom',
-							url: FRONT_OFFICE_URL,
-							start_date: '5 June 2023',
-							questionnaire_due_date: '12 June 2023',
-							local_planning_authority: 'Maidstone Borough Council',
-							appeal_type: 'Householder',
-							procedure_type: 'a written procedure',
-							appellant_email_address: 'test@136s7.com'
-						},
-						reference: null
-					}
-				);
-
-				// eslint-disable-next-line no-undef
-				expect(mockSendEmail).toHaveBeenCalledWith(
-					config.govNotify.template.appealStartDateChange.lpa.id,
-					'maid@lpa-email.gov.uk',
-					{
-						emailReplyToId: null,
-						personalisation: {
-							appeal_reference_number: '1345264',
-							lpa_reference: '48269/APP/2021/1482',
-							site_address: '96 The Avenue, Leftfield, Maidstone, Kent, MD21 5XY, United Kingdom',
-							url: FRONT_OFFICE_URL,
-							start_date: '5 June 2023',
-							questionnaire_due_date: '12 June 2023',
-							local_planning_authority: 'Maidstone Borough Council',
-							appeal_type: 'Householder',
-							procedure_type: 'a written procedure',
-							appellant_email_address: 'test@136s7.com'
-						},
-						reference: null
-					}
-				);
-				expect(response.status).toEqual(200);
 			});
 		});
 	});

--- a/appeals/api/src/server/endpoints/appellant-cases/__tests__/appellant-cases.test.js
+++ b/appeals/api/src/server/endpoints/appellant-cases/__tests__/appellant-cases.test.js
@@ -930,6 +930,16 @@ describe('appellant cases routes', () => {
 					id: 1,
 					azureAdUserId
 				});
+				// @ts-ignore
+				databaseConnector.documentVersion.findMany.mockResolvedValue([]);
+				// @ts-ignore
+				databaseConnector.documentVersion.update.mockResolvedValue([]);
+				// @ts-ignore
+				databaseConnector.documentRedactionStatus.findMany.mockResolvedValue([
+					{ id: 1, key: 'no_redaction_required' }
+				]);
+				// @ts-ignore
+				databaseConnector.document.findUnique.mockResolvedValue(null);
 
 				const body = {
 					validationOutcome: 'valid'

--- a/appeals/api/src/server/endpoints/appellant-cases/appellant-cases.service.js
+++ b/appeals/api/src/server/endpoints/appellant-cases/appellant-cases.service.js
@@ -19,6 +19,8 @@ import stringTokenReplacement from '#utils/string-token-replacement.js';
 import config from '#config/config.js';
 import formatDate from '#utils/date-formatter.js';
 import { getFormattedReasons } from '#utils/appeal-formatter.js';
+import * as documentRepository from '#repositories/document.repository.js';
+import { broadcasters } from '#endpoints/integrations/integrations.broadcasters.js';
 
 /** @typedef {import('@pins/appeals.api').Appeals.UpdateAppellantCaseValidationOutcomeParams} UpdateAppellantCaseValidationOutcomeParams */
 /** @typedef {import('express').Request} Request */
@@ -82,6 +84,15 @@ const updateAppellantCaseValidationOutcome = async (
 	}
 
 	if (isOutcomeValid(validationOutcome.name)) {
+		const documentsUpdated = await documentRepository.setRedactionStatusOnValidation(appeal.id);
+		for (const documentUpdated of documentsUpdated) {
+			await broadcasters.broadcastDocument(
+				documentUpdated.documentGuid,
+				documentUpdated.version,
+				'update'
+			);
+		}
+
 		const recipientEmail = appeal.agent?.email || appeal.appellant?.email;
 		if (!recipientEmail) {
 			throw new Error(ERROR_NO_RECIPIENT_EMAIL);

--- a/appeals/api/src/server/endpoints/integrations/__tests__/integrations.test.js
+++ b/appeals/api/src/server/endpoints/integrations/__tests__/integrations.test.js
@@ -132,7 +132,6 @@ describe('/appeals/case-submission', () => {
 				}
 			});
 
-			expect(databaseConnector.documentRedactionStatus.findMany).toHaveBeenCalled();
 			expect(databaseConnector.document.createMany).toHaveBeenCalled();
 			expect(databaseConnector.documentVersion.createMany).toHaveBeenCalled();
 			expect(databaseConnector.documentVersion.findMany).toHaveBeenCalled();

--- a/appeals/api/src/server/endpoints/lpa-questionnaires/__tests__/lpa-questionnaires.test.js
+++ b/appeals/api/src/server/endpoints/lpa-questionnaires/__tests__/lpa-questionnaires.test.js
@@ -181,10 +181,20 @@ describe('lpa questionnaires routes', () => {
 					lpaQuestionnaireIncompleteReasons
 				);
 				// @ts-ignore
+				databaseConnector.documentVersion.findMany.mockResolvedValue([]);
+				// @ts-ignore
+				databaseConnector.documentVersion.update.mockResolvedValue([]);
+				// @ts-ignore
+				databaseConnector.document.findUnique.mockResolvedValue(null);
+				// @ts-ignore
 				databaseConnector.user.upsert.mockResolvedValue({
 					id: 1,
 					azureAdUserId
 				});
+				// @ts-ignore
+				databaseConnector.documentRedactionStatus.findMany.mockResolvedValue([
+					{ id: 1, key: 'no_redaction_required' }
+				]);
 
 				const body = {
 					validationOutcome: 'complete'
@@ -246,6 +256,16 @@ describe('lpa questionnaires routes', () => {
 				databaseConnector.lPAQuestionnaireValidationOutcome.findUnique.mockResolvedValue(
 					lpaQuestionnaireValidationOutcomes[0]
 				);
+				// @ts-ignore
+				databaseConnector.documentVersion.findMany.mockResolvedValue([]);
+				// @ts-ignore
+				databaseConnector.documentVersion.update.mockResolvedValue([]);
+				// @ts-ignore
+				databaseConnector.document.findUnique.mockResolvedValue(null);
+				// @ts-ignore
+				databaseConnector.documentRedactionStatus.findMany.mockResolvedValue([
+					{ id: 1, key: 'no_redaction_required' }
+				]);
 
 				const body = {
 					validationOutcome: 'complete'
@@ -295,6 +315,12 @@ describe('lpa questionnaires routes', () => {
 				databaseConnector.lPAQuestionnaireIncompleteReason.findMany.mockResolvedValue(
 					lpaQuestionnaireIncompleteReasons
 				);
+				// @ts-ignore
+				databaseConnector.documentVersion.findMany.mockResolvedValue([]);
+				// @ts-ignore
+				databaseConnector.documentRedactionStatus.findMany.mockResolvedValue([
+					{ id: 1, key: 'no_redaction_required' }
+				]);
 				// @ts-ignore
 				databaseConnector.user.upsert.mockResolvedValue({
 					id: 1,

--- a/appeals/api/src/server/repositories/integrations.repository.js
+++ b/appeals/api/src/server/repositories/integrations.repository.js
@@ -1,6 +1,5 @@
 import { databaseConnector } from '#utils/database-connector.js';
 import { mapBlobPath } from '#endpoints/documents/documents.mapper.js';
-import { getDefaultRedactionStatus } from './document-metadata.repository.js';
 import { createAppealReference } from '#utils/appeal-reference.js';
 import config from '#config/config.js';
 import { APPEAL_CASE_STATUS, APPEAL_DOCUMENT_TYPE } from 'pins-data-model';
@@ -169,7 +168,6 @@ const setAppealRelationships = async (tx, appealId, caseReference, relatedRefere
  * @returns {Promise<import('#db-client').DocumentVersion[]>}
  */
 const setDocumentVersions = async (tx, appealId, caseReference, documents) => {
-	const unredactedStatus = await getDefaultRedactionStatus();
 	if (documents) {
 		const caseFolders = await tx.folder.findMany({ where: { caseId: appealId } });
 
@@ -212,8 +210,7 @@ const setDocumentVersions = async (tx, appealId, caseReference, documents) => {
 					documentURI,
 					blobStoragePath,
 					dateReceived: new Date().toISOString(),
-					draft: false,
-					redactionStatusId: unredactedStatus?.id
+					draft: false
 				};
 			})
 		});

--- a/appeals/web/src/server/appeals/appeal-details/appellant-case/__tests__/__snapshots__/appellant-case.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/appellant-case/__tests__/__snapshots__/appellant-case.test.js.snap
@@ -1948,6 +1948,11 @@ exports[`appellant-case GET /appellant-case should render review outcome form fi
                         </div>
                     </fieldset>
                 </div>
+                <div class="govuk-warning-text"><span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+                    <strong                     class="govuk-warning-text__text"><span class="govuk-warning-text__assistive">Warning</span> Do not select
+                        an outcome until you have reviewed all of the supporting documents and
+                        redacted any sensitive information.</strong>
+                </div>
                 <button class="govuk-button" data-module="govuk-button">Continue</button>
             </form>
         </div>
@@ -3126,7 +3131,7 @@ exports[`appellant-case GET /appellant-case/check-your-answers should render the
                     </dd>
                 </div>
             </dl>
-            <div class="govuk-inset-text">Confirming this review will inform the relevant parties of the outcome</div>
+            <div class="govuk-inset-text">Confirming this review will inform the relevant parties of the outcome.</div>
             <form             method="post" novalidate="novalidate">
                 <button type="submit" data-prevent-double-click="true" class="govuk-button"
                 data-module="govuk-button">Confirm</button>
@@ -3173,7 +3178,7 @@ exports[`appellant-case GET /appellant-case/check-your-answers should render the
                     </dd>
                 </div>
             </dl>
-            <div class="govuk-inset-text">Confirming this review will inform the relevant parties of the outcome</div>
+            <div class="govuk-inset-text">Confirming this review will inform the relevant parties of the outcome.</div>
             <form             method="post" novalidate="novalidate">
                 <button type="submit" data-prevent-double-click="true" class="govuk-button"
                 data-module="govuk-button">Confirm</button>

--- a/appeals/web/src/server/appeals/appeal-details/appellant-case/__tests__/appellant-case.test.js
+++ b/appeals/web/src/server/appeals/appeal-details/appellant-case/__tests__/appellant-case.test.js
@@ -2178,7 +2178,7 @@ describe('appellant-case', () => {
 				'Review outcome</dt><dd class="govuk-summary-list__value"> Invalid</dd>'
 			);
 			expect(unprettifiedElement.innerHTML).toContain(
-				'Confirming this review will inform the relevant parties of the outcome</div>'
+				'Confirming this review will inform the relevant parties of the outcome.</div>'
 			);
 			expect(unprettifiedElement.innerHTML).toContain('Confirm</button>');
 		});
@@ -2227,7 +2227,7 @@ describe('appellant-case', () => {
 				'Review outcome</dt><dd class="govuk-summary-list__value"> Incomplete</dd>'
 			);
 			expect(unprettifiedElement.innerHTML).toContain(
-				'Confirming this review will inform the relevant parties of the outcome</div>'
+				'Confirming this review will inform the relevant parties of the outcome.</div>'
 			);
 			expect(unprettifiedElement.innerHTML).toContain('Confirm</button>');
 		});
@@ -4442,7 +4442,7 @@ describe('appellant-case', () => {
 				`href="/appeals-service/appeal-details/1/appellant-case/add-document-details/${documentFolderInfo.folderId}"> Change</a>`
 			);
 			expect(unprettifiedElement.innerHTML).toContain('Redaction status</dt>');
-			expect(unprettifiedElement.innerHTML).toContain('Unredacted</dd>');
+			expect(unprettifiedElement.innerHTML).toContain('No redaction required</dd>');
 			expect(unprettifiedElement.innerHTML).toContain('Confirm</button>');
 		});
 	});
@@ -4601,7 +4601,7 @@ describe('appellant-case', () => {
 				`href="/appeals-service/appeal-details/1/appellant-case/add-document-details/${documentFolderInfo.folderId}/1"> Change</a></dd>`
 			);
 			expect(unprettifiedElement.innerHTML).toContain('Redaction status</dt>');
-			expect(unprettifiedElement.innerHTML).toContain('Unredacted</dd>');
+			expect(unprettifiedElement.innerHTML).toContain('No redaction required</dd>');
 			expect(unprettifiedElement.innerHTML).toContain('Confirm</button>');
 		});
 	});

--- a/appeals/web/src/server/appeals/appeal-details/appellant-case/appellant-case.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/appellant-case/appellant-case.mapper.js
@@ -101,6 +101,14 @@ export async function appellantCasePage(appellantCaseData, appealDetails, curren
 	/** @type {PageComponent[]} */
 	const reviewOutcomeComponents = [];
 
+	/** @type {PageComponent} */
+	const documentsWarningComponent = {
+		type: 'warning-text',
+		parameters: {
+			text: 'Do not select an outcome until you have reviewed all of the supporting documents and redacted any sensitive information.'
+		}
+	};
+
 	if (
 		reviewOutcomeRadiosInputInstruction &&
 		appealDetails.appealStatus === APPEAL_CASE_STATUS.VALIDATION
@@ -109,6 +117,7 @@ export async function appellantCasePage(appellantCaseData, appealDetails, curren
 			type: 'radios',
 			parameters: reviewOutcomeRadiosInputInstruction.properties
 		});
+		reviewOutcomeComponents.push(documentsWarningComponent);
 	}
 
 	if (
@@ -383,7 +392,7 @@ export function checkAndConfirmPage(
 	const insetTextComponent = {
 		type: 'inset-text',
 		parameters: {
-			text: 'Confirming this review will inform the relevant parties of the outcome'
+			text: 'Confirming this review will inform the relevant parties of the outcome.'
 		}
 	};
 

--- a/appeals/web/src/server/appeals/appeal-details/costs/__tests__/__snapshots__/costs.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/costs/__tests__/__snapshots__/costs.test.js.snap
@@ -423,7 +423,7 @@ exports[`costs application, withdrawal and correspondence GET /costs/:costsCateg
                     </dl>
                 </td>
                 <td class="govuk-table__cell">1 February 2023</td>
-                <td class="govuk-table__cell">Redacted</td>
+                <td class="govuk-table__cell">No redaction required</td>
                 <td class="govuk-table__cell"><a href="/appeals-service/appeal-details/1/costs/appellant/application/manage-documents/1/15d19184-155b-4b6c-bba6-2bd2a61ca9a3"
                     class="govuk-link">View and edit <span class="govuk-visually-hidden">test-pdf-documentFolderInfo.pdf</span></a>
                 </td>
@@ -475,7 +475,7 @@ exports[`costs application, withdrawal and correspondence GET /costs/:costsCateg
                     </dl>
                 </td>
                 <td class="govuk-table__cell">1 February 2023</td>
-                <td class="govuk-table__cell">Redacted</td>
+                <td class="govuk-table__cell">No redaction required</td>
                 <td class="govuk-table__cell"><a href="/appeals-service/appeal-details/1/costs/appellant/correspondence/manage-documents/3/15d19184-155b-4b6c-bba6-2bd2a61ca9a3"
                     class="govuk-link">View and edit <span class="govuk-visually-hidden">test-pdf-documentFolderInfo.pdf</span></a>
                 </td>
@@ -527,7 +527,7 @@ exports[`costs application, withdrawal and correspondence GET /costs/:costsCateg
                     </dl>
                 </td>
                 <td class="govuk-table__cell">1 February 2023</td>
-                <td class="govuk-table__cell">Redacted</td>
+                <td class="govuk-table__cell">No redaction required</td>
                 <td class="govuk-table__cell"><a href="/appeals-service/appeal-details/1/costs/appellant/withdrawal/manage-documents/2/15d19184-155b-4b6c-bba6-2bd2a61ca9a3"
                     class="govuk-link">View and edit <span class="govuk-visually-hidden">test-pdf-documentFolderInfo.pdf</span></a>
                 </td>
@@ -579,7 +579,7 @@ exports[`costs application, withdrawal and correspondence GET /costs/:costsCateg
                     </dl>
                 </td>
                 <td class="govuk-table__cell">1 February 2023</td>
-                <td class="govuk-table__cell">Redacted</td>
+                <td class="govuk-table__cell">No redaction required</td>
                 <td class="govuk-table__cell"><a href="/appeals-service/appeal-details/1/costs/lpa/application/manage-documents/4/15d19184-155b-4b6c-bba6-2bd2a61ca9a3"
                     class="govuk-link">View and edit <span class="govuk-visually-hidden">test-pdf-documentFolderInfo.pdf</span></a>
                 </td>
@@ -631,7 +631,7 @@ exports[`costs application, withdrawal and correspondence GET /costs/:costsCateg
                     </dl>
                 </td>
                 <td class="govuk-table__cell">1 February 2023</td>
-                <td class="govuk-table__cell">Redacted</td>
+                <td class="govuk-table__cell">No redaction required</td>
                 <td class="govuk-table__cell"><a href="/appeals-service/appeal-details/1/costs/lpa/correspondence/manage-documents/6/15d19184-155b-4b6c-bba6-2bd2a61ca9a3"
                     class="govuk-link">View and edit <span class="govuk-visually-hidden">test-pdf-documentFolderInfo.pdf</span></a>
                 </td>
@@ -683,7 +683,7 @@ exports[`costs application, withdrawal and correspondence GET /costs/:costsCateg
                     </dl>
                 </td>
                 <td class="govuk-table__cell">1 February 2023</td>
-                <td class="govuk-table__cell">Redacted</td>
+                <td class="govuk-table__cell">No redaction required</td>
                 <td class="govuk-table__cell"><a href="/appeals-service/appeal-details/1/costs/lpa/withdrawal/manage-documents/5/15d19184-155b-4b6c-bba6-2bd2a61ca9a3"
                     class="govuk-link">View and edit <span class="govuk-visually-hidden">test-pdf-documentFolderInfo.pdf</span></a>
                 </td>
@@ -4997,7 +4997,7 @@ exports[`costs decision GET /costs/decision/manage-documents/:folderId should re
                     </dl>
                 </td>
                 <td class="govuk-table__cell">1 February 2023</td>
-                <td class="govuk-table__cell">Redacted</td>
+                <td class="govuk-table__cell">No redaction required</td>
                 <td class="govuk-table__cell"><a href="/appeals-service/appeal-details/1/costs/decision/manage-documents/7/15d19184-155b-4b6c-bba6-2bd2a61ca9a3"
                     class="govuk-link">View and edit <span class="govuk-visually-hidden">test-pdf-documentFolderInfo.pdf</span></a>
                 </td>

--- a/appeals/web/src/server/appeals/appeal-details/costs/__tests__/costs.test.js
+++ b/appeals/web/src/server/appeals/appeal-details/costs/__tests__/costs.test.js
@@ -570,7 +570,7 @@ describe('costs', () => {
 											month: '2',
 											year: '2023'
 										},
-										redactionStatus: 2
+										redactionStatus: 3
 									}
 								]
 							});
@@ -971,7 +971,7 @@ describe('costs', () => {
 							`${dateISOStringToDisplayDate(new Date().toISOString())}</dd>`
 						);
 						expect(unprettifiedElement.innerHTML).toContain('Redaction status</dt>');
-						expect(unprettifiedElement.innerHTML).toContain('Unredacted</dd>');
+						expect(unprettifiedElement.innerHTML).toContain('No redaction required</dd>');
 						expect(unprettifiedElement.innerHTML).toContain(
 							`<a class="govuk-link" href="/appeals-service/appeal-details/1/costs/${costsCategory}/${costsDocumentType}/upload-documents/${costsFolder.folderId}"> Change</a></dd>`
 						);
@@ -1087,7 +1087,7 @@ describe('costs', () => {
 							`${dateISOStringToDisplayDate(new Date().toISOString())}</dd>`
 						);
 						expect(unprettifiedElement.innerHTML).toContain('Redaction status</dt>');
-						expect(unprettifiedElement.innerHTML).toContain('Unredacted</dd>');
+						expect(unprettifiedElement.innerHTML).toContain('No redaction required</dd>');
 						expect(unprettifiedElement.innerHTML).toContain(
 							`<a class="govuk-link" href="/appeals-service/appeal-details/1/costs/${costsCategory}/${costsDocumentType}/upload-documents/${costsFolder.folderId}/1"> Change</a></dd>`
 						);

--- a/appeals/web/src/server/appeals/appeal-details/internal-correspondence/__tests__/__snapshots__/internal-correspondence.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/internal-correspondence/__tests__/__snapshots__/internal-correspondence.test.js.snap
@@ -116,7 +116,7 @@ exports[`internal correspondence GET /internal-correspondence/:correspondenceCat
                                 <div class="govuk-radios__divider">Or</div>
                                 <div class="govuk-radios__item">
                                     <input class="govuk-radios__input" id="items[0][redactionStatus]-4" name="items[0][redactionStatus]"
-                                    type="radio" value="no redaction required">
+                                    type="radio" value="no redaction required" checked>
                                     <label class="govuk-label govuk-radios__label" for="items[0][redactionStatus]-4">No redaction required</label>
                                 </div>
                             </div>
@@ -194,7 +194,7 @@ exports[`internal correspondence GET /internal-correspondence/:correspondenceCat
                                 <div class="govuk-radios__divider">Or</div>
                                 <div class="govuk-radios__item">
                                     <input class="govuk-radios__input" id="items[0][redactionStatus]-4" name="items[0][redactionStatus]"
-                                    type="radio" value="no redaction required">
+                                    type="radio" value="no redaction required" checked>
                                     <label class="govuk-label govuk-radios__label" for="items[0][redactionStatus]-4">No redaction required</label>
                                 </div>
                             </div>
@@ -315,7 +315,7 @@ exports[`internal correspondence GET /internal-correspondence/:correspondenceCat
                     </dl>
                 </td>
                 <td class="govuk-table__cell">1 February 2023</td>
-                <td class="govuk-table__cell">Redacted</td>
+                <td class="govuk-table__cell">No redaction required</td>
                 <td class="govuk-table__cell"><a href="/appeals-service/appeal-details/1/internal-correspondence/cross-team/manage-documents/10/15d19184-155b-4b6c-bba6-2bd2a61ca9a3"
                     class="govuk-link">View and edit <span class="govuk-visually-hidden">test-pdf-documentFolderInfo.pdf</span></a>
                 </td>
@@ -367,7 +367,7 @@ exports[`internal correspondence GET /internal-correspondence/:correspondenceCat
                     </dl>
                 </td>
                 <td class="govuk-table__cell">1 February 2023</td>
-                <td class="govuk-table__cell">Redacted</td>
+                <td class="govuk-table__cell">No redaction required</td>
                 <td class="govuk-table__cell"><a href="/appeals-service/appeal-details/1/internal-correspondence/inspector/manage-documents/11/15d19184-155b-4b6c-bba6-2bd2a61ca9a3"
                     class="govuk-link">View and edit <span class="govuk-visually-hidden">test-pdf-documentFolderInfo.pdf</span></a>
                 </td>

--- a/appeals/web/src/server/appeals/appeal-details/internal-correspondence/__tests__/internal-correspondence.test.js
+++ b/appeals/web/src/server/appeals/appeal-details/internal-correspondence/__tests__/internal-correspondence.test.js
@@ -1135,7 +1135,7 @@ describe('internal correspondence', () => {
 					`href="/appeals-service/appeal-details/1/internal-correspondence/${correspondenceCategory}/add-document-details/${folder.folderId}"> Change</a></dd>`
 				);
 				expect(unprettifiedElement.innerHTML).toContain('Redaction status</dt>');
-				expect(unprettifiedElement.innerHTML).toContain('Unredacted</dd>');
+				expect(unprettifiedElement.innerHTML).toContain('No redaction required</dd>');
 				expect(unprettifiedElement.innerHTML).toContain('Confirm</button>');
 			});
 		}
@@ -1294,7 +1294,7 @@ describe('internal correspondence', () => {
 					`href="/appeals-service/appeal-details/1/internal-correspondence/${correspondenceCategory}/add-document-details/${folder.folderId}/1"> Change</a></dd>`
 				);
 				expect(unprettifiedElement.innerHTML).toContain('Redaction status</dt>');
-				expect(unprettifiedElement.innerHTML).toContain('Unredacted</dd>');
+				expect(unprettifiedElement.innerHTML).toContain('No redaction required</dd>');
 				expect(unprettifiedElement.innerHTML).toContain('Confirm</button>');
 			});
 		}
@@ -1674,7 +1674,7 @@ describe('internal correspondence', () => {
 					'name="items[0][redactionStatus]" type="radio" value="unredacted">'
 				);
 				expect(unprettifiedElement.innerHTML).toContain(
-					'name="items[0][redactionStatus]" type="radio" value="no redaction required">'
+					'name="items[0][redactionStatus]" type="radio" value="no redaction required" checked>'
 				);
 				expect(unprettifiedElement.innerHTML).toContain('Confirm</button>');
 			});

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/__tests__/__snapshots__/lpa-questionnaire.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/__tests__/__snapshots__/lpa-questionnaire.test.js.snap
@@ -315,10 +315,15 @@ exports[`LPA Questionnaire review GET / should render review outcome form fields
                         </div>
                     </div>
                 </div>
-                <div class="govuk-inset-text">Confirming this review will inform the relevant parties of the outcome</div>
-                <button                 class="govuk-button" data-module="govuk-button">Confirm</button>
-            </form>
+                <div class="govuk-inset-text">Confirming this review will inform the relevant parties of the outcome.</div>
+                <div                 class="govuk-warning-text"><span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+                    <strong                     class="govuk-warning-text__text"><span class="govuk-warning-text__assistive">Warning</span> Do not select
+                        an outcome until you have reviewed all of the supporting documents and
+                        redacted any sensitive information.</strong>
         </div>
+        <button class="govuk-button" data-module="govuk-button">Confirm</button>
+        </form>
+    </div>
     </div>
 </main>"
 `;
@@ -1348,7 +1353,7 @@ exports[`LPA Questionnaire review GET /appeals-service/appeal-details/1/lpa-ques
                     </dd>
                 </div>
             </dl>
-            <div class="govuk-inset-text">Confirming this review will inform the relevant parties of the outcome</div>
+            <div class="govuk-inset-text">Confirming this review will inform the relevant parties of the outcome.</div>
             <form             method="post" novalidate="novalidate">
                 <button type="submit" data-prevent-double-click="true" class="govuk-button"
                 data-module="govuk-button">Confirm</button>

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/__tests__/lpa-questionnaire.test.js
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/__tests__/lpa-questionnaire.test.js
@@ -440,7 +440,7 @@ describe('LPA Questionnaire review', () => {
 				'name="review-outcome" type="radio" value="incomplete">'
 			);
 			expect(unprettifiedElement.innerHTML).toContain(
-				'Confirming this review will inform the relevant parties of the outcome</div>'
+				'Confirming this review will inform the relevant parties of the outcome.</div>'
 			);
 			expect(unprettifiedElement.innerHTML).toContain('Confirm</button>');
 		}, 10000);
@@ -1430,7 +1430,7 @@ describe('LPA Questionnaire review', () => {
 			);
 			expect(unprettifiedElement.innerHTML).toContain('Incomplete reasons</dt>');
 			expect(unprettifiedElement.innerHTML).toContain(
-				'Confirming this review will inform the relevant parties of the outcome</div>'
+				'Confirming this review will inform the relevant parties of the outcome.</div>'
 			);
 			expect(unprettifiedElement.innerHTML).toContain('Confirm</button>');
 		});
@@ -2654,7 +2654,7 @@ describe('LPA Questionnaire review', () => {
 				`${dateISOStringToDisplayDate(new Date().toISOString())}</dd>`
 			);
 			expect(unprettifiedElement.innerHTML).toContain('Redaction status</dt>');
-			expect(unprettifiedElement.innerHTML).toContain('Unredacted</dd>');
+			expect(unprettifiedElement.innerHTML).toContain('No redaction required</dd>');
 			expect(unprettifiedElement.innerHTML).toContain(
 				`<a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/add-documents/${documentFolderInfo.folderId}"> Change</a></dd>`
 			);
@@ -2800,7 +2800,7 @@ describe('LPA Questionnaire review', () => {
 				`${dateISOStringToDisplayDate(new Date().toISOString())}</dd>`
 			);
 			expect(unprettifiedElement.innerHTML).toContain('Redaction status</dt>');
-			expect(unprettifiedElement.innerHTML).toContain('Unredacted</dd>');
+			expect(unprettifiedElement.innerHTML).toContain('No redaction required</dd>');
 			expect(unprettifiedElement.innerHTML).toContain(
 				`<a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/add-documents/${documentFolderInfo.folderId}/1"> Change</a></dd>`
 			);

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/lpa-questionnaire.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/lpa-questionnaire.mapper.js
@@ -104,7 +104,15 @@ export async function lpaQuestionnairePage(lpaqDetails, appealDetails, currentRo
 	const insetTextComponent = {
 		type: 'inset-text',
 		parameters: {
-			text: 'Confirming this review will inform the relevant parties of the outcome'
+			text: 'Confirming this review will inform the relevant parties of the outcome.'
+		}
+	};
+
+	/** @type {PageComponent} */
+	const documentsWarningComponent = {
+		type: 'warning-text',
+		parameters: {
+			text: 'Do not select an outcome until you have reviewed all of the supporting documents and redacted any sensitive information.'
 		}
 	};
 
@@ -130,6 +138,7 @@ export async function lpaQuestionnairePage(lpaqDetails, appealDetails, currentRo
 			parameters: reviewOutcomeRadiosInputInstruction.properties
 		});
 		reviewOutcomeComponents.push(insetTextComponent);
+		reviewOutcomeComponents.push(documentsWarningComponent);
 	}
 
 	if (getDocumentsForVirusStatus(lpaqDetails, 'not_scanned').length > 0) {
@@ -392,7 +401,7 @@ export function checkAndConfirmPage(
 	const insetTextComponent = {
 		type: 'inset-text',
 		parameters: {
-			text: 'Confirming this review will inform the relevant parties of the outcome'
+			text: 'Confirming this review will inform the relevant parties of the outcome.'
 		}
 	};
 

--- a/appeals/web/src/server/appeals/appeal-documents/appeal-documents.controller.js
+++ b/appeals/web/src/server/appeals/appeal-documents/appeal-documents.controller.js
@@ -25,7 +25,6 @@ import {
 	createNewDocumentVersion
 } from '#app/components/file-uploader.component.js';
 import config from '@pins/appeals.web/environment/config.js';
-import { redactionStatusNameToId } from '#lib/redaction-statuses.js';
 import { isFileUploadInfoItemArray } from '#lib/ts-utilities.js';
 import { getTodaysISOString } from '#lib/dates.js';
 import { folderIsAdditionalDocuments } from '#lib/documents.js';
@@ -156,7 +155,6 @@ export const postDocumentUpload = async ({ request, response, nextPageUrl }) => 
 	/** @type {import('#appeals/appeal-documents/appeal-documents.types').UncommittedFile[]} */
 	const uncommittedFiles = uploadInfo.map((infoItem) => ({
 		...infoItem,
-		redactionStatus: redactionStatusNameToId(redactionStatuses, 'unredacted'),
 		receivedDate: getTodaysISOString()
 	}));
 

--- a/appeals/web/src/server/appeals/appeal-documents/appeal-documents.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-documents/appeal-documents.mapper.js
@@ -468,7 +468,7 @@ function mapFileUploadInfoItemToDocumentDetailsPageComponents({
 							(bodyRedactionStatus
 								? bodyRedactionStatus
 								: redactionStatusIdToName(redactionStatuses, uncommittedFile.redactionStatus)) ===
-							'no redaction required'
+								'no redaction required' || !uncommittedFile.redactionStatus
 					}
 				]
 			}
@@ -575,9 +575,9 @@ function mapDocumentDetailsItemToDocumentDetailsPageComponents(item, redactionSt
 						value: 'no redaction required',
 						checked:
 							bodyRedactionStatus ===
-							redactionStatuses.find(
-								(status) => status.key === APPEAL_REDACTED_STATUS.NO_REDACTION_REQUIRED
-							)?.name
+								redactionStatuses.find(
+									(status) => status.key === APPEAL_REDACTED_STATUS.NO_REDACTION_REQUIRED
+								)?.name || !bodyRedactionStatus
 					}
 				]
 			}

--- a/appeals/web/src/server/views/patterns/display-page.pattern.njk
+++ b/appeals/web/src/server/views/patterns/display-page.pattern.njk
@@ -48,7 +48,7 @@
 {%- block pageContent -%}
 	{%- set formComponents = [] -%}
 	{%- for component in pageContent.pageComponents -%}
-		{%- if component.type === 'radios' or component.type === 'checkboxes' or (component.type === 'inset-text' and formComponents | length) -%}
+		{%- if component.type === 'radios' or component.type === 'checkboxes' or (component.type === 'inset-text' and formComponents | length) or (component.type === 'warning-text' and formComponents | length) -%}
 			{%- set _ = formComponents.push(component) -%}
 		{%- elif component.type !== 'error-summary' and component.type !== 'notification-banner' -%}
 			{%- include "../appeals/components/page-component.njk" -%}

--- a/appeals/web/testing/app/fixtures/referencedata.js
+++ b/appeals/web/testing/app/fixtures/referencedata.js
@@ -28,7 +28,7 @@ export const documentFileInfo = {
 		datePublished: null,
 		isDeleted: false,
 		isLateEntry: false,
-		redactedStatus: null,
+		redactedStatus: 3,
 		documentURI:
 			'https://127.0.0.1:10000/devstoreaccount1/document-service-uploads/document-service-uploads/appeal/APP-Q9999-D-21-655112/d51f408c-7c6f-4f49-bcc0-abbb5bea3be6/v1/ph0.jpeg',
 		dateReceived: '2023-10-11T13:57:41.592Z'
@@ -1536,7 +1536,7 @@ export const documentFolderInfoWithoutDraftDocuments = {
 			latestDocumentVersion: {
 				draft: false,
 				dateReceived: '2023-02-01T01:00:00.000Z',
-				redactionStatus: 'Redacted',
+				redactionStatus: null,
 				size: 129363,
 				mime: 'application/pdf',
 				isLateEntry: false
@@ -1548,7 +1548,7 @@ export const documentFolderInfoWithoutDraftDocuments = {
 			latestDocumentVersion: {
 				draft: false,
 				dateReceived: '2024-03-02T01:00:00.000Z',
-				redactionStatus: 'Unredacted',
+				redactionStatus: null,
 				size: 11815175,
 				mime: 'video/mp4',
 				virusCheckStatus: APPEAL_VIRUS_CHECK_STATUS.NOT_SCANNED,
@@ -2089,7 +2089,7 @@ export const costsFolderInfoAppellantApplication = {
 			latestDocumentVersion: {
 				draft: false,
 				dateReceived: '2023-02-01T01:00:00.000Z',
-				redactionStatus: 'Redacted',
+				redactionStatus: 'No redaction required',
 				size: 129363,
 				mime: 'application/pdf',
 				virusCheckStatus: APPEAL_VIRUS_CHECK_STATUS.SCANNED,
@@ -2201,7 +2201,7 @@ export const appealCostsDocumentItem = {
 		dateReceived: '2024-04-09T13:10:07.562Z',
 		isDeleted: false,
 		isLateEntry: false,
-		redactionStatusId: 2,
+		redactionStatusId: 0,
 		redacted: false,
 		documentURI:
 			'https://127.0.0.1:10000/devstoreaccount1/document-service-uploads/document-service-uploads/appeal/6014692/d2197025-5edb-4477-8e98-2a1bf13ed2ea/v1/test-doc-alternate.docx'
@@ -2209,7 +2209,7 @@ export const appealCostsDocumentItem = {
 };
 
 export const fileUploadInfo =
-	'[{"name": "test-document.txt", "GUID": "1", "fileRowId": "1", "blobStoreUrl": "/", "mimeType": "txt", "documentType": "txt", "size": 1, "stage": "appellant-case"}]';
+	'[{"name": "test-document.txt", "GUID": "1", "fileRowId": "1", "blobStoreUrl": "/", "mimeType": "txt", "documentType": "txt", "size": 1, "stage": "appellant-case", "redactionStatus": 3}]';
 
 export const withdrawalRequestData = {
 	withdrawal: {


### PR DESCRIPTION
Sets default redaction statuses

It will set redaction status to NULL (for documents received through appellant case and LPAQ), which is then updated to 'No redaction required' when validating those submissions.

It will pre-check 'No redaction required' on documents uploaded directly in the back office.

## Issue ticket number and link

[A2-1161](https://pins-ds.atlassian.net/browse/A2-1161)

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [ ] I have performed a self-review of my own code
- [ ] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [ ] I have referenced the ticket number above
- [ ] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes


[A2-1161]: https://pins-ds.atlassian.net/browse/A2-1161?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ