### PR TITLE
fix(web): ensuring correct content displays when no Address is provided

### DIFF
--- a/appeals/web/src/server/appeals/appeal-details/interested-party-comments/add-ip-comment/add-ip-comment.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/interested-party-comments/add-ip-comment/add-ip-comment.mapper.js
@@ -217,7 +217,7 @@ export const dateSubmittedPage = (appealDetails, errors, date) => ({
 /**
 /**
  * @param {Appeal} appealDetails
- * @param {{ firstName: string, lastName: string, emailAddress: string, addressLine1: string, addressLine2: string, town: string, county: string, postCode: string, redactionStatus: boolean, 'date-day': string, 'date-month': string, 'date-year': string }} values
+ * @param {{ firstName: string, lastName: string, addressProvided: string, emailAddress: string, addressLine1: string, addressLine2: string, town: string, county: string, postCode: string, redactionStatus: boolean, 'date-day': string, 'date-month': string, 'date-year': string }} values
  * @param {{ files: [{ name:string }] }} fileUpload
  * @param {import('@pins/express').ValidationErrors | undefined} errors
  * @returns {PageContent}
@@ -256,7 +256,11 @@ export const checkYourAnswersPage = (appealDetails, values, fileUpload, errors) 
 							text: 'Address'
 						},
 						value: {
-							html: addressToMultilineStringHtml(values)
+							html: `${
+								values?.addressProvided === 'no'
+									? 'Not provided'
+									: addressToMultilineStringHtml(values)
+							}`
 						},
 						actions: {
 							items: [


### PR DESCRIPTION
Updating the add ip comment mapper to ensure that when no address is provided the correct content is displayed on the screen

## Describe your changes

<!--
    Please include a summary of the change along with any relevant context.
    List any dependencies that are required for this change.
-->

## Issue ticket number and link

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [ ] I have performed a self-review of my own code
- [ ] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [ ] I have referenced the ticket number above
- [ ] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
