### PR TITLE
feat(appeals): boolean fields A2-981

### DIFF
--- a/appeals/api/src/database/migrations/20241028120027_add_is_aonb_national_landscape_lpaq_s78/migration.sql
+++ b/appeals/api/src/database/migrations/20241028120027_add_is_aonb_national_landscape_lpaq_s78/migration.sql
@@ -1,0 +1,19 @@
+BEGIN TRY
+
+BEGIN TRAN;
+
+-- AlterTable
+ALTER TABLE [dbo].[LPAQuestionnaire] ADD [isAonbNationalLandscape] BIT;
+
+COMMIT TRAN;
+
+END TRY
+BEGIN CATCH
+
+IF @@TRANCOUNT > 0
+BEGIN
+    ROLLBACK TRAN;
+END;
+THROW
+
+END CATCH

--- a/appeals/api/src/database/schema.prisma
+++ b/appeals/api/src/database/schema.prisma
@@ -390,6 +390,7 @@ model LPAQuestionnaire {
   // S78 fields
   affectsScheduledMonument            Boolean?
   hasProtectedSpecies                 Boolean?
+  isAonbNationalLandscape             Boolean?
   designatedSitesNames                String?
   hasTreePreservationOrder            Boolean?
   isGypsyOrTravellerSite              Boolean?

--- a/appeals/api/src/server/endpoints/appeals.d.ts
+++ b/appeals/api/src/server/endpoints/appeals.d.ts
@@ -319,9 +319,12 @@ interface SingleLPAQuestionnaireResponse {
 	lpaStatement?: string | null;
 	extraConditions?: string | null;
 	hasExtraConditions?: boolean | null;
-	affectsScheduledMonument?: boolean | null;
 	eiaColumnTwoThreshold?: boolean | null;
 	eiaRequiresEnvironmentalStatement?: boolean | null;
+	affectsScheduledMonument?: boolean;
+	hasProtectedSpecies?: boolean;
+	isAonbNationalLandscape?: boolean;
+	isGypsyOrTravellerSite?: boolean;
 }
 
 interface UpdateLPAQuestionnaireRequest {
@@ -340,6 +343,10 @@ interface UpdateLPAQuestionnaireRequest {
 	isAffectingNeighbouringSites?: boolean;
 	eiaColumnTwoThreshold?: boolean;
 	eiaRequiresEnvironmentalStatement?: boolean;
+	affectsScheduledMonument?: boolean;
+	hasProtectedSpecies?: boolean;
+	isAonbNationalLandscape?: boolean;
+	isGypsyOrTravellerSite?: boolean;
 }
 
 interface UpdateLPAQuestionnaireValidationOutcomeParams {

--- a/appeals/api/src/server/endpoints/constants.js
+++ b/appeals/api/src/server/endpoints/constants.js
@@ -73,6 +73,14 @@ export const AUDIT_TRAIL_LPAQ_IS_GREEN_BELT_UPDATED = 'Green belt status updated
 export const AUDIT_TRAIL_LPAQ_SITE_ACCESS_DETAILS_UPDATED = 'Inspector access (lpa) updated';
 export const AUDIT_TRAIL_LPAQ_SITE_SAFETY_DETAILS_UPDATED =
 	'Site health and safety risks (LPA answer) updated';
+export const AUDIT_TRAIL_LPAQ_HAS_PROTECTED_SPECIES_UPDATED = 'Protected species status updated';
+export const AUDIT_TRAIL_LPAQ_AFFECTS_SCHEDULED_MONUMENT_UPDATED =
+	'Scheduled monument status updated';
+export const AUDIT_TRAIL_LPAQ_IS_AONB_NATIONAL_LANDSCAPE_UPDATED =
+	'Outstanding natural beauty area status updated';
+export const AUDIT_TRAIL_LPAQ_IS_GYPSY_OR_TRAVELLER_SITE_UPDATED =
+	'Gypsy or Traveller communities status updated';
+
 export const AUDIT_TRAIL_LISTED_BUILDING_ADDED = 'A listed building was added';
 export const AUDIT_TRAIL_LISTED_BUILDING_UPDATED = 'A listed building was updated';
 export const AUDIT_TRAIL_LISTED_BUILDING_REMOVED = 'A listed building was removed';

--- a/appeals/api/src/server/endpoints/lpa-questionnaires/lpa-questionnaires.controller.js
+++ b/appeals/api/src/server/endpoints/lpa-questionnaires/lpa-questionnaires.controller.js
@@ -47,7 +47,11 @@ const updateLPAQuestionnaireById = async (req, res) => {
 			lpaNotificationMethods,
 			isAffectingNeighbouringSites,
 			eiaColumnTwoThreshold,
-			eiaRequiresEnvironmentalStatement
+			eiaRequiresEnvironmentalStatement,
+			affectsScheduledMonument,
+			hasProtectedSpecies,
+			isAonbNationalLandscape,
+			isGypsyOrTravellerSite
 		},
 		params,
 		validationOutcome
@@ -84,7 +88,11 @@ const updateLPAQuestionnaireById = async (req, res) => {
 					lpaNotificationMethods,
 					isAffectingNeighbouringSites,
 					eiaColumnTwoThreshold,
-					eiaRequiresEnvironmentalStatement
+					eiaRequiresEnvironmentalStatement,
+					affectsScheduledMonument,
+					hasProtectedSpecies,
+					isAonbNationalLandscape,
+					isGypsyOrTravellerSite
 			  });
 
 		const updatedProperties = Object.keys(body).filter((key) => body[key] !== undefined);
@@ -123,7 +131,11 @@ const updateLPAQuestionnaireById = async (req, res) => {
 				extraConditions,
 				lpaCostsAppliedFor,
 				isConservationArea,
-				isCorrectAppealType
+				isCorrectAppealType,
+				affectsScheduledMonument,
+				hasProtectedSpecies,
+				isAonbNationalLandscape,
+				isGypsyOrTravellerSite
 		  };
 
 	return res.send(response);

--- a/appeals/api/src/server/endpoints/lpa-questionnaires/lpa-questionnaires.formatter.js
+++ b/appeals/api/src/server/endpoints/lpa-questionnaires/lpa-questionnaires.formatter.js
@@ -67,7 +67,11 @@ const formatLpaQuestionnaire = (appeal, folders = null) => {
 			hasExtraConditions: lpaQuestionnaire.newConditionDetails !== null,
 			affectsSheduledMonument: lpaQuestionnaire.affectsScheduledMonument,
 			eiaColumnTwoThreshold: lpaQuestionnaire.eiaColumnTwoThreshold,
-			eiaRequiresEnvironmentalStatement: lpaQuestionnaire.eiaRequiresEnvironmentalStatement
+			eiaRequiresEnvironmentalStatement: lpaQuestionnaire.eiaRequiresEnvironmentalStatement,
+			affectsScheduledMonument: lpaQuestionnaire.affectsScheduledMonument,
+			hasProtectedSpecies: lpaQuestionnaire.hasProtectedSpecies,
+			isAonbNationalLandscape: lpaQuestionnaire.isAonbNationalLandscape,
+			isGypsyOrTravellerSite: lpaQuestionnaire.isGypsyOrTravellerSite
 		};
 	} else {
 		return {};

--- a/appeals/api/src/server/endpoints/lpa-questionnaires/lpa-questionnaires.validators.js
+++ b/appeals/api/src/server/endpoints/lpa-questionnaires/lpa-questionnaires.validators.js
@@ -60,6 +60,10 @@ const patchLPAQuestionnaireValidator = composeMiddleware(
 		'inspectorAccessDetails',
 		true
 	),
+	validateBooleanParameter('affectsScheduledMonument'),
+	validateBooleanParameter('hasProtectedSpecies'),
+	validateBooleanParameter('isAonbNationalLandscape'),
+	validateBooleanParameter('isGypsyOrTravellerSite'),
 	validationErrorHandler
 );
 

--- a/appeals/api/src/server/repositories/lpa-questionnaire.repository.js
+++ b/appeals/api/src/server/repositories/lpa-questionnaire.repository.js
@@ -36,7 +36,11 @@ const updateLPAQuestionnaireById = (id, data) => {
 				lpaNotificationMethods: processNotificationMethods(id, data, transaction),
 				isAffectingNeighbouringSites: data.isAffectingNeighbouringSites,
 				eiaColumnTwoThreshold: data.eiaColumnTwoThreshold,
-				eiaRequiresEnvironmentalStatement: data.eiaRequiresEnvironmentalStatement
+				eiaRequiresEnvironmentalStatement: data.eiaRequiresEnvironmentalStatement,
+				affectsScheduledMonument: data.affectsScheduledMonument,
+				hasProtectedSpecies: data.hasProtectedSpecies,
+				isAonbNationalLandscape: data.isAonbNationalLandscape,
+				isGypsyOrTravellerSite: data.isGypsyOrTravellerSite
 			}
 		})
 	);

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/affects-scheduled-monument/__tests__/__snapshots__/affects-scheduled-monument.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/affects-scheduled-monument/__tests__/__snapshots__/affects-scheduled-monument.test.js.snap
@@ -1,0 +1,33 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`scheduled-monument GET /change should render the affectsScheduledMonument change page when accessed from LPAQ page 1`] = `
+"<main class="govuk-main-wrapper " id="main-content" role="main">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <div class="govuk-grid-row">
+                <div class="govuk-grid-column-full"><span class="govuk-caption-l govuk-!-margin-bottom-3">Appeal 351062</span>
+                    <h1                     class="govuk-heading-l govuk-!-margin-bottom-3">Change whether scheduled monument affected</h1>
+                </div>
+            </div>
+            <form method="POST" novalidate="novalidate">
+                <div class="govuk-form-group">
+                    <div class="govuk-radios" data-module="govuk-radios">
+                        <div class="govuk-radios__item">
+                            <input class="govuk-radios__input" id="affectsScheduledMonumentRadio"
+                            name="affectsScheduledMonumentRadio" type="radio" value="yes">
+                            <label class="govuk-label govuk-radios__label" for="affectsScheduledMonumentRadio">Affected</label>
+                        </div>
+                        <div class="govuk-radios__item">
+                            <input class="govuk-radios__input" id="affectsScheduledMonumentRadio-2"
+                            name="affectsScheduledMonumentRadio" type="radio" value="no" checked>
+                            <label class="govuk-label govuk-radios__label" for="affectsScheduledMonumentRadio-2">Not affected</label>
+                        </div>
+                    </div>
+                </div>
+                <button type="submit" data-prevent-double-click="true" class="govuk-button"
+                data-module="govuk-button">Continue</button>
+            </form>
+        </div>
+    </div>
+</main>"
+`;

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/affects-scheduled-monument/__tests__/affects-scheduled-monument.test.js
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/affects-scheduled-monument/__tests__/affects-scheduled-monument.test.js
@@ -1,0 +1,94 @@
+import { parseHtml } from '@pins/platform';
+import supertest from 'supertest';
+import {
+	appealData,
+	lpaQuestionnaireDataNotValidated
+} from '#testing/app/fixtures/referencedata.js';
+import { createTestEnvironment } from '#testing/index.js';
+import nock from 'nock';
+
+const { app, installMockApi, teardown } = createTestEnvironment();
+const request = supertest(app);
+const appealId = appealData.appealId;
+const lpaQuestionnaireId = appealData.lpaQuestionnaireId;
+const lpaQuestionnaireUrl = `/appeals-service/appeal-details/${appealId}/lpa-questionnaire/${lpaQuestionnaireId}`;
+
+describe('scheduled-monument', () => {
+	beforeEach(installMockApi), afterEach(teardown);
+
+	describe('GET /change', () => {
+		it('should render the affectsScheduledMonument change page when accessed from LPAQ page', async () => {
+			nock('http://test/')
+				.get(`/appeals/${appealId}/lpa-questionnaires/${lpaQuestionnaireId}`)
+				.reply(200, lpaQuestionnaireDataNotValidated);
+			const response = await request.get(
+				`${lpaQuestionnaireUrl}/affects-scheduled-monument/change`
+			);
+
+			const mainInnerHtml = parseHtml(response.text).innerHTML;
+			expect(response.statusCode).toEqual(200);
+
+			expect(mainInnerHtml).toMatchSnapshot();
+			expect(mainInnerHtml).toContain('Change whether scheduled monument affected</h1>');
+		});
+
+		it('should render a back link to LPAQ page on the affectsScheduledMonument change page when accessed from LPAQ page', async () => {
+			nock('http://test/')
+				.get(`/appeals/${appealId}/lpa-questionnaires/${lpaQuestionnaireId}`)
+				.reply(200, lpaQuestionnaireDataNotValidated);
+			const response = await request.get(
+				`${lpaQuestionnaireUrl}/affects-scheduled-monument/change`
+			);
+
+			const backLinkInnerHtml = parseHtml(response.text, {
+				rootElement: '.govuk-back-link'
+			}).innerHTML;
+
+			expect(response.statusCode).toEqual(200);
+
+			expect(backLinkInnerHtml).toContain(`href="${lpaQuestionnaireUrl}`);
+		});
+	});
+
+	describe('POST /change', () => {
+		it('should re-direct to LPA questionnaire if "yes" when accessed from LPAQ page', async () => {
+			const validData = {
+				affectsScheduledMonumentRadio: 'yes'
+			};
+
+			const apiCall = nock('http://test/')
+				.patch(`/appeals/${appealId}/lpa-questionnaires/${lpaQuestionnaireId}`)
+				.reply(200, {});
+
+			const response = await request
+				.post(`${lpaQuestionnaireUrl}/affects-scheduled-monument/change`)
+				.send(validData);
+
+			expect(apiCall.isDone()).toBe(true);
+			expect(response.statusCode).toBe(302);
+			expect(response.text).toBe(
+				`Found. Redirecting to /appeals-service/appeal-details/${appealId}/lpa-questionnaire/${lpaQuestionnaireId}`
+			);
+		});
+
+		it('should re-direct to LPA questionnaire if "no" when accessed from LPAQ page', async () => {
+			const validData = {
+				affectsScheduledMonumentRadio: 'no'
+			};
+
+			const apiCall = nock('http://test/')
+				.patch(`/appeals/${appealId}/lpa-questionnaires/${lpaQuestionnaireId}`)
+				.reply(200, {});
+
+			const response = await request
+				.post(`${lpaQuestionnaireUrl}/affects-scheduled-monument/change`)
+				.send(validData);
+
+			expect(apiCall.isDone()).toBe(true);
+			expect(response.statusCode).toBe(302);
+			expect(response.text).toBe(
+				`Found. Redirecting to /appeals-service/appeal-details/${appealId}/lpa-questionnaire/${lpaQuestionnaireId}`
+			);
+		});
+	});
+});

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/affects-scheduled-monument/affects-scheduled-monument.controller.js
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/affects-scheduled-monument/affects-scheduled-monument.controller.js
@@ -1,0 +1,105 @@
+import { convertFromYesNoNullToBooleanOrNull } from '#lib/boolean-formatter.js';
+import logger from '#lib/logger.js';
+import { addNotificationBannerToSession } from '#lib/session-utilities.js';
+import { getOriginPathname, isInternalUrl } from '#lib/url-utilities.js';
+import { getLpaQuestionnaireFromId } from '../lpa-questionnaire.service.js';
+import * as mapper from './affects-scheduled-monument.mapper.js';
+import * as service from './affects-scheduled-monument.service.js';
+/**
+ * @param {import('@pins/express/types/express.js').Request} request
+ * @param {import('@pins/express/types/express.js').RenderedResponse<any, any, Number>} response
+ */
+export const getChangeAffectsScheduledMonument = async (request, response) => {
+	return renderChangeAffectsScheduledMonument(request, response);
+};
+
+/**
+ * @param {import('@pins/express/types/express.js').Request} request
+ * @param {import('@pins/express/types/express.js').RenderedResponse<any, any, Number>} response
+ */
+const renderChangeAffectsScheduledMonument = async (request, response) => {
+	try {
+		const { currentAppeal, session, errors, originalUrl, apiClient } = request;
+		const origin = originalUrl.split('/').slice(0, -2).join('/');
+		const data = await getLpaQuestionnaireFromId(
+			apiClient,
+			currentAppeal.appealId,
+			currentAppeal.lpaQuestionnaireId
+		);
+
+		const currentRadioValue =
+			convertFromYesNoNullToBooleanOrNull(session.affectsScheduledMonument) ??
+			data.affectsScheduledMonument;
+		const mappedPageContents = mapper.changeAffectsScheduledMonument(
+			currentAppeal,
+			currentRadioValue?.toString() || '',
+			origin
+		);
+
+		return response.status(200).render('patterns/change-page.pattern.njk', {
+			pageContent: mappedPageContents,
+			errors
+		});
+	} catch (error) {
+		logger.error(error);
+	}
+
+	return response.status(500).render('app/500.njk');
+};
+
+/**
+ * @param {import('@pins/express/types/express.js').Request} request
+ * @param {import('@pins/express/types/express.js').RenderedResponse<any, any, Number>} response
+ */
+export const postChangeAffectsScheduledMonument = async (request, response) => {
+	request.session.affectsScheduledMonument = request.body['affectsScheduledMonumentRadio'];
+
+	if (request.errors) {
+		return renderChangeAffectsScheduledMonument(request, response);
+	}
+
+	try {
+		const {
+			apiClient,
+			params: { appealId },
+			currentAppeal,
+			session
+		} = request;
+
+		const currentUrl = getOriginPathname(request);
+		const origin = currentUrl.split('/').slice(0, -2).join('/');
+
+		if (!isInternalUrl(origin, request)) {
+			return response.status(400).render('errorPageTemplate', {
+				message: 'Invalid redirection attempt detected.'
+			});
+		}
+
+		await service.changeAffectsScheduledMonument(
+			apiClient,
+			appealId,
+			currentAppeal.lpaQuestionnaireId,
+			session.affectsScheduledMonument
+		);
+
+		addNotificationBannerToSession(
+			session,
+			'changePage',
+			appealId,
+			'',
+			'Scheduled monument status changed '
+		);
+
+		delete request.session.affectsScheduledMonument;
+
+		if (!origin.startsWith('/')) {
+			throw new Error('unexpected originalUrl');
+		} else {
+			return response.redirect(origin);
+		}
+	} catch (error) {
+		logger.error(error);
+	}
+	delete request.session.affectsScheduledMonument;
+	return response.status(500).render('app/500.njk');
+};

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/affects-scheduled-monument/affects-scheduled-monument.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/affects-scheduled-monument/affects-scheduled-monument.mapper.js
@@ -1,0 +1,32 @@
+/**
+ * @typedef {import('../../appeal-details.types.js').WebAppeal} Appeal
+ */
+import { appealShortReference } from '#lib/appeals-formatter.js';
+import { yesNoInput } from '#lib/mappers/components/radio.js';
+
+/**
+ * @param {Appeal} appealData
+ * @param {string} data
+ * @param {string} origin
+ * @returns {PageContent}
+ */
+export const changeAffectsScheduledMonument = (appealData, data, origin) => {
+	const shortAppealReference = appealShortReference(appealData.appealReference);
+
+	/** @type {PageContent} */
+	const pageContent = {
+		title: `Affects scheduled monument`,
+		backLinkUrl: origin,
+		preHeading: `Appeal ${shortAppealReference}`,
+		heading: `Change whether scheduled monument affected`,
+		pageComponents: [
+			yesNoInput({
+				name: 'affectsScheduledMonumentRadio',
+				value: data,
+				customYesLabel: 'Affected',
+				customNoLabel: 'Not affected'
+			})
+		]
+	};
+	return pageContent;
+};

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/affects-scheduled-monument/affects-scheduled-monument.router.js
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/affects-scheduled-monument/affects-scheduled-monument.router.js
@@ -1,0 +1,12 @@
+import { Router as createRouter } from 'express';
+import * as controllers from './affects-scheduled-monument.controller.js';
+import { asyncHandler } from '@pins/express';
+
+const router = createRouter({ mergeParams: true });
+
+router
+	.route('/change')
+	.get(asyncHandler(controllers.getChangeAffectsScheduledMonument))
+	.post(asyncHandler(controllers.postChangeAffectsScheduledMonument));
+
+export default router;

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/affects-scheduled-monument/affects-scheduled-monument.service.js
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/affects-scheduled-monument/affects-scheduled-monument.service.js
@@ -1,0 +1,19 @@
+import { convertFromYesNoToBoolean } from '#lib/boolean-formatter.js';
+
+/**
+ *
+ * @param {import('got').Got} apiClient
+ * @param {string} appealId
+ * @param {string} lpaQuestionnaireId
+ * @param {string} inputData
+ * @returns {Promise<{}>}
+ */
+export function changeAffectsScheduledMonument(apiClient, appealId, lpaQuestionnaireId, inputData) {
+	const formattedValue = convertFromYesNoToBoolean(inputData);
+
+	return apiClient.patch(`appeals/${appealId}/lpa-questionnaires/${lpaQuestionnaireId}`, {
+		json: {
+			affectsScheduledMonument: formattedValue
+		}
+	});
+}

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/has-protected-species/__tests__/__snapshots__/has-protected-species.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/has-protected-species/__tests__/__snapshots__/has-protected-species.test.js.snap
@@ -1,0 +1,33 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`protected-species GET /change should render the hasProtectedSpecies change page when accessed from LPAQ page 1`] = `
+"<main class="govuk-main-wrapper " id="main-content" role="main">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <div class="govuk-grid-row">
+                <div class="govuk-grid-column-full"><span class="govuk-caption-l govuk-!-margin-bottom-3">Appeal 351062</span>
+                    <h1                     class="govuk-heading-l govuk-!-margin-bottom-3">Change whether protected species affected</h1>
+                </div>
+            </div>
+            <form method="POST" novalidate="novalidate">
+                <div class="govuk-form-group">
+                    <div class="govuk-radios" data-module="govuk-radios">
+                        <div class="govuk-radios__item">
+                            <input class="govuk-radios__input" id="protectedSpeciesRadio" name="protectedSpeciesRadio"
+                            type="radio" value="yes" checked>
+                            <label class="govuk-label govuk-radios__label" for="protectedSpeciesRadio">Affected</label>
+                        </div>
+                        <div class="govuk-radios__item">
+                            <input class="govuk-radios__input" id="protectedSpeciesRadio-2" name="protectedSpeciesRadio"
+                            type="radio" value="no">
+                            <label class="govuk-label govuk-radios__label" for="protectedSpeciesRadio-2">Not affected</label>
+                        </div>
+                    </div>
+                </div>
+                <button type="submit" data-prevent-double-click="true" class="govuk-button"
+                data-module="govuk-button">Continue</button>
+            </form>
+        </div>
+    </div>
+</main>"
+`;

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/has-protected-species/__tests__/has-protected-species.test.js
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/has-protected-species/__tests__/has-protected-species.test.js
@@ -1,0 +1,90 @@
+import { parseHtml } from '@pins/platform';
+import supertest from 'supertest';
+import {
+	appealData,
+	lpaQuestionnaireDataNotValidated
+} from '#testing/app/fixtures/referencedata.js';
+import { createTestEnvironment } from '#testing/index.js';
+import nock from 'nock';
+
+const { app, installMockApi, teardown } = createTestEnvironment();
+const request = supertest(app);
+const appealId = appealData.appealId;
+const lpaQuestionnaireId = appealData.lpaQuestionnaireId;
+const lpaQuestionnaireUrl = `/appeals-service/appeal-details/${appealId}/lpa-questionnaire/${lpaQuestionnaireId}`;
+
+describe('protected-species', () => {
+	beforeEach(installMockApi), afterEach(teardown);
+
+	describe('GET /change', () => {
+		it('should render the hasProtectedSpecies change page when accessed from LPAQ page', async () => {
+			nock('http://test/')
+				.get(`/appeals/${appealId}/lpa-questionnaires/${lpaQuestionnaireId}`)
+				.reply(200, lpaQuestionnaireDataNotValidated);
+			const response = await request.get(`${lpaQuestionnaireUrl}/has-protected-species/change`);
+
+			const mainInnerHtml = parseHtml(response.text).innerHTML;
+			expect(response.statusCode).toEqual(200);
+
+			expect(mainInnerHtml).toMatchSnapshot();
+			expect(mainInnerHtml).toContain('Change whether protected species affected</h1>');
+		});
+
+		it('should render a back link to LPAQ page on the hasProtectedSpecies change page when accessed from LPAQ page', async () => {
+			nock('http://test/')
+				.get(`/appeals/${appealId}/lpa-questionnaires/${lpaQuestionnaireId}`)
+				.reply(200, lpaQuestionnaireDataNotValidated);
+			const response = await request.get(`${lpaQuestionnaireUrl}/has-protected-species/change`);
+
+			const backLinkInnerHtml = parseHtml(response.text, {
+				rootElement: '.govuk-back-link'
+			}).innerHTML;
+
+			expect(response.statusCode).toEqual(200);
+
+			expect(backLinkInnerHtml).toContain(`href="${lpaQuestionnaireUrl}`);
+		});
+	});
+
+	describe('POST /change', () => {
+		it('should re-direct to LPA questionnaire if "yes" when accessed from LPAQ page', async () => {
+			const validData = {
+				protectedSpeciesRadio: 'yes'
+			};
+
+			const apiCall = nock('http://test/')
+				.patch(`/appeals/${appealId}/lpa-questionnaires/${lpaQuestionnaireId}`)
+				.reply(200, {});
+
+			const response = await request
+				.post(`${lpaQuestionnaireUrl}/has-protected-species/change`)
+				.send(validData);
+
+			expect(apiCall.isDone()).toBe(true);
+			expect(response.statusCode).toBe(302);
+			expect(response.text).toBe(
+				`Found. Redirecting to /appeals-service/appeal-details/${appealId}/lpa-questionnaire/${lpaQuestionnaireId}`
+			);
+		});
+
+		it('should re-direct to LPA questionnaire if "no" when accessed from LPAQ page', async () => {
+			const validData = {
+				protectedSpeciesRadio: 'no'
+			};
+
+			const apiCall = nock('http://test/')
+				.patch(`/appeals/${appealId}/lpa-questionnaires/${lpaQuestionnaireId}`)
+				.reply(200, {});
+
+			const response = await request
+				.post(`${lpaQuestionnaireUrl}/has-protected-species/change`)
+				.send(validData);
+
+			expect(apiCall.isDone()).toBe(true);
+			expect(response.statusCode).toBe(302);
+			expect(response.text).toBe(
+				`Found. Redirecting to /appeals-service/appeal-details/${appealId}/lpa-questionnaire/${lpaQuestionnaireId}`
+			);
+		});
+	});
+});

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/has-protected-species/has-protected-species.controller.js
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/has-protected-species/has-protected-species.controller.js
@@ -1,0 +1,104 @@
+import { convertFromYesNoNullToBooleanOrNull } from '#lib/boolean-formatter.js';
+import logger from '#lib/logger.js';
+import { addNotificationBannerToSession } from '#lib/session-utilities.js';
+import { getOriginPathname, isInternalUrl } from '#lib/url-utilities.js';
+import { getLpaQuestionnaireFromId } from '../lpa-questionnaire.service.js';
+import * as mapper from './has-protected-species.mapper.js';
+import * as service from './has-protected-species.service.js';
+/**
+ * @param {import('@pins/express/types/express.js').Request} request
+ * @param {import('@pins/express/types/express.js').RenderedResponse<any, any, Number>} response
+ */
+export const getChangeHasProtectedSpecies = async (request, response) => {
+	return renderChangeHasProtectedSpecies(request, response);
+};
+
+/**
+ * @param {import('@pins/express/types/express.js').Request} request
+ * @param {import('@pins/express/types/express.js').RenderedResponse<any, any, Number>} response
+ */
+const renderChangeHasProtectedSpecies = async (request, response) => {
+	try {
+		const { currentAppeal, session, errors, originalUrl, apiClient } = request;
+		const origin = originalUrl.split('/').slice(0, -2).join('/');
+		const data = await getLpaQuestionnaireFromId(
+			apiClient,
+			currentAppeal.appealId,
+			currentAppeal.lpaQuestionnaireId
+		);
+
+		const currentRadioValue =
+			convertFromYesNoNullToBooleanOrNull(session.hasProtectedSpecies) ?? data.hasProtectedSpecies;
+		const mappedPageContents = mapper.changeHasProtectedSpecies(
+			currentAppeal,
+			currentRadioValue?.toString() || '',
+			origin
+		);
+
+		return response.status(200).render('patterns/change-page.pattern.njk', {
+			pageContent: mappedPageContents,
+			errors
+		});
+	} catch (error) {
+		logger.error(error);
+	}
+
+	return response.status(500).render('app/500.njk');
+};
+
+/**
+ * @param {import('@pins/express/types/express.js').Request} request
+ * @param {import('@pins/express/types/express.js').RenderedResponse<any, any, Number>} response
+ */
+export const postChangeHasProtectedSpecies = async (request, response) => {
+	request.session.hasProtectedSpecies = request.body['protectedSpeciesRadio'];
+
+	if (request.errors) {
+		return renderChangeHasProtectedSpecies(request, response);
+	}
+
+	try {
+		const {
+			apiClient,
+			params: { appealId },
+			currentAppeal,
+			session
+		} = request;
+
+		const currentUrl = getOriginPathname(request);
+		const origin = currentUrl.split('/').slice(0, -2).join('/');
+
+		if (!isInternalUrl(origin, request)) {
+			return response.status(400).render('errorPageTemplate', {
+				message: 'Invalid redirection attempt detected.'
+			});
+		}
+
+		await service.changeHasProtectedSpecies(
+			apiClient,
+			appealId,
+			currentAppeal.lpaQuestionnaireId,
+			session.hasProtectedSpecies
+		);
+
+		addNotificationBannerToSession(
+			session,
+			'changePage',
+			appealId,
+			'',
+			'Protected species status changed'
+		);
+
+		delete request.session.hasProtectedSpecies;
+
+		if (!origin.startsWith('/')) {
+			throw new Error('unexpected originalUrl');
+		} else {
+			return response.redirect(origin);
+		}
+	} catch (error) {
+		logger.error(error);
+	}
+	delete request.session.hasProtectedSpecies;
+	return response.status(500).render('app/500.njk');
+};

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/has-protected-species/has-protected-species.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/has-protected-species/has-protected-species.mapper.js
@@ -1,0 +1,32 @@
+/**
+ * @typedef {import('../../appeal-details.types.js').WebAppeal} Appeal
+ */
+import { appealShortReference } from '#lib/appeals-formatter.js';
+import { yesNoInput } from '#lib/mappers/components/radio.js';
+
+/**
+ * @param {Appeal} appealData
+ * @param {string} data
+ * @param {string} origin
+ * @returns {PageContent}
+ */
+export const changeHasProtectedSpecies = (appealData, data, origin) => {
+	const shortAppealReference = appealShortReference(appealData.appealReference);
+
+	/** @type {PageContent} */
+	const pageContent = {
+		title: `Protected species`,
+		backLinkUrl: origin,
+		preHeading: `Appeal ${shortAppealReference}`,
+		heading: `Change whether protected species affected`,
+		pageComponents: [
+			yesNoInput({
+				name: 'protectedSpeciesRadio',
+				value: data,
+				customYesLabel: 'Affected',
+				customNoLabel: 'Not affected'
+			})
+		]
+	};
+	return pageContent;
+};

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/has-protected-species/has-protected-species.router.js
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/has-protected-species/has-protected-species.router.js
@@ -1,0 +1,12 @@
+import { Router as createRouter } from 'express';
+import * as controllers from './has-protected-species.controller.js';
+import { asyncHandler } from '@pins/express';
+
+const router = createRouter({ mergeParams: true });
+
+router
+	.route('/change')
+	.get(asyncHandler(controllers.getChangeHasProtectedSpecies))
+	.post(asyncHandler(controllers.postChangeHasProtectedSpecies));
+
+export default router;

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/has-protected-species/has-protected-species.service.js
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/has-protected-species/has-protected-species.service.js
@@ -1,0 +1,19 @@
+import { convertFromYesNoToBoolean } from '#lib/boolean-formatter.js';
+
+/**
+ *
+ * @param {import('got').Got} apiClient
+ * @param {string} appealId
+ * @param {string} lpaQuestionnaireId
+ * @param {string} inputData
+ * @returns {Promise<{}>}
+ */
+export function changeHasProtectedSpecies(apiClient, appealId, lpaQuestionnaireId, inputData) {
+	const formattedValue = convertFromYesNoToBoolean(inputData);
+
+	return apiClient.patch(`appeals/${appealId}/lpa-questionnaires/${lpaQuestionnaireId}`, {
+		json: {
+			hasProtectedSpecies: formattedValue
+		}
+	});
+}

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/is-aonb-national-landscape/__tests__/__snapshots__/is-aonb-national-landscape.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/is-aonb-national-landscape/__tests__/__snapshots__/is-aonb-national-landscape.test.js.snap
@@ -1,0 +1,33 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`is-aonb-national-landscape GET /change should render the isAonbNationalLandscape change page when accessed from LPAQ page 1`] = `
+"<main class="govuk-main-wrapper " id="main-content" role="main">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <div class="govuk-grid-row">
+                <div class="govuk-grid-column-full"><span class="govuk-caption-l govuk-!-margin-bottom-3">Appeal 351062</span>
+                    <h1                     class="govuk-heading-l govuk-!-margin-bottom-3">Change whether in area of outstanding natural beauty</h1>
+                </div>
+            </div>
+            <form method="POST" novalidate="novalidate">
+                <div class="govuk-form-group">
+                    <div class="govuk-radios" data-module="govuk-radios">
+                        <div class="govuk-radios__item">
+                            <input class="govuk-radios__input" id="isAonbNationalLandscapeRadio" name="isAonbNationalLandscapeRadio"
+                            type="radio" value="yes">
+                            <label class="govuk-label govuk-radios__label" for="isAonbNationalLandscapeRadio">In area</label>
+                        </div>
+                        <div class="govuk-radios__item">
+                            <input class="govuk-radios__input" id="isAonbNationalLandscapeRadio-2"
+                            name="isAonbNationalLandscapeRadio" type="radio" value="no" checked>
+                            <label class="govuk-label govuk-radios__label" for="isAonbNationalLandscapeRadio-2">Not in area</label>
+                        </div>
+                    </div>
+                </div>
+                <button type="submit" data-prevent-double-click="true" class="govuk-button"
+                data-module="govuk-button">Continue</button>
+            </form>
+        </div>
+    </div>
+</main>"
+`;

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/is-aonb-national-landscape/__tests__/is-aonb-national-landscape.test.js
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/is-aonb-national-landscape/__tests__/is-aonb-national-landscape.test.js
@@ -1,0 +1,94 @@
+import { parseHtml } from '@pins/platform';
+import supertest from 'supertest';
+import {
+	appealData,
+	lpaQuestionnaireDataNotValidated
+} from '#testing/app/fixtures/referencedata.js';
+import { createTestEnvironment } from '#testing/index.js';
+import nock from 'nock';
+
+const { app, installMockApi, teardown } = createTestEnvironment();
+const request = supertest(app);
+const appealId = appealData.appealId;
+const lpaQuestionnaireId = appealData.lpaQuestionnaireId;
+const lpaQuestionnaireUrl = `/appeals-service/appeal-details/${appealId}/lpa-questionnaire/${lpaQuestionnaireId}`;
+
+describe('is-aonb-national-landscape', () => {
+	beforeEach(installMockApi), afterEach(teardown);
+
+	describe('GET /change', () => {
+		it('should render the isAonbNationalLandscape change page when accessed from LPAQ page', async () => {
+			nock('http://test/')
+				.get(`/appeals/${appealId}/lpa-questionnaires/${lpaQuestionnaireId}`)
+				.reply(200, lpaQuestionnaireDataNotValidated);
+			const response = await request.get(
+				`${lpaQuestionnaireUrl}/is-aonb-national-landscape/change`
+			);
+
+			const mainInnerHtml = parseHtml(response.text).innerHTML;
+			expect(response.statusCode).toEqual(200);
+
+			expect(mainInnerHtml).toMatchSnapshot();
+			expect(mainInnerHtml).toContain('Change whether in area of outstanding natural beauty</h1>');
+		});
+
+		it('should render a back link to LPAQ page on the isAonbNationalLandscape change page when accessed from LPAQ page', async () => {
+			nock('http://test/')
+				.get(`/appeals/${appealId}/lpa-questionnaires/${lpaQuestionnaireId}`)
+				.reply(200, lpaQuestionnaireDataNotValidated);
+			const response = await request.get(
+				`${lpaQuestionnaireUrl}/is-aonb-national-landscape/change`
+			);
+
+			const backLinkInnerHtml = parseHtml(response.text, {
+				rootElement: '.govuk-back-link'
+			}).innerHTML;
+
+			expect(response.statusCode).toEqual(200);
+
+			expect(backLinkInnerHtml).toContain(`href="${lpaQuestionnaireUrl}`);
+		});
+	});
+
+	describe('POST /change', () => {
+		it('should re-direct to LPA questionnaire if "yes" when accessed from LPAQ page', async () => {
+			const validData = {
+				isAonbNationalLandscapeRadio: 'yes'
+			};
+
+			const apiCall = nock('http://test/')
+				.patch(`/appeals/${appealId}/lpa-questionnaires/${lpaQuestionnaireId}`)
+				.reply(200, {});
+
+			const response = await request
+				.post(`${lpaQuestionnaireUrl}/is-aonb-national-landscape/change`)
+				.send(validData);
+
+			expect(apiCall.isDone()).toBe(true);
+			expect(response.statusCode).toBe(302);
+			expect(response.text).toBe(
+				`Found. Redirecting to /appeals-service/appeal-details/${appealId}/lpa-questionnaire/${lpaQuestionnaireId}`
+			);
+		});
+
+		it('should re-direct to LPA questionnaire if "no" when accessed from LPAQ page', async () => {
+			const validData = {
+				isAonbNationalLandscapeRadio: 'no'
+			};
+
+			const apiCall = nock('http://test/')
+				.patch(`/appeals/${appealId}/lpa-questionnaires/${lpaQuestionnaireId}`)
+				.reply(200, {});
+
+			const response = await request
+				.post(`${lpaQuestionnaireUrl}/is-aonb-national-landscape/change`)
+				.send(validData);
+
+			expect(apiCall.isDone()).toBe(true);
+			expect(response.statusCode).toBe(302);
+			expect(response.text).toBe(
+				`Found. Redirecting to /appeals-service/appeal-details/${appealId}/lpa-questionnaire/${lpaQuestionnaireId}`
+			);
+		});
+	});
+});

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/is-aonb-national-landscape/is-aonb-national-landscape.controller.js
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/is-aonb-national-landscape/is-aonb-national-landscape.controller.js
@@ -1,0 +1,105 @@
+import { convertFromYesNoNullToBooleanOrNull } from '#lib/boolean-formatter.js';
+import logger from '#lib/logger.js';
+import { addNotificationBannerToSession } from '#lib/session-utilities.js';
+import { getOriginPathname, isInternalUrl } from '#lib/url-utilities.js';
+import { getLpaQuestionnaireFromId } from '../lpa-questionnaire.service.js';
+import * as mapper from './is-aonb-national-landscape.mapper.js';
+import * as service from './is-aonb-national-landscape.service.js';
+/**
+ * @param {import('@pins/express/types/express.js').Request} request
+ * @param {import('@pins/express/types/express.js').RenderedResponse<any, any, Number>} response
+ */ //isAonbNationalLandscape
+export const getChangeIsAonbNationalLandscape = async (request, response) => {
+	return renderChangeIsAonbNationalLandscape(request, response);
+};
+
+/**
+ * @param {import('@pins/express/types/express.js').Request} request
+ * @param {import('@pins/express/types/express.js').RenderedResponse<any, any, Number>} response
+ */
+const renderChangeIsAonbNationalLandscape = async (request, response) => {
+	try {
+		const { currentAppeal, session, errors, originalUrl, apiClient } = request;
+		const origin = originalUrl.split('/').slice(0, -2).join('/');
+		const data = await getLpaQuestionnaireFromId(
+			apiClient,
+			currentAppeal.appealId,
+			currentAppeal.lpaQuestionnaireId
+		);
+
+		const currentRadioValue =
+			convertFromYesNoNullToBooleanOrNull(session.isAonbNationalLandscape) ??
+			data.isAonbNationalLandscape;
+		const mappedPageContents = mapper.changeIsAonbNationalLandscape(
+			currentAppeal,
+			currentRadioValue?.toString() || '',
+			origin
+		);
+
+		return response.status(200).render('patterns/change-page.pattern.njk', {
+			pageContent: mappedPageContents,
+			errors
+		});
+	} catch (error) {
+		logger.error(error);
+	}
+
+	return response.status(500).render('app/500.njk');
+};
+
+/**
+ * @param {import('@pins/express/types/express.js').Request} request
+ * @param {import('@pins/express/types/express.js').RenderedResponse<any, any, Number>} response
+ */
+export const postChangeIsAonbNationalLandscape = async (request, response) => {
+	request.session.isAonbNationalLandscape = request.body['isAonbNationalLandscapeRadio'];
+
+	if (request.errors) {
+		return renderChangeIsAonbNationalLandscape(request, response);
+	}
+
+	try {
+		const {
+			apiClient,
+			params: { appealId },
+			currentAppeal,
+			session
+		} = request;
+
+		const currentUrl = getOriginPathname(request);
+		const origin = currentUrl.split('/').slice(0, -2).join('/');
+
+		if (!isInternalUrl(origin, request)) {
+			return response.status(400).render('errorPageTemplate', {
+				message: 'Invalid redirection attempt detected.'
+			});
+		}
+
+		await service.changeIsAonbNationalLandscape(
+			apiClient,
+			appealId,
+			currentAppeal.lpaQuestionnaireId,
+			session.isAonbNationalLandscape
+		);
+
+		addNotificationBannerToSession(
+			session,
+			'changePage',
+			appealId,
+			'',
+			'Outstanding natural beauty area status changed'
+		);
+
+		delete request.session.isAonbNationalLandscape;
+
+		if (!origin.startsWith('/')) {
+			throw new Error('unexpected originalUrl');
+		} else {
+			return response.redirect(origin);
+		}
+	} catch (error) {
+		logger.error(error);
+	}
+	delete request.session.isAonbNationalLandscape;
+	return response.status(500).render('app/500.njk');
+};

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/is-aonb-national-landscape/is-aonb-national-landscape.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/is-aonb-national-landscape/is-aonb-national-landscape.mapper.js
@@ -1,0 +1,32 @@
+/**
+ * @typedef {import('../../appeal-details.types.js').WebAppeal} Appeal
+ */
+import { appealShortReference } from '#lib/appeals-formatter.js';
+import { yesNoInput } from '#lib/mappers/components/radio.js';
+
+/**
+ * @param {Appeal} appealData
+ * @param {string} data
+ * @param {string} origin
+ * @returns {PageContent}
+ */
+export const changeIsAonbNationalLandscape = (appealData, data, origin) => {
+	const shortAppealReference = appealShortReference(appealData.appealReference);
+
+	/** @type {PageContent} */
+	const pageContent = {
+		title: `Outstanding natural beauty area`,
+		backLinkUrl: origin,
+		preHeading: `Appeal ${shortAppealReference}`,
+		heading: `Change whether in area of outstanding natural beauty`,
+		pageComponents: [
+			yesNoInput({
+				name: 'isAonbNationalLandscapeRadio',
+				value: data,
+				customYesLabel: 'In area',
+				customNoLabel: 'Not in area'
+			})
+		]
+	};
+	return pageContent;
+};

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/is-aonb-national-landscape/is-aonb-national-landscape.router.js
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/is-aonb-national-landscape/is-aonb-national-landscape.router.js
@@ -1,0 +1,12 @@
+import { Router as createRouter } from 'express';
+import * as controllers from './is-aonb-national-landscape.controller.js';
+import { asyncHandler } from '@pins/express';
+
+const router = createRouter({ mergeParams: true });
+
+router
+	.route('/change')
+	.get(asyncHandler(controllers.getChangeIsAonbNationalLandscape))
+	.post(asyncHandler(controllers.postChangeIsAonbNationalLandscape));
+
+export default router;

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/is-aonb-national-landscape/is-aonb-national-landscape.service.js
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/is-aonb-national-landscape/is-aonb-national-landscape.service.js
@@ -1,0 +1,19 @@
+import { convertFromYesNoToBoolean } from '#lib/boolean-formatter.js';
+
+/**
+ *
+ * @param {import('got').Got} apiClient
+ * @param {string} appealId
+ * @param {string} lpaQuestionnaireId
+ * @param {string} inputData
+ * @returns {Promise<{}>}
+ */
+export function changeIsAonbNationalLandscape(apiClient, appealId, lpaQuestionnaireId, inputData) {
+	const formattedValue = convertFromYesNoToBoolean(inputData);
+
+	return apiClient.patch(`appeals/${appealId}/lpa-questionnaires/${lpaQuestionnaireId}`, {
+		json: {
+			isAonbNationalLandscape: formattedValue
+		}
+	});
+}

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/is-gypsy-or-traveller-site/__tests__/__snapshots__/is-gypsy-or-traveller-site.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/is-gypsy-or-traveller-site/__tests__/__snapshots__/is-gypsy-or-traveller-site.test.js.snap
@@ -1,0 +1,33 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`is-gypsy-or-traveller-site GET /change should render the greenBelt change page when accessed from LPAQ page 1`] = `
+"<main class="govuk-main-wrapper " id="main-content" role="main">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <div class="govuk-grid-row">
+                <div class="govuk-grid-column-full"><span class="govuk-caption-l govuk-!-margin-bottom-3">Appeal 351062</span>
+                    <h1                     class="govuk-heading-l govuk-!-margin-bottom-3">Change whether Gypsy or Traveller communities affected</h1>
+                </div>
+            </div>
+            <form method="POST" novalidate="novalidate">
+                <div class="govuk-form-group">
+                    <div class="govuk-radios" data-module="govuk-radios">
+                        <div class="govuk-radios__item">
+                            <input class="govuk-radios__input" id="isGypsyOrTravellerSiteRadio" name="isGypsyOrTravellerSiteRadio"
+                            type="radio" value="yes" checked>
+                            <label class="govuk-label govuk-radios__label" for="isGypsyOrTravellerSiteRadio">Affected</label>
+                        </div>
+                        <div class="govuk-radios__item">
+                            <input class="govuk-radios__input" id="isGypsyOrTravellerSiteRadio-2"
+                            name="isGypsyOrTravellerSiteRadio" type="radio" value="no">
+                            <label class="govuk-label govuk-radios__label" for="isGypsyOrTravellerSiteRadio-2">Not affected</label>
+                        </div>
+                    </div>
+                </div>
+                <button type="submit" data-prevent-double-click="true" class="govuk-button"
+                data-module="govuk-button">Continue</button>
+            </form>
+        </div>
+    </div>
+</main>"
+`;

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/is-gypsy-or-traveller-site/__tests__/is-gypsy-or-traveller-site.test.js
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/is-gypsy-or-traveller-site/__tests__/is-gypsy-or-traveller-site.test.js
@@ -1,0 +1,96 @@
+import { parseHtml } from '@pins/platform';
+import supertest from 'supertest';
+import {
+	appealData,
+	lpaQuestionnaireDataNotValidated
+} from '#testing/app/fixtures/referencedata.js';
+import { createTestEnvironment } from '#testing/index.js';
+import nock from 'nock';
+
+const { app, installMockApi, teardown } = createTestEnvironment();
+const request = supertest(app);
+const appealId = appealData.appealId;
+const lpaQuestionnaireId = appealData.lpaQuestionnaireId;
+const lpaQuestionnaireUrl = `/appeals-service/appeal-details/${appealId}/lpa-questionnaire/${lpaQuestionnaireId}`;
+
+describe('is-gypsy-or-traveller-site', () => {
+	beforeEach(installMockApi), afterEach(teardown);
+
+	describe('GET /change', () => {
+		it('should render the greenBelt change page when accessed from LPAQ page', async () => {
+			nock('http://test/')
+				.get(`/appeals/${appealId}/lpa-questionnaires/${lpaQuestionnaireId}`)
+				.reply(200, lpaQuestionnaireDataNotValidated);
+			const response = await request.get(
+				`${lpaQuestionnaireUrl}/is-gypsy-or-traveller-site/change`
+			);
+
+			const mainInnerHtml = parseHtml(response.text).innerHTML;
+			expect(response.statusCode).toEqual(200);
+
+			expect(mainInnerHtml).toMatchSnapshot();
+			expect(mainInnerHtml).toContain(
+				'Change whether Gypsy or Traveller communities affected</h1>'
+			);
+		});
+
+		it('should render a back link to LPAQ page on the greenBelt change page when accessed from LPAQ page', async () => {
+			nock('http://test/')
+				.get(`/appeals/${appealId}/lpa-questionnaires/${lpaQuestionnaireId}`)
+				.reply(200, lpaQuestionnaireDataNotValidated);
+			const response = await request.get(
+				`${lpaQuestionnaireUrl}/is-gypsy-or-traveller-site/change`
+			);
+
+			const backLinkInnerHtml = parseHtml(response.text, {
+				rootElement: '.govuk-back-link'
+			}).innerHTML;
+
+			expect(response.statusCode).toEqual(200);
+
+			expect(backLinkInnerHtml).toContain(`href="${lpaQuestionnaireUrl}`);
+		});
+	});
+
+	describe('POST /change', () => {
+		it('should re-direct to LPA questionnaire if "yes" when accessed from LPAQ page', async () => {
+			const validData = {
+				isGypsyOrTravellerSiteRadio: 'yes'
+			};
+
+			const apiCall = nock('http://test/')
+				.patch(`/appeals/${appealId}/lpa-questionnaires/${lpaQuestionnaireId}`)
+				.reply(200, {});
+
+			const response = await request
+				.post(`${lpaQuestionnaireUrl}/is-gypsy-or-traveller-site/change`)
+				.send(validData);
+
+			expect(apiCall.isDone()).toBe(true);
+			expect(response.statusCode).toBe(302);
+			expect(response.text).toBe(
+				`Found. Redirecting to /appeals-service/appeal-details/${appealId}/lpa-questionnaire/${lpaQuestionnaireId}`
+			);
+		});
+
+		it('should re-direct to LPA questionnaire if "no" when accessed from LPAQ page', async () => {
+			const validData = {
+				isGypsyOrTravellerSiteRadio: 'no'
+			};
+
+			const apiCall = nock('http://test/')
+				.patch(`/appeals/${appealId}/lpa-questionnaires/${lpaQuestionnaireId}`)
+				.reply(200, {});
+
+			const response = await request
+				.post(`${lpaQuestionnaireUrl}/is-gypsy-or-traveller-site/change`)
+				.send(validData);
+
+			expect(apiCall.isDone()).toBe(true);
+			expect(response.statusCode).toBe(302);
+			expect(response.text).toBe(
+				`Found. Redirecting to /appeals-service/appeal-details/${appealId}/lpa-questionnaire/${lpaQuestionnaireId}`
+			);
+		});
+	});
+});

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/is-gypsy-or-traveller-site/is-gypsy-or-traveller-site.controller.js
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/is-gypsy-or-traveller-site/is-gypsy-or-traveller-site.controller.js
@@ -1,0 +1,104 @@
+import { convertFromYesNoNullToBooleanOrNull } from '#lib/boolean-formatter.js';
+import logger from '#lib/logger.js';
+import { addNotificationBannerToSession } from '#lib/session-utilities.js';
+import { getOriginPathname, isInternalUrl } from '#lib/url-utilities.js';
+import { getLpaQuestionnaireFromId } from '../lpa-questionnaire.service.js';
+import * as mapper from './is-gypsy-or-traveller-site.mapper.js';
+import * as service from './is-gypsy-or-traveller-site.service.js';
+/**
+ * @param {import('@pins/express/types/express.js').Request} request
+ * @param {import('@pins/express/types/express.js').RenderedResponse<any, any, Number>} response
+ */
+export const getChangeIsGypsyOrTravellerSite = async (request, response) => {
+	return renderChangeIsGypsyOrTravellerSite(request, response);
+};
+
+/**
+ * @param {import('@pins/express/types/express.js').Request} request
+ * @param {import('@pins/express/types/express.js').RenderedResponse<any, any, Number>} response
+ */
+const renderChangeIsGypsyOrTravellerSite = async (request, response) => {
+	try {
+		const { currentAppeal, session, errors, originalUrl, apiClient } = request;
+		const origin = originalUrl.split('/').slice(0, -2).join('/');
+		const data = await getLpaQuestionnaireFromId(
+			apiClient,
+			currentAppeal.appealId,
+			currentAppeal.lpaQuestionnaireId
+		);
+
+		const currentRadioValue =
+			convertFromYesNoNullToBooleanOrNull(session.hasProtectedSpecies) ?? data.hasProtectedSpecies;
+		const mappedPageContents = mapper.changeIsGypsyOrTravellerSite(
+			currentAppeal,
+			currentRadioValue?.toString() || '',
+			origin
+		);
+
+		return response.status(200).render('patterns/change-page.pattern.njk', {
+			pageContent: mappedPageContents,
+			errors
+		});
+	} catch (error) {
+		logger.error(error);
+	}
+
+	return response.status(500).render('app/500.njk');
+};
+
+/**
+ * @param {import('@pins/express/types/express.js').Request} request
+ * @param {import('@pins/express/types/express.js').RenderedResponse<any, any, Number>} response
+ */
+export const postChangeIsGypsyOrTravellerSite = async (request, response) => {
+	request.session.isGypsyOrTravellerSite = request.body['isGypsyOrTravellerSiteRadio'];
+
+	if (request.errors) {
+		return renderChangeIsGypsyOrTravellerSite(request, response);
+	}
+
+	try {
+		const {
+			apiClient,
+			params: { appealId },
+			currentAppeal,
+			session
+		} = request;
+
+		const currentUrl = getOriginPathname(request);
+		const origin = currentUrl.split('/').slice(0, -2).join('/');
+
+		if (!isInternalUrl(origin, request)) {
+			return response.status(400).render('errorPageTemplate', {
+				message: 'Invalid redirection attempt detected.'
+			});
+		}
+
+		await service.changeAffectsScheduledMonument(
+			apiClient,
+			appealId,
+			currentAppeal.lpaQuestionnaireId,
+			session.isGypsyOrTravellerSite
+		);
+
+		addNotificationBannerToSession(
+			session,
+			'changePage',
+			appealId,
+			'',
+			'Gypsy or Traveller communities status changed'
+		);
+
+		delete request.session.isGypsyOrTravellerSite;
+
+		if (!origin.startsWith('/')) {
+			throw new Error('unexpected originalUrl');
+		} else {
+			return response.redirect(origin);
+		}
+	} catch (error) {
+		logger.error(error);
+	}
+	delete request.session.isGypsyOrTravellerSite;
+	return response.status(500).render('app/500.njk');
+};

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/is-gypsy-or-traveller-site/is-gypsy-or-traveller-site.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/is-gypsy-or-traveller-site/is-gypsy-or-traveller-site.mapper.js
@@ -1,0 +1,32 @@
+/**
+ * @typedef {import('../../appeal-details.types.js').WebAppeal} Appeal
+ */
+import { appealShortReference } from '#lib/appeals-formatter.js';
+import { yesNoInput } from '#lib/mappers/components/radio.js';
+
+/**
+ * @param {Appeal} appealData
+ * @param {string} data
+ * @param {string} origin
+ * @returns {PageContent}
+ */
+export const changeIsGypsyOrTravellerSite = (appealData, data, origin) => {
+	const shortAppealReference = appealShortReference(appealData.appealReference);
+
+	/** @type {PageContent} */
+	const pageContent = {
+		title: `Gypsy or Traveller communities status`,
+		backLinkUrl: origin,
+		preHeading: `Appeal ${shortAppealReference}`,
+		heading: `Change whether Gypsy or Traveller communities affected`,
+		pageComponents: [
+			yesNoInput({
+				name: 'isGypsyOrTravellerSiteRadio',
+				value: data,
+				customYesLabel: 'Affected',
+				customNoLabel: 'Not affected'
+			})
+		]
+	};
+	return pageContent;
+};

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/is-gypsy-or-traveller-site/is-gypsy-or-traveller-site.router.js
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/is-gypsy-or-traveller-site/is-gypsy-or-traveller-site.router.js
@@ -1,0 +1,12 @@
+import { Router as createRouter } from 'express';
+import * as controllers from './is-gypsy-or-traveller-site.controller.js';
+import { asyncHandler } from '@pins/express';
+
+const router = createRouter({ mergeParams: true });
+
+router
+	.route('/change')
+	.get(asyncHandler(controllers.getChangeIsGypsyOrTravellerSite))
+	.post(asyncHandler(controllers.postChangeIsGypsyOrTravellerSite));
+
+export default router;

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/is-gypsy-or-traveller-site/is-gypsy-or-traveller-site.service.js
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/is-gypsy-or-traveller-site/is-gypsy-or-traveller-site.service.js
@@ -1,0 +1,19 @@
+import { convertFromYesNoToBoolean } from '#lib/boolean-formatter.js';
+
+/**
+ *
+ * @param {import('got').Got} apiClient
+ * @param {string} appealId
+ * @param {string} lpaQuestionnaireId
+ * @param {string} inputData
+ * @returns {Promise<{}>}
+ */
+export function changeAffectsScheduledMonument(apiClient, appealId, lpaQuestionnaireId, inputData) {
+	const formattedValue = convertFromYesNoToBoolean(inputData);
+
+	return apiClient.patch(`appeals/${appealId}/lpa-questionnaires/${lpaQuestionnaireId}`, {
+		json: {
+			isGypsyOrTravellerSite: formattedValue
+		}
+	});
+}

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/lpa-questionnaire.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/lpa-questionnaire.mapper.js
@@ -864,9 +864,13 @@ const generateS78LpaQuestionnaireComponents = (mappedLPAQData, mappedAppealDetai
 			rows: [
 				mappedLPAQData.lpaq?.isCorrectAppealType?.display.summaryListItem,
 				mappedLPAQData.lpaq?.affectsListedBuildingDetails?.display.summaryListItem,
+				mappedLPAQData.lpaq?.affectsScheduledMonument?.display.summaryListItem,
 				mappedLPAQData.lpaq?.conservationAreaMap?.display.summaryListItem,
+				mappedLPAQData.lpaq?.hasProtectedSpecies?.display.summaryListItem,
 				mappedLPAQData.lpaq?.siteWithinGreenBelt?.display.summaryListItem,
+				mappedLPAQData.lpaq?.isAonbNationalLandscape?.display.summaryListItem,
 				mappedLPAQData.lpaq?.treePreservationPlan?.display.summaryListItem,
+				mappedLPAQData.lpaq?.isGypsyOrTravellerSite?.display.summaryListItem,
 				mappedLPAQData.lpaq?.definitiveMapStatement?.display.summaryListItem
 			].filter(isDefined)
 		}

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/lpa-questionnaire.router.js
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/lpa-questionnaire.router.js
@@ -25,6 +25,10 @@ import extraConditionsRouter from './extra-conditions/extra-conditions.router.js
 import notificationMethodsRouter from './notification-methods/notification-methods.router.js';
 import affectedListedBuildingsRouter from './affected-listed-buildings/affected-listed-buildings.router.js';
 import environmentalImpactAssessmentRouter from './environmental-impact-assessment/environmental-impact-assessment.router.js';
+import hasProtectedSpeciesRouter from './has-protected-species/has-protected-species.router.js';
+import affectsScheduledMonumentRouter from './affects-scheduled-monument/affects-scheduled-monument.router.js';
+import isGypsyOrTravellerSiteRouter from './is-gypsy-or-traveller-site/is-gypsy-or-traveller-site.router.js';
+import isAonbNationalLandscapeRouter from './is-aonb-national-landscape/is-aonb-national-landscape.router.js';
 
 const router = createRouter({ mergeParams: true });
 
@@ -104,6 +108,34 @@ router.use(
 	validateAppeal,
 	assertUserHasPermission(permissionNames.updateCase),
 	environmentalImpactAssessmentRouter
+);
+
+router.use(
+	'/:lpaQuestionnaireId/has-protected-species',
+	validateAppeal,
+	assertUserHasPermission(permissionNames.updateCase),
+	hasProtectedSpeciesRouter
+);
+
+router.use(
+	'/:lpaQuestionnaireId/affects-scheduled-monument',
+	validateAppeal,
+	assertUserHasPermission(permissionNames.updateCase),
+	affectsScheduledMonumentRouter
+);
+
+router.use(
+	'/:lpaQuestionnaireId/is-gypsy-or-traveller-site',
+	validateAppeal,
+	assertUserHasPermission(permissionNames.updateCase),
+	isGypsyOrTravellerSiteRouter
+);
+
+router.use(
+	'/:lpaQuestionnaireId/is-aonb-national-landscape',
+	validateAppeal,
+	assertUserHasPermission(permissionNames.updateCase),
+	isAonbNationalLandscapeRouter
 );
 
 router

--- a/appeals/web/src/server/lib/mappers/lpa-questionnaire/s78.js
+++ b/appeals/web/src/server/lib/mappers/lpa-questionnaire/s78.js
@@ -1,4 +1,5 @@
 import { submaps as hasSubmaps } from './has.js';
+import { mapAffectsScheduledMonument } from './submappers/map-affects-scheduled-monument.js';
 import { mapCommunityInfrastructureLevy } from './submappers/map-community-infrastructure-levy.js';
 import { mapConsultationResponses } from './submappers/map-consultation-responses.js';
 import { mapDefinitiveMapStatement } from './submappers/map-definitive-map-statement.js';
@@ -7,6 +8,9 @@ import { mapEiaEnvironmentalStatement } from './submappers/map-eia-environmental
 import { mapEiaRequiresEnvironmentalStatement } from './submappers/map-eia-requires-environmental-statement.js';
 import { mapEiaScreeningDirection } from './submappers/map-eia-screening-direction.js';
 import { mapEiaScreeningOpinion } from './submappers/map-eia-screening-opinion.js';
+import { mapHasProtectedSpecies } from './submappers/map-has-protected-species.js';
+import { mapIsAonbNationalLandscape } from './submappers/map-is-aonb-national-landscape.js';
+import { mapIsGypsyOrTravellerSite } from './submappers/map-is-gypsy-or-traveller-site.js';
 import { mapTreePreservationPlan } from './submappers/map-tree-preservation-plan.js';
 
 export const submaps = {
@@ -19,5 +23,9 @@ export const submaps = {
 	consultationResponses: mapConsultationResponses,
 	eiaEnvironmentalStatement: mapEiaEnvironmentalStatement,
 	eiaScreeningOpinion: mapEiaScreeningOpinion,
-	eiaScreeningDirection: mapEiaScreeningDirection
+	eiaScreeningDirection: mapEiaScreeningDirection,
+	affectsScheduledMonument: mapAffectsScheduledMonument,
+	hasProtectedSpecies: mapHasProtectedSpecies,
+	isGypsyOrTravellerSite: mapIsGypsyOrTravellerSite,
+	isAonbNationalLandscape: mapIsAonbNationalLandscape
 };

--- a/appeals/web/src/server/lib/mappers/lpa-questionnaire/submappers/map-affects-scheduled-monument.js
+++ b/appeals/web/src/server/lib/mappers/lpa-questionnaire/submappers/map-affects-scheduled-monument.js
@@ -1,0 +1,17 @@
+import { booleanSummaryListItem } from '#lib/mappers/components/boolean.js';
+
+/** @type {import("../lpa-questionnaire.mapper.js").SubMapper} */
+export const mapAffectsScheduledMonument = ({
+	lpaQuestionnaireData,
+	currentRoute,
+	userHasUpdateCase
+}) =>
+	booleanSummaryListItem({
+		id: 'affects-scheduled-monument',
+		text: 'Affects scheduled monument',
+		value: lpaQuestionnaireData.affectsScheduledMonument,
+		defaultText: '',
+		addCyAttribute: true,
+		link: `${currentRoute}/affects-scheduled-monument/change`,
+		editable: userHasUpdateCase
+	});

--- a/appeals/web/src/server/lib/mappers/lpa-questionnaire/submappers/map-has-protected-species.js
+++ b/appeals/web/src/server/lib/mappers/lpa-questionnaire/submappers/map-has-protected-species.js
@@ -1,0 +1,13 @@
+import { booleanSummaryListItem } from '#lib/mappers/components/boolean.js';
+
+/** @type {import("../lpa-questionnaire.mapper.js").SubMapper} */
+export const mapHasProtectedSpecies = ({ lpaQuestionnaireData, currentRoute, userHasUpdateCase }) =>
+	booleanSummaryListItem({
+		id: 'has-protected-species',
+		text: 'Affects protected species',
+		value: lpaQuestionnaireData.hasProtectedSpecies,
+		defaultText: '',
+		addCyAttribute: true,
+		link: `${currentRoute}/has-protected-species/change`,
+		editable: userHasUpdateCase
+	});

--- a/appeals/web/src/server/lib/mappers/lpa-questionnaire/submappers/map-is-aonb-national-landscape.js
+++ b/appeals/web/src/server/lib/mappers/lpa-questionnaire/submappers/map-is-aonb-national-landscape.js
@@ -1,0 +1,17 @@
+import { booleanSummaryListItem } from '#lib/mappers/components/boolean.js';
+
+/** @type {import("../lpa-questionnaire.mapper.js").SubMapper} */
+export const mapIsAonbNationalLandscape = ({
+	lpaQuestionnaireData,
+	currentRoute,
+	userHasUpdateCase
+}) =>
+	booleanSummaryListItem({
+		id: 'is-aonb-national-landscape',
+		text: 'In area of outstanding natural beauty',
+		value: lpaQuestionnaireData.isAonbNationalLandscape,
+		defaultText: '',
+		addCyAttribute: true,
+		link: `${currentRoute}/is-aonb-national-landscape/change`,
+		editable: userHasUpdateCase
+	});

--- a/appeals/web/src/server/lib/mappers/lpa-questionnaire/submappers/map-is-gypsy-or-traveller-site.js
+++ b/appeals/web/src/server/lib/mappers/lpa-questionnaire/submappers/map-is-gypsy-or-traveller-site.js
@@ -1,0 +1,17 @@
+import { booleanSummaryListItem } from '#lib/mappers/components/boolean.js';
+
+/** @type {import("../lpa-questionnaire.mapper.js").SubMapper} */
+export const mapIsGypsyOrTravellerSite = ({
+	lpaQuestionnaireData,
+	currentRoute,
+	userHasUpdateCase
+}) =>
+	booleanSummaryListItem({
+		id: 'is-gypsy-or-traveller-site',
+		text: 'Affects Gypsy or Traveller communities',
+		value: lpaQuestionnaireData.isGypsyOrTravellerSite,
+		defaultText: '',
+		addCyAttribute: true,
+		link: `${currentRoute}/is-gypsy-or-traveller-site/change`,
+		editable: userHasUpdateCase
+	});


### PR DESCRIPTION
Adds the following boolen fields on S78 LPAQs (with standard change pages):

- affectsScheduledMonument
- hasProtectedSpecies
- isAonbNationalLandscape
- isGypsyOrTravellerSite

## Issue ticket number and link

[A2-981](https://pins-ds.atlassian.net/browse/A2-981)

<img width="1022" alt="image" src="https://github.com/user-attachments/assets/f0ef5b75-70c3-4890-86c9-d4718d906a59">


## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [ ] I have performed a self-review of my own code
- [ ] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [ ] I have referenced the ticket number above
- [ ] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes


[A2-981]: https://pins-ds.atlassian.net/browse/A2-981?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ