### PR TITLE
feat(appeals): rename files case audit A2-1138

### DIFF
--- a/appeals/api/src/server/endpoints/constants.js
+++ b/appeals/api/src/server/endpoints/constants.js
@@ -35,6 +35,8 @@ export const AUDIT_TRAIL_DOCUMENT_NO_REDACTION_REQUIRED =
 	'Document {replacement0} (version {replacement1}) marked as requiring no redaction';
 export const AUDIT_TRAIL_DOCUMENT_DATE_CHANGED =
 	'Document {replacement0} (version {replacement1}) received date changed';
+export const AUDIT_TRAIL_DOCUMENT_NAME_CHANGED =
+	'Document {replacement0} has been renamed as {replacement1}';
 export const AUDIT_TRAIL_LPAQ_IMPORT_MSG = 'The LPA questionnaire was received';
 export const AUDIT_TRAIL_PROGRESSED_TO_STATUS = 'The case has progressed to {replacement0}';
 export const AUDIT_TRAIL_SUBMISSION_INCOMPLETE = 'The {replacement0} was marked as incomplete';

--- a/appeals/api/src/server/endpoints/documents/__tests__/documents.test.js
+++ b/appeals/api/src/server/endpoints/documents/__tests__/documents.test.js
@@ -237,6 +237,7 @@ describe('/appeals/:appealId/documents', () => {
 
 			expect(databaseConnector.documentVersion.update).toHaveBeenCalledTimes(2);
 			expect(databaseConnector.document.update).toHaveBeenCalledTimes(1);
+			expect(databaseConnector.auditTrail.create).toHaveBeenCalledTimes(3);
 			expect(response.status).toEqual(200);
 		});
 	});

--- a/appeals/api/src/server/endpoints/documents/documents.controller.js
+++ b/appeals/api/src/server/endpoints/documents/documents.controller.js
@@ -8,7 +8,8 @@ import {
 	AUDIT_TRAIL_DOCUMENT_REDACTED,
 	AUDIT_TRAIL_DOCUMENT_UNREDACTED,
 	AUDIT_TRAIL_DOCUMENT_NO_REDACTION_REQUIRED,
-	AUDIT_TRAIL_DOCUMENT_DATE_CHANGED
+	AUDIT_TRAIL_DOCUMENT_DATE_CHANGED,
+	AUDIT_TRAIL_DOCUMENT_NAME_CHANGED
 } from '#endpoints/constants.js';
 import logger from '#utils/logger.js';
 import * as service from './documents.service.js';
@@ -218,6 +219,21 @@ const updateDocuments = async (req, res) => {
 			document.latestVersion = latestDocument?.latestDocumentVersion?.version;
 
 			if (latestDocument && latestDocument.name) {
+				if (document.fileName && document.fileName !== latestDocument.name) {
+					const nameChangedMessage = stringTokenReplacement(AUDIT_TRAIL_DOCUMENT_NAME_CHANGED, [
+						latestDocument.name,
+						document.fileName
+					]);
+					await logAuditTrail(
+						latestDocument.name,
+						document.latestVersion,
+						nameChangedMessage,
+						req,
+						appeal.id,
+						latestDocument.guid
+					);
+				}
+
 				if (document.redactionStatus !== latestDocument?.latestDocumentVersion?.redactionStatusId) {
 					const auditTrailMessage = getAuditMessage(document.redactionStatus);
 					if (auditTrailMessage) {


### PR DESCRIPTION
This adds the case audit requirement not implemented in the previous PR for this ticket

API:
- Add case audit trail for filename rename 

TESTING:
- Ran all unit tests in API.
- Manually tested within browser and checked case audit

## Issue ticket number and link

[A2-1138 Rename files](https://pins-ds.atlassian.net/browse/A2-1138)

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [x] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [x] I have included unit tests to cover any testable code changes
