### PR TITLE
fix(appeals): filename rename fails when redaction status is not set (A2-1516)

### DIFF
--- a/appeals/api/src/server/endpoints/appeals.d.ts
+++ b/appeals/api/src/server/endpoints/appeals.d.ts
@@ -785,11 +785,15 @@ type GetAuditTrailsResponse = {
 		| undefined;
 }[];
 
+type UpdateDocumentFileNameRequest = {
+	id: string;
+	fileName: string;
+}[];
+
 type UpdateDocumentsRequest = {
 	id: string;
 	receivedDate: string;
 	redactionStatus: number;
-	fileName: string;
 	latestVersion: number;
 	published: boolean;
 	draft: boolean;
@@ -868,6 +872,7 @@ export {
 	UpdateAppellantCaseValidationOutcomeParams,
 	UpdateAppellantRequest,
 	UpdateDocumentsRequest,
+	UpdateDocumentFileNameRequest,
 	UpdateDocumentsAvCheckRequest,
 	UpdateLPAQuestionnaireValidationOutcomeParams,
 	UpdateLPAQuestionnaireRequest,

--- a/appeals/api/src/server/endpoints/documents/documents.routes.js
+++ b/appeals/api/src/server/endpoints/documents/documents.routes.js
@@ -9,6 +9,7 @@ import {
 	getDocumentValidator,
 	getDocumentsValidator,
 	patchDocumentsValidator,
+	patchDocumentFileNameValidator,
 	patchDocumentsAvCheckValidator
 } from './documents.validators.js';
 import * as controller from './documents.controller.js';
@@ -200,6 +201,35 @@ router.patch(
 	patchDocumentsValidator,
 	checkAppealExistsByIdAndAddToRequest,
 	asyncHandler(controller.updateDocuments)
+);
+
+router.patch(
+	'/:appealId/documents/:documentId',
+	/*
+		#swagger.tags = ['Documents']
+		#swagger.path = '/appeals/{appealId}/documents/{documentId}'
+		#swagger.description = Updates document file name
+		#swagger.parameters['azureAdUserId'] = {
+			in: 'header',
+			required: true,
+			example: '434bff4e-8191-4ce0-9a0a-91e5d6cdd882'
+		}
+		#swagger.requestBody = {
+			in: 'body',
+			description: 'Document to update file name',
+			schema: { $ref: '#/components/schemas/UpdateDocumentFileNameRequest' },
+			required: true
+		}
+		#swagger.responses[200] = {
+			description: 'Document to update filename',
+			schema: { $ref: '#/components/schemas/UpdateDocumentFileNameResponse' }
+		}
+		#swagger.responses[400] = {}
+		#swagger.responses[404] = {}
+	 */
+	patchDocumentFileNameValidator,
+	checkAppealExistsByIdAndAddToRequest,
+	asyncHandler(controller.updateDocumentFileName)
 );
 
 router.patch(

--- a/appeals/api/src/server/endpoints/documents/documents.validators.js
+++ b/appeals/api/src/server/endpoints/documents/documents.validators.js
@@ -95,6 +95,12 @@ const patchDocumentsValidator = composeMiddleware(
 	validateUuidParameter({ parameterName: 'documents.*.id', parameterType: body }),
 	validateDateParameter({ parameterName: 'documents.*.receivedDate', isRequired: true }),
 	body('documents').custom(validateDocumentRedactionStatusIds),
+	validationErrorHandler
+);
+
+const patchDocumentFileNameValidator = composeMiddleware(
+	validateIdParameter('appealId'),
+	validateUuidParameter({ parameterName: 'documents.*.id', parameterType: body }),
 	validateFileNameParameter({ parameterName: 'documents.*.fileName' }),
 	validationErrorHandler
 );
@@ -114,5 +120,6 @@ export {
 	getDocumentValidator,
 	getFolderIdValidator,
 	patchDocumentsValidator,
+	patchDocumentFileNameValidator,
 	patchDocumentsAvCheckValidator
 };

--- a/appeals/api/src/server/repositories/document.repository.js
+++ b/appeals/api/src/server/repositories/document.repository.js
@@ -177,6 +177,20 @@ export const updateDocuments = (data) => {
 };
 
 /**
+ * @param {guid} documentId
+ * @param {UpdateDocumentFileNameRequest} document
+ * @returns
+ */
+export const updateDocumentById = (documentId, document) => {
+	return databaseConnector.document.update({
+		data: { name: document.fileName },
+		where: {
+			guid: documentId
+		}
+	});
+};
+
+/**
  * @param {number} appealId
  * @returns {Promise<{documentGuid: string, version: number}[]>}
  */

--- a/appeals/api/src/server/swagger.js
+++ b/appeals/api/src/server/swagger.js
@@ -812,6 +812,14 @@ export const spec = {
 				}
 			]
 		},
+		UpdateDocumentFileNameRequest: {
+			id: '987e66e0-1db4-404b-8213-8082919159e9',
+			fileName: 'renamed-document.pdf'
+		},
+		UpdateDocumentFileNameResponse: {
+			id: '987e66e0-1db4-404b-8213-8082919159e9',
+			fileName: 'renamed-document.pdf'
+		},
 		UpdateDocumentsAvCheckRequest: {
 			documents: [
 				{

--- a/appeals/web/src/server/appeals/appeal-details/costs/__tests__/__snapshots__/costs.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/costs/__tests__/__snapshots__/costs.test.js.snap
@@ -4360,6 +4360,19 @@ exports[`costs application, withdrawal and correspondence POST /costs/:costsCate
 </main>"
 `;
 
+exports[`costs application, withdrawal and correspondence POST /costs/:costsCategory/:costsDocumentType/check-your-answers/:folderId should send an API request to create a new document and redirect to the appeal details page (lpa application) 1`] = `
+"<main class="govuk-main-wrapper " id="main-content" role="main">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <h1 class="govuk-heading-xl">Sorry, there is a problem with the service</h1>
+            <p class="govuk-body">Try again later.</p>
+            <p class="govuk-body"><a href="https://has-appeal.herokuapp.com/help/contact" class="govuk-link">Contact the Planning Inspectorate Customer Support</a> if
+                the problem persists.</p>
+        </div>
+    </div>
+</main>"
+`;
+
 exports[`costs application, withdrawal and correspondence POST /costs/:costsCategory/:costsDocumentType/check-your-answers/:folderId/:documentId should render a 500 error page if fileUploadInfo is not present in the session (appellant application) 1`] = `
 "<main class="govuk-main-wrapper " id="main-content" role="main">
     <div class="govuk-grid-row">

--- a/appeals/web/src/server/appeals/appeal-details/costs/__tests__/costs.test.js
+++ b/appeals/web/src/server/appeals/appeal-details/costs/__tests__/costs.test.js
@@ -1552,7 +1552,7 @@ describe('costs', () => {
 		describe('POST /costs/:costsCategory/:costsDocumentType/change-document-name/:folderId/:documentId', () => {
 			beforeEach(() => {
 				nock('http://test/').get('/appeals/document-redaction-statuses').reply(200, []);
-				nock('http://test/').patch(`/appeals/1/documents`).reply(200, []);
+				nock('http://test/').patch('/appeals/1/documents/1').reply(200, {});
 				nock('http://test/')
 					.get('/appeals/1/documents/1/versions')
 					.reply(200, documentFileVersionsInfoChecked);

--- a/appeals/web/src/server/appeals/appeal-details/internal-correspondence/__tests__/internal-correspondence.test.js
+++ b/appeals/web/src/server/appeals/appeal-details/internal-correspondence/__tests__/internal-correspondence.test.js
@@ -1990,7 +1990,7 @@ describe('internal correspondence', () => {
 	describe('POST /internal-correspondence/:correspondenceCategory/change-document-name/:folderId/:documentId', () => {
 		beforeEach(() => {
 			nock('http://test/').get('/appeals/document-redaction-statuses').reply(200, []);
-			nock('http://test/').patch(`/appeals/1/documents`).reply(200, []);
+			nock('http://test/').patch('/appeals/1/documents/1').reply(200, {});
 			nock('http://test/').get('/appeals/1/document-folders/10').reply(200, documentFolderInfo);
 			nock('http://test/').get('/appeals/1/document-folders/11').reply(200, documentFolderInfo);
 			nock('http://test/').get('/appeals/1/documents/1').reply(200, documentFileInfo);

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/__tests__/lpa-questionnaire.test.js
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/__tests__/lpa-questionnaire.test.js
@@ -2626,7 +2626,7 @@ describe('LPA Questionnaire review', () => {
 	describe('POST /lpa-questionnaire/2/change-document-name/:folderId/:documentId', () => {
 		beforeEach(() => {
 			nock('http://test/').get('/appeals/document-redaction-statuses').reply(200, []);
-			nock('http://test/').patch(`/appeals/1/documents`).reply(200, []);
+			nock('http://test/').patch('/appeals/1/documents/1').reply(200, {});
 			nock('http://test/').get('/appeals/1/document-folders/1').reply(200, documentFolderInfo);
 			nock('http://test/').get('/appeals/1/documents/1').reply(200, documentFileInfo);
 		});

--- a/appeals/web/src/server/appeals/appeal-documents/__tests__/appeal-documents.test.js
+++ b/appeals/web/src/server/appeals/appeal-documents/__tests__/appeal-documents.test.js
@@ -230,7 +230,9 @@ describe('appeal-documents', () => {
 				.get(`/appeals/${validAppealId}/documents/${documentId}`)
 				.reply(200, fileInfo);
 			nock('http://test/').get('/appeals/document-redaction-statuses').reply(200, []);
-			nock('http://test/').patch(`/appeals/${validAppealId}/documents`).reply(200, []);
+			nock('http://test/')
+				.patch(`/appeals/${validAppealId}/documents/${documentId}`)
+				.reply(200, {});
 		});
 
 		it('should render change filename page', async () => {

--- a/appeals/web/src/server/appeals/appeal-documents/appeal-documents.controller.js
+++ b/appeals/web/src/server/appeals/appeal-documents/appeal-documents.controller.js
@@ -4,7 +4,8 @@ import {
 	updateDocuments,
 	getFileVersionsInfo,
 	getFileInfo,
-	deleteDocument
+	deleteDocument,
+	updateDocument
 } from './appeal.documents.service.js';
 import {
 	mapDocumentDetailsFormDataToAPIRequest,
@@ -712,17 +713,8 @@ export const postChangeDocumentFileName = async ({
 			return response.status(500).render('app/500.njk');
 		}
 
-		const { dateReceived, redactionStatus } = currentFile.latestDocumentVersion;
-
-		const redactionStatuses = await getDocumentRedactionStatuses(apiClient);
-
-		const apiRequest = mapDocumentFileNameFormDataToAPIRequest(
-			body,
-			dateReceived,
-			redactionStatus,
-			redactionStatuses
-		);
-		const updateDocumentsResult = await updateDocuments(apiClient, appealId, apiRequest);
+		const apiRequest = mapDocumentFileNameFormDataToAPIRequest(body);
+		const updateDocumentsResult = await updateDocument(apiClient, appealId, apiRequest);
 
 		if (updateDocumentsResult) {
 			addNotificationBannerToSession(

--- a/appeals/web/src/server/appeals/appeal-documents/appeal-documents.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-documents/appeal-documents.mapper.js
@@ -1629,6 +1629,28 @@ const mapDocumentVersionToAuditActivityHtml = async (
 
 /**
  *
+ * @typedef {Object} DocumentFileNameFormData
+ * @property {string} documentId
+ * @property {string} fileName
+ */
+
+/**
+ *
+ * @param {DocumentFileNameFormData} formData
+ * @returns {import('./appeal.documents.service.js').DocumentDetailAPIPatchRequest}
+ */
+export const mapDocumentFileNameFormDataToAPIRequest = (formData) => {
+	const { documentId, fileName } = formData;
+	return {
+		document: {
+			id: documentId,
+			fileName
+		}
+	};
+};
+
+/**
+ *
  * @typedef {Object} DocumentDetailsFormItem
  * @property {string} documentId
  * @property {Object<string, string>} receivedDate
@@ -1640,40 +1662,6 @@ const mapDocumentVersionToAuditActivityHtml = async (
  * @typedef {Object} DocumentDetailsFormData
  * @property {DocumentDetailsFormItem[]} items
  */
-
-/**
- *
- * @typedef {Object} DocumentFileNameFormData
- * @property {string} documentId
- * @property {string} fileName
- */
-
-/**
- *
- * @param {DocumentFileNameFormData} formData
- * @param {string} dateReceived
- * @param {string} redactionStatus
- * @param {import('@pins/appeals.api').Schema.DocumentRedactionStatus[]|undefined} redactionStatuses
- * @returns {import('./appeal.documents.service.js').DocumentDetailsAPIPatchRequest}
- */
-export const mapDocumentFileNameFormDataToAPIRequest = (
-	formData,
-	dateReceived,
-	redactionStatus,
-	redactionStatuses
-) => {
-	const { documentId, fileName } = formData;
-	return {
-		documents: [
-			{
-				id: documentId,
-				receivedDate: dateReceived,
-				redactionStatus: mapRedactionStatusNameToId(redactionStatuses, redactionStatus),
-				fileName
-			}
-		]
-	};
-};
 
 /**
  *

--- a/appeals/web/src/server/appeals/appeal-documents/appeal.documents.service.js
+++ b/appeals/web/src/server/appeals/appeal-documents/appeal.documents.service.js
@@ -71,11 +71,52 @@ export const getDocumentRedactionStatuses = async (apiClient) => {
 };
 
 /**
+ * @typedef {Object} DocumentDetailAPIDocument
+ * @property {string} id
+ * @property {string} fileName
+ */
+
+/**
+ * @typedef {Object} DocumentDetailAPIPatchRequest
+ * @property {DocumentDetailAPIDocument} document
+ */
+
+/**
+ * @typedef {Object} DocumentDetailAPIPatchResponse
+ * @property {DocumentDetailAPIDocument} document
+ */
+
+/**
+ * @param {import('got').Got} apiClient
+ * @param {string} appealId
+ * @param {DocumentDetailAPIPatchRequest} documentDetail
+ * @returns {Promise<DocumentDetailAPIPatchResponse|undefined>}
+ */
+
+export const updateDocument = async (apiClient, appealId, documentDetail) => {
+	try {
+		return await apiClient
+			.patch(`appeals/${appealId}/documents/${documentDetail.document.id}`, {
+				json: {
+					document: documentDetail.document
+				}
+			})
+			.json();
+	} catch (error) {
+		logger.error(
+			error,
+			error instanceof Error
+				? error.message
+				: 'An error occurred while attempting to patch the document API endpoint'
+		);
+	}
+};
+
+/**
  * @typedef {Object} DocumentDetailsAPIDocument
  * @property {string} id
  * @property {string} receivedDate
  * @property {number} redactionStatus
- * @property {string} [fileName]
  */
 
 /**


### PR DESCRIPTION
This adds the case audit requirement not implemented in the previous PR for this ticket

API:
- Add new route to patch a single document to update filename
- Add new types for above

WEB:
- Remove unnecessary data from patch request
- Update unit tests

TESTING:
- Ran all unit tests in API.
- Manually tested within browser and checked case audit

## Issue ticket number and link

[A2-1516 Rename fails when redaction status is not](https://pins-ds.atlassian.net/browse/A2-1516)

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [x] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [x] I have included unit tests to cover any testable code changes
