### PR TITLE
fix(web): regressions A2-1563 A2-1559

### DIFF
--- a/appeals/web/src/server/appeals/appeal-details/__tests__/__snapshots__/appeal-details.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/__tests__/__snapshots__/appeal-details.test.js.snap
@@ -639,6 +639,9 @@ exports[`appeal-details GET /:appealId should not render action links to the man
                         </div>
                         <div class="govuk-summary-list__row appeal-start-date"><dt class="govuk-summary-list__key"> Start date</dt>
                             <dd class="govuk-summary-list__value">23 May 2023</dd>
+                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/start-case/change"
+                                data-cy="change-start-case-date"> Change<span class="govuk-visually-hidden"> Start date</span></a>
+                            </dd>
                         </div>
                         <div class="govuk-summary-list__row appeal-lpa-questionnaire-due-date"><dt class="govuk-summary-list__key"> LPA questionnaire due</dt>
                             <dd class="govuk-summary-list__value">11 October 2023</dd>
@@ -1084,6 +1087,9 @@ exports[`appeal-details GET /:appealId should render a Decision inset panel when
                         </div>
                         <div class="govuk-summary-list__row appeal-start-date"><dt class="govuk-summary-list__key"> Start date</dt>
                             <dd class="govuk-summary-list__value">23 May 2023</dd>
+                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/start-case/change"
+                                data-cy="change-start-case-date"> Change<span class="govuk-visually-hidden"> Start date</span></a>
+                            </dd>
                         </div>
                         <div class="govuk-summary-list__row appeal-lpa-questionnaire-due-date"><dt class="govuk-summary-list__key"> LPA questionnaire due</dt>
                             <dd class="govuk-summary-list__value">11 October 2023</dd>
@@ -1524,6 +1530,9 @@ exports[`appeal-details GET /:appealId should render a child tag next to the app
                         </div>
                         <div class="govuk-summary-list__row appeal-start-date"><dt class="govuk-summary-list__key"> Start date</dt>
                             <dd class="govuk-summary-list__value">23 May 2023</dd>
+                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/start-case/change"
+                                data-cy="change-start-case-date"> Change<span class="govuk-visually-hidden"> Start date</span></a>
+                            </dd>
                         </div>
                         <div class="govuk-summary-list__row appeal-lpa-questionnaire-due-date"><dt class="govuk-summary-list__key"> LPA questionnaire due</dt>
                             <dd class="govuk-summary-list__value">11 October 2023</dd>
@@ -1964,6 +1973,9 @@ exports[`appeal-details GET /:appealId should render a lead tag next to the appe
                         </div>
                         <div class="govuk-summary-list__row appeal-start-date"><dt class="govuk-summary-list__key"> Start date</dt>
                             <dd class="govuk-summary-list__value">23 May 2023</dd>
+                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/start-case/change"
+                                data-cy="change-start-case-date"> Change<span class="govuk-visually-hidden"> Start date</span></a>
+                            </dd>
                         </div>
                         <div class="govuk-summary-list__row appeal-lpa-questionnaire-due-date"><dt class="govuk-summary-list__key"> LPA questionnaire due</dt>
                             <dd class="govuk-summary-list__value">11 October 2023</dd>
@@ -2420,6 +2432,9 @@ exports[`appeal-details GET /:appealId should render action links to the manage 
                         </div>
                         <div class="govuk-summary-list__row appeal-start-date"><dt class="govuk-summary-list__key"> Start date</dt>
                             <dd class="govuk-summary-list__value">23 May 2023</dd>
+                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/start-case/change"
+                                data-cy="change-start-case-date"> Change<span class="govuk-visually-hidden"> Start date</span></a>
+                            </dd>
                         </div>
                         <div class="govuk-summary-list__row appeal-lpa-questionnaire-due-date"><dt class="govuk-summary-list__key"> LPA questionnaire due</dt>
                             <dd class="govuk-summary-list__value">11 October 2023</dd>
@@ -2861,6 +2876,9 @@ exports[`appeal-details GET /:appealId should render an Issue a decision notific
                         </div>
                         <div class="govuk-summary-list__row appeal-start-date"><dt class="govuk-summary-list__key"> Start date</dt>
                             <dd class="govuk-summary-list__value">23 May 2023</dd>
+                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/start-case/change"
+                                data-cy="change-start-case-date"> Change<span class="govuk-visually-hidden"> Start date</span></a>
+                            </dd>
                         </div>
                         <div class="govuk-summary-list__row appeal-lpa-questionnaire-due-date"><dt class="govuk-summary-list__key"> LPA questionnaire due</dt>
                             <dd class="govuk-summary-list__value">11 October 2023</dd>
@@ -3289,6 +3307,9 @@ exports[`appeal-details GET /:appealId should render an action link to the add l
                         </div>
                         <div class="govuk-summary-list__row appeal-start-date"><dt class="govuk-summary-list__key"> Start date</dt>
                             <dd class="govuk-summary-list__value">23 May 2023</dd>
+                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/start-case/change"
+                                data-cy="change-start-case-date"> Change<span class="govuk-visually-hidden"> Start date</span></a>
+                            </dd>
                         </div>
                         <div class="govuk-summary-list__row appeal-lpa-questionnaire-due-date"><dt class="govuk-summary-list__key"> LPA questionnaire due</dt>
                             <dd class="govuk-summary-list__value">11 October 2023</dd>
@@ -5075,6 +5096,9 @@ exports[`appeal-details GET /:appealId should render the case reference for each
                         </div>
                         <div class="govuk-summary-list__row appeal-start-date"><dt class="govuk-summary-list__key"> Start date</dt>
                             <dd class="govuk-summary-list__value">23 May 2023</dd>
+                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/start-case/change"
+                                data-cy="change-start-case-date"> Change<span class="govuk-visually-hidden"> Start date</span></a>
+                            </dd>
                         </div>
                         <div class="govuk-summary-list__row appeal-lpa-questionnaire-due-date"><dt class="govuk-summary-list__key"> LPA questionnaire due</dt>
                             <dd class="govuk-summary-list__value">11 October 2023</dd>
@@ -5657,6 +5681,9 @@ exports[`appeal-details GET /:appealId should render the lead or child status af
                         </div>
                         <div class="govuk-summary-list__row appeal-start-date"><dt class="govuk-summary-list__key"> Start date</dt>
                             <dd class="govuk-summary-list__value">23 May 2023</dd>
+                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/start-case/change"
+                                data-cy="change-start-case-date"> Change<span class="govuk-visually-hidden"> Start date</span></a>
+                            </dd>
                         </div>
                         <div class="govuk-summary-list__row appeal-lpa-questionnaire-due-date"><dt class="govuk-summary-list__key"> LPA questionnaire due</dt>
                             <dd class="govuk-summary-list__value">11 October 2023</dd>
@@ -6111,6 +6138,9 @@ exports[`appeal-details GET /:appealId should render the received appeal details
                         </div>
                         <div class="govuk-summary-list__row appeal-start-date"><dt class="govuk-summary-list__key"> Start date</dt>
                             <dd class="govuk-summary-list__value">23 May 2023</dd>
+                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/3/start-case/change"
+                                data-cy="change-start-case-date"> Change<span class="govuk-visually-hidden"> Start date</span></a>
+                            </dd>
                         </div>
                         <div class="govuk-summary-list__row appeal-lpa-questionnaire-due-date"><dt class="govuk-summary-list__key"> LPA questionnaire due</dt>
                             <dd class="govuk-summary-list__value">11 October 2023</dd>
@@ -6536,6 +6566,9 @@ exports[`appeal-details GET /:appealId should render the received appeal details
                         </div>
                         <div class="govuk-summary-list__row appeal-start-date"><dt class="govuk-summary-list__key"> Start date</dt>
                             <dd class="govuk-summary-list__value">23 May 2023</dd>
+                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/start-case/change"
+                                data-cy="change-start-case-date"> Change<span class="govuk-visually-hidden"> Start date</span></a>
+                            </dd>
                         </div>
                         <div class="govuk-summary-list__row appeal-lpa-questionnaire-due-date"><dt class="govuk-summary-list__key"> LPA questionnaire due</dt>
                             <dd class="govuk-summary-list__value">11 October 2023</dd>
@@ -6985,6 +7018,9 @@ exports[`appeal-details GET /:appealId should render the received appeal details
                         </div>
                         <div class="govuk-summary-list__row appeal-start-date"><dt class="govuk-summary-list__key"> Start date</dt>
                             <dd class="govuk-summary-list__value">23 May 2023</dd>
+                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/start-case/change"
+                                data-cy="change-start-case-date"> Change<span class="govuk-visually-hidden"> Start date</span></a>
+                            </dd>
                         </div>
                         <div class="govuk-summary-list__row appeal-lpa-questionnaire-due-date"><dt class="govuk-summary-list__key"> LPA questionnaire due</dt>
                             <dd class="govuk-summary-list__value">11 October 2023</dd>
@@ -7414,7 +7450,7 @@ exports[`appeal-details GET /:appealId should render the received appeal details
                         <div class="govuk-summary-list__row appeal-start-date"><dt class="govuk-summary-list__key"> Start date</dt>
                             <dd class="govuk-summary-list__value">Not added</dd>
                             <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/start-case/add"
-                                data-cy="add-start-date"> Add<span class="govuk-visually-hidden"> Start date</span></a>
+                                data-cy="add-start-case-date"> Add<span class="govuk-visually-hidden"> Start date</span></a>
                             </dd>
                         </div>
                     </dl>
@@ -7965,6 +8001,9 @@ exports[`appeal-details should not render a back button 1`] = `
                                     </div>
                                     <div class="govuk-summary-list__row appeal-start-date"><dt class="govuk-summary-list__key"> Start date</dt>
                                         <dd class="govuk-summary-list__value">23 May 2023</dd>
+                                        <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/start-case/change"
+                                            data-cy="change-start-case-date"> Change<span class="govuk-visually-hidden"> Start date</span></a>
+                                        </dd>
                                     </div>
                                     <div class="govuk-summary-list__row appeal-lpa-questionnaire-due-date"><dt class="govuk-summary-list__key"> LPA questionnaire due</dt>
                                         <dd class="govuk-summary-list__value">11 October 2023</dd>

--- a/appeals/web/src/server/lib/mappers/appeal/submappers/cross-team-correspondence.mapper.js
+++ b/appeals/web/src/server/lib/mappers/appeal/submappers/cross-team-correspondence.mapper.js
@@ -8,7 +8,7 @@ export const mapCrossTeamCorrespondence = ({ appealDetails, currentRoute, sessio
 		id: 'cross-team-correspondence',
 		text: 'Cross-team correspondence',
 		appealId: appealDetails.appealId,
-		folderInfo: appealDetails.internalCorrespondence?.inspector,
+		folderInfo: appealDetails.internalCorrespondence?.crossTeam,
 		showDocuments: false,
 		editable: userHasPermission(permissionNames.viewCaseDetails, session),
 		uploadUrlTemplate: `${currentRoute}/internal-correspondence/cross-team/upload-documents/${appealDetails.internalCorrespondence?.crossTeam?.folderId}`,

--- a/appeals/web/src/server/lib/mappers/appeal/submappers/started-at.mapper.js
+++ b/appeals/web/src/server/lib/mappers/appeal/submappers/started-at.mapper.js
@@ -2,9 +2,24 @@ import { dateISOStringToDisplayDate } from '#lib/dates.js';
 import { textSummaryListItem } from '#lib/mappers/index.js';
 
 /** @type {import('../appeal.mapper.js').SubMapper} */
-export const mapStartedAt = ({ appealDetails, currentRoute, userHasUpdateCasePermission }) =>
-	textSummaryListItem({
-		id: 'start-date',
+export const mapStartedAt = ({ appealDetails, currentRoute, userHasUpdateCasePermission }) => {
+	if (
+		appealDetails.startedAt &&
+		appealDetails.documentationSummary?.lpaQuestionnaire?.status === 'not_received'
+	) {
+		return textSummaryListItem({
+			id: 'start-case-date',
+			text: 'Start date',
+			value: dateISOStringToDisplayDate(appealDetails.startedAt, 'Not added'),
+			link: `${currentRoute}/start-case/change`,
+			editable: Boolean(appealDetails.validAt && userHasUpdateCasePermission),
+			classes: 'appeal-start-date',
+			actionText: 'Change'
+		});
+	}
+
+	return textSummaryListItem({
+		id: 'start-case-date',
 		text: 'Start date',
 		value: dateISOStringToDisplayDate(appealDetails.startedAt, 'Not added'),
 		link: `${currentRoute}/start-case/add`,
@@ -14,3 +29,4 @@ export const mapStartedAt = ({ appealDetails, currentRoute, userHasUpdateCasePer
 		classes: 'appeal-start-date',
 		actionText: 'Add'
 	});
+};


### PR DESCRIPTION
Fixes 2 regressions from recent component refactoring:

- A2-1563 (Cross-team correspondence not saving)
- A2-1559 (Change start date button not appearing)

## Issue ticket number and link
[A2-1563 ](https://pins-ds.atlassian.net/browse/A2-1563)
[A2-1559](https://pins-ds.atlassian.net/browse/A2-1559) 

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [ ] I have performed a self-review of my own code
- [ ] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [ ] I have referenced the ticket number above
- [ ] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes


[A2-1559]: https://pins-ds.atlassian.net/browse/A2-1559?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ