### PR TITLE
fix(api): add case history constants for s78 lpaq levy adoption date fields

### DIFF
--- a/appeals/api/src/server/endpoints/constants.js
+++ b/appeals/api/src/server/endpoints/constants.js
@@ -84,6 +84,10 @@ export const AUDIT_TRAIL_LPAQ_IS_GYPSY_OR_TRAVELLER_SITE_UPDATED =
 	'Gypsy or Traveller communities status updated';
 export const AUDIT_TRAIL_LPAQ_IS_INFRASTRUCTURE_LEVY_FORMALLY_ADOPTED_UPDATED =
 	'Infrastructure levy formally adopted status updated';
+export const AUDIT_TRAIL_LPAQ_INFRASTRUCTURE_LEVY_ADOPTED_DATE_UPDATED =
+	'Levy adoption date changed';
+export const AUDIT_TRAIL_LPAQ_INFRASTRUCTURE_LEVY_EXPECTED_DATE_UPDATED =
+	'Expected levy adoption date changed';
 
 export const AUDIT_TRAIL_LISTED_BUILDING_ADDED = 'A listed building was added';
 export const AUDIT_TRAIL_LISTED_BUILDING_UPDATED = 'A listed building was updated';

--- a/appeals/api/src/server/endpoints/lpa-questionnaires/lpa-questionnaires.controller.js
+++ b/appeals/api/src/server/endpoints/lpa-questionnaires/lpa-questionnaires.controller.js
@@ -106,20 +106,19 @@ const updateLPAQuestionnaireById = async (req, res) => {
 			  });
 
 		const updatedProperties = Object.keys(body).filter((key) => body[key] !== undefined);
-		let auditTrailDetail = CONSTANTS.AUDIT_TRAIL_LPAQ_UPDATED;
 
-		if (updatedProperties.length === 1) {
-			const updatedProperty = updatedProperties[0];
-			const constantKey = `AUDIT_TRAIL_LPAQ_${camelToScreamingSnake(updatedProperty)}_UPDATED`;
-			// @ts-ignore
-			auditTrailDetail = CONSTANTS[constantKey] || auditTrailDetail;
-		}
-
-		await createAuditTrail({
-			appealId: appeal.id,
-			azureAdUserId: req.get('azureAdUserId'),
-			details: auditTrailDetail
-		});
+		await Promise.all(
+			updatedProperties.map((updatedProperty) =>
+				createAuditTrail({
+					appealId: appeal.id,
+					azureAdUserId: req.get('azureAdUserId'),
+					details:
+						// @ts-ignore
+						CONSTANTS[`AUDIT_TRAIL_LPAQ_${camelToScreamingSnake(updatedProperty)}_UPDATED`] ||
+						CONSTANTS.AUDIT_TRAIL_LPAQ_UPDATED
+				})
+			)
+		);
 
 		await broadcasters.broadcastAppeal(appeal.id);
 	} catch (error) {


### PR DESCRIPTION
## Describe your changes

Add case history constants entries for s78 lpaq fields:

- infrastructure levy adoption date changed
- infrastructure levy expected adoption date changed

This PR also includes a small refactor to the lpaq controller to allow it to correctly create case history entries when multiple fields are updated simultaneously.

## Issue ticket number and link

A2-1286

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [ ] I have performed a self-review of my own code
- [ ] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [ ] I have referenced the ticket number above
- [ ] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
