### PR TITLE
test(appeals): fix for national list search using defined requestBody

### DIFF
--- a/appeals/e2e/cypress/e2e/back-office-appeals/nationalListSearch.spec.js
+++ b/appeals/e2e/cypress/e2e/back-office-appeals/nationalListSearch.spec.js
@@ -6,8 +6,10 @@ import { ListCasesPage } from '../../page_objects/listCasesPage';
 import { urlPaths } from '../../support/urlPaths';
 import { appealsApiRequests } from '../../fixtures/appealsApiRequests';
 import { tag } from '../../support/tag';
+import { createApiSubmission } from '../../support/appealsApiClient.js';
 
 const listCasesPage = new ListCasesPage();
+
 describe('All cases search', () => {
 	beforeEach(() => {
 		cy.login(users.appeals.caseAdmin);
@@ -33,9 +35,9 @@ describe('All cases search', () => {
 		{ tags: tag.smoke },
 		() => {
 			const postcode = 'XX12 3XX';
-			let requestBody = appealsApiRequests.caseSubmission;
-			requestBody.casedata.siteAddressPostcode = postcode;
 
+			let requestBody = createApiSubmission(appealsApiRequests.caseSubmission, 'appellant');
+			requestBody.casedata.siteAddressPostcode = postcode;
 			cy.createCase(requestBody).then((caseRef) => {
 				const testData = { rowIndex: 0, cellIndex: 1, textToMatch: postcode, strict: false };
 				cy.visit(urlPaths.appealsList);

--- a/appeals/e2e/cypress/support/appealsApiClient.js
+++ b/appeals/e2e/cypress/support/appealsApiClient.js
@@ -4,7 +4,7 @@ import { apiPaths } from './apiPaths.js';
 
 const baseUrl = Cypress.config('apiBaseUrl');
 
-const createApiSubmission = (submission, type) => {
+export const createApiSubmission = (submission, type) => {
 	const env = baseUrl.indexOf('test') > -1 ? 'test' : 'dev';
 
 	return {


### PR DESCRIPTION
## Describe your changes
Fix to an e2e test to enable a defined requestBody to be used in national list search for postcode 

<!--
    Please include a summary of the change along with any relevant context.
    List any dependencies that are required for this change.
-->

## Issue ticket number and link

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [ ] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
