### PR TITLE
feat(appeals): amend copy costs application (a2-540)

### DIFF
--- a/appeals/web/src/server/appeals/appeal-details/appellant-case/__tests__/__snapshots__/appellant-case.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/appellant-case/__tests__/__snapshots__/appellant-case.test.js.snap
@@ -226,10 +226,10 @@ exports[`appellant-case GET /appellant-case should render a "Inspector access (a
                         data-cy="add-related-appeals"> Add<span class="govuk-visually-hidden"> Related appeals</span></a>
                     </dd>
                 </div>
-                <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Costs document</dt>
+                <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Costs application</dt>
                     <dd class="govuk-summary-list__value">No documents available</dd>
                     <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/add-documents/1"
-                        data-cy="add-costs-document"> Add<span class="govuk-visually-hidden"> Costs document</span></a>
+                        data-cy="add-costs-document"> Add<span class="govuk-visually-hidden"> Costs application</span></a>
                     </dd>
                 </div>
             </dl>
@@ -469,10 +469,10 @@ exports[`appellant-case GET /appellant-case should render a "LPA application ref
                         data-cy="add-related-appeals"> Add<span class="govuk-visually-hidden"> Related appeals</span></a>
                     </dd>
                 </div>
-                <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Costs document</dt>
+                <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Costs application</dt>
                     <dd class="govuk-summary-list__value">No documents available</dd>
                     <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/add-documents/1"
-                        data-cy="add-costs-document"> Add<span class="govuk-visually-hidden"> Costs document</span></a>
+                        data-cy="add-costs-document"> Add<span class="govuk-visually-hidden"> Costs application</span></a>
                     </dd>
                 </div>
             </dl>
@@ -724,10 +724,10 @@ exports[`appellant-case GET /appellant-case should render a "Site area updated" 
                         data-cy="add-related-appeals"> Add<span class="govuk-visually-hidden"> Related appeals</span></a>
                     </dd>
                 </div>
-                <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Costs document</dt>
+                <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Costs application</dt>
                     <dd class="govuk-summary-list__value">No documents available</dd>
                     <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/add-documents/1"
-                        data-cy="add-costs-document"> Add<span class="govuk-visually-hidden"> Costs document</span></a>
+                        data-cy="add-costs-document"> Add<span class="govuk-visually-hidden"> Costs application</span></a>
                     </dd>
                 </div>
             </dl>
@@ -967,10 +967,10 @@ exports[`appellant-case GET /appellant-case should render a "Site health and saf
                         data-cy="add-related-appeals"> Add<span class="govuk-visually-hidden"> Related appeals</span></a>
                     </dd>
                 </div>
-                <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Costs document</dt>
+                <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Costs application</dt>
                     <dd class="govuk-summary-list__value">No documents available</dd>
                     <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/add-documents/1"
-                        data-cy="add-costs-document"> Add<span class="govuk-visually-hidden"> Costs document</span></a>
+                        data-cy="add-costs-document"> Add<span class="govuk-visually-hidden"> Costs application</span></a>
                     </dd>
                 </div>
             </dl>
@@ -1210,10 +1210,10 @@ exports[`appellant-case GET /appellant-case should render a "Site updated" notif
                         data-cy="add-related-appeals"> Add<span class="govuk-visually-hidden"> Related appeals</span></a>
                     </dd>
                 </div>
-                <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Costs document</dt>
+                <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Costs application</dt>
                     <dd class="govuk-summary-list__value">No documents available</dd>
                     <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/add-documents/1"
-                        data-cy="add-costs-document"> Add<span class="govuk-visually-hidden"> Costs document</span></a>
+                        data-cy="add-costs-document"> Add<span class="govuk-visually-hidden"> Costs application</span></a>
                     </dd>
                 </div>
             </dl>
@@ -1465,10 +1465,10 @@ exports[`appellant-case GET /appellant-case should render a success notification
                         data-cy="add-related-appeals"> Add<span class="govuk-visually-hidden"> Related appeals</span></a>
                     </dd>
                 </div>
-                <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Costs document</dt>
+                <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Costs application</dt>
                     <dd class="govuk-summary-list__value">No documents available</dd>
                     <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/add-documents/1"
-                        data-cy="add-costs-document"> Add<span class="govuk-visually-hidden"> Costs document</span></a>
+                        data-cy="add-costs-document"> Add<span class="govuk-visually-hidden"> Costs application</span></a>
                     </dd>
                 </div>
             </dl>
@@ -1790,10 +1790,10 @@ exports[`appellant-case GET /appellant-case should render review outcome form fi
                         data-cy="add-related-appeals"> Add<span class="govuk-visually-hidden"> Related appeals</span></a>
                     </dd>
                 </div>
-                <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Costs document</dt>
+                <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Costs application</dt>
                     <dd class="govuk-summary-list__value">No documents available</dd>
                     <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/add-documents/1"
-                        data-cy="add-costs-document"> Add<span class="govuk-visually-hidden"> Costs document</span></a>
+                        data-cy="add-costs-document"> Add<span class="govuk-visually-hidden"> Costs application</span></a>
                     </dd>
                 </div>
             </dl>
@@ -2118,10 +2118,10 @@ exports[`appellant-case GET /appellant-case should render the appellant case pag
                     <dd class="govuk-summary-list__actions"><a class="govuk-link" href="#" data-cy="add-planning-obligation"> Add<span class="govuk-visually-hidden"> Planning obligation</span></a>
                     </dd>
                 </div>
-                <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Costs document</dt>
+                <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Costs application</dt>
                     <dd class="govuk-summary-list__value">No documents available</dd>
                     <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/add-documents/1"
-                        data-cy="add-costs-document"> Add<span class="govuk-visually-hidden"> Costs document</span></a>
+                        data-cy="add-costs-document"> Add<span class="govuk-visually-hidden"> Costs application</span></a>
                     </dd>
                 </div>
             </dl>
@@ -2336,10 +2336,10 @@ exports[`appellant-case GET /appellant-case should render the appellant case pag
                         data-cy="add-related-appeals"> Add<span class="govuk-visually-hidden"> Related appeals</span></a>
                     </dd>
                 </div>
-                <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Costs document</dt>
+                <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Costs application</dt>
                     <dd class="govuk-summary-list__value">No documents available</dd>
                     <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/add-documents/1"
-                        data-cy="add-costs-document"> Add<span class="govuk-visually-hidden"> Costs document</span></a>
+                        data-cy="add-costs-document"> Add<span class="govuk-visually-hidden"> Costs application</span></a>
                     </dd>
                 </div>
             </dl>
@@ -4607,10 +4607,10 @@ exports[`appellant-case POST /appellant-case should re-render the appellant case
                         data-cy="add-related-appeals"> Add<span class="govuk-visually-hidden"> Related appeals</span></a>
                     </dd>
                 </div>
-                <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Costs document</dt>
+                <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Costs application</dt>
                     <dd class="govuk-summary-list__value">No documents available</dd>
                     <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/add-documents/1"
-                        data-cy="add-costs-document"> Add<span class="govuk-visually-hidden"> Costs document</span></a>
+                        data-cy="add-costs-document"> Add<span class="govuk-visually-hidden"> Costs application</span></a>
                     </dd>
                 </div>
             </dl>

--- a/appeals/web/src/server/lib/mappers/data/appellant-case/submappers/costs-document.js
+++ b/appeals/web/src/server/lib/mappers/data/appellant-case/submappers/costs-document.js
@@ -12,7 +12,7 @@ export const mapCostsDocument = ({ appellantCaseData, appealDetails, userHasUpda
 		editable: userHasUpdateCase,
 		uploadUrlTemplate: documentUploadUrlTemplate,
 		id: 'costs-appellant',
-		text: 'Costs document',
+		text: 'Costs application',
 		folderInfo: appealDetails.costs.appellantApplicationFolder,
 		cypressDataName: 'costs-document'
 	});


### PR DESCRIPTION
Amend copy on some existing rows on HAS appellant case

WEB:
- Changed "Cost document" copy to "Cost application" as instructed
- Manually tested within browser
- Updated snapshots

Please note the other copy changes have already been done in this PR: [A2-1186](https://github.com/Planning-Inspectorate/appeals-back-office/pull/682)

## Issue ticket number and link

[A2-540 Amend copy on some existing rows on HAS appellant case](https://pins-ds.atlassian.net/browse/A2-540)

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [x] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes


[A2-1186]: https://pins-ds.atlassian.net/browse/A2-1186?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ