### PR TITLE
fix(appeals): redis pingInterval default to 300000

### DIFF
--- a/packages/platform/utils/__tests__/redis.test.js
+++ b/packages/platform/utils/__tests__/redis.test.js
@@ -17,7 +17,7 @@ describe('redis', () => {
 			},
 			{
 				name: 'too many parts',
-				str: 'some.example.org:6380,password=some_password,ssl=True,abortConnect=False,extra=thing',
+				str: 'some.example.org:6380,password=some_password,ssl=True,abortConnect=False,pingInterval=20000,extra=thing',
 				want: {},
 				error: true
 			},
@@ -40,15 +40,34 @@ describe('redis', () => {
 				error: true
 			},
 			{
-				name: 'valid config is parsed',
+				name: 'valid config without ping settings is parsed',
 				str: 'some.example.org:1234,password=some_password,ssl=True,abortConnect=False',
 				want: {
 					host: 'some.example.org',
 					port: 1234,
 					password: 'some_password',
 					ssl: true,
-					abortConnect: false
+					abortConnect: false,
+					pingInterval: 300000
 				}
+			},
+			{
+				name: 'valid config with ping settings is parsed',
+				str: 'some.example.org:1234,password=some_password,ssl=True,abortConnect=False,pingInterval=20000',
+				want: {
+					host: 'some.example.org',
+					port: 1234,
+					password: 'some_password',
+					ssl: true,
+					abortConnect: false,
+					pingInterval: 20000
+				}
+			},
+			{
+				name: 'invalid pingInterval',
+				str: 'some.example.org:1234,password=some_password,ssl=True,abortConnect=False,pingInterval=not-a-number',
+				want: {},
+				error: true
 			},
 			{
 				name: 'case insentive for true/false',
@@ -58,7 +77,8 @@ describe('redis', () => {
 					port: 1234,
 					password: 'some_password',
 					ssl: true,
-					abortConnect: false
+					abortConnect: false,
+					pingInterval: 300000
 				}
 			}
 		];

--- a/packages/platform/utils/redis.js
+++ b/packages/platform/utils/redis.js
@@ -5,6 +5,7 @@
  * @property {string} password
  * @property {boolean} ssl
  * @property {boolean} abortConnect
+ * @property {number} pingInterval
  */
 
 /**
@@ -16,10 +17,10 @@ export function parseRedisConnectionString(str) {
 		throw new Error('not a string');
 	}
 	const parts = str.split(',');
-	if (parts.length !== 4) {
-		throw new Error('unexpected redis connection string format, expected 4 parts');
+	if (parts.length !== 4 && parts.length !== 5) {
+		throw new Error('unexpected redis connection string format, expected 4 or 5 parts');
 	}
-	const [hostPort, passwordPart, sslPart, abortConnectPart] = parts;
+	const [hostPort, passwordPart, sslPart, abortConnectPart, pingIntervalPart] = parts;
 	const hostParts = hostPort.split(':');
 	if (hostParts.length !== 2) {
 		throw new Error('unexpected host:port format for redis string, expected 2 parts');
@@ -35,11 +36,22 @@ export function parseRedisConnectionString(str) {
 	const ssl = sslPart.toLowerCase().endsWith('true');
 	const abortConnect = abortConnectPart.toLowerCase().endsWith('true');
 
+	if (pingIntervalPart && !pingIntervalPart.startsWith('pingInterval=')) {
+		throw new Error('unexpected pingInterval for redis string, expected pingInterval=');
+	}
+	const pingInterval = pingIntervalPart
+		? parseInt(pingIntervalPart.substring('pingInterval='.length))
+		: 300000; //5 minutes default
+	if (isNaN(pingInterval)) {
+		throw new Error('unexpected ping interval for redis string, expected int');
+	}
+
 	return {
 		host: hostParts[0],
 		port,
 		password,
 		ssl,
-		abortConnect
+		abortConnect,
+		pingInterval
 	};
 }

--- a/packages/redis/src/index.js
+++ b/packages/redis/src/index.js
@@ -21,7 +21,8 @@ export class RedisClient {
 				port: redisParams.port,
 				tls: redisParams.ssl
 			},
-			password: redisParams.password
+			password: redisParams.password,
+			pingInterval: redisParams.pingInterval
 		});
 
 		/** @param {Error} err */


### PR DESCRIPTION
Sets the redis ping interval to 5 minutes by default. Overrideable through the `pingInterval` attribute in the connection string stored in keyvault.


## Issue ticket number and link

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [ ] I have performed a self-review of my own code
- [ ] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [ ] I have referenced the ticket number above
- [ ] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
