### PR TITLE
Fix/a2 1183 bugs

### DIFF
--- a/appeals/web/src/server/appeals/appeal-details/interested-party-comments/view-and-review/__tests__/__snapshots__/view-and-review.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/interested-party-comments/view-and-review/__tests__/__snapshots__/view-and-review.test.js.snap
@@ -18,9 +18,6 @@ exports[`interested-party-comments GET /reject/check-your-answers should render 
                         <div class="pins-show-more">Awaiting review comment 47</div>
                     </dd>
                 </div>
-                <div class="govuk-summary-list__row govuk-summary-list__row--no-actions"><dt class="govuk-summary-list__key"> Supporting documents</dt>
-                    <dd class="govuk-summary-list__value">Not provided</dd>
-                </div>
                 <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Review decision</dt>
                     <dd class="govuk-summary-list__value">Comment rejected</dd>
                     <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/interested-party-comments/3670/review"> Change<span class="govuk-visually-hidden"> Review decision</span></a>

--- a/appeals/web/src/server/appeals/appeal-details/interested-party-comments/view-and-review/page-components/review.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/interested-party-comments/view-and-review/page-components/review.mapper.js
@@ -66,7 +66,10 @@ export function reviewInterestedPartyCommentPage(appealDetails, comment, session
 				{
 					value: COMMENT_STATUS.INVALID,
 					text: 'Reject comment',
-					checked: comment?.status === COMMENT_STATUS.INVALID
+					checked:
+						comment?.status === COMMENT_STATUS.INVALID ||
+						(comment?.status === COMMENT_STATUS.AWAITING_REVIEW &&
+							session.rejectIpComment?.commentId === comment.id)
 				}
 			]
 		}

--- a/appeals/web/src/server/appeals/appeal-details/interested-party-comments/view-and-review/reject/reject.middleware.js
+++ b/appeals/web/src/server/appeals/appeal-details/interested-party-comments/view-and-review/reject/reject.middleware.js
@@ -1,0 +1,15 @@
+/**
+ * @param {import('@pins/express/types/express.js').Request} request
+ * @param {import('@pins/express/types/express.js').RenderedResponse<any, any, Number>} response
+ * @param {() => any} next
+ * */
+export async function initialiseSession(request, response, next) {
+	const { rejectIpComment } = request.session;
+	const commentId = parseInt(request.params.commentId);
+
+	if (!rejectIpComment || rejectIpComment.commentId !== commentId) {
+		request.session.rejectIpComment = { commentId };
+	}
+
+	next();
+}

--- a/appeals/web/src/server/appeals/appeal-details/interested-party-comments/view-and-review/reject/reject.router.js
+++ b/appeals/web/src/server/appeals/appeal-details/interested-party-comments/view-and-review/reject/reject.router.js
@@ -1,6 +1,8 @@
+import { saveBodyToSession } from '#lib/middleware/save-body-to-session.js';
 import { asyncHandler } from '@pins/express';
 import { Router as createRouter } from 'express';
 import * as controller from './reject.controller.js';
+import { initialiseSession } from './reject.middleware.js';
 import {
 	validateAllowResubmit,
 	validateRejectReason,
@@ -9,19 +11,26 @@ import {
 
 const router = createRouter({ mergeParams: true });
 
+router.use(initialiseSession);
+
 router
 	.route('/select-reason')
 	.get(asyncHandler(controller.renderSelectReason))
 	.post(
 		validateRejectReason,
 		validateRejectionReasonTextItems,
+		saveBodyToSession('rejectIpComment'),
 		asyncHandler(controller.postRejectReason)
 	);
 
 router
 	.route('/allow-resubmit')
 	.get(asyncHandler(controller.renderAllowResubmit))
-	.post(validateAllowResubmit, asyncHandler(controller.postAllowResubmit));
+	.post(
+		validateAllowResubmit,
+		saveBodyToSession('rejectIpComment'),
+		asyncHandler(controller.postAllowResubmit)
+	);
 
 router
 	.route('/check-your-answers')


### PR DESCRIPTION
## Describe your changes

* fix(web): hide 'Supporting documents' row when no documents were given
* fix(web): persist reject option on review page if flow is in progress
* fix(web): persist rejection reasons when going back in the flow
* fix(web): persist reason text items when returning to reasons page
* fix(web): only use session values if relevant to current comment
* fix(web): delete rejectIpComment session after submitting rejection
* fix(web): persist selection for allow resubmit during flow
* chore(web): initialise rejectIpComment session using a middleware

## Issue ticket number and link

[A2-1183](https://pins-ds.atlassian.net/browse/A2-1183)

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes


[A2-1183]: https://pins-ds.atlassian.net/browse/A2-1183?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ