### PR TITLE
fix(web): fix appellant case and lpaq incomplete banners still displaying after marked as valid/complete

### DIFF
--- a/appeals/web/src/server/appeals/appeal-details/appellant-case/appellant-case.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/appellant-case/appellant-case.mapper.js
@@ -442,7 +442,13 @@ export function mapNotificationBannerComponentParameters(
 	appealId,
 	appealDueDate
 ) {
-	if (validationOutcome === 'invalid' || validationOutcome === 'incomplete') {
+	if (
+		validationOutcome === 'valid' &&
+		'notificationBanners' in session &&
+		'appellantCaseNotValid' in session.notificationBanners
+	) {
+		delete session.notificationBanners.appellantCaseNotValid;
+	} else if (validationOutcome === 'invalid' || validationOutcome === 'incomplete') {
 		if (!Array.isArray(notValidReasons)) {
 			notValidReasons = [notValidReasons];
 		}

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/__tests__/lpa-questionnaire.test.js
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/__tests__/lpa-questionnaire.test.js
@@ -319,6 +319,35 @@ describe('LPA Questionnaire review', () => {
 			expect(unprettifiedNotificationBannerElementHTML).toContain('test reason 6</li>');
 		});
 
+		it('should not render an "LPA questionnaire incomplete" notification banner when the LPA questionnaire is marked as incomplete and then marked as complete', async () => {
+			nock('http://test/')
+				.get('/appeals/1/lpa-questionnaires/2')
+				.reply(200, lpaQuestionnaireDataIncompleteOutcome);
+
+			const incompleteOutcomeResponse = await request.get(baseUrl);
+
+			const unprettifiedNotificationBannerElementHTML = parseHtml(incompleteOutcomeResponse.text, {
+				rootElement: notificationBannerElement,
+				skipPrettyPrint: true
+			}).innerHTML;
+
+			expect(unprettifiedNotificationBannerElementHTML).toContain(
+				'LPA Questionnaire is incomplete</h3>'
+			);
+
+			nock('http://test/')
+				.get('/appeals/1/lpa-questionnaires/2')
+				.reply(200, lpaQuestionnaireDataCompleteOutcome);
+
+			const completeOutcomeResponse = await request.get(baseUrl);
+
+			const unprettifiedCompleteOutcomeHTML = parseHtml(completeOutcomeResponse.text, {
+				skipPrettyPrint: true
+			}).innerHTML;
+
+			expect(unprettifiedCompleteOutcomeHTML).not.toContain('LPA Questionnaire is incomplete</h3>');
+		});
+
 		it('should render a "Notification methods updated" success notification banner when notification methods are changed', async () => {
 			nock('http://test/').get(`/appeals/1`).reply(200, appealData).persist();
 			nock('http://test/')

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/lpa-questionnaire.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/lpa-questionnaire.mapper.js
@@ -446,7 +446,13 @@ export function checkAndConfirmPage(
 function mapNotificationBannerComponentParameters(session, lpaqData, appealId, lpaqDueDate) {
 	const validationOutcome = lpaqData.validation?.outcome?.toLowerCase();
 
-	if (validationOutcome === 'incomplete') {
+	if (
+		validationOutcome === 'complete' &&
+		'notificationBanners' in session &&
+		'lpaQuestionnaireNotValid' in session.notificationBanners
+	) {
+		delete session.notificationBanners.lpaQuestionnaireNotValid;
+	} else if (validationOutcome === 'incomplete') {
 		if (!('notificationBanners' in session)) {
 			session.notificationBanners = {};
 		}


### PR DESCRIPTION
## Describe your changes

Fixes a bug where the appellant case and LPAQ "incomplete" notification banners were still displayed after the appellant case/LPAQ were marked as "incomplete" and then re-reviewed as "valid" or "complete"

## Issue ticket number and link

A2-1269

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [ ] I have performed a self-review of my own code
- [ ] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [ ] I have referenced the ticket number above
- [ ] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
