### PR TITLE
Fix/a2 1505 tables to summary lists

### DIFF
--- a/appeals/web/src/server/appeals/appeal-details/allocation-details/__tests__/__snapshots__/allocation-details.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/allocation-details/__tests__/__snapshots__/allocation-details.test.js.snap
@@ -42,7 +42,7 @@ exports[`Allocation Details should render "Select allocation specialism" Page 1`
 "<main class="govuk-main-wrapper " id="main-content" role="main">
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-full"><span class="govuk-caption-l govuk-!-margin-bottom-3">Appeal 351062</span>
-            <h1             class="govuk-heading-xl govuk-!-margin-bottom-3">Select allocation specialism(s)</h1>
+            <h1             class="govuk-heading-xl govuk-!-margin-bottom-3">Select allocation specialisms</h1>
         </div>
     </div>
     <div class="govuk-grid-row">
@@ -110,7 +110,7 @@ exports[`Allocation Details should render "Select allocation specialism" with er
     </div>
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-full"><span class="govuk-caption-l govuk-!-margin-bottom-3">Appeal 351062</span>
-            <h1             class="govuk-heading-xl govuk-!-margin-bottom-3">Select allocation specialism(s)</h1>
+            <h1             class="govuk-heading-xl govuk-!-margin-bottom-3">Select allocation specialisms</h1>
         </div>
     </div>
     <div class="govuk-grid-row">

--- a/appeals/web/src/server/appeals/appeal-details/allocation-details/__tests__/__snapshots__/allocation-details.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/allocation-details/__tests__/__snapshots__/allocation-details.test.js.snap
@@ -9,36 +9,27 @@ exports[`Allocation Details should render "Check answers" Page 1`] = `
     </div>
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds govuk-!-margin-top-5 govuk-!-margin-bottom-6">
-            <table class="govuk-table">
-                <tbody class="govuk-table__body">
-                    <tr class="govuk-table__row">
-                        <td class="govuk-table__cell"><strong>Level</strong>
-                        </td>
-                        <td class="govuk-table__cell">A</td>
-                        <td class="govuk-table__cell"><a href="/appeals-service/appeal-details/1/allocation-details/allocation-level">Change</a>
-                        </td>
-                    </tr>
-                    <tr class="govuk-table__row">
-                        <td class="govuk-table__cell"><strong>Band</strong>
-                        </td>
-                        <td class="govuk-table__cell">3</td>
-                        <td class="govuk-table__cell"></td>
-                    </tr>
-                    <tr class="govuk-table__row">
-                        <td class="govuk-table__cell"><strong>Specialism</strong>
-                        </td>
-                        <td class="govuk-table__cell">
-                            <ul class="govuk-!-padding-0 govuk-!-margin-0 govuk-!-margin-left-4">
-                                <li>Specialism 1</li>
-                                <li>Specialism 2</li>
-                                <li>Specialism 3</li>
-                            </ul>
-                        </td>
-                        <td class="govuk-table__cell"><a href="/appeals-service/appeal-details/1/allocation-details/allocation-specialism">Change</a>
-                        </td>
-                    </tr>
-                </tbody>
-            </table>
+            <dl class="govuk-summary-list">
+                <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Level</dt>
+                    <dd class="govuk-summary-list__value">A</dd>
+                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/allocation-details/allocation-level"> Change<span class="govuk-visually-hidden"> level</span></a>
+                    </dd>
+                </div>
+                <div class="govuk-summary-list__row govuk-summary-list__row--no-actions"><dt class="govuk-summary-list__key"> Band</dt>
+                    <dd class="govuk-summary-list__value">3</dd>
+                </div>
+                <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Specialism</dt>
+                    <dd class="govuk-summary-list__value">
+                        <ul class="govuk-!-padding-0 govuk-!-margin-0 govuk-!-margin-left-4">
+                            <li>Specialism 1</li>
+                            <li>Specialism 2</li>
+                            <li>Specialism 3</li>
+                        </ul>
+                    </dd>
+                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/allocation-details/allocation-specialism"> Change<span class="govuk-visually-hidden"> specialism</span></a>
+                    </dd>
+                </div>
+            </dl>
         </div>
     </div>
     <form action="" method="POST" novalidate>
@@ -56,20 +47,14 @@ exports[`Allocation Details should render "Select allocation specialism" Page 1`
     </div>
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds govuk-!-margin-top-5 govuk-!-margin-bottom-6">
-            <table class="govuk-table">
-                <tbody class="govuk-table__body">
-                    <tr class="govuk-table__row">
-                        <td class="govuk-table__cell"><strong>Level</strong>
-                        </td>
-                        <td class="govuk-table__cell">A</td>
-                    </tr>
-                    <tr class="govuk-table__row">
-                        <td class="govuk-table__cell"><strong>Band</strong>
-                        </td>
-                        <td class="govuk-table__cell">3</td>
-                    </tr>
-                </tbody>
-            </table>
+            <dl class="govuk-summary-list">
+                <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Level</dt>
+                    <dd class="govuk-summary-list__value">A</dd>
+                </div>
+                <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Band</dt>
+                    <dd class="govuk-summary-list__value">3</dd>
+                </div>
+            </dl>
         </div>
     </div>
     <div class="govuk-grid-row">
@@ -130,20 +115,14 @@ exports[`Allocation Details should render "Select allocation specialism" with er
     </div>
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds govuk-!-margin-top-5 govuk-!-margin-bottom-6">
-            <table class="govuk-table">
-                <tbody class="govuk-table__body">
-                    <tr class="govuk-table__row">
-                        <td class="govuk-table__cell"><strong>Level</strong>
-                        </td>
-                        <td class="govuk-table__cell">A</td>
-                    </tr>
-                    <tr class="govuk-table__row">
-                        <td class="govuk-table__cell"><strong>Band</strong>
-                        </td>
-                        <td class="govuk-table__cell">3</td>
-                    </tr>
-                </tbody>
-            </table>
+            <dl class="govuk-summary-list">
+                <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Level</dt>
+                    <dd class="govuk-summary-list__value">A</dd>
+                </div>
+                <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Band</dt>
+                    <dd class="govuk-summary-list__value">3</dd>
+                </div>
+            </dl>
         </div>
     </div>
     <div class="govuk-grid-row">

--- a/appeals/web/src/server/appeals/appeal-details/allocation-details/__tests__/allocation-details.test.js
+++ b/appeals/web/src/server/appeals/appeal-details/allocation-details/__tests__/allocation-details.test.js
@@ -69,7 +69,7 @@ describe('Allocation Details', () => {
 		const element = parseHtml(response.text);
 
 		expect(element.innerHTML).toMatchSnapshot();
-		expect(element.innerHTML).toContain('Select allocation specialism(s)</h1>');
+		expect(element.innerHTML).toContain('Select allocation specialisms</h1>');
 	});
 
 	it('should render "Select allocation specialism" with error (no answer provided)', async () => {

--- a/appeals/web/src/server/appeals/appeal-details/allocation-details/__tests__/allocation-details.test.js
+++ b/appeals/web/src/server/appeals/appeal-details/allocation-details/__tests__/allocation-details.test.js
@@ -141,9 +141,9 @@ describe('Allocation Details', () => {
 
 		expect(element.innerHTML).toMatchSnapshot();
 		expect(element.innerHTML).toContain('Check answers</h1>');
-		expect(element.innerHTML).toContain('Level</strong>');
-		expect(element.innerHTML).toContain('Band</strong>');
-		expect(element.innerHTML).toContain('Specialism</strong>');
+		expect(element.innerHTML).toContain('Level</dt>');
+		expect(element.innerHTML).toContain('Band</dt>');
+		expect(element.innerHTML).toContain('Specialism</dt>');
 		expect(element.innerHTML).toContain('Confirm</button>');
 	});
 

--- a/appeals/web/src/server/appeals/appeal-details/allocation-details/allocation-details.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/allocation-details/allocation-details.mapper.js
@@ -66,11 +66,11 @@ export function allocationDetailsSpecialismPage(
 
 	/** @type {PageContent} */
 	const pageContent = {
-		title: `Select allocation specialism(s) - ${shortAppealReference}`,
+		title: `Select allocation specialisms - ${shortAppealReference}`,
 		backLinkUrl: `/appeals-service/appeal-details/${appealDetails.appealId}/allocation-details/allocation-level`,
 		backLinkText: 'Back',
 		preHeading: `Appeal ${shortAppealReference}`,
-		heading: 'Select allocation specialism(s)',
+		heading: 'Select allocation specialisms',
 		pageComponents: [
 			{
 				type: 'summary-list',

--- a/appeals/web/src/server/appeals/appeal-details/allocation-details/allocation-details.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/allocation-details/allocation-details.mapper.js
@@ -73,31 +73,30 @@ export function allocationDetailsSpecialismPage(
 		heading: 'Select allocation specialism(s)',
 		pageComponents: [
 			{
-				type: 'table',
+				type: 'summary-list',
 				wrapperHtml: {
 					opening:
 						'<div class="govuk-grid-row"><div class="govuk-grid-column-two-thirds govuk-!-margin-top-5 govuk-!-margin-bottom-6">',
 					closing: '</div></div>'
 				},
 				parameters: {
-					firstCellIsHeader: false,
 					rows: [
-						[
-							{
-								html: '<strong>Level</strong>'
+						{
+							key: {
+								text: 'Level'
 							},
-							{
-								html: selectedAllocationLevel && selectedAllocationLevel.level
+							value: {
+								text: selectedAllocationLevel && selectedAllocationLevel.level
 							}
-						],
-						[
-							{
-								html: '<strong>Band</strong>'
+						},
+						{
+							key: {
+								text: 'Band'
 							},
-							{
-								html: selectedAllocationLevel && selectedAllocationLevel.band
+							value: {
+								text: selectedAllocationLevel && selectedAllocationLevel.band
 							}
-						]
+						}
 					]
 				}
 			},
@@ -153,48 +152,56 @@ export function allocationDetailsCheckAnswersPage(
 		heading: 'Check answers',
 		pageComponents: [
 			{
-				type: 'table',
+				type: 'summary-list',
 				wrapperHtml: {
 					opening:
 						'<div class="govuk-grid-row"><div class="govuk-grid-column-two-thirds govuk-!-margin-top-5 govuk-!-margin-bottom-6">',
 					closing: '</div></div>'
 				},
 				parameters: {
-					firstCellIsHeader: false,
 					rows: [
-						[
-							{
-								html: '<strong>Level</strong>'
+						{
+							key: {
+								text: 'Level'
 							},
-							{
-								html: selectedAllocationLevel.level
+							value: {
+								text: selectedAllocationLevel.level
 							},
-							{
-								html: `<a href="/appeals-service/appeal-details/${appealDetails.appealId}/allocation-details/allocation-level">Change</a>`
+							actions: {
+								items: [
+									{
+										href: `/appeals-service/appeal-details/${appealDetails.appealId}/allocation-details/allocation-level`,
+										text: 'Change',
+										visuallyHiddenText: 'level'
+									}
+								]
 							}
-						],
-						[
-							{
-								html: '<strong>Band</strong>'
+						},
+						{
+							key: {
+								text: 'Band'
 							},
-							{
-								html: selectedAllocationLevel.band
-							},
-							{
-								text: ''
+							value: {
+								text: selectedAllocationLevel.band
 							}
-						],
-						[
-							{
-								html: '<strong>Specialism</strong>'
+						},
+						{
+							key: {
+								text: 'Specialism'
 							},
-							{
+							value: {
 								html: `<ul class="govuk-!-padding-0 govuk-!-margin-0 govuk-!-margin-left-4">${selectedAllocationSpecialismsHtml}</ul>`
 							},
-							{
-								html: `<a href="/appeals-service/appeal-details/${appealDetails.appealId}/allocation-details/allocation-specialism">Change</a>`
+							actions: {
+								items: [
+									{
+										href: `/appeals-service/appeal-details/${appealDetails.appealId}/allocation-details/allocation-specialism`,
+										text: 'Change',
+										visuallyHiddenText: 'specialism'
+									}
+								]
 							}
-						]
+						}
 					]
 				}
 			},

--- a/appeals/web/src/server/appeals/appeal-details/other-appeals/__tests__/__snapshots__/other-appeals.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/other-appeals/__tests__/__snapshots__/other-appeals.test.js.snap
@@ -29,40 +29,26 @@ exports[`other-appeals GET /other-appeals/confirm should render the "Related app
             </div>
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full govuk-!-margin-top-5 govuk-!-margin-bottom-6">
-                    <table class="govuk-table">
-                        <tbody class="govuk-table__body">
-                            <tr class="govuk-table__row">
-                                <td class="govuk-table__cell"><strong>Appeal reference</strong>
-                                </td>
-                                <td class="govuk-table__cell">12345</td>
-                            </tr>
-                            <tr class="govuk-table__row">
-                                <td class="govuk-table__cell"><strong>Appeal type</strong>
-                                </td>
-                                <td class="govuk-table__cell">Planning Appeal (W)</td>
-                            </tr>
-                            <tr class="govuk-table__row">
-                                <td class="govuk-table__cell"><strong>Site address</strong>
-                                </td>
-                                <td class="govuk-table__cell"></td>
-                            </tr>
-                            <tr class="govuk-table__row">
-                                <td class="govuk-table__cell"><strong>Local planning authority (LPA)</strong>
-                                </td>
-                                <td class="govuk-table__cell">Bristol City Council</td>
-                            </tr>
-                            <tr class="govuk-table__row">
-                                <td class="govuk-table__cell"><strong>Appellant name</strong>
-                                </td>
-                                <td class="govuk-table__cell">Mr John Wick</td>
-                            </tr>
-                            <tr class="govuk-table__row">
-                                <td class="govuk-table__cell"><strong>Agent name</strong>
-                                </td>
-                                <td class="govuk-table__cell">Mr John Smith (Smith Planning Agency)</td>
-                            </tr>
-                        </tbody>
-                    </table>
+                    <dl class="govuk-summary-list">
+                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Appeal reference</dt>
+                            <dd class="govuk-summary-list__value">12345</dd>
+                        </div>
+                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Appeal type</dt>
+                            <dd class="govuk-summary-list__value">Planning Appeal (W)</dd>
+                        </div>
+                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Site address</dt>
+                            <dd class="govuk-summary-list__value"></dd>
+                        </div>
+                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Local planning authority (LPA)</dt>
+                            <dd                             class="govuk-summary-list__value">Bristol City Council</dd>
+                        </div>
+                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Appellant name</dt>
+                            <dd class="govuk-summary-list__value">Mr John Wick</dd>
+                        </div>
+                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Agent name</dt>
+                            <dd class="govuk-summary-list__value">Mr John Smith (Smith Planning Agency)</dd>
+                        </div>
+                    </dl>
                 </div>
             </div>
             <form method="post" novalidate="novalidate">
@@ -362,40 +348,26 @@ exports[`other-appeals POST /other-appeals/confirm should re-render the "Related
             </div>
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full govuk-!-margin-top-5 govuk-!-margin-bottom-6">
-                    <table class="govuk-table">
-                        <tbody class="govuk-table__body">
-                            <tr class="govuk-table__row">
-                                <td class="govuk-table__cell"><strong>Appeal reference</strong>
-                                </td>
-                                <td class="govuk-table__cell">12345</td>
-                            </tr>
-                            <tr class="govuk-table__row">
-                                <td class="govuk-table__cell"><strong>Appeal type</strong>
-                                </td>
-                                <td class="govuk-table__cell">Planning Appeal (W)</td>
-                            </tr>
-                            <tr class="govuk-table__row">
-                                <td class="govuk-table__cell"><strong>Site address</strong>
-                                </td>
-                                <td class="govuk-table__cell"></td>
-                            </tr>
-                            <tr class="govuk-table__row">
-                                <td class="govuk-table__cell"><strong>Local planning authority (LPA)</strong>
-                                </td>
-                                <td class="govuk-table__cell">Bristol City Council</td>
-                            </tr>
-                            <tr class="govuk-table__row">
-                                <td class="govuk-table__cell"><strong>Appellant name</strong>
-                                </td>
-                                <td class="govuk-table__cell">Mr John Wick</td>
-                            </tr>
-                            <tr class="govuk-table__row">
-                                <td class="govuk-table__cell"><strong>Agent name</strong>
-                                </td>
-                                <td class="govuk-table__cell">Mr John Smith (Smith Planning Agency)</td>
-                            </tr>
-                        </tbody>
-                    </table>
+                    <dl class="govuk-summary-list">
+                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Appeal reference</dt>
+                            <dd class="govuk-summary-list__value">12345</dd>
+                        </div>
+                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Appeal type</dt>
+                            <dd class="govuk-summary-list__value">Planning Appeal (W)</dd>
+                        </div>
+                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Site address</dt>
+                            <dd class="govuk-summary-list__value"></dd>
+                        </div>
+                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Local planning authority (LPA)</dt>
+                            <dd                             class="govuk-summary-list__value">Bristol City Council</dd>
+                        </div>
+                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Appellant name</dt>
+                            <dd class="govuk-summary-list__value">Mr John Wick</dd>
+                        </div>
+                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Agent name</dt>
+                            <dd class="govuk-summary-list__value">Mr John Smith (Smith Planning Agency)</dd>
+                        </div>
+                    </dl>
                 </div>
             </div>
             <form method="post" novalidate="novalidate">

--- a/appeals/web/src/server/appeals/appeal-details/other-appeals/__tests__/other-appeals.test.js
+++ b/appeals/web/src/server/appeals/appeal-details/other-appeals/__tests__/other-appeals.test.js
@@ -158,14 +158,12 @@ describe('other-appeals', () => {
 
 			const unprettifiedElement = parseHtml(response.text, { skipPrettyPrint: true });
 
-			expect(unprettifiedElement.innerHTML).toContain('Appeal reference</strong></td>');
-			expect(unprettifiedElement.innerHTML).toContain('Appeal type</strong></td>');
-			expect(unprettifiedElement.innerHTML).toContain('Site address</strong></td>');
-			expect(unprettifiedElement.innerHTML).toContain(
-				'Local planning authority (LPA)</strong></td>'
-			);
-			expect(unprettifiedElement.innerHTML).toContain('Appellant name</strong></td>');
-			expect(unprettifiedElement.innerHTML).toContain('Agent name</strong></td>');
+			expect(unprettifiedElement.innerHTML).toContain('Appeal reference</dt>');
+			expect(unprettifiedElement.innerHTML).toContain('Appeal type</dt>');
+			expect(unprettifiedElement.innerHTML).toContain('Site address</dt>');
+			expect(unprettifiedElement.innerHTML).toContain('Local planning authority (LPA)</dt>');
+			expect(unprettifiedElement.innerHTML).toContain('Appellant name</dt>');
+			expect(unprettifiedElement.innerHTML).toContain('Agent name</dt>');
 			expect(unprettifiedElement.innerHTML).toContain(
 				'Do you want to relate these appeals?</legend>'
 			);

--- a/appeals/web/src/server/appeals/appeal-details/other-appeals/other-appeals.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/other-appeals/other-appeals.mapper.js
@@ -76,65 +76,64 @@ export function confirmOtherAppealsPage(currentAppeal, relatedAppeal, origin) {
 	/** @type {PageComponent[]} */
 	const pageComponents = [
 		{
-			type: 'table',
+			type: 'summary-list',
 			wrapperHtml: {
 				opening:
 					'<div class="govuk-grid-row"><div class="govuk-grid-column-full govuk-!-margin-top-5 govuk-!-margin-bottom-6">',
 				closing: '</div></div>'
 			},
 			parameters: {
-				firstCellIsHeader: false,
 				rows: [
-					[
-						{
-							html: '<strong>Appeal reference</strong>'
+					{
+						key: {
+							text: 'Appeal reference'
 						},
-						{
-							html: `${relatedAppeal.appealReference}${
+						value: {
+							text: `${relatedAppeal.appealReference}${
 								relatedAppeal.source === 'horizon' ? ' (Horizon)' : ''
 							}`
 						}
-					],
-					[
-						{
-							html: '<strong>Appeal type</strong>'
+					},
+					{
+						key: {
+							text: 'Appeal type'
 						},
-						{
-							html: relatedAppeal.appealType || ''
+						value: {
+							text: relatedAppeal.appealType || ''
 						}
-					],
-					[
-						{
-							html: '<strong>Site address</strong>'
+					},
+					{
+						key: {
+							text: 'Site address'
 						},
-						{
-							html: relatedAppeal.siteAddress ? addressToString(relatedAppeal.siteAddress) : ''
+						value: {
+							text: relatedAppeal.siteAddress ? addressToString(relatedAppeal.siteAddress) : ''
 						}
-					],
-					[
-						{
-							html: '<strong>Local planning authority (LPA)</strong>'
+					},
+					{
+						key: {
+							text: 'Local planning authority (LPA)'
 						},
-						{
-							html: relatedAppeal.localPlanningDepartment || ''
+						value: {
+							text: relatedAppeal.localPlanningDepartment || ''
 						}
-					],
-					[
-						{
-							html: '<strong>Appellant name</strong>'
+					},
+					{
+						key: {
+							text: 'Appellant name'
 						},
-						{
-							html: relatedAppeal.appellantName || ''
+						value: {
+							text: relatedAppeal.appellantName || ''
 						}
-					],
-					[
-						{
-							html: '<strong>Agent name</strong>'
+					},
+					{
+						key: {
+							text: 'Agent name'
 						},
-						{
-							html: relatedAppeal.agentName || ''
+						value: {
+							text: relatedAppeal.agentName || ''
 						}
-					]
+					}
 				]
 			}
 		}


### PR DESCRIPTION
## Describe your changes

- Changed a few simple tables to summary lists

Content change:
- 'specialism(s)' changed to 'specialisms'

## Issue ticket number and link

[A2-1505 Adaptability - Info and relationships - Layout Table Present](https://pins-ds.atlassian.net.mcas.ms/browse/A2-1505)

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)
