### PR TITLE
feat(web): update case details correspondence rows to display number of documents

### DIFF
--- a/appeals/web/src/server/appeals/appeal-details/__tests__/__snapshots__/appeal-details.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/__tests__/__snapshots__/appeal-details.test.js.snap
@@ -888,13 +888,13 @@ exports[`appeal-details GET /:appealId should not render action links to the man
                         aria-labelledby="accordion-default1-heading-8">
                             <dl class="govuk-summary-list">
                                 <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Cross-team correspondence</dt>
-                                    <dd                                     class="govuk-summary-list__value"></dd>
+                                    <dd                                     class="govuk-summary-list__value">No documents</dd>
                                         <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/internal-correspondence/cross-team/upload-documents/10"
                                             data-cy="add-cross-team-correspondence"> Add<span class="govuk-visually-hidden"> Cross-team correspondence</span></a>
                                         </dd>
                                 </div>
                                 <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Inspector correspondence</dt>
-                                    <dd                                     class="govuk-summary-list__value"></dd>
+                                    <dd                                     class="govuk-summary-list__value">No documents</dd>
                                         <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/internal-correspondence/inspector/upload-documents/11"
                                             data-cy="add-inspector-correspondence"> Add<span class="govuk-visually-hidden"> Inspector correspondence</span></a>
                                         </dd>
@@ -1371,13 +1371,13 @@ exports[`appeal-details GET /:appealId should render a Decision inset panel when
                     aria-labelledby="accordion-default1-heading-8">
                         <dl class="govuk-summary-list">
                             <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Cross-team correspondence</dt>
-                                <dd                                 class="govuk-summary-list__value"></dd>
+                                <dd                                 class="govuk-summary-list__value">No documents</dd>
                                     <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/internal-correspondence/cross-team/upload-documents/10"
                                         data-cy="add-cross-team-correspondence"> Add<span class="govuk-visually-hidden"> Cross-team correspondence</span></a>
                                     </dd>
                             </div>
                             <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Inspector correspondence</dt>
-                                <dd                                 class="govuk-summary-list__value"></dd>
+                                <dd                                 class="govuk-summary-list__value">No documents</dd>
                                     <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/internal-correspondence/inspector/upload-documents/11"
                                         data-cy="add-inspector-correspondence"> Add<span class="govuk-visually-hidden"> Inspector correspondence</span></a>
                                     </dd>
@@ -1842,13 +1842,13 @@ exports[`appeal-details GET /:appealId should render a child tag next to the app
                         aria-labelledby="accordion-default1-heading-8">
                             <dl class="govuk-summary-list">
                                 <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Cross-team correspondence</dt>
-                                    <dd                                     class="govuk-summary-list__value"></dd>
+                                    <dd                                     class="govuk-summary-list__value">No documents</dd>
                                         <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/internal-correspondence/cross-team/upload-documents/10"
                                             data-cy="add-cross-team-correspondence"> Add<span class="govuk-visually-hidden"> Cross-team correspondence</span></a>
                                         </dd>
                                 </div>
                                 <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Inspector correspondence</dt>
-                                    <dd                                     class="govuk-summary-list__value"></dd>
+                                    <dd                                     class="govuk-summary-list__value">No documents</dd>
                                         <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/internal-correspondence/inspector/upload-documents/11"
                                             data-cy="add-inspector-correspondence"> Add<span class="govuk-visually-hidden"> Inspector correspondence</span></a>
                                         </dd>
@@ -2316,13 +2316,13 @@ exports[`appeal-details GET /:appealId should render a lead tag next to the appe
                         aria-labelledby="accordion-default1-heading-8">
                             <dl class="govuk-summary-list">
                                 <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Cross-team correspondence</dt>
-                                    <dd                                     class="govuk-summary-list__value"></dd>
+                                    <dd                                     class="govuk-summary-list__value">No documents</dd>
                                         <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/internal-correspondence/cross-team/upload-documents/10"
                                             data-cy="add-cross-team-correspondence"> Add<span class="govuk-visually-hidden"> Cross-team correspondence</span></a>
                                         </dd>
                                 </div>
                                 <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Inspector correspondence</dt>
-                                    <dd                                     class="govuk-summary-list__value"></dd>
+                                    <dd                                     class="govuk-summary-list__value">No documents</dd>
                                         <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/internal-correspondence/inspector/upload-documents/11"
                                             data-cy="add-inspector-correspondence"> Add<span class="govuk-visually-hidden"> Inspector correspondence</span></a>
                                         </dd>
@@ -2806,13 +2806,13 @@ exports[`appeal-details GET /:appealId should render action links to the manage 
                         aria-labelledby="accordion-default1-heading-8">
                             <dl class="govuk-summary-list">
                                 <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Cross-team correspondence</dt>
-                                    <dd                                     class="govuk-summary-list__value"></dd>
+                                    <dd                                     class="govuk-summary-list__value">No documents</dd>
                                         <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/internal-correspondence/cross-team/upload-documents/10"
                                             data-cy="add-cross-team-correspondence"> Add<span class="govuk-visually-hidden"> Cross-team correspondence</span></a>
                                         </dd>
                                 </div>
                                 <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Inspector correspondence</dt>
-                                    <dd                                     class="govuk-summary-list__value"></dd>
+                                    <dd                                     class="govuk-summary-list__value">No documents</dd>
                                         <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/internal-correspondence/inspector/upload-documents/11"
                                             data-cy="add-inspector-correspondence"> Add<span class="govuk-visually-hidden"> Inspector correspondence</span></a>
                                         </dd>
@@ -3285,13 +3285,13 @@ exports[`appeal-details GET /:appealId should render an Issue a decision notific
                     aria-labelledby="accordion-default1-heading-8">
                         <dl class="govuk-summary-list">
                             <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Cross-team correspondence</dt>
-                                <dd                                 class="govuk-summary-list__value"></dd>
+                                <dd                                 class="govuk-summary-list__value">No documents</dd>
                                     <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/internal-correspondence/cross-team/upload-documents/10"
                                         data-cy="add-cross-team-correspondence"> Add<span class="govuk-visually-hidden"> Cross-team correspondence</span></a>
                                     </dd>
                             </div>
                             <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Inspector correspondence</dt>
-                                <dd                                 class="govuk-summary-list__value"></dd>
+                                <dd                                 class="govuk-summary-list__value">No documents</dd>
                                     <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/internal-correspondence/inspector/upload-documents/11"
                                         data-cy="add-inspector-correspondence"> Add<span class="govuk-visually-hidden"> Inspector correspondence</span></a>
                                     </dd>
@@ -3745,13 +3745,13 @@ exports[`appeal-details GET /:appealId should render an action link to the add l
                     aria-labelledby="accordion-default1-heading-8">
                         <dl class="govuk-summary-list">
                             <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Cross-team correspondence</dt>
-                                <dd                                 class="govuk-summary-list__value"></dd>
+                                <dd                                 class="govuk-summary-list__value">No documents</dd>
                                     <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/internal-correspondence/cross-team/upload-documents/10"
                                         data-cy="add-cross-team-correspondence"> Add<span class="govuk-visually-hidden"> Cross-team correspondence</span></a>
                                     </dd>
                             </div>
                             <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Inspector correspondence</dt>
-                                <dd                                 class="govuk-summary-list__value"></dd>
+                                <dd                                 class="govuk-summary-list__value">No documents</dd>
                                     <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/internal-correspondence/inspector/upload-documents/11"
                                         data-cy="add-inspector-correspondence"> Add<span class="govuk-visually-hidden"> Inspector correspondence</span></a>
                                     </dd>
@@ -4225,13 +4225,13 @@ exports[`appeal-details GET /:appealId should render the appellant case status a
                     aria-labelledby="accordion-default1-heading-8">
                         <dl class="govuk-summary-list">
                             <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Cross-team correspondence</dt>
-                                <dd                                 class="govuk-summary-list__value"></dd>
+                                <dd                                 class="govuk-summary-list__value">No documents</dd>
                                     <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/internal-correspondence/cross-team/upload-documents/10"
                                         data-cy="add-cross-team-correspondence"> Add<span class="govuk-visually-hidden"> Cross-team correspondence</span></a>
                                     </dd>
                             </div>
                             <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Inspector correspondence</dt>
-                                <dd                                 class="govuk-summary-list__value"></dd>
+                                <dd                                 class="govuk-summary-list__value">No documents</dd>
                                     <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/internal-correspondence/inspector/upload-documents/11"
                                         data-cy="add-inspector-correspondence"> Add<span class="govuk-visually-hidden"> Inspector correspondence</span></a>
                                     </dd>
@@ -4705,13 +4705,13 @@ exports[`appeal-details GET /:appealId should render the appellant case status a
                     aria-labelledby="accordion-default1-heading-8">
                         <dl class="govuk-summary-list">
                             <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Cross-team correspondence</dt>
-                                <dd                                 class="govuk-summary-list__value"></dd>
+                                <dd                                 class="govuk-summary-list__value">No documents</dd>
                                     <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/internal-correspondence/cross-team/upload-documents/10"
                                         data-cy="add-cross-team-correspondence"> Add<span class="govuk-visually-hidden"> Cross-team correspondence</span></a>
                                     </dd>
                             </div>
                             <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Inspector correspondence</dt>
-                                <dd                                 class="govuk-summary-list__value"></dd>
+                                <dd                                 class="govuk-summary-list__value">No documents</dd>
                                     <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/internal-correspondence/inspector/upload-documents/11"
                                         data-cy="add-inspector-correspondence"> Add<span class="govuk-visually-hidden"> Inspector correspondence</span></a>
                                     </dd>
@@ -5185,13 +5185,13 @@ exports[`appeal-details GET /:appealId should render the appellant case status a
                     aria-labelledby="accordion-default1-heading-8">
                         <dl class="govuk-summary-list">
                             <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Cross-team correspondence</dt>
-                                <dd                                 class="govuk-summary-list__value"></dd>
+                                <dd                                 class="govuk-summary-list__value">No documents</dd>
                                     <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/internal-correspondence/cross-team/upload-documents/10"
                                         data-cy="add-cross-team-correspondence"> Add<span class="govuk-visually-hidden"> Cross-team correspondence</span></a>
                                     </dd>
                             </div>
                             <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Inspector correspondence</dt>
-                                <dd                                 class="govuk-summary-list__value"></dd>
+                                <dd                                 class="govuk-summary-list__value">No documents</dd>
                                     <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/internal-correspondence/inspector/upload-documents/11"
                                         data-cy="add-inspector-correspondence"> Add<span class="govuk-visually-hidden"> Inspector correspondence</span></a>
                                     </dd>
@@ -5661,13 +5661,13 @@ exports[`appeal-details GET /:appealId should render the case reference for each
                         aria-labelledby="accordion-default1-heading-8">
                             <dl class="govuk-summary-list">
                                 <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Cross-team correspondence</dt>
-                                    <dd                                     class="govuk-summary-list__value"></dd>
+                                    <dd                                     class="govuk-summary-list__value">No documents</dd>
                                         <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/internal-correspondence/cross-team/upload-documents/10"
                                             data-cy="add-cross-team-correspondence"> Add<span class="govuk-visually-hidden"> Cross-team correspondence</span></a>
                                         </dd>
                                 </div>
                                 <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Inspector correspondence</dt>
-                                    <dd                                     class="govuk-summary-list__value"></dd>
+                                    <dd                                     class="govuk-summary-list__value">No documents</dd>
                                         <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/internal-correspondence/inspector/upload-documents/11"
                                             data-cy="add-inspector-correspondence"> Add<span class="govuk-visually-hidden"> Inspector correspondence</span></a>
                                         </dd>
@@ -6165,13 +6165,13 @@ exports[`appeal-details GET /:appealId should render the lead or child status af
                         aria-labelledby="accordion-default1-heading-8">
                             <dl class="govuk-summary-list">
                                 <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Cross-team correspondence</dt>
-                                    <dd                                     class="govuk-summary-list__value"></dd>
+                                    <dd                                     class="govuk-summary-list__value">No documents</dd>
                                         <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/internal-correspondence/cross-team/upload-documents/10"
                                             data-cy="add-cross-team-correspondence"> Add<span class="govuk-visually-hidden"> Cross-team correspondence</span></a>
                                         </dd>
                                 </div>
                                 <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Inspector correspondence</dt>
-                                    <dd                                     class="govuk-summary-list__value"></dd>
+                                    <dd                                     class="govuk-summary-list__value">No documents</dd>
                                         <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/internal-correspondence/inspector/upload-documents/11"
                                             data-cy="add-inspector-correspondence"> Add<span class="govuk-visually-hidden"> Inspector correspondence</span></a>
                                         </dd>
@@ -6653,13 +6653,13 @@ exports[`appeal-details GET /:appealId should render the received appeal details
                         aria-labelledby="accordion-default3-heading-8">
                             <dl class="govuk-summary-list">
                                 <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Cross-team correspondence</dt>
-                                    <dd                                     class="govuk-summary-list__value"></dd>
+                                    <dd                                     class="govuk-summary-list__value">No documents</dd>
                                         <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/3/internal-correspondence/cross-team/upload-documents/10"
                                             data-cy="add-cross-team-correspondence"> Add<span class="govuk-visually-hidden"> Cross-team correspondence</span></a>
                                         </dd>
                                 </div>
                                 <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Inspector correspondence</dt>
-                                    <dd                                     class="govuk-summary-list__value"></dd>
+                                    <dd                                     class="govuk-summary-list__value">No documents</dd>
                                         <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/3/internal-correspondence/inspector/upload-documents/11"
                                             data-cy="add-inspector-correspondence"> Add<span class="govuk-visually-hidden"> Inspector correspondence</span></a>
                                         </dd>
@@ -7113,13 +7113,13 @@ exports[`appeal-details GET /:appealId should render the received appeal details
                     aria-labelledby="accordion-default1-heading-8">
                         <dl class="govuk-summary-list">
                             <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Cross-team correspondence</dt>
-                                <dd                                 class="govuk-summary-list__value"></dd>
+                                <dd                                 class="govuk-summary-list__value">No documents</dd>
                                     <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/internal-correspondence/cross-team/upload-documents/10"
                                         data-cy="add-cross-team-correspondence"> Add<span class="govuk-visually-hidden"> Cross-team correspondence</span></a>
                                     </dd>
                             </div>
                             <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Inspector correspondence</dt>
-                                <dd                                 class="govuk-summary-list__value"></dd>
+                                <dd                                 class="govuk-summary-list__value">No documents</dd>
                                     <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/internal-correspondence/inspector/upload-documents/11"
                                         data-cy="add-inspector-correspondence"> Add<span class="govuk-visually-hidden"> Inspector correspondence</span></a>
                                     </dd>
@@ -7596,13 +7596,13 @@ exports[`appeal-details GET /:appealId should render the received appeal details
                         aria-labelledby="accordion-default2-heading-8">
                             <dl class="govuk-summary-list">
                                 <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Cross-team correspondence</dt>
-                                    <dd                                     class="govuk-summary-list__value"></dd>
+                                    <dd                                     class="govuk-summary-list__value">No documents</dd>
                                         <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/internal-correspondence/cross-team/upload-documents/10"
                                             data-cy="add-cross-team-correspondence"> Add<span class="govuk-visually-hidden"> Cross-team correspondence</span></a>
                                         </dd>
                                 </div>
                                 <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Inspector correspondence</dt>
-                                    <dd                                     class="govuk-summary-list__value"></dd>
+                                    <dd                                     class="govuk-summary-list__value">No documents</dd>
                                         <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/internal-correspondence/inspector/upload-documents/11"
                                             data-cy="add-inspector-correspondence"> Add<span class="govuk-visually-hidden"> Inspector correspondence</span></a>
                                         </dd>
@@ -8042,13 +8042,13 @@ exports[`appeal-details GET /:appealId should render the received appeal details
                     aria-labelledby="accordion-default1-heading-8">
                         <dl class="govuk-summary-list">
                             <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Cross-team correspondence</dt>
-                                <dd                                 class="govuk-summary-list__value"></dd>
+                                <dd                                 class="govuk-summary-list__value">No documents</dd>
                                     <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/internal-correspondence/cross-team/upload-documents/10"
                                         data-cy="add-cross-team-correspondence"> Add<span class="govuk-visually-hidden"> Cross-team correspondence</span></a>
                                     </dd>
                             </div>
                             <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Inspector correspondence</dt>
-                                <dd                                 class="govuk-summary-list__value"></dd>
+                                <dd                                 class="govuk-summary-list__value">No documents</dd>
                                     <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/internal-correspondence/inspector/upload-documents/11"
                                         data-cy="add-inspector-correspondence"> Add<span class="govuk-visually-hidden"> Inspector correspondence</span></a>
                                     </dd>
@@ -8531,13 +8531,13 @@ exports[`appeal-details should not render a back button 1`] = `
                                 aria-labelledby="accordion-default2-heading-8">
                                     <dl class="govuk-summary-list">
                                         <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Cross-team correspondence</dt>
-                                            <dd                                             class="govuk-summary-list__value"></dd>
+                                            <dd                                             class="govuk-summary-list__value">No documents</dd>
                                                 <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/internal-correspondence/cross-team/upload-documents/10"
                                                     data-cy="add-cross-team-correspondence"> Add<span class="govuk-visually-hidden"> Cross-team correspondence</span></a>
                                                 </dd>
                                         </div>
                                         <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Inspector correspondence</dt>
-                                            <dd                                             class="govuk-summary-list__value"></dd>
+                                            <dd                                             class="govuk-summary-list__value">No documents</dd>
                                                 <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/internal-correspondence/inspector/upload-documents/11"
                                                     data-cy="add-inspector-correspondence"> Add<span class="govuk-visually-hidden"> Inspector correspondence</span></a>
                                                 </dd>

--- a/appeals/web/src/server/appeals/appeals.types.d.ts
+++ b/appeals/web/src/server/appeals/appeals.types.d.ts
@@ -26,6 +26,7 @@ export interface DayMonthYearHourMinute {
 }
 
 export type DocumentVirusCheckStatus = 'not_scanned' | 'scanned' | 'affected';
+export type DocumentRowDisplayMode = 'none' | 'number' | 'list';
 
 declare global {
 	namespace Express {

--- a/appeals/web/src/server/lib/mappers/components/instructions/document.js
+++ b/appeals/web/src/server/lib/mappers/components/instructions/document.js
@@ -13,7 +13,7 @@ import { formatDocumentActionLink, formatDocumentValues } from '#lib/display-pag
  * @param {string} options.manageUrl
  * @param {string} options.uploadUrlTemplate
  * @param {string} [options.cypressDataName]
- * @param {boolean} [options.showDocuments]
+ * @param {import('#appeals/appeals.types.js').DocumentRowDisplayMode} [options.displayMode]
  * @returns {Instructions}
  */
 export function documentSummaryListItem({
@@ -25,7 +25,7 @@ export function documentSummaryListItem({
 	manageUrl,
 	uploadUrlTemplate,
 	cypressDataName = id,
-	showDocuments = true
+	displayMode = 'list'
 }) {
 	const documents = (isFolderInfo(folderInfo) && folderInfo.documents) || [];
 	/** @type {ActionItemProperties[]} */
@@ -51,7 +51,7 @@ export function documentSummaryListItem({
 		display: {
 			summaryListItem: {
 				key: { text },
-				value: showDocuments ? formatDocumentValues(appealId, documents) : '',
+				value: formatDocumentValues({ appealId, documents, displayMode }),
 				actions: { items: actions }
 			}
 		}

--- a/appeals/web/src/server/lib/mappers/data/appeal/submappers/cross-team-correspondence.mapper.js
+++ b/appeals/web/src/server/lib/mappers/data/appeal/submappers/cross-team-correspondence.mapper.js
@@ -9,7 +9,7 @@ export const mapCrossTeamCorrespondence = ({ appealDetails, currentRoute, sessio
 		text: 'Cross-team correspondence',
 		appealId: appealDetails.appealId,
 		folderInfo: appealDetails.internalCorrespondence?.crossTeam,
-		showDocuments: false,
+		displayMode: 'number',
 		editable: userHasPermission(permissionNames.viewCaseDetails, session),
 		uploadUrlTemplate: `${currentRoute}/internal-correspondence/cross-team/upload-documents/${appealDetails.internalCorrespondence?.crossTeam?.folderId}`,
 		manageUrl: `${currentRoute}/internal-correspondence/cross-team/manage-documents/${appealDetails.internalCorrespondence?.crossTeam?.folderId}`

--- a/appeals/web/src/server/lib/mappers/data/appeal/submappers/inspector-correspondence.mapper.js
+++ b/appeals/web/src/server/lib/mappers/data/appeal/submappers/inspector-correspondence.mapper.js
@@ -9,7 +9,7 @@ export const mapInspectorCorrespondence = ({ appealDetails, currentRoute, sessio
 		text: 'Inspector correspondence',
 		appealId: appealDetails.appealId,
 		folderInfo: appealDetails.internalCorrespondence?.inspector,
-		showDocuments: false,
+		displayMode: 'number',
 		editable: userHasPermission(permissionNames.viewCaseDetails, session),
 		uploadUrlTemplate: `${currentRoute}/internal-correspondence/inspector/upload-documents/${appealDetails.internalCorrespondence?.inspector?.folderId}`,
 		manageUrl: `${currentRoute}/internal-correspondence/inspector/manage-documents/${appealDetails.internalCorrespondence?.inspector?.folderId}`

--- a/appeals/web/src/server/lib/mappers/data/appellant-case/submappers/additional-documents.js
+++ b/appeals/web/src/server/lib/mappers/data/appellant-case/submappers/additional-documents.js
@@ -16,13 +16,14 @@ export const mapAdditionalDocuments = ({ appellantCaseData }) => ({
 								text: 'Additional documents',
 								classes: 'govuk-visually-hidden'
 							},
-							value: formatDocumentValues(
-								appellantCaseData.appealId,
-								isFolderInfo(appellantCaseData.documents.appellantCaseCorrespondence)
+							value: formatDocumentValues({
+								appealId: appellantCaseData.appealId,
+								documents: isFolderInfo(appellantCaseData.documents.appellantCaseCorrespondence)
 									? appellantCaseData.documents.appellantCaseCorrespondence.documents || []
 									: [],
-								true
-							),
+								displayMode: 'list',
+								isAdditionalDocuments: true
+							}),
 							actions: {
 								items: []
 							}

--- a/appeals/web/src/server/lib/mappers/data/lpa-questionnaire/common.js
+++ b/appeals/web/src/server/lib/mappers/data/lpa-questionnaire/common.js
@@ -32,7 +32,7 @@ export const mapDocumentManageUrl = (caseId, lpaQuestionnaireId, folderId) => {
  * @param {string} options.text
  * @param {import('@pins/appeals.api/src/server/endpoints/appeals.js').FolderInfo|null|undefined} options.folderInfo
  * @param {string} [options.cypressDataName]
- * @param {boolean} [options.showDocuments]
+ * @param {import('#appeals/appeals.types.js').DocumentRowDisplayMode} [options.displayMode]
  * @param {import('@pins/appeals.api/src/server/endpoints/appeals.js').SingleLPAQuestionnaireResponse} options.lpaQuestionnaireData
  * @param {import('#lib/active-directory-token.js').SessionWithAuth} options.session
  * @returns {Instructions}
@@ -42,7 +42,7 @@ export const documentInstruction = ({
 	text,
 	folderInfo,
 	cypressDataName,
-	showDocuments = true,
+	displayMode,
 	lpaQuestionnaireData,
 	session
 }) => {
@@ -51,7 +51,7 @@ export const documentInstruction = ({
 		text,
 		appealId: lpaQuestionnaireData.appealId,
 		folderInfo,
-		showDocuments,
+		displayMode,
 		editable: userHasPermission(permissionNames.updateCase, session),
 		uploadUrlTemplate: buildDocumentUploadUrlTemplate(lpaQuestionnaireData.lpaQuestionnaireId),
 		manageUrl: mapDocumentManageUrl(

--- a/appeals/web/src/server/lib/mappers/data/lpa-questionnaire/submappers/map-additional-documents-contents.js
+++ b/appeals/web/src/server/lib/mappers/data/lpa-questionnaire/submappers/map-additional-documents-contents.js
@@ -16,13 +16,13 @@ export const mapAdditionalDocumentsContents = ({ lpaQuestionnaireData }) => ({
 								text: 'Additional documents',
 								classes: 'govuk-visually-hidden'
 							},
-							value: formatDocumentValues(
-								lpaQuestionnaireData.appealId,
-								isFolderInfo(lpaQuestionnaireData.documents.lpaCaseCorrespondence)
+							value: formatDocumentValues({
+								appealId: lpaQuestionnaireData.appealId,
+								documents: isFolderInfo(lpaQuestionnaireData.documents.lpaCaseCorrespondence)
 									? lpaQuestionnaireData.documents.lpaCaseCorrespondence.documents || []
 									: [],
-								true
-							),
+								isAdditionalDocuments: true
+							}),
 							actions: {
 								items: []
 							}


### PR DESCRIPTION
## Describe your changes

Add option to display document row values as text indicating the number of contained documents, rather than a file list. Applied to case details > case management > cross-team correspondence and inspector correspondence rows. Supporting refactoring.

## Issue ticket number and link

A2-1659

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [ ] I have performed a self-review of my own code
- [ ] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [ ] I have referenced the ticket number above
- [ ] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
