### PR TITLE
fix(tooling): updating node app service module version to 1.31

### DIFF
--- a/infrastructure/app-api.tf
+++ b/infrastructure/app-api.tf
@@ -1,6 +1,6 @@
 module "app_api" {
   #checkov:skip=CKV_TF_1: Use of commit hash are not required for our Terraform modules
-  source = "github.com/Planning-Inspectorate/infrastructure-modules.git//modules/node-app-service?ref=1.30"
+  source = "github.com/Planning-Inspectorate/infrastructure-modules.git//modules/node-app-service?ref=1.31"
 
   resource_group_name = azurerm_resource_group.primary.name
   location            = module.primary_region.location

--- a/infrastructure/app-web.tf
+++ b/infrastructure/app-web.tf
@@ -1,6 +1,6 @@
 module "app_web" {
   #checkov:skip=CKV_TF_1: Use of commit hash are not required for our Terraform modules
-  source = "github.com/Planning-Inspectorate/infrastructure-modules.git//modules/node-app-service?ref=1.30"
+  source = "github.com/Planning-Inspectorate/infrastructure-modules.git//modules/node-app-service?ref=1.31"
 
   resource_group_name = azurerm_resource_group.primary.name
   location            = module.primary_region.location


### PR DESCRIPTION
## Describe your changes

In v1.31, DOCKER_ENABLE_CI tag is set false which is essential to ensure that continuous deployment is not enabled for app services 

Comparison between 130 (current) and 1.31(new)
https://github.com/Planning-Inspectorate/infrastructure-modules/compare/1.30...1.31

<!--
    Please include a summary of the change along with any relevant context.
    List any dependencies that are required for this change.
-->

## Issue ticket number and link

https://pins-ds.atlassian.net/browse/DEV-273

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [ ] I have performed a self-review of my own code
- [ ] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [ ] I have referenced the ticket number above
- [ ] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
