### PR TITLE
Fix/a2 1504 a11y fieldsets legends update

### DIFF
--- a/appeals/web/src/server/appeals/appeal-details/allocation-details/__tests__/__snapshots__/allocation-details.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/allocation-details/__tests__/__snapshots__/allocation-details.test.js.snap
@@ -163,14 +163,16 @@ exports[`Allocation Details should render "Select the allocation level" Page 1`]
 "<main class="govuk-main-wrapper " id="main-content" role="main">
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-full"><span class="govuk-caption-l govuk-!-margin-bottom-3">Appeal 351062</span>
-            <h1             class="govuk-heading-xl govuk-!-margin-bottom-3">Select allocation level</h1>
         </div>
     </div>
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-full">
             <form action="" method="POST" novalidate>
-                <div class="govuk-!-margin-top-8">
-                    <div class="govuk-form-group">
+                <div class="govuk-form-group">
+                    <fieldset class="govuk-fieldset">
+                        <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+                            <h1 class="govuk-fieldset__heading"> Select allocation level</h1>
+                        </legend>
                         <div class="govuk-radios" data-module="govuk-radios">
                             <div class="govuk-radios__item">
                                 <input class="govuk-radios__input" id="allocation-level" name="allocation-level"
@@ -183,7 +185,7 @@ exports[`Allocation Details should render "Select the allocation level" Page 1`]
                                 <label class="govuk-label govuk-radios__label" for="allocation-level-2">B</label>
                             </div>
                         </div>
-                    </div>
+                    </fieldset>
                 </div>
                 <button class="govuk-button" data-module="govuk-button">Continue</button>
             </form>
@@ -211,14 +213,16 @@ exports[`Allocation Details should render "Select the allocation level" with err
     </div>
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-full"><span class="govuk-caption-l govuk-!-margin-bottom-3">Appeal 351062</span>
-            <h1             class="govuk-heading-xl govuk-!-margin-bottom-3">Select allocation level</h1>
         </div>
     </div>
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-full">
             <form action="" method="POST" novalidate>
-                <div class="govuk-!-margin-top-8">
-                    <div class="govuk-form-group">
+                <div class="govuk-form-group">
+                    <fieldset class="govuk-fieldset">
+                        <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+                            <h1 class="govuk-fieldset__heading"> Select allocation level</h1>
+                        </legend>
                         <div class="govuk-radios" data-module="govuk-radios">
                             <div class="govuk-radios__item">
                                 <input class="govuk-radios__input" id="allocation-level" name="allocation-level"
@@ -231,7 +235,7 @@ exports[`Allocation Details should render "Select the allocation level" with err
                                 <label class="govuk-label govuk-radios__label" for="allocation-level-2">B</label>
                             </div>
                         </div>
-                    </div>
+                    </fieldset>
                 </div>
                 <button class="govuk-button" data-module="govuk-button">Continue</button>
             </form>

--- a/appeals/web/src/server/appeals/appeal-details/allocation-details/allocation-details.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/allocation-details/allocation-details.mapper.js
@@ -25,18 +25,20 @@ export function allocationDetailsLevelPage(
 		backLinkText: 'Back to case details',
 		backLinkUrl: `/appeals-service/appeal-details/${appealDetails.appealId}`,
 		preHeading: `Appeal ${shortAppealReference}`,
-		heading: 'Select allocation level',
 		pageComponents: [
 			{
 				type: 'radios',
-				wrapperHtml: {
-					opening: '<div class="govuk-!-margin-top-8">',
-					closing: '</div>'
-				},
 				parameters: {
 					name: 'allocation-level',
 					idPrefix: 'allocation-level',
 					value: selectedAllocationLevel || null,
+					fieldset: {
+						legend: {
+							text: 'Select allocation level',
+							isPageHeading: true,
+							classes: 'govuk-fieldset__legend--l'
+						}
+					},
 					items: allocationDetailsData.allocationDetailsLevels.map((item) => ({
 						value: item.level,
 						text: item.level

--- a/appeals/web/src/server/appeals/appeal-details/appellant-case/agricultural-holding/__tests__/__snapshots__/agricultural-holding.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/appellant-case/agricultural-holding/__tests__/__snapshots__/agricultural-holding.test.js.snap
@@ -6,25 +6,29 @@ exports[`agricultural-holding GET /change should render the change part of agric
         <div class="govuk-grid-column-two-thirds">
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full"><span class="govuk-caption-l govuk-!-margin-bottom-3">Appeal 351062</span>
-                    <h1                     class="govuk-heading-l govuk-!-margin-bottom-3">Change part of agricultural holding</h1>
                 </div>
             </div>
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full">
                     <form method="POST" novalidate="novalidate">
                         <div class="govuk-form-group">
-                            <div class="govuk-radios" data-module="govuk-radios">
-                                <div class="govuk-radios__item">
-                                    <input class="govuk-radios__input" id="partOfAgriculturalHoldingRadio"
-                                    name="partOfAgriculturalHoldingRadio" type="radio" value="yes">
-                                    <label class="govuk-label govuk-radios__label" for="partOfAgriculturalHoldingRadio">Yes</label>
+                            <fieldset class="govuk-fieldset">
+                                <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+                                    <h1 class="govuk-fieldset__heading"> Change part of agricultural holding</h1>
+                                </legend>
+                                <div class="govuk-radios" data-module="govuk-radios">
+                                    <div class="govuk-radios__item">
+                                        <input class="govuk-radios__input" id="partOfAgriculturalHoldingRadio"
+                                        name="partOfAgriculturalHoldingRadio" type="radio" value="yes">
+                                        <label class="govuk-label govuk-radios__label" for="partOfAgriculturalHoldingRadio">Yes</label>
+                                    </div>
+                                    <div class="govuk-radios__item">
+                                        <input class="govuk-radios__input" id="partOfAgriculturalHoldingRadio-2"
+                                        name="partOfAgriculturalHoldingRadio" type="radio" value="no" checked>
+                                        <label class="govuk-label govuk-radios__label" for="partOfAgriculturalHoldingRadio-2">No</label>
+                                    </div>
                                 </div>
-                                <div class="govuk-radios__item">
-                                    <input class="govuk-radios__input" id="partOfAgriculturalHoldingRadio-2"
-                                    name="partOfAgriculturalHoldingRadio" type="radio" value="no" checked>
-                                    <label class="govuk-label govuk-radios__label" for="partOfAgriculturalHoldingRadio-2">No</label>
-                                </div>
-                            </div>
+                            </fieldset>
                         </div>
                         <button type="submit" data-prevent-double-click="true" class="govuk-button"
                         data-module="govuk-button">Continue</button>
@@ -42,25 +46,29 @@ exports[`agricultural-holding GET /change should render the change part of agric
         <div class="govuk-grid-column-two-thirds">
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full"><span class="govuk-caption-l govuk-!-margin-bottom-3">Appeal 351062</span>
-                    <h1                     class="govuk-heading-l govuk-!-margin-bottom-3">Change part of agricultural holding</h1>
                 </div>
             </div>
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full">
                     <form method="POST" novalidate="novalidate">
                         <div class="govuk-form-group">
-                            <div class="govuk-radios" data-module="govuk-radios">
-                                <div class="govuk-radios__item">
-                                    <input class="govuk-radios__input" id="partOfAgriculturalHoldingRadio"
-                                    name="partOfAgriculturalHoldingRadio" type="radio" value="yes" checked>
-                                    <label class="govuk-label govuk-radios__label" for="partOfAgriculturalHoldingRadio">Yes</label>
+                            <fieldset class="govuk-fieldset">
+                                <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+                                    <h1 class="govuk-fieldset__heading"> Change part of agricultural holding</h1>
+                                </legend>
+                                <div class="govuk-radios" data-module="govuk-radios">
+                                    <div class="govuk-radios__item">
+                                        <input class="govuk-radios__input" id="partOfAgriculturalHoldingRadio"
+                                        name="partOfAgriculturalHoldingRadio" type="radio" value="yes" checked>
+                                        <label class="govuk-label govuk-radios__label" for="partOfAgriculturalHoldingRadio">Yes</label>
+                                    </div>
+                                    <div class="govuk-radios__item">
+                                        <input class="govuk-radios__input" id="partOfAgriculturalHoldingRadio-2"
+                                        name="partOfAgriculturalHoldingRadio" type="radio" value="no">
+                                        <label class="govuk-label govuk-radios__label" for="partOfAgriculturalHoldingRadio-2">No</label>
+                                    </div>
                                 </div>
-                                <div class="govuk-radios__item">
-                                    <input class="govuk-radios__input" id="partOfAgriculturalHoldingRadio-2"
-                                    name="partOfAgriculturalHoldingRadio" type="radio" value="no">
-                                    <label class="govuk-label govuk-radios__label" for="partOfAgriculturalHoldingRadio-2">No</label>
-                                </div>
-                            </div>
+                            </fieldset>
                         </div>
                         <button type="submit" data-prevent-double-click="true" class="govuk-button"
                         data-module="govuk-button">Continue</button>
@@ -78,25 +86,29 @@ exports[`agricultural-holding GET /other-tenants/change should render the change
         <div class="govuk-grid-column-two-thirds">
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full"><span class="govuk-caption-l govuk-!-margin-bottom-3">Appeal 351062</span>
-                    <h1                     class="govuk-heading-l govuk-!-margin-bottom-3">Change other tenants of agricultural holding</h1>
                 </div>
             </div>
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full">
                     <form method="POST" novalidate="novalidate">
                         <div class="govuk-form-group">
-                            <div class="govuk-radios" data-module="govuk-radios">
-                                <div class="govuk-radios__item">
-                                    <input class="govuk-radios__input" id="otherTenantsOfAgriculturalHoldingRadio"
-                                    name="otherTenantsOfAgriculturalHoldingRadio" type="radio" value="yes">
-                                    <label class="govuk-label govuk-radios__label" for="otherTenantsOfAgriculturalHoldingRadio">Yes</label>
+                            <fieldset class="govuk-fieldset">
+                                <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+                                    <h1 class="govuk-fieldset__heading"> Change other tenants of agricultural holding</h1>
+                                </legend>
+                                <div class="govuk-radios" data-module="govuk-radios">
+                                    <div class="govuk-radios__item">
+                                        <input class="govuk-radios__input" id="otherTenantsOfAgriculturalHoldingRadio"
+                                        name="otherTenantsOfAgriculturalHoldingRadio" type="radio" value="yes">
+                                        <label class="govuk-label govuk-radios__label" for="otherTenantsOfAgriculturalHoldingRadio">Yes</label>
+                                    </div>
+                                    <div class="govuk-radios__item">
+                                        <input class="govuk-radios__input" id="otherTenantsOfAgriculturalHoldingRadio-2"
+                                        name="otherTenantsOfAgriculturalHoldingRadio" type="radio" value="no" checked>
+                                        <label class="govuk-label govuk-radios__label" for="otherTenantsOfAgriculturalHoldingRadio-2">No</label>
+                                    </div>
                                 </div>
-                                <div class="govuk-radios__item">
-                                    <input class="govuk-radios__input" id="otherTenantsOfAgriculturalHoldingRadio-2"
-                                    name="otherTenantsOfAgriculturalHoldingRadio" type="radio" value="no" checked>
-                                    <label class="govuk-label govuk-radios__label" for="otherTenantsOfAgriculturalHoldingRadio-2">No</label>
-                                </div>
-                            </div>
+                            </fieldset>
                         </div>
                         <button type="submit" data-prevent-double-click="true" class="govuk-button"
                         data-module="govuk-button">Continue</button>
@@ -114,26 +126,30 @@ exports[`agricultural-holding GET /other-tenants/change should render the change
         <div class="govuk-grid-column-two-thirds">
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full"><span class="govuk-caption-l govuk-!-margin-bottom-3">Appeal 351062</span>
-                    <h1                     class="govuk-heading-l govuk-!-margin-bottom-3">Change other tenants of agricultural holding</h1>
                 </div>
             </div>
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full">
                     <form method="POST" novalidate="novalidate">
                         <div class="govuk-form-group">
-                            <div class="govuk-radios" data-module="govuk-radios">
-                                <div class="govuk-radios__item">
-                                    <input class="govuk-radios__input" id="otherTenantsOfAgriculturalHoldingRadio"
-                                    name="otherTenantsOfAgriculturalHoldingRadio" type="radio" value="yes"
-                                    checked>
-                                    <label class="govuk-label govuk-radios__label" for="otherTenantsOfAgriculturalHoldingRadio">Yes</label>
+                            <fieldset class="govuk-fieldset">
+                                <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+                                    <h1 class="govuk-fieldset__heading"> Change other tenants of agricultural holding</h1>
+                                </legend>
+                                <div class="govuk-radios" data-module="govuk-radios">
+                                    <div class="govuk-radios__item">
+                                        <input class="govuk-radios__input" id="otherTenantsOfAgriculturalHoldingRadio"
+                                        name="otherTenantsOfAgriculturalHoldingRadio" type="radio" value="yes"
+                                        checked>
+                                        <label class="govuk-label govuk-radios__label" for="otherTenantsOfAgriculturalHoldingRadio">Yes</label>
+                                    </div>
+                                    <div class="govuk-radios__item">
+                                        <input class="govuk-radios__input" id="otherTenantsOfAgriculturalHoldingRadio-2"
+                                        name="otherTenantsOfAgriculturalHoldingRadio" type="radio" value="no">
+                                        <label class="govuk-label govuk-radios__label" for="otherTenantsOfAgriculturalHoldingRadio-2">No</label>
+                                    </div>
                                 </div>
-                                <div class="govuk-radios__item">
-                                    <input class="govuk-radios__input" id="otherTenantsOfAgriculturalHoldingRadio-2"
-                                    name="otherTenantsOfAgriculturalHoldingRadio" type="radio" value="no">
-                                    <label class="govuk-label govuk-radios__label" for="otherTenantsOfAgriculturalHoldingRadio-2">No</label>
-                                </div>
-                            </div>
+                            </fieldset>
                         </div>
                         <button type="submit" data-prevent-double-click="true" class="govuk-button"
                         data-module="govuk-button">Continue</button>
@@ -151,25 +167,29 @@ exports[`agricultural-holding GET /tenant/change should render the change tenant
         <div class="govuk-grid-column-two-thirds">
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full"><span class="govuk-caption-l govuk-!-margin-bottom-3">Appeal 351062</span>
-                    <h1                     class="govuk-heading-l govuk-!-margin-bottom-3">Change tenant of agricultural holding</h1>
                 </div>
             </div>
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full">
                     <form method="POST" novalidate="novalidate">
                         <div class="govuk-form-group">
-                            <div class="govuk-radios" data-module="govuk-radios">
-                                <div class="govuk-radios__item">
-                                    <input class="govuk-radios__input" id="tenantOfAgriculturalHoldingRadio"
-                                    name="tenantOfAgriculturalHoldingRadio" type="radio" value="yes">
-                                    <label class="govuk-label govuk-radios__label" for="tenantOfAgriculturalHoldingRadio">Yes</label>
+                            <fieldset class="govuk-fieldset">
+                                <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+                                    <h1 class="govuk-fieldset__heading"> Change tenant of agricultural holding</h1>
+                                </legend>
+                                <div class="govuk-radios" data-module="govuk-radios">
+                                    <div class="govuk-radios__item">
+                                        <input class="govuk-radios__input" id="tenantOfAgriculturalHoldingRadio"
+                                        name="tenantOfAgriculturalHoldingRadio" type="radio" value="yes">
+                                        <label class="govuk-label govuk-radios__label" for="tenantOfAgriculturalHoldingRadio">Yes</label>
+                                    </div>
+                                    <div class="govuk-radios__item">
+                                        <input class="govuk-radios__input" id="tenantOfAgriculturalHoldingRadio-2"
+                                        name="tenantOfAgriculturalHoldingRadio" type="radio" value="no" checked>
+                                        <label class="govuk-label govuk-radios__label" for="tenantOfAgriculturalHoldingRadio-2">No</label>
+                                    </div>
                                 </div>
-                                <div class="govuk-radios__item">
-                                    <input class="govuk-radios__input" id="tenantOfAgriculturalHoldingRadio-2"
-                                    name="tenantOfAgriculturalHoldingRadio" type="radio" value="no" checked>
-                                    <label class="govuk-label govuk-radios__label" for="tenantOfAgriculturalHoldingRadio-2">No</label>
-                                </div>
-                            </div>
+                            </fieldset>
                         </div>
                         <button type="submit" data-prevent-double-click="true" class="govuk-button"
                         data-module="govuk-button">Continue</button>
@@ -187,25 +207,29 @@ exports[`agricultural-holding GET /tenant/change should render the change tenant
         <div class="govuk-grid-column-two-thirds">
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full"><span class="govuk-caption-l govuk-!-margin-bottom-3">Appeal 351062</span>
-                    <h1                     class="govuk-heading-l govuk-!-margin-bottom-3">Change tenant of agricultural holding</h1>
                 </div>
             </div>
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full">
                     <form method="POST" novalidate="novalidate">
                         <div class="govuk-form-group">
-                            <div class="govuk-radios" data-module="govuk-radios">
-                                <div class="govuk-radios__item">
-                                    <input class="govuk-radios__input" id="tenantOfAgriculturalHoldingRadio"
-                                    name="tenantOfAgriculturalHoldingRadio" type="radio" value="yes" checked>
-                                    <label class="govuk-label govuk-radios__label" for="tenantOfAgriculturalHoldingRadio">Yes</label>
+                            <fieldset class="govuk-fieldset">
+                                <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+                                    <h1 class="govuk-fieldset__heading"> Change tenant of agricultural holding</h1>
+                                </legend>
+                                <div class="govuk-radios" data-module="govuk-radios">
+                                    <div class="govuk-radios__item">
+                                        <input class="govuk-radios__input" id="tenantOfAgriculturalHoldingRadio"
+                                        name="tenantOfAgriculturalHoldingRadio" type="radio" value="yes" checked>
+                                        <label class="govuk-label govuk-radios__label" for="tenantOfAgriculturalHoldingRadio">Yes</label>
+                                    </div>
+                                    <div class="govuk-radios__item">
+                                        <input class="govuk-radios__input" id="tenantOfAgriculturalHoldingRadio-2"
+                                        name="tenantOfAgriculturalHoldingRadio" type="radio" value="no">
+                                        <label class="govuk-label govuk-radios__label" for="tenantOfAgriculturalHoldingRadio-2">No</label>
+                                    </div>
                                 </div>
-                                <div class="govuk-radios__item">
-                                    <input class="govuk-radios__input" id="tenantOfAgriculturalHoldingRadio-2"
-                                    name="tenantOfAgriculturalHoldingRadio" type="radio" value="no">
-                                    <label class="govuk-label govuk-radios__label" for="tenantOfAgriculturalHoldingRadio-2">No</label>
-                                </div>
-                            </div>
+                            </fieldset>
                         </div>
                         <button type="submit" data-prevent-double-click="true" class="govuk-button"
                         data-module="govuk-button">Continue</button>

--- a/appeals/web/src/server/appeals/appeal-details/appellant-case/agricultural-holding/agricultural-holding.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/appellant-case/agricultural-holding/agricultural-holding.mapper.js
@@ -28,11 +28,12 @@ export const changePartOfAgriculturalHoldingPage = (
 		title: `Change part of agricultural holding`,
 		backLinkUrl: `/appeals-service/appeal-details/${appealData.appealId}/appellant-case`,
 		preHeading: `Appeal ${shortAppealReference}`,
-		heading: `Change part of agricultural holding`,
 		pageComponents: [
 			yesNoInput({
 				name: 'partOfAgriculturalHoldingRadio',
-				value: partOfAgriculturalHolding
+				value: partOfAgriculturalHolding,
+				legendText: 'Change part of agricultural holding',
+				legendIsPageHeading: true
 			})
 		]
 	};
@@ -64,11 +65,12 @@ export const changeTenantOfAgriculturalHoldingPage = (
 		title: `Change tenant of agricultural holding`,
 		backLinkUrl: `/appeals-service/appeal-details/${appealData.appealId}/appellant-case`,
 		preHeading: `Appeal ${shortAppealReference}`,
-		heading: `Change tenant of agricultural holding`,
 		pageComponents: [
 			yesNoInput({
 				name: 'tenantOfAgriculturalHoldingRadio',
-				value: tenantOfAgriculturalHolding
+				value: tenantOfAgriculturalHolding,
+				legendText: 'Change tenant of agricultural holding',
+				legendIsPageHeading: true
 			})
 		]
 	};
@@ -100,11 +102,12 @@ export const changeOtherTenantsOfAgriculturalHoldingPage = (
 		title: `Change other tenants of agricultural holding`,
 		backLinkUrl: `/appeals-service/appeal-details/${appealData.appealId}/appellant-case`,
 		preHeading: `Appeal ${shortAppealReference}`,
-		heading: `Change other tenants of agricultural holding`,
 		pageComponents: [
 			yesNoInput({
 				name: 'otherTenantsOfAgriculturalHoldingRadio',
-				value: otherTenantsOfAgriculturalHolding
+				value: otherTenantsOfAgriculturalHolding,
+				legendText: 'Change other tenants of agricultural holding',
+				legendIsPageHeading: true
 			})
 		]
 	};

--- a/appeals/web/src/server/appeals/appeal-details/appellant-case/application-decision-date/__tests__/__snapshots__/application-decision-date.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/appellant-case/application-decision-date/__tests__/__snapshots__/application-decision-date.test.js.snap
@@ -6,40 +6,44 @@ exports[`application-decision-date GET /change should render the application dec
         <div class="govuk-grid-column-two-thirds">
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full"><span class="govuk-caption-l govuk-!-margin-bottom-3">Appeal 351062</span>
-                    <h1                     class="govuk-heading-l govuk-!-margin-bottom-3">Change application decision date</h1>
                 </div>
             </div>
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full">
                     <form method="POST" novalidate="novalidate">
                         <div class="govuk-form-group">
-                            <div id="application-decision-date-hint" class="govuk-hint">For example, 27 3 2007</div>
-                            <div class="govuk-date-input" id="application-decision-date">
-                                <div class="govuk-date-input__item">
-                                    <div class="govuk-form-group">
-                                        <label class="govuk-label govuk-date-input__label" for="application-decision-date-day">Day</label>
-                                        <input class="govuk-input govuk-date-input__input govuk-input--width-2"
-                                        id="application-decision-date-day" name="application-decision-date-day"
-                                        type="text" inputmode="numeric">
+                            <fieldset class="govuk-fieldset" role="group" aria-describedby="application-decision-date-hint">
+                                <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+                                    <h1 class="govuk-fieldset__heading"> Change application decision date</h1>
+                                </legend>
+                                <div id="application-decision-date-hint" class="govuk-hint">For example, 27 3 2007</div>
+                                <div class="govuk-date-input" id="application-decision-date">
+                                    <div class="govuk-date-input__item">
+                                        <div class="govuk-form-group">
+                                            <label class="govuk-label govuk-date-input__label" for="application-decision-date-day">Day</label>
+                                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                                            id="application-decision-date-day" name="application-decision-date-day"
+                                            type="text" inputmode="numeric">
+                                        </div>
+                                    </div>
+                                    <div class="govuk-date-input__item">
+                                        <div class="govuk-form-group">
+                                            <label class="govuk-label govuk-date-input__label" for="application-decision-date-month">Month</label>
+                                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                                            id="application-decision-date-month" name="application-decision-date-month"
+                                            type="text" inputmode="numeric">
+                                        </div>
+                                    </div>
+                                    <div class="govuk-date-input__item">
+                                        <div class="govuk-form-group">
+                                            <label class="govuk-label govuk-date-input__label" for="application-decision-date-year">Year</label>
+                                            <input class="govuk-input govuk-date-input__input govuk-input--width-4"
+                                            id="application-decision-date-year" name="application-decision-date-year"
+                                            type="text" inputmode="numeric">
+                                        </div>
                                     </div>
                                 </div>
-                                <div class="govuk-date-input__item">
-                                    <div class="govuk-form-group">
-                                        <label class="govuk-label govuk-date-input__label" for="application-decision-date-month">Month</label>
-                                        <input class="govuk-input govuk-date-input__input govuk-input--width-2"
-                                        id="application-decision-date-month" name="application-decision-date-month"
-                                        type="text" inputmode="numeric">
-                                    </div>
-                                </div>
-                                <div class="govuk-date-input__item">
-                                    <div class="govuk-form-group">
-                                        <label class="govuk-label govuk-date-input__label" for="application-decision-date-year">Year</label>
-                                        <input class="govuk-input govuk-date-input__input govuk-input--width-4"
-                                        id="application-decision-date-year" name="application-decision-date-year"
-                                        type="text" inputmode="numeric">
-                                    </div>
-                                </div>
-                            </div>
+                            </fieldset>
                         </div>
                         <button type="submit" data-prevent-double-click="true" class="govuk-button"
                         data-module="govuk-button">Continue</button>
@@ -70,40 +74,44 @@ exports[`application-decision-date POST /change should re-render applicationdeci
             </div>
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full"><span class="govuk-caption-l govuk-!-margin-bottom-3">Appeal 351062</span>
-                    <h1                     class="govuk-heading-l govuk-!-margin-bottom-3">Change application decision date</h1>
                 </div>
             </div>
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full">
                     <form method="POST" novalidate="novalidate">
                         <div class="govuk-form-group">
-                            <div id="application-decision-date-hint" class="govuk-hint">For example, 27 3 2007</div>
-                            <div class="govuk-date-input" id="application-decision-date">
-                                <div class="govuk-date-input__item">
-                                    <div class="govuk-form-group">
-                                        <label class="govuk-label govuk-date-input__label" for="application-decision-date-day">Day</label>
-                                        <input class="govuk-input govuk-date-input__input govuk-input--width-2"
-                                        id="application-decision-date-day" name="application-decision-date-day"
-                                        type="text" value="32" inputmode="numeric">
+                            <fieldset class="govuk-fieldset" role="group" aria-describedby="application-decision-date-hint">
+                                <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+                                    <h1 class="govuk-fieldset__heading"> Change application decision date</h1>
+                                </legend>
+                                <div id="application-decision-date-hint" class="govuk-hint">For example, 27 3 2007</div>
+                                <div class="govuk-date-input" id="application-decision-date">
+                                    <div class="govuk-date-input__item">
+                                        <div class="govuk-form-group">
+                                            <label class="govuk-label govuk-date-input__label" for="application-decision-date-day">Day</label>
+                                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                                            id="application-decision-date-day" name="application-decision-date-day"
+                                            type="text" value="32" inputmode="numeric">
+                                        </div>
+                                    </div>
+                                    <div class="govuk-date-input__item">
+                                        <div class="govuk-form-group">
+                                            <label class="govuk-label govuk-date-input__label" for="application-decision-date-month">Month</label>
+                                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                                            id="application-decision-date-month" name="application-decision-date-month"
+                                            type="text" value="06" inputmode="numeric">
+                                        </div>
+                                    </div>
+                                    <div class="govuk-date-input__item">
+                                        <div class="govuk-form-group">
+                                            <label class="govuk-label govuk-date-input__label" for="application-decision-date-year">Year</label>
+                                            <input class="govuk-input govuk-date-input__input govuk-input--width-4"
+                                            id="application-decision-date-year" name="application-decision-date-year"
+                                            type="text" value="2021" inputmode="numeric">
+                                        </div>
                                     </div>
                                 </div>
-                                <div class="govuk-date-input__item">
-                                    <div class="govuk-form-group">
-                                        <label class="govuk-label govuk-date-input__label" for="application-decision-date-month">Month</label>
-                                        <input class="govuk-input govuk-date-input__input govuk-input--width-2"
-                                        id="application-decision-date-month" name="application-decision-date-month"
-                                        type="text" value="06" inputmode="numeric">
-                                    </div>
-                                </div>
-                                <div class="govuk-date-input__item">
-                                    <div class="govuk-form-group">
-                                        <label class="govuk-label govuk-date-input__label" for="application-decision-date-year">Year</label>
-                                        <input class="govuk-input govuk-date-input__input govuk-input--width-4"
-                                        id="application-decision-date-year" name="application-decision-date-year"
-                                        type="text" value="2021" inputmode="numeric">
-                                    </div>
-                                </div>
-                            </div>
+                            </fieldset>
                         </div>
                         <button type="submit" data-prevent-double-click="true" class="govuk-button"
                         data-module="govuk-button">Continue</button>
@@ -134,40 +142,44 @@ exports[`application-decision-date POST /change should re-render applicationdeci
             </div>
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full"><span class="govuk-caption-l govuk-!-margin-bottom-3">Appeal 351062</span>
-                    <h1                     class="govuk-heading-l govuk-!-margin-bottom-3">Change application decision date</h1>
                 </div>
             </div>
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full">
                     <form method="POST" novalidate="novalidate">
                         <div class="govuk-form-group">
-                            <div id="application-decision-date-hint" class="govuk-hint">For example, 27 3 2007</div>
-                            <div class="govuk-date-input" id="application-decision-date">
-                                <div class="govuk-date-input__item">
-                                    <div class="govuk-form-group">
-                                        <label class="govuk-label govuk-date-input__label" for="application-decision-date-day">Day</label>
-                                        <input class="govuk-input govuk-date-input__input govuk-input--width-2"
-                                        id="application-decision-date-day" name="application-decision-date-day"
-                                        type="text" value="15" inputmode="numeric">
+                            <fieldset class="govuk-fieldset" role="group" aria-describedby="application-decision-date-hint">
+                                <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+                                    <h1 class="govuk-fieldset__heading"> Change application decision date</h1>
+                                </legend>
+                                <div id="application-decision-date-hint" class="govuk-hint">For example, 27 3 2007</div>
+                                <div class="govuk-date-input" id="application-decision-date">
+                                    <div class="govuk-date-input__item">
+                                        <div class="govuk-form-group">
+                                            <label class="govuk-label govuk-date-input__label" for="application-decision-date-day">Day</label>
+                                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                                            id="application-decision-date-day" name="application-decision-date-day"
+                                            type="text" value="15" inputmode="numeric">
+                                        </div>
+                                    </div>
+                                    <div class="govuk-date-input__item">
+                                        <div class="govuk-form-group">
+                                            <label class="govuk-label govuk-date-input__label" for="application-decision-date-month">Month</label>
+                                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                                            id="application-decision-date-month" name="application-decision-date-month"
+                                            type="text" value="15" inputmode="numeric">
+                                        </div>
+                                    </div>
+                                    <div class="govuk-date-input__item">
+                                        <div class="govuk-form-group">
+                                            <label class="govuk-label govuk-date-input__label" for="application-decision-date-year">Year</label>
+                                            <input class="govuk-input govuk-date-input__input govuk-input--width-4"
+                                            id="application-decision-date-year" name="application-decision-date-year"
+                                            type="text" value="2021" inputmode="numeric">
+                                        </div>
                                     </div>
                                 </div>
-                                <div class="govuk-date-input__item">
-                                    <div class="govuk-form-group">
-                                        <label class="govuk-label govuk-date-input__label" for="application-decision-date-month">Month</label>
-                                        <input class="govuk-input govuk-date-input__input govuk-input--width-2"
-                                        id="application-decision-date-month" name="application-decision-date-month"
-                                        type="text" value="15" inputmode="numeric">
-                                    </div>
-                                </div>
-                                <div class="govuk-date-input__item">
-                                    <div class="govuk-form-group">
-                                        <label class="govuk-label govuk-date-input__label" for="application-decision-date-year">Year</label>
-                                        <input class="govuk-input govuk-date-input__input govuk-input--width-4"
-                                        id="application-decision-date-year" name="application-decision-date-year"
-                                        type="text" value="2021" inputmode="numeric">
-                                    </div>
-                                </div>
-                            </div>
+                            </fieldset>
                         </div>
                         <button type="submit" data-prevent-double-click="true" class="govuk-button"
                         data-module="govuk-button">Continue</button>
@@ -198,40 +210,44 @@ exports[`application-decision-date POST /change should re-render to applicationd
             </div>
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full"><span class="govuk-caption-l govuk-!-margin-bottom-3">Appeal 351062</span>
-                    <h1                     class="govuk-heading-l govuk-!-margin-bottom-3">Change application decision date</h1>
                 </div>
             </div>
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full">
                     <form method="POST" novalidate="novalidate">
                         <div class="govuk-form-group">
-                            <div id="application-decision-date-hint" class="govuk-hint">For example, 27 3 2007</div>
-                            <div class="govuk-date-input" id="application-decision-date">
-                                <div class="govuk-date-input__item">
-                                    <div class="govuk-form-group">
-                                        <label class="govuk-label govuk-date-input__label" for="application-decision-date-day">Day</label>
-                                        <input class="govuk-input govuk-date-input__input govuk-input--width-2"
-                                        id="application-decision-date-day" name="application-decision-date-day"
-                                        type="text" value="15" inputmode="numeric">
+                            <fieldset class="govuk-fieldset" role="group" aria-describedby="application-decision-date-hint">
+                                <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+                                    <h1 class="govuk-fieldset__heading"> Change application decision date</h1>
+                                </legend>
+                                <div id="application-decision-date-hint" class="govuk-hint">For example, 27 3 2007</div>
+                                <div class="govuk-date-input" id="application-decision-date">
+                                    <div class="govuk-date-input__item">
+                                        <div class="govuk-form-group">
+                                            <label class="govuk-label govuk-date-input__label" for="application-decision-date-day">Day</label>
+                                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                                            id="application-decision-date-day" name="application-decision-date-day"
+                                            type="text" value="15" inputmode="numeric">
+                                        </div>
+                                    </div>
+                                    <div class="govuk-date-input__item">
+                                        <div class="govuk-form-group">
+                                            <label class="govuk-label govuk-date-input__label" for="application-decision-date-month">Month</label>
+                                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                                            id="application-decision-date-month" name="application-decision-date-month"
+                                            type="text" value="12" inputmode="numeric">
+                                        </div>
+                                    </div>
+                                    <div class="govuk-date-input__item">
+                                        <div class="govuk-form-group">
+                                            <label class="govuk-label govuk-date-input__label" for="application-decision-date-year">Year</label>
+                                            <input class="govuk-input govuk-date-input__input govuk-input--width-4"
+                                            id="application-decision-date-year" name="application-decision-date-year"
+                                            type="text" value="a" inputmode="numeric">
+                                        </div>
                                     </div>
                                 </div>
-                                <div class="govuk-date-input__item">
-                                    <div class="govuk-form-group">
-                                        <label class="govuk-label govuk-date-input__label" for="application-decision-date-month">Month</label>
-                                        <input class="govuk-input govuk-date-input__input govuk-input--width-2"
-                                        id="application-decision-date-month" name="application-decision-date-month"
-                                        type="text" value="12" inputmode="numeric">
-                                    </div>
-                                </div>
-                                <div class="govuk-date-input__item">
-                                    <div class="govuk-form-group">
-                                        <label class="govuk-label govuk-date-input__label" for="application-decision-date-year">Year</label>
-                                        <input class="govuk-input govuk-date-input__input govuk-input--width-4"
-                                        id="application-decision-date-year" name="application-decision-date-year"
-                                        type="text" value="a" inputmode="numeric">
-                                    </div>
-                                </div>
-                            </div>
+                            </fieldset>
                         </div>
                         <button type="submit" data-prevent-double-click="true" class="govuk-button"
                         data-module="govuk-button">Continue</button>

--- a/appeals/web/src/server/appeals/appeal-details/appellant-case/application-decision-date/application-decision-date.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/appellant-case/application-decision-date/application-decision-date.mapper.js
@@ -44,7 +44,6 @@ export const changeApplicationDecisionDatePage = (
 		title: 'Change application decision date',
 		backLinkUrl: `/appeals-service/appeal-details/${appealData.appealId}/appellant-case`,
 		preHeading: `Appeal ${shortAppealReference}`,
-		heading: 'Change application decision date',
 		pageComponents: [
 			{
 				type: 'date-input',
@@ -52,6 +51,13 @@ export const changeApplicationDecisionDatePage = (
 					name: 'applicationDecisionDate',
 					id: 'application-decision-date',
 					namePrefix: 'application-decision-date',
+					fieldset: {
+						legend: {
+							text: 'Change application decision date',
+							isPageHeading: true,
+							classes: 'govuk-fieldset__legend--l'
+						}
+					},
 					hint: {
 						text: 'For example, 27 3 2007'
 					},

--- a/appeals/web/src/server/appeals/appeal-details/appellant-case/application-outcome/__tests__/__snapshots__/application-outcome.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/appellant-case/application-outcome/__tests__/__snapshots__/application-outcome.test.js.snap
@@ -6,30 +6,34 @@ exports[`application-outcome GET /change should render the applicationOutcome ch
         <div class="govuk-grid-column-two-thirds">
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full"><span class="govuk-caption-l govuk-!-margin-bottom-3">Appeal 351062</span>
-                    <h1                     class="govuk-heading-l govuk-!-margin-bottom-3">Change application decision outcome</h1>
                 </div>
             </div>
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full">
                     <form method="POST" novalidate="novalidate">
                         <div class="govuk-form-group">
-                            <div class="govuk-radios" data-module="govuk-radios">
-                                <div class="govuk-radios__item">
-                                    <input class="govuk-radios__input" id="application-outcome" name="applicationOutcome"
-                                    type="radio" value="granted">
-                                    <label class="govuk-label govuk-radios__label" for="application-outcome">Granted with conditions</label>
+                            <fieldset class="govuk-fieldset">
+                                <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+                                    <h1 class="govuk-fieldset__heading"> Change application decision outcome</h1>
+                                </legend>
+                                <div class="govuk-radios" data-module="govuk-radios">
+                                    <div class="govuk-radios__item">
+                                        <input class="govuk-radios__input" id="application-outcome" name="applicationOutcome"
+                                        type="radio" value="granted">
+                                        <label class="govuk-label govuk-radios__label" for="application-outcome">Granted with conditions</label>
+                                    </div>
+                                    <div class="govuk-radios__item">
+                                        <input class="govuk-radios__input" id="application-outcome-2" name="applicationOutcome"
+                                        type="radio" value="refused">
+                                        <label class="govuk-label govuk-radios__label" for="application-outcome-2">Refused</label>
+                                    </div>
+                                    <div class="govuk-radios__item">
+                                        <input class="govuk-radios__input" id="application-outcome-3" name="applicationOutcome"
+                                        type="radio" value="not_received">
+                                        <label class="govuk-label govuk-radios__label" for="application-outcome-3">Not received</label>
+                                    </div>
                                 </div>
-                                <div class="govuk-radios__item">
-                                    <input class="govuk-radios__input" id="application-outcome-2" name="applicationOutcome"
-                                    type="radio" value="refused">
-                                    <label class="govuk-label govuk-radios__label" for="application-outcome-2">Refused</label>
-                                </div>
-                                <div class="govuk-radios__item">
-                                    <input class="govuk-radios__input" id="application-outcome-3" name="applicationOutcome"
-                                    type="radio" value="not_received">
-                                    <label class="govuk-label govuk-radios__label" for="application-outcome-3">Not received</label>
-                                </div>
-                            </div>
+                            </fieldset>
                         </div>
                         <button type="submit" data-prevent-double-click="true" class="govuk-button"
                         data-module="govuk-button">Continue</button>
@@ -58,30 +62,34 @@ exports[`application-outcome POST /change should re-render applicationOutcome ch
             </div>
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full"><span class="govuk-caption-l govuk-!-margin-bottom-3">Appeal 351062</span>
-                    <h1                     class="govuk-heading-l govuk-!-margin-bottom-3">Change application decision outcome</h1>
                 </div>
             </div>
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full">
                     <form method="POST" novalidate="novalidate">
                         <div class="govuk-form-group">
-                            <div class="govuk-radios" data-module="govuk-radios">
-                                <div class="govuk-radios__item">
-                                    <input class="govuk-radios__input" id="application-outcome" name="applicationOutcome"
-                                    type="radio" value="granted">
-                                    <label class="govuk-label govuk-radios__label" for="application-outcome">Granted with conditions</label>
+                            <fieldset class="govuk-fieldset">
+                                <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+                                    <h1 class="govuk-fieldset__heading"> Change application decision outcome</h1>
+                                </legend>
+                                <div class="govuk-radios" data-module="govuk-radios">
+                                    <div class="govuk-radios__item">
+                                        <input class="govuk-radios__input" id="application-outcome" name="applicationOutcome"
+                                        type="radio" value="granted">
+                                        <label class="govuk-label govuk-radios__label" for="application-outcome">Granted with conditions</label>
+                                    </div>
+                                    <div class="govuk-radios__item">
+                                        <input class="govuk-radios__input" id="application-outcome-2" name="applicationOutcome"
+                                        type="radio" value="refused">
+                                        <label class="govuk-label govuk-radios__label" for="application-outcome-2">Refused</label>
+                                    </div>
+                                    <div class="govuk-radios__item">
+                                        <input class="govuk-radios__input" id="application-outcome-3" name="applicationOutcome"
+                                        type="radio" value="not_received">
+                                        <label class="govuk-label govuk-radios__label" for="application-outcome-3">Not received</label>
+                                    </div>
                                 </div>
-                                <div class="govuk-radios__item">
-                                    <input class="govuk-radios__input" id="application-outcome-2" name="applicationOutcome"
-                                    type="radio" value="refused">
-                                    <label class="govuk-label govuk-radios__label" for="application-outcome-2">Refused</label>
-                                </div>
-                                <div class="govuk-radios__item">
-                                    <input class="govuk-radios__input" id="application-outcome-3" name="applicationOutcome"
-                                    type="radio" value="not_received">
-                                    <label class="govuk-label govuk-radios__label" for="application-outcome-3">Not received</label>
-                                </div>
-                            </div>
+                            </fieldset>
                         </div>
                         <button type="submit" data-prevent-double-click="true" class="govuk-button"
                         data-module="govuk-button">Continue</button>

--- a/appeals/web/src/server/appeals/appeal-details/appellant-case/application-outcome/application-outcome.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/appellant-case/application-outcome/application-outcome.mapper.js
@@ -18,11 +18,12 @@ export const changeApplicationOutcomePage = (appealData, appellantCaseData, stor
 		title: 'Change application decision outcome',
 		backLinkUrl: `/appeals-service/appeal-details/${appealData.appealId}/appellant-case`,
 		preHeading: `Appeal ${shortAppealReference}`,
-		heading: `Change application decision outcome`,
 		pageComponents: [
 			radiosInput({
 				name: 'applicationOutcome',
 				idPrefix: 'application-outcome',
+				legendText: 'Change application decision outcome',
+				legendIsPageHeading: true,
 				items: [
 					{
 						value: 'granted',

--- a/appeals/web/src/server/appeals/appeal-details/appellant-case/application-submission-date/__tests__/__snapshots__/application-submission-date.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/appellant-case/application-submission-date/__tests__/__snapshots__/application-submission-date.test.js.snap
@@ -6,40 +6,44 @@ exports[`application-submission-date GET /change should render the applicationSu
         <div class="govuk-grid-column-two-thirds">
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full"><span class="govuk-caption-l govuk-!-margin-bottom-3">Appeal 351062</span>
-                    <h1                     class="govuk-heading-l govuk-!-margin-bottom-3">Change date application submitted</h1>
                 </div>
             </div>
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full">
                     <form method="POST" novalidate="novalidate">
                         <div class="govuk-form-group">
-                            <div id="application-submission-date-hint" class="govuk-hint">For example, 27 3 2007</div>
-                            <div class="govuk-date-input" id="application-submission-date">
-                                <div class="govuk-date-input__item">
-                                    <div class="govuk-form-group">
-                                        <label class="govuk-label govuk-date-input__label" for="application-submission-date-day">Day</label>
-                                        <input class="govuk-input govuk-date-input__input govuk-input--width-2"
-                                        id="application-submission-date-day" name="application-submission-date-day"
-                                        type="text" inputmode="numeric">
+                            <fieldset class="govuk-fieldset" role="group" aria-describedby="application-submission-date-hint">
+                                <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+                                    <h1 class="govuk-fieldset__heading"> Change date application submitted</h1>
+                                </legend>
+                                <div id="application-submission-date-hint" class="govuk-hint">For example, 27 3 2007</div>
+                                <div class="govuk-date-input" id="application-submission-date">
+                                    <div class="govuk-date-input__item">
+                                        <div class="govuk-form-group">
+                                            <label class="govuk-label govuk-date-input__label" for="application-submission-date-day">Day</label>
+                                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                                            id="application-submission-date-day" name="application-submission-date-day"
+                                            type="text" inputmode="numeric">
+                                        </div>
+                                    </div>
+                                    <div class="govuk-date-input__item">
+                                        <div class="govuk-form-group">
+                                            <label class="govuk-label govuk-date-input__label" for="application-submission-date-month">Month</label>
+                                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                                            id="application-submission-date-month" name="application-submission-date-month"
+                                            type="text" inputmode="numeric">
+                                        </div>
+                                    </div>
+                                    <div class="govuk-date-input__item">
+                                        <div class="govuk-form-group">
+                                            <label class="govuk-label govuk-date-input__label" for="application-submission-date-year">Year</label>
+                                            <input class="govuk-input govuk-date-input__input govuk-input--width-4"
+                                            id="application-submission-date-year" name="application-submission-date-year"
+                                            type="text" inputmode="numeric">
+                                        </div>
                                     </div>
                                 </div>
-                                <div class="govuk-date-input__item">
-                                    <div class="govuk-form-group">
-                                        <label class="govuk-label govuk-date-input__label" for="application-submission-date-month">Month</label>
-                                        <input class="govuk-input govuk-date-input__input govuk-input--width-2"
-                                        id="application-submission-date-month" name="application-submission-date-month"
-                                        type="text" inputmode="numeric">
-                                    </div>
-                                </div>
-                                <div class="govuk-date-input__item">
-                                    <div class="govuk-form-group">
-                                        <label class="govuk-label govuk-date-input__label" for="application-submission-date-year">Year</label>
-                                        <input class="govuk-input govuk-date-input__input govuk-input--width-4"
-                                        id="application-submission-date-year" name="application-submission-date-year"
-                                        type="text" inputmode="numeric">
-                                    </div>
-                                </div>
-                            </div>
+                            </fieldset>
                         </div>
                         <button type="submit" data-prevent-double-click="true" class="govuk-button"
                         data-module="govuk-button">Continue</button>
@@ -68,40 +72,44 @@ exports[`application-submission-date POST /change should re-render application s
             </div>
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full"><span class="govuk-caption-l govuk-!-margin-bottom-3">Appeal 351062</span>
-                    <h1                     class="govuk-heading-l govuk-!-margin-bottom-3">Change date application submitted</h1>
                 </div>
             </div>
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full">
                     <form method="POST" novalidate="novalidate">
                         <div class="govuk-form-group">
-                            <div id="application-submission-date-hint" class="govuk-hint">For example, 27 3 2007</div>
-                            <div class="govuk-date-input" id="application-submission-date">
-                                <div class="govuk-date-input__item">
-                                    <div class="govuk-form-group">
-                                        <label class="govuk-label govuk-date-input__label" for="application-submission-date-day">Day</label>
-                                        <input class="govuk-input govuk-date-input__input govuk-input--width-2"
-                                        id="application-submission-date-day" name="application-submission-date-day"
-                                        type="text" inputmode="numeric">
+                            <fieldset class="govuk-fieldset" role="group" aria-describedby="application-submission-date-hint">
+                                <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+                                    <h1 class="govuk-fieldset__heading"> Change date application submitted</h1>
+                                </legend>
+                                <div id="application-submission-date-hint" class="govuk-hint">For example, 27 3 2007</div>
+                                <div class="govuk-date-input" id="application-submission-date">
+                                    <div class="govuk-date-input__item">
+                                        <div class="govuk-form-group">
+                                            <label class="govuk-label govuk-date-input__label" for="application-submission-date-day">Day</label>
+                                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                                            id="application-submission-date-day" name="application-submission-date-day"
+                                            type="text" inputmode="numeric">
+                                        </div>
+                                    </div>
+                                    <div class="govuk-date-input__item">
+                                        <div class="govuk-form-group">
+                                            <label class="govuk-label govuk-date-input__label" for="application-submission-date-month">Month</label>
+                                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                                            id="application-submission-date-month" name="application-submission-date-month"
+                                            type="text" inputmode="numeric">
+                                        </div>
+                                    </div>
+                                    <div class="govuk-date-input__item">
+                                        <div class="govuk-form-group">
+                                            <label class="govuk-label govuk-date-input__label" for="application-submission-date-year">Year</label>
+                                            <input class="govuk-input govuk-date-input__input govuk-input--width-4"
+                                            id="application-submission-date-year" name="application-submission-date-year"
+                                            type="text" inputmode="numeric">
+                                        </div>
                                     </div>
                                 </div>
-                                <div class="govuk-date-input__item">
-                                    <div class="govuk-form-group">
-                                        <label class="govuk-label govuk-date-input__label" for="application-submission-date-month">Month</label>
-                                        <input class="govuk-input govuk-date-input__input govuk-input--width-2"
-                                        id="application-submission-date-month" name="application-submission-date-month"
-                                        type="text" inputmode="numeric">
-                                    </div>
-                                </div>
-                                <div class="govuk-date-input__item">
-                                    <div class="govuk-form-group">
-                                        <label class="govuk-label govuk-date-input__label" for="application-submission-date-year">Year</label>
-                                        <input class="govuk-input govuk-date-input__input govuk-input--width-4"
-                                        id="application-submission-date-year" name="application-submission-date-year"
-                                        type="text" inputmode="numeric">
-                                    </div>
-                                </div>
-                            </div>
+                            </fieldset>
                         </div>
                         <button type="submit" data-prevent-double-click="true" class="govuk-button"
                         data-module="govuk-button">Continue</button>
@@ -132,40 +140,44 @@ exports[`application-submission-date POST /change should re-render application s
             </div>
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full"><span class="govuk-caption-l govuk-!-margin-bottom-3">Appeal 351062</span>
-                    <h1                     class="govuk-heading-l govuk-!-margin-bottom-3">Change date application submitted</h1>
                 </div>
             </div>
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full">
                     <form method="POST" novalidate="novalidate">
                         <div class="govuk-form-group">
-                            <div id="application-submission-date-hint" class="govuk-hint">For example, 27 3 2007</div>
-                            <div class="govuk-date-input" id="application-submission-date">
-                                <div class="govuk-date-input__item">
-                                    <div class="govuk-form-group">
-                                        <label class="govuk-label govuk-date-input__label" for="application-submission-date-day">Day</label>
-                                        <input class="govuk-input govuk-date-input__input govuk-input--width-2"
-                                        id="application-submission-date-day" name="application-submission-date-day"
-                                        type="text" inputmode="numeric">
+                            <fieldset class="govuk-fieldset" role="group" aria-describedby="application-submission-date-hint">
+                                <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+                                    <h1 class="govuk-fieldset__heading"> Change date application submitted</h1>
+                                </legend>
+                                <div id="application-submission-date-hint" class="govuk-hint">For example, 27 3 2007</div>
+                                <div class="govuk-date-input" id="application-submission-date">
+                                    <div class="govuk-date-input__item">
+                                        <div class="govuk-form-group">
+                                            <label class="govuk-label govuk-date-input__label" for="application-submission-date-day">Day</label>
+                                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                                            id="application-submission-date-day" name="application-submission-date-day"
+                                            type="text" inputmode="numeric">
+                                        </div>
+                                    </div>
+                                    <div class="govuk-date-input__item">
+                                        <div class="govuk-form-group">
+                                            <label class="govuk-label govuk-date-input__label" for="application-submission-date-month">Month</label>
+                                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                                            id="application-submission-date-month" name="application-submission-date-month"
+                                            type="text" inputmode="numeric">
+                                        </div>
+                                    </div>
+                                    <div class="govuk-date-input__item">
+                                        <div class="govuk-form-group">
+                                            <label class="govuk-label govuk-date-input__label" for="application-submission-date-year">Year</label>
+                                            <input class="govuk-input govuk-date-input__input govuk-input--width-4"
+                                            id="application-submission-date-year" name="application-submission-date-year"
+                                            type="text" inputmode="numeric">
+                                        </div>
                                     </div>
                                 </div>
-                                <div class="govuk-date-input__item">
-                                    <div class="govuk-form-group">
-                                        <label class="govuk-label govuk-date-input__label" for="application-submission-date-month">Month</label>
-                                        <input class="govuk-input govuk-date-input__input govuk-input--width-2"
-                                        id="application-submission-date-month" name="application-submission-date-month"
-                                        type="text" inputmode="numeric">
-                                    </div>
-                                </div>
-                                <div class="govuk-date-input__item">
-                                    <div class="govuk-form-group">
-                                        <label class="govuk-label govuk-date-input__label" for="application-submission-date-year">Year</label>
-                                        <input class="govuk-input govuk-date-input__input govuk-input--width-4"
-                                        id="application-submission-date-year" name="application-submission-date-year"
-                                        type="text" inputmode="numeric">
-                                    </div>
-                                </div>
-                            </div>
+                            </fieldset>
                         </div>
                         <button type="submit" data-prevent-double-click="true" class="govuk-button"
                         data-module="govuk-button">Continue</button>
@@ -196,40 +208,44 @@ exports[`application-submission-date POST /change should re-render application s
             </div>
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full"><span class="govuk-caption-l govuk-!-margin-bottom-3">Appeal 351062</span>
-                    <h1                     class="govuk-heading-l govuk-!-margin-bottom-3">Change date application submitted</h1>
                 </div>
             </div>
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full">
                     <form method="POST" novalidate="novalidate">
                         <div class="govuk-form-group">
-                            <div id="application-submission-date-hint" class="govuk-hint">For example, 27 3 2007</div>
-                            <div class="govuk-date-input" id="application-submission-date">
-                                <div class="govuk-date-input__item">
-                                    <div class="govuk-form-group">
-                                        <label class="govuk-label govuk-date-input__label" for="application-submission-date-day">Day</label>
-                                        <input class="govuk-input govuk-date-input__input govuk-input--width-2"
-                                        id="application-submission-date-day" name="application-submission-date-day"
-                                        type="text" inputmode="numeric">
+                            <fieldset class="govuk-fieldset" role="group" aria-describedby="application-submission-date-hint">
+                                <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+                                    <h1 class="govuk-fieldset__heading"> Change date application submitted</h1>
+                                </legend>
+                                <div id="application-submission-date-hint" class="govuk-hint">For example, 27 3 2007</div>
+                                <div class="govuk-date-input" id="application-submission-date">
+                                    <div class="govuk-date-input__item">
+                                        <div class="govuk-form-group">
+                                            <label class="govuk-label govuk-date-input__label" for="application-submission-date-day">Day</label>
+                                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                                            id="application-submission-date-day" name="application-submission-date-day"
+                                            type="text" inputmode="numeric">
+                                        </div>
+                                    </div>
+                                    <div class="govuk-date-input__item">
+                                        <div class="govuk-form-group">
+                                            <label class="govuk-label govuk-date-input__label" for="application-submission-date-month">Month</label>
+                                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                                            id="application-submission-date-month" name="application-submission-date-month"
+                                            type="text" inputmode="numeric">
+                                        </div>
+                                    </div>
+                                    <div class="govuk-date-input__item">
+                                        <div class="govuk-form-group">
+                                            <label class="govuk-label govuk-date-input__label" for="application-submission-date-year">Year</label>
+                                            <input class="govuk-input govuk-date-input__input govuk-input--width-4"
+                                            id="application-submission-date-year" name="application-submission-date-year"
+                                            type="text" inputmode="numeric">
+                                        </div>
                                     </div>
                                 </div>
-                                <div class="govuk-date-input__item">
-                                    <div class="govuk-form-group">
-                                        <label class="govuk-label govuk-date-input__label" for="application-submission-date-month">Month</label>
-                                        <input class="govuk-input govuk-date-input__input govuk-input--width-2"
-                                        id="application-submission-date-month" name="application-submission-date-month"
-                                        type="text" inputmode="numeric">
-                                    </div>
-                                </div>
-                                <div class="govuk-date-input__item">
-                                    <div class="govuk-form-group">
-                                        <label class="govuk-label govuk-date-input__label" for="application-submission-date-year">Year</label>
-                                        <input class="govuk-input govuk-date-input__input govuk-input--width-4"
-                                        id="application-submission-date-year" name="application-submission-date-year"
-                                        type="text" inputmode="numeric">
-                                    </div>
-                                </div>
-                            </div>
+                            </fieldset>
                         </div>
                         <button type="submit" data-prevent-double-click="true" class="govuk-button"
                         data-module="govuk-button">Continue</button>
@@ -260,40 +276,44 @@ exports[`application-submission-date POST /change should re-render application s
             </div>
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full"><span class="govuk-caption-l govuk-!-margin-bottom-3">Appeal 351062</span>
-                    <h1                     class="govuk-heading-l govuk-!-margin-bottom-3">Change date application submitted</h1>
                 </div>
             </div>
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full">
                     <form method="POST" novalidate="novalidate">
                         <div class="govuk-form-group">
-                            <div id="application-submission-date-hint" class="govuk-hint">For example, 27 3 2007</div>
-                            <div class="govuk-date-input" id="application-submission-date">
-                                <div class="govuk-date-input__item">
-                                    <div class="govuk-form-group">
-                                        <label class="govuk-label govuk-date-input__label" for="application-submission-date-day">Day</label>
-                                        <input class="govuk-input govuk-date-input__input govuk-input--width-2"
-                                        id="application-submission-date-day" name="application-submission-date-day"
-                                        type="text" inputmode="numeric">
+                            <fieldset class="govuk-fieldset" role="group" aria-describedby="application-submission-date-hint">
+                                <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+                                    <h1 class="govuk-fieldset__heading"> Change date application submitted</h1>
+                                </legend>
+                                <div id="application-submission-date-hint" class="govuk-hint">For example, 27 3 2007</div>
+                                <div class="govuk-date-input" id="application-submission-date">
+                                    <div class="govuk-date-input__item">
+                                        <div class="govuk-form-group">
+                                            <label class="govuk-label govuk-date-input__label" for="application-submission-date-day">Day</label>
+                                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                                            id="application-submission-date-day" name="application-submission-date-day"
+                                            type="text" inputmode="numeric">
+                                        </div>
+                                    </div>
+                                    <div class="govuk-date-input__item">
+                                        <div class="govuk-form-group">
+                                            <label class="govuk-label govuk-date-input__label" for="application-submission-date-month">Month</label>
+                                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                                            id="application-submission-date-month" name="application-submission-date-month"
+                                            type="text" inputmode="numeric">
+                                        </div>
+                                    </div>
+                                    <div class="govuk-date-input__item">
+                                        <div class="govuk-form-group">
+                                            <label class="govuk-label govuk-date-input__label" for="application-submission-date-year">Year</label>
+                                            <input class="govuk-input govuk-date-input__input govuk-input--width-4"
+                                            id="application-submission-date-year" name="application-submission-date-year"
+                                            type="text" inputmode="numeric">
+                                        </div>
                                     </div>
                                 </div>
-                                <div class="govuk-date-input__item">
-                                    <div class="govuk-form-group">
-                                        <label class="govuk-label govuk-date-input__label" for="application-submission-date-month">Month</label>
-                                        <input class="govuk-input govuk-date-input__input govuk-input--width-2"
-                                        id="application-submission-date-month" name="application-submission-date-month"
-                                        type="text" inputmode="numeric">
-                                    </div>
-                                </div>
-                                <div class="govuk-date-input__item">
-                                    <div class="govuk-form-group">
-                                        <label class="govuk-label govuk-date-input__label" for="application-submission-date-year">Year</label>
-                                        <input class="govuk-input govuk-date-input__input govuk-input--width-4"
-                                        id="application-submission-date-year" name="application-submission-date-year"
-                                        type="text" inputmode="numeric">
-                                    </div>
-                                </div>
-                            </div>
+                            </fieldset>
                         </div>
                         <button type="submit" data-prevent-double-click="true" class="govuk-button"
                         data-module="govuk-button">Continue</button>
@@ -322,40 +342,44 @@ exports[`application-submission-date POST /change should re-render the Date page
             </div>
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full"><span class="govuk-caption-l govuk-!-margin-bottom-3">Appeal 351062</span>
-                    <h1                     class="govuk-heading-l govuk-!-margin-bottom-3">Change date application submitted</h1>
                 </div>
             </div>
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full">
                     <form method="POST" novalidate="novalidate">
                         <div class="govuk-form-group">
-                            <div id="application-submission-date-hint" class="govuk-hint">For example, 27 3 2007</div>
-                            <div class="govuk-date-input" id="application-submission-date">
-                                <div class="govuk-date-input__item">
-                                    <div class="govuk-form-group">
-                                        <label class="govuk-label govuk-date-input__label" for="application-submission-date-day">Day</label>
-                                        <input class="govuk-input govuk-date-input__input govuk-input--width-2"
-                                        id="application-submission-date-day" name="application-submission-date-day"
-                                        type="text" inputmode="numeric">
+                            <fieldset class="govuk-fieldset" role="group" aria-describedby="application-submission-date-hint">
+                                <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+                                    <h1 class="govuk-fieldset__heading"> Change date application submitted</h1>
+                                </legend>
+                                <div id="application-submission-date-hint" class="govuk-hint">For example, 27 3 2007</div>
+                                <div class="govuk-date-input" id="application-submission-date">
+                                    <div class="govuk-date-input__item">
+                                        <div class="govuk-form-group">
+                                            <label class="govuk-label govuk-date-input__label" for="application-submission-date-day">Day</label>
+                                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                                            id="application-submission-date-day" name="application-submission-date-day"
+                                            type="text" inputmode="numeric">
+                                        </div>
+                                    </div>
+                                    <div class="govuk-date-input__item">
+                                        <div class="govuk-form-group">
+                                            <label class="govuk-label govuk-date-input__label" for="application-submission-date-month">Month</label>
+                                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                                            id="application-submission-date-month" name="application-submission-date-month"
+                                            type="text" inputmode="numeric">
+                                        </div>
+                                    </div>
+                                    <div class="govuk-date-input__item">
+                                        <div class="govuk-form-group">
+                                            <label class="govuk-label govuk-date-input__label" for="application-submission-date-year">Year</label>
+                                            <input class="govuk-input govuk-date-input__input govuk-input--width-4"
+                                            id="application-submission-date-year" name="application-submission-date-year"
+                                            type="text" inputmode="numeric">
+                                        </div>
                                     </div>
                                 </div>
-                                <div class="govuk-date-input__item">
-                                    <div class="govuk-form-group">
-                                        <label class="govuk-label govuk-date-input__label" for="application-submission-date-month">Month</label>
-                                        <input class="govuk-input govuk-date-input__input govuk-input--width-2"
-                                        id="application-submission-date-month" name="application-submission-date-month"
-                                        type="text" inputmode="numeric">
-                                    </div>
-                                </div>
-                                <div class="govuk-date-input__item">
-                                    <div class="govuk-form-group">
-                                        <label class="govuk-label govuk-date-input__label" for="application-submission-date-year">Year</label>
-                                        <input class="govuk-input govuk-date-input__input govuk-input--width-4"
-                                        id="application-submission-date-year" name="application-submission-date-year"
-                                        type="text" inputmode="numeric">
-                                    </div>
-                                </div>
-                            </div>
+                            </fieldset>
                         </div>
                         <button type="submit" data-prevent-double-click="true" class="govuk-button"
                         data-module="govuk-button">Continue</button>
@@ -386,40 +410,44 @@ exports[`application-submission-date POST /change should re-render the Date page
             </div>
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full"><span class="govuk-caption-l govuk-!-margin-bottom-3">Appeal 351062</span>
-                    <h1                     class="govuk-heading-l govuk-!-margin-bottom-3">Change date application submitted</h1>
                 </div>
             </div>
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full">
                     <form method="POST" novalidate="novalidate">
                         <div class="govuk-form-group">
-                            <div id="application-submission-date-hint" class="govuk-hint">For example, 27 3 2007</div>
-                            <div class="govuk-date-input" id="application-submission-date">
-                                <div class="govuk-date-input__item">
-                                    <div class="govuk-form-group">
-                                        <label class="govuk-label govuk-date-input__label" for="application-submission-date-day">Day</label>
-                                        <input class="govuk-input govuk-date-input__input govuk-input--width-2"
-                                        id="application-submission-date-day" name="application-submission-date-day"
-                                        type="text" inputmode="numeric">
+                            <fieldset class="govuk-fieldset" role="group" aria-describedby="application-submission-date-hint">
+                                <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+                                    <h1 class="govuk-fieldset__heading"> Change date application submitted</h1>
+                                </legend>
+                                <div id="application-submission-date-hint" class="govuk-hint">For example, 27 3 2007</div>
+                                <div class="govuk-date-input" id="application-submission-date">
+                                    <div class="govuk-date-input__item">
+                                        <div class="govuk-form-group">
+                                            <label class="govuk-label govuk-date-input__label" for="application-submission-date-day">Day</label>
+                                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                                            id="application-submission-date-day" name="application-submission-date-day"
+                                            type="text" inputmode="numeric">
+                                        </div>
+                                    </div>
+                                    <div class="govuk-date-input__item">
+                                        <div class="govuk-form-group">
+                                            <label class="govuk-label govuk-date-input__label" for="application-submission-date-month">Month</label>
+                                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                                            id="application-submission-date-month" name="application-submission-date-month"
+                                            type="text" inputmode="numeric">
+                                        </div>
+                                    </div>
+                                    <div class="govuk-date-input__item">
+                                        <div class="govuk-form-group">
+                                            <label class="govuk-label govuk-date-input__label" for="application-submission-date-year">Year</label>
+                                            <input class="govuk-input govuk-date-input__input govuk-input--width-4"
+                                            id="application-submission-date-year" name="application-submission-date-year"
+                                            type="text" inputmode="numeric">
+                                        </div>
                                     </div>
                                 </div>
-                                <div class="govuk-date-input__item">
-                                    <div class="govuk-form-group">
-                                        <label class="govuk-label govuk-date-input__label" for="application-submission-date-month">Month</label>
-                                        <input class="govuk-input govuk-date-input__input govuk-input--width-2"
-                                        id="application-submission-date-month" name="application-submission-date-month"
-                                        type="text" inputmode="numeric">
-                                    </div>
-                                </div>
-                                <div class="govuk-date-input__item">
-                                    <div class="govuk-form-group">
-                                        <label class="govuk-label govuk-date-input__label" for="application-submission-date-year">Year</label>
-                                        <input class="govuk-input govuk-date-input__input govuk-input--width-4"
-                                        id="application-submission-date-year" name="application-submission-date-year"
-                                        type="text" inputmode="numeric">
-                                    </div>
-                                </div>
-                            </div>
+                            </fieldset>
                         </div>
                         <button type="submit" data-prevent-double-click="true" class="govuk-button"
                         data-module="govuk-button">Continue</button>
@@ -450,40 +478,44 @@ exports[`application-submission-date POST /change should re-render the Date page
             </div>
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full"><span class="govuk-caption-l govuk-!-margin-bottom-3">Appeal 351062</span>
-                    <h1                     class="govuk-heading-l govuk-!-margin-bottom-3">Change date application submitted</h1>
                 </div>
             </div>
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full">
                     <form method="POST" novalidate="novalidate">
                         <div class="govuk-form-group">
-                            <div id="application-submission-date-hint" class="govuk-hint">For example, 27 3 2007</div>
-                            <div class="govuk-date-input" id="application-submission-date">
-                                <div class="govuk-date-input__item">
-                                    <div class="govuk-form-group">
-                                        <label class="govuk-label govuk-date-input__label" for="application-submission-date-day">Day</label>
-                                        <input class="govuk-input govuk-date-input__input govuk-input--width-2"
-                                        id="application-submission-date-day" name="application-submission-date-day"
-                                        type="text" inputmode="numeric">
+                            <fieldset class="govuk-fieldset" role="group" aria-describedby="application-submission-date-hint">
+                                <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+                                    <h1 class="govuk-fieldset__heading"> Change date application submitted</h1>
+                                </legend>
+                                <div id="application-submission-date-hint" class="govuk-hint">For example, 27 3 2007</div>
+                                <div class="govuk-date-input" id="application-submission-date">
+                                    <div class="govuk-date-input__item">
+                                        <div class="govuk-form-group">
+                                            <label class="govuk-label govuk-date-input__label" for="application-submission-date-day">Day</label>
+                                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                                            id="application-submission-date-day" name="application-submission-date-day"
+                                            type="text" inputmode="numeric">
+                                        </div>
+                                    </div>
+                                    <div class="govuk-date-input__item">
+                                        <div class="govuk-form-group">
+                                            <label class="govuk-label govuk-date-input__label" for="application-submission-date-month">Month</label>
+                                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                                            id="application-submission-date-month" name="application-submission-date-month"
+                                            type="text" inputmode="numeric">
+                                        </div>
+                                    </div>
+                                    <div class="govuk-date-input__item">
+                                        <div class="govuk-form-group">
+                                            <label class="govuk-label govuk-date-input__label" for="application-submission-date-year">Year</label>
+                                            <input class="govuk-input govuk-date-input__input govuk-input--width-4"
+                                            id="application-submission-date-year" name="application-submission-date-year"
+                                            type="text" inputmode="numeric">
+                                        </div>
                                     </div>
                                 </div>
-                                <div class="govuk-date-input__item">
-                                    <div class="govuk-form-group">
-                                        <label class="govuk-label govuk-date-input__label" for="application-submission-date-month">Month</label>
-                                        <input class="govuk-input govuk-date-input__input govuk-input--width-2"
-                                        id="application-submission-date-month" name="application-submission-date-month"
-                                        type="text" inputmode="numeric">
-                                    </div>
-                                </div>
-                                <div class="govuk-date-input__item">
-                                    <div class="govuk-form-group">
-                                        <label class="govuk-label govuk-date-input__label" for="application-submission-date-year">Year</label>
-                                        <input class="govuk-input govuk-date-input__input govuk-input--width-4"
-                                        id="application-submission-date-year" name="application-submission-date-year"
-                                        type="text" inputmode="numeric">
-                                    </div>
-                                </div>
-                            </div>
+                            </fieldset>
                         </div>
                         <button type="submit" data-prevent-double-click="true" class="govuk-button"
                         data-module="govuk-button">Continue</button>
@@ -514,40 +546,44 @@ exports[`application-submission-date POST /change should re-render the Date page
             </div>
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full"><span class="govuk-caption-l govuk-!-margin-bottom-3">Appeal 351062</span>
-                    <h1                     class="govuk-heading-l govuk-!-margin-bottom-3">Change date application submitted</h1>
                 </div>
             </div>
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full">
                     <form method="POST" novalidate="novalidate">
                         <div class="govuk-form-group">
-                            <div id="application-submission-date-hint" class="govuk-hint">For example, 27 3 2007</div>
-                            <div class="govuk-date-input" id="application-submission-date">
-                                <div class="govuk-date-input__item">
-                                    <div class="govuk-form-group">
-                                        <label class="govuk-label govuk-date-input__label" for="application-submission-date-day">Day</label>
-                                        <input class="govuk-input govuk-date-input__input govuk-input--width-2"
-                                        id="application-submission-date-day" name="application-submission-date-day"
-                                        type="text" inputmode="numeric">
+                            <fieldset class="govuk-fieldset" role="group" aria-describedby="application-submission-date-hint">
+                                <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+                                    <h1 class="govuk-fieldset__heading"> Change date application submitted</h1>
+                                </legend>
+                                <div id="application-submission-date-hint" class="govuk-hint">For example, 27 3 2007</div>
+                                <div class="govuk-date-input" id="application-submission-date">
+                                    <div class="govuk-date-input__item">
+                                        <div class="govuk-form-group">
+                                            <label class="govuk-label govuk-date-input__label" for="application-submission-date-day">Day</label>
+                                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                                            id="application-submission-date-day" name="application-submission-date-day"
+                                            type="text" inputmode="numeric">
+                                        </div>
+                                    </div>
+                                    <div class="govuk-date-input__item">
+                                        <div class="govuk-form-group">
+                                            <label class="govuk-label govuk-date-input__label" for="application-submission-date-month">Month</label>
+                                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                                            id="application-submission-date-month" name="application-submission-date-month"
+                                            type="text" inputmode="numeric">
+                                        </div>
+                                    </div>
+                                    <div class="govuk-date-input__item">
+                                        <div class="govuk-form-group">
+                                            <label class="govuk-label govuk-date-input__label" for="application-submission-date-year">Year</label>
+                                            <input class="govuk-input govuk-date-input__input govuk-input--width-4"
+                                            id="application-submission-date-year" name="application-submission-date-year"
+                                            type="text" inputmode="numeric">
+                                        </div>
                                     </div>
                                 </div>
-                                <div class="govuk-date-input__item">
-                                    <div class="govuk-form-group">
-                                        <label class="govuk-label govuk-date-input__label" for="application-submission-date-month">Month</label>
-                                        <input class="govuk-input govuk-date-input__input govuk-input--width-2"
-                                        id="application-submission-date-month" name="application-submission-date-month"
-                                        type="text" inputmode="numeric">
-                                    </div>
-                                </div>
-                                <div class="govuk-date-input__item">
-                                    <div class="govuk-form-group">
-                                        <label class="govuk-label govuk-date-input__label" for="application-submission-date-year">Year</label>
-                                        <input class="govuk-input govuk-date-input__input govuk-input--width-4"
-                                        id="application-submission-date-year" name="application-submission-date-year"
-                                        type="text" inputmode="numeric">
-                                    </div>
-                                </div>
-                            </div>
+                            </fieldset>
                         </div>
                         <button type="submit" data-prevent-double-click="true" class="govuk-button"
                         data-module="govuk-button">Continue</button>
@@ -576,40 +612,44 @@ exports[`application-submission-date POST /change should re-render the Date page
             </div>
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full"><span class="govuk-caption-l govuk-!-margin-bottom-3">Appeal 351062</span>
-                    <h1                     class="govuk-heading-l govuk-!-margin-bottom-3">Change date application submitted</h1>
                 </div>
             </div>
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full">
                     <form method="POST" novalidate="novalidate">
                         <div class="govuk-form-group">
-                            <div id="application-submission-date-hint" class="govuk-hint">For example, 27 3 2007</div>
-                            <div class="govuk-date-input" id="application-submission-date">
-                                <div class="govuk-date-input__item">
-                                    <div class="govuk-form-group">
-                                        <label class="govuk-label govuk-date-input__label" for="application-submission-date-day">Day</label>
-                                        <input class="govuk-input govuk-date-input__input govuk-input--width-2"
-                                        id="application-submission-date-day" name="application-submission-date-day"
-                                        type="text" inputmode="numeric">
+                            <fieldset class="govuk-fieldset" role="group" aria-describedby="application-submission-date-hint">
+                                <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+                                    <h1 class="govuk-fieldset__heading"> Change date application submitted</h1>
+                                </legend>
+                                <div id="application-submission-date-hint" class="govuk-hint">For example, 27 3 2007</div>
+                                <div class="govuk-date-input" id="application-submission-date">
+                                    <div class="govuk-date-input__item">
+                                        <div class="govuk-form-group">
+                                            <label class="govuk-label govuk-date-input__label" for="application-submission-date-day">Day</label>
+                                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                                            id="application-submission-date-day" name="application-submission-date-day"
+                                            type="text" inputmode="numeric">
+                                        </div>
+                                    </div>
+                                    <div class="govuk-date-input__item">
+                                        <div class="govuk-form-group">
+                                            <label class="govuk-label govuk-date-input__label" for="application-submission-date-month">Month</label>
+                                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                                            id="application-submission-date-month" name="application-submission-date-month"
+                                            type="text" inputmode="numeric">
+                                        </div>
+                                    </div>
+                                    <div class="govuk-date-input__item">
+                                        <div class="govuk-form-group">
+                                            <label class="govuk-label govuk-date-input__label" for="application-submission-date-year">Year</label>
+                                            <input class="govuk-input govuk-date-input__input govuk-input--width-4"
+                                            id="application-submission-date-year" name="application-submission-date-year"
+                                            type="text" inputmode="numeric">
+                                        </div>
                                     </div>
                                 </div>
-                                <div class="govuk-date-input__item">
-                                    <div class="govuk-form-group">
-                                        <label class="govuk-label govuk-date-input__label" for="application-submission-date-month">Month</label>
-                                        <input class="govuk-input govuk-date-input__input govuk-input--width-2"
-                                        id="application-submission-date-month" name="application-submission-date-month"
-                                        type="text" inputmode="numeric">
-                                    </div>
-                                </div>
-                                <div class="govuk-date-input__item">
-                                    <div class="govuk-form-group">
-                                        <label class="govuk-label govuk-date-input__label" for="application-submission-date-year">Year</label>
-                                        <input class="govuk-input govuk-date-input__input govuk-input--width-4"
-                                        id="application-submission-date-year" name="application-submission-date-year"
-                                        type="text" inputmode="numeric">
-                                    </div>
-                                </div>
-                            </div>
+                            </fieldset>
                         </div>
                         <button type="submit" data-prevent-double-click="true" class="govuk-button"
                         data-module="govuk-button">Continue</button>
@@ -640,40 +680,44 @@ exports[`application-submission-date POST /change should re-render the Date page
             </div>
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full"><span class="govuk-caption-l govuk-!-margin-bottom-3">Appeal 351062</span>
-                    <h1                     class="govuk-heading-l govuk-!-margin-bottom-3">Change date application submitted</h1>
                 </div>
             </div>
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full">
                     <form method="POST" novalidate="novalidate">
                         <div class="govuk-form-group">
-                            <div id="application-submission-date-hint" class="govuk-hint">For example, 27 3 2007</div>
-                            <div class="govuk-date-input" id="application-submission-date">
-                                <div class="govuk-date-input__item">
-                                    <div class="govuk-form-group">
-                                        <label class="govuk-label govuk-date-input__label" for="application-submission-date-day">Day</label>
-                                        <input class="govuk-input govuk-date-input__input govuk-input--width-2"
-                                        id="application-submission-date-day" name="application-submission-date-day"
-                                        type="text" inputmode="numeric">
+                            <fieldset class="govuk-fieldset" role="group" aria-describedby="application-submission-date-hint">
+                                <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+                                    <h1 class="govuk-fieldset__heading"> Change date application submitted</h1>
+                                </legend>
+                                <div id="application-submission-date-hint" class="govuk-hint">For example, 27 3 2007</div>
+                                <div class="govuk-date-input" id="application-submission-date">
+                                    <div class="govuk-date-input__item">
+                                        <div class="govuk-form-group">
+                                            <label class="govuk-label govuk-date-input__label" for="application-submission-date-day">Day</label>
+                                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                                            id="application-submission-date-day" name="application-submission-date-day"
+                                            type="text" inputmode="numeric">
+                                        </div>
+                                    </div>
+                                    <div class="govuk-date-input__item">
+                                        <div class="govuk-form-group">
+                                            <label class="govuk-label govuk-date-input__label" for="application-submission-date-month">Month</label>
+                                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                                            id="application-submission-date-month" name="application-submission-date-month"
+                                            type="text" inputmode="numeric">
+                                        </div>
+                                    </div>
+                                    <div class="govuk-date-input__item">
+                                        <div class="govuk-form-group">
+                                            <label class="govuk-label govuk-date-input__label" for="application-submission-date-year">Year</label>
+                                            <input class="govuk-input govuk-date-input__input govuk-input--width-4"
+                                            id="application-submission-date-year" name="application-submission-date-year"
+                                            type="text" inputmode="numeric">
+                                        </div>
                                     </div>
                                 </div>
-                                <div class="govuk-date-input__item">
-                                    <div class="govuk-form-group">
-                                        <label class="govuk-label govuk-date-input__label" for="application-submission-date-month">Month</label>
-                                        <input class="govuk-input govuk-date-input__input govuk-input--width-2"
-                                        id="application-submission-date-month" name="application-submission-date-month"
-                                        type="text" inputmode="numeric">
-                                    </div>
-                                </div>
-                                <div class="govuk-date-input__item">
-                                    <div class="govuk-form-group">
-                                        <label class="govuk-label govuk-date-input__label" for="application-submission-date-year">Year</label>
-                                        <input class="govuk-input govuk-date-input__input govuk-input--width-4"
-                                        id="application-submission-date-year" name="application-submission-date-year"
-                                        type="text" inputmode="numeric">
-                                    </div>
-                                </div>
-                            </div>
+                            </fieldset>
                         </div>
                         <button type="submit" data-prevent-double-click="true" class="govuk-button"
                         data-module="govuk-button">Continue</button>
@@ -704,40 +748,44 @@ exports[`application-submission-date POST /change should re-render the Date page
             </div>
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full"><span class="govuk-caption-l govuk-!-margin-bottom-3">Appeal 351062</span>
-                    <h1                     class="govuk-heading-l govuk-!-margin-bottom-3">Change date application submitted</h1>
                 </div>
             </div>
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full">
                     <form method="POST" novalidate="novalidate">
                         <div class="govuk-form-group">
-                            <div id="application-submission-date-hint" class="govuk-hint">For example, 27 3 2007</div>
-                            <div class="govuk-date-input" id="application-submission-date">
-                                <div class="govuk-date-input__item">
-                                    <div class="govuk-form-group">
-                                        <label class="govuk-label govuk-date-input__label" for="application-submission-date-day">Day</label>
-                                        <input class="govuk-input govuk-date-input__input govuk-input--width-2"
-                                        id="application-submission-date-day" name="application-submission-date-day"
-                                        type="text" inputmode="numeric">
+                            <fieldset class="govuk-fieldset" role="group" aria-describedby="application-submission-date-hint">
+                                <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+                                    <h1 class="govuk-fieldset__heading"> Change date application submitted</h1>
+                                </legend>
+                                <div id="application-submission-date-hint" class="govuk-hint">For example, 27 3 2007</div>
+                                <div class="govuk-date-input" id="application-submission-date">
+                                    <div class="govuk-date-input__item">
+                                        <div class="govuk-form-group">
+                                            <label class="govuk-label govuk-date-input__label" for="application-submission-date-day">Day</label>
+                                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                                            id="application-submission-date-day" name="application-submission-date-day"
+                                            type="text" inputmode="numeric">
+                                        </div>
+                                    </div>
+                                    <div class="govuk-date-input__item">
+                                        <div class="govuk-form-group">
+                                            <label class="govuk-label govuk-date-input__label" for="application-submission-date-month">Month</label>
+                                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                                            id="application-submission-date-month" name="application-submission-date-month"
+                                            type="text" inputmode="numeric">
+                                        </div>
+                                    </div>
+                                    <div class="govuk-date-input__item">
+                                        <div class="govuk-form-group">
+                                            <label class="govuk-label govuk-date-input__label" for="application-submission-date-year">Year</label>
+                                            <input class="govuk-input govuk-date-input__input govuk-input--width-4"
+                                            id="application-submission-date-year" name="application-submission-date-year"
+                                            type="text" inputmode="numeric">
+                                        </div>
                                     </div>
                                 </div>
-                                <div class="govuk-date-input__item">
-                                    <div class="govuk-form-group">
-                                        <label class="govuk-label govuk-date-input__label" for="application-submission-date-month">Month</label>
-                                        <input class="govuk-input govuk-date-input__input govuk-input--width-2"
-                                        id="application-submission-date-month" name="application-submission-date-month"
-                                        type="text" inputmode="numeric">
-                                    </div>
-                                </div>
-                                <div class="govuk-date-input__item">
-                                    <div class="govuk-form-group">
-                                        <label class="govuk-label govuk-date-input__label" for="application-submission-date-year">Year</label>
-                                        <input class="govuk-input govuk-date-input__input govuk-input--width-4"
-                                        id="application-submission-date-year" name="application-submission-date-year"
-                                        type="text" inputmode="numeric">
-                                    </div>
-                                </div>
-                            </div>
+                            </fieldset>
                         </div>
                         <button type="submit" data-prevent-double-click="true" class="govuk-button"
                         data-module="govuk-button">Continue</button>
@@ -766,40 +814,44 @@ exports[`application-submission-date POST /change should re-render the Date page
             </div>
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full"><span class="govuk-caption-l govuk-!-margin-bottom-3">Appeal 351062</span>
-                    <h1                     class="govuk-heading-l govuk-!-margin-bottom-3">Change date application submitted</h1>
                 </div>
             </div>
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full">
                     <form method="POST" novalidate="novalidate">
                         <div class="govuk-form-group">
-                            <div id="application-submission-date-hint" class="govuk-hint">For example, 27 3 2007</div>
-                            <div class="govuk-date-input" id="application-submission-date">
-                                <div class="govuk-date-input__item">
-                                    <div class="govuk-form-group">
-                                        <label class="govuk-label govuk-date-input__label" for="application-submission-date-day">Day</label>
-                                        <input class="govuk-input govuk-date-input__input govuk-input--width-2"
-                                        id="application-submission-date-day" name="application-submission-date-day"
-                                        type="text" inputmode="numeric">
+                            <fieldset class="govuk-fieldset" role="group" aria-describedby="application-submission-date-hint">
+                                <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+                                    <h1 class="govuk-fieldset__heading"> Change date application submitted</h1>
+                                </legend>
+                                <div id="application-submission-date-hint" class="govuk-hint">For example, 27 3 2007</div>
+                                <div class="govuk-date-input" id="application-submission-date">
+                                    <div class="govuk-date-input__item">
+                                        <div class="govuk-form-group">
+                                            <label class="govuk-label govuk-date-input__label" for="application-submission-date-day">Day</label>
+                                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                                            id="application-submission-date-day" name="application-submission-date-day"
+                                            type="text" inputmode="numeric">
+                                        </div>
+                                    </div>
+                                    <div class="govuk-date-input__item">
+                                        <div class="govuk-form-group">
+                                            <label class="govuk-label govuk-date-input__label" for="application-submission-date-month">Month</label>
+                                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                                            id="application-submission-date-month" name="application-submission-date-month"
+                                            type="text" inputmode="numeric">
+                                        </div>
+                                    </div>
+                                    <div class="govuk-date-input__item">
+                                        <div class="govuk-form-group">
+                                            <label class="govuk-label govuk-date-input__label" for="application-submission-date-year">Year</label>
+                                            <input class="govuk-input govuk-date-input__input govuk-input--width-4"
+                                            id="application-submission-date-year" name="application-submission-date-year"
+                                            type="text" inputmode="numeric">
+                                        </div>
                                     </div>
                                 </div>
-                                <div class="govuk-date-input__item">
-                                    <div class="govuk-form-group">
-                                        <label class="govuk-label govuk-date-input__label" for="application-submission-date-month">Month</label>
-                                        <input class="govuk-input govuk-date-input__input govuk-input--width-2"
-                                        id="application-submission-date-month" name="application-submission-date-month"
-                                        type="text" inputmode="numeric">
-                                    </div>
-                                </div>
-                                <div class="govuk-date-input__item">
-                                    <div class="govuk-form-group">
-                                        <label class="govuk-label govuk-date-input__label" for="application-submission-date-year">Year</label>
-                                        <input class="govuk-input govuk-date-input__input govuk-input--width-4"
-                                        id="application-submission-date-year" name="application-submission-date-year"
-                                        type="text" inputmode="numeric">
-                                    </div>
-                                </div>
-                            </div>
+                            </fieldset>
                         </div>
                         <button type="submit" data-prevent-double-click="true" class="govuk-button"
                         data-module="govuk-button">Continue</button>

--- a/appeals/web/src/server/appeals/appeal-details/appellant-case/application-submission-date/application-submission-date.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/appellant-case/application-submission-date/application-submission-date.mapper.js
@@ -42,7 +42,6 @@ export const changeApplicationSubmissionDatePage = (
 		title: `Change date application submitted`,
 		backLinkUrl: `/appeals-service/appeal-details/${appealData.appealId}/appellant-case`,
 		preHeading: `Appeal ${shortAppealReference}`,
-		heading: `Change date application submitted`,
 		pageComponents: [
 			{
 				type: 'date-input',
@@ -53,10 +52,10 @@ export const changeApplicationSubmissionDatePage = (
 					hint: {
 						text: 'For example, 27 3 2007'
 					},
-					fieldSet: {
+					fieldset: {
 						legend: {
-							text: `When was the application submitted?`,
-							isPageHeading: false,
+							text: 'Change date application submitted',
+							isPageHeading: true,
 							classes: 'govuk-fieldset__legend--l'
 						}
 					},

--- a/appeals/web/src/server/appeals/appeal-details/appellant-case/development-description/development-description.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/appellant-case/development-description/development-description.mapper.js
@@ -30,8 +30,7 @@ export const changeDevelopmentDescriptionPage = (
 					id: 'development-description',
 					maxlength: 1000,
 					label: {
-						text: 'Enter the original description of the development',
-						isPageHeading: false
+						text: 'Enter the original description of the development'
 					},
 					value: storedSessionData ?? appellantCaseData.developmentDescription?.details ?? ''
 				}

--- a/appeals/web/src/server/appeals/appeal-details/appellant-case/owners-known/__tests__/__snapshots__/owners-known.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/appellant-case/owners-known/__tests__/__snapshots__/owners-known.test.js.snap
@@ -6,35 +6,39 @@ exports[`owners-known GET /change should render the change owners known page wit
         <div class="govuk-grid-column-two-thirds">
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full"><span class="govuk-caption-l govuk-!-margin-bottom-3">Appeal 351062</span>
-                    <h1                     class="govuk-heading-l govuk-!-margin-bottom-3">Change owners known</h1>
                 </div>
             </div>
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full">
                     <form method="POST" novalidate="novalidate">
                         <div class="govuk-form-group">
-                            <div class="govuk-radios" data-module="govuk-radios">
-                                <div class="govuk-radios__item">
-                                    <input class="govuk-radios__input" id="owners-known-radio" name="ownersKnownRadio"
-                                    type="radio" value="No" checked>
-                                    <label class="govuk-label govuk-radios__label" for="owners-known-radio">No</label>
+                            <fieldset class="govuk-fieldset">
+                                <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+                                    <h1 class="govuk-fieldset__heading"> Change owners known</h1>
+                                </legend>
+                                <div class="govuk-radios" data-module="govuk-radios">
+                                    <div class="govuk-radios__item">
+                                        <input class="govuk-radios__input" id="owners-known-radio" name="ownersKnownRadio"
+                                        type="radio" value="No" checked>
+                                        <label class="govuk-label govuk-radios__label" for="owners-known-radio">No</label>
+                                    </div>
+                                    <div class="govuk-radios__item">
+                                        <input class="govuk-radios__input" id="owners-known-radio-2" name="ownersKnownRadio"
+                                        type="radio" value="Yes">
+                                        <label class="govuk-label govuk-radios__label" for="owners-known-radio-2">Yes</label>
+                                    </div>
+                                    <div class="govuk-radios__item">
+                                        <input class="govuk-radios__input" id="owners-known-radio-3" name="ownersKnownRadio"
+                                        type="radio" value="Some">
+                                        <label class="govuk-label govuk-radios__label" for="owners-known-radio-3">Some</label>
+                                    </div>
+                                    <div class="govuk-radios__item">
+                                        <input class="govuk-radios__input" id="owners-known-radio-4" name="ownersKnownRadio"
+                                        type="radio" value="not-applicable">
+                                        <label class="govuk-label govuk-radios__label" for="owners-known-radio-4">Not applicable</label>
+                                    </div>
                                 </div>
-                                <div class="govuk-radios__item">
-                                    <input class="govuk-radios__input" id="owners-known-radio-2" name="ownersKnownRadio"
-                                    type="radio" value="Yes">
-                                    <label class="govuk-label govuk-radios__label" for="owners-known-radio-2">Yes</label>
-                                </div>
-                                <div class="govuk-radios__item">
-                                    <input class="govuk-radios__input" id="owners-known-radio-3" name="ownersKnownRadio"
-                                    type="radio" value="Some">
-                                    <label class="govuk-label govuk-radios__label" for="owners-known-radio-3">Some</label>
-                                </div>
-                                <div class="govuk-radios__item">
-                                    <input class="govuk-radios__input" id="owners-known-radio-4" name="ownersKnownRadio"
-                                    type="radio" value="not-applicable">
-                                    <label class="govuk-label govuk-radios__label" for="owners-known-radio-4">Not applicable</label>
-                                </div>
-                            </div>
+                            </fieldset>
                         </div>
                         <button type="submit" data-prevent-double-click="true" class="govuk-button"
                         data-module="govuk-button">Continue</button>
@@ -52,35 +56,39 @@ exports[`owners-known GET /change should render the change owners known page wit
         <div class="govuk-grid-column-two-thirds">
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full"><span class="govuk-caption-l govuk-!-margin-bottom-3">Appeal 351062</span>
-                    <h1                     class="govuk-heading-l govuk-!-margin-bottom-3">Change owners known</h1>
                 </div>
             </div>
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full">
                     <form method="POST" novalidate="novalidate">
                         <div class="govuk-form-group">
-                            <div class="govuk-radios" data-module="govuk-radios">
-                                <div class="govuk-radios__item">
-                                    <input class="govuk-radios__input" id="owners-known-radio" name="ownersKnownRadio"
-                                    type="radio" value="No">
-                                    <label class="govuk-label govuk-radios__label" for="owners-known-radio">No</label>
+                            <fieldset class="govuk-fieldset">
+                                <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+                                    <h1 class="govuk-fieldset__heading"> Change owners known</h1>
+                                </legend>
+                                <div class="govuk-radios" data-module="govuk-radios">
+                                    <div class="govuk-radios__item">
+                                        <input class="govuk-radios__input" id="owners-known-radio" name="ownersKnownRadio"
+                                        type="radio" value="No">
+                                        <label class="govuk-label govuk-radios__label" for="owners-known-radio">No</label>
+                                    </div>
+                                    <div class="govuk-radios__item">
+                                        <input class="govuk-radios__input" id="owners-known-radio-2" name="ownersKnownRadio"
+                                        type="radio" value="Yes">
+                                        <label class="govuk-label govuk-radios__label" for="owners-known-radio-2">Yes</label>
+                                    </div>
+                                    <div class="govuk-radios__item">
+                                        <input class="govuk-radios__input" id="owners-known-radio-3" name="ownersKnownRadio"
+                                        type="radio" value="Some" checked>
+                                        <label class="govuk-label govuk-radios__label" for="owners-known-radio-3">Some</label>
+                                    </div>
+                                    <div class="govuk-radios__item">
+                                        <input class="govuk-radios__input" id="owners-known-radio-4" name="ownersKnownRadio"
+                                        type="radio" value="not-applicable">
+                                        <label class="govuk-label govuk-radios__label" for="owners-known-radio-4">Not applicable</label>
+                                    </div>
                                 </div>
-                                <div class="govuk-radios__item">
-                                    <input class="govuk-radios__input" id="owners-known-radio-2" name="ownersKnownRadio"
-                                    type="radio" value="Yes">
-                                    <label class="govuk-label govuk-radios__label" for="owners-known-radio-2">Yes</label>
-                                </div>
-                                <div class="govuk-radios__item">
-                                    <input class="govuk-radios__input" id="owners-known-radio-3" name="ownersKnownRadio"
-                                    type="radio" value="Some" checked>
-                                    <label class="govuk-label govuk-radios__label" for="owners-known-radio-3">Some</label>
-                                </div>
-                                <div class="govuk-radios__item">
-                                    <input class="govuk-radios__input" id="owners-known-radio-4" name="ownersKnownRadio"
-                                    type="radio" value="not-applicable">
-                                    <label class="govuk-label govuk-radios__label" for="owners-known-radio-4">Not applicable</label>
-                                </div>
-                            </div>
+                            </fieldset>
                         </div>
                         <button type="submit" data-prevent-double-click="true" class="govuk-button"
                         data-module="govuk-button">Continue</button>
@@ -98,35 +106,39 @@ exports[`owners-known GET /change should render the change owners known page wit
         <div class="govuk-grid-column-two-thirds">
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full"><span class="govuk-caption-l govuk-!-margin-bottom-3">Appeal 351062</span>
-                    <h1                     class="govuk-heading-l govuk-!-margin-bottom-3">Change owners known</h1>
                 </div>
             </div>
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full">
                     <form method="POST" novalidate="novalidate">
                         <div class="govuk-form-group">
-                            <div class="govuk-radios" data-module="govuk-radios">
-                                <div class="govuk-radios__item">
-                                    <input class="govuk-radios__input" id="owners-known-radio" name="ownersKnownRadio"
-                                    type="radio" value="No">
-                                    <label class="govuk-label govuk-radios__label" for="owners-known-radio">No</label>
+                            <fieldset class="govuk-fieldset">
+                                <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+                                    <h1 class="govuk-fieldset__heading"> Change owners known</h1>
+                                </legend>
+                                <div class="govuk-radios" data-module="govuk-radios">
+                                    <div class="govuk-radios__item">
+                                        <input class="govuk-radios__input" id="owners-known-radio" name="ownersKnownRadio"
+                                        type="radio" value="No">
+                                        <label class="govuk-label govuk-radios__label" for="owners-known-radio">No</label>
+                                    </div>
+                                    <div class="govuk-radios__item">
+                                        <input class="govuk-radios__input" id="owners-known-radio-2" name="ownersKnownRadio"
+                                        type="radio" value="Yes" checked>
+                                        <label class="govuk-label govuk-radios__label" for="owners-known-radio-2">Yes</label>
+                                    </div>
+                                    <div class="govuk-radios__item">
+                                        <input class="govuk-radios__input" id="owners-known-radio-3" name="ownersKnownRadio"
+                                        type="radio" value="Some">
+                                        <label class="govuk-label govuk-radios__label" for="owners-known-radio-3">Some</label>
+                                    </div>
+                                    <div class="govuk-radios__item">
+                                        <input class="govuk-radios__input" id="owners-known-radio-4" name="ownersKnownRadio"
+                                        type="radio" value="not-applicable">
+                                        <label class="govuk-label govuk-radios__label" for="owners-known-radio-4">Not applicable</label>
+                                    </div>
                                 </div>
-                                <div class="govuk-radios__item">
-                                    <input class="govuk-radios__input" id="owners-known-radio-2" name="ownersKnownRadio"
-                                    type="radio" value="Yes" checked>
-                                    <label class="govuk-label govuk-radios__label" for="owners-known-radio-2">Yes</label>
-                                </div>
-                                <div class="govuk-radios__item">
-                                    <input class="govuk-radios__input" id="owners-known-radio-3" name="ownersKnownRadio"
-                                    type="radio" value="Some">
-                                    <label class="govuk-label govuk-radios__label" for="owners-known-radio-3">Some</label>
-                                </div>
-                                <div class="govuk-radios__item">
-                                    <input class="govuk-radios__input" id="owners-known-radio-4" name="ownersKnownRadio"
-                                    type="radio" value="not-applicable">
-                                    <label class="govuk-label govuk-radios__label" for="owners-known-radio-4">Not applicable</label>
-                                </div>
-                            </div>
+                            </fieldset>
                         </div>
                         <button type="submit" data-prevent-double-click="true" class="govuk-button"
                         data-module="govuk-button">Continue</button>
@@ -144,35 +156,39 @@ exports[`owners-known GET /change should render the change owners known page wit
         <div class="govuk-grid-column-two-thirds">
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full"><span class="govuk-caption-l govuk-!-margin-bottom-3">Appeal 351062</span>
-                    <h1                     class="govuk-heading-l govuk-!-margin-bottom-3">Change owners known</h1>
                 </div>
             </div>
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full">
                     <form method="POST" novalidate="novalidate">
                         <div class="govuk-form-group">
-                            <div class="govuk-radios" data-module="govuk-radios">
-                                <div class="govuk-radios__item">
-                                    <input class="govuk-radios__input" id="owners-known-radio" name="ownersKnownRadio"
-                                    type="radio" value="No">
-                                    <label class="govuk-label govuk-radios__label" for="owners-known-radio">No</label>
+                            <fieldset class="govuk-fieldset">
+                                <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+                                    <h1 class="govuk-fieldset__heading"> Change owners known</h1>
+                                </legend>
+                                <div class="govuk-radios" data-module="govuk-radios">
+                                    <div class="govuk-radios__item">
+                                        <input class="govuk-radios__input" id="owners-known-radio" name="ownersKnownRadio"
+                                        type="radio" value="No">
+                                        <label class="govuk-label govuk-radios__label" for="owners-known-radio">No</label>
+                                    </div>
+                                    <div class="govuk-radios__item">
+                                        <input class="govuk-radios__input" id="owners-known-radio-2" name="ownersKnownRadio"
+                                        type="radio" value="Yes">
+                                        <label class="govuk-label govuk-radios__label" for="owners-known-radio-2">Yes</label>
+                                    </div>
+                                    <div class="govuk-radios__item">
+                                        <input class="govuk-radios__input" id="owners-known-radio-3" name="ownersKnownRadio"
+                                        type="radio" value="Some">
+                                        <label class="govuk-label govuk-radios__label" for="owners-known-radio-3">Some</label>
+                                    </div>
+                                    <div class="govuk-radios__item">
+                                        <input class="govuk-radios__input" id="owners-known-radio-4" name="ownersKnownRadio"
+                                        type="radio" value="not-applicable" checked>
+                                        <label class="govuk-label govuk-radios__label" for="owners-known-radio-4">Not applicable</label>
+                                    </div>
                                 </div>
-                                <div class="govuk-radios__item">
-                                    <input class="govuk-radios__input" id="owners-known-radio-2" name="ownersKnownRadio"
-                                    type="radio" value="Yes">
-                                    <label class="govuk-label govuk-radios__label" for="owners-known-radio-2">Yes</label>
-                                </div>
-                                <div class="govuk-radios__item">
-                                    <input class="govuk-radios__input" id="owners-known-radio-3" name="ownersKnownRadio"
-                                    type="radio" value="Some">
-                                    <label class="govuk-label govuk-radios__label" for="owners-known-radio-3">Some</label>
-                                </div>
-                                <div class="govuk-radios__item">
-                                    <input class="govuk-radios__input" id="owners-known-radio-4" name="ownersKnownRadio"
-                                    type="radio" value="not-applicable" checked>
-                                    <label class="govuk-label govuk-radios__label" for="owners-known-radio-4">Not applicable</label>
-                                </div>
-                            </div>
+                            </fieldset>
                         </div>
                         <button type="submit" data-prevent-double-click="true" class="govuk-button"
                         data-module="govuk-button">Continue</button>

--- a/appeals/web/src/server/appeals/appeal-details/appellant-case/owners-known/owners-known.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/appellant-case/owners-known/owners-known.mapper.js
@@ -24,17 +24,16 @@ export const changeOwnersKnownPage = (appealData, appellantCaseData, storedSessi
 		title: `Change owners known`,
 		backLinkUrl: `/appeals-service/appeal-details/${appealData.appealId}/appellant-case`,
 		preHeading: `Appeal ${shortAppealReference}`,
-		heading: `Change owners known`,
 		pageComponents: [
 			{
 				type: 'radios',
 				parameters: {
 					name: 'ownersKnownRadio',
 					idPrefix: 'owners-known-radio',
-					fieldSet: {
+					fieldset: {
 						legend: {
-							text: `Does the appellant know the other landowners?`,
-							isPageHeading: false,
+							text: 'Change owners known',
+							isPageHeading: true,
 							classes: 'govuk-fieldset__legend--l'
 						}
 					},

--- a/appeals/web/src/server/appeals/appeal-details/appellant-case/planning-obligation/__tests__/__snapshots__/planning-obligation.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/appellant-case/planning-obligation/__tests__/__snapshots__/planning-obligation.test.js.snap
@@ -6,30 +6,34 @@ exports[`planning-obligation GET /status/change should render the change plannin
         <div class="govuk-grid-column-two-thirds">
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full"><span class="govuk-caption-l govuk-!-margin-bottom-3">Appeal 351062</span>
-                    <h1                     class="govuk-heading-l govuk-!-margin-bottom-3">Change planning obligation status</h1>
                 </div>
             </div>
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full">
                     <form method="POST" novalidate="novalidate">
                         <div class="govuk-form-group">
-                            <div class="govuk-radios" data-module="govuk-radios">
-                                <div class="govuk-radios__item">
-                                    <input class="govuk-radios__input" id="planning-obligation-status-radio"
-                                    name="planningObligationStatusRadio" type="radio" value="not_started">
-                                    <label class="govuk-label govuk-radios__label" for="planning-obligation-status-radio">Not yet started</label>
+                            <fieldset class="govuk-fieldset">
+                                <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+                                    <h1 class="govuk-fieldset__heading"> Change planning obligation status</h1>
+                                </legend>
+                                <div class="govuk-radios" data-module="govuk-radios">
+                                    <div class="govuk-radios__item">
+                                        <input class="govuk-radios__input" id="planning-obligation-status-radio"
+                                        name="planningObligationStatusRadio" type="radio" value="not_started">
+                                        <label class="govuk-label govuk-radios__label" for="planning-obligation-status-radio">Not yet started</label>
+                                    </div>
+                                    <div class="govuk-radios__item">
+                                        <input class="govuk-radios__input" id="planning-obligation-status-radio-2"
+                                        name="planningObligationStatusRadio" type="radio" value="finalised" checked>
+                                        <label class="govuk-label govuk-radios__label" for="planning-obligation-status-radio-2">Finalised</label>
+                                    </div>
+                                    <div class="govuk-radios__item">
+                                        <input class="govuk-radios__input" id="planning-obligation-status-radio-3"
+                                        name="planningObligationStatusRadio" type="radio" value="not-applicable">
+                                        <label class="govuk-label govuk-radios__label" for="planning-obligation-status-radio-3">Not applicable</label>
+                                    </div>
                                 </div>
-                                <div class="govuk-radios__item">
-                                    <input class="govuk-radios__input" id="planning-obligation-status-radio-2"
-                                    name="planningObligationStatusRadio" type="radio" value="finalised" checked>
-                                    <label class="govuk-label govuk-radios__label" for="planning-obligation-status-radio-2">Finalised</label>
-                                </div>
-                                <div class="govuk-radios__item">
-                                    <input class="govuk-radios__input" id="planning-obligation-status-radio-3"
-                                    name="planningObligationStatusRadio" type="radio" value="not-applicable">
-                                    <label class="govuk-label govuk-radios__label" for="planning-obligation-status-radio-3">Not applicable</label>
-                                </div>
-                            </div>
+                            </fieldset>
                         </div>
                         <button type="submit" data-prevent-double-click="true" class="govuk-button"
                         data-module="govuk-button">Continue</button>
@@ -47,31 +51,35 @@ exports[`planning-obligation GET /status/change should render the change plannin
         <div class="govuk-grid-column-two-thirds">
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full"><span class="govuk-caption-l govuk-!-margin-bottom-3">Appeal 351062</span>
-                    <h1                     class="govuk-heading-l govuk-!-margin-bottom-3">Change planning obligation status</h1>
                 </div>
             </div>
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full">
                     <form method="POST" novalidate="novalidate">
                         <div class="govuk-form-group">
-                            <div class="govuk-radios" data-module="govuk-radios">
-                                <div class="govuk-radios__item">
-                                    <input class="govuk-radios__input" id="planning-obligation-status-radio"
-                                    name="planningObligationStatusRadio" type="radio" value="not_started">
-                                    <label class="govuk-label govuk-radios__label" for="planning-obligation-status-radio">Not yet started</label>
+                            <fieldset class="govuk-fieldset">
+                                <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+                                    <h1 class="govuk-fieldset__heading"> Change planning obligation status</h1>
+                                </legend>
+                                <div class="govuk-radios" data-module="govuk-radios">
+                                    <div class="govuk-radios__item">
+                                        <input class="govuk-radios__input" id="planning-obligation-status-radio"
+                                        name="planningObligationStatusRadio" type="radio" value="not_started">
+                                        <label class="govuk-label govuk-radios__label" for="planning-obligation-status-radio">Not yet started</label>
+                                    </div>
+                                    <div class="govuk-radios__item">
+                                        <input class="govuk-radios__input" id="planning-obligation-status-radio-2"
+                                        name="planningObligationStatusRadio" type="radio" value="finalised">
+                                        <label class="govuk-label govuk-radios__label" for="planning-obligation-status-radio-2">Finalised</label>
+                                    </div>
+                                    <div class="govuk-radios__item">
+                                        <input class="govuk-radios__input" id="planning-obligation-status-radio-3"
+                                        name="planningObligationStatusRadio" type="radio" value="not-applicable"
+                                        checked>
+                                        <label class="govuk-label govuk-radios__label" for="planning-obligation-status-radio-3">Not applicable</label>
+                                    </div>
                                 </div>
-                                <div class="govuk-radios__item">
-                                    <input class="govuk-radios__input" id="planning-obligation-status-radio-2"
-                                    name="planningObligationStatusRadio" type="radio" value="finalised">
-                                    <label class="govuk-label govuk-radios__label" for="planning-obligation-status-radio-2">Finalised</label>
-                                </div>
-                                <div class="govuk-radios__item">
-                                    <input class="govuk-radios__input" id="planning-obligation-status-radio-3"
-                                    name="planningObligationStatusRadio" type="radio" value="not-applicable"
-                                    checked>
-                                    <label class="govuk-label govuk-radios__label" for="planning-obligation-status-radio-3">Not applicable</label>
-                                </div>
-                            </div>
+                            </fieldset>
                         </div>
                         <button type="submit" data-prevent-double-click="true" class="govuk-button"
                         data-module="govuk-button">Continue</button>
@@ -89,30 +97,34 @@ exports[`planning-obligation GET /status/change should render the change plannin
         <div class="govuk-grid-column-two-thirds">
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full"><span class="govuk-caption-l govuk-!-margin-bottom-3">Appeal 351062</span>
-                    <h1                     class="govuk-heading-l govuk-!-margin-bottom-3">Change planning obligation status</h1>
                 </div>
             </div>
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full">
                     <form method="POST" novalidate="novalidate">
                         <div class="govuk-form-group">
-                            <div class="govuk-radios" data-module="govuk-radios">
-                                <div class="govuk-radios__item">
-                                    <input class="govuk-radios__input" id="planning-obligation-status-radio"
-                                    name="planningObligationStatusRadio" type="radio" value="not_started" checked>
-                                    <label class="govuk-label govuk-radios__label" for="planning-obligation-status-radio">Not yet started</label>
+                            <fieldset class="govuk-fieldset">
+                                <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+                                    <h1 class="govuk-fieldset__heading"> Change planning obligation status</h1>
+                                </legend>
+                                <div class="govuk-radios" data-module="govuk-radios">
+                                    <div class="govuk-radios__item">
+                                        <input class="govuk-radios__input" id="planning-obligation-status-radio"
+                                        name="planningObligationStatusRadio" type="radio" value="not_started" checked>
+                                        <label class="govuk-label govuk-radios__label" for="planning-obligation-status-radio">Not yet started</label>
+                                    </div>
+                                    <div class="govuk-radios__item">
+                                        <input class="govuk-radios__input" id="planning-obligation-status-radio-2"
+                                        name="planningObligationStatusRadio" type="radio" value="finalised">
+                                        <label class="govuk-label govuk-radios__label" for="planning-obligation-status-radio-2">Finalised</label>
+                                    </div>
+                                    <div class="govuk-radios__item">
+                                        <input class="govuk-radios__input" id="planning-obligation-status-radio-3"
+                                        name="planningObligationStatusRadio" type="radio" value="not-applicable">
+                                        <label class="govuk-label govuk-radios__label" for="planning-obligation-status-radio-3">Not applicable</label>
+                                    </div>
                                 </div>
-                                <div class="govuk-radios__item">
-                                    <input class="govuk-radios__input" id="planning-obligation-status-radio-2"
-                                    name="planningObligationStatusRadio" type="radio" value="finalised">
-                                    <label class="govuk-label govuk-radios__label" for="planning-obligation-status-radio-2">Finalised</label>
-                                </div>
-                                <div class="govuk-radios__item">
-                                    <input class="govuk-radios__input" id="planning-obligation-status-radio-3"
-                                    name="planningObligationStatusRadio" type="radio" value="not-applicable">
-                                    <label class="govuk-label govuk-radios__label" for="planning-obligation-status-radio-3">Not applicable</label>
-                                </div>
-                            </div>
+                            </fieldset>
                         </div>
                         <button type="submit" data-prevent-double-click="true" class="govuk-button"
                         data-module="govuk-button">Continue</button>

--- a/appeals/web/src/server/appeals/appeal-details/appellant-case/planning-obligation/planning-obligation.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/appellant-case/planning-obligation/planning-obligation.mapper.js
@@ -27,17 +27,16 @@ export const changePlanningObligationStatusPage = (
 		title: 'Change planning obligation status',
 		backLinkUrl: `/appeals-service/appeal-details/${appealData.appealId}/appellant-case`,
 		preHeading: `Appeal ${shortAppealReference}`,
-		heading: 'Change planning obligation status',
 		pageComponents: [
 			{
 				type: 'radios',
 				parameters: {
 					name: 'planningObligationStatusRadio',
 					idPrefix: 'planning-obligation-status-radio',
-					fieldSet: {
+					fieldset: {
 						legend: {
-							text: 'What is the status of the planning obligation?',
-							isPageHeading: false,
+							text: 'Change planning obligation status',
+							isPageHeading: true,
 							classes: 'govuk-fieldset__legend--l'
 						}
 					},

--- a/appeals/web/src/server/appeals/appeal-details/appellant-case/procedure-preference/__tests__/__snapshots__/procedure-preference.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/appellant-case/procedure-preference/__tests__/__snapshots__/procedure-preference.test.js.snap
@@ -6,30 +6,34 @@ exports[`procedure-preference GET /change should render the change procedure pre
         <div class="govuk-grid-column-two-thirds">
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full"><span class="govuk-caption-l govuk-!-margin-bottom-3">Appeal 351062</span>
-                    <h1                     class="govuk-heading-l govuk-!-margin-bottom-3">Change procedure preference</h1>
                 </div>
             </div>
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full">
                     <form method="POST" novalidate="novalidate">
                         <div class="govuk-form-group">
-                            <div class="govuk-radios" data-module="govuk-radios">
-                                <div class="govuk-radios__item">
-                                    <input class="govuk-radios__input" id="procedurePreferenceRadio" name="procedurePreferenceRadio"
-                                    type="radio" value="hearing">
-                                    <label class="govuk-label govuk-radios__label" for="procedurePreferenceRadio">Hearing</label>
+                            <fieldset class="govuk-fieldset">
+                                <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+                                    <h1 class="govuk-fieldset__heading"> Change procedure preference</h1>
+                                </legend>
+                                <div class="govuk-radios" data-module="govuk-radios">
+                                    <div class="govuk-radios__item">
+                                        <input class="govuk-radios__input" id="procedure-preference-radio" name="procedurePreferenceRadio"
+                                        type="radio" value="hearing">
+                                        <label class="govuk-label govuk-radios__label" for="procedure-preference-radio">Hearing</label>
+                                    </div>
+                                    <div class="govuk-radios__item">
+                                        <input class="govuk-radios__input" id="procedure-preference-radio-2" name="procedurePreferenceRadio"
+                                        type="radio" value="inquiry">
+                                        <label class="govuk-label govuk-radios__label" for="procedure-preference-radio-2">Inquiry</label>
+                                    </div>
+                                    <div class="govuk-radios__item">
+                                        <input class="govuk-radios__input" id="procedure-preference-radio-3" name="procedurePreferenceRadio"
+                                        type="radio" value="written">
+                                        <label class="govuk-label govuk-radios__label" for="procedure-preference-radio-3">Written</label>
+                                    </div>
                                 </div>
-                                <div class="govuk-radios__item">
-                                    <input class="govuk-radios__input" id="procedurePreferenceRadio-2" name="procedurePreferenceRadio"
-                                    type="radio" value="inquiry">
-                                    <label class="govuk-label govuk-radios__label" for="procedurePreferenceRadio-2">Inquiry</label>
-                                </div>
-                                <div class="govuk-radios__item">
-                                    <input class="govuk-radios__input" id="procedurePreferenceRadio-3" name="procedurePreferenceRadio"
-                                    type="radio" value="written">
-                                    <label class="govuk-label govuk-radios__label" for="procedurePreferenceRadio-3">Written</label>
-                                </div>
-                            </div>
+                            </fieldset>
                         </div>
                         <button type="submit" data-prevent-double-click="true" class="govuk-button"
                         data-module="govuk-button">Continue</button>
@@ -47,30 +51,34 @@ exports[`procedure-preference GET /change should render the change procedure pre
         <div class="govuk-grid-column-two-thirds">
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full"><span class="govuk-caption-l govuk-!-margin-bottom-3">Appeal 351062</span>
-                    <h1                     class="govuk-heading-l govuk-!-margin-bottom-3">Change procedure preference</h1>
                 </div>
             </div>
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full">
                     <form method="POST" novalidate="novalidate">
                         <div class="govuk-form-group">
-                            <div class="govuk-radios" data-module="govuk-radios">
-                                <div class="govuk-radios__item">
-                                    <input class="govuk-radios__input" id="procedurePreferenceRadio" name="procedurePreferenceRadio"
-                                    type="radio" value="hearing" checked>
-                                    <label class="govuk-label govuk-radios__label" for="procedurePreferenceRadio">Hearing</label>
+                            <fieldset class="govuk-fieldset">
+                                <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+                                    <h1 class="govuk-fieldset__heading"> Change procedure preference</h1>
+                                </legend>
+                                <div class="govuk-radios" data-module="govuk-radios">
+                                    <div class="govuk-radios__item">
+                                        <input class="govuk-radios__input" id="procedure-preference-radio" name="procedurePreferenceRadio"
+                                        type="radio" value="hearing" checked>
+                                        <label class="govuk-label govuk-radios__label" for="procedure-preference-radio">Hearing</label>
+                                    </div>
+                                    <div class="govuk-radios__item">
+                                        <input class="govuk-radios__input" id="procedure-preference-radio-2" name="procedurePreferenceRadio"
+                                        type="radio" value="inquiry">
+                                        <label class="govuk-label govuk-radios__label" for="procedure-preference-radio-2">Inquiry</label>
+                                    </div>
+                                    <div class="govuk-radios__item">
+                                        <input class="govuk-radios__input" id="procedure-preference-radio-3" name="procedurePreferenceRadio"
+                                        type="radio" value="written">
+                                        <label class="govuk-label govuk-radios__label" for="procedure-preference-radio-3">Written</label>
+                                    </div>
                                 </div>
-                                <div class="govuk-radios__item">
-                                    <input class="govuk-radios__input" id="procedurePreferenceRadio-2" name="procedurePreferenceRadio"
-                                    type="radio" value="inquiry">
-                                    <label class="govuk-label govuk-radios__label" for="procedurePreferenceRadio-2">Inquiry</label>
-                                </div>
-                                <div class="govuk-radios__item">
-                                    <input class="govuk-radios__input" id="procedurePreferenceRadio-3" name="procedurePreferenceRadio"
-                                    type="radio" value="written">
-                                    <label class="govuk-label govuk-radios__label" for="procedurePreferenceRadio-3">Written</label>
-                                </div>
-                            </div>
+                            </fieldset>
                         </div>
                         <button type="submit" data-prevent-double-click="true" class="govuk-button"
                         data-module="govuk-button">Continue</button>
@@ -88,30 +96,34 @@ exports[`procedure-preference GET /change should render the change procedure pre
         <div class="govuk-grid-column-two-thirds">
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full"><span class="govuk-caption-l govuk-!-margin-bottom-3">Appeal 351062</span>
-                    <h1                     class="govuk-heading-l govuk-!-margin-bottom-3">Change procedure preference</h1>
                 </div>
             </div>
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full">
                     <form method="POST" novalidate="novalidate">
                         <div class="govuk-form-group">
-                            <div class="govuk-radios" data-module="govuk-radios">
-                                <div class="govuk-radios__item">
-                                    <input class="govuk-radios__input" id="procedurePreferenceRadio" name="procedurePreferenceRadio"
-                                    type="radio" value="hearing">
-                                    <label class="govuk-label govuk-radios__label" for="procedurePreferenceRadio">Hearing</label>
+                            <fieldset class="govuk-fieldset">
+                                <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+                                    <h1 class="govuk-fieldset__heading"> Change procedure preference</h1>
+                                </legend>
+                                <div class="govuk-radios" data-module="govuk-radios">
+                                    <div class="govuk-radios__item">
+                                        <input class="govuk-radios__input" id="procedure-preference-radio" name="procedurePreferenceRadio"
+                                        type="radio" value="hearing">
+                                        <label class="govuk-label govuk-radios__label" for="procedure-preference-radio">Hearing</label>
+                                    </div>
+                                    <div class="govuk-radios__item">
+                                        <input class="govuk-radios__input" id="procedure-preference-radio-2" name="procedurePreferenceRadio"
+                                        type="radio" value="inquiry" checked>
+                                        <label class="govuk-label govuk-radios__label" for="procedure-preference-radio-2">Inquiry</label>
+                                    </div>
+                                    <div class="govuk-radios__item">
+                                        <input class="govuk-radios__input" id="procedure-preference-radio-3" name="procedurePreferenceRadio"
+                                        type="radio" value="written">
+                                        <label class="govuk-label govuk-radios__label" for="procedure-preference-radio-3">Written</label>
+                                    </div>
                                 </div>
-                                <div class="govuk-radios__item">
-                                    <input class="govuk-radios__input" id="procedurePreferenceRadio-2" name="procedurePreferenceRadio"
-                                    type="radio" value="inquiry" checked>
-                                    <label class="govuk-label govuk-radios__label" for="procedurePreferenceRadio-2">Inquiry</label>
-                                </div>
-                                <div class="govuk-radios__item">
-                                    <input class="govuk-radios__input" id="procedurePreferenceRadio-3" name="procedurePreferenceRadio"
-                                    type="radio" value="written">
-                                    <label class="govuk-label govuk-radios__label" for="procedurePreferenceRadio-3">Written</label>
-                                </div>
-                            </div>
+                            </fieldset>
                         </div>
                         <button type="submit" data-prevent-double-click="true" class="govuk-button"
                         data-module="govuk-button">Continue</button>
@@ -129,30 +141,34 @@ exports[`procedure-preference GET /change should render the change procedure pre
         <div class="govuk-grid-column-two-thirds">
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full"><span class="govuk-caption-l govuk-!-margin-bottom-3">Appeal 351062</span>
-                    <h1                     class="govuk-heading-l govuk-!-margin-bottom-3">Change procedure preference</h1>
                 </div>
             </div>
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full">
                     <form method="POST" novalidate="novalidate">
                         <div class="govuk-form-group">
-                            <div class="govuk-radios" data-module="govuk-radios">
-                                <div class="govuk-radios__item">
-                                    <input class="govuk-radios__input" id="procedurePreferenceRadio" name="procedurePreferenceRadio"
-                                    type="radio" value="hearing">
-                                    <label class="govuk-label govuk-radios__label" for="procedurePreferenceRadio">Hearing</label>
+                            <fieldset class="govuk-fieldset">
+                                <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+                                    <h1 class="govuk-fieldset__heading"> Change procedure preference</h1>
+                                </legend>
+                                <div class="govuk-radios" data-module="govuk-radios">
+                                    <div class="govuk-radios__item">
+                                        <input class="govuk-radios__input" id="procedure-preference-radio" name="procedurePreferenceRadio"
+                                        type="radio" value="hearing">
+                                        <label class="govuk-label govuk-radios__label" for="procedure-preference-radio">Hearing</label>
+                                    </div>
+                                    <div class="govuk-radios__item">
+                                        <input class="govuk-radios__input" id="procedure-preference-radio-2" name="procedurePreferenceRadio"
+                                        type="radio" value="inquiry">
+                                        <label class="govuk-label govuk-radios__label" for="procedure-preference-radio-2">Inquiry</label>
+                                    </div>
+                                    <div class="govuk-radios__item">
+                                        <input class="govuk-radios__input" id="procedure-preference-radio-3" name="procedurePreferenceRadio"
+                                        type="radio" value="written" checked>
+                                        <label class="govuk-label govuk-radios__label" for="procedure-preference-radio-3">Written</label>
+                                    </div>
                                 </div>
-                                <div class="govuk-radios__item">
-                                    <input class="govuk-radios__input" id="procedurePreferenceRadio-2" name="procedurePreferenceRadio"
-                                    type="radio" value="inquiry">
-                                    <label class="govuk-label govuk-radios__label" for="procedurePreferenceRadio-2">Inquiry</label>
-                                </div>
-                                <div class="govuk-radios__item">
-                                    <input class="govuk-radios__input" id="procedurePreferenceRadio-3" name="procedurePreferenceRadio"
-                                    type="radio" value="written" checked>
-                                    <label class="govuk-label govuk-radios__label" for="procedurePreferenceRadio-3">Written</label>
-                                </div>
-                            </div>
+                            </fieldset>
                         </div>
                         <button type="submit" data-prevent-double-click="true" class="govuk-button"
                         data-module="govuk-button">Continue</button>

--- a/appeals/web/src/server/appeals/appeal-details/appellant-case/procedure-preference/procedure-preference.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/appellant-case/procedure-preference/procedure-preference.mapper.js
@@ -24,12 +24,19 @@ export const changeProcedurePreferencePage = (appealData, appellantCaseData, sto
 		title: `Change procedure preference`,
 		backLinkUrl: `/appeals-service/appeal-details/${appealData.appealId}/appellant-case`,
 		preHeading: `Appeal ${shortAppealReference}`,
-		heading: `Change procedure preference`,
 		pageComponents: [
 			{
 				type: 'radios',
 				parameters: {
 					name: 'procedurePreferenceRadio',
+					idPrefix: 'procedure-preference-radio',
+					fieldset: {
+						legend: {
+							text: 'Change procedure preference',
+							isPageHeading: true,
+							classes: 'govuk-fieldset__legend--l'
+						}
+					},
 					items: [
 						{
 							value: 'hearing',

--- a/appeals/web/src/server/appeals/appeal-details/appellant-case/site-ownership/__tests__/__snapshots__/site-ownership.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/appellant-case/site-ownership/__tests__/__snapshots__/site-ownership.test.js.snap
@@ -6,30 +6,34 @@ exports[`site-ownership GET /change should render the siteOwnership change page 
         <div class="govuk-grid-column-two-thirds">
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full"><span class="govuk-caption-l govuk-!-margin-bottom-3">Appeal 351062</span>
-                    <h1                     class="govuk-heading-l govuk-!-margin-bottom-3">Change the site ownership</h1>
                 </div>
             </div>
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full">
                     <form method="POST" novalidate="novalidate">
                         <div class="govuk-form-group">
-                            <div class="govuk-radios" data-module="govuk-radios">
-                                <div class="govuk-radios__item">
-                                    <input class="govuk-radios__input" id="site-ownership-radio" name="siteOwnershipRadio"
-                                    type="radio" value="fully" checked>
-                                    <label class="govuk-label govuk-radios__label" for="site-ownership-radio">Fully owned by appellant</label>
+                            <fieldset class="govuk-fieldset">
+                                <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+                                    <h1 class="govuk-fieldset__heading"> Change the site ownership</h1>
+                                </legend>
+                                <div class="govuk-radios" data-module="govuk-radios">
+                                    <div class="govuk-radios__item">
+                                        <input class="govuk-radios__input" id="site-ownership-radio" name="siteOwnershipRadio"
+                                        type="radio" value="fully" checked>
+                                        <label class="govuk-label govuk-radios__label" for="site-ownership-radio">Fully owned by appellant</label>
+                                    </div>
+                                    <div class="govuk-radios__item">
+                                        <input class="govuk-radios__input" id="site-ownership-radio-2" name="siteOwnershipRadio"
+                                        type="radio" value="partially">
+                                        <label class="govuk-label govuk-radios__label" for="site-ownership-radio-2">Partially owned by appellant</label>
+                                    </div>
+                                    <div class="govuk-radios__item">
+                                        <input class="govuk-radios__input" id="site-ownership-radio-3" name="siteOwnershipRadio"
+                                        type="radio" value="none">
+                                        <label class="govuk-label govuk-radios__label" for="site-ownership-radio-3">Not owned by appellant</label>
+                                    </div>
                                 </div>
-                                <div class="govuk-radios__item">
-                                    <input class="govuk-radios__input" id="site-ownership-radio-2" name="siteOwnershipRadio"
-                                    type="radio" value="partially">
-                                    <label class="govuk-label govuk-radios__label" for="site-ownership-radio-2">Partially owned by appellant</label>
-                                </div>
-                                <div class="govuk-radios__item">
-                                    <input class="govuk-radios__input" id="site-ownership-radio-3" name="siteOwnershipRadio"
-                                    type="radio" value="none">
-                                    <label class="govuk-label govuk-radios__label" for="site-ownership-radio-3">Not owned by appellant</label>
-                                </div>
-                            </div>
+                            </fieldset>
                         </div>
                         <button type="submit" data-prevent-double-click="true" class="govuk-button"
                         data-module="govuk-button">Continue</button>

--- a/appeals/web/src/server/appeals/appeal-details/appellant-case/site-ownership/site-ownership.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/appellant-case/site-ownership/site-ownership.mapper.js
@@ -25,17 +25,16 @@ export const changeSiteOwnershipPage = (appealData, appellantCaseData, storedSes
 		title: `Change the site ownership`,
 		backLinkUrl: `/appeals-service/appeal-details/${appealData.appealId}/appellant-case`,
 		preHeading: `Appeal ${shortAppealReference}`,
-		heading: `Change the site ownership`,
 		pageComponents: [
 			{
 				type: 'radios',
 				parameters: {
 					name: 'siteOwnershipRadio',
 					idPrefix: 'site-ownership-radio',
-					fieldSet: {
+					fieldset: {
 						legend: {
-							text: `Is the site fully owned or partially owned by the appellant`,
-							isPageHeading: false,
+							text: 'Change the site ownership',
+							isPageHeading: true,
 							classes: 'govuk-fieldset__legend--l'
 						}
 					},

--- a/appeals/web/src/server/appeals/appeal-details/change-appeal-type/__tests__/__snapshots__/change-appeal-type.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/change-appeal-type/__tests__/__snapshots__/change-appeal-type.test.js.snap
@@ -32,7 +32,6 @@ exports[`change-appeal-type GET /change-appeal-type/appeal-type should render th
         <div class="govuk-grid-column-two-thirds">
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full"><span class="govuk-caption-l govuk-!-margin-bottom-3">Appeal 351062</span>
-                    <h1                     class="govuk-heading-l govuk-!-margin-bottom-3">What type should this appeal be?</h1>
                 </div>
             </div>
             <div class="govuk-grid-row">
@@ -40,6 +39,9 @@ exports[`change-appeal-type GET /change-appeal-type/appeal-type should render th
                     <form method="POST" novalidate="novalidate">
                         <div class="govuk-form-group">
                             <fieldset class="govuk-fieldset">
+                                <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+                                    <h1 class="govuk-fieldset__heading"> What type should this appeal be?</h1>
+                                </legend>
                                 <div class="govuk-radios" data-module="govuk-radios">
                                     <div class="govuk-radios__item">
                                         <input class="govuk-radios__input" id="appeal-type" name="appealType"
@@ -70,7 +72,6 @@ exports[`change-appeal-type GET /change-appeal-type/change-appeal-final-date sho
         <div class="govuk-grid-column-two-thirds">
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full"><span class="govuk-caption-l govuk-!-margin-bottom-3">Appeal 351062</span>
-                    <h1                     class="govuk-heading-l govuk-!-margin-bottom-3">What is the final date the appellant must resubmit by?</h1>
                 </div>
             </div>
             <div class="govuk-grid-row">
@@ -78,6 +79,9 @@ exports[`change-appeal-type GET /change-appeal-type/change-appeal-final-date sho
                     <form method="POST" novalidate="novalidate">
                         <div class="govuk-form-group">
                             <fieldset class="govuk-fieldset" role="group" aria-describedby="change-appeal-final-date-hint">
+                                <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+                                    <h1 class="govuk-fieldset__heading"> What is the final date the appellant must resubmit by?</h1>
+                                </legend>
                                 <div id="change-appeal-final-date-hint" class="govuk-hint">For example, 27 3 2023</div>
                                 <div class="govuk-date-input" id="change-appeal-final-date">
                                     <div class="govuk-date-input__item">
@@ -193,7 +197,6 @@ exports[`change-appeal-type GET /change-appeal-type/resubmit should render the r
         <div class="govuk-grid-column-two-thirds">
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full"><span class="govuk-caption-l govuk-!-margin-bottom-3">Appeal 351062</span>
-                    <h1                     class="govuk-heading-l govuk-!-margin-bottom-3">Should the appellant be asked to resubmit this appeal?</h1>
                 </div>
             </div>
             <div class="govuk-grid-row">
@@ -201,6 +204,9 @@ exports[`change-appeal-type GET /change-appeal-type/resubmit should render the r
                     <form method="POST" novalidate="novalidate">
                         <div class="govuk-form-group">
                             <fieldset class="govuk-fieldset">
+                                <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+                                    <h1 class="govuk-fieldset__heading"> Should the appellant be asked to resubmit this appeal?</h1>
+                                </legend>
                                 <div class="govuk-radios" data-module="govuk-radios">
                                     <div class="govuk-radios__item">
                                         <input class="govuk-radios__input" id="appeal-resubmit" name="appealResubmit"
@@ -329,7 +335,6 @@ exports[`change-appeal-type POST /change-appeal-type/appeal-type should re-rende
             </div>
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full"><span class="govuk-caption-l govuk-!-margin-bottom-3">Appeal 351062</span>
-                    <h1                     class="govuk-heading-l govuk-!-margin-bottom-3">What type should this appeal be?</h1>
                 </div>
             </div>
             <div class="govuk-grid-row">
@@ -337,6 +342,9 @@ exports[`change-appeal-type POST /change-appeal-type/appeal-type should re-rende
                     <form method="POST" novalidate="novalidate">
                         <div class="govuk-form-group">
                             <fieldset class="govuk-fieldset">
+                                <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+                                    <h1 class="govuk-fieldset__heading"> What type should this appeal be?</h1>
+                                </legend>
                                 <div class="govuk-radios" data-module="govuk-radios">
                                     <div class="govuk-radios__item">
                                         <input class="govuk-radios__input" id="appeal-type" name="appealType"
@@ -477,7 +485,6 @@ exports[`change-appeal-type POST /change-appeal-type/resubmit should re-render t
             </div>
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full"><span class="govuk-caption-l govuk-!-margin-bottom-3">Appeal 351062</span>
-                    <h1                     class="govuk-heading-l govuk-!-margin-bottom-3">Should the appellant be asked to resubmit this appeal?</h1>
                 </div>
             </div>
             <div class="govuk-grid-row">
@@ -485,6 +492,9 @@ exports[`change-appeal-type POST /change-appeal-type/resubmit should re-render t
                     <form method="POST" novalidate="novalidate">
                         <div class="govuk-form-group">
                             <fieldset class="govuk-fieldset">
+                                <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+                                    <h1 class="govuk-fieldset__heading"> Should the appellant be asked to resubmit this appeal?</h1>
+                                </legend>
                                 <div class="govuk-radios" data-module="govuk-radios">
                                     <div class="govuk-radios__item">
                                         <input class="govuk-radios__input" id="appeal-resubmit" name="appealResubmit"
@@ -526,7 +536,6 @@ exports[`change-appeal-type should re-render the final date page with an error m
             </div>
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full"><span class="govuk-caption-l govuk-!-margin-bottom-3">Appeal 351062</span>
-                    <h1                     class="govuk-heading-l govuk-!-margin-bottom-3">What is the final date the appellant must resubmit by?</h1>
                 </div>
             </div>
             <div class="govuk-grid-row">
@@ -534,6 +543,9 @@ exports[`change-appeal-type should re-render the final date page with an error m
                     <form method="POST" novalidate="novalidate">
                         <div class="govuk-form-group">
                             <fieldset class="govuk-fieldset" role="group" aria-describedby="change-appeal-final-date-hint">
+                                <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+                                    <h1 class="govuk-fieldset__heading"> What is the final date the appellant must resubmit by?</h1>
+                                </legend>
                                 <div id="change-appeal-final-date-hint" class="govuk-hint">For example, 27 3 2023</div>
                                 <div class="govuk-date-input" id="change-appeal-final-date">
                                     <div class="govuk-date-input__item">
@@ -592,7 +604,6 @@ exports[`change-appeal-type should re-render the final date page with an error m
             </div>
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full"><span class="govuk-caption-l govuk-!-margin-bottom-3">Appeal 351062</span>
-                    <h1                     class="govuk-heading-l govuk-!-margin-bottom-3">What is the final date the appellant must resubmit by?</h1>
                 </div>
             </div>
             <div class="govuk-grid-row">
@@ -600,6 +611,9 @@ exports[`change-appeal-type should re-render the final date page with an error m
                     <form method="POST" novalidate="novalidate">
                         <div class="govuk-form-group">
                             <fieldset class="govuk-fieldset" role="group" aria-describedby="change-appeal-final-date-hint">
+                                <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+                                    <h1 class="govuk-fieldset__heading"> What is the final date the appellant must resubmit by?</h1>
+                                </legend>
                                 <div id="change-appeal-final-date-hint" class="govuk-hint">For example, 27 3 2023</div>
                                 <div class="govuk-date-input" id="change-appeal-final-date">
                                     <div class="govuk-date-input__item">
@@ -660,7 +674,6 @@ exports[`change-appeal-type should re-render the final date page with an error m
             </div>
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full"><span class="govuk-caption-l govuk-!-margin-bottom-3">Appeal 351062</span>
-                    <h1                     class="govuk-heading-l govuk-!-margin-bottom-3">What is the final date the appellant must resubmit by?</h1>
                 </div>
             </div>
             <div class="govuk-grid-row">
@@ -668,6 +681,9 @@ exports[`change-appeal-type should re-render the final date page with an error m
                     <form method="POST" novalidate="novalidate">
                         <div class="govuk-form-group">
                             <fieldset class="govuk-fieldset" role="group" aria-describedby="change-appeal-final-date-hint">
+                                <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+                                    <h1 class="govuk-fieldset__heading"> What is the final date the appellant must resubmit by?</h1>
+                                </legend>
                                 <div id="change-appeal-final-date-hint" class="govuk-hint">For example, 27 3 2023</div>
                                 <div class="govuk-date-input" id="change-appeal-final-date">
                                     <div class="govuk-date-input__item">
@@ -726,7 +742,6 @@ exports[`change-appeal-type should re-render the final date page with an error m
             </div>
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full"><span class="govuk-caption-l govuk-!-margin-bottom-3">Appeal 351062</span>
-                    <h1                     class="govuk-heading-l govuk-!-margin-bottom-3">What is the final date the appellant must resubmit by?</h1>
                 </div>
             </div>
             <div class="govuk-grid-row">
@@ -734,6 +749,9 @@ exports[`change-appeal-type should re-render the final date page with an error m
                     <form method="POST" novalidate="novalidate">
                         <div class="govuk-form-group">
                             <fieldset class="govuk-fieldset" role="group" aria-describedby="change-appeal-final-date-hint">
+                                <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+                                    <h1 class="govuk-fieldset__heading"> What is the final date the appellant must resubmit by?</h1>
+                                </legend>
                                 <div id="change-appeal-final-date-hint" class="govuk-hint">For example, 27 3 2023</div>
                                 <div class="govuk-date-input" id="change-appeal-final-date">
                                     <div class="govuk-date-input__item">
@@ -794,7 +812,6 @@ exports[`change-appeal-type should re-render the final date page with an error m
             </div>
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full"><span class="govuk-caption-l govuk-!-margin-bottom-3">Appeal 351062</span>
-                    <h1                     class="govuk-heading-l govuk-!-margin-bottom-3">What is the final date the appellant must resubmit by?</h1>
                 </div>
             </div>
             <div class="govuk-grid-row">
@@ -802,6 +819,9 @@ exports[`change-appeal-type should re-render the final date page with an error m
                     <form method="POST" novalidate="novalidate">
                         <div class="govuk-form-group">
                             <fieldset class="govuk-fieldset" role="group" aria-describedby="change-appeal-final-date-hint">
+                                <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+                                    <h1 class="govuk-fieldset__heading"> What is the final date the appellant must resubmit by?</h1>
+                                </legend>
                                 <div id="change-appeal-final-date-hint" class="govuk-hint">For example, 27 3 2023</div>
                                 <div class="govuk-date-input" id="change-appeal-final-date">
                                     <div class="govuk-date-input__item">
@@ -862,7 +882,6 @@ exports[`change-appeal-type should re-render the final date page with an error m
             </div>
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full"><span class="govuk-caption-l govuk-!-margin-bottom-3">Appeal 351062</span>
-                    <h1                     class="govuk-heading-l govuk-!-margin-bottom-3">What is the final date the appellant must resubmit by?</h1>
                 </div>
             </div>
             <div class="govuk-grid-row">
@@ -870,6 +889,9 @@ exports[`change-appeal-type should re-render the final date page with an error m
                     <form method="POST" novalidate="novalidate">
                         <div class="govuk-form-group">
                             <fieldset class="govuk-fieldset" role="group" aria-describedby="change-appeal-final-date-hint">
+                                <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+                                    <h1 class="govuk-fieldset__heading"> What is the final date the appellant must resubmit by?</h1>
+                                </legend>
                                 <div id="change-appeal-final-date-hint" class="govuk-hint">For example, 27 3 2023</div>
                                 <div class="govuk-date-input" id="change-appeal-final-date">
                                     <div class="govuk-date-input__item">

--- a/appeals/web/src/server/appeals/appeal-details/change-appeal-type/change-appeal-type.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/change-appeal-type/change-appeal-type.mapper.js
@@ -28,7 +28,9 @@ export function appealTypePage(appealDetails, appealTypes, changeAppeal) {
 			idPrefix: 'appeal-type',
 			fieldset: {
 				legend: {
-					classes: 'govuk-fieldset__legend--m'
+					text: 'What type should this appeal be?',
+					isPageHeading: true,
+					classes: 'govuk-fieldset__legend--l'
 				}
 			},
 			items: mapAppealTypesToSelectItemParameters(appealTypes, changeAppeal)
@@ -42,7 +44,6 @@ export function appealTypePage(appealDetails, appealTypes, changeAppeal) {
 		title: `What type should this appeal be? - ${shortAppealReference}`,
 		backLinkUrl: `/appeals-service/appeal-details/${appealDetails.appealId}`,
 		preHeading: `Appeal ${shortAppealReference}`,
-		heading: 'What type should this appeal be?',
 		pageComponents: [selectAppealTypeRadiosComponent]
 	};
 
@@ -80,7 +81,9 @@ export function resubmitAppealPage(appealDetails, changeAppeal) {
 			idPrefix: 'appeal-resubmit',
 			fieldset: {
 				legend: {
-					classes: 'govuk-fieldset__legend--m'
+					text: 'Should the appellant be asked to resubmit this appeal?',
+					isPageHeading: true,
+					classes: 'govuk-fieldset__legend--l'
 				}
 			},
 			items: [
@@ -105,7 +108,6 @@ export function resubmitAppealPage(appealDetails, changeAppeal) {
 		title: `Should the appellant be asked to resubmit this appeal? - ${shortAppealReference}`,
 		backLinkUrl: `/appeals-service/appeal-details/${appealDetails.appealId}/change-appeal-type/appeal-type`,
 		preHeading: `Appeal ${shortAppealReference}`,
-		heading: 'Should the appellant be asked to resubmit this appeal?',
 		pageComponents: [selectResubmitAppealComponent]
 	};
 
@@ -305,8 +307,9 @@ export function changeAppealFinalDatePage(appealDetails, changeDay, changeMonth,
 			namePrefix: 'change-appeal-final-date',
 			fieldset: {
 				legend: {
-					text: '',
-					classes: 'govuk-fieldset__legend--m'
+					text: 'What is the final date the appellant must resubmit by?',
+					isPageHeading: true,
+					classes: 'govuk-fieldset__legend--l'
 				}
 			},
 			hint: {
@@ -347,7 +350,6 @@ export function changeAppealFinalDatePage(appealDetails, changeDay, changeMonth,
 		title: `What is the final date the appellant must resubmit by? - ${shortAppealReference}`,
 		backLinkUrl: `/appeals-service/appeal-details/${appealDetails.appealId}/change-appeal-type/resubmit`,
 		preHeading: `Appeal ${shortAppealReference}`,
-		heading: 'What is the final date the appellant must resubmit by?',
 		pageComponents: [selectDateComponent, insetTextComponent],
 		submitButtonText: 'Confirm'
 	};

--- a/appeals/web/src/server/appeals/appeal-details/green-belt/__tests__/__snapshots__/green-belt.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/green-belt/__tests__/__snapshots__/green-belt.test.js.snap
@@ -6,25 +6,29 @@ exports[`green-belt GET /change should render the greenBelt change page when acc
         <div class="govuk-grid-column-two-thirds">
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full"><span class="govuk-caption-l govuk-!-margin-bottom-3">Appeal 351062</span>
-                    <h1                     class="govuk-heading-l govuk-!-margin-bottom-3">Is the site in a green belt?</h1>
                 </div>
             </div>
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full">
                     <form method="POST" novalidate="novalidate">
                         <div class="govuk-form-group">
-                            <div class="govuk-radios" data-module="govuk-radios">
-                                <div class="govuk-radios__item">
-                                    <input class="govuk-radios__input" id="greenBeltRadio" name="greenBeltRadio"
-                                    type="radio" value="yes">
-                                    <label class="govuk-label govuk-radios__label" for="greenBeltRadio">Yes</label>
+                            <fieldset class="govuk-fieldset">
+                                <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+                                    <h1 class="govuk-fieldset__heading"> Is the site in a green belt?</h1>
+                                </legend>
+                                <div class="govuk-radios" data-module="govuk-radios">
+                                    <div class="govuk-radios__item">
+                                        <input class="govuk-radios__input" id="greenBeltRadio" name="greenBeltRadio"
+                                        type="radio" value="yes">
+                                        <label class="govuk-label govuk-radios__label" for="greenBeltRadio">Yes</label>
+                                    </div>
+                                    <div class="govuk-radios__item">
+                                        <input class="govuk-radios__input" id="greenBeltRadio-2" name="greenBeltRadio"
+                                        type="radio" value="no">
+                                        <label class="govuk-label govuk-radios__label" for="greenBeltRadio-2">No</label>
+                                    </div>
                                 </div>
-                                <div class="govuk-radios__item">
-                                    <input class="govuk-radios__input" id="greenBeltRadio-2" name="greenBeltRadio"
-                                    type="radio" value="no">
-                                    <label class="govuk-label govuk-radios__label" for="greenBeltRadio-2">No</label>
-                                </div>
-                            </div>
+                            </fieldset>
                         </div>
                         <button type="submit" data-prevent-double-click="true" class="govuk-button"
                         data-module="govuk-button">Continue</button>
@@ -42,25 +46,29 @@ exports[`green-belt GET /change should render the greenBelt change page when acc
         <div class="govuk-grid-column-two-thirds">
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full"><span class="govuk-caption-l govuk-!-margin-bottom-3">Appeal 351062</span>
-                    <h1                     class="govuk-heading-l govuk-!-margin-bottom-3">Is the site in a green belt?</h1>
                 </div>
             </div>
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full">
                     <form method="POST" novalidate="novalidate">
                         <div class="govuk-form-group">
-                            <div class="govuk-radios" data-module="govuk-radios">
-                                <div class="govuk-radios__item">
-                                    <input class="govuk-radios__input" id="greenBeltRadio" name="greenBeltRadio"
-                                    type="radio" value="yes">
-                                    <label class="govuk-label govuk-radios__label" for="greenBeltRadio">Yes</label>
+                            <fieldset class="govuk-fieldset">
+                                <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+                                    <h1 class="govuk-fieldset__heading"> Is the site in a green belt?</h1>
+                                </legend>
+                                <div class="govuk-radios" data-module="govuk-radios">
+                                    <div class="govuk-radios__item">
+                                        <input class="govuk-radios__input" id="greenBeltRadio" name="greenBeltRadio"
+                                        type="radio" value="yes">
+                                        <label class="govuk-label govuk-radios__label" for="greenBeltRadio">Yes</label>
+                                    </div>
+                                    <div class="govuk-radios__item">
+                                        <input class="govuk-radios__input" id="greenBeltRadio-2" name="greenBeltRadio"
+                                        type="radio" value="no">
+                                        <label class="govuk-label govuk-radios__label" for="greenBeltRadio-2">No</label>
+                                    </div>
                                 </div>
-                                <div class="govuk-radios__item">
-                                    <input class="govuk-radios__input" id="greenBeltRadio-2" name="greenBeltRadio"
-                                    type="radio" value="no">
-                                    <label class="govuk-label govuk-radios__label" for="greenBeltRadio-2">No</label>
-                                </div>
-                            </div>
+                            </fieldset>
                         </div>
                         <button type="submit" data-prevent-double-click="true" class="govuk-button"
                         data-module="govuk-button">Continue</button>

--- a/appeals/web/src/server/appeals/appeal-details/green-belt/green-belt.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/green-belt/green-belt.mapper.js
@@ -18,8 +18,14 @@ export const changeGreenBeltPage = (appealData, data, origin) => {
 		title: `Is the site in a green belt?`,
 		backLinkUrl: origin,
 		preHeading: `Appeal ${shortAppealReference}`,
-		heading: `Is the site in a green belt?`,
-		pageComponents: [yesNoInput({ name: 'greenBeltRadio', value: data })]
+		pageComponents: [
+			yesNoInput({
+				name: 'greenBeltRadio',
+				value: data,
+				legendText: 'Is the site in a green belt?',
+				legendIsPageHeading: true
+			})
+		]
 	};
 	return pageContent;
 };

--- a/appeals/web/src/server/appeals/appeal-details/inspector-access/__tests__/__snapshots__/inspector-access.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/inspector-access/__tests__/__snapshots__/inspector-access.test.js.snap
@@ -6,33 +6,37 @@ exports[`inspector-access GET /change/:source should render changeInspectorAcces
         <div class="govuk-grid-column-two-thirds">
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full"><span class="govuk-caption-l govuk-!-margin-bottom-3">Appeal 351062</span>
-                    <h1                     class="govuk-heading-l govuk-!-margin-bottom-3">Change the inspector access (appellant answer)</h1>
                 </div>
             </div>
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full">
                     <form method="POST" novalidate="novalidate">
                         <div class="govuk-form-group">
-                            <div class="govuk-radios" data-module="govuk-radios">
-                                <div class="govuk-radios__item">
-                                    <input class="govuk-radios__input" id="inspectorAccessRadio" name="inspectorAccessRadio"
-                                    type="radio" value="yes" data-aria-controls="conditional-inspectorAccessRadio">
-                                    <label class="govuk-label govuk-radios__label" for="inspectorAccessRadio">Yes</label>
-                                </div>
-                                <div class="govuk-radios__conditional govuk-radios__conditional--hidden"
-                                id="conditional-inspectorAccessRadio">
-                                    <div class="govuk-form-group">
-                                        <label class="govuk-label" for="inspector-access-details">Inspector access (appellant details)</label>
-                                        <textarea class="govuk-textarea"
-                                        id="inspector-access-details" name="inspectorAccessDetails" rows="3"></textarea>
+                            <fieldset class="govuk-fieldset">
+                                <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+                                    <h1 class="govuk-fieldset__heading"> Change the inspector access (appellant answer)</h1>
+                                </legend>
+                                <div class="govuk-radios" data-module="govuk-radios">
+                                    <div class="govuk-radios__item">
+                                        <input class="govuk-radios__input" id="inspectorAccessRadio" name="inspectorAccessRadio"
+                                        type="radio" value="yes" data-aria-controls="conditional-inspectorAccessRadio">
+                                        <label class="govuk-label govuk-radios__label" for="inspectorAccessRadio">Yes</label>
+                                    </div>
+                                    <div class="govuk-radios__conditional govuk-radios__conditional--hidden"
+                                    id="conditional-inspectorAccessRadio">
+                                        <div class="govuk-form-group">
+                                            <label class="govuk-label" for="inspector-access-details">Inspector access (appellant details)</label>
+                                            <textarea class="govuk-textarea"
+                                            id="inspector-access-details" name="inspectorAccessDetails" rows="3"></textarea>
+                                        </div>
+                                    </div>
+                                    <div class="govuk-radios__item">
+                                        <input class="govuk-radios__input" id="inspectorAccessRadio-2" name="inspectorAccessRadio"
+                                        type="radio" value="no" checked>
+                                        <label class="govuk-label govuk-radios__label" for="inspectorAccessRadio-2">No</label>
                                     </div>
                                 </div>
-                                <div class="govuk-radios__item">
-                                    <input class="govuk-radios__input" id="inspectorAccessRadio-2" name="inspectorAccessRadio"
-                                    type="radio" value="no" checked>
-                                    <label class="govuk-label govuk-radios__label" for="inspectorAccessRadio-2">No</label>
-                                </div>
-                            </div>
+                            </fieldset>
                         </div>
                         <button type="submit" data-prevent-double-click="true" class="govuk-button"
                         data-module="govuk-button">Continue</button>
@@ -50,33 +54,37 @@ exports[`inspector-access GET /change/:source should render changeInspectorAcces
         <div class="govuk-grid-column-two-thirds">
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full"><span class="govuk-caption-l govuk-!-margin-bottom-3">Appeal 351062</span>
-                    <h1                     class="govuk-heading-l govuk-!-margin-bottom-3">Change the inspector access (appellant answer)</h1>
                 </div>
             </div>
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full">
                     <form method="POST" novalidate="novalidate">
                         <div class="govuk-form-group">
-                            <div class="govuk-radios" data-module="govuk-radios">
-                                <div class="govuk-radios__item">
-                                    <input class="govuk-radios__input" id="inspectorAccessRadio" name="inspectorAccessRadio"
-                                    type="radio" value="yes" data-aria-controls="conditional-inspectorAccessRadio">
-                                    <label class="govuk-label govuk-radios__label" for="inspectorAccessRadio">Yes</label>
-                                </div>
-                                <div class="govuk-radios__conditional govuk-radios__conditional--hidden"
-                                id="conditional-inspectorAccessRadio">
-                                    <div class="govuk-form-group">
-                                        <label class="govuk-label" for="inspector-access-details">Inspector access (appellant details)</label>
-                                        <textarea class="govuk-textarea"
-                                        id="inspector-access-details" name="inspectorAccessDetails" rows="3"></textarea>
+                            <fieldset class="govuk-fieldset">
+                                <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+                                    <h1 class="govuk-fieldset__heading"> Change the inspector access (appellant answer)</h1>
+                                </legend>
+                                <div class="govuk-radios" data-module="govuk-radios">
+                                    <div class="govuk-radios__item">
+                                        <input class="govuk-radios__input" id="inspectorAccessRadio" name="inspectorAccessRadio"
+                                        type="radio" value="yes" data-aria-controls="conditional-inspectorAccessRadio">
+                                        <label class="govuk-label govuk-radios__label" for="inspectorAccessRadio">Yes</label>
+                                    </div>
+                                    <div class="govuk-radios__conditional govuk-radios__conditional--hidden"
+                                    id="conditional-inspectorAccessRadio">
+                                        <div class="govuk-form-group">
+                                            <label class="govuk-label" for="inspector-access-details">Inspector access (appellant details)</label>
+                                            <textarea class="govuk-textarea"
+                                            id="inspector-access-details" name="inspectorAccessDetails" rows="3"></textarea>
+                                        </div>
+                                    </div>
+                                    <div class="govuk-radios__item">
+                                        <input class="govuk-radios__input" id="inspectorAccessRadio-2" name="inspectorAccessRadio"
+                                        type="radio" value="no" checked>
+                                        <label class="govuk-label govuk-radios__label" for="inspectorAccessRadio-2">No</label>
                                     </div>
                                 </div>
-                                <div class="govuk-radios__item">
-                                    <input class="govuk-radios__input" id="inspectorAccessRadio-2" name="inspectorAccessRadio"
-                                    type="radio" value="no" checked>
-                                    <label class="govuk-label govuk-radios__label" for="inspectorAccessRadio-2">No</label>
-                                </div>
-                            </div>
+                            </fieldset>
                         </div>
                         <button type="submit" data-prevent-double-click="true" class="govuk-button"
                         data-module="govuk-button">Continue</button>
@@ -94,33 +102,37 @@ exports[`inspector-access GET /change/:source should render changeInspectorAcces
         <div class="govuk-grid-column-two-thirds">
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full"><span class="govuk-caption-l govuk-!-margin-bottom-3">Appeal 351062</span>
-                    <h1                     class="govuk-heading-l govuk-!-margin-bottom-3">Change the inspector access (LPA answer)</h1>
                 </div>
             </div>
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full">
                     <form method="POST" novalidate="novalidate">
                         <div class="govuk-form-group">
-                            <div class="govuk-radios" data-module="govuk-radios">
-                                <div class="govuk-radios__item">
-                                    <input class="govuk-radios__input" id="inspectorAccessRadio" name="inspectorAccessRadio"
-                                    type="radio" value="yes" data-aria-controls="conditional-inspectorAccessRadio">
-                                    <label class="govuk-label govuk-radios__label" for="inspectorAccessRadio">Yes</label>
-                                </div>
-                                <div class="govuk-radios__conditional govuk-radios__conditional--hidden"
-                                id="conditional-inspectorAccessRadio">
-                                    <div class="govuk-form-group">
-                                        <label class="govuk-label" for="inspector-access-details">Inspector access (LPA details)</label>
-                                        <textarea class="govuk-textarea"
-                                        id="inspector-access-details" name="inspectorAccessDetails" rows="3"></textarea>
+                            <fieldset class="govuk-fieldset">
+                                <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+                                    <h1 class="govuk-fieldset__heading"> Change the inspector access (LPA answer)</h1>
+                                </legend>
+                                <div class="govuk-radios" data-module="govuk-radios">
+                                    <div class="govuk-radios__item">
+                                        <input class="govuk-radios__input" id="inspectorAccessRadio" name="inspectorAccessRadio"
+                                        type="radio" value="yes" data-aria-controls="conditional-inspectorAccessRadio">
+                                        <label class="govuk-label govuk-radios__label" for="inspectorAccessRadio">Yes</label>
+                                    </div>
+                                    <div class="govuk-radios__conditional govuk-radios__conditional--hidden"
+                                    id="conditional-inspectorAccessRadio">
+                                        <div class="govuk-form-group">
+                                            <label class="govuk-label" for="inspector-access-details">Inspector access (LPA details)</label>
+                                            <textarea class="govuk-textarea"
+                                            id="inspector-access-details" name="inspectorAccessDetails" rows="3"></textarea>
+                                        </div>
+                                    </div>
+                                    <div class="govuk-radios__item">
+                                        <input class="govuk-radios__input" id="inspectorAccessRadio-2" name="inspectorAccessRadio"
+                                        type="radio" value="no" checked>
+                                        <label class="govuk-label govuk-radios__label" for="inspectorAccessRadio-2">No</label>
                                     </div>
                                 </div>
-                                <div class="govuk-radios__item">
-                                    <input class="govuk-radios__input" id="inspectorAccessRadio-2" name="inspectorAccessRadio"
-                                    type="radio" value="no" checked>
-                                    <label class="govuk-label govuk-radios__label" for="inspectorAccessRadio-2">No</label>
-                                </div>
-                            </div>
+                            </fieldset>
                         </div>
                         <button type="submit" data-prevent-double-click="true" class="govuk-button"
                         data-module="govuk-button">Continue</button>
@@ -138,33 +150,37 @@ exports[`inspector-access GET /change/:source should render changeInspectorAcces
         <div class="govuk-grid-column-two-thirds">
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full"><span class="govuk-caption-l govuk-!-margin-bottom-3">Appeal 351062</span>
-                    <h1                     class="govuk-heading-l govuk-!-margin-bottom-3">Change the inspector access (LPA answer)</h1>
                 </div>
             </div>
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full">
                     <form method="POST" novalidate="novalidate">
                         <div class="govuk-form-group">
-                            <div class="govuk-radios" data-module="govuk-radios">
-                                <div class="govuk-radios__item">
-                                    <input class="govuk-radios__input" id="inspectorAccessRadio" name="inspectorAccessRadio"
-                                    type="radio" value="yes" data-aria-controls="conditional-inspectorAccessRadio">
-                                    <label class="govuk-label govuk-radios__label" for="inspectorAccessRadio">Yes</label>
-                                </div>
-                                <div class="govuk-radios__conditional govuk-radios__conditional--hidden"
-                                id="conditional-inspectorAccessRadio">
-                                    <div class="govuk-form-group">
-                                        <label class="govuk-label" for="inspector-access-details">Inspector access (LPA details)</label>
-                                        <textarea class="govuk-textarea"
-                                        id="inspector-access-details" name="inspectorAccessDetails" rows="3"></textarea>
+                            <fieldset class="govuk-fieldset">
+                                <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+                                    <h1 class="govuk-fieldset__heading"> Change the inspector access (LPA answer)</h1>
+                                </legend>
+                                <div class="govuk-radios" data-module="govuk-radios">
+                                    <div class="govuk-radios__item">
+                                        <input class="govuk-radios__input" id="inspectorAccessRadio" name="inspectorAccessRadio"
+                                        type="radio" value="yes" data-aria-controls="conditional-inspectorAccessRadio">
+                                        <label class="govuk-label govuk-radios__label" for="inspectorAccessRadio">Yes</label>
+                                    </div>
+                                    <div class="govuk-radios__conditional govuk-radios__conditional--hidden"
+                                    id="conditional-inspectorAccessRadio">
+                                        <div class="govuk-form-group">
+                                            <label class="govuk-label" for="inspector-access-details">Inspector access (LPA details)</label>
+                                            <textarea class="govuk-textarea"
+                                            id="inspector-access-details" name="inspectorAccessDetails" rows="3"></textarea>
+                                        </div>
+                                    </div>
+                                    <div class="govuk-radios__item">
+                                        <input class="govuk-radios__input" id="inspectorAccessRadio-2" name="inspectorAccessRadio"
+                                        type="radio" value="no" checked>
+                                        <label class="govuk-label govuk-radios__label" for="inspectorAccessRadio-2">No</label>
                                     </div>
                                 </div>
-                                <div class="govuk-radios__item">
-                                    <input class="govuk-radios__input" id="inspectorAccessRadio-2" name="inspectorAccessRadio"
-                                    type="radio" value="no" checked>
-                                    <label class="govuk-label govuk-radios__label" for="inspectorAccessRadio-2">No</label>
-                                </div>
-                            </div>
+                            </fieldset>
                         </div>
                         <button type="submit" data-prevent-double-click="true" class="govuk-button"
                         data-module="govuk-button">Continue</button>
@@ -193,32 +209,36 @@ exports[`inspector-access POST /change/:source should re-render changeInspectorA
             </div>
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full"><span class="govuk-caption-l govuk-!-margin-bottom-3">Appeal 351062</span>
-                    <h1                     class="govuk-heading-l govuk-!-margin-bottom-3">Change the inspector access (LPA answer)</h1>
                 </div>
             </div>
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full">
                     <form method="POST" novalidate="novalidate">
                         <div class="govuk-form-group">
-                            <div class="govuk-radios" data-module="govuk-radios">
-                                <div class="govuk-radios__item">
-                                    <input class="govuk-radios__input" id="inspectorAccessRadio" name="inspectorAccessRadio"
-                                    type="radio" value="yes" checked data-aria-controls="conditional-inspectorAccessRadio">
-                                    <label class="govuk-label govuk-radios__label" for="inspectorAccessRadio">Yes</label>
-                                </div>
-                                <div class="govuk-radios__conditional" id="conditional-inspectorAccessRadio">
-                                    <div class="govuk-form-group">
-                                        <label class="govuk-label" for="inspector-access-details">Inspector access (LPA details)</label>
-                                        <textarea class="govuk-textarea"
-                                        id="inspector-access-details" name="inspectorAccessDetails" rows="3">aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa</textarea>
+                            <fieldset class="govuk-fieldset">
+                                <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+                                    <h1 class="govuk-fieldset__heading"> Change the inspector access (LPA answer)</h1>
+                                </legend>
+                                <div class="govuk-radios" data-module="govuk-radios">
+                                    <div class="govuk-radios__item">
+                                        <input class="govuk-radios__input" id="inspectorAccessRadio" name="inspectorAccessRadio"
+                                        type="radio" value="yes" checked data-aria-controls="conditional-inspectorAccessRadio">
+                                        <label class="govuk-label govuk-radios__label" for="inspectorAccessRadio">Yes</label>
+                                    </div>
+                                    <div class="govuk-radios__conditional" id="conditional-inspectorAccessRadio">
+                                        <div class="govuk-form-group">
+                                            <label class="govuk-label" for="inspector-access-details">Inspector access (LPA details)</label>
+                                            <textarea class="govuk-textarea"
+                                            id="inspector-access-details" name="inspectorAccessDetails" rows="3">aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa</textarea>
+                                        </div>
+                                    </div>
+                                    <div class="govuk-radios__item">
+                                        <input class="govuk-radios__input" id="inspectorAccessRadio-2" name="inspectorAccessRadio"
+                                        type="radio" value="no">
+                                        <label class="govuk-label govuk-radios__label" for="inspectorAccessRadio-2">No</label>
                                     </div>
                                 </div>
-                                <div class="govuk-radios__item">
-                                    <input class="govuk-radios__input" id="inspectorAccessRadio-2" name="inspectorAccessRadio"
-                                    type="radio" value="no">
-                                    <label class="govuk-label govuk-radios__label" for="inspectorAccessRadio-2">No</label>
-                                </div>
-                            </div>
+                            </fieldset>
                         </div>
                         <button type="submit" data-prevent-double-click="true" class="govuk-button"
                         data-module="govuk-button">Continue</button>
@@ -247,32 +267,36 @@ exports[`inspector-access POST /change/:source should re-render changeInspectorA
             </div>
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full"><span class="govuk-caption-l govuk-!-margin-bottom-3">Appeal 351062</span>
-                    <h1                     class="govuk-heading-l govuk-!-margin-bottom-3">Change the inspector access (LPA answer)</h1>
                 </div>
             </div>
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full">
                     <form method="POST" novalidate="novalidate">
                         <div class="govuk-form-group">
-                            <div class="govuk-radios" data-module="govuk-radios">
-                                <div class="govuk-radios__item">
-                                    <input class="govuk-radios__input" id="inspectorAccessRadio" name="inspectorAccessRadio"
-                                    type="radio" value="yes" checked data-aria-controls="conditional-inspectorAccessRadio">
-                                    <label class="govuk-label govuk-radios__label" for="inspectorAccessRadio">Yes</label>
-                                </div>
-                                <div class="govuk-radios__conditional" id="conditional-inspectorAccessRadio">
-                                    <div class="govuk-form-group">
-                                        <label class="govuk-label" for="inspector-access-details">Inspector access (LPA details)</label>
-                                        <textarea class="govuk-textarea"
-                                        id="inspector-access-details" name="inspectorAccessDetails" rows="3"></textarea>
+                            <fieldset class="govuk-fieldset">
+                                <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+                                    <h1 class="govuk-fieldset__heading"> Change the inspector access (LPA answer)</h1>
+                                </legend>
+                                <div class="govuk-radios" data-module="govuk-radios">
+                                    <div class="govuk-radios__item">
+                                        <input class="govuk-radios__input" id="inspectorAccessRadio" name="inspectorAccessRadio"
+                                        type="radio" value="yes" checked data-aria-controls="conditional-inspectorAccessRadio">
+                                        <label class="govuk-label govuk-radios__label" for="inspectorAccessRadio">Yes</label>
+                                    </div>
+                                    <div class="govuk-radios__conditional" id="conditional-inspectorAccessRadio">
+                                        <div class="govuk-form-group">
+                                            <label class="govuk-label" for="inspector-access-details">Inspector access (LPA details)</label>
+                                            <textarea class="govuk-textarea"
+                                            id="inspector-access-details" name="inspectorAccessDetails" rows="3"></textarea>
+                                        </div>
+                                    </div>
+                                    <div class="govuk-radios__item">
+                                        <input class="govuk-radios__input" id="inspectorAccessRadio-2" name="inspectorAccessRadio"
+                                        type="radio" value="no">
+                                        <label class="govuk-label govuk-radios__label" for="inspectorAccessRadio-2">No</label>
                                     </div>
                                 </div>
-                                <div class="govuk-radios__item">
-                                    <input class="govuk-radios__input" id="inspectorAccessRadio-2" name="inspectorAccessRadio"
-                                    type="radio" value="no">
-                                    <label class="govuk-label govuk-radios__label" for="inspectorAccessRadio-2">No</label>
-                                </div>
-                            </div>
+                            </fieldset>
                         </div>
                         <button type="submit" data-prevent-double-click="true" class="govuk-button"
                         data-module="govuk-button">Continue</button>

--- a/appeals/web/src/server/appeals/appeal-details/inspector-access/inspector-access.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/inspector-access/inspector-access.mapper.js
@@ -28,11 +28,12 @@ export const changeInspectorAccessPage = (appealData, storedSessionData, origin,
 		title: `Change the inspector access (${formattedSource} answer)`,
 		backLinkUrl: origin,
 		preHeading: `Appeal ${shortAppealReference}`,
-		heading: `Change the inspector access (${formattedSource} answer)`,
 		pageComponents: [
 			yesNoInput({
 				name: 'inspectorAccessRadio',
 				value: currentRadioValue,
+				legendText: `Change the inspector access (${formattedSource} answer)`,
+				legendIsPageHeading: true,
 				yesConditional: {
 					id: 'inspector-access-details',
 					name: 'inspectorAccessDetails',

--- a/appeals/web/src/server/appeals/appeal-details/interested-party-comments/add-ip-comment/__tests__/__snapshots__/add-ip-comment.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/interested-party-comments/add-ip-comment/__tests__/__snapshots__/add-ip-comment.test.js.snap
@@ -6,25 +6,29 @@ exports[`add-ip-comment GET /add/check-address should match the snapshot 1`] = `
         <div class="govuk-grid-column-two-thirds">
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full"><span class="govuk-caption-l govuk-!-margin-bottom-3">Appeal 351062</span>
-                    <h1                     class="govuk-heading-xl govuk-!-margin-bottom-3">Did the interested party provide an address?</h1>
                 </div>
             </div>
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full">
                     <form method="post" novalidate="novalidate">
                         <div class="govuk-form-group">
-                            <div class="govuk-radios" data-module="govuk-radios">
-                                <div class="govuk-radios__item">
-                                    <input class="govuk-radios__input" id="address-provided" name="addressProvided"
-                                    type="radio" value="yes">
-                                    <label class="govuk-label govuk-radios__label" for="address-provided">Yes</label>
+                            <fieldset class="govuk-fieldset">
+                                <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+                                    <h1 class="govuk-fieldset__heading"> Did the interested party provide an address?</h1>
+                                </legend>
+                                <div class="govuk-radios" data-module="govuk-radios">
+                                    <div class="govuk-radios__item">
+                                        <input class="govuk-radios__input" id="address-provided" name="addressProvided"
+                                        type="radio" value="yes">
+                                        <label class="govuk-label govuk-radios__label" for="address-provided">Yes</label>
+                                    </div>
+                                    <div class="govuk-radios__item">
+                                        <input class="govuk-radios__input" id="address-provided-2" name="addressProvided"
+                                        type="radio" value="no">
+                                        <label class="govuk-label govuk-radios__label" for="address-provided-2">No</label>
+                                    </div>
                                 </div>
-                                <div class="govuk-radios__item">
-                                    <input class="govuk-radios__input" id="address-provided-2" name="addressProvided"
-                                    type="radio" value="no">
-                                    <label class="govuk-label govuk-radios__label" for="address-provided-2">No</label>
-                                </div>
-                            </div>
+                            </fieldset>
                         </div>
                         <button class="govuk-button" data-module="govuk-button">Continue</button>
                     </form>
@@ -180,37 +184,41 @@ exports[`add-ip-comment GET /date-submitted should match the snapshot 1`] = `
         <div class="govuk-grid-column-two-thirds">
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full"><span class="govuk-caption-l govuk-!-margin-bottom-3">Appeal 351062</span>
-                    <h1                     class="govuk-heading-l govuk-!-margin-bottom-3">When did the interested party submit the comment?</h1>
                 </div>
             </div>
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full">
                     <form method="POST" novalidate="novalidate">
                         <div class="govuk-form-group">
-                            <div id="date-hint" class="govuk-hint">For example, 27 3 2024</div>
-                            <div class="govuk-date-input" id="date">
-                                <div class="govuk-date-input__item">
-                                    <div class="govuk-form-group">
-                                        <label class="govuk-label govuk-date-input__label" for="date-day">Day</label>
-                                        <input class="govuk-input govuk-date-input__input govuk-input--width-2"
-                                        id="date-day" name="day" type="text" inputmode="numeric">
+                            <fieldset class="govuk-fieldset" role="group" aria-describedby="date-hint">
+                                <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+                                    <h1 class="govuk-fieldset__heading"> When did the interested party submit the comment?</h1>
+                                </legend>
+                                <div id="date-hint" class="govuk-hint">For example, 27 3 2024</div>
+                                <div class="govuk-date-input" id="date">
+                                    <div class="govuk-date-input__item">
+                                        <div class="govuk-form-group">
+                                            <label class="govuk-label govuk-date-input__label" for="date-day">Day</label>
+                                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                                            id="date-day" name="day" type="text" inputmode="numeric">
+                                        </div>
+                                    </div>
+                                    <div class="govuk-date-input__item">
+                                        <div class="govuk-form-group">
+                                            <label class="govuk-label govuk-date-input__label" for="date-month">Month</label>
+                                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                                            id="date-month" name="month" type="text" inputmode="numeric">
+                                        </div>
+                                    </div>
+                                    <div class="govuk-date-input__item">
+                                        <div class="govuk-form-group">
+                                            <label class="govuk-label govuk-date-input__label" for="date-year">Year</label>
+                                            <input class="govuk-input govuk-date-input__input govuk-input--width-4"
+                                            id="date-year" name="year" type="text" inputmode="numeric">
+                                        </div>
                                     </div>
                                 </div>
-                                <div class="govuk-date-input__item">
-                                    <div class="govuk-form-group">
-                                        <label class="govuk-label govuk-date-input__label" for="date-month">Month</label>
-                                        <input class="govuk-input govuk-date-input__input govuk-input--width-2"
-                                        id="date-month" name="month" type="text" inputmode="numeric">
-                                    </div>
-                                </div>
-                                <div class="govuk-date-input__item">
-                                    <div class="govuk-form-group">
-                                        <label class="govuk-label govuk-date-input__label" for="date-year">Year</label>
-                                        <input class="govuk-input govuk-date-input__input govuk-input--width-4"
-                                        id="date-year" name="year" type="text" inputmode="numeric">
-                                    </div>
-                                </div>
-                            </div>
+                            </fieldset>
                         </div>
                         <button type="submit" data-prevent-double-click="true" class="govuk-button"
                         data-module="govuk-button">Continue</button>

--- a/appeals/web/src/server/appeals/appeal-details/interested-party-comments/add-ip-comment/__tests__/add-ip-comment.test.js
+++ b/appeals/web/src/server/appeals/appeal-details/interested-party-comments/add-ip-comment/__tests__/add-ip-comment.test.js
@@ -48,7 +48,7 @@ describe('add-ip-comment', () => {
 		});
 
 		it('should render the correct heading', () => {
-			expect(pageHtml.querySelector('h1')?.innerHTML).toBe('Interested party&#39;s details');
+			expect(pageHtml.querySelector('h1')?.innerHTML.trim()).toBe('Interested party&#39;s details');
 		});
 
 		it('should render a First name field', () => {
@@ -86,7 +86,7 @@ describe('add-ip-comment', () => {
 		});
 
 		it('should render the correct heading', () => {
-			expect(pageHtml.querySelector('h1')?.innerHTML).toBe(
+			expect(pageHtml.querySelector('h1')?.innerHTML.trim()).toBe(
 				'Did the interested party provide an address?'
 			);
 		});
@@ -119,7 +119,7 @@ describe('add-ip-comment', () => {
 		});
 
 		it('should render the correct heading', () => {
-			expect(pageHtml.querySelector('h1')?.innerHTML).toBe('Interested party&#39;s address');
+			expect(pageHtml.querySelector('h1')?.innerHTML.trim()).toBe('Interested party&#39;s address');
 		});
 
 		it('should render an Address line 1 field', () => {
@@ -302,7 +302,7 @@ describe('add-ip-comment', () => {
 		});
 
 		it('should render the correct heading', () => {
-			expect(pageHtml.querySelector('h1')?.innerHTML).toBe(
+			expect(pageHtml.querySelector('h1')?.innerHTML.trim()).toBe(
 				'When did the interested party submit the comment?'
 			);
 		});
@@ -368,7 +368,7 @@ describe('add-ip-comment', () => {
 			expect(response.statusCode).toBe(400);
 
 			const element = parseHtml(response.text);
-			expect(element.querySelector('h1')?.innerHTML).toBe(
+			expect(element.querySelector('h1')?.innerHTML.trim()).toBe(
 				'When did the interested party submit the comment?'
 			);
 
@@ -393,7 +393,7 @@ describe('add-ip-comment', () => {
 			expect(response.statusCode).toBe(400);
 
 			const element = parseHtml(response.text);
-			expect(element.querySelector('h1')?.innerHTML).toBe(
+			expect(element.querySelector('h1')?.innerHTML.trim()).toBe(
 				'When did the interested party submit the comment?'
 			);
 
@@ -418,7 +418,7 @@ describe('add-ip-comment', () => {
 			expect(response.statusCode).toBe(400);
 
 			const element = parseHtml(response.text);
-			expect(element.querySelector('h1')?.innerHTML).toBe(
+			expect(element.querySelector('h1')?.innerHTML.trim()).toBe(
 				'When did the interested party submit the comment?'
 			);
 
@@ -454,7 +454,7 @@ describe('add-ip-comment', () => {
 		});
 
 		it('should render the correct heading', () => {
-			expect(pageHtml.querySelector('h1')?.innerHTML).toBe(
+			expect(pageHtml.querySelector('h1')?.innerHTML.trim()).toBe(
 				'Check details and add interested party comment'
 			);
 		});

--- a/appeals/web/src/server/appeals/appeal-details/interested-party-comments/add-ip-comment/add-ip-comment.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/interested-party-comments/add-ip-comment/add-ip-comment.mapper.js
@@ -79,7 +79,6 @@ export const checkAddressPage = (appealDetails, errors) => ({
 	title: 'Did the interested party provide an address?',
 	backLinkUrl: `/appeals-service/appeal-details/${appealDetails.appealId}/interested-party-comments/add/ip-details`,
 	preHeading: `Appeal ${appealShortReference(appealDetails.appealReference)}`,
-	heading: 'Did the interested party provide an address?',
 	submitButtonProperties: {
 		text: 'Continue'
 	},
@@ -89,6 +88,13 @@ export const checkAddressPage = (appealDetails, errors) => ({
 			parameters: {
 				name: 'addressProvided',
 				idPrefix: 'address-provided',
+				fieldset: {
+					legend: {
+						text: 'Did the interested party provide an address?',
+						isPageHeading: true,
+						classes: 'govuk-fieldset__legend--l'
+					}
+				},
 				items: [
 					{
 						value: 'yes',

--- a/appeals/web/src/server/appeals/appeal-details/interested-party-comments/common/date-submitted.js
+++ b/appeals/web/src/server/appeals/appeal-details/interested-party-comments/common/date-submitted.js
@@ -16,9 +16,15 @@ export const mapper = (appealDetails, errors, date, backLinkUrl) => ({
 	title: 'When did the interested party submit the comment?',
 	backLinkUrl,
 	preHeading: `Appeal ${appealShortReference(appealDetails.appealReference)}`,
-	heading: 'When did the interested party submit the comment?',
 	pageComponents: [
-		dateInput({ id: 'date', name: 'date', value: date, hint: 'For example, 27 3 2024' })
+		dateInput({
+			id: 'date',
+			name: 'date',
+			value: date,
+			legendText: 'When did the interested party submit the comment?',
+			legendIsPageHeading: true,
+			hint: 'For example, 27 3 2024'
+		})
 	]
 });
 

--- a/appeals/web/src/server/appeals/appeal-details/interested-party-comments/common/redaction-status.js
+++ b/appeals/web/src/server/appeals/appeal-details/interested-party-comments/common/redaction-status.js
@@ -30,10 +30,11 @@ const mapper = (appealDetails, errors, backLinkUrl) => ({
 	title: 'Redaction status',
 	backLinkUrl,
 	preHeading: `Appeal ${appealShortReference(appealDetails.appealReference)}`,
-	heading: 'Redaction status',
 	pageComponents: [
 		radiosInput({
 			name,
+			legendText: 'Redaction status',
+			legendIsPageHeading: true,
 			items: Object.entries(statusFormatMap).map(([value, text]) => ({ value, text })),
 			value: APPEAL_REDACTED_STATUS.NO_REDACTION_REQUIRED
 		})

--- a/appeals/web/src/server/appeals/appeal-details/interested-party-comments/redact/components/redact-input.js
+++ b/appeals/web/src/server/appeals/appeal-details/interested-party-comments/redact/components/redact-input.js
@@ -12,10 +12,8 @@ export const redactInput = (comment, session) => [
 		name: 'redactedRepresentation',
 		id: 'redact-textarea',
 		readonly: true,
-		label: {
-			text: 'Redacted comment',
-			classes: 'govuk-label--s'
-		},
+		labelText: 'Redacted comment',
+		labelClasses: 'govuk-label--s',
 		value:
 			session?.redactedRepresentation ||
 			comment.redactedRepresentation ||

--- a/appeals/web/src/server/appeals/appeal-details/interested-party-comments/view-and-review/page-components/reject.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/interested-party-comments/view-and-review/page-components/reject.mapper.js
@@ -51,18 +51,19 @@ export async function rejectAllowResubmitPage(apiClient, appealDetails, comment,
 
 	/** @type {PageContent} */
 	const pageContent = {
-		heading: 'Do you want to allow the interested party to resubmit a comment?',
 		backLinkUrl: `/appeals-service/appeal-details/${appealDetails.appealId}/interested-party-comments/${comment.id}/reject/select-reason`,
 		preHeading: `Appeal ${shortReference}`,
 		headingClasses: 'govuk-heading-l',
-		hint: `The interested party can resubmit their comment by ${deadlineString}.`,
 		submitButtonProperties: {
 			text: 'Continue'
 		},
 		pageComponents: [
 			yesNoInput({
 				name: 'allowResubmit',
-				value: sessionValue
+				value: sessionValue,
+				legendText: 'Do you want to allow the interested party to resubmit a comment?',
+				legendIsPageHeading: true,
+				hint: `The interested party can resubmit their comment by ${deadlineString}.`
 			})
 		]
 	};

--- a/appeals/web/src/server/appeals/appeal-details/issue-decision/__tests__/__snapshots__/issue-decision.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/issue-decision/__tests__/__snapshots__/issue-decision.test.js.snap
@@ -49,35 +49,39 @@ exports[`issue-decision GET /decision should render the 'what is the decision' p
         <div class="govuk-grid-column-two-thirds">
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full"><span class="govuk-caption-l govuk-!-margin-bottom-3">Appeal 351062</span>
-                    <h1                     class="govuk-heading-l govuk-!-margin-bottom-3">What is the decision?</h1>
                 </div>
             </div>
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full">
                     <form method="POST" novalidate="novalidate">
                         <div class="govuk-form-group">
-                            <div class="govuk-radios" data-module="govuk-radios">
-                                <div class="govuk-radios__item">
-                                    <input class="govuk-radios__input" id="decision" name="decision" type="radio"
-                                    value="Allowed">
-                                    <label class="govuk-label govuk-radios__label" for="decision">Allowed</label>
+                            <fieldset class="govuk-fieldset">
+                                <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+                                    <h1 class="govuk-fieldset__heading"> What is the decision?</h1>
+                                </legend>
+                                <div class="govuk-radios" data-module="govuk-radios">
+                                    <div class="govuk-radios__item">
+                                        <input class="govuk-radios__input" id="decision" name="decision" type="radio"
+                                        value="Allowed">
+                                        <label class="govuk-label govuk-radios__label" for="decision">Allowed</label>
+                                    </div>
+                                    <div class="govuk-radios__item">
+                                        <input class="govuk-radios__input" id="decision-2" name="decision" type="radio"
+                                        value="Dismissed">
+                                        <label class="govuk-label govuk-radios__label" for="decision-2">Dismissed</label>
+                                    </div>
+                                    <div class="govuk-radios__item">
+                                        <input class="govuk-radios__input" id="decision-3" name="decision" type="radio"
+                                        value="Split">
+                                        <label class="govuk-label govuk-radios__label" for="decision-3">Split Decision</label>
+                                    </div>
+                                    <div class="govuk-radios__item">
+                                        <input class="govuk-radios__input" id="decision-4" name="decision" type="radio"
+                                        value="Invalid">
+                                        <label class="govuk-label govuk-radios__label" for="decision-4">Invalid</label>
+                                    </div>
                                 </div>
-                                <div class="govuk-radios__item">
-                                    <input class="govuk-radios__input" id="decision-2" name="decision" type="radio"
-                                    value="Dismissed">
-                                    <label class="govuk-label govuk-radios__label" for="decision-2">Dismissed</label>
-                                </div>
-                                <div class="govuk-radios__item">
-                                    <input class="govuk-radios__input" id="decision-3" name="decision" type="radio"
-                                    value="Split">
-                                    <label class="govuk-label govuk-radios__label" for="decision-3">Split Decision</label>
-                                </div>
-                                <div class="govuk-radios__item">
-                                    <input class="govuk-radios__input" id="decision-4" name="decision" type="radio"
-                                    value="Invalid">
-                                    <label class="govuk-label govuk-radios__label" for="decision-4">Invalid</label>
-                                </div>
-                            </div>
+                            </fieldset>
                         </div>
                         <button type="submit" data-prevent-double-click="true" class="govuk-button"
                         data-module="govuk-button">Continue</button>

--- a/appeals/web/src/server/appeals/appeal-details/issue-decision/issue-decision.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/issue-decision/issue-decision.mapper.js
@@ -23,6 +23,13 @@ export function issueDecisionPage(appealDetails, inspectorDecision) {
 		parameters: {
 			name: 'decision',
 			idPrefix: 'decision',
+			fieldset: {
+				legend: {
+					text: 'What is the decision?',
+					isPageHeading: true,
+					classes: 'govuk-fieldset__legend--l'
+				}
+			},
 			items: [
 				{
 					value: 'Allowed',
@@ -55,7 +62,6 @@ export function issueDecisionPage(appealDetails, inspectorDecision) {
 		title: `What is the decision? - ${shortAppealReference}`,
 		backLinkUrl: `/appeals-service/appeal-details/${appealDetails.appealId}`,
 		preHeading: `Appeal ${shortAppealReference}`,
-		heading: 'What is the decision?',
 		pageComponents: [selectVisitTypeComponent]
 	};
 

--- a/appeals/web/src/server/appeals/appeal-details/linked-appeals/__tests__/__snapshots__/linked-appeals.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/linked-appeals/__tests__/__snapshots__/linked-appeals.test.js.snap
@@ -4,7 +4,6 @@ exports[`linked-appeals GET /change-appeal-type/unlink-appeal should render the 
 "<main class="govuk-main-wrapper " id="main-content" role="main">
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-full"><span class="govuk-caption-l govuk-!-margin-bottom-3">Appeal 351062</span>
-            <h1             class="govuk-heading-xl govuk-!-margin-bottom-3">Do you want to unlink the appeal from appeal 351062?</h1>
         </div>
     </div>
     <div class="govuk-grid-row">
@@ -12,6 +11,9 @@ exports[`linked-appeals GET /change-appeal-type/unlink-appeal should render the 
             <form action="" method="POST" novalidate>
                 <div class="govuk-form-group">
                     <fieldset class="govuk-fieldset">
+                        <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+                            <h1 class="govuk-fieldset__heading"> Do you want to unlink the appeal 725284 from appeal 351062?</h1>
+                        </legend>
                         <div class="govuk-radios" data-module="govuk-radios">
                             <div class="govuk-radios__item">
                                 <input class="govuk-radios__input" id="unlink-appeal" name="unlinkAppeal"
@@ -860,7 +862,7 @@ exports[`linked-appeals GET /linked-appeals/manage should render the manage link
                     data-cy="76215416">76215416</a>
                 </td>
                 <td class="govuk-table__cell">Commercial</td>
-                <td class="govuk-table__cell"><a class="govuk-link" data-cy="unlink-appeal-APP/Q9999/D/21/351062" href="/appeals-service/appeal-details/1/linked-appeals/unlink-appeal/3/3047/2">Unlink</a>
+                <td class="govuk-table__cell"><a class="govuk-link" data-cy="unlink-appeal-APP/Q9999/D/21/351062" href="/appeals-service/appeal-details/1/linked-appeals/unlink-appeal/3/1/2">Unlink</a>
                 </td>
             </tr>
         </tbody>
@@ -892,7 +894,7 @@ exports[`linked-appeals GET /linked-appeals/manage should render the manage link
                     data-cy="APP/Q9999/D/21/725284">725284</a>
                 </td>
                 <td class="govuk-table__cell">Householder</td>
-                <td class="govuk-table__cell"><a class="govuk-link" data-cy="unlink-appeal-APP/Q9999/D/21/351062" href="/appeals-service/appeal-details/1/linked-appeals/unlink-appeal/2/3046/1">Unlink</a>
+                <td class="govuk-table__cell"><a class="govuk-link" data-cy="unlink-appeal-APP/Q9999/D/21/351062" href="/appeals-service/appeal-details/1/linked-appeals/unlink-appeal/2/1/1">Unlink</a>
                 </td>
             </tr>
             <tr class="govuk-table__row">
@@ -900,7 +902,7 @@ exports[`linked-appeals GET /linked-appeals/manage should render the manage link
                     data-cy="76215416">76215416</a>
                 </td>
                 <td class="govuk-table__cell">Commercial</td>
-                <td class="govuk-table__cell"><a class="govuk-link" data-cy="unlink-appeal-APP/Q9999/D/21/351062" href="/appeals-service/appeal-details/1/linked-appeals/unlink-appeal/3/3047/1">Unlink</a>
+                <td class="govuk-table__cell"><a class="govuk-link" data-cy="unlink-appeal-APP/Q9999/D/21/351062" href="/appeals-service/appeal-details/1/linked-appeals/unlink-appeal/3/1/1">Unlink</a>
                 </td>
             </tr>
         </tbody>
@@ -927,7 +929,6 @@ exports[`linked-appeals POST /change-appeal-type/unlink-appeal should re-render 
     </div>
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-full"><span class="govuk-caption-l govuk-!-margin-bottom-3">Appeal 351062</span>
-            <h1             class="govuk-heading-xl govuk-!-margin-bottom-3">Do you want to unlink the appeal from appeal 351062?</h1>
         </div>
     </div>
     <div class="govuk-grid-row">
@@ -935,6 +936,9 @@ exports[`linked-appeals POST /change-appeal-type/unlink-appeal should re-render 
             <form action="" method="POST" novalidate>
                 <div class="govuk-form-group">
                     <fieldset class="govuk-fieldset">
+                        <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+                            <h1 class="govuk-fieldset__heading"> Do you want to unlink the appeal 725284 from appeal 351062?</h1>
+                        </legend>
                         <div class="govuk-radios" data-module="govuk-radios">
                             <div class="govuk-radios__item">
                                 <input class="govuk-radios__input" id="unlink-appeal" name="unlinkAppeal"

--- a/appeals/web/src/server/appeals/appeal-details/linked-appeals/__tests__/linked-appeals.test.js
+++ b/appeals/web/src/server/appeals/appeal-details/linked-appeals/__tests__/linked-appeals.test.js
@@ -29,7 +29,7 @@ const leadAppealDataWithLinkedAppeals = {
 			isParentAppeal: false,
 			linkingDate: new Date('2024-02-09T09:41:13.611Z'),
 			appealType: 'Householder',
-			relationshipId: 3046
+			relationshipId: 1
 		},
 		{
 			appealId: 3,
@@ -37,7 +37,7 @@ const leadAppealDataWithLinkedAppeals = {
 			isParentAppeal: false,
 			linkingDate: new Date('2024-02-09T09:41:13.611Z'),
 			appealType: 'Unknown',
-			relationshipId: 3047,
+			relationshipId: 1,
 			externalSource: true,
 			externalAppealType: 'Commercial'
 		}
@@ -1218,7 +1218,7 @@ describe('linked-appeals', () => {
 
 			expect(element.innerHTML).toMatchSnapshot();
 			expect(element.innerHTML).toContain(
-				'Do you want to unlink the appeal from appeal 351062?</h1>'
+				'Do you want to unlink the appeal 725284 from appeal 351062?</h1>'
 			);
 
 			const unprettifiedElement = parseHtml(response.text, { skipPrettyPrint: true });
@@ -1275,7 +1275,7 @@ describe('linked-appeals', () => {
 
 			expect(element.innerHTML).toMatchSnapshot();
 			expect(element.innerHTML).toContain(
-				'Do you want to unlink the appeal from appeal 351062?</h1>'
+				'Do you want to unlink the appeal 725284 from appeal 351062?</h1>'
 			);
 
 			const errorSummaryHtml = parseHtml(response.text, {

--- a/appeals/web/src/server/appeals/appeal-details/linked-appeals/linked-appeals.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/linked-appeals/linked-appeals.mapper.js
@@ -511,6 +511,10 @@ export function addLinkedAppealCheckAndConfirmPage(
  * @returns {PageContent}
  */
 export function unlinkAppealPage(appealData, childRef, appealId, relationshipId, backLinkAppealId) {
+	const shortAppealReference = appealShortReference(appealData.appealReference);
+	const shortChildAppealReference = appealShortReference(childRef);
+	const titleAndHeading = `Do you want to unlink the appeal ${shortChildAppealReference} from appeal ${shortAppealReference}?`;
+
 	/** @type {PageComponent} */
 	const selectAppealTypeRadiosComponent = {
 		type: 'radios',
@@ -519,7 +523,9 @@ export function unlinkAppealPage(appealData, childRef, appealId, relationshipId,
 			idPrefix: 'unlink-appeal',
 			fieldset: {
 				legend: {
-					classes: 'govuk-fieldset__legend--m'
+					text: titleAndHeading,
+					isPageHeading: true,
+					classes: 'govuk-fieldset__legend--l'
 				}
 			},
 			items: [
@@ -535,16 +541,11 @@ export function unlinkAppealPage(appealData, childRef, appealId, relationshipId,
 		}
 	};
 
-	const shortAppealReference = appealShortReference(appealData.appealReference);
-	const shortChildAppealReference = appealShortReference(childRef);
-	const titleAndHeading = `Do you want to unlink the appeal ${shortChildAppealReference} from appeal ${shortAppealReference}?`;
-
 	/** @type {PageContent} */
 	const pageContent = {
 		title: titleAndHeading,
 		backLinkUrl: generateUnlinkAppealBackLinkUrl(appealId, relationshipId, backLinkAppealId),
 		preHeading: `Appeal ${shortAppealReference}`,
-		heading: titleAndHeading,
 		pageComponents: [selectAppealTypeRadiosComponent]
 	};
 

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/__tests__/__snapshots__/lpa-questionnaire.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/__tests__/__snapshots__/lpa-questionnaire.test.js.snap
@@ -331,25 +331,24 @@ exports[`LPA Questionnaire review GET / should render review outcome form fields
     </div>
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-full">
-            <h2>What is the outcome of your review?</h2>
-        </div>
-    </div>
-    <div class="govuk-grid-row">
-        <div class="govuk-grid-column-full">
             <form action="" method="POST" novalidate>
                 <div class="govuk-form-group">
-                    <div class="govuk-radios" data-module="govuk-radios">
-                        <div class="govuk-radios__item">
-                            <input class="govuk-radios__input" id="review-outcome" name="review-outcome"
-                            type="radio" value="complete">
-                            <label class="govuk-label govuk-radios__label" for="review-outcome">Complete</label>
+                    <fieldset class="govuk-fieldset">
+                        <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">What is the outcome of your review?</legend>
+                        <div class="govuk-radios"
+                        data-module="govuk-radios">
+                            <div class="govuk-radios__item">
+                                <input class="govuk-radios__input" id="review-outcome" name="review-outcome"
+                                type="radio" value="complete">
+                                <label class="govuk-label govuk-radios__label" for="review-outcome">Complete</label>
+                            </div>
+                            <div class="govuk-radios__item">
+                                <input class="govuk-radios__input" id="review-outcome-2" name="review-outcome"
+                                type="radio" value="incomplete">
+                                <label class="govuk-label govuk-radios__label" for="review-outcome-2">Incomplete</label>
+                            </div>
                         </div>
-                        <div class="govuk-radios__item">
-                            <input class="govuk-radios__input" id="review-outcome-2" name="review-outcome"
-                            type="radio" value="incomplete">
-                            <label class="govuk-label govuk-radios__label" for="review-outcome-2">Incomplete</label>
-                        </div>
-                    </div>
+                    </fieldset>
                 </div>
                 <div class="govuk-inset-text">Confirming this review will inform the relevant parties of the outcome.</div>
                 <div                 class="govuk-warning-text"><span class="govuk-warning-text__icon" aria-hidden="true">!</span>

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/__tests__/lpa-questionnaire.test.js
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/__tests__/lpa-questionnaire.test.js
@@ -505,7 +505,9 @@ describe('LPA Questionnaire review', () => {
 
 			const unprettifiedElement = parseHtml(response.text, { skipPrettyPrint: true });
 
-			expect(unprettifiedElement.innerHTML).toContain('What is the outcome of your review?</h2>');
+			expect(unprettifiedElement.innerHTML).toContain(
+				'What is the outcome of your review?</legend>'
+			);
 			expect(unprettifiedElement.innerHTML).toContain(
 				'name="review-outcome" type="radio" value="complete">'
 			);
@@ -539,7 +541,7 @@ describe('LPA Questionnaire review', () => {
 				const unprettifiedElement = parseHtml(response.text, { skipPrettyPrint: true });
 
 				expect(unprettifiedElement.innerHTML).not.toContain(
-					'What is the outcome of your review?</h2>'
+					'What is the outcome of your review?</legend>'
 				);
 				expect(unprettifiedElement.innerHTML).not.toContain(
 					'name="reviewOutcome" type="radio" value="valid">'

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/affects-scheduled-monument/__tests__/__snapshots__/affects-scheduled-monument.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/affects-scheduled-monument/__tests__/__snapshots__/affects-scheduled-monument.test.js.snap
@@ -6,25 +6,29 @@ exports[`affects-scheduled-monument GET /change should render the affectsSchedul
         <div class="govuk-grid-column-two-thirds">
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full"><span class="govuk-caption-l govuk-!-margin-bottom-3">Appeal 351062</span>
-                    <h1                     class="govuk-heading-l govuk-!-margin-bottom-3">Change whether scheduled monument affected</h1>
                 </div>
             </div>
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full">
                     <form method="POST" novalidate="novalidate">
                         <div class="govuk-form-group">
-                            <div class="govuk-radios" data-module="govuk-radios">
-                                <div class="govuk-radios__item">
-                                    <input class="govuk-radios__input" id="affectsScheduledMonumentRadio"
-                                    name="affectsScheduledMonumentRadio" type="radio" value="yes">
-                                    <label class="govuk-label govuk-radios__label" for="affectsScheduledMonumentRadio">Affected</label>
+                            <fieldset class="govuk-fieldset">
+                                <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+                                    <h1 class="govuk-fieldset__heading"> Change whether scheduled monument affected</h1>
+                                </legend>
+                                <div class="govuk-radios" data-module="govuk-radios">
+                                    <div class="govuk-radios__item">
+                                        <input class="govuk-radios__input" id="affectsScheduledMonumentRadio"
+                                        name="affectsScheduledMonumentRadio" type="radio" value="yes">
+                                        <label class="govuk-label govuk-radios__label" for="affectsScheduledMonumentRadio">Affected</label>
+                                    </div>
+                                    <div class="govuk-radios__item">
+                                        <input class="govuk-radios__input" id="affectsScheduledMonumentRadio-2"
+                                        name="affectsScheduledMonumentRadio" type="radio" value="no">
+                                        <label class="govuk-label govuk-radios__label" for="affectsScheduledMonumentRadio-2">Not affected</label>
+                                    </div>
                                 </div>
-                                <div class="govuk-radios__item">
-                                    <input class="govuk-radios__input" id="affectsScheduledMonumentRadio-2"
-                                    name="affectsScheduledMonumentRadio" type="radio" value="no">
-                                    <label class="govuk-label govuk-radios__label" for="affectsScheduledMonumentRadio-2">Not affected</label>
-                                </div>
-                            </div>
+                            </fieldset>
                         </div>
                         <button type="submit" data-prevent-double-click="true" class="govuk-button"
                         data-module="govuk-button">Continue</button>

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/affects-scheduled-monument/affects-scheduled-monument.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/affects-scheduled-monument/affects-scheduled-monument.mapper.js
@@ -18,11 +18,12 @@ export const changeAffectsScheduledMonument = (appealData, data, origin) => {
 		title: `Affects scheduled monument`,
 		backLinkUrl: origin,
 		preHeading: `Appeal ${shortAppealReference}`,
-		heading: `Change whether scheduled monument affected`,
 		pageComponents: [
 			yesNoInput({
 				name: 'affectsScheduledMonumentRadio',
 				value: data,
+				legendText: 'Change whether scheduled monument affected',
+				legendIsPageHeading: true,
 				customYesLabel: 'Affected',
 				customNoLabel: 'Not affected'
 			})

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/correct-appeal-type/__tests__/__snapshots__/correct-appeal-type.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/correct-appeal-type/__tests__/__snapshots__/correct-appeal-type.test.js.snap
@@ -6,25 +6,29 @@ exports[`correct-appeal-type GET /change should render the correctAppealType cha
         <div class="govuk-grid-column-two-thirds">
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full"><span class="govuk-caption-l govuk-!-margin-bottom-3">Appeal 351062</span>
-                    <h1                     class="govuk-heading-l govuk-!-margin-bottom-3">Is the appeal type correct (LPA response)?</h1>
                 </div>
             </div>
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full">
                     <form method="POST" novalidate="novalidate">
                         <div class="govuk-form-group">
-                            <div class="govuk-radios" data-module="govuk-radios">
-                                <div class="govuk-radios__item">
-                                    <input class="govuk-radios__input" id="correctAppealTypeRadio" name="correctAppealTypeRadio"
-                                    type="radio" value="yes" checked>
-                                    <label class="govuk-label govuk-radios__label" for="correctAppealTypeRadio">Yes</label>
+                            <fieldset class="govuk-fieldset">
+                                <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+                                    <h1 class="govuk-fieldset__heading"> Is the appeal type correct (LPA response)?</h1>
+                                </legend>
+                                <div class="govuk-radios" data-module="govuk-radios">
+                                    <div class="govuk-radios__item">
+                                        <input class="govuk-radios__input" id="correctAppealTypeRadio" name="correctAppealTypeRadio"
+                                        type="radio" value="yes" checked>
+                                        <label class="govuk-label govuk-radios__label" for="correctAppealTypeRadio">Yes</label>
+                                    </div>
+                                    <div class="govuk-radios__item">
+                                        <input class="govuk-radios__input" id="correctAppealTypeRadio-2" name="correctAppealTypeRadio"
+                                        type="radio" value="no">
+                                        <label class="govuk-label govuk-radios__label" for="correctAppealTypeRadio-2">No</label>
+                                    </div>
                                 </div>
-                                <div class="govuk-radios__item">
-                                    <input class="govuk-radios__input" id="correctAppealTypeRadio-2" name="correctAppealTypeRadio"
-                                    type="radio" value="no">
-                                    <label class="govuk-label govuk-radios__label" for="correctAppealTypeRadio-2">No</label>
-                                </div>
-                            </div>
+                            </fieldset>
                         </div>
                         <button type="submit" data-prevent-double-click="true" class="govuk-button"
                         data-module="govuk-button">Continue</button>

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/correct-appeal-type/correct-appeal-type.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/correct-appeal-type/correct-appeal-type.mapper.js
@@ -25,11 +25,12 @@ export const changeCorrectAppealTypePage = (
 		title: `Change the LPA response to "Is the appeal type correct"?`,
 		backLinkUrl: `/appeals-service/appeal-details/${appealData.appealId}/lpa-questionnaire/${appealData.lpaQuestionnaireId}`,
 		preHeading: `Appeal ${shortAppealReference}`,
-		heading: `Is the appeal type correct (LPA response)?`,
 		pageComponents: [
 			yesNoInput({
 				name: 'correctAppealTypeRadio',
-				value: currentRadioValue
+				value: currentRadioValue,
+				legendText: 'Is the appeal type correct (LPA response)?',
+				legendIsPageHeading: true
 			})
 		]
 	};

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/eia-development-description/__tests__/__snapshots__/eia-development-description.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/eia-development-description/__tests__/__snapshots__/eia-development-description.test.js.snap
@@ -6,80 +6,84 @@ exports[`eia-development-description GET /change should render the development d
         <div class="govuk-grid-column-two-thirds">
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full"><span class="govuk-caption-l govuk-!-margin-bottom-3">Appeal 351062</span>
-                    <h1                     class="govuk-heading-l govuk-!-margin-bottom-3">Change description of development</h1>
                 </div>
             </div>
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full">
                     <form method="POST" novalidate="novalidate">
                         <div class="govuk-form-group">
-                            <div class="govuk-radios" data-module="govuk-radios">
-                                <div class="govuk-radios__item">
-                                    <input class="govuk-radios__input" id="eiaDevelopmentDescription" name="eiaDevelopmentDescription"
-                                    type="radio" value="agriculture-aquaculture" checked>
-                                    <label class="govuk-label govuk-radios__label" for="eiaDevelopmentDescription">Agriculture and aquaculture</label>
+                            <fieldset class="govuk-fieldset">
+                                <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+                                    <h1 class="govuk-fieldset__heading"> Change description of development</h1>
+                                </legend>
+                                <div class="govuk-radios" data-module="govuk-radios">
+                                    <div class="govuk-radios__item">
+                                        <input class="govuk-radios__input" id="eiaDevelopmentDescription" name="eiaDevelopmentDescription"
+                                        type="radio" value="agriculture-aquaculture" checked>
+                                        <label class="govuk-label govuk-radios__label" for="eiaDevelopmentDescription">Agriculture and aquaculture</label>
+                                    </div>
+                                    <div class="govuk-radios__item">
+                                        <input class="govuk-radios__input" id="eiaDevelopmentDescription-2" name="eiaDevelopmentDescription"
+                                        type="radio" value="change-extensions">
+                                        <label class="govuk-label govuk-radios__label" for="eiaDevelopmentDescription-2">Changes and extensions</label>
+                                    </div>
+                                    <div class="govuk-radios__item">
+                                        <input class="govuk-radios__input" id="eiaDevelopmentDescription-3" name="eiaDevelopmentDescription"
+                                        type="radio" value="chemical-industry">
+                                        <label class="govuk-label govuk-radios__label" for="eiaDevelopmentDescription-3">Chemical industry (unless included in Schedule 1)</label>
+                                    </div>
+                                    <div class="govuk-radios__item">
+                                        <input class="govuk-radios__input" id="eiaDevelopmentDescription-4" name="eiaDevelopmentDescription"
+                                        type="radio" value="energy-industry">
+                                        <label class="govuk-label govuk-radios__label" for="eiaDevelopmentDescription-4">Energy industry</label>
+                                    </div>
+                                    <div class="govuk-radios__item">
+                                        <input class="govuk-radios__input" id="eiaDevelopmentDescription-5" name="eiaDevelopmentDescription"
+                                        type="radio" value="extractive-industry">
+                                        <label class="govuk-label govuk-radios__label" for="eiaDevelopmentDescription-5">Extractive industry</label>
+                                    </div>
+                                    <div class="govuk-radios__item">
+                                        <input class="govuk-radios__input" id="eiaDevelopmentDescription-6" name="eiaDevelopmentDescription"
+                                        type="radio" value="food-industry">
+                                        <label class="govuk-label govuk-radios__label" for="eiaDevelopmentDescription-6">Food industry</label>
+                                    </div>
+                                    <div class="govuk-radios__item">
+                                        <input class="govuk-radios__input" id="eiaDevelopmentDescription-7" name="eiaDevelopmentDescription"
+                                        type="radio" value="infrastructure-projects">
+                                        <label class="govuk-label govuk-radios__label" for="eiaDevelopmentDescription-7">Infrastructure projects</label>
+                                    </div>
+                                    <div class="govuk-radios__item">
+                                        <input class="govuk-radios__input" id="eiaDevelopmentDescription-8" name="eiaDevelopmentDescription"
+                                        type="radio" value="mineral-industry">
+                                        <label class="govuk-label govuk-radios__label" for="eiaDevelopmentDescription-8">Mineral industry</label>
+                                    </div>
+                                    <div class="govuk-radios__item">
+                                        <input class="govuk-radios__input" id="eiaDevelopmentDescription-9" name="eiaDevelopmentDescription"
+                                        type="radio" value="other-projects">
+                                        <label class="govuk-label govuk-radios__label" for="eiaDevelopmentDescription-9">Other projects</label>
+                                    </div>
+                                    <div class="govuk-radios__item">
+                                        <input class="govuk-radios__input" id="eiaDevelopmentDescription-10" name="eiaDevelopmentDescription"
+                                        type="radio" value="production-processing-of-metals">
+                                        <label class="govuk-label govuk-radios__label" for="eiaDevelopmentDescription-10">Production and processing of metals</label>
+                                    </div>
+                                    <div class="govuk-radios__item">
+                                        <input class="govuk-radios__input" id="eiaDevelopmentDescription-11" name="eiaDevelopmentDescription"
+                                        type="radio" value="rubber-industry">
+                                        <label class="govuk-label govuk-radios__label" for="eiaDevelopmentDescription-11">Rubber industry</label>
+                                    </div>
+                                    <div class="govuk-radios__item">
+                                        <input class="govuk-radios__input" id="eiaDevelopmentDescription-12" name="eiaDevelopmentDescription"
+                                        type="radio" value="textile-industries">
+                                        <label class="govuk-label govuk-radios__label" for="eiaDevelopmentDescription-12">Textile, leather, wood and paper industries</label>
+                                    </div>
+                                    <div class="govuk-radios__item">
+                                        <input class="govuk-radios__input" id="eiaDevelopmentDescription-13" name="eiaDevelopmentDescription"
+                                        type="radio" value="tourism-leisure">
+                                        <label class="govuk-label govuk-radios__label" for="eiaDevelopmentDescription-13">Tourism and leisure</label>
+                                    </div>
                                 </div>
-                                <div class="govuk-radios__item">
-                                    <input class="govuk-radios__input" id="eiaDevelopmentDescription-2" name="eiaDevelopmentDescription"
-                                    type="radio" value="change-extensions">
-                                    <label class="govuk-label govuk-radios__label" for="eiaDevelopmentDescription-2">Changes and extensions</label>
-                                </div>
-                                <div class="govuk-radios__item">
-                                    <input class="govuk-radios__input" id="eiaDevelopmentDescription-3" name="eiaDevelopmentDescription"
-                                    type="radio" value="chemical-industry">
-                                    <label class="govuk-label govuk-radios__label" for="eiaDevelopmentDescription-3">Chemical industry (unless included in Schedule 1)</label>
-                                </div>
-                                <div class="govuk-radios__item">
-                                    <input class="govuk-radios__input" id="eiaDevelopmentDescription-4" name="eiaDevelopmentDescription"
-                                    type="radio" value="energy-industry">
-                                    <label class="govuk-label govuk-radios__label" for="eiaDevelopmentDescription-4">Energy industry</label>
-                                </div>
-                                <div class="govuk-radios__item">
-                                    <input class="govuk-radios__input" id="eiaDevelopmentDescription-5" name="eiaDevelopmentDescription"
-                                    type="radio" value="extractive-industry">
-                                    <label class="govuk-label govuk-radios__label" for="eiaDevelopmentDescription-5">Extractive industry</label>
-                                </div>
-                                <div class="govuk-radios__item">
-                                    <input class="govuk-radios__input" id="eiaDevelopmentDescription-6" name="eiaDevelopmentDescription"
-                                    type="radio" value="food-industry">
-                                    <label class="govuk-label govuk-radios__label" for="eiaDevelopmentDescription-6">Food industry</label>
-                                </div>
-                                <div class="govuk-radios__item">
-                                    <input class="govuk-radios__input" id="eiaDevelopmentDescription-7" name="eiaDevelopmentDescription"
-                                    type="radio" value="infrastructure-projects">
-                                    <label class="govuk-label govuk-radios__label" for="eiaDevelopmentDescription-7">Infrastructure projects</label>
-                                </div>
-                                <div class="govuk-radios__item">
-                                    <input class="govuk-radios__input" id="eiaDevelopmentDescription-8" name="eiaDevelopmentDescription"
-                                    type="radio" value="mineral-industry">
-                                    <label class="govuk-label govuk-radios__label" for="eiaDevelopmentDescription-8">Mineral industry</label>
-                                </div>
-                                <div class="govuk-radios__item">
-                                    <input class="govuk-radios__input" id="eiaDevelopmentDescription-9" name="eiaDevelopmentDescription"
-                                    type="radio" value="other-projects">
-                                    <label class="govuk-label govuk-radios__label" for="eiaDevelopmentDescription-9">Other projects</label>
-                                </div>
-                                <div class="govuk-radios__item">
-                                    <input class="govuk-radios__input" id="eiaDevelopmentDescription-10" name="eiaDevelopmentDescription"
-                                    type="radio" value="production-processing-of-metals">
-                                    <label class="govuk-label govuk-radios__label" for="eiaDevelopmentDescription-10">Production and processing of metals</label>
-                                </div>
-                                <div class="govuk-radios__item">
-                                    <input class="govuk-radios__input" id="eiaDevelopmentDescription-11" name="eiaDevelopmentDescription"
-                                    type="radio" value="rubber-industry">
-                                    <label class="govuk-label govuk-radios__label" for="eiaDevelopmentDescription-11">Rubber industry</label>
-                                </div>
-                                <div class="govuk-radios__item">
-                                    <input class="govuk-radios__input" id="eiaDevelopmentDescription-12" name="eiaDevelopmentDescription"
-                                    type="radio" value="textile-industries">
-                                    <label class="govuk-label govuk-radios__label" for="eiaDevelopmentDescription-12">Textile, leather, wood and paper industries</label>
-                                </div>
-                                <div class="govuk-radios__item">
-                                    <input class="govuk-radios__input" id="eiaDevelopmentDescription-13" name="eiaDevelopmentDescription"
-                                    type="radio" value="tourism-leisure">
-                                    <label class="govuk-label govuk-radios__label" for="eiaDevelopmentDescription-13">Tourism and leisure</label>
-                                </div>
-                            </div>
+                            </fieldset>
                         </div>
                         <button type="submit" data-prevent-double-click="true" class="govuk-button"
                         data-module="govuk-button">Continue</button>

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/eia-development-description/eia-development-description.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/eia-development-description/eia-development-description.mapper.js
@@ -38,11 +38,11 @@ export function changeEiaDevelopmentDescriptionPage(appealData, existingValue) {
 		title: `Change description of development`,
 		backLinkUrl: `/appeals-service/appeal-details/${appealData.appealId}/lpa-questionnaire/${appealData.lpaQuestionnaireId}`,
 		preHeading: `Appeal ${shortAppealReference}`,
-		heading: `Change description of development`,
-		headingClasses: 'govuk-heading-l',
 		pageComponents: [
 			radiosInput({
 				name: 'eiaDevelopmentDescription',
+				legendText: 'Change description of development',
+				legendIsPageHeading: true,
 				items: Object.values(APPEAL_EIA_DEVELOPMENT_DESCRIPTION).map((value) => ({
 					text: eiaDescriptions[value],
 					value

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/eia-environmental-impact-schedule/__tests__/__snapshots__/eia-environmental-impact-schedule.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/eia-environmental-impact-schedule/__tests__/__snapshots__/eia-environmental-impact-schedule.test.js.snap
@@ -6,31 +6,35 @@ exports[`eia-environmental-impact-schedule GET /change should render the develop
         <div class="govuk-grid-column-two-thirds">
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full"><span class="govuk-caption-l govuk-!-margin-bottom-3">Appeal 351062</span>
-                    <h1                     class="govuk-heading-l govuk-!-margin-bottom-3">Change development category</h1>
                 </div>
             </div>
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full">
                     <form method="POST" novalidate="novalidate">
                         <div class="govuk-form-group">
-                            <div class="govuk-radios" data-module="govuk-radios">
-                                <div class="govuk-radios__item">
-                                    <input class="govuk-radios__input" id="eiaEnvironmentalImpactSchedule"
-                                    name="eiaEnvironmentalImpactSchedule" type="radio" value="schedule-1">
-                                    <label class="govuk-label govuk-radios__label" for="eiaEnvironmentalImpactSchedule">Schedule 1</label>
+                            <fieldset class="govuk-fieldset">
+                                <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+                                    <h1 class="govuk-fieldset__heading"> Change development category</h1>
+                                </legend>
+                                <div class="govuk-radios" data-module="govuk-radios">
+                                    <div class="govuk-radios__item">
+                                        <input class="govuk-radios__input" id="eiaEnvironmentalImpactSchedule"
+                                        name="eiaEnvironmentalImpactSchedule" type="radio" value="schedule-1">
+                                        <label class="govuk-label govuk-radios__label" for="eiaEnvironmentalImpactSchedule">Schedule 1</label>
+                                    </div>
+                                    <div class="govuk-radios__item">
+                                        <input class="govuk-radios__input" id="eiaEnvironmentalImpactSchedule-2"
+                                        name="eiaEnvironmentalImpactSchedule" type="radio" value="schedule-2">
+                                        <label class="govuk-label govuk-radios__label" for="eiaEnvironmentalImpactSchedule-2">Schedule 2</label>
+                                    </div>
+                                    <div class="govuk-radios__divider">or</div>
+                                    <div class="govuk-radios__item">
+                                        <input class="govuk-radios__input" id="eiaEnvironmentalImpactSchedule-4"
+                                        name="eiaEnvironmentalImpactSchedule" type="radio" value="other" checked>
+                                        <label class="govuk-label govuk-radios__label" for="eiaEnvironmentalImpactSchedule-4">Other</label>
+                                    </div>
                                 </div>
-                                <div class="govuk-radios__item">
-                                    <input class="govuk-radios__input" id="eiaEnvironmentalImpactSchedule-2"
-                                    name="eiaEnvironmentalImpactSchedule" type="radio" value="schedule-2">
-                                    <label class="govuk-label govuk-radios__label" for="eiaEnvironmentalImpactSchedule-2">Schedule 2</label>
-                                </div>
-                                <div class="govuk-radios__divider">or</div>
-                                <div class="govuk-radios__item">
-                                    <input class="govuk-radios__input" id="eiaEnvironmentalImpactSchedule-4"
-                                    name="eiaEnvironmentalImpactSchedule" type="radio" value="other" checked>
-                                    <label class="govuk-label govuk-radios__label" for="eiaEnvironmentalImpactSchedule-4">Other</label>
-                                </div>
-                            </div>
+                            </fieldset>
                         </div>
                         <button type="submit" data-prevent-double-click="true" class="govuk-button"
                         data-module="govuk-button">Continue</button>
@@ -48,31 +52,35 @@ exports[`eia-environmental-impact-schedule GET /change should render the develop
         <div class="govuk-grid-column-two-thirds">
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full"><span class="govuk-caption-l govuk-!-margin-bottom-3">Appeal 351062</span>
-                    <h1                     class="govuk-heading-l govuk-!-margin-bottom-3">Change development category</h1>
                 </div>
             </div>
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full">
                     <form method="POST" novalidate="novalidate">
                         <div class="govuk-form-group">
-                            <div class="govuk-radios" data-module="govuk-radios">
-                                <div class="govuk-radios__item">
-                                    <input class="govuk-radios__input" id="eiaEnvironmentalImpactSchedule"
-                                    name="eiaEnvironmentalImpactSchedule" type="radio" value="schedule-1" checked>
-                                    <label class="govuk-label govuk-radios__label" for="eiaEnvironmentalImpactSchedule">Schedule 1</label>
+                            <fieldset class="govuk-fieldset">
+                                <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+                                    <h1 class="govuk-fieldset__heading"> Change development category</h1>
+                                </legend>
+                                <div class="govuk-radios" data-module="govuk-radios">
+                                    <div class="govuk-radios__item">
+                                        <input class="govuk-radios__input" id="eiaEnvironmentalImpactSchedule"
+                                        name="eiaEnvironmentalImpactSchedule" type="radio" value="schedule-1" checked>
+                                        <label class="govuk-label govuk-radios__label" for="eiaEnvironmentalImpactSchedule">Schedule 1</label>
+                                    </div>
+                                    <div class="govuk-radios__item">
+                                        <input class="govuk-radios__input" id="eiaEnvironmentalImpactSchedule-2"
+                                        name="eiaEnvironmentalImpactSchedule" type="radio" value="schedule-2">
+                                        <label class="govuk-label govuk-radios__label" for="eiaEnvironmentalImpactSchedule-2">Schedule 2</label>
+                                    </div>
+                                    <div class="govuk-radios__divider">or</div>
+                                    <div class="govuk-radios__item">
+                                        <input class="govuk-radios__input" id="eiaEnvironmentalImpactSchedule-4"
+                                        name="eiaEnvironmentalImpactSchedule" type="radio" value="other">
+                                        <label class="govuk-label govuk-radios__label" for="eiaEnvironmentalImpactSchedule-4">Other</label>
+                                    </div>
                                 </div>
-                                <div class="govuk-radios__item">
-                                    <input class="govuk-radios__input" id="eiaEnvironmentalImpactSchedule-2"
-                                    name="eiaEnvironmentalImpactSchedule" type="radio" value="schedule-2">
-                                    <label class="govuk-label govuk-radios__label" for="eiaEnvironmentalImpactSchedule-2">Schedule 2</label>
-                                </div>
-                                <div class="govuk-radios__divider">or</div>
-                                <div class="govuk-radios__item">
-                                    <input class="govuk-radios__input" id="eiaEnvironmentalImpactSchedule-4"
-                                    name="eiaEnvironmentalImpactSchedule" type="radio" value="other">
-                                    <label class="govuk-label govuk-radios__label" for="eiaEnvironmentalImpactSchedule-4">Other</label>
-                                </div>
-                            </div>
+                            </fieldset>
                         </div>
                         <button type="submit" data-prevent-double-click="true" class="govuk-button"
                         data-module="govuk-button">Continue</button>

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/eia-environmental-impact-schedule/eia-environmental-impact-schedule.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/eia-environmental-impact-schedule/eia-environmental-impact-schedule.mapper.js
@@ -20,11 +20,11 @@ export function changeEiaEnvironmentalImpactSchedulePage(appealData, existingVal
 		title: `Change development category`,
 		backLinkUrl: `/appeals-service/appeal-details/${appealData.appealId}/lpa-questionnaire/${appealData.lpaQuestionnaireId}`,
 		preHeading: `Appeal ${shortAppealReference}`,
-		heading: `Change development category`,
-		headingClasses: 'govuk-heading-l',
 		pageComponents: [
 			radiosInput({
 				name: 'eiaEnvironmentalImpactSchedule',
+				legendText: 'Change development category',
+				legendIsPageHeading: true,
 				items: [
 					...Object.values(APPEAL_EIA_ENVIRONMENTAL_IMPACT_SCHEDULE).map((schedule) => ({
 						text: capitalizeFirstLetter(snakeCaseToSpaceSeparated(schedule)),

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/environmental-impact-assessment/__tests__/__snapshots__/environmental-impact-assessment.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/environmental-impact-assessment/__tests__/__snapshots__/environmental-impact-assessment.test.js.snap
@@ -6,25 +6,29 @@ exports[`environmental-impact-assessment change pages GET /environmental-impact-
         <div class="govuk-grid-column-two-thirds">
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full"><span class="govuk-caption-l govuk-!-margin-bottom-3">Appeal 351062</span>
-                    <h1                     class="govuk-heading-l govuk-!-margin-bottom-3">Change whether meets or exceeds column 2 threshold criteria</h1>
                 </div>
             </div>
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full">
                     <form method="POST" novalidate="novalidate">
                         <div class="govuk-form-group">
-                            <div class="govuk-radios" data-module="govuk-radios">
-                                <div class="govuk-radios__item">
-                                    <input class="govuk-radios__input" id="eiaColumnTwoThreshold" name="eiaColumnTwoThreshold"
-                                    type="radio" value="yes">
-                                    <label class="govuk-label govuk-radios__label" for="eiaColumnTwoThreshold">Meets or exceeds</label>
+                            <fieldset class="govuk-fieldset">
+                                <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+                                    <h1 class="govuk-fieldset__heading"> Change whether meets or exceeds column 2 threshold criteria</h1>
+                                </legend>
+                                <div class="govuk-radios" data-module="govuk-radios">
+                                    <div class="govuk-radios__item">
+                                        <input class="govuk-radios__input" id="eiaColumnTwoThreshold" name="eiaColumnTwoThreshold"
+                                        type="radio" value="yes">
+                                        <label class="govuk-label govuk-radios__label" for="eiaColumnTwoThreshold">Meets or exceeds</label>
+                                    </div>
+                                    <div class="govuk-radios__item">
+                                        <input class="govuk-radios__input" id="eiaColumnTwoThreshold-2" name="eiaColumnTwoThreshold"
+                                        type="radio" value="no" checked>
+                                        <label class="govuk-label govuk-radios__label" for="eiaColumnTwoThreshold-2">Does not meet or exceed</label>
+                                    </div>
                                 </div>
-                                <div class="govuk-radios__item">
-                                    <input class="govuk-radios__input" id="eiaColumnTwoThreshold-2" name="eiaColumnTwoThreshold"
-                                    type="radio" value="no" checked>
-                                    <label class="govuk-label govuk-radios__label" for="eiaColumnTwoThreshold-2">Does not meet or exceed</label>
-                                </div>
-                            </div>
+                            </fieldset>
                         </div>
                         <button type="submit" data-prevent-double-click="true" class="govuk-button"
                         data-module="govuk-button">Continue</button>
@@ -42,25 +46,29 @@ exports[`environmental-impact-assessment change pages GET /environmental-impact-
         <div class="govuk-grid-column-two-thirds">
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full"><span class="govuk-caption-l govuk-!-margin-bottom-3">Appeal 351062</span>
-                    <h1                     class="govuk-heading-l govuk-!-margin-bottom-3">Change whether meets or exceeds column 2 threshold criteria</h1>
                 </div>
             </div>
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full">
                     <form method="POST" novalidate="novalidate">
                         <div class="govuk-form-group">
-                            <div class="govuk-radios" data-module="govuk-radios">
-                                <div class="govuk-radios__item">
-                                    <input class="govuk-radios__input" id="eiaColumnTwoThreshold" name="eiaColumnTwoThreshold"
-                                    type="radio" value="yes" checked>
-                                    <label class="govuk-label govuk-radios__label" for="eiaColumnTwoThreshold">Meets or exceeds</label>
+                            <fieldset class="govuk-fieldset">
+                                <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+                                    <h1 class="govuk-fieldset__heading"> Change whether meets or exceeds column 2 threshold criteria</h1>
+                                </legend>
+                                <div class="govuk-radios" data-module="govuk-radios">
+                                    <div class="govuk-radios__item">
+                                        <input class="govuk-radios__input" id="eiaColumnTwoThreshold" name="eiaColumnTwoThreshold"
+                                        type="radio" value="yes" checked>
+                                        <label class="govuk-label govuk-radios__label" for="eiaColumnTwoThreshold">Meets or exceeds</label>
+                                    </div>
+                                    <div class="govuk-radios__item">
+                                        <input class="govuk-radios__input" id="eiaColumnTwoThreshold-2" name="eiaColumnTwoThreshold"
+                                        type="radio" value="no">
+                                        <label class="govuk-label govuk-radios__label" for="eiaColumnTwoThreshold-2">Does not meet or exceed</label>
+                                    </div>
                                 </div>
-                                <div class="govuk-radios__item">
-                                    <input class="govuk-radios__input" id="eiaColumnTwoThreshold-2" name="eiaColumnTwoThreshold"
-                                    type="radio" value="no">
-                                    <label class="govuk-label govuk-radios__label" for="eiaColumnTwoThreshold-2">Does not meet or exceed</label>
-                                </div>
-                            </div>
+                            </fieldset>
                         </div>
                         <button type="submit" data-prevent-double-click="true" class="govuk-button"
                         data-module="govuk-button">Continue</button>
@@ -166,25 +174,29 @@ exports[`environmental-impact-assessment change pages GET /environmental-impact-
         <div class="govuk-grid-column-two-thirds">
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full"><span class="govuk-caption-l govuk-!-margin-bottom-3">Appeal 351062</span>
-                    <h1                     class="govuk-heading-l govuk-!-margin-bottom-3">Change opinion that environmental statement needed</h1>
                 </div>
             </div>
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full">
                     <form method="POST" novalidate="novalidate">
                         <div class="govuk-form-group">
-                            <div class="govuk-radios" data-module="govuk-radios">
-                                <div class="govuk-radios__item">
-                                    <input class="govuk-radios__input" id="eiaRequiresEnvironmentalStatement"
-                                    name="eiaRequiresEnvironmentalStatement" type="radio" value="yes" checked>
-                                    <label class="govuk-label govuk-radios__label" for="eiaRequiresEnvironmentalStatement">Needed</label>
+                            <fieldset class="govuk-fieldset">
+                                <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+                                    <h1 class="govuk-fieldset__heading"> Change opinion that environmental statement needed</h1>
+                                </legend>
+                                <div class="govuk-radios" data-module="govuk-radios">
+                                    <div class="govuk-radios__item">
+                                        <input class="govuk-radios__input" id="eiaRequiresEnvironmentalStatement"
+                                        name="eiaRequiresEnvironmentalStatement" type="radio" value="yes" checked>
+                                        <label class="govuk-label govuk-radios__label" for="eiaRequiresEnvironmentalStatement">Needed</label>
+                                    </div>
+                                    <div class="govuk-radios__item">
+                                        <input class="govuk-radios__input" id="eiaRequiresEnvironmentalStatement-2"
+                                        name="eiaRequiresEnvironmentalStatement" type="radio" value="no">
+                                        <label class="govuk-label govuk-radios__label" for="eiaRequiresEnvironmentalStatement-2">Not needed</label>
+                                    </div>
                                 </div>
-                                <div class="govuk-radios__item">
-                                    <input class="govuk-radios__input" id="eiaRequiresEnvironmentalStatement-2"
-                                    name="eiaRequiresEnvironmentalStatement" type="radio" value="no">
-                                    <label class="govuk-label govuk-radios__label" for="eiaRequiresEnvironmentalStatement-2">Not needed</label>
-                                </div>
-                            </div>
+                            </fieldset>
                         </div>
                         <button type="submit" data-prevent-double-click="true" class="govuk-button"
                         data-module="govuk-button">Continue</button>
@@ -202,25 +214,29 @@ exports[`environmental-impact-assessment change pages GET /environmental-impact-
         <div class="govuk-grid-column-two-thirds">
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full"><span class="govuk-caption-l govuk-!-margin-bottom-3">Appeal 351062</span>
-                    <h1                     class="govuk-heading-l govuk-!-margin-bottom-3">Change opinion that environmental statement needed</h1>
                 </div>
             </div>
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full">
                     <form method="POST" novalidate="novalidate">
                         <div class="govuk-form-group">
-                            <div class="govuk-radios" data-module="govuk-radios">
-                                <div class="govuk-radios__item">
-                                    <input class="govuk-radios__input" id="eiaRequiresEnvironmentalStatement"
-                                    name="eiaRequiresEnvironmentalStatement" type="radio" value="yes">
-                                    <label class="govuk-label govuk-radios__label" for="eiaRequiresEnvironmentalStatement">Needed</label>
+                            <fieldset class="govuk-fieldset">
+                                <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+                                    <h1 class="govuk-fieldset__heading"> Change opinion that environmental statement needed</h1>
+                                </legend>
+                                <div class="govuk-radios" data-module="govuk-radios">
+                                    <div class="govuk-radios__item">
+                                        <input class="govuk-radios__input" id="eiaRequiresEnvironmentalStatement"
+                                        name="eiaRequiresEnvironmentalStatement" type="radio" value="yes">
+                                        <label class="govuk-label govuk-radios__label" for="eiaRequiresEnvironmentalStatement">Needed</label>
+                                    </div>
+                                    <div class="govuk-radios__item">
+                                        <input class="govuk-radios__input" id="eiaRequiresEnvironmentalStatement-2"
+                                        name="eiaRequiresEnvironmentalStatement" type="radio" value="no" checked>
+                                        <label class="govuk-label govuk-radios__label" for="eiaRequiresEnvironmentalStatement-2">Not needed</label>
+                                    </div>
                                 </div>
-                                <div class="govuk-radios__item">
-                                    <input class="govuk-radios__input" id="eiaRequiresEnvironmentalStatement-2"
-                                    name="eiaRequiresEnvironmentalStatement" type="radio" value="no" checked>
-                                    <label class="govuk-label govuk-radios__label" for="eiaRequiresEnvironmentalStatement-2">Not needed</label>
-                                </div>
-                            </div>
+                            </fieldset>
                         </div>
                         <button type="submit" data-prevent-double-click="true" class="govuk-button"
                         data-module="govuk-button">Continue</button>

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/environmental-impact-assessment/environmental-impact-assessment.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/environmental-impact-assessment/environmental-impact-assessment.mapper.js
@@ -18,12 +18,12 @@ export function changeEiaColumnTwoThresholdPage(appealData, existingValue) {
 		title: `Change whether meets or exceeds column 2 threshold criteria`,
 		backLinkUrl: `/appeals-service/appeal-details/${appealData.appealId}/lpa-questionnaire/${appealData.lpaQuestionnaireId}`,
 		preHeading: `Appeal ${shortAppealReference}`,
-		heading: `Change whether meets or exceeds column 2 threshold criteria`,
-		headingClasses: 'govuk-heading-l',
 		pageComponents: [
 			yesNoInput({
 				name: 'eiaColumnTwoThreshold',
 				value: existingValue,
+				legendText: 'Change whether meets or exceeds column 2 threshold criteria',
+				legendIsPageHeading: true,
 				customYesLabel: 'Meets or exceeds',
 				customNoLabel: 'Does not meet or exceed'
 			})
@@ -45,12 +45,12 @@ export function changeEiaRequiresEnvironmentalStatementPage(appealData, existing
 		title: `Change opinion that environmental statement needed`,
 		backLinkUrl: `/appeals-service/appeal-details/${appealData.appealId}/lpa-questionnaire/${appealData.lpaQuestionnaireId}`,
 		preHeading: `Appeal ${shortAppealReference}`,
-		heading: `Change opinion that environmental statement needed`,
-		headingClasses: 'govuk-heading-l',
 		pageComponents: [
 			yesNoInput({
 				name: 'eiaRequiresEnvironmentalStatement',
 				value: existingValue,
+				legendText: 'Change opinion that environmental statement needed',
+				legendIsPageHeading: true,
 				customYesLabel: 'Needed',
 				customNoLabel: 'Not needed'
 			})

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/extra-conditions/__tests__/__snapshots__/extra-conditions.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/extra-conditions/__tests__/__snapshots__/extra-conditions.test.js.snap
@@ -6,32 +6,36 @@ exports[`extra-conditions GET /change should render the change extra conditions 
         <div class="govuk-grid-column-two-thirds">
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full"><span class="govuk-caption-l govuk-!-margin-bottom-3">Appeal 351062</span>
-                    <h1                     class="govuk-heading-l govuk-!-margin-bottom-3">Change extra conditions</h1>
                 </div>
             </div>
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full">
                     <form method="POST" novalidate="novalidate">
                         <div class="govuk-form-group">
-                            <div class="govuk-radios" data-module="govuk-radios">
-                                <div class="govuk-radios__item">
-                                    <input class="govuk-radios__input" id="extraConditionsRadio" name="extraConditionsRadio"
-                                    type="radio" value="yes" checked data-aria-controls="conditional-extraConditionsRadio">
-                                    <label class="govuk-label govuk-radios__label" for="extraConditionsRadio">Yes</label>
-                                </div>
-                                <div class="govuk-radios__conditional" id="conditional-extraConditionsRadio">
-                                    <div class="govuk-form-group">
-                                        <label class="govuk-label" for="extra-conditions-details">Extra conditions details</label>
-                                        <textarea class="govuk-textarea" id="extra-conditions-details"
-                                        name="extraConditionsDetails" rows="3">Some extra conditions</textarea>
+                            <fieldset class="govuk-fieldset">
+                                <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+                                    <h1 class="govuk-fieldset__heading"> Change extra conditions</h1>
+                                </legend>
+                                <div class="govuk-radios" data-module="govuk-radios">
+                                    <div class="govuk-radios__item">
+                                        <input class="govuk-radios__input" id="extraConditionsRadio" name="extraConditionsRadio"
+                                        type="radio" value="yes" checked data-aria-controls="conditional-extraConditionsRadio">
+                                        <label class="govuk-label govuk-radios__label" for="extraConditionsRadio">Yes</label>
+                                    </div>
+                                    <div class="govuk-radios__conditional" id="conditional-extraConditionsRadio">
+                                        <div class="govuk-form-group">
+                                            <label class="govuk-label" for="extra-conditions-details">Extra conditions details</label>
+                                            <textarea class="govuk-textarea" id="extra-conditions-details"
+                                            name="extraConditionsDetails" rows="3">Some extra conditions</textarea>
+                                        </div>
+                                    </div>
+                                    <div class="govuk-radios__item">
+                                        <input class="govuk-radios__input" id="extraConditionsRadio-2" name="extraConditionsRadio"
+                                        type="radio" value="no">
+                                        <label class="govuk-label govuk-radios__label" for="extraConditionsRadio-2">No</label>
                                     </div>
                                 </div>
-                                <div class="govuk-radios__item">
-                                    <input class="govuk-radios__input" id="extraConditionsRadio-2" name="extraConditionsRadio"
-                                    type="radio" value="no">
-                                    <label class="govuk-label govuk-radios__label" for="extraConditionsRadio-2">No</label>
-                                </div>
-                            </div>
+                            </fieldset>
                         </div>
                         <button type="submit" data-prevent-double-click="true" class="govuk-button"
                         data-module="govuk-button">Continue</button>
@@ -60,32 +64,36 @@ exports[`extra-conditions POST /change should re-render the change extra conditi
             </div>
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full"><span class="govuk-caption-l govuk-!-margin-bottom-3">Appeal 351062</span>
-                    <h1                     class="govuk-heading-l govuk-!-margin-bottom-3">Change extra conditions</h1>
                 </div>
             </div>
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full">
                     <form method="POST" novalidate="novalidate">
                         <div class="govuk-form-group">
-                            <div class="govuk-radios" data-module="govuk-radios">
-                                <div class="govuk-radios__item">
-                                    <input class="govuk-radios__input" id="extraConditionsRadio" name="extraConditionsRadio"
-                                    type="radio" value="yes" checked data-aria-controls="conditional-extraConditionsRadio">
-                                    <label class="govuk-label govuk-radios__label" for="extraConditionsRadio">Yes</label>
-                                </div>
-                                <div class="govuk-radios__conditional" id="conditional-extraConditionsRadio">
-                                    <div class="govuk-form-group">
-                                        <label class="govuk-label" for="extra-conditions-details">Extra conditions details</label>
-                                        <textarea class="govuk-textarea" id="extra-conditions-details"
-                                        name="extraConditionsDetails" rows="3"></textarea>
+                            <fieldset class="govuk-fieldset">
+                                <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+                                    <h1 class="govuk-fieldset__heading"> Change extra conditions</h1>
+                                </legend>
+                                <div class="govuk-radios" data-module="govuk-radios">
+                                    <div class="govuk-radios__item">
+                                        <input class="govuk-radios__input" id="extraConditionsRadio" name="extraConditionsRadio"
+                                        type="radio" value="yes" checked data-aria-controls="conditional-extraConditionsRadio">
+                                        <label class="govuk-label govuk-radios__label" for="extraConditionsRadio">Yes</label>
+                                    </div>
+                                    <div class="govuk-radios__conditional" id="conditional-extraConditionsRadio">
+                                        <div class="govuk-form-group">
+                                            <label class="govuk-label" for="extra-conditions-details">Extra conditions details</label>
+                                            <textarea class="govuk-textarea" id="extra-conditions-details"
+                                            name="extraConditionsDetails" rows="3"></textarea>
+                                        </div>
+                                    </div>
+                                    <div class="govuk-radios__item">
+                                        <input class="govuk-radios__input" id="extraConditionsRadio-2" name="extraConditionsRadio"
+                                        type="radio" value="no">
+                                        <label class="govuk-label govuk-radios__label" for="extraConditionsRadio-2">No</label>
                                     </div>
                                 </div>
-                                <div class="govuk-radios__item">
-                                    <input class="govuk-radios__input" id="extraConditionsRadio-2" name="extraConditionsRadio"
-                                    type="radio" value="no">
-                                    <label class="govuk-label govuk-radios__label" for="extraConditionsRadio-2">No</label>
-                                </div>
-                            </div>
+                            </fieldset>
                         </div>
                         <button type="submit" data-prevent-double-click="true" class="govuk-button"
                         data-module="govuk-button">Continue</button>
@@ -114,32 +122,36 @@ exports[`extra-conditions should re-render the change extra conditions page with
             </div>
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full"><span class="govuk-caption-l govuk-!-margin-bottom-3">Appeal 351062</span>
-                    <h1                     class="govuk-heading-l govuk-!-margin-bottom-3">Change extra conditions</h1>
                 </div>
             </div>
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full">
                     <form method="POST" novalidate="novalidate">
                         <div class="govuk-form-group">
-                            <div class="govuk-radios" data-module="govuk-radios">
-                                <div class="govuk-radios__item">
-                                    <input class="govuk-radios__input" id="extraConditionsRadio" name="extraConditionsRadio"
-                                    type="radio" value="yes" checked data-aria-controls="conditional-extraConditionsRadio">
-                                    <label class="govuk-label govuk-radios__label" for="extraConditionsRadio">Yes</label>
-                                </div>
-                                <div class="govuk-radios__conditional" id="conditional-extraConditionsRadio">
-                                    <div class="govuk-form-group">
-                                        <label class="govuk-label" for="extra-conditions-details">Extra conditions details</label>
-                                        <textarea class="govuk-textarea" id="extra-conditions-details"
-                                        name="extraConditionsDetails" rows="3">aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa</textarea>
+                            <fieldset class="govuk-fieldset">
+                                <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+                                    <h1 class="govuk-fieldset__heading"> Change extra conditions</h1>
+                                </legend>
+                                <div class="govuk-radios" data-module="govuk-radios">
+                                    <div class="govuk-radios__item">
+                                        <input class="govuk-radios__input" id="extraConditionsRadio" name="extraConditionsRadio"
+                                        type="radio" value="yes" checked data-aria-controls="conditional-extraConditionsRadio">
+                                        <label class="govuk-label govuk-radios__label" for="extraConditionsRadio">Yes</label>
+                                    </div>
+                                    <div class="govuk-radios__conditional" id="conditional-extraConditionsRadio">
+                                        <div class="govuk-form-group">
+                                            <label class="govuk-label" for="extra-conditions-details">Extra conditions details</label>
+                                            <textarea class="govuk-textarea" id="extra-conditions-details"
+                                            name="extraConditionsDetails" rows="3">aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa</textarea>
+                                        </div>
+                                    </div>
+                                    <div class="govuk-radios__item">
+                                        <input class="govuk-radios__input" id="extraConditionsRadio-2" name="extraConditionsRadio"
+                                        type="radio" value="no">
+                                        <label class="govuk-label govuk-radios__label" for="extraConditionsRadio-2">No</label>
                                     </div>
                                 </div>
-                                <div class="govuk-radios__item">
-                                    <input class="govuk-radios__input" id="extraConditionsRadio-2" name="extraConditionsRadio"
-                                    type="radio" value="no">
-                                    <label class="govuk-label govuk-radios__label" for="extraConditionsRadio-2">No</label>
-                                </div>
-                            </div>
+                            </fieldset>
                         </div>
                         <button type="submit" data-prevent-double-click="true" class="govuk-button"
                         data-module="govuk-button">Continue</button>

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/extra-conditions/extra-conditions.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/extra-conditions/extra-conditions.mapper.js
@@ -25,11 +25,12 @@ export const changeExtraConditionsPage = (appealData, lpaqData, storedSessionDat
 		title: `Change extra conditions`,
 		backLinkUrl: backLinkUrl,
 		preHeading: `Appeal ${shortAppealReference}`,
-		heading: `Change extra conditions`,
 		pageComponents: [
 			yesNoInput({
 				name: 'extraConditionsRadio',
 				value: currentRadioValue,
+				legendText: 'Change extra conditions',
+				legendIsPageHeading: true,
 				yesConditional: {
 					id: 'extra-conditions-details',
 					name: 'extraConditionsDetails',

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/has-community-infrastructure-levy/__tests__/__snapshots__/has-community-infrastructure-levy.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/has-community-infrastructure-levy/__tests__/__snapshots__/has-community-infrastructure-levy.test.js.snap
@@ -6,25 +6,29 @@ exports[`has-community-infrastructure-levy GET /has-community-infrastructure-lev
         <div class="govuk-grid-column-two-thirds">
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full"><span class="govuk-caption-l govuk-!-margin-bottom-3">Appeal 351062</span>
-                    <h1                     class="govuk-heading-l govuk-!-margin-bottom-3">Change community infrastructure levy status</h1>
                 </div>
             </div>
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full">
                     <form method="POST" novalidate="novalidate">
                         <div class="govuk-form-group">
-                            <div class="govuk-radios" data-module="govuk-radios">
-                                <div class="govuk-radios__item">
-                                    <input class="govuk-radios__input" id="hasCommunityInfrastructureLevyRadio"
-                                    name="hasCommunityInfrastructureLevyRadio" type="radio" value="yes">
-                                    <label class="govuk-label govuk-radios__label" for="hasCommunityInfrastructureLevyRadio">Has infrastructure levy</label>
+                            <fieldset class="govuk-fieldset">
+                                <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+                                    <h1 class="govuk-fieldset__heading"> Change community infrastructure levy status</h1>
+                                </legend>
+                                <div class="govuk-radios" data-module="govuk-radios">
+                                    <div class="govuk-radios__item">
+                                        <input class="govuk-radios__input" id="hasCommunityInfrastructureLevyRadio"
+                                        name="hasCommunityInfrastructureLevyRadio" type="radio" value="yes">
+                                        <label class="govuk-label govuk-radios__label" for="hasCommunityInfrastructureLevyRadio">Has infrastructure levy</label>
+                                    </div>
+                                    <div class="govuk-radios__item">
+                                        <input class="govuk-radios__input" id="hasCommunityInfrastructureLevyRadio-2"
+                                        name="hasCommunityInfrastructureLevyRadio" type="radio" value="no" checked>
+                                        <label class="govuk-label govuk-radios__label" for="hasCommunityInfrastructureLevyRadio-2">Does not have infrastructure levy</label>
+                                    </div>
                                 </div>
-                                <div class="govuk-radios__item">
-                                    <input class="govuk-radios__input" id="hasCommunityInfrastructureLevyRadio-2"
-                                    name="hasCommunityInfrastructureLevyRadio" type="radio" value="no" checked>
-                                    <label class="govuk-label govuk-radios__label" for="hasCommunityInfrastructureLevyRadio-2">Does not have infrastructure levy</label>
-                                </div>
-                            </div>
+                            </fieldset>
                         </div>
                         <button type="submit" data-prevent-double-click="true" class="govuk-button"
                         data-module="govuk-button">Continue</button>
@@ -42,25 +46,29 @@ exports[`has-community-infrastructure-levy GET /has-community-infrastructure-lev
         <div class="govuk-grid-column-two-thirds">
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full"><span class="govuk-caption-l govuk-!-margin-bottom-3">Appeal 351062</span>
-                    <h1                     class="govuk-heading-l govuk-!-margin-bottom-3">Change community infrastructure levy status</h1>
                 </div>
             </div>
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full">
                     <form method="POST" novalidate="novalidate">
                         <div class="govuk-form-group">
-                            <div class="govuk-radios" data-module="govuk-radios">
-                                <div class="govuk-radios__item">
-                                    <input class="govuk-radios__input" id="hasCommunityInfrastructureLevyRadio"
-                                    name="hasCommunityInfrastructureLevyRadio" type="radio" value="yes" checked>
-                                    <label class="govuk-label govuk-radios__label" for="hasCommunityInfrastructureLevyRadio">Has infrastructure levy</label>
+                            <fieldset class="govuk-fieldset">
+                                <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+                                    <h1 class="govuk-fieldset__heading"> Change community infrastructure levy status</h1>
+                                </legend>
+                                <div class="govuk-radios" data-module="govuk-radios">
+                                    <div class="govuk-radios__item">
+                                        <input class="govuk-radios__input" id="hasCommunityInfrastructureLevyRadio"
+                                        name="hasCommunityInfrastructureLevyRadio" type="radio" value="yes" checked>
+                                        <label class="govuk-label govuk-radios__label" for="hasCommunityInfrastructureLevyRadio">Has infrastructure levy</label>
+                                    </div>
+                                    <div class="govuk-radios__item">
+                                        <input class="govuk-radios__input" id="hasCommunityInfrastructureLevyRadio-2"
+                                        name="hasCommunityInfrastructureLevyRadio" type="radio" value="no">
+                                        <label class="govuk-label govuk-radios__label" for="hasCommunityInfrastructureLevyRadio-2">Does not have infrastructure levy</label>
+                                    </div>
                                 </div>
-                                <div class="govuk-radios__item">
-                                    <input class="govuk-radios__input" id="hasCommunityInfrastructureLevyRadio-2"
-                                    name="hasCommunityInfrastructureLevyRadio" type="radio" value="no">
-                                    <label class="govuk-label govuk-radios__label" for="hasCommunityInfrastructureLevyRadio-2">Does not have infrastructure levy</label>
-                                </div>
-                            </div>
+                            </fieldset>
                         </div>
                         <button type="submit" data-prevent-double-click="true" class="govuk-button"
                         data-module="govuk-button">Continue</button>

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/has-community-infrastructure-levy/has-community-infrastructure-levy.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/has-community-infrastructure-levy/has-community-infrastructure-levy.mapper.js
@@ -18,11 +18,12 @@ export const changeHasCommunityInfrastructureLevy = (appealData, existingValue, 
 		title: 'Community infrastructure levy status',
 		backLinkUrl,
 		preHeading: `Appeal ${shortAppealReference}`,
-		heading: 'Change community infrastructure levy status',
 		pageComponents: [
 			yesNoInput({
 				name: 'hasCommunityInfrastructureLevyRadio',
 				value: existingValue,
+				legendText: 'Change community infrastructure levy status',
+				legendIsPageHeading: true,
 				customYesLabel: 'Has infrastructure levy',
 				customNoLabel: 'Does not have infrastructure levy'
 			})

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/has-protected-species/__tests__/__snapshots__/has-protected-species.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/has-protected-species/__tests__/__snapshots__/has-protected-species.test.js.snap
@@ -6,25 +6,29 @@ exports[`has-protected-species GET /change should render the hasProtectedSpecies
         <div class="govuk-grid-column-two-thirds">
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full"><span class="govuk-caption-l govuk-!-margin-bottom-3">Appeal 351062</span>
-                    <h1                     class="govuk-heading-l govuk-!-margin-bottom-3">Change whether protected species affected</h1>
                 </div>
             </div>
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full">
                     <form method="POST" novalidate="novalidate">
                         <div class="govuk-form-group">
-                            <div class="govuk-radios" data-module="govuk-radios">
-                                <div class="govuk-radios__item">
-                                    <input class="govuk-radios__input" id="protectedSpeciesRadio" name="protectedSpeciesRadio"
-                                    type="radio" value="yes" checked>
-                                    <label class="govuk-label govuk-radios__label" for="protectedSpeciesRadio">Affected</label>
+                            <fieldset class="govuk-fieldset">
+                                <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+                                    <h1 class="govuk-fieldset__heading"> Change whether protected species affected</h1>
+                                </legend>
+                                <div class="govuk-radios" data-module="govuk-radios">
+                                    <div class="govuk-radios__item">
+                                        <input class="govuk-radios__input" id="protectedSpeciesRadio" name="protectedSpeciesRadio"
+                                        type="radio" value="yes" checked>
+                                        <label class="govuk-label govuk-radios__label" for="protectedSpeciesRadio">Affected</label>
+                                    </div>
+                                    <div class="govuk-radios__item">
+                                        <input class="govuk-radios__input" id="protectedSpeciesRadio-2" name="protectedSpeciesRadio"
+                                        type="radio" value="no">
+                                        <label class="govuk-label govuk-radios__label" for="protectedSpeciesRadio-2">Not affected</label>
+                                    </div>
                                 </div>
-                                <div class="govuk-radios__item">
-                                    <input class="govuk-radios__input" id="protectedSpeciesRadio-2" name="protectedSpeciesRadio"
-                                    type="radio" value="no">
-                                    <label class="govuk-label govuk-radios__label" for="protectedSpeciesRadio-2">Not affected</label>
-                                </div>
-                            </div>
+                            </fieldset>
                         </div>
                         <button type="submit" data-prevent-double-click="true" class="govuk-button"
                         data-module="govuk-button">Continue</button>

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/has-protected-species/has-protected-species.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/has-protected-species/has-protected-species.mapper.js
@@ -18,11 +18,12 @@ export const changeHasProtectedSpecies = (appealData, data, origin) => {
 		title: `Protected species`,
 		backLinkUrl: origin,
 		preHeading: `Appeal ${shortAppealReference}`,
-		heading: `Change whether protected species affected`,
 		pageComponents: [
 			yesNoInput({
 				name: 'protectedSpeciesRadio',
 				value: data,
+				legendText: 'Change whether protected species affected',
+				legendIsPageHeading: true,
 				customYesLabel: 'Affected',
 				customNoLabel: 'Not affected'
 			})

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/infrastructure-levy-adopted-date/__tests__/__snapshots__/infrastructure-levy-adopted-date.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/infrastructure-levy-adopted-date/__tests__/__snapshots__/infrastructure-levy-adopted-date.test.js.snap
@@ -6,39 +6,43 @@ exports[`infrastructure-levy-adopted-date GET /change should render the infrastr
         <div class="govuk-grid-column-two-thirds">
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full"><span class="govuk-caption-l govuk-!-margin-bottom-3">Appeal 351062</span>
-                    <h1                     class="govuk-heading-l govuk-!-margin-bottom-3">Change levy adoption date</h1>
                 </div>
             </div>
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full">
                     <form method="POST" novalidate="novalidate">
                         <div class="govuk-form-group">
-                            <div class="govuk-date-input" id="infrastructure-levy-adopted-date">
-                                <div class="govuk-date-input__item">
-                                    <div class="govuk-form-group">
-                                        <label class="govuk-label govuk-date-input__label" for="infrastructure-levy-adopted-date-levy-adopted-date-day">Day</label>
-                                        <input class="govuk-input govuk-date-input__input govuk-input--width-2"
-                                        id="infrastructure-levy-adopted-date-levy-adopted-date-day" name="levy-adopted-date-day"
-                                        type="text" inputmode="numeric">
+                            <fieldset class="govuk-fieldset" role="group">
+                                <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+                                    <h1 class="govuk-fieldset__heading"> Change levy adoption date</h1>
+                                </legend>
+                                <div class="govuk-date-input" id="infrastructure-levy-adopted-date">
+                                    <div class="govuk-date-input__item">
+                                        <div class="govuk-form-group">
+                                            <label class="govuk-label govuk-date-input__label" for="infrastructure-levy-adopted-date-levy-adopted-date-day">Day</label>
+                                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                                            id="infrastructure-levy-adopted-date-levy-adopted-date-day" name="levy-adopted-date-day"
+                                            type="text" inputmode="numeric">
+                                        </div>
+                                    </div>
+                                    <div class="govuk-date-input__item">
+                                        <div class="govuk-form-group">
+                                            <label class="govuk-label govuk-date-input__label" for="infrastructure-levy-adopted-date-levy-adopted-date-month">Month</label>
+                                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                                            id="infrastructure-levy-adopted-date-levy-adopted-date-month" name="levy-adopted-date-month"
+                                            type="text" inputmode="numeric">
+                                        </div>
+                                    </div>
+                                    <div class="govuk-date-input__item">
+                                        <div class="govuk-form-group">
+                                            <label class="govuk-label govuk-date-input__label" for="infrastructure-levy-adopted-date-levy-adopted-date-year">Year</label>
+                                            <input class="govuk-input govuk-date-input__input govuk-input--width-4"
+                                            id="infrastructure-levy-adopted-date-levy-adopted-date-year" name="levy-adopted-date-year"
+                                            type="text" inputmode="numeric">
+                                        </div>
                                     </div>
                                 </div>
-                                <div class="govuk-date-input__item">
-                                    <div class="govuk-form-group">
-                                        <label class="govuk-label govuk-date-input__label" for="infrastructure-levy-adopted-date-levy-adopted-date-month">Month</label>
-                                        <input class="govuk-input govuk-date-input__input govuk-input--width-2"
-                                        id="infrastructure-levy-adopted-date-levy-adopted-date-month" name="levy-adopted-date-month"
-                                        type="text" inputmode="numeric">
-                                    </div>
-                                </div>
-                                <div class="govuk-date-input__item">
-                                    <div class="govuk-form-group">
-                                        <label class="govuk-label govuk-date-input__label" for="infrastructure-levy-adopted-date-levy-adopted-date-year">Year</label>
-                                        <input class="govuk-input govuk-date-input__input govuk-input--width-4"
-                                        id="infrastructure-levy-adopted-date-levy-adopted-date-year" name="levy-adopted-date-year"
-                                        type="text" inputmode="numeric">
-                                    </div>
-                                </div>
-                            </div>
+                            </fieldset>
                         </div>
                         <button type="submit" data-prevent-double-click="true" class="govuk-button"
                         data-module="govuk-button">Continue</button>
@@ -67,39 +71,43 @@ exports[`infrastructure-levy-adopted-date POST /change should re-render the levy
             </div>
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full"><span class="govuk-caption-l govuk-!-margin-bottom-3">Appeal 351062</span>
-                    <h1                     class="govuk-heading-l govuk-!-margin-bottom-3">Change levy adoption date</h1>
                 </div>
             </div>
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full">
                     <form method="POST" novalidate="novalidate">
                         <div class="govuk-form-group">
-                            <div class="govuk-date-input" id="infrastructure-levy-adopted-date">
-                                <div class="govuk-date-input__item">
-                                    <div class="govuk-form-group">
-                                        <label class="govuk-label govuk-date-input__label" for="infrastructure-levy-adopted-date-levy-adopted-date-day">Day</label>
-                                        <input class="govuk-input govuk-date-input__input govuk-input--width-2"
-                                        id="infrastructure-levy-adopted-date-levy-adopted-date-day" name="levy-adopted-date-day"
-                                        type="text" inputmode="numeric">
+                            <fieldset class="govuk-fieldset" role="group">
+                                <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+                                    <h1 class="govuk-fieldset__heading"> Change levy adoption date</h1>
+                                </legend>
+                                <div class="govuk-date-input" id="infrastructure-levy-adopted-date">
+                                    <div class="govuk-date-input__item">
+                                        <div class="govuk-form-group">
+                                            <label class="govuk-label govuk-date-input__label" for="infrastructure-levy-adopted-date-levy-adopted-date-day">Day</label>
+                                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                                            id="infrastructure-levy-adopted-date-levy-adopted-date-day" name="levy-adopted-date-day"
+                                            type="text" inputmode="numeric">
+                                        </div>
+                                    </div>
+                                    <div class="govuk-date-input__item">
+                                        <div class="govuk-form-group">
+                                            <label class="govuk-label govuk-date-input__label" for="infrastructure-levy-adopted-date-levy-adopted-date-month">Month</label>
+                                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                                            id="infrastructure-levy-adopted-date-levy-adopted-date-month" name="levy-adopted-date-month"
+                                            type="text" inputmode="numeric">
+                                        </div>
+                                    </div>
+                                    <div class="govuk-date-input__item">
+                                        <div class="govuk-form-group">
+                                            <label class="govuk-label govuk-date-input__label" for="infrastructure-levy-adopted-date-levy-adopted-date-year">Year</label>
+                                            <input class="govuk-input govuk-date-input__input govuk-input--width-4"
+                                            id="infrastructure-levy-adopted-date-levy-adopted-date-year" name="levy-adopted-date-year"
+                                            type="text" inputmode="numeric">
+                                        </div>
                                     </div>
                                 </div>
-                                <div class="govuk-date-input__item">
-                                    <div class="govuk-form-group">
-                                        <label class="govuk-label govuk-date-input__label" for="infrastructure-levy-adopted-date-levy-adopted-date-month">Month</label>
-                                        <input class="govuk-input govuk-date-input__input govuk-input--width-2"
-                                        id="infrastructure-levy-adopted-date-levy-adopted-date-month" name="levy-adopted-date-month"
-                                        type="text" inputmode="numeric">
-                                    </div>
-                                </div>
-                                <div class="govuk-date-input__item">
-                                    <div class="govuk-form-group">
-                                        <label class="govuk-label govuk-date-input__label" for="infrastructure-levy-adopted-date-levy-adopted-date-year">Year</label>
-                                        <input class="govuk-input govuk-date-input__input govuk-input--width-4"
-                                        id="infrastructure-levy-adopted-date-levy-adopted-date-year" name="levy-adopted-date-year"
-                                        type="text" inputmode="numeric">
-                                    </div>
-                                </div>
-                            </div>
+                            </fieldset>
                         </div>
                         <button type="submit" data-prevent-double-click="true" class="govuk-button"
                         data-module="govuk-button">Continue</button>
@@ -130,39 +138,43 @@ exports[`infrastructure-levy-adopted-date POST /change should re-render the levy
             </div>
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full"><span class="govuk-caption-l govuk-!-margin-bottom-3">Appeal 351062</span>
-                    <h1                     class="govuk-heading-l govuk-!-margin-bottom-3">Change levy adoption date</h1>
                 </div>
             </div>
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full">
                     <form method="POST" novalidate="novalidate">
                         <div class="govuk-form-group">
-                            <div class="govuk-date-input" id="infrastructure-levy-adopted-date">
-                                <div class="govuk-date-input__item">
-                                    <div class="govuk-form-group">
-                                        <label class="govuk-label govuk-date-input__label" for="infrastructure-levy-adopted-date-levy-adopted-date-day">Day</label>
-                                        <input class="govuk-input govuk-date-input__input govuk-input--width-2"
-                                        id="infrastructure-levy-adopted-date-levy-adopted-date-day" name="levy-adopted-date-day"
-                                        type="text" inputmode="numeric">
+                            <fieldset class="govuk-fieldset" role="group">
+                                <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+                                    <h1 class="govuk-fieldset__heading"> Change levy adoption date</h1>
+                                </legend>
+                                <div class="govuk-date-input" id="infrastructure-levy-adopted-date">
+                                    <div class="govuk-date-input__item">
+                                        <div class="govuk-form-group">
+                                            <label class="govuk-label govuk-date-input__label" for="infrastructure-levy-adopted-date-levy-adopted-date-day">Day</label>
+                                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                                            id="infrastructure-levy-adopted-date-levy-adopted-date-day" name="levy-adopted-date-day"
+                                            type="text" inputmode="numeric">
+                                        </div>
+                                    </div>
+                                    <div class="govuk-date-input__item">
+                                        <div class="govuk-form-group">
+                                            <label class="govuk-label govuk-date-input__label" for="infrastructure-levy-adopted-date-levy-adopted-date-month">Month</label>
+                                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                                            id="infrastructure-levy-adopted-date-levy-adopted-date-month" name="levy-adopted-date-month"
+                                            type="text" inputmode="numeric">
+                                        </div>
+                                    </div>
+                                    <div class="govuk-date-input__item">
+                                        <div class="govuk-form-group">
+                                            <label class="govuk-label govuk-date-input__label" for="infrastructure-levy-adopted-date-levy-adopted-date-year">Year</label>
+                                            <input class="govuk-input govuk-date-input__input govuk-input--width-4"
+                                            id="infrastructure-levy-adopted-date-levy-adopted-date-year" name="levy-adopted-date-year"
+                                            type="text" inputmode="numeric">
+                                        </div>
                                     </div>
                                 </div>
-                                <div class="govuk-date-input__item">
-                                    <div class="govuk-form-group">
-                                        <label class="govuk-label govuk-date-input__label" for="infrastructure-levy-adopted-date-levy-adopted-date-month">Month</label>
-                                        <input class="govuk-input govuk-date-input__input govuk-input--width-2"
-                                        id="infrastructure-levy-adopted-date-levy-adopted-date-month" name="levy-adopted-date-month"
-                                        type="text" inputmode="numeric">
-                                    </div>
-                                </div>
-                                <div class="govuk-date-input__item">
-                                    <div class="govuk-form-group">
-                                        <label class="govuk-label govuk-date-input__label" for="infrastructure-levy-adopted-date-levy-adopted-date-year">Year</label>
-                                        <input class="govuk-input govuk-date-input__input govuk-input--width-4"
-                                        id="infrastructure-levy-adopted-date-levy-adopted-date-year" name="levy-adopted-date-year"
-                                        type="text" inputmode="numeric">
-                                    </div>
-                                </div>
-                            </div>
+                            </fieldset>
                         </div>
                         <button type="submit" data-prevent-double-click="true" class="govuk-button"
                         data-module="govuk-button">Continue</button>
@@ -193,39 +205,43 @@ exports[`infrastructure-levy-adopted-date POST /change should re-render the levy
             </div>
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full"><span class="govuk-caption-l govuk-!-margin-bottom-3">Appeal 351062</span>
-                    <h1                     class="govuk-heading-l govuk-!-margin-bottom-3">Change levy adoption date</h1>
                 </div>
             </div>
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full">
                     <form method="POST" novalidate="novalidate">
                         <div class="govuk-form-group">
-                            <div class="govuk-date-input" id="infrastructure-levy-adopted-date">
-                                <div class="govuk-date-input__item">
-                                    <div class="govuk-form-group">
-                                        <label class="govuk-label govuk-date-input__label" for="infrastructure-levy-adopted-date-levy-adopted-date-day">Day</label>
-                                        <input class="govuk-input govuk-date-input__input govuk-input--width-2"
-                                        id="infrastructure-levy-adopted-date-levy-adopted-date-day" name="levy-adopted-date-day"
-                                        type="text" inputmode="numeric">
+                            <fieldset class="govuk-fieldset" role="group">
+                                <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+                                    <h1 class="govuk-fieldset__heading"> Change levy adoption date</h1>
+                                </legend>
+                                <div class="govuk-date-input" id="infrastructure-levy-adopted-date">
+                                    <div class="govuk-date-input__item">
+                                        <div class="govuk-form-group">
+                                            <label class="govuk-label govuk-date-input__label" for="infrastructure-levy-adopted-date-levy-adopted-date-day">Day</label>
+                                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                                            id="infrastructure-levy-adopted-date-levy-adopted-date-day" name="levy-adopted-date-day"
+                                            type="text" inputmode="numeric">
+                                        </div>
+                                    </div>
+                                    <div class="govuk-date-input__item">
+                                        <div class="govuk-form-group">
+                                            <label class="govuk-label govuk-date-input__label" for="infrastructure-levy-adopted-date-levy-adopted-date-month">Month</label>
+                                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                                            id="infrastructure-levy-adopted-date-levy-adopted-date-month" name="levy-adopted-date-month"
+                                            type="text" inputmode="numeric">
+                                        </div>
+                                    </div>
+                                    <div class="govuk-date-input__item">
+                                        <div class="govuk-form-group">
+                                            <label class="govuk-label govuk-date-input__label" for="infrastructure-levy-adopted-date-levy-adopted-date-year">Year</label>
+                                            <input class="govuk-input govuk-date-input__input govuk-input--width-4"
+                                            id="infrastructure-levy-adopted-date-levy-adopted-date-year" name="levy-adopted-date-year"
+                                            type="text" inputmode="numeric">
+                                        </div>
                                     </div>
                                 </div>
-                                <div class="govuk-date-input__item">
-                                    <div class="govuk-form-group">
-                                        <label class="govuk-label govuk-date-input__label" for="infrastructure-levy-adopted-date-levy-adopted-date-month">Month</label>
-                                        <input class="govuk-input govuk-date-input__input govuk-input--width-2"
-                                        id="infrastructure-levy-adopted-date-levy-adopted-date-month" name="levy-adopted-date-month"
-                                        type="text" inputmode="numeric">
-                                    </div>
-                                </div>
-                                <div class="govuk-date-input__item">
-                                    <div class="govuk-form-group">
-                                        <label class="govuk-label govuk-date-input__label" for="infrastructure-levy-adopted-date-levy-adopted-date-year">Year</label>
-                                        <input class="govuk-input govuk-date-input__input govuk-input--width-4"
-                                        id="infrastructure-levy-adopted-date-levy-adopted-date-year" name="levy-adopted-date-year"
-                                        type="text" inputmode="numeric">
-                                    </div>
-                                </div>
-                            </div>
+                            </fieldset>
                         </div>
                         <button type="submit" data-prevent-double-click="true" class="govuk-button"
                         data-module="govuk-button">Continue</button>
@@ -256,39 +272,43 @@ exports[`infrastructure-levy-adopted-date POST /change should re-render the levy
             </div>
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full"><span class="govuk-caption-l govuk-!-margin-bottom-3">Appeal 351062</span>
-                    <h1                     class="govuk-heading-l govuk-!-margin-bottom-3">Change levy adoption date</h1>
                 </div>
             </div>
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full">
                     <form method="POST" novalidate="novalidate">
                         <div class="govuk-form-group">
-                            <div class="govuk-date-input" id="infrastructure-levy-adopted-date">
-                                <div class="govuk-date-input__item">
-                                    <div class="govuk-form-group">
-                                        <label class="govuk-label govuk-date-input__label" for="infrastructure-levy-adopted-date-levy-adopted-date-day">Day</label>
-                                        <input class="govuk-input govuk-date-input__input govuk-input--width-2"
-                                        id="infrastructure-levy-adopted-date-levy-adopted-date-day" name="levy-adopted-date-day"
-                                        type="text" inputmode="numeric">
+                            <fieldset class="govuk-fieldset" role="group">
+                                <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+                                    <h1 class="govuk-fieldset__heading"> Change levy adoption date</h1>
+                                </legend>
+                                <div class="govuk-date-input" id="infrastructure-levy-adopted-date">
+                                    <div class="govuk-date-input__item">
+                                        <div class="govuk-form-group">
+                                            <label class="govuk-label govuk-date-input__label" for="infrastructure-levy-adopted-date-levy-adopted-date-day">Day</label>
+                                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                                            id="infrastructure-levy-adopted-date-levy-adopted-date-day" name="levy-adopted-date-day"
+                                            type="text" inputmode="numeric">
+                                        </div>
+                                    </div>
+                                    <div class="govuk-date-input__item">
+                                        <div class="govuk-form-group">
+                                            <label class="govuk-label govuk-date-input__label" for="infrastructure-levy-adopted-date-levy-adopted-date-month">Month</label>
+                                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                                            id="infrastructure-levy-adopted-date-levy-adopted-date-month" name="levy-adopted-date-month"
+                                            type="text" inputmode="numeric">
+                                        </div>
+                                    </div>
+                                    <div class="govuk-date-input__item">
+                                        <div class="govuk-form-group">
+                                            <label class="govuk-label govuk-date-input__label" for="infrastructure-levy-adopted-date-levy-adopted-date-year">Year</label>
+                                            <input class="govuk-input govuk-date-input__input govuk-input--width-4"
+                                            id="infrastructure-levy-adopted-date-levy-adopted-date-year" name="levy-adopted-date-year"
+                                            type="text" inputmode="numeric">
+                                        </div>
                                     </div>
                                 </div>
-                                <div class="govuk-date-input__item">
-                                    <div class="govuk-form-group">
-                                        <label class="govuk-label govuk-date-input__label" for="infrastructure-levy-adopted-date-levy-adopted-date-month">Month</label>
-                                        <input class="govuk-input govuk-date-input__input govuk-input--width-2"
-                                        id="infrastructure-levy-adopted-date-levy-adopted-date-month" name="levy-adopted-date-month"
-                                        type="text" inputmode="numeric">
-                                    </div>
-                                </div>
-                                <div class="govuk-date-input__item">
-                                    <div class="govuk-form-group">
-                                        <label class="govuk-label govuk-date-input__label" for="infrastructure-levy-adopted-date-levy-adopted-date-year">Year</label>
-                                        <input class="govuk-input govuk-date-input__input govuk-input--width-4"
-                                        id="infrastructure-levy-adopted-date-levy-adopted-date-year" name="levy-adopted-date-year"
-                                        type="text" inputmode="numeric">
-                                    </div>
-                                </div>
-                            </div>
+                            </fieldset>
                         </div>
                         <button type="submit" data-prevent-double-click="true" class="govuk-button"
                         data-module="govuk-button">Continue</button>
@@ -317,39 +337,43 @@ exports[`infrastructure-levy-adopted-date POST /change should re-render the levy
             </div>
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full"><span class="govuk-caption-l govuk-!-margin-bottom-3">Appeal 351062</span>
-                    <h1                     class="govuk-heading-l govuk-!-margin-bottom-3">Change levy adoption date</h1>
                 </div>
             </div>
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full">
                     <form method="POST" novalidate="novalidate">
                         <div class="govuk-form-group">
-                            <div class="govuk-date-input" id="infrastructure-levy-adopted-date">
-                                <div class="govuk-date-input__item">
-                                    <div class="govuk-form-group">
-                                        <label class="govuk-label govuk-date-input__label" for="infrastructure-levy-adopted-date-levy-adopted-date-day">Day</label>
-                                        <input class="govuk-input govuk-date-input__input govuk-input--width-2"
-                                        id="infrastructure-levy-adopted-date-levy-adopted-date-day" name="levy-adopted-date-day"
-                                        type="text" inputmode="numeric">
+                            <fieldset class="govuk-fieldset" role="group">
+                                <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+                                    <h1 class="govuk-fieldset__heading"> Change levy adoption date</h1>
+                                </legend>
+                                <div class="govuk-date-input" id="infrastructure-levy-adopted-date">
+                                    <div class="govuk-date-input__item">
+                                        <div class="govuk-form-group">
+                                            <label class="govuk-label govuk-date-input__label" for="infrastructure-levy-adopted-date-levy-adopted-date-day">Day</label>
+                                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                                            id="infrastructure-levy-adopted-date-levy-adopted-date-day" name="levy-adopted-date-day"
+                                            type="text" inputmode="numeric">
+                                        </div>
+                                    </div>
+                                    <div class="govuk-date-input__item">
+                                        <div class="govuk-form-group">
+                                            <label class="govuk-label govuk-date-input__label" for="infrastructure-levy-adopted-date-levy-adopted-date-month">Month</label>
+                                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                                            id="infrastructure-levy-adopted-date-levy-adopted-date-month" name="levy-adopted-date-month"
+                                            type="text" inputmode="numeric">
+                                        </div>
+                                    </div>
+                                    <div class="govuk-date-input__item">
+                                        <div class="govuk-form-group">
+                                            <label class="govuk-label govuk-date-input__label" for="infrastructure-levy-adopted-date-levy-adopted-date-year">Year</label>
+                                            <input class="govuk-input govuk-date-input__input govuk-input--width-4"
+                                            id="infrastructure-levy-adopted-date-levy-adopted-date-year" name="levy-adopted-date-year"
+                                            type="text" inputmode="numeric">
+                                        </div>
                                     </div>
                                 </div>
-                                <div class="govuk-date-input__item">
-                                    <div class="govuk-form-group">
-                                        <label class="govuk-label govuk-date-input__label" for="infrastructure-levy-adopted-date-levy-adopted-date-month">Month</label>
-                                        <input class="govuk-input govuk-date-input__input govuk-input--width-2"
-                                        id="infrastructure-levy-adopted-date-levy-adopted-date-month" name="levy-adopted-date-month"
-                                        type="text" inputmode="numeric">
-                                    </div>
-                                </div>
-                                <div class="govuk-date-input__item">
-                                    <div class="govuk-form-group">
-                                        <label class="govuk-label govuk-date-input__label" for="infrastructure-levy-adopted-date-levy-adopted-date-year">Year</label>
-                                        <input class="govuk-input govuk-date-input__input govuk-input--width-4"
-                                        id="infrastructure-levy-adopted-date-levy-adopted-date-year" name="levy-adopted-date-year"
-                                        type="text" inputmode="numeric">
-                                    </div>
-                                </div>
-                            </div>
+                            </fieldset>
                         </div>
                         <button type="submit" data-prevent-double-click="true" class="govuk-button"
                         data-module="govuk-button">Continue</button>
@@ -380,39 +404,43 @@ exports[`infrastructure-levy-adopted-date POST /change should re-render the levy
             </div>
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full"><span class="govuk-caption-l govuk-!-margin-bottom-3">Appeal 351062</span>
-                    <h1                     class="govuk-heading-l govuk-!-margin-bottom-3">Change levy adoption date</h1>
                 </div>
             </div>
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full">
                     <form method="POST" novalidate="novalidate">
                         <div class="govuk-form-group">
-                            <div class="govuk-date-input" id="infrastructure-levy-adopted-date">
-                                <div class="govuk-date-input__item">
-                                    <div class="govuk-form-group">
-                                        <label class="govuk-label govuk-date-input__label" for="infrastructure-levy-adopted-date-levy-adopted-date-day">Day</label>
-                                        <input class="govuk-input govuk-date-input__input govuk-input--width-2"
-                                        id="infrastructure-levy-adopted-date-levy-adopted-date-day" name="levy-adopted-date-day"
-                                        type="text" inputmode="numeric">
+                            <fieldset class="govuk-fieldset" role="group">
+                                <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+                                    <h1 class="govuk-fieldset__heading"> Change levy adoption date</h1>
+                                </legend>
+                                <div class="govuk-date-input" id="infrastructure-levy-adopted-date">
+                                    <div class="govuk-date-input__item">
+                                        <div class="govuk-form-group">
+                                            <label class="govuk-label govuk-date-input__label" for="infrastructure-levy-adopted-date-levy-adopted-date-day">Day</label>
+                                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                                            id="infrastructure-levy-adopted-date-levy-adopted-date-day" name="levy-adopted-date-day"
+                                            type="text" inputmode="numeric">
+                                        </div>
+                                    </div>
+                                    <div class="govuk-date-input__item">
+                                        <div class="govuk-form-group">
+                                            <label class="govuk-label govuk-date-input__label" for="infrastructure-levy-adopted-date-levy-adopted-date-month">Month</label>
+                                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                                            id="infrastructure-levy-adopted-date-levy-adopted-date-month" name="levy-adopted-date-month"
+                                            type="text" inputmode="numeric">
+                                        </div>
+                                    </div>
+                                    <div class="govuk-date-input__item">
+                                        <div class="govuk-form-group">
+                                            <label class="govuk-label govuk-date-input__label" for="infrastructure-levy-adopted-date-levy-adopted-date-year">Year</label>
+                                            <input class="govuk-input govuk-date-input__input govuk-input--width-4"
+                                            id="infrastructure-levy-adopted-date-levy-adopted-date-year" name="levy-adopted-date-year"
+                                            type="text" inputmode="numeric">
+                                        </div>
                                     </div>
                                 </div>
-                                <div class="govuk-date-input__item">
-                                    <div class="govuk-form-group">
-                                        <label class="govuk-label govuk-date-input__label" for="infrastructure-levy-adopted-date-levy-adopted-date-month">Month</label>
-                                        <input class="govuk-input govuk-date-input__input govuk-input--width-2"
-                                        id="infrastructure-levy-adopted-date-levy-adopted-date-month" name="levy-adopted-date-month"
-                                        type="text" inputmode="numeric">
-                                    </div>
-                                </div>
-                                <div class="govuk-date-input__item">
-                                    <div class="govuk-form-group">
-                                        <label class="govuk-label govuk-date-input__label" for="infrastructure-levy-adopted-date-levy-adopted-date-year">Year</label>
-                                        <input class="govuk-input govuk-date-input__input govuk-input--width-4"
-                                        id="infrastructure-levy-adopted-date-levy-adopted-date-year" name="levy-adopted-date-year"
-                                        type="text" inputmode="numeric">
-                                    </div>
-                                </div>
-                            </div>
+                            </fieldset>
                         </div>
                         <button type="submit" data-prevent-double-click="true" class="govuk-button"
                         data-module="govuk-button">Continue</button>
@@ -443,39 +471,43 @@ exports[`infrastructure-levy-adopted-date POST /change should re-render the levy
             </div>
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full"><span class="govuk-caption-l govuk-!-margin-bottom-3">Appeal 351062</span>
-                    <h1                     class="govuk-heading-l govuk-!-margin-bottom-3">Change levy adoption date</h1>
                 </div>
             </div>
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full">
                     <form method="POST" novalidate="novalidate">
                         <div class="govuk-form-group">
-                            <div class="govuk-date-input" id="infrastructure-levy-adopted-date">
-                                <div class="govuk-date-input__item">
-                                    <div class="govuk-form-group">
-                                        <label class="govuk-label govuk-date-input__label" for="infrastructure-levy-adopted-date-levy-adopted-date-day">Day</label>
-                                        <input class="govuk-input govuk-date-input__input govuk-input--width-2"
-                                        id="infrastructure-levy-adopted-date-levy-adopted-date-day" name="levy-adopted-date-day"
-                                        type="text" inputmode="numeric">
+                            <fieldset class="govuk-fieldset" role="group">
+                                <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+                                    <h1 class="govuk-fieldset__heading"> Change levy adoption date</h1>
+                                </legend>
+                                <div class="govuk-date-input" id="infrastructure-levy-adopted-date">
+                                    <div class="govuk-date-input__item">
+                                        <div class="govuk-form-group">
+                                            <label class="govuk-label govuk-date-input__label" for="infrastructure-levy-adopted-date-levy-adopted-date-day">Day</label>
+                                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                                            id="infrastructure-levy-adopted-date-levy-adopted-date-day" name="levy-adopted-date-day"
+                                            type="text" inputmode="numeric">
+                                        </div>
+                                    </div>
+                                    <div class="govuk-date-input__item">
+                                        <div class="govuk-form-group">
+                                            <label class="govuk-label govuk-date-input__label" for="infrastructure-levy-adopted-date-levy-adopted-date-month">Month</label>
+                                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                                            id="infrastructure-levy-adopted-date-levy-adopted-date-month" name="levy-adopted-date-month"
+                                            type="text" inputmode="numeric">
+                                        </div>
+                                    </div>
+                                    <div class="govuk-date-input__item">
+                                        <div class="govuk-form-group">
+                                            <label class="govuk-label govuk-date-input__label" for="infrastructure-levy-adopted-date-levy-adopted-date-year">Year</label>
+                                            <input class="govuk-input govuk-date-input__input govuk-input--width-4"
+                                            id="infrastructure-levy-adopted-date-levy-adopted-date-year" name="levy-adopted-date-year"
+                                            type="text" inputmode="numeric">
+                                        </div>
                                     </div>
                                 </div>
-                                <div class="govuk-date-input__item">
-                                    <div class="govuk-form-group">
-                                        <label class="govuk-label govuk-date-input__label" for="infrastructure-levy-adopted-date-levy-adopted-date-month">Month</label>
-                                        <input class="govuk-input govuk-date-input__input govuk-input--width-2"
-                                        id="infrastructure-levy-adopted-date-levy-adopted-date-month" name="levy-adopted-date-month"
-                                        type="text" inputmode="numeric">
-                                    </div>
-                                </div>
-                                <div class="govuk-date-input__item">
-                                    <div class="govuk-form-group">
-                                        <label class="govuk-label govuk-date-input__label" for="infrastructure-levy-adopted-date-levy-adopted-date-year">Year</label>
-                                        <input class="govuk-input govuk-date-input__input govuk-input--width-4"
-                                        id="infrastructure-levy-adopted-date-levy-adopted-date-year" name="levy-adopted-date-year"
-                                        type="text" inputmode="numeric">
-                                    </div>
-                                </div>
-                            </div>
+                            </fieldset>
                         </div>
                         <button type="submit" data-prevent-double-click="true" class="govuk-button"
                         data-module="govuk-button">Continue</button>
@@ -506,39 +538,43 @@ exports[`infrastructure-levy-adopted-date POST /change should re-render the levy
             </div>
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full"><span class="govuk-caption-l govuk-!-margin-bottom-3">Appeal 351062</span>
-                    <h1                     class="govuk-heading-l govuk-!-margin-bottom-3">Change levy adoption date</h1>
                 </div>
             </div>
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full">
                     <form method="POST" novalidate="novalidate">
                         <div class="govuk-form-group">
-                            <div class="govuk-date-input" id="infrastructure-levy-adopted-date">
-                                <div class="govuk-date-input__item">
-                                    <div class="govuk-form-group">
-                                        <label class="govuk-label govuk-date-input__label" for="infrastructure-levy-adopted-date-levy-adopted-date-day">Day</label>
-                                        <input class="govuk-input govuk-date-input__input govuk-input--width-2"
-                                        id="infrastructure-levy-adopted-date-levy-adopted-date-day" name="levy-adopted-date-day"
-                                        type="text" inputmode="numeric">
+                            <fieldset class="govuk-fieldset" role="group">
+                                <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+                                    <h1 class="govuk-fieldset__heading"> Change levy adoption date</h1>
+                                </legend>
+                                <div class="govuk-date-input" id="infrastructure-levy-adopted-date">
+                                    <div class="govuk-date-input__item">
+                                        <div class="govuk-form-group">
+                                            <label class="govuk-label govuk-date-input__label" for="infrastructure-levy-adopted-date-levy-adopted-date-day">Day</label>
+                                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                                            id="infrastructure-levy-adopted-date-levy-adopted-date-day" name="levy-adopted-date-day"
+                                            type="text" inputmode="numeric">
+                                        </div>
+                                    </div>
+                                    <div class="govuk-date-input__item">
+                                        <div class="govuk-form-group">
+                                            <label class="govuk-label govuk-date-input__label" for="infrastructure-levy-adopted-date-levy-adopted-date-month">Month</label>
+                                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                                            id="infrastructure-levy-adopted-date-levy-adopted-date-month" name="levy-adopted-date-month"
+                                            type="text" inputmode="numeric">
+                                        </div>
+                                    </div>
+                                    <div class="govuk-date-input__item">
+                                        <div class="govuk-form-group">
+                                            <label class="govuk-label govuk-date-input__label" for="infrastructure-levy-adopted-date-levy-adopted-date-year">Year</label>
+                                            <input class="govuk-input govuk-date-input__input govuk-input--width-4"
+                                            id="infrastructure-levy-adopted-date-levy-adopted-date-year" name="levy-adopted-date-year"
+                                            type="text" inputmode="numeric">
+                                        </div>
                                     </div>
                                 </div>
-                                <div class="govuk-date-input__item">
-                                    <div class="govuk-form-group">
-                                        <label class="govuk-label govuk-date-input__label" for="infrastructure-levy-adopted-date-levy-adopted-date-month">Month</label>
-                                        <input class="govuk-input govuk-date-input__input govuk-input--width-2"
-                                        id="infrastructure-levy-adopted-date-levy-adopted-date-month" name="levy-adopted-date-month"
-                                        type="text" inputmode="numeric">
-                                    </div>
-                                </div>
-                                <div class="govuk-date-input__item">
-                                    <div class="govuk-form-group">
-                                        <label class="govuk-label govuk-date-input__label" for="infrastructure-levy-adopted-date-levy-adopted-date-year">Year</label>
-                                        <input class="govuk-input govuk-date-input__input govuk-input--width-4"
-                                        id="infrastructure-levy-adopted-date-levy-adopted-date-year" name="levy-adopted-date-year"
-                                        type="text" inputmode="numeric">
-                                    </div>
-                                </div>
-                            </div>
+                            </fieldset>
                         </div>
                         <button type="submit" data-prevent-double-click="true" class="govuk-button"
                         data-module="govuk-button">Continue</button>
@@ -567,39 +603,43 @@ exports[`infrastructure-levy-adopted-date POST /change should re-render the levy
             </div>
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full"><span class="govuk-caption-l govuk-!-margin-bottom-3">Appeal 351062</span>
-                    <h1                     class="govuk-heading-l govuk-!-margin-bottom-3">Change levy adoption date</h1>
                 </div>
             </div>
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full">
                     <form method="POST" novalidate="novalidate">
                         <div class="govuk-form-group">
-                            <div class="govuk-date-input" id="infrastructure-levy-adopted-date">
-                                <div class="govuk-date-input__item">
-                                    <div class="govuk-form-group">
-                                        <label class="govuk-label govuk-date-input__label" for="infrastructure-levy-adopted-date-levy-adopted-date-day">Day</label>
-                                        <input class="govuk-input govuk-date-input__input govuk-input--width-2"
-                                        id="infrastructure-levy-adopted-date-levy-adopted-date-day" name="levy-adopted-date-day"
-                                        type="text" inputmode="numeric">
+                            <fieldset class="govuk-fieldset" role="group">
+                                <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+                                    <h1 class="govuk-fieldset__heading"> Change levy adoption date</h1>
+                                </legend>
+                                <div class="govuk-date-input" id="infrastructure-levy-adopted-date">
+                                    <div class="govuk-date-input__item">
+                                        <div class="govuk-form-group">
+                                            <label class="govuk-label govuk-date-input__label" for="infrastructure-levy-adopted-date-levy-adopted-date-day">Day</label>
+                                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                                            id="infrastructure-levy-adopted-date-levy-adopted-date-day" name="levy-adopted-date-day"
+                                            type="text" inputmode="numeric">
+                                        </div>
+                                    </div>
+                                    <div class="govuk-date-input__item">
+                                        <div class="govuk-form-group">
+                                            <label class="govuk-label govuk-date-input__label" for="infrastructure-levy-adopted-date-levy-adopted-date-month">Month</label>
+                                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                                            id="infrastructure-levy-adopted-date-levy-adopted-date-month" name="levy-adopted-date-month"
+                                            type="text" inputmode="numeric">
+                                        </div>
+                                    </div>
+                                    <div class="govuk-date-input__item">
+                                        <div class="govuk-form-group">
+                                            <label class="govuk-label govuk-date-input__label" for="infrastructure-levy-adopted-date-levy-adopted-date-year">Year</label>
+                                            <input class="govuk-input govuk-date-input__input govuk-input--width-4"
+                                            id="infrastructure-levy-adopted-date-levy-adopted-date-year" name="levy-adopted-date-year"
+                                            type="text" inputmode="numeric">
+                                        </div>
                                     </div>
                                 </div>
-                                <div class="govuk-date-input__item">
-                                    <div class="govuk-form-group">
-                                        <label class="govuk-label govuk-date-input__label" for="infrastructure-levy-adopted-date-levy-adopted-date-month">Month</label>
-                                        <input class="govuk-input govuk-date-input__input govuk-input--width-2"
-                                        id="infrastructure-levy-adopted-date-levy-adopted-date-month" name="levy-adopted-date-month"
-                                        type="text" inputmode="numeric">
-                                    </div>
-                                </div>
-                                <div class="govuk-date-input__item">
-                                    <div class="govuk-form-group">
-                                        <label class="govuk-label govuk-date-input__label" for="infrastructure-levy-adopted-date-levy-adopted-date-year">Year</label>
-                                        <input class="govuk-input govuk-date-input__input govuk-input--width-4"
-                                        id="infrastructure-levy-adopted-date-levy-adopted-date-year" name="levy-adopted-date-year"
-                                        type="text" inputmode="numeric">
-                                    </div>
-                                </div>
-                            </div>
+                            </fieldset>
                         </div>
                         <button type="submit" data-prevent-double-click="true" class="govuk-button"
                         data-module="govuk-button">Continue</button>
@@ -630,39 +670,43 @@ exports[`infrastructure-levy-adopted-date POST /change should re-render the levy
             </div>
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full"><span class="govuk-caption-l govuk-!-margin-bottom-3">Appeal 351062</span>
-                    <h1                     class="govuk-heading-l govuk-!-margin-bottom-3">Change levy adoption date</h1>
                 </div>
             </div>
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full">
                     <form method="POST" novalidate="novalidate">
                         <div class="govuk-form-group">
-                            <div class="govuk-date-input" id="infrastructure-levy-adopted-date">
-                                <div class="govuk-date-input__item">
-                                    <div class="govuk-form-group">
-                                        <label class="govuk-label govuk-date-input__label" for="infrastructure-levy-adopted-date-levy-adopted-date-day">Day</label>
-                                        <input class="govuk-input govuk-date-input__input govuk-input--width-2"
-                                        id="infrastructure-levy-adopted-date-levy-adopted-date-day" name="levy-adopted-date-day"
-                                        type="text" inputmode="numeric">
+                            <fieldset class="govuk-fieldset" role="group">
+                                <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+                                    <h1 class="govuk-fieldset__heading"> Change levy adoption date</h1>
+                                </legend>
+                                <div class="govuk-date-input" id="infrastructure-levy-adopted-date">
+                                    <div class="govuk-date-input__item">
+                                        <div class="govuk-form-group">
+                                            <label class="govuk-label govuk-date-input__label" for="infrastructure-levy-adopted-date-levy-adopted-date-day">Day</label>
+                                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                                            id="infrastructure-levy-adopted-date-levy-adopted-date-day" name="levy-adopted-date-day"
+                                            type="text" inputmode="numeric">
+                                        </div>
+                                    </div>
+                                    <div class="govuk-date-input__item">
+                                        <div class="govuk-form-group">
+                                            <label class="govuk-label govuk-date-input__label" for="infrastructure-levy-adopted-date-levy-adopted-date-month">Month</label>
+                                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                                            id="infrastructure-levy-adopted-date-levy-adopted-date-month" name="levy-adopted-date-month"
+                                            type="text" inputmode="numeric">
+                                        </div>
+                                    </div>
+                                    <div class="govuk-date-input__item">
+                                        <div class="govuk-form-group">
+                                            <label class="govuk-label govuk-date-input__label" for="infrastructure-levy-adopted-date-levy-adopted-date-year">Year</label>
+                                            <input class="govuk-input govuk-date-input__input govuk-input--width-4"
+                                            id="infrastructure-levy-adopted-date-levy-adopted-date-year" name="levy-adopted-date-year"
+                                            type="text" inputmode="numeric">
+                                        </div>
                                     </div>
                                 </div>
-                                <div class="govuk-date-input__item">
-                                    <div class="govuk-form-group">
-                                        <label class="govuk-label govuk-date-input__label" for="infrastructure-levy-adopted-date-levy-adopted-date-month">Month</label>
-                                        <input class="govuk-input govuk-date-input__input govuk-input--width-2"
-                                        id="infrastructure-levy-adopted-date-levy-adopted-date-month" name="levy-adopted-date-month"
-                                        type="text" inputmode="numeric">
-                                    </div>
-                                </div>
-                                <div class="govuk-date-input__item">
-                                    <div class="govuk-form-group">
-                                        <label class="govuk-label govuk-date-input__label" for="infrastructure-levy-adopted-date-levy-adopted-date-year">Year</label>
-                                        <input class="govuk-input govuk-date-input__input govuk-input--width-4"
-                                        id="infrastructure-levy-adopted-date-levy-adopted-date-year" name="levy-adopted-date-year"
-                                        type="text" inputmode="numeric">
-                                    </div>
-                                </div>
-                            </div>
+                            </fieldset>
                         </div>
                         <button type="submit" data-prevent-double-click="true" class="govuk-button"
                         data-module="govuk-button">Continue</button>
@@ -693,39 +737,43 @@ exports[`infrastructure-levy-adopted-date POST /change should re-render the levy
             </div>
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full"><span class="govuk-caption-l govuk-!-margin-bottom-3">Appeal 351062</span>
-                    <h1                     class="govuk-heading-l govuk-!-margin-bottom-3">Change levy adoption date</h1>
                 </div>
             </div>
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full">
                     <form method="POST" novalidate="novalidate">
                         <div class="govuk-form-group">
-                            <div class="govuk-date-input" id="infrastructure-levy-adopted-date">
-                                <div class="govuk-date-input__item">
-                                    <div class="govuk-form-group">
-                                        <label class="govuk-label govuk-date-input__label" for="infrastructure-levy-adopted-date-levy-adopted-date-day">Day</label>
-                                        <input class="govuk-input govuk-date-input__input govuk-input--width-2"
-                                        id="infrastructure-levy-adopted-date-levy-adopted-date-day" name="levy-adopted-date-day"
-                                        type="text" inputmode="numeric">
+                            <fieldset class="govuk-fieldset" role="group">
+                                <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+                                    <h1 class="govuk-fieldset__heading"> Change levy adoption date</h1>
+                                </legend>
+                                <div class="govuk-date-input" id="infrastructure-levy-adopted-date">
+                                    <div class="govuk-date-input__item">
+                                        <div class="govuk-form-group">
+                                            <label class="govuk-label govuk-date-input__label" for="infrastructure-levy-adopted-date-levy-adopted-date-day">Day</label>
+                                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                                            id="infrastructure-levy-adopted-date-levy-adopted-date-day" name="levy-adopted-date-day"
+                                            type="text" inputmode="numeric">
+                                        </div>
+                                    </div>
+                                    <div class="govuk-date-input__item">
+                                        <div class="govuk-form-group">
+                                            <label class="govuk-label govuk-date-input__label" for="infrastructure-levy-adopted-date-levy-adopted-date-month">Month</label>
+                                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                                            id="infrastructure-levy-adopted-date-levy-adopted-date-month" name="levy-adopted-date-month"
+                                            type="text" inputmode="numeric">
+                                        </div>
+                                    </div>
+                                    <div class="govuk-date-input__item">
+                                        <div class="govuk-form-group">
+                                            <label class="govuk-label govuk-date-input__label" for="infrastructure-levy-adopted-date-levy-adopted-date-year">Year</label>
+                                            <input class="govuk-input govuk-date-input__input govuk-input--width-4"
+                                            id="infrastructure-levy-adopted-date-levy-adopted-date-year" name="levy-adopted-date-year"
+                                            type="text" inputmode="numeric">
+                                        </div>
                                     </div>
                                 </div>
-                                <div class="govuk-date-input__item">
-                                    <div class="govuk-form-group">
-                                        <label class="govuk-label govuk-date-input__label" for="infrastructure-levy-adopted-date-levy-adopted-date-month">Month</label>
-                                        <input class="govuk-input govuk-date-input__input govuk-input--width-2"
-                                        id="infrastructure-levy-adopted-date-levy-adopted-date-month" name="levy-adopted-date-month"
-                                        type="text" inputmode="numeric">
-                                    </div>
-                                </div>
-                                <div class="govuk-date-input__item">
-                                    <div class="govuk-form-group">
-                                        <label class="govuk-label govuk-date-input__label" for="infrastructure-levy-adopted-date-levy-adopted-date-year">Year</label>
-                                        <input class="govuk-input govuk-date-input__input govuk-input--width-4"
-                                        id="infrastructure-levy-adopted-date-levy-adopted-date-year" name="levy-adopted-date-year"
-                                        type="text" inputmode="numeric">
-                                    </div>
-                                </div>
-                            </div>
+                            </fieldset>
                         </div>
                         <button type="submit" data-prevent-double-click="true" class="govuk-button"
                         data-module="govuk-button">Continue</button>

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/infrastructure-levy-adopted-date/infrastructure-levy-adopted-date.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/infrastructure-levy-adopted-date/infrastructure-levy-adopted-date.mapper.js
@@ -19,11 +19,12 @@ export const changeInfrastructureLevyAdoptedDate = (appealData, existingValue, b
 		title: 'Levy adoption date',
 		backLinkUrl,
 		preHeading: `Appeal ${shortAppealReference}`,
-		heading: 'Change levy adoption date',
 		pageComponents: [
 			dateInput({
 				name: 'infrastructureLevyAdoptedDate',
 				namePrefix: 'levy-adopted-date',
+				legendText: 'Change levy adoption date',
+				legendIsPageHeading: true,
 				value: dateISOStringToDayMonthYearHourMinute(existingValue)
 			})
 		]

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/infrastructure-levy-expected-date/__tests__/__snapshots__/infrastructure-levy-expected-date.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/infrastructure-levy-expected-date/__tests__/__snapshots__/infrastructure-levy-expected-date.test.js.snap
@@ -6,39 +6,43 @@ exports[`infrastructure-levy-expected-date GET /change should render the infrast
         <div class="govuk-grid-column-two-thirds">
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full"><span class="govuk-caption-l govuk-!-margin-bottom-3">Appeal 351062</span>
-                    <h1                     class="govuk-heading-l govuk-!-margin-bottom-3">Change expected levy adoption date</h1>
                 </div>
             </div>
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full">
                     <form method="POST" novalidate="novalidate">
                         <div class="govuk-form-group">
-                            <div class="govuk-date-input" id="infrastructure-levy-expected-date">
-                                <div class="govuk-date-input__item">
-                                    <div class="govuk-form-group">
-                                        <label class="govuk-label govuk-date-input__label" for="infrastructure-levy-expected-date-levy-expected-date-day">Day</label>
-                                        <input class="govuk-input govuk-date-input__input govuk-input--width-2"
-                                        id="infrastructure-levy-expected-date-levy-expected-date-day" name="levy-expected-date-day"
-                                        type="text" inputmode="numeric">
+                            <fieldset class="govuk-fieldset" role="group">
+                                <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+                                    <h1 class="govuk-fieldset__heading"> Change expected levy adoption date</h1>
+                                </legend>
+                                <div class="govuk-date-input" id="infrastructure-levy-expected-date">
+                                    <div class="govuk-date-input__item">
+                                        <div class="govuk-form-group">
+                                            <label class="govuk-label govuk-date-input__label" for="infrastructure-levy-expected-date-levy-expected-date-day">Day</label>
+                                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                                            id="infrastructure-levy-expected-date-levy-expected-date-day" name="levy-expected-date-day"
+                                            type="text" inputmode="numeric">
+                                        </div>
+                                    </div>
+                                    <div class="govuk-date-input__item">
+                                        <div class="govuk-form-group">
+                                            <label class="govuk-label govuk-date-input__label" for="infrastructure-levy-expected-date-levy-expected-date-month">Month</label>
+                                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                                            id="infrastructure-levy-expected-date-levy-expected-date-month" name="levy-expected-date-month"
+                                            type="text" inputmode="numeric">
+                                        </div>
+                                    </div>
+                                    <div class="govuk-date-input__item">
+                                        <div class="govuk-form-group">
+                                            <label class="govuk-label govuk-date-input__label" for="infrastructure-levy-expected-date-levy-expected-date-year">Year</label>
+                                            <input class="govuk-input govuk-date-input__input govuk-input--width-4"
+                                            id="infrastructure-levy-expected-date-levy-expected-date-year" name="levy-expected-date-year"
+                                            type="text" inputmode="numeric">
+                                        </div>
                                     </div>
                                 </div>
-                                <div class="govuk-date-input__item">
-                                    <div class="govuk-form-group">
-                                        <label class="govuk-label govuk-date-input__label" for="infrastructure-levy-expected-date-levy-expected-date-month">Month</label>
-                                        <input class="govuk-input govuk-date-input__input govuk-input--width-2"
-                                        id="infrastructure-levy-expected-date-levy-expected-date-month" name="levy-expected-date-month"
-                                        type="text" inputmode="numeric">
-                                    </div>
-                                </div>
-                                <div class="govuk-date-input__item">
-                                    <div class="govuk-form-group">
-                                        <label class="govuk-label govuk-date-input__label" for="infrastructure-levy-expected-date-levy-expected-date-year">Year</label>
-                                        <input class="govuk-input govuk-date-input__input govuk-input--width-4"
-                                        id="infrastructure-levy-expected-date-levy-expected-date-year" name="levy-expected-date-year"
-                                        type="text" inputmode="numeric">
-                                    </div>
-                                </div>
-                            </div>
+                            </fieldset>
                         </div>
                         <button type="submit" data-prevent-double-click="true" class="govuk-button"
                         data-module="govuk-button">Continue</button>
@@ -67,39 +71,43 @@ exports[`infrastructure-levy-expected-date POST /change should re-render the exp
             </div>
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full"><span class="govuk-caption-l govuk-!-margin-bottom-3">Appeal 351062</span>
-                    <h1                     class="govuk-heading-l govuk-!-margin-bottom-3">Change expected levy adoption date</h1>
                 </div>
             </div>
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full">
                     <form method="POST" novalidate="novalidate">
                         <div class="govuk-form-group">
-                            <div class="govuk-date-input" id="infrastructure-levy-expected-date">
-                                <div class="govuk-date-input__item">
-                                    <div class="govuk-form-group">
-                                        <label class="govuk-label govuk-date-input__label" for="infrastructure-levy-expected-date-levy-expected-date-day">Day</label>
-                                        <input class="govuk-input govuk-date-input__input govuk-input--width-2"
-                                        id="infrastructure-levy-expected-date-levy-expected-date-day" name="levy-expected-date-day"
-                                        type="text" inputmode="numeric">
+                            <fieldset class="govuk-fieldset" role="group">
+                                <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+                                    <h1 class="govuk-fieldset__heading"> Change expected levy adoption date</h1>
+                                </legend>
+                                <div class="govuk-date-input" id="infrastructure-levy-expected-date">
+                                    <div class="govuk-date-input__item">
+                                        <div class="govuk-form-group">
+                                            <label class="govuk-label govuk-date-input__label" for="infrastructure-levy-expected-date-levy-expected-date-day">Day</label>
+                                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                                            id="infrastructure-levy-expected-date-levy-expected-date-day" name="levy-expected-date-day"
+                                            type="text" inputmode="numeric">
+                                        </div>
+                                    </div>
+                                    <div class="govuk-date-input__item">
+                                        <div class="govuk-form-group">
+                                            <label class="govuk-label govuk-date-input__label" for="infrastructure-levy-expected-date-levy-expected-date-month">Month</label>
+                                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                                            id="infrastructure-levy-expected-date-levy-expected-date-month" name="levy-expected-date-month"
+                                            type="text" inputmode="numeric">
+                                        </div>
+                                    </div>
+                                    <div class="govuk-date-input__item">
+                                        <div class="govuk-form-group">
+                                            <label class="govuk-label govuk-date-input__label" for="infrastructure-levy-expected-date-levy-expected-date-year">Year</label>
+                                            <input class="govuk-input govuk-date-input__input govuk-input--width-4"
+                                            id="infrastructure-levy-expected-date-levy-expected-date-year" name="levy-expected-date-year"
+                                            type="text" inputmode="numeric">
+                                        </div>
                                     </div>
                                 </div>
-                                <div class="govuk-date-input__item">
-                                    <div class="govuk-form-group">
-                                        <label class="govuk-label govuk-date-input__label" for="infrastructure-levy-expected-date-levy-expected-date-month">Month</label>
-                                        <input class="govuk-input govuk-date-input__input govuk-input--width-2"
-                                        id="infrastructure-levy-expected-date-levy-expected-date-month" name="levy-expected-date-month"
-                                        type="text" inputmode="numeric">
-                                    </div>
-                                </div>
-                                <div class="govuk-date-input__item">
-                                    <div class="govuk-form-group">
-                                        <label class="govuk-label govuk-date-input__label" for="infrastructure-levy-expected-date-levy-expected-date-year">Year</label>
-                                        <input class="govuk-input govuk-date-input__input govuk-input--width-4"
-                                        id="infrastructure-levy-expected-date-levy-expected-date-year" name="levy-expected-date-year"
-                                        type="text" inputmode="numeric">
-                                    </div>
-                                </div>
-                            </div>
+                            </fieldset>
                         </div>
                         <button type="submit" data-prevent-double-click="true" class="govuk-button"
                         data-module="govuk-button">Continue</button>
@@ -130,39 +138,43 @@ exports[`infrastructure-levy-expected-date POST /change should re-render the exp
             </div>
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full"><span class="govuk-caption-l govuk-!-margin-bottom-3">Appeal 351062</span>
-                    <h1                     class="govuk-heading-l govuk-!-margin-bottom-3">Change expected levy adoption date</h1>
                 </div>
             </div>
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full">
                     <form method="POST" novalidate="novalidate">
                         <div class="govuk-form-group">
-                            <div class="govuk-date-input" id="infrastructure-levy-expected-date">
-                                <div class="govuk-date-input__item">
-                                    <div class="govuk-form-group">
-                                        <label class="govuk-label govuk-date-input__label" for="infrastructure-levy-expected-date-levy-expected-date-day">Day</label>
-                                        <input class="govuk-input govuk-date-input__input govuk-input--width-2"
-                                        id="infrastructure-levy-expected-date-levy-expected-date-day" name="levy-expected-date-day"
-                                        type="text" inputmode="numeric">
+                            <fieldset class="govuk-fieldset" role="group">
+                                <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+                                    <h1 class="govuk-fieldset__heading"> Change expected levy adoption date</h1>
+                                </legend>
+                                <div class="govuk-date-input" id="infrastructure-levy-expected-date">
+                                    <div class="govuk-date-input__item">
+                                        <div class="govuk-form-group">
+                                            <label class="govuk-label govuk-date-input__label" for="infrastructure-levy-expected-date-levy-expected-date-day">Day</label>
+                                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                                            id="infrastructure-levy-expected-date-levy-expected-date-day" name="levy-expected-date-day"
+                                            type="text" inputmode="numeric">
+                                        </div>
+                                    </div>
+                                    <div class="govuk-date-input__item">
+                                        <div class="govuk-form-group">
+                                            <label class="govuk-label govuk-date-input__label" for="infrastructure-levy-expected-date-levy-expected-date-month">Month</label>
+                                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                                            id="infrastructure-levy-expected-date-levy-expected-date-month" name="levy-expected-date-month"
+                                            type="text" inputmode="numeric">
+                                        </div>
+                                    </div>
+                                    <div class="govuk-date-input__item">
+                                        <div class="govuk-form-group">
+                                            <label class="govuk-label govuk-date-input__label" for="infrastructure-levy-expected-date-levy-expected-date-year">Year</label>
+                                            <input class="govuk-input govuk-date-input__input govuk-input--width-4"
+                                            id="infrastructure-levy-expected-date-levy-expected-date-year" name="levy-expected-date-year"
+                                            type="text" inputmode="numeric">
+                                        </div>
                                     </div>
                                 </div>
-                                <div class="govuk-date-input__item">
-                                    <div class="govuk-form-group">
-                                        <label class="govuk-label govuk-date-input__label" for="infrastructure-levy-expected-date-levy-expected-date-month">Month</label>
-                                        <input class="govuk-input govuk-date-input__input govuk-input--width-2"
-                                        id="infrastructure-levy-expected-date-levy-expected-date-month" name="levy-expected-date-month"
-                                        type="text" inputmode="numeric">
-                                    </div>
-                                </div>
-                                <div class="govuk-date-input__item">
-                                    <div class="govuk-form-group">
-                                        <label class="govuk-label govuk-date-input__label" for="infrastructure-levy-expected-date-levy-expected-date-year">Year</label>
-                                        <input class="govuk-input govuk-date-input__input govuk-input--width-4"
-                                        id="infrastructure-levy-expected-date-levy-expected-date-year" name="levy-expected-date-year"
-                                        type="text" inputmode="numeric">
-                                    </div>
-                                </div>
-                            </div>
+                            </fieldset>
                         </div>
                         <button type="submit" data-prevent-double-click="true" class="govuk-button"
                         data-module="govuk-button">Continue</button>
@@ -193,39 +205,43 @@ exports[`infrastructure-levy-expected-date POST /change should re-render the exp
             </div>
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full"><span class="govuk-caption-l govuk-!-margin-bottom-3">Appeal 351062</span>
-                    <h1                     class="govuk-heading-l govuk-!-margin-bottom-3">Change expected levy adoption date</h1>
                 </div>
             </div>
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full">
                     <form method="POST" novalidate="novalidate">
                         <div class="govuk-form-group">
-                            <div class="govuk-date-input" id="infrastructure-levy-expected-date">
-                                <div class="govuk-date-input__item">
-                                    <div class="govuk-form-group">
-                                        <label class="govuk-label govuk-date-input__label" for="infrastructure-levy-expected-date-levy-expected-date-day">Day</label>
-                                        <input class="govuk-input govuk-date-input__input govuk-input--width-2"
-                                        id="infrastructure-levy-expected-date-levy-expected-date-day" name="levy-expected-date-day"
-                                        type="text" inputmode="numeric">
+                            <fieldset class="govuk-fieldset" role="group">
+                                <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+                                    <h1 class="govuk-fieldset__heading"> Change expected levy adoption date</h1>
+                                </legend>
+                                <div class="govuk-date-input" id="infrastructure-levy-expected-date">
+                                    <div class="govuk-date-input__item">
+                                        <div class="govuk-form-group">
+                                            <label class="govuk-label govuk-date-input__label" for="infrastructure-levy-expected-date-levy-expected-date-day">Day</label>
+                                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                                            id="infrastructure-levy-expected-date-levy-expected-date-day" name="levy-expected-date-day"
+                                            type="text" inputmode="numeric">
+                                        </div>
+                                    </div>
+                                    <div class="govuk-date-input__item">
+                                        <div class="govuk-form-group">
+                                            <label class="govuk-label govuk-date-input__label" for="infrastructure-levy-expected-date-levy-expected-date-month">Month</label>
+                                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                                            id="infrastructure-levy-expected-date-levy-expected-date-month" name="levy-expected-date-month"
+                                            type="text" inputmode="numeric">
+                                        </div>
+                                    </div>
+                                    <div class="govuk-date-input__item">
+                                        <div class="govuk-form-group">
+                                            <label class="govuk-label govuk-date-input__label" for="infrastructure-levy-expected-date-levy-expected-date-year">Year</label>
+                                            <input class="govuk-input govuk-date-input__input govuk-input--width-4"
+                                            id="infrastructure-levy-expected-date-levy-expected-date-year" name="levy-expected-date-year"
+                                            type="text" inputmode="numeric">
+                                        </div>
                                     </div>
                                 </div>
-                                <div class="govuk-date-input__item">
-                                    <div class="govuk-form-group">
-                                        <label class="govuk-label govuk-date-input__label" for="infrastructure-levy-expected-date-levy-expected-date-month">Month</label>
-                                        <input class="govuk-input govuk-date-input__input govuk-input--width-2"
-                                        id="infrastructure-levy-expected-date-levy-expected-date-month" name="levy-expected-date-month"
-                                        type="text" inputmode="numeric">
-                                    </div>
-                                </div>
-                                <div class="govuk-date-input__item">
-                                    <div class="govuk-form-group">
-                                        <label class="govuk-label govuk-date-input__label" for="infrastructure-levy-expected-date-levy-expected-date-year">Year</label>
-                                        <input class="govuk-input govuk-date-input__input govuk-input--width-4"
-                                        id="infrastructure-levy-expected-date-levy-expected-date-year" name="levy-expected-date-year"
-                                        type="text" inputmode="numeric">
-                                    </div>
-                                </div>
-                            </div>
+                            </fieldset>
                         </div>
                         <button type="submit" data-prevent-double-click="true" class="govuk-button"
                         data-module="govuk-button">Continue</button>
@@ -256,39 +272,43 @@ exports[`infrastructure-levy-expected-date POST /change should re-render the exp
             </div>
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full"><span class="govuk-caption-l govuk-!-margin-bottom-3">Appeal 351062</span>
-                    <h1                     class="govuk-heading-l govuk-!-margin-bottom-3">Change expected levy adoption date</h1>
                 </div>
             </div>
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full">
                     <form method="POST" novalidate="novalidate">
                         <div class="govuk-form-group">
-                            <div class="govuk-date-input" id="infrastructure-levy-expected-date">
-                                <div class="govuk-date-input__item">
-                                    <div class="govuk-form-group">
-                                        <label class="govuk-label govuk-date-input__label" for="infrastructure-levy-expected-date-levy-expected-date-day">Day</label>
-                                        <input class="govuk-input govuk-date-input__input govuk-input--width-2"
-                                        id="infrastructure-levy-expected-date-levy-expected-date-day" name="levy-expected-date-day"
-                                        type="text" inputmode="numeric">
+                            <fieldset class="govuk-fieldset" role="group">
+                                <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+                                    <h1 class="govuk-fieldset__heading"> Change expected levy adoption date</h1>
+                                </legend>
+                                <div class="govuk-date-input" id="infrastructure-levy-expected-date">
+                                    <div class="govuk-date-input__item">
+                                        <div class="govuk-form-group">
+                                            <label class="govuk-label govuk-date-input__label" for="infrastructure-levy-expected-date-levy-expected-date-day">Day</label>
+                                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                                            id="infrastructure-levy-expected-date-levy-expected-date-day" name="levy-expected-date-day"
+                                            type="text" inputmode="numeric">
+                                        </div>
+                                    </div>
+                                    <div class="govuk-date-input__item">
+                                        <div class="govuk-form-group">
+                                            <label class="govuk-label govuk-date-input__label" for="infrastructure-levy-expected-date-levy-expected-date-month">Month</label>
+                                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                                            id="infrastructure-levy-expected-date-levy-expected-date-month" name="levy-expected-date-month"
+                                            type="text" inputmode="numeric">
+                                        </div>
+                                    </div>
+                                    <div class="govuk-date-input__item">
+                                        <div class="govuk-form-group">
+                                            <label class="govuk-label govuk-date-input__label" for="infrastructure-levy-expected-date-levy-expected-date-year">Year</label>
+                                            <input class="govuk-input govuk-date-input__input govuk-input--width-4"
+                                            id="infrastructure-levy-expected-date-levy-expected-date-year" name="levy-expected-date-year"
+                                            type="text" inputmode="numeric">
+                                        </div>
                                     </div>
                                 </div>
-                                <div class="govuk-date-input__item">
-                                    <div class="govuk-form-group">
-                                        <label class="govuk-label govuk-date-input__label" for="infrastructure-levy-expected-date-levy-expected-date-month">Month</label>
-                                        <input class="govuk-input govuk-date-input__input govuk-input--width-2"
-                                        id="infrastructure-levy-expected-date-levy-expected-date-month" name="levy-expected-date-month"
-                                        type="text" inputmode="numeric">
-                                    </div>
-                                </div>
-                                <div class="govuk-date-input__item">
-                                    <div class="govuk-form-group">
-                                        <label class="govuk-label govuk-date-input__label" for="infrastructure-levy-expected-date-levy-expected-date-year">Year</label>
-                                        <input class="govuk-input govuk-date-input__input govuk-input--width-4"
-                                        id="infrastructure-levy-expected-date-levy-expected-date-year" name="levy-expected-date-year"
-                                        type="text" inputmode="numeric">
-                                    </div>
-                                </div>
-                            </div>
+                            </fieldset>
                         </div>
                         <button type="submit" data-prevent-double-click="true" class="govuk-button"
                         data-module="govuk-button">Continue</button>
@@ -317,39 +337,43 @@ exports[`infrastructure-levy-expected-date POST /change should re-render the exp
             </div>
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full"><span class="govuk-caption-l govuk-!-margin-bottom-3">Appeal 351062</span>
-                    <h1                     class="govuk-heading-l govuk-!-margin-bottom-3">Change expected levy adoption date</h1>
                 </div>
             </div>
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full">
                     <form method="POST" novalidate="novalidate">
                         <div class="govuk-form-group">
-                            <div class="govuk-date-input" id="infrastructure-levy-expected-date">
-                                <div class="govuk-date-input__item">
-                                    <div class="govuk-form-group">
-                                        <label class="govuk-label govuk-date-input__label" for="infrastructure-levy-expected-date-levy-expected-date-day">Day</label>
-                                        <input class="govuk-input govuk-date-input__input govuk-input--width-2"
-                                        id="infrastructure-levy-expected-date-levy-expected-date-day" name="levy-expected-date-day"
-                                        type="text" inputmode="numeric">
+                            <fieldset class="govuk-fieldset" role="group">
+                                <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+                                    <h1 class="govuk-fieldset__heading"> Change expected levy adoption date</h1>
+                                </legend>
+                                <div class="govuk-date-input" id="infrastructure-levy-expected-date">
+                                    <div class="govuk-date-input__item">
+                                        <div class="govuk-form-group">
+                                            <label class="govuk-label govuk-date-input__label" for="infrastructure-levy-expected-date-levy-expected-date-day">Day</label>
+                                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                                            id="infrastructure-levy-expected-date-levy-expected-date-day" name="levy-expected-date-day"
+                                            type="text" inputmode="numeric">
+                                        </div>
+                                    </div>
+                                    <div class="govuk-date-input__item">
+                                        <div class="govuk-form-group">
+                                            <label class="govuk-label govuk-date-input__label" for="infrastructure-levy-expected-date-levy-expected-date-month">Month</label>
+                                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                                            id="infrastructure-levy-expected-date-levy-expected-date-month" name="levy-expected-date-month"
+                                            type="text" inputmode="numeric">
+                                        </div>
+                                    </div>
+                                    <div class="govuk-date-input__item">
+                                        <div class="govuk-form-group">
+                                            <label class="govuk-label govuk-date-input__label" for="infrastructure-levy-expected-date-levy-expected-date-year">Year</label>
+                                            <input class="govuk-input govuk-date-input__input govuk-input--width-4"
+                                            id="infrastructure-levy-expected-date-levy-expected-date-year" name="levy-expected-date-year"
+                                            type="text" inputmode="numeric">
+                                        </div>
                                     </div>
                                 </div>
-                                <div class="govuk-date-input__item">
-                                    <div class="govuk-form-group">
-                                        <label class="govuk-label govuk-date-input__label" for="infrastructure-levy-expected-date-levy-expected-date-month">Month</label>
-                                        <input class="govuk-input govuk-date-input__input govuk-input--width-2"
-                                        id="infrastructure-levy-expected-date-levy-expected-date-month" name="levy-expected-date-month"
-                                        type="text" inputmode="numeric">
-                                    </div>
-                                </div>
-                                <div class="govuk-date-input__item">
-                                    <div class="govuk-form-group">
-                                        <label class="govuk-label govuk-date-input__label" for="infrastructure-levy-expected-date-levy-expected-date-year">Year</label>
-                                        <input class="govuk-input govuk-date-input__input govuk-input--width-4"
-                                        id="infrastructure-levy-expected-date-levy-expected-date-year" name="levy-expected-date-year"
-                                        type="text" inputmode="numeric">
-                                    </div>
-                                </div>
-                            </div>
+                            </fieldset>
                         </div>
                         <button type="submit" data-prevent-double-click="true" class="govuk-button"
                         data-module="govuk-button">Continue</button>
@@ -380,39 +404,43 @@ exports[`infrastructure-levy-expected-date POST /change should re-render the exp
             </div>
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full"><span class="govuk-caption-l govuk-!-margin-bottom-3">Appeal 351062</span>
-                    <h1                     class="govuk-heading-l govuk-!-margin-bottom-3">Change expected levy adoption date</h1>
                 </div>
             </div>
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full">
                     <form method="POST" novalidate="novalidate">
                         <div class="govuk-form-group">
-                            <div class="govuk-date-input" id="infrastructure-levy-expected-date">
-                                <div class="govuk-date-input__item">
-                                    <div class="govuk-form-group">
-                                        <label class="govuk-label govuk-date-input__label" for="infrastructure-levy-expected-date-levy-expected-date-day">Day</label>
-                                        <input class="govuk-input govuk-date-input__input govuk-input--width-2"
-                                        id="infrastructure-levy-expected-date-levy-expected-date-day" name="levy-expected-date-day"
-                                        type="text" inputmode="numeric">
+                            <fieldset class="govuk-fieldset" role="group">
+                                <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+                                    <h1 class="govuk-fieldset__heading"> Change expected levy adoption date</h1>
+                                </legend>
+                                <div class="govuk-date-input" id="infrastructure-levy-expected-date">
+                                    <div class="govuk-date-input__item">
+                                        <div class="govuk-form-group">
+                                            <label class="govuk-label govuk-date-input__label" for="infrastructure-levy-expected-date-levy-expected-date-day">Day</label>
+                                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                                            id="infrastructure-levy-expected-date-levy-expected-date-day" name="levy-expected-date-day"
+                                            type="text" inputmode="numeric">
+                                        </div>
+                                    </div>
+                                    <div class="govuk-date-input__item">
+                                        <div class="govuk-form-group">
+                                            <label class="govuk-label govuk-date-input__label" for="infrastructure-levy-expected-date-levy-expected-date-month">Month</label>
+                                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                                            id="infrastructure-levy-expected-date-levy-expected-date-month" name="levy-expected-date-month"
+                                            type="text" inputmode="numeric">
+                                        </div>
+                                    </div>
+                                    <div class="govuk-date-input__item">
+                                        <div class="govuk-form-group">
+                                            <label class="govuk-label govuk-date-input__label" for="infrastructure-levy-expected-date-levy-expected-date-year">Year</label>
+                                            <input class="govuk-input govuk-date-input__input govuk-input--width-4"
+                                            id="infrastructure-levy-expected-date-levy-expected-date-year" name="levy-expected-date-year"
+                                            type="text" inputmode="numeric">
+                                        </div>
                                     </div>
                                 </div>
-                                <div class="govuk-date-input__item">
-                                    <div class="govuk-form-group">
-                                        <label class="govuk-label govuk-date-input__label" for="infrastructure-levy-expected-date-levy-expected-date-month">Month</label>
-                                        <input class="govuk-input govuk-date-input__input govuk-input--width-2"
-                                        id="infrastructure-levy-expected-date-levy-expected-date-month" name="levy-expected-date-month"
-                                        type="text" inputmode="numeric">
-                                    </div>
-                                </div>
-                                <div class="govuk-date-input__item">
-                                    <div class="govuk-form-group">
-                                        <label class="govuk-label govuk-date-input__label" for="infrastructure-levy-expected-date-levy-expected-date-year">Year</label>
-                                        <input class="govuk-input govuk-date-input__input govuk-input--width-4"
-                                        id="infrastructure-levy-expected-date-levy-expected-date-year" name="levy-expected-date-year"
-                                        type="text" inputmode="numeric">
-                                    </div>
-                                </div>
-                            </div>
+                            </fieldset>
                         </div>
                         <button type="submit" data-prevent-double-click="true" class="govuk-button"
                         data-module="govuk-button">Continue</button>
@@ -443,39 +471,43 @@ exports[`infrastructure-levy-expected-date POST /change should re-render the exp
             </div>
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full"><span class="govuk-caption-l govuk-!-margin-bottom-3">Appeal 351062</span>
-                    <h1                     class="govuk-heading-l govuk-!-margin-bottom-3">Change expected levy adoption date</h1>
                 </div>
             </div>
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full">
                     <form method="POST" novalidate="novalidate">
                         <div class="govuk-form-group">
-                            <div class="govuk-date-input" id="infrastructure-levy-expected-date">
-                                <div class="govuk-date-input__item">
-                                    <div class="govuk-form-group">
-                                        <label class="govuk-label govuk-date-input__label" for="infrastructure-levy-expected-date-levy-expected-date-day">Day</label>
-                                        <input class="govuk-input govuk-date-input__input govuk-input--width-2"
-                                        id="infrastructure-levy-expected-date-levy-expected-date-day" name="levy-expected-date-day"
-                                        type="text" inputmode="numeric">
+                            <fieldset class="govuk-fieldset" role="group">
+                                <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+                                    <h1 class="govuk-fieldset__heading"> Change expected levy adoption date</h1>
+                                </legend>
+                                <div class="govuk-date-input" id="infrastructure-levy-expected-date">
+                                    <div class="govuk-date-input__item">
+                                        <div class="govuk-form-group">
+                                            <label class="govuk-label govuk-date-input__label" for="infrastructure-levy-expected-date-levy-expected-date-day">Day</label>
+                                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                                            id="infrastructure-levy-expected-date-levy-expected-date-day" name="levy-expected-date-day"
+                                            type="text" inputmode="numeric">
+                                        </div>
+                                    </div>
+                                    <div class="govuk-date-input__item">
+                                        <div class="govuk-form-group">
+                                            <label class="govuk-label govuk-date-input__label" for="infrastructure-levy-expected-date-levy-expected-date-month">Month</label>
+                                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                                            id="infrastructure-levy-expected-date-levy-expected-date-month" name="levy-expected-date-month"
+                                            type="text" inputmode="numeric">
+                                        </div>
+                                    </div>
+                                    <div class="govuk-date-input__item">
+                                        <div class="govuk-form-group">
+                                            <label class="govuk-label govuk-date-input__label" for="infrastructure-levy-expected-date-levy-expected-date-year">Year</label>
+                                            <input class="govuk-input govuk-date-input__input govuk-input--width-4"
+                                            id="infrastructure-levy-expected-date-levy-expected-date-year" name="levy-expected-date-year"
+                                            type="text" inputmode="numeric">
+                                        </div>
                                     </div>
                                 </div>
-                                <div class="govuk-date-input__item">
-                                    <div class="govuk-form-group">
-                                        <label class="govuk-label govuk-date-input__label" for="infrastructure-levy-expected-date-levy-expected-date-month">Month</label>
-                                        <input class="govuk-input govuk-date-input__input govuk-input--width-2"
-                                        id="infrastructure-levy-expected-date-levy-expected-date-month" name="levy-expected-date-month"
-                                        type="text" inputmode="numeric">
-                                    </div>
-                                </div>
-                                <div class="govuk-date-input__item">
-                                    <div class="govuk-form-group">
-                                        <label class="govuk-label govuk-date-input__label" for="infrastructure-levy-expected-date-levy-expected-date-year">Year</label>
-                                        <input class="govuk-input govuk-date-input__input govuk-input--width-4"
-                                        id="infrastructure-levy-expected-date-levy-expected-date-year" name="levy-expected-date-year"
-                                        type="text" inputmode="numeric">
-                                    </div>
-                                </div>
-                            </div>
+                            </fieldset>
                         </div>
                         <button type="submit" data-prevent-double-click="true" class="govuk-button"
                         data-module="govuk-button">Continue</button>
@@ -506,39 +538,43 @@ exports[`infrastructure-levy-expected-date POST /change should re-render the exp
             </div>
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full"><span class="govuk-caption-l govuk-!-margin-bottom-3">Appeal 351062</span>
-                    <h1                     class="govuk-heading-l govuk-!-margin-bottom-3">Change expected levy adoption date</h1>
                 </div>
             </div>
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full">
                     <form method="POST" novalidate="novalidate">
                         <div class="govuk-form-group">
-                            <div class="govuk-date-input" id="infrastructure-levy-expected-date">
-                                <div class="govuk-date-input__item">
-                                    <div class="govuk-form-group">
-                                        <label class="govuk-label govuk-date-input__label" for="infrastructure-levy-expected-date-levy-expected-date-day">Day</label>
-                                        <input class="govuk-input govuk-date-input__input govuk-input--width-2"
-                                        id="infrastructure-levy-expected-date-levy-expected-date-day" name="levy-expected-date-day"
-                                        type="text" inputmode="numeric">
+                            <fieldset class="govuk-fieldset" role="group">
+                                <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+                                    <h1 class="govuk-fieldset__heading"> Change expected levy adoption date</h1>
+                                </legend>
+                                <div class="govuk-date-input" id="infrastructure-levy-expected-date">
+                                    <div class="govuk-date-input__item">
+                                        <div class="govuk-form-group">
+                                            <label class="govuk-label govuk-date-input__label" for="infrastructure-levy-expected-date-levy-expected-date-day">Day</label>
+                                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                                            id="infrastructure-levy-expected-date-levy-expected-date-day" name="levy-expected-date-day"
+                                            type="text" inputmode="numeric">
+                                        </div>
+                                    </div>
+                                    <div class="govuk-date-input__item">
+                                        <div class="govuk-form-group">
+                                            <label class="govuk-label govuk-date-input__label" for="infrastructure-levy-expected-date-levy-expected-date-month">Month</label>
+                                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                                            id="infrastructure-levy-expected-date-levy-expected-date-month" name="levy-expected-date-month"
+                                            type="text" inputmode="numeric">
+                                        </div>
+                                    </div>
+                                    <div class="govuk-date-input__item">
+                                        <div class="govuk-form-group">
+                                            <label class="govuk-label govuk-date-input__label" for="infrastructure-levy-expected-date-levy-expected-date-year">Year</label>
+                                            <input class="govuk-input govuk-date-input__input govuk-input--width-4"
+                                            id="infrastructure-levy-expected-date-levy-expected-date-year" name="levy-expected-date-year"
+                                            type="text" inputmode="numeric">
+                                        </div>
                                     </div>
                                 </div>
-                                <div class="govuk-date-input__item">
-                                    <div class="govuk-form-group">
-                                        <label class="govuk-label govuk-date-input__label" for="infrastructure-levy-expected-date-levy-expected-date-month">Month</label>
-                                        <input class="govuk-input govuk-date-input__input govuk-input--width-2"
-                                        id="infrastructure-levy-expected-date-levy-expected-date-month" name="levy-expected-date-month"
-                                        type="text" inputmode="numeric">
-                                    </div>
-                                </div>
-                                <div class="govuk-date-input__item">
-                                    <div class="govuk-form-group">
-                                        <label class="govuk-label govuk-date-input__label" for="infrastructure-levy-expected-date-levy-expected-date-year">Year</label>
-                                        <input class="govuk-input govuk-date-input__input govuk-input--width-4"
-                                        id="infrastructure-levy-expected-date-levy-expected-date-year" name="levy-expected-date-year"
-                                        type="text" inputmode="numeric">
-                                    </div>
-                                </div>
-                            </div>
+                            </fieldset>
                         </div>
                         <button type="submit" data-prevent-double-click="true" class="govuk-button"
                         data-module="govuk-button">Continue</button>
@@ -567,39 +603,43 @@ exports[`infrastructure-levy-expected-date POST /change should re-render the lev
             </div>
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full"><span class="govuk-caption-l govuk-!-margin-bottom-3">Appeal 351062</span>
-                    <h1                     class="govuk-heading-l govuk-!-margin-bottom-3">Change expected levy adoption date</h1>
                 </div>
             </div>
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full">
                     <form method="POST" novalidate="novalidate">
                         <div class="govuk-form-group">
-                            <div class="govuk-date-input" id="infrastructure-levy-expected-date">
-                                <div class="govuk-date-input__item">
-                                    <div class="govuk-form-group">
-                                        <label class="govuk-label govuk-date-input__label" for="infrastructure-levy-expected-date-levy-expected-date-day">Day</label>
-                                        <input class="govuk-input govuk-date-input__input govuk-input--width-2"
-                                        id="infrastructure-levy-expected-date-levy-expected-date-day" name="levy-expected-date-day"
-                                        type="text" inputmode="numeric">
+                            <fieldset class="govuk-fieldset" role="group">
+                                <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+                                    <h1 class="govuk-fieldset__heading"> Change expected levy adoption date</h1>
+                                </legend>
+                                <div class="govuk-date-input" id="infrastructure-levy-expected-date">
+                                    <div class="govuk-date-input__item">
+                                        <div class="govuk-form-group">
+                                            <label class="govuk-label govuk-date-input__label" for="infrastructure-levy-expected-date-levy-expected-date-day">Day</label>
+                                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                                            id="infrastructure-levy-expected-date-levy-expected-date-day" name="levy-expected-date-day"
+                                            type="text" inputmode="numeric">
+                                        </div>
+                                    </div>
+                                    <div class="govuk-date-input__item">
+                                        <div class="govuk-form-group">
+                                            <label class="govuk-label govuk-date-input__label" for="infrastructure-levy-expected-date-levy-expected-date-month">Month</label>
+                                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                                            id="infrastructure-levy-expected-date-levy-expected-date-month" name="levy-expected-date-month"
+                                            type="text" inputmode="numeric">
+                                        </div>
+                                    </div>
+                                    <div class="govuk-date-input__item">
+                                        <div class="govuk-form-group">
+                                            <label class="govuk-label govuk-date-input__label" for="infrastructure-levy-expected-date-levy-expected-date-year">Year</label>
+                                            <input class="govuk-input govuk-date-input__input govuk-input--width-4"
+                                            id="infrastructure-levy-expected-date-levy-expected-date-year" name="levy-expected-date-year"
+                                            type="text" inputmode="numeric">
+                                        </div>
                                     </div>
                                 </div>
-                                <div class="govuk-date-input__item">
-                                    <div class="govuk-form-group">
-                                        <label class="govuk-label govuk-date-input__label" for="infrastructure-levy-expected-date-levy-expected-date-month">Month</label>
-                                        <input class="govuk-input govuk-date-input__input govuk-input--width-2"
-                                        id="infrastructure-levy-expected-date-levy-expected-date-month" name="levy-expected-date-month"
-                                        type="text" inputmode="numeric">
-                                    </div>
-                                </div>
-                                <div class="govuk-date-input__item">
-                                    <div class="govuk-form-group">
-                                        <label class="govuk-label govuk-date-input__label" for="infrastructure-levy-expected-date-levy-expected-date-year">Year</label>
-                                        <input class="govuk-input govuk-date-input__input govuk-input--width-4"
-                                        id="infrastructure-levy-expected-date-levy-expected-date-year" name="levy-expected-date-year"
-                                        type="text" inputmode="numeric">
-                                    </div>
-                                </div>
-                            </div>
+                            </fieldset>
                         </div>
                         <button type="submit" data-prevent-double-click="true" class="govuk-button"
                         data-module="govuk-button">Continue</button>
@@ -630,39 +670,43 @@ exports[`infrastructure-levy-expected-date POST /change should re-render the lev
             </div>
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full"><span class="govuk-caption-l govuk-!-margin-bottom-3">Appeal 351062</span>
-                    <h1                     class="govuk-heading-l govuk-!-margin-bottom-3">Change expected levy adoption date</h1>
                 </div>
             </div>
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full">
                     <form method="POST" novalidate="novalidate">
                         <div class="govuk-form-group">
-                            <div class="govuk-date-input" id="infrastructure-levy-expected-date">
-                                <div class="govuk-date-input__item">
-                                    <div class="govuk-form-group">
-                                        <label class="govuk-label govuk-date-input__label" for="infrastructure-levy-expected-date-levy-expected-date-day">Day</label>
-                                        <input class="govuk-input govuk-date-input__input govuk-input--width-2"
-                                        id="infrastructure-levy-expected-date-levy-expected-date-day" name="levy-expected-date-day"
-                                        type="text" inputmode="numeric">
+                            <fieldset class="govuk-fieldset" role="group">
+                                <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+                                    <h1 class="govuk-fieldset__heading"> Change expected levy adoption date</h1>
+                                </legend>
+                                <div class="govuk-date-input" id="infrastructure-levy-expected-date">
+                                    <div class="govuk-date-input__item">
+                                        <div class="govuk-form-group">
+                                            <label class="govuk-label govuk-date-input__label" for="infrastructure-levy-expected-date-levy-expected-date-day">Day</label>
+                                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                                            id="infrastructure-levy-expected-date-levy-expected-date-day" name="levy-expected-date-day"
+                                            type="text" inputmode="numeric">
+                                        </div>
+                                    </div>
+                                    <div class="govuk-date-input__item">
+                                        <div class="govuk-form-group">
+                                            <label class="govuk-label govuk-date-input__label" for="infrastructure-levy-expected-date-levy-expected-date-month">Month</label>
+                                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                                            id="infrastructure-levy-expected-date-levy-expected-date-month" name="levy-expected-date-month"
+                                            type="text" inputmode="numeric">
+                                        </div>
+                                    </div>
+                                    <div class="govuk-date-input__item">
+                                        <div class="govuk-form-group">
+                                            <label class="govuk-label govuk-date-input__label" for="infrastructure-levy-expected-date-levy-expected-date-year">Year</label>
+                                            <input class="govuk-input govuk-date-input__input govuk-input--width-4"
+                                            id="infrastructure-levy-expected-date-levy-expected-date-year" name="levy-expected-date-year"
+                                            type="text" inputmode="numeric">
+                                        </div>
                                     </div>
                                 </div>
-                                <div class="govuk-date-input__item">
-                                    <div class="govuk-form-group">
-                                        <label class="govuk-label govuk-date-input__label" for="infrastructure-levy-expected-date-levy-expected-date-month">Month</label>
-                                        <input class="govuk-input govuk-date-input__input govuk-input--width-2"
-                                        id="infrastructure-levy-expected-date-levy-expected-date-month" name="levy-expected-date-month"
-                                        type="text" inputmode="numeric">
-                                    </div>
-                                </div>
-                                <div class="govuk-date-input__item">
-                                    <div class="govuk-form-group">
-                                        <label class="govuk-label govuk-date-input__label" for="infrastructure-levy-expected-date-levy-expected-date-year">Year</label>
-                                        <input class="govuk-input govuk-date-input__input govuk-input--width-4"
-                                        id="infrastructure-levy-expected-date-levy-expected-date-year" name="levy-expected-date-year"
-                                        type="text" inputmode="numeric">
-                                    </div>
-                                </div>
-                            </div>
+                            </fieldset>
                         </div>
                         <button type="submit" data-prevent-double-click="true" class="govuk-button"
                         data-module="govuk-button">Continue</button>
@@ -693,39 +737,43 @@ exports[`infrastructure-levy-expected-date POST /change should re-render the lev
             </div>
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full"><span class="govuk-caption-l govuk-!-margin-bottom-3">Appeal 351062</span>
-                    <h1                     class="govuk-heading-l govuk-!-margin-bottom-3">Change expected levy adoption date</h1>
                 </div>
             </div>
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full">
                     <form method="POST" novalidate="novalidate">
                         <div class="govuk-form-group">
-                            <div class="govuk-date-input" id="infrastructure-levy-expected-date">
-                                <div class="govuk-date-input__item">
-                                    <div class="govuk-form-group">
-                                        <label class="govuk-label govuk-date-input__label" for="infrastructure-levy-expected-date-levy-expected-date-day">Day</label>
-                                        <input class="govuk-input govuk-date-input__input govuk-input--width-2"
-                                        id="infrastructure-levy-expected-date-levy-expected-date-day" name="levy-expected-date-day"
-                                        type="text" inputmode="numeric">
+                            <fieldset class="govuk-fieldset" role="group">
+                                <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+                                    <h1 class="govuk-fieldset__heading"> Change expected levy adoption date</h1>
+                                </legend>
+                                <div class="govuk-date-input" id="infrastructure-levy-expected-date">
+                                    <div class="govuk-date-input__item">
+                                        <div class="govuk-form-group">
+                                            <label class="govuk-label govuk-date-input__label" for="infrastructure-levy-expected-date-levy-expected-date-day">Day</label>
+                                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                                            id="infrastructure-levy-expected-date-levy-expected-date-day" name="levy-expected-date-day"
+                                            type="text" inputmode="numeric">
+                                        </div>
+                                    </div>
+                                    <div class="govuk-date-input__item">
+                                        <div class="govuk-form-group">
+                                            <label class="govuk-label govuk-date-input__label" for="infrastructure-levy-expected-date-levy-expected-date-month">Month</label>
+                                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                                            id="infrastructure-levy-expected-date-levy-expected-date-month" name="levy-expected-date-month"
+                                            type="text" inputmode="numeric">
+                                        </div>
+                                    </div>
+                                    <div class="govuk-date-input__item">
+                                        <div class="govuk-form-group">
+                                            <label class="govuk-label govuk-date-input__label" for="infrastructure-levy-expected-date-levy-expected-date-year">Year</label>
+                                            <input class="govuk-input govuk-date-input__input govuk-input--width-4"
+                                            id="infrastructure-levy-expected-date-levy-expected-date-year" name="levy-expected-date-year"
+                                            type="text" inputmode="numeric">
+                                        </div>
                                     </div>
                                 </div>
-                                <div class="govuk-date-input__item">
-                                    <div class="govuk-form-group">
-                                        <label class="govuk-label govuk-date-input__label" for="infrastructure-levy-expected-date-levy-expected-date-month">Month</label>
-                                        <input class="govuk-input govuk-date-input__input govuk-input--width-2"
-                                        id="infrastructure-levy-expected-date-levy-expected-date-month" name="levy-expected-date-month"
-                                        type="text" inputmode="numeric">
-                                    </div>
-                                </div>
-                                <div class="govuk-date-input__item">
-                                    <div class="govuk-form-group">
-                                        <label class="govuk-label govuk-date-input__label" for="infrastructure-levy-expected-date-levy-expected-date-year">Year</label>
-                                        <input class="govuk-input govuk-date-input__input govuk-input--width-4"
-                                        id="infrastructure-levy-expected-date-levy-expected-date-year" name="levy-expected-date-year"
-                                        type="text" inputmode="numeric">
-                                    </div>
-                                </div>
-                            </div>
+                            </fieldset>
                         </div>
                         <button type="submit" data-prevent-double-click="true" class="govuk-button"
                         data-module="govuk-button">Continue</button>

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/infrastructure-levy-expected-date/infrastructure-levy-expected-date.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/infrastructure-levy-expected-date/infrastructure-levy-expected-date.mapper.js
@@ -19,11 +19,12 @@ export const changeInfrastructureLevyExpectedDate = (appealData, existingValue, 
 		title: 'Expected levy adoption date',
 		backLinkUrl,
 		preHeading: `Appeal ${shortAppealReference}`,
-		heading: 'Change expected levy adoption date',
 		pageComponents: [
 			dateInput({
 				name: 'infrastructureLevyExpectedDate',
 				namePrefix: 'levy-expected-date',
+				legendText: 'Change expected levy adoption date',
+				legendIsPageHeading: true,
 				value: dateISOStringToDayMonthYearHourMinute(existingValue)
 			})
 		]

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/is-aonb-national-landscape/__tests__/__snapshots__/is-aonb-national-landscape.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/is-aonb-national-landscape/__tests__/__snapshots__/is-aonb-national-landscape.test.js.snap
@@ -6,25 +6,29 @@ exports[`is-aonb-national-landscape GET /change should render the isAonbNational
         <div class="govuk-grid-column-two-thirds">
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full"><span class="govuk-caption-l govuk-!-margin-bottom-3">Appeal 351062</span>
-                    <h1                     class="govuk-heading-l govuk-!-margin-bottom-3">Change whether in area of outstanding natural beauty</h1>
                 </div>
             </div>
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full">
                     <form method="POST" novalidate="novalidate">
                         <div class="govuk-form-group">
-                            <div class="govuk-radios" data-module="govuk-radios">
-                                <div class="govuk-radios__item">
-                                    <input class="govuk-radios__input" id="isAonbNationalLandscapeRadio" name="isAonbNationalLandscapeRadio"
-                                    type="radio" value="yes">
-                                    <label class="govuk-label govuk-radios__label" for="isAonbNationalLandscapeRadio">In area</label>
+                            <fieldset class="govuk-fieldset">
+                                <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+                                    <h1 class="govuk-fieldset__heading"> Change whether in area of outstanding natural beauty</h1>
+                                </legend>
+                                <div class="govuk-radios" data-module="govuk-radios">
+                                    <div class="govuk-radios__item">
+                                        <input class="govuk-radios__input" id="isAonbNationalLandscapeRadio" name="isAonbNationalLandscapeRadio"
+                                        type="radio" value="yes">
+                                        <label class="govuk-label govuk-radios__label" for="isAonbNationalLandscapeRadio">In area</label>
+                                    </div>
+                                    <div class="govuk-radios__item">
+                                        <input class="govuk-radios__input" id="isAonbNationalLandscapeRadio-2"
+                                        name="isAonbNationalLandscapeRadio" type="radio" value="no">
+                                        <label class="govuk-label govuk-radios__label" for="isAonbNationalLandscapeRadio-2">Not in area</label>
+                                    </div>
                                 </div>
-                                <div class="govuk-radios__item">
-                                    <input class="govuk-radios__input" id="isAonbNationalLandscapeRadio-2"
-                                    name="isAonbNationalLandscapeRadio" type="radio" value="no">
-                                    <label class="govuk-label govuk-radios__label" for="isAonbNationalLandscapeRadio-2">Not in area</label>
-                                </div>
-                            </div>
+                            </fieldset>
                         </div>
                         <button type="submit" data-prevent-double-click="true" class="govuk-button"
                         data-module="govuk-button">Continue</button>

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/is-aonb-national-landscape/is-aonb-national-landscape.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/is-aonb-national-landscape/is-aonb-national-landscape.mapper.js
@@ -18,11 +18,12 @@ export const changeIsAonbNationalLandscape = (appealData, data, origin) => {
 		title: `Outstanding natural beauty area`,
 		backLinkUrl: origin,
 		preHeading: `Appeal ${shortAppealReference}`,
-		heading: `Change whether in area of outstanding natural beauty`,
 		pageComponents: [
 			yesNoInput({
 				name: 'isAonbNationalLandscapeRadio',
 				value: data,
+				legendText: 'Change whether in area of outstanding natural beauty',
+				legendIsPageHeading: true,
 				customYesLabel: 'In area',
 				customNoLabel: 'Not in area'
 			})

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/is-gypsy-or-traveller-site/__tests__/__snapshots__/is-gypsy-or-traveller-site.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/is-gypsy-or-traveller-site/__tests__/__snapshots__/is-gypsy-or-traveller-site.test.js.snap
@@ -6,25 +6,29 @@ exports[`is-gypsy-or-traveller-site GET /change should render the greenBelt chan
         <div class="govuk-grid-column-two-thirds">
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full"><span class="govuk-caption-l govuk-!-margin-bottom-3">Appeal 351062</span>
-                    <h1                     class="govuk-heading-l govuk-!-margin-bottom-3">Change whether Gypsy or Traveller communities affected</h1>
                 </div>
             </div>
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full">
                     <form method="POST" novalidate="novalidate">
                         <div class="govuk-form-group">
-                            <div class="govuk-radios" data-module="govuk-radios">
-                                <div class="govuk-radios__item">
-                                    <input class="govuk-radios__input" id="isGypsyOrTravellerSiteRadio" name="isGypsyOrTravellerSiteRadio"
-                                    type="radio" value="yes" checked>
-                                    <label class="govuk-label govuk-radios__label" for="isGypsyOrTravellerSiteRadio">Affected</label>
+                            <fieldset class="govuk-fieldset">
+                                <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+                                    <h1 class="govuk-fieldset__heading"> Change whether Gypsy or Traveller communities affected</h1>
+                                </legend>
+                                <div class="govuk-radios" data-module="govuk-radios">
+                                    <div class="govuk-radios__item">
+                                        <input class="govuk-radios__input" id="isGypsyOrTravellerSiteRadio" name="isGypsyOrTravellerSiteRadio"
+                                        type="radio" value="yes" checked>
+                                        <label class="govuk-label govuk-radios__label" for="isGypsyOrTravellerSiteRadio">Affected</label>
+                                    </div>
+                                    <div class="govuk-radios__item">
+                                        <input class="govuk-radios__input" id="isGypsyOrTravellerSiteRadio-2"
+                                        name="isGypsyOrTravellerSiteRadio" type="radio" value="no">
+                                        <label class="govuk-label govuk-radios__label" for="isGypsyOrTravellerSiteRadio-2">Not affected</label>
+                                    </div>
                                 </div>
-                                <div class="govuk-radios__item">
-                                    <input class="govuk-radios__input" id="isGypsyOrTravellerSiteRadio-2"
-                                    name="isGypsyOrTravellerSiteRadio" type="radio" value="no">
-                                    <label class="govuk-label govuk-radios__label" for="isGypsyOrTravellerSiteRadio-2">Not affected</label>
-                                </div>
-                            </div>
+                            </fieldset>
                         </div>
                         <button type="submit" data-prevent-double-click="true" class="govuk-button"
                         data-module="govuk-button">Continue</button>

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/is-gypsy-or-traveller-site/is-gypsy-or-traveller-site.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/is-gypsy-or-traveller-site/is-gypsy-or-traveller-site.mapper.js
@@ -18,11 +18,12 @@ export const changeIsGypsyOrTravellerSite = (appealData, data, origin) => {
 		title: `Gypsy or Traveller communities status`,
 		backLinkUrl: origin,
 		preHeading: `Appeal ${shortAppealReference}`,
-		heading: `Change whether Gypsy or Traveller communities affected`,
 		pageComponents: [
 			yesNoInput({
 				name: 'isGypsyOrTravellerSiteRadio',
 				value: data,
+				legendText: 'Change whether Gypsy or Traveller communities affected',
+				legendIsPageHeading: true,
 				customYesLabel: 'Affected',
 				customNoLabel: 'Not affected'
 			})

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/is-infrastructure-levy-formally-adopted/__tests__/__snapshots__/is-infrastructure-levy-formally-adopted.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/is-infrastructure-levy-formally-adopted/__tests__/__snapshots__/is-infrastructure-levy-formally-adopted.test.js.snap
@@ -6,26 +6,30 @@ exports[`is-infrastructure-levy-formally-adopted GET /is-infrastructure-levy-for
         <div class="govuk-grid-column-two-thirds">
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full"><span class="govuk-caption-l govuk-!-margin-bottom-3">Appeal 351062</span>
-                    <h1                     class="govuk-heading-l govuk-!-margin-bottom-3">Change whether levy formally adopted</h1>
                 </div>
             </div>
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full">
                     <form method="POST" novalidate="novalidate">
                         <div class="govuk-form-group">
-                            <div class="govuk-radios" data-module="govuk-radios">
-                                <div class="govuk-radios__item">
-                                    <input class="govuk-radios__input" id="isInfrastructureLevyFormallyAdoptedRadio"
-                                    name="isInfrastructureLevyFormallyAdoptedRadio" type="radio" value="yes"
-                                    checked>
-                                    <label class="govuk-label govuk-radios__label" for="isInfrastructureLevyFormallyAdoptedRadio">Formally adopted</label>
+                            <fieldset class="govuk-fieldset">
+                                <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+                                    <h1 class="govuk-fieldset__heading"> Change whether levy formally adopted</h1>
+                                </legend>
+                                <div class="govuk-radios" data-module="govuk-radios">
+                                    <div class="govuk-radios__item">
+                                        <input class="govuk-radios__input" id="isInfrastructureLevyFormallyAdoptedRadio"
+                                        name="isInfrastructureLevyFormallyAdoptedRadio" type="radio" value="yes"
+                                        checked>
+                                        <label class="govuk-label govuk-radios__label" for="isInfrastructureLevyFormallyAdoptedRadio">Formally adopted</label>
+                                    </div>
+                                    <div class="govuk-radios__item">
+                                        <input class="govuk-radios__input" id="isInfrastructureLevyFormallyAdoptedRadio-2"
+                                        name="isInfrastructureLevyFormallyAdoptedRadio" type="radio" value="no">
+                                        <label class="govuk-label govuk-radios__label" for="isInfrastructureLevyFormallyAdoptedRadio-2">Not formally adopted</label>
+                                    </div>
                                 </div>
-                                <div class="govuk-radios__item">
-                                    <input class="govuk-radios__input" id="isInfrastructureLevyFormallyAdoptedRadio-2"
-                                    name="isInfrastructureLevyFormallyAdoptedRadio" type="radio" value="no">
-                                    <label class="govuk-label govuk-radios__label" for="isInfrastructureLevyFormallyAdoptedRadio-2">Not formally adopted</label>
-                                </div>
-                            </div>
+                            </fieldset>
                         </div>
                         <button type="submit" data-prevent-double-click="true" class="govuk-button"
                         data-module="govuk-button">Continue</button>
@@ -43,26 +47,30 @@ exports[`is-infrastructure-levy-formally-adopted GET /is-infrastructure-levy-for
         <div class="govuk-grid-column-two-thirds">
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full"><span class="govuk-caption-l govuk-!-margin-bottom-3">Appeal 351062</span>
-                    <h1                     class="govuk-heading-l govuk-!-margin-bottom-3">Change whether levy formally adopted</h1>
                 </div>
             </div>
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full">
                     <form method="POST" novalidate="novalidate">
                         <div class="govuk-form-group">
-                            <div class="govuk-radios" data-module="govuk-radios">
-                                <div class="govuk-radios__item">
-                                    <input class="govuk-radios__input" id="isInfrastructureLevyFormallyAdoptedRadio"
-                                    name="isInfrastructureLevyFormallyAdoptedRadio" type="radio" value="yes">
-                                    <label class="govuk-label govuk-radios__label" for="isInfrastructureLevyFormallyAdoptedRadio">Formally adopted</label>
+                            <fieldset class="govuk-fieldset">
+                                <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+                                    <h1 class="govuk-fieldset__heading"> Change whether levy formally adopted</h1>
+                                </legend>
+                                <div class="govuk-radios" data-module="govuk-radios">
+                                    <div class="govuk-radios__item">
+                                        <input class="govuk-radios__input" id="isInfrastructureLevyFormallyAdoptedRadio"
+                                        name="isInfrastructureLevyFormallyAdoptedRadio" type="radio" value="yes">
+                                        <label class="govuk-label govuk-radios__label" for="isInfrastructureLevyFormallyAdoptedRadio">Formally adopted</label>
+                                    </div>
+                                    <div class="govuk-radios__item">
+                                        <input class="govuk-radios__input" id="isInfrastructureLevyFormallyAdoptedRadio-2"
+                                        name="isInfrastructureLevyFormallyAdoptedRadio" type="radio" value="no"
+                                        checked>
+                                        <label class="govuk-label govuk-radios__label" for="isInfrastructureLevyFormallyAdoptedRadio-2">Not formally adopted</label>
+                                    </div>
                                 </div>
-                                <div class="govuk-radios__item">
-                                    <input class="govuk-radios__input" id="isInfrastructureLevyFormallyAdoptedRadio-2"
-                                    name="isInfrastructureLevyFormallyAdoptedRadio" type="radio" value="no"
-                                    checked>
-                                    <label class="govuk-label govuk-radios__label" for="isInfrastructureLevyFormallyAdoptedRadio-2">Not formally adopted</label>
-                                </div>
-                            </div>
+                            </fieldset>
                         </div>
                         <button type="submit" data-prevent-double-click="true" class="govuk-button"
                         data-module="govuk-button">Continue</button>

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/is-infrastructure-levy-formally-adopted/is-infrastructure-levy-formally-adopted.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/is-infrastructure-levy-formally-adopted/is-infrastructure-levy-formally-adopted.mapper.js
@@ -22,11 +22,12 @@ export const changeIsInfrastructureLevyFormallyAdopted = (
 		title: 'Levy formally adopted',
 		backLinkUrl,
 		preHeading: `Appeal ${shortAppealReference}`,
-		heading: 'Change whether levy formally adopted',
 		pageComponents: [
 			yesNoInput({
 				name: 'isInfrastructureLevyFormallyAdoptedRadio',
 				value: existingValue,
+				legendText: 'Change whether levy formally adopted',
+				legendIsPageHeading: true,
 				customYesLabel: 'Formally adopted',
 				customNoLabel: 'Not formally adopted'
 			})

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/lpa-questionnaire.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/lpa-questionnaire.mapper.js
@@ -139,16 +139,6 @@ export async function lpaQuestionnairePage(lpaqDetails, appealDetails, currentRo
 		userHasPermission(permissionNames.setStageOutcome, session)
 	) {
 		reviewOutcomeComponents.push({
-			type: 'html',
-			wrapperHtml: {
-				opening: '<div class="govuk-grid-row"><div class="govuk-grid-column-full">',
-				closing: '</div></div>'
-			},
-			parameters: {
-				html: '<h2>What is the outcome of your review?</h2>'
-			}
-		});
-		reviewOutcomeComponents.push({
 			type: 'radios',
 			parameters: reviewOutcomeRadiosInputInstruction.properties
 		});

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/notification-methods/__tests__/__snapshots__/notification-methods.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/notification-methods/__tests__/__snapshots__/notification-methods.test.js.snap
@@ -6,30 +6,34 @@ exports[`notification-methods GET /change should render the change notification 
         <div class="govuk-grid-column-two-thirds">
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full"><span class="govuk-caption-l govuk-!-margin-bottom-3">Appeal 351062</span>
-                    <h1                     class="govuk-heading-l govuk-!-margin-bottom-3">Change notification methods</h1>
                 </div>
             </div>
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full">
                     <form method="POST" novalidate="novalidate">
                         <div class="govuk-form-group">
-                            <div class="govuk-checkboxes" data-module="govuk-checkboxes">
-                                <div class="govuk-checkboxes__item">
-                                    <input class="govuk-checkboxes__input" id="notificationMethodsCheckboxes"
-                                    name="notificationMethodsCheckboxes" type="checkbox" value="9029" checked>
-                                    <label class="govuk-label govuk-checkboxes__label" for="notificationMethodsCheckboxes">A site notice</label>
+                            <fieldset class="govuk-fieldset">
+                                <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+                                    <h1 class="govuk-fieldset__heading"> Change notification methods</h1>
+                                </legend>
+                                <div class="govuk-checkboxes" data-module="govuk-checkboxes">
+                                    <div class="govuk-checkboxes__item">
+                                        <input class="govuk-checkboxes__input" id="notificationMethodsCheckboxes"
+                                        name="notificationMethodsCheckboxes" type="checkbox" value="9029" checked>
+                                        <label class="govuk-label govuk-checkboxes__label" for="notificationMethodsCheckboxes">A site notice</label>
+                                    </div>
+                                    <div class="govuk-checkboxes__item">
+                                        <input class="govuk-checkboxes__input" id="notificationMethodsCheckboxes-2"
+                                        name="notificationMethodsCheckboxes" type="checkbox" value="9030" checked>
+                                        <label class="govuk-label govuk-checkboxes__label" for="notificationMethodsCheckboxes-2">Letter/email to interested parties</label>
+                                    </div>
+                                    <div class="govuk-checkboxes__item">
+                                        <input class="govuk-checkboxes__input" id="notificationMethodsCheckboxes-3"
+                                        name="notificationMethodsCheckboxes" type="checkbox" value="9031">
+                                        <label class="govuk-label govuk-checkboxes__label" for="notificationMethodsCheckboxes-3">A press advert</label>
+                                    </div>
                                 </div>
-                                <div class="govuk-checkboxes__item">
-                                    <input class="govuk-checkboxes__input" id="notificationMethodsCheckboxes-2"
-                                    name="notificationMethodsCheckboxes" type="checkbox" value="9030" checked>
-                                    <label class="govuk-label govuk-checkboxes__label" for="notificationMethodsCheckboxes-2">Letter/email to interested parties</label>
-                                </div>
-                                <div class="govuk-checkboxes__item">
-                                    <input class="govuk-checkboxes__input" id="notificationMethodsCheckboxes-3"
-                                    name="notificationMethodsCheckboxes" type="checkbox" value="9031">
-                                    <label class="govuk-label govuk-checkboxes__label" for="notificationMethodsCheckboxes-3">A press advert</label>
-                                </div>
-                            </div>
+                            </fieldset>
                         </div>
                         <button type="submit" data-prevent-double-click="true" class="govuk-button"
                         data-module="govuk-button">Continue</button>

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/notification-methods/notification-methods.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/notification-methods/notification-methods.mapper.js
@@ -31,17 +31,16 @@ export const changeNotificationMethodsPage = (
 		title: `Change notification methods`,
 		backLinkUrl: backLinkUrl,
 		preHeading: `Appeal ${shortAppealReference}`,
-		heading: `Change notification methods`,
 		pageComponents: [
 			{
 				type: 'checkboxes',
 				parameters: {
 					name: 'notificationMethodsCheckboxes',
 					id: 'notification-methods-checkboxes',
-					fieldSet: {
+					fieldset: {
 						legend: {
-							text: `Which notification methods apply?`,
-							isPageHeading: false,
+							text: 'Change notification methods',
+							isPageHeading: true,
 							classes: 'govuk-fieldset__legend--l'
 						}
 					},

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/procedure-preference/__tests__/__snapshots__/procedure-preference.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/procedure-preference/__tests__/__snapshots__/procedure-preference.test.js.snap
@@ -6,30 +6,34 @@ exports[`procedure-preference GET /change should render the change procedure pre
         <div class="govuk-grid-column-two-thirds">
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full"><span class="govuk-caption-l govuk-!-margin-bottom-3">Appeal 351062</span>
-                    <h1                     class="govuk-heading-l govuk-!-margin-bottom-3">Change procedure preference</h1>
                 </div>
             </div>
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full">
                     <form method="POST" novalidate="novalidate">
                         <div class="govuk-form-group">
-                            <div class="govuk-radios" data-module="govuk-radios">
-                                <div class="govuk-radios__item">
-                                    <input class="govuk-radios__input" id="procedurePreferenceRadio" name="procedurePreferenceRadio"
-                                    type="radio" value="hearing">
-                                    <label class="govuk-label govuk-radios__label" for="procedurePreferenceRadio">Hearing</label>
+                            <fieldset class="govuk-fieldset">
+                                <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+                                    <h1 class="govuk-fieldset__heading"> Change procedure preference</h1>
+                                </legend>
+                                <div class="govuk-radios" data-module="govuk-radios">
+                                    <div class="govuk-radios__item">
+                                        <input class="govuk-radios__input" id="procedurePreferenceRadio" name="procedurePreferenceRadio"
+                                        type="radio" value="hearing">
+                                        <label class="govuk-label govuk-radios__label" for="procedurePreferenceRadio">Hearing</label>
+                                    </div>
+                                    <div class="govuk-radios__item">
+                                        <input class="govuk-radios__input" id="procedurePreferenceRadio-2" name="procedurePreferenceRadio"
+                                        type="radio" value="inquiry">
+                                        <label class="govuk-label govuk-radios__label" for="procedurePreferenceRadio-2">Inquiry</label>
+                                    </div>
+                                    <div class="govuk-radios__item">
+                                        <input class="govuk-radios__input" id="procedurePreferenceRadio-3" name="procedurePreferenceRadio"
+                                        type="radio" value="written">
+                                        <label class="govuk-label govuk-radios__label" for="procedurePreferenceRadio-3">Written</label>
+                                    </div>
                                 </div>
-                                <div class="govuk-radios__item">
-                                    <input class="govuk-radios__input" id="procedurePreferenceRadio-2" name="procedurePreferenceRadio"
-                                    type="radio" value="inquiry">
-                                    <label class="govuk-label govuk-radios__label" for="procedurePreferenceRadio-2">Inquiry</label>
-                                </div>
-                                <div class="govuk-radios__item">
-                                    <input class="govuk-radios__input" id="procedurePreferenceRadio-3" name="procedurePreferenceRadio"
-                                    type="radio" value="written">
-                                    <label class="govuk-label govuk-radios__label" for="procedurePreferenceRadio-3">Written</label>
-                                </div>
-                            </div>
+                            </fieldset>
                         </div>
                         <button type="submit" data-prevent-double-click="true" class="govuk-button"
                         data-module="govuk-button">Continue</button>
@@ -47,30 +51,34 @@ exports[`procedure-preference GET /change should render the change procedure pre
         <div class="govuk-grid-column-two-thirds">
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full"><span class="govuk-caption-l govuk-!-margin-bottom-3">Appeal 351062</span>
-                    <h1                     class="govuk-heading-l govuk-!-margin-bottom-3">Change procedure preference</h1>
                 </div>
             </div>
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full">
                     <form method="POST" novalidate="novalidate">
                         <div class="govuk-form-group">
-                            <div class="govuk-radios" data-module="govuk-radios">
-                                <div class="govuk-radios__item">
-                                    <input class="govuk-radios__input" id="procedurePreferenceRadio" name="procedurePreferenceRadio"
-                                    type="radio" value="hearing" checked>
-                                    <label class="govuk-label govuk-radios__label" for="procedurePreferenceRadio">Hearing</label>
+                            <fieldset class="govuk-fieldset">
+                                <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+                                    <h1 class="govuk-fieldset__heading"> Change procedure preference</h1>
+                                </legend>
+                                <div class="govuk-radios" data-module="govuk-radios">
+                                    <div class="govuk-radios__item">
+                                        <input class="govuk-radios__input" id="procedurePreferenceRadio" name="procedurePreferenceRadio"
+                                        type="radio" value="hearing" checked>
+                                        <label class="govuk-label govuk-radios__label" for="procedurePreferenceRadio">Hearing</label>
+                                    </div>
+                                    <div class="govuk-radios__item">
+                                        <input class="govuk-radios__input" id="procedurePreferenceRadio-2" name="procedurePreferenceRadio"
+                                        type="radio" value="inquiry">
+                                        <label class="govuk-label govuk-radios__label" for="procedurePreferenceRadio-2">Inquiry</label>
+                                    </div>
+                                    <div class="govuk-radios__item">
+                                        <input class="govuk-radios__input" id="procedurePreferenceRadio-3" name="procedurePreferenceRadio"
+                                        type="radio" value="written">
+                                        <label class="govuk-label govuk-radios__label" for="procedurePreferenceRadio-3">Written</label>
+                                    </div>
                                 </div>
-                                <div class="govuk-radios__item">
-                                    <input class="govuk-radios__input" id="procedurePreferenceRadio-2" name="procedurePreferenceRadio"
-                                    type="radio" value="inquiry">
-                                    <label class="govuk-label govuk-radios__label" for="procedurePreferenceRadio-2">Inquiry</label>
-                                </div>
-                                <div class="govuk-radios__item">
-                                    <input class="govuk-radios__input" id="procedurePreferenceRadio-3" name="procedurePreferenceRadio"
-                                    type="radio" value="written">
-                                    <label class="govuk-label govuk-radios__label" for="procedurePreferenceRadio-3">Written</label>
-                                </div>
-                            </div>
+                            </fieldset>
                         </div>
                         <button type="submit" data-prevent-double-click="true" class="govuk-button"
                         data-module="govuk-button">Continue</button>
@@ -88,30 +96,34 @@ exports[`procedure-preference GET /change should render the change procedure pre
         <div class="govuk-grid-column-two-thirds">
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full"><span class="govuk-caption-l govuk-!-margin-bottom-3">Appeal 351062</span>
-                    <h1                     class="govuk-heading-l govuk-!-margin-bottom-3">Change procedure preference</h1>
                 </div>
             </div>
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full">
                     <form method="POST" novalidate="novalidate">
                         <div class="govuk-form-group">
-                            <div class="govuk-radios" data-module="govuk-radios">
-                                <div class="govuk-radios__item">
-                                    <input class="govuk-radios__input" id="procedurePreferenceRadio" name="procedurePreferenceRadio"
-                                    type="radio" value="hearing">
-                                    <label class="govuk-label govuk-radios__label" for="procedurePreferenceRadio">Hearing</label>
+                            <fieldset class="govuk-fieldset">
+                                <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+                                    <h1 class="govuk-fieldset__heading"> Change procedure preference</h1>
+                                </legend>
+                                <div class="govuk-radios" data-module="govuk-radios">
+                                    <div class="govuk-radios__item">
+                                        <input class="govuk-radios__input" id="procedurePreferenceRadio" name="procedurePreferenceRadio"
+                                        type="radio" value="hearing">
+                                        <label class="govuk-label govuk-radios__label" for="procedurePreferenceRadio">Hearing</label>
+                                    </div>
+                                    <div class="govuk-radios__item">
+                                        <input class="govuk-radios__input" id="procedurePreferenceRadio-2" name="procedurePreferenceRadio"
+                                        type="radio" value="inquiry" checked>
+                                        <label class="govuk-label govuk-radios__label" for="procedurePreferenceRadio-2">Inquiry</label>
+                                    </div>
+                                    <div class="govuk-radios__item">
+                                        <input class="govuk-radios__input" id="procedurePreferenceRadio-3" name="procedurePreferenceRadio"
+                                        type="radio" value="written">
+                                        <label class="govuk-label govuk-radios__label" for="procedurePreferenceRadio-3">Written</label>
+                                    </div>
                                 </div>
-                                <div class="govuk-radios__item">
-                                    <input class="govuk-radios__input" id="procedurePreferenceRadio-2" name="procedurePreferenceRadio"
-                                    type="radio" value="inquiry" checked>
-                                    <label class="govuk-label govuk-radios__label" for="procedurePreferenceRadio-2">Inquiry</label>
-                                </div>
-                                <div class="govuk-radios__item">
-                                    <input class="govuk-radios__input" id="procedurePreferenceRadio-3" name="procedurePreferenceRadio"
-                                    type="radio" value="written">
-                                    <label class="govuk-label govuk-radios__label" for="procedurePreferenceRadio-3">Written</label>
-                                </div>
-                            </div>
+                            </fieldset>
                         </div>
                         <button type="submit" data-prevent-double-click="true" class="govuk-button"
                         data-module="govuk-button">Continue</button>
@@ -129,30 +141,34 @@ exports[`procedure-preference GET /change should render the change procedure pre
         <div class="govuk-grid-column-two-thirds">
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full"><span class="govuk-caption-l govuk-!-margin-bottom-3">Appeal 351062</span>
-                    <h1                     class="govuk-heading-l govuk-!-margin-bottom-3">Change procedure preference</h1>
                 </div>
             </div>
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full">
                     <form method="POST" novalidate="novalidate">
                         <div class="govuk-form-group">
-                            <div class="govuk-radios" data-module="govuk-radios">
-                                <div class="govuk-radios__item">
-                                    <input class="govuk-radios__input" id="procedurePreferenceRadio" name="procedurePreferenceRadio"
-                                    type="radio" value="hearing">
-                                    <label class="govuk-label govuk-radios__label" for="procedurePreferenceRadio">Hearing</label>
+                            <fieldset class="govuk-fieldset">
+                                <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+                                    <h1 class="govuk-fieldset__heading"> Change procedure preference</h1>
+                                </legend>
+                                <div class="govuk-radios" data-module="govuk-radios">
+                                    <div class="govuk-radios__item">
+                                        <input class="govuk-radios__input" id="procedurePreferenceRadio" name="procedurePreferenceRadio"
+                                        type="radio" value="hearing">
+                                        <label class="govuk-label govuk-radios__label" for="procedurePreferenceRadio">Hearing</label>
+                                    </div>
+                                    <div class="govuk-radios__item">
+                                        <input class="govuk-radios__input" id="procedurePreferenceRadio-2" name="procedurePreferenceRadio"
+                                        type="radio" value="inquiry">
+                                        <label class="govuk-label govuk-radios__label" for="procedurePreferenceRadio-2">Inquiry</label>
+                                    </div>
+                                    <div class="govuk-radios__item">
+                                        <input class="govuk-radios__input" id="procedurePreferenceRadio-3" name="procedurePreferenceRadio"
+                                        type="radio" value="written" checked>
+                                        <label class="govuk-label govuk-radios__label" for="procedurePreferenceRadio-3">Written</label>
+                                    </div>
                                 </div>
-                                <div class="govuk-radios__item">
-                                    <input class="govuk-radios__input" id="procedurePreferenceRadio-2" name="procedurePreferenceRadio"
-                                    type="radio" value="inquiry">
-                                    <label class="govuk-label govuk-radios__label" for="procedurePreferenceRadio-2">Inquiry</label>
-                                </div>
-                                <div class="govuk-radios__item">
-                                    <input class="govuk-radios__input" id="procedurePreferenceRadio-3" name="procedurePreferenceRadio"
-                                    type="radio" value="written" checked>
-                                    <label class="govuk-label govuk-radios__label" for="procedurePreferenceRadio-3">Written</label>
-                                </div>
-                            </div>
+                            </fieldset>
                         </div>
                         <button type="submit" data-prevent-double-click="true" class="govuk-button"
                         data-module="govuk-button">Continue</button>
@@ -170,13 +186,13 @@ exports[`procedure-preference GET /details/change should render the change reaso
         <div class="govuk-grid-column-two-thirds">
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full"><span class="govuk-caption-l govuk-!-margin-bottom-3">Appeal 351062</span>
-                    <h1                     class="govuk-heading-l govuk-!-margin-bottom-3">Change reason for preference</h1>
                 </div>
             </div>
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full">
                     <form method="POST" novalidate="novalidate">
                         <div class="govuk-form-group">
+                            <h1 class="govuk-label-wrapper"><label class="govuk-label govuk-label--l" for="procedure-preference-details"> Change reason for preference</label></h1>
                             <textarea class="govuk-textarea" id="procedure-preference-details" name="procedurePreferenceDetailsTextarea"
                             rows="5">Example procedure preference details text</textarea>
                         </div>
@@ -196,13 +212,13 @@ exports[`procedure-preference GET /details/change should render the change reaso
         <div class="govuk-grid-column-two-thirds">
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full"><span class="govuk-caption-l govuk-!-margin-bottom-3">Appeal 351062</span>
-                    <h1                     class="govuk-heading-l govuk-!-margin-bottom-3">Change reason for preference</h1>
                 </div>
             </div>
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full">
                     <form method="POST" novalidate="novalidate">
                         <div class="govuk-form-group">
+                            <h1 class="govuk-label-wrapper"><label class="govuk-label govuk-label--l" for="procedure-preference-details"> Change reason for preference</label></h1>
                             <textarea class="govuk-textarea" id="procedure-preference-details" name="procedurePreferenceDetailsTextarea"
                             rows="5"></textarea>
                         </div>

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/procedure-preference/__tests__/procedure-preference.test.js
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/procedure-preference/__tests__/procedure-preference.test.js
@@ -233,7 +233,7 @@ describe('procedure-preference', () => {
 
 			const unprettifiedElement = parseHtml(response.text, { skipPrettyPrint: true });
 
-			expect(unprettifiedElement.innerHTML).toContain('Change reason for preference</h1>');
+			expect(unprettifiedElement.innerHTML).toContain('Change reason for preference</label></h1>');
 			expect(unprettifiedElement.innerHTML).toContain(
 				'<textarea class="govuk-textarea" id="procedure-preference-details" name="procedurePreferenceDetailsTextarea" rows="5"></textarea>'
 			);

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/procedure-preference/procedure-preference.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/procedure-preference/procedure-preference.mapper.js
@@ -29,10 +29,11 @@ export const changeProcedurePreferencePage = (
 		title: `Change procedure preference`,
 		backLinkUrl: `/appeals-service/appeal-details/${appealData.appealId}/lpa-questionnaire/${lpaQuestionnaireData.lpaQuestionnaireId}`,
 		preHeading: `Appeal ${shortAppealReference}`,
-		heading: `Change procedure preference`,
 		pageComponents: [
 			radiosInput({
 				name: 'procedurePreferenceRadio',
+				legendText: 'Change procedure preference',
+				legendIsPageHeading: true,
 				items: [
 					{
 						value: 'hearing',
@@ -81,11 +82,12 @@ export const changeProcedurePreferenceDetailsPage = (
 		title: `Change reason for preference`,
 		backLinkUrl: `/appeals-service/appeal-details/${appealData.appealId}/lpa-questionnaire/${lpaQuestionnaireData.lpaQuestionnaireId}`,
 		preHeading: `Appeal ${shortAppealReference}`,
-		heading: `Change reason for preference`,
 		pageComponents: [
 			textareaInput({
 				name: 'procedurePreferenceDetailsTextarea',
 				id: 'procedure-preference-details',
+				labelText: 'Change reason for preference',
+				labelIsPageHeading: true,
 				value: procedurePreferenceDetails || ''
 			})
 		]

--- a/appeals/web/src/server/appeals/appeal-details/neighbouring-sites/__tests__/__snapshots__/neighbouring-sites.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/neighbouring-sites/__tests__/__snapshots__/neighbouring-sites.test.js.snap
@@ -135,25 +135,29 @@ exports[`neighbouring-sites GET /change/affected should render the change neighb
         <div class="govuk-grid-column-two-thirds">
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full"><span class="govuk-caption-l govuk-!-margin-bottom-3">Appeal 351062</span>
-                    <h1                     class="govuk-heading-l govuk-!-margin-bottom-3">Could a neighbouring site be affected?</h1>
                 </div>
             </div>
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full">
                     <form method="POST" novalidate="novalidate">
                         <div class="govuk-form-group">
-                            <div class="govuk-radios" data-module="govuk-radios">
-                                <div class="govuk-radios__item">
-                                    <input class="govuk-radios__input" id="neighbouringSiteAffected" name="neighbouringSiteAffected"
-                                    type="radio" value="yes">
-                                    <label class="govuk-label govuk-radios__label" for="neighbouringSiteAffected">Yes</label>
+                            <fieldset class="govuk-fieldset">
+                                <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+                                    <h1 class="govuk-fieldset__heading"> Could a neighbouring site be affected?</h1>
+                                </legend>
+                                <div class="govuk-radios" data-module="govuk-radios">
+                                    <div class="govuk-radios__item">
+                                        <input class="govuk-radios__input" id="neighbouringSiteAffected" name="neighbouringSiteAffected"
+                                        type="radio" value="yes">
+                                        <label class="govuk-label govuk-radios__label" for="neighbouringSiteAffected">Yes</label>
+                                    </div>
+                                    <div class="govuk-radios__item">
+                                        <input class="govuk-radios__input" id="neighbouringSiteAffected-2" name="neighbouringSiteAffected"
+                                        type="radio" value="no">
+                                        <label class="govuk-label govuk-radios__label" for="neighbouringSiteAffected-2">No</label>
+                                    </div>
                                 </div>
-                                <div class="govuk-radios__item">
-                                    <input class="govuk-radios__input" id="neighbouringSiteAffected-2" name="neighbouringSiteAffected"
-                                    type="radio" value="no">
-                                    <label class="govuk-label govuk-radios__label" for="neighbouringSiteAffected-2">No</label>
-                                </div>
-                            </div>
+                            </fieldset>
                         </div>
                         <button type="submit" data-prevent-double-click="true" class="govuk-button"
                         data-module="govuk-button">Continue</button>
@@ -171,25 +175,29 @@ exports[`neighbouring-sites GET /change/affected should render the change neighb
         <div class="govuk-grid-column-two-thirds">
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full"><span class="govuk-caption-l govuk-!-margin-bottom-3">Appeal 351062</span>
-                    <h1                     class="govuk-heading-l govuk-!-margin-bottom-3">Could a neighbouring site be affected?</h1>
                 </div>
             </div>
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full">
                     <form method="POST" novalidate="novalidate">
                         <div class="govuk-form-group">
-                            <div class="govuk-radios" data-module="govuk-radios">
-                                <div class="govuk-radios__item">
-                                    <input class="govuk-radios__input" id="neighbouringSiteAffected" name="neighbouringSiteAffected"
-                                    type="radio" value="yes">
-                                    <label class="govuk-label govuk-radios__label" for="neighbouringSiteAffected">Yes</label>
+                            <fieldset class="govuk-fieldset">
+                                <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+                                    <h1 class="govuk-fieldset__heading"> Could a neighbouring site be affected?</h1>
+                                </legend>
+                                <div class="govuk-radios" data-module="govuk-radios">
+                                    <div class="govuk-radios__item">
+                                        <input class="govuk-radios__input" id="neighbouringSiteAffected" name="neighbouringSiteAffected"
+                                        type="radio" value="yes">
+                                        <label class="govuk-label govuk-radios__label" for="neighbouringSiteAffected">Yes</label>
+                                    </div>
+                                    <div class="govuk-radios__item">
+                                        <input class="govuk-radios__input" id="neighbouringSiteAffected-2" name="neighbouringSiteAffected"
+                                        type="radio" value="no">
+                                        <label class="govuk-label govuk-radios__label" for="neighbouringSiteAffected-2">No</label>
+                                    </div>
                                 </div>
-                                <div class="govuk-radios__item">
-                                    <input class="govuk-radios__input" id="neighbouringSiteAffected-2" name="neighbouringSiteAffected"
-                                    type="radio" value="no">
-                                    <label class="govuk-label govuk-radios__label" for="neighbouringSiteAffected-2">No</label>
-                                </div>
-                            </div>
+                            </fieldset>
                         </div>
                         <button type="submit" data-prevent-double-click="true" class="govuk-button"
                         data-module="govuk-button">Continue</button>

--- a/appeals/web/src/server/appeals/appeal-details/neighbouring-sites/neighbouring-sites.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/neighbouring-sites/neighbouring-sites.mapper.js
@@ -317,11 +317,12 @@ export function changeNeighbouringSiteAffectedPage(appealData, origin) {
 		title: 'Update neighbouring site affected',
 		backLinkUrl: origin,
 		preHeading: `Appeal ${shortAppealReference}`,
-		heading: 'Could a neighbouring site be affected?',
 		pageComponents: [
 			yesNoInput({
 				name: 'neighbouringSiteAffected',
-				value: appealData.isAffectingNeighbouringSites
+				value: appealData.isAffectingNeighbouringSites,
+				legendText: 'Could a neighbouring site be affected?',
+				legendIsPageHeading: true
 			})
 		]
 	};

--- a/appeals/web/src/server/appeals/appeal-details/other-appeals/__tests__/__snapshots__/other-appeals.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/other-appeals/__tests__/__snapshots__/other-appeals.test.js.snap
@@ -93,7 +93,6 @@ exports[`other-appeals GET /other-appeals/manage should render the "Do you want 
 "<main class="govuk-main-wrapper " id="main-content" role="main">
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-full"><span class="govuk-caption-l govuk-!-margin-bottom-3">Appeal 351062</span>
-            <h1             class="govuk-heading-xl govuk-!-margin-bottom-3">Do you want to remove the relationship between appeal 2 and appeal 351062?</h1>
         </div>
     </div>
     <div class="govuk-grid-row">
@@ -101,6 +100,9 @@ exports[`other-appeals GET /other-appeals/manage should render the "Do you want 
             <form action="" method="POST" novalidate>
                 <div class="govuk-form-group">
                     <fieldset class="govuk-fieldset">
+                        <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+                            <h1 class="govuk-fieldset__heading"> Do you want to remove the relationship between appeal 2 and appeal 351062?</h1>
+                        </legend>
                         <div class="govuk-radios" data-module="govuk-radios">
                             <div class="govuk-radios__item">
                                 <input class="govuk-radios__input" id="remove-appeal-relationship" name="removeAppealRelationship"
@@ -141,7 +143,6 @@ exports[`other-appeals GET /other-appeals/manage should render the "Do you want 
     </div>
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-full"><span class="govuk-caption-l govuk-!-margin-bottom-3">Appeal 351062</span>
-            <h1             class="govuk-heading-xl govuk-!-margin-bottom-3">Do you want to remove the relationship between appeal 2 and appeal 351062?</h1>
         </div>
     </div>
     <div class="govuk-grid-row">
@@ -149,6 +150,9 @@ exports[`other-appeals GET /other-appeals/manage should render the "Do you want 
             <form action="" method="POST" novalidate>
                 <div class="govuk-form-group">
                     <fieldset class="govuk-fieldset">
+                        <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+                            <h1 class="govuk-fieldset__heading"> Do you want to remove the relationship between appeal 2 and appeal 351062?</h1>
+                        </legend>
                         <div class="govuk-radios" data-module="govuk-radios">
                             <div class="govuk-radios__item">
                                 <input class="govuk-radios__input" id="remove-appeal-relationship" name="removeAppealRelationship"

--- a/appeals/web/src/server/appeals/appeal-details/other-appeals/other-appeals.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/other-appeals/other-appeals.mapper.js
@@ -308,6 +308,9 @@ export function manageOtherAppealsPage(appealData, request, origin) {
  * @returns {PageContent}
  */
 export function removeAppealRelationshipPage(appealData, relatedAppealShortReference, origin) {
+	const shortAppealReference = appealShortReference(appealData.appealReference);
+	const titleAndHeading = `Do you want to remove the relationship between appeal ${relatedAppealShortReference} and appeal ${shortAppealReference}?`;
+
 	/** @type {PageComponent} */
 	const selectAppealTypeRadiosComponent = {
 		type: 'radios',
@@ -316,7 +319,9 @@ export function removeAppealRelationshipPage(appealData, relatedAppealShortRefer
 			idPrefix: 'remove-appeal-relationship',
 			fieldset: {
 				legend: {
-					classes: 'govuk-fieldset__legend--m'
+					text: titleAndHeading,
+					isPageHeading: true,
+					classes: 'govuk-fieldset__legend--l'
 				}
 			},
 			items: [
@@ -332,15 +337,11 @@ export function removeAppealRelationshipPage(appealData, relatedAppealShortRefer
 		}
 	};
 
-	const shortAppealReference = appealShortReference(appealData.appealReference);
-	const titleAndHeading = `Do you want to remove the relationship between appeal ${relatedAppealShortReference} and appeal ${shortAppealReference}?`;
-
 	/** @type {PageContent} */
 	const pageContent = {
 		title: titleAndHeading,
 		backLinkUrl: `${origin}/other-appeals/manage`,
 		preHeading: `Appeal ${shortAppealReference}`,
-		heading: titleAndHeading,
 		pageComponents: [selectAppealTypeRadiosComponent]
 	};
 

--- a/appeals/web/src/server/appeals/appeal-details/safety-risks/__tests__/__snapshots__/safety-risks.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/safety-risks/__tests__/__snapshots__/safety-risks.test.js.snap
@@ -6,33 +6,37 @@ exports[`safety-risks GET /change/:source should render changeSafetyRisksAccess 
         <div class="govuk-grid-column-two-thirds">
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full"><span class="govuk-caption-l govuk-!-margin-bottom-3">Appeal 351062</span>
-                    <h1                     class="govuk-heading-l govuk-!-margin-bottom-3">Change the site health and safety risks (LPA answer)</h1>
                 </div>
             </div>
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full">
                     <form method="POST" novalidate="novalidate">
                         <div class="govuk-form-group">
-                            <div class="govuk-radios" data-module="govuk-radios">
-                                <div class="govuk-radios__item">
-                                    <input class="govuk-radios__input" id="safetyRisksRadio" name="safetyRisksRadio"
-                                    type="radio" value="yes" data-aria-controls="conditional-safetyRisksRadio">
-                                    <label class="govuk-label govuk-radios__label" for="safetyRisksRadio">Yes</label>
-                                </div>
-                                <div class="govuk-radios__conditional govuk-radios__conditional--hidden"
-                                id="conditional-safetyRisksRadio">
-                                    <div class="govuk-form-group">
-                                        <label class="govuk-label" for="safety-risks-details">Health and safety risks (LPA details)</label>
-                                        <textarea class="govuk-textarea"
-                                        id="safety-risks-details" name="safetyRisksDetails" rows="3"></textarea>
+                            <fieldset class="govuk-fieldset">
+                                <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+                                    <h1 class="govuk-fieldset__heading"> Change the site health and safety risks (LPA answer)</h1>
+                                </legend>
+                                <div class="govuk-radios" data-module="govuk-radios">
+                                    <div class="govuk-radios__item">
+                                        <input class="govuk-radios__input" id="safetyRisksRadio" name="safetyRisksRadio"
+                                        type="radio" value="yes" data-aria-controls="conditional-safetyRisksRadio">
+                                        <label class="govuk-label govuk-radios__label" for="safetyRisksRadio">Yes</label>
+                                    </div>
+                                    <div class="govuk-radios__conditional govuk-radios__conditional--hidden"
+                                    id="conditional-safetyRisksRadio">
+                                        <div class="govuk-form-group">
+                                            <label class="govuk-label" for="safety-risks-details">Health and safety risks (LPA details)</label>
+                                            <textarea class="govuk-textarea"
+                                            id="safety-risks-details" name="safetyRisksDetails" rows="3"></textarea>
+                                        </div>
+                                    </div>
+                                    <div class="govuk-radios__item">
+                                        <input class="govuk-radios__input" id="safetyRisksRadio-2" name="safetyRisksRadio"
+                                        type="radio" value="no" checked>
+                                        <label class="govuk-label govuk-radios__label" for="safetyRisksRadio-2">No</label>
                                     </div>
                                 </div>
-                                <div class="govuk-radios__item">
-                                    <input class="govuk-radios__input" id="safetyRisksRadio-2" name="safetyRisksRadio"
-                                    type="radio" value="no" checked>
-                                    <label class="govuk-label govuk-radios__label" for="safetyRisksRadio-2">No</label>
-                                </div>
-                            </div>
+                            </fieldset>
                         </div>
                         <button type="submit" data-prevent-double-click="true" class="govuk-button"
                         data-module="govuk-button">Continue</button>
@@ -50,33 +54,37 @@ exports[`safety-risks GET /change/:source should render changeSafetyRisksAccess 
         <div class="govuk-grid-column-two-thirds">
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full"><span class="govuk-caption-l govuk-!-margin-bottom-3">Appeal 351062</span>
-                    <h1                     class="govuk-heading-l govuk-!-margin-bottom-3">Change the site health and safety risks (LPA answer)</h1>
                 </div>
             </div>
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full">
                     <form method="POST" novalidate="novalidate">
                         <div class="govuk-form-group">
-                            <div class="govuk-radios" data-module="govuk-radios">
-                                <div class="govuk-radios__item">
-                                    <input class="govuk-radios__input" id="safetyRisksRadio" name="safetyRisksRadio"
-                                    type="radio" value="yes" data-aria-controls="conditional-safetyRisksRadio">
-                                    <label class="govuk-label govuk-radios__label" for="safetyRisksRadio">Yes</label>
-                                </div>
-                                <div class="govuk-radios__conditional govuk-radios__conditional--hidden"
-                                id="conditional-safetyRisksRadio">
-                                    <div class="govuk-form-group">
-                                        <label class="govuk-label" for="safety-risks-details">Health and safety risks (LPA details)</label>
-                                        <textarea class="govuk-textarea"
-                                        id="safety-risks-details" name="safetyRisksDetails" rows="3"></textarea>
+                            <fieldset class="govuk-fieldset">
+                                <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+                                    <h1 class="govuk-fieldset__heading"> Change the site health and safety risks (LPA answer)</h1>
+                                </legend>
+                                <div class="govuk-radios" data-module="govuk-radios">
+                                    <div class="govuk-radios__item">
+                                        <input class="govuk-radios__input" id="safetyRisksRadio" name="safetyRisksRadio"
+                                        type="radio" value="yes" data-aria-controls="conditional-safetyRisksRadio">
+                                        <label class="govuk-label govuk-radios__label" for="safetyRisksRadio">Yes</label>
+                                    </div>
+                                    <div class="govuk-radios__conditional govuk-radios__conditional--hidden"
+                                    id="conditional-safetyRisksRadio">
+                                        <div class="govuk-form-group">
+                                            <label class="govuk-label" for="safety-risks-details">Health and safety risks (LPA details)</label>
+                                            <textarea class="govuk-textarea"
+                                            id="safety-risks-details" name="safetyRisksDetails" rows="3"></textarea>
+                                        </div>
+                                    </div>
+                                    <div class="govuk-radios__item">
+                                        <input class="govuk-radios__input" id="safetyRisksRadio-2" name="safetyRisksRadio"
+                                        type="radio" value="no" checked>
+                                        <label class="govuk-label govuk-radios__label" for="safetyRisksRadio-2">No</label>
                                     </div>
                                 </div>
-                                <div class="govuk-radios__item">
-                                    <input class="govuk-radios__input" id="safetyRisksRadio-2" name="safetyRisksRadio"
-                                    type="radio" value="no" checked>
-                                    <label class="govuk-label govuk-radios__label" for="safetyRisksRadio-2">No</label>
-                                </div>
-                            </div>
+                            </fieldset>
                         </div>
                         <button type="submit" data-prevent-double-click="true" class="govuk-button"
                         data-module="govuk-button">Continue</button>
@@ -94,32 +102,36 @@ exports[`safety-risks GET /change/:source should render changeSafetyRisksAccess 
         <div class="govuk-grid-column-two-thirds">
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full"><span class="govuk-caption-l govuk-!-margin-bottom-3">Appeal 351062</span>
-                    <h1                     class="govuk-heading-l govuk-!-margin-bottom-3">Change the site health and safety risks (appellant answer)</h1>
                 </div>
             </div>
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full">
                     <form method="POST" novalidate="novalidate">
                         <div class="govuk-form-group">
-                            <div class="govuk-radios" data-module="govuk-radios">
-                                <div class="govuk-radios__item">
-                                    <input class="govuk-radios__input" id="safetyRisksRadio" name="safetyRisksRadio"
-                                    type="radio" value="yes" checked data-aria-controls="conditional-safetyRisksRadio">
-                                    <label class="govuk-label govuk-radios__label" for="safetyRisksRadio">Yes</label>
-                                </div>
-                                <div class="govuk-radios__conditional" id="conditional-safetyRisksRadio">
-                                    <div class="govuk-form-group">
-                                        <label class="govuk-label" for="safety-risks-details">Health and safety risks (appellant details)</label>
-                                        <textarea class="govuk-textarea"
-                                        id="safety-risks-details" name="safetyRisksDetails" rows="3">Dogs on site</textarea>
+                            <fieldset class="govuk-fieldset">
+                                <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+                                    <h1 class="govuk-fieldset__heading"> Change the site health and safety risks (appellant answer)</h1>
+                                </legend>
+                                <div class="govuk-radios" data-module="govuk-radios">
+                                    <div class="govuk-radios__item">
+                                        <input class="govuk-radios__input" id="safetyRisksRadio" name="safetyRisksRadio"
+                                        type="radio" value="yes" checked data-aria-controls="conditional-safetyRisksRadio">
+                                        <label class="govuk-label govuk-radios__label" for="safetyRisksRadio">Yes</label>
+                                    </div>
+                                    <div class="govuk-radios__conditional" id="conditional-safetyRisksRadio">
+                                        <div class="govuk-form-group">
+                                            <label class="govuk-label" for="safety-risks-details">Health and safety risks (appellant details)</label>
+                                            <textarea class="govuk-textarea"
+                                            id="safety-risks-details" name="safetyRisksDetails" rows="3">Dogs on site</textarea>
+                                        </div>
+                                    </div>
+                                    <div class="govuk-radios__item">
+                                        <input class="govuk-radios__input" id="safetyRisksRadio-2" name="safetyRisksRadio"
+                                        type="radio" value="no">
+                                        <label class="govuk-label govuk-radios__label" for="safetyRisksRadio-2">No</label>
                                     </div>
                                 </div>
-                                <div class="govuk-radios__item">
-                                    <input class="govuk-radios__input" id="safetyRisksRadio-2" name="safetyRisksRadio"
-                                    type="radio" value="no">
-                                    <label class="govuk-label govuk-radios__label" for="safetyRisksRadio-2">No</label>
-                                </div>
-                            </div>
+                            </fieldset>
                         </div>
                         <button type="submit" data-prevent-double-click="true" class="govuk-button"
                         data-module="govuk-button">Continue</button>
@@ -137,32 +149,36 @@ exports[`safety-risks GET /change/:source should render changeSafetyRisksAccess 
         <div class="govuk-grid-column-two-thirds">
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full"><span class="govuk-caption-l govuk-!-margin-bottom-3">Appeal 351062</span>
-                    <h1                     class="govuk-heading-l govuk-!-margin-bottom-3">Change the site health and safety risks (appellant answer)</h1>
                 </div>
             </div>
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full">
                     <form method="POST" novalidate="novalidate">
                         <div class="govuk-form-group">
-                            <div class="govuk-radios" data-module="govuk-radios">
-                                <div class="govuk-radios__item">
-                                    <input class="govuk-radios__input" id="safetyRisksRadio" name="safetyRisksRadio"
-                                    type="radio" value="yes" checked data-aria-controls="conditional-safetyRisksRadio">
-                                    <label class="govuk-label govuk-radios__label" for="safetyRisksRadio">Yes</label>
-                                </div>
-                                <div class="govuk-radios__conditional" id="conditional-safetyRisksRadio">
-                                    <div class="govuk-form-group">
-                                        <label class="govuk-label" for="safety-risks-details">Health and safety risks (appellant details)</label>
-                                        <textarea class="govuk-textarea"
-                                        id="safety-risks-details" name="safetyRisksDetails" rows="3">Dogs on site</textarea>
+                            <fieldset class="govuk-fieldset">
+                                <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+                                    <h1 class="govuk-fieldset__heading"> Change the site health and safety risks (appellant answer)</h1>
+                                </legend>
+                                <div class="govuk-radios" data-module="govuk-radios">
+                                    <div class="govuk-radios__item">
+                                        <input class="govuk-radios__input" id="safetyRisksRadio" name="safetyRisksRadio"
+                                        type="radio" value="yes" checked data-aria-controls="conditional-safetyRisksRadio">
+                                        <label class="govuk-label govuk-radios__label" for="safetyRisksRadio">Yes</label>
+                                    </div>
+                                    <div class="govuk-radios__conditional" id="conditional-safetyRisksRadio">
+                                        <div class="govuk-form-group">
+                                            <label class="govuk-label" for="safety-risks-details">Health and safety risks (appellant details)</label>
+                                            <textarea class="govuk-textarea"
+                                            id="safety-risks-details" name="safetyRisksDetails" rows="3">Dogs on site</textarea>
+                                        </div>
+                                    </div>
+                                    <div class="govuk-radios__item">
+                                        <input class="govuk-radios__input" id="safetyRisksRadio-2" name="safetyRisksRadio"
+                                        type="radio" value="no">
+                                        <label class="govuk-label govuk-radios__label" for="safetyRisksRadio-2">No</label>
                                     </div>
                                 </div>
-                                <div class="govuk-radios__item">
-                                    <input class="govuk-radios__input" id="safetyRisksRadio-2" name="safetyRisksRadio"
-                                    type="radio" value="no">
-                                    <label class="govuk-label govuk-radios__label" for="safetyRisksRadio-2">No</label>
-                                </div>
-                            </div>
+                            </fieldset>
                         </div>
                         <button type="submit" data-prevent-double-click="true" class="govuk-button"
                         data-module="govuk-button">Continue</button>
@@ -191,32 +207,36 @@ exports[`safety-risks POST /change/:source should re-render changeSafetyRisksAcc
             </div>
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full"><span class="govuk-caption-l govuk-!-margin-bottom-3">Appeal 351062</span>
-                    <h1                     class="govuk-heading-l govuk-!-margin-bottom-3">Change the site health and safety risks (LPA answer)</h1>
                 </div>
             </div>
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full">
                     <form method="POST" novalidate="novalidate">
                         <div class="govuk-form-group">
-                            <div class="govuk-radios" data-module="govuk-radios">
-                                <div class="govuk-radios__item">
-                                    <input class="govuk-radios__input" id="safetyRisksRadio" name="safetyRisksRadio"
-                                    type="radio" value="yes" checked data-aria-controls="conditional-safetyRisksRadio">
-                                    <label class="govuk-label govuk-radios__label" for="safetyRisksRadio">Yes</label>
-                                </div>
-                                <div class="govuk-radios__conditional" id="conditional-safetyRisksRadio">
-                                    <div class="govuk-form-group">
-                                        <label class="govuk-label" for="safety-risks-details">Health and safety risks (LPA details)</label>
-                                        <textarea class="govuk-textarea"
-                                        id="safety-risks-details" name="safetyRisksDetails" rows="3"></textarea>
+                            <fieldset class="govuk-fieldset">
+                                <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+                                    <h1 class="govuk-fieldset__heading"> Change the site health and safety risks (LPA answer)</h1>
+                                </legend>
+                                <div class="govuk-radios" data-module="govuk-radios">
+                                    <div class="govuk-radios__item">
+                                        <input class="govuk-radios__input" id="safetyRisksRadio" name="safetyRisksRadio"
+                                        type="radio" value="yes" checked data-aria-controls="conditional-safetyRisksRadio">
+                                        <label class="govuk-label govuk-radios__label" for="safetyRisksRadio">Yes</label>
+                                    </div>
+                                    <div class="govuk-radios__conditional" id="conditional-safetyRisksRadio">
+                                        <div class="govuk-form-group">
+                                            <label class="govuk-label" for="safety-risks-details">Health and safety risks (LPA details)</label>
+                                            <textarea class="govuk-textarea"
+                                            id="safety-risks-details" name="safetyRisksDetails" rows="3"></textarea>
+                                        </div>
+                                    </div>
+                                    <div class="govuk-radios__item">
+                                        <input class="govuk-radios__input" id="safetyRisksRadio-2" name="safetyRisksRadio"
+                                        type="radio" value="no">
+                                        <label class="govuk-label govuk-radios__label" for="safetyRisksRadio-2">No</label>
                                     </div>
                                 </div>
-                                <div class="govuk-radios__item">
-                                    <input class="govuk-radios__input" id="safetyRisksRadio-2" name="safetyRisksRadio"
-                                    type="radio" value="no">
-                                    <label class="govuk-label govuk-radios__label" for="safetyRisksRadio-2">No</label>
-                                </div>
-                            </div>
+                            </fieldset>
                         </div>
                         <button type="submit" data-prevent-double-click="true" class="govuk-button"
                         data-module="govuk-button">Continue</button>
@@ -245,32 +265,36 @@ exports[`safety-risks POST /change/:source should re-render changeSafetyRisksAcc
             </div>
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full"><span class="govuk-caption-l govuk-!-margin-bottom-3">Appeal 351062</span>
-                    <h1                     class="govuk-heading-l govuk-!-margin-bottom-3">Change the site health and safety risks (LPA answer)</h1>
                 </div>
             </div>
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full">
                     <form method="POST" novalidate="novalidate">
                         <div class="govuk-form-group">
-                            <div class="govuk-radios" data-module="govuk-radios">
-                                <div class="govuk-radios__item">
-                                    <input class="govuk-radios__input" id="safetyRisksRadio" name="safetyRisksRadio"
-                                    type="radio" value="yes" checked data-aria-controls="conditional-safetyRisksRadio">
-                                    <label class="govuk-label govuk-radios__label" for="safetyRisksRadio">Yes</label>
-                                </div>
-                                <div class="govuk-radios__conditional" id="conditional-safetyRisksRadio">
-                                    <div class="govuk-form-group">
-                                        <label class="govuk-label" for="safety-risks-details">Health and safety risks (LPA details)</label>
-                                        <textarea class="govuk-textarea"
-                                        id="safety-risks-details" name="safetyRisksDetails" rows="3">aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa</textarea>
+                            <fieldset class="govuk-fieldset">
+                                <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+                                    <h1 class="govuk-fieldset__heading"> Change the site health and safety risks (LPA answer)</h1>
+                                </legend>
+                                <div class="govuk-radios" data-module="govuk-radios">
+                                    <div class="govuk-radios__item">
+                                        <input class="govuk-radios__input" id="safetyRisksRadio" name="safetyRisksRadio"
+                                        type="radio" value="yes" checked data-aria-controls="conditional-safetyRisksRadio">
+                                        <label class="govuk-label govuk-radios__label" for="safetyRisksRadio">Yes</label>
+                                    </div>
+                                    <div class="govuk-radios__conditional" id="conditional-safetyRisksRadio">
+                                        <div class="govuk-form-group">
+                                            <label class="govuk-label" for="safety-risks-details">Health and safety risks (LPA details)</label>
+                                            <textarea class="govuk-textarea"
+                                            id="safety-risks-details" name="safetyRisksDetails" rows="3">aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa</textarea>
+                                        </div>
+                                    </div>
+                                    <div class="govuk-radios__item">
+                                        <input class="govuk-radios__input" id="safetyRisksRadio-2" name="safetyRisksRadio"
+                                        type="radio" value="no">
+                                        <label class="govuk-label govuk-radios__label" for="safetyRisksRadio-2">No</label>
                                     </div>
                                 </div>
-                                <div class="govuk-radios__item">
-                                    <input class="govuk-radios__input" id="safetyRisksRadio-2" name="safetyRisksRadio"
-                                    type="radio" value="no">
-                                    <label class="govuk-label govuk-radios__label" for="safetyRisksRadio-2">No</label>
-                                </div>
-                            </div>
+                            </fieldset>
                         </div>
                         <button type="submit" data-prevent-double-click="true" class="govuk-button"
                         data-module="govuk-button">Continue</button>

--- a/appeals/web/src/server/appeals/appeal-details/safety-risks/safety-risks.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/safety-risks/safety-risks.mapper.js
@@ -27,11 +27,12 @@ export const changeSafetyRisksPage = (appealData, storedSessionData, backLinkUrl
 		title: `Change the site health and safety risks (${formattedSource} answer)`,
 		backLinkUrl: backLinkUrl,
 		preHeading: `Appeal ${shortAppealReference}`,
-		heading: `Change the site health and safety risks (${formattedSource} answer)`,
 		pageComponents: [
 			yesNoInput({
 				name: 'safetyRisksRadio',
 				value: currentRadioValue,
+				legendText: `Change the site health and safety risks (${formattedSource} answer)`,
+				legendIsPageHeading: true,
 				yesConditional: {
 					id: 'safety-risks-details',
 					name: 'safetyRisksDetails',

--- a/appeals/web/src/server/appeals/appeal-details/withdrawal/__tests__/__snapshots__/withdrawal.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/withdrawal/__tests__/__snapshots__/withdrawal.test.js.snap
@@ -6,30 +6,34 @@ exports[`withdrawal GET /redaction-status should render the redaction status pag
         <div class="govuk-grid-column-two-thirds">
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full"><span class="govuk-caption-l govuk-!-margin-bottom-3">Appeal 351062</span>
-                    <h1                     class="govuk-heading-l govuk-!-margin-bottom-3">What is the redaction status of this document?</h1>
                 </div>
             </div>
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full">
                     <form method="POST" novalidate="novalidate">
                         <div class="govuk-form-group">
-                            <div class="govuk-radios" data-module="govuk-radios">
-                                <div class="govuk-radios__item">
-                                    <input class="govuk-radios__input" id="withdrawal-redaction-status" name="withdrawal-redaction-status"
-                                    type="radio" value="redacted">
-                                    <label class="govuk-label govuk-radios__label" for="withdrawal-redaction-status">Redacted</label>
+                            <fieldset class="govuk-fieldset">
+                                <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+                                    <h1 class="govuk-fieldset__heading"> What is the redaction status of this document?</h1>
+                                </legend>
+                                <div class="govuk-radios" data-module="govuk-radios">
+                                    <div class="govuk-radios__item">
+                                        <input class="govuk-radios__input" id="withdrawal-redaction-status" name="withdrawal-redaction-status"
+                                        type="radio" value="redacted">
+                                        <label class="govuk-label govuk-radios__label" for="withdrawal-redaction-status">Redacted</label>
+                                    </div>
+                                    <div class="govuk-radios__item">
+                                        <input class="govuk-radios__input" id="withdrawal-redaction-status-2"
+                                        name="withdrawal-redaction-status" type="radio" value="unredacted" checked>
+                                        <label class="govuk-label govuk-radios__label" for="withdrawal-redaction-status-2">Unredacted</label>
+                                    </div>
+                                    <div class="govuk-radios__item">
+                                        <input class="govuk-radios__input" id="withdrawal-redaction-status-3"
+                                        name="withdrawal-redaction-status" type="radio" value="no redaction required">
+                                        <label class="govuk-label govuk-radios__label" for="withdrawal-redaction-status-3">No redaction required</label>
+                                    </div>
                                 </div>
-                                <div class="govuk-radios__item">
-                                    <input class="govuk-radios__input" id="withdrawal-redaction-status-2"
-                                    name="withdrawal-redaction-status" type="radio" value="unredacted" checked>
-                                    <label class="govuk-label govuk-radios__label" for="withdrawal-redaction-status-2">Unredacted</label>
-                                </div>
-                                <div class="govuk-radios__item">
-                                    <input class="govuk-radios__input" id="withdrawal-redaction-status-3"
-                                    name="withdrawal-redaction-status" type="radio" value="no redaction required">
-                                    <label class="govuk-label govuk-radios__label" for="withdrawal-redaction-status-3">No redaction required</label>
-                                </div>
-                            </div>
+                            </fieldset>
                         </div>
                         <button type="submit" data-prevent-double-click="true" class="govuk-button"
                         data-module="govuk-button">Continue</button>
@@ -289,30 +293,34 @@ exports[`withdrawal POST /redaction-status should re-render the redaction status
             </div>
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full"><span class="govuk-caption-l govuk-!-margin-bottom-3">Appeal 351062</span>
-                    <h1                     class="govuk-heading-l govuk-!-margin-bottom-3">What is the redaction status of this document?</h1>
                 </div>
             </div>
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full">
                     <form method="POST" novalidate="novalidate">
                         <div class="govuk-form-group">
-                            <div class="govuk-radios" data-module="govuk-radios">
-                                <div class="govuk-radios__item">
-                                    <input class="govuk-radios__input" id="withdrawal-redaction-status" name="withdrawal-redaction-status"
-                                    type="radio" value="redacted">
-                                    <label class="govuk-label govuk-radios__label" for="withdrawal-redaction-status">Redacted</label>
+                            <fieldset class="govuk-fieldset">
+                                <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+                                    <h1 class="govuk-fieldset__heading"> What is the redaction status of this document?</h1>
+                                </legend>
+                                <div class="govuk-radios" data-module="govuk-radios">
+                                    <div class="govuk-radios__item">
+                                        <input class="govuk-radios__input" id="withdrawal-redaction-status" name="withdrawal-redaction-status"
+                                        type="radio" value="redacted">
+                                        <label class="govuk-label govuk-radios__label" for="withdrawal-redaction-status">Redacted</label>
+                                    </div>
+                                    <div class="govuk-radios__item">
+                                        <input class="govuk-radios__input" id="withdrawal-redaction-status-2"
+                                        name="withdrawal-redaction-status" type="radio" value="unredacted" checked>
+                                        <label class="govuk-label govuk-radios__label" for="withdrawal-redaction-status-2">Unredacted</label>
+                                    </div>
+                                    <div class="govuk-radios__item">
+                                        <input class="govuk-radios__input" id="withdrawal-redaction-status-3"
+                                        name="withdrawal-redaction-status" type="radio" value="no redaction required">
+                                        <label class="govuk-label govuk-radios__label" for="withdrawal-redaction-status-3">No redaction required</label>
+                                    </div>
                                 </div>
-                                <div class="govuk-radios__item">
-                                    <input class="govuk-radios__input" id="withdrawal-redaction-status-2"
-                                    name="withdrawal-redaction-status" type="radio" value="unredacted" checked>
-                                    <label class="govuk-label govuk-radios__label" for="withdrawal-redaction-status-2">Unredacted</label>
-                                </div>
-                                <div class="govuk-radios__item">
-                                    <input class="govuk-radios__input" id="withdrawal-redaction-status-3"
-                                    name="withdrawal-redaction-status" type="radio" value="no redaction required">
-                                    <label class="govuk-label govuk-radios__label" for="withdrawal-redaction-status-3">No redaction required</label>
-                                </div>
-                            </div>
+                            </fieldset>
                         </div>
                         <button type="submit" data-prevent-double-click="true" class="govuk-button"
                         data-module="govuk-button">Continue</button>

--- a/appeals/web/src/server/appeals/appeal-details/withdrawal/withdrawal.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/withdrawal/withdrawal.mapper.js
@@ -251,13 +251,19 @@ export function withdrawalDocumentRedactionStatusPage(
 		title: `What is the redaction status of this document? - ${shortAppealReference}`,
 		backLinkUrl: `/appeals-service/appeal-details/${appealDetails.appealId}/withdrawal/withdrawal-request-date`,
 		preHeading: `Appeal ${shortAppealReference}`,
-		heading: 'What is the redaction status of this document?',
 		pageComponents: [
 			{
 				type: 'radios',
 				parameters: {
 					name: 'withdrawal-redaction-status',
 					idPrefix: 'withdrawal-redaction-status',
+					fieldset: {
+						legend: {
+							text: 'What is the redaction status of this document?',
+							isPageHeading: true,
+							classes: 'govuk-fieldset__legend--l'
+						}
+					},
 					items: redactionStatusesItems
 				}
 			}

--- a/appeals/web/src/server/lib/mappers/components/page-components/date.js
+++ b/appeals/web/src/server/lib/mappers/components/page-components/date.js
@@ -12,10 +12,19 @@ import { kebabCase } from 'lodash-es';
  * @param {string} [params.namePrefix]
  * @param {DayMonthYearHourMinute|null} [params.value]
  * @param {string} [params.legendText]
+ * @param {boolean} [params.legendIsPageHeading=false]
  * @param {string} [params.hint]
  * @returns {PageComponent}
  */
-export function dateInput({ name, id, namePrefix, value, legendText, hint }) {
+export function dateInput({
+	name,
+	id,
+	namePrefix,
+	value,
+	legendText,
+	legendIsPageHeading = false,
+	hint
+}) {
 	const formattedNamePrefix = namePrefix ? `${namePrefix}-` : '';
 
 	/** @type {PageComponent} */
@@ -53,7 +62,7 @@ export function dateInput({ name, id, namePrefix, value, legendText, hint }) {
 		component.parameters.fieldset = {
 			legend: {
 				text: legendText,
-				isPageHeading: false,
+				isPageHeading: legendIsPageHeading,
 				classes: 'govuk-fieldset__legend--l'
 			}
 		};

--- a/appeals/web/src/server/lib/mappers/components/page-components/radio.js
+++ b/appeals/web/src/server/lib/mappers/components/page-components/radio.js
@@ -5,13 +5,14 @@
 /**
  * @param {RadiosPageComponent} component
  * @param {string} legendText
+ * @param {boolean} [isPageHeading=false]
  * @returns
  */
-function addFieldsetLegendText(component, legendText) {
+function addFieldsetLegendText(component, legendText, isPageHeading = false) {
 	component.parameters.fieldset = {
 		legend: {
 			text: legendText,
-			isPageHeading: false,
+			isPageHeading,
 			classes: 'govuk-fieldset__legend--l'
 		}
 	};
@@ -56,18 +57,22 @@ export function conditionalFormatter(id, name, hint, details, type = 'textarea')
  * @param {string} [params.id]
  * @param {string|boolean|null} [params.value]
  * @param {string} [params.legendText]
+ * @param {boolean} [params.legendIsPageHeading]
  * @param {ConditionalParams} [params.yesConditional]
  * @param {string} [params.customYesLabel]
  * @param {string} [params.customNoLabel]
+ * @param {string} [params.hint]
  * @returns {RadiosPageComponent}
  */
 export function yesNoInput({
 	name,
 	value,
 	legendText,
+	legendIsPageHeading = false,
 	yesConditional,
 	customYesLabel,
-	customNoLabel
+	customNoLabel,
+	hint
 }) {
 	/** @type {RadioItem} */
 	const yes = {
@@ -101,7 +106,10 @@ export function yesNoInput({
 		}
 	};
 	if (legendText) {
-		addFieldsetLegendText(component, legendText);
+		addFieldsetLegendText(component, legendText, legendIsPageHeading);
+	}
+	if (hint) {
+		component.parameters.hint = { text: hint };
 	}
 	return component;
 }
@@ -113,9 +121,17 @@ export function yesNoInput({
  * @param {string} [params.idPrefix]
  * @param {string|null} [params.value]
  * @param {string} [params.legendText]
+ * @param {boolean} [params.legendIsPageHeading]
  * @returns {PageComponent}
  */
-export function radiosInput({ name, items, idPrefix, value, legendText }) {
+export function radiosInput({
+	name,
+	items,
+	idPrefix,
+	value,
+	legendText,
+	legendIsPageHeading = false
+}) {
 	/** @type {PageComponent} */
 	const component = {
 		type: 'radios',
@@ -127,7 +143,7 @@ export function radiosInput({ name, items, idPrefix, value, legendText }) {
 		}
 	};
 	if (legendText) {
-		addFieldsetLegendText(component, legendText);
+		addFieldsetLegendText(component, legendText, legendIsPageHeading);
 	}
 	return component;
 }

--- a/appeals/web/src/server/lib/mappers/components/page-components/textarea.js
+++ b/appeals/web/src/server/lib/mappers/components/page-components/textarea.js
@@ -5,11 +5,21 @@ import { kebabCase } from 'lodash-es';
  * @param {string} params.name
  * @param {string} [params.id]
  * @param {string|null} [params.value]
+ * @param {string} [params.labelText]
+ * @param {boolean} [params.labelIsPageHeading]
+ * @param {string} [params.labelClasses]
  * @param {boolean} [params.readonly]
- * @param {{ text: string, classes: string }} [params.label]
  * @returns {PageComponent}
  */
-export function textareaInput({ name, id, value, readonly, label }) {
+export function textareaInput({
+	name,
+	id,
+	value,
+	labelText,
+	labelIsPageHeading = false,
+	labelClasses,
+	readonly
+}) {
 	/** @type {PageComponent} */
 	const component = {
 		type: 'textarea',
@@ -17,7 +27,11 @@ export function textareaInput({ name, id, value, readonly, label }) {
 			name,
 			id: id || kebabCase(name),
 			value,
-			label,
+			label: labelText && {
+				text: labelText,
+				isPageHeading: labelIsPageHeading,
+				classes: labelClasses || 'govuk-label--l'
+			},
 			attributes: { ...(readonly && { readonly }) }
 		}
 	};

--- a/appeals/web/src/server/lib/mappers/data/lpa-questionnaire/submappers/map-review-outcome.js
+++ b/appeals/web/src/server/lib/mappers/data/lpa-questionnaire/submappers/map-review-outcome.js
@@ -33,6 +33,12 @@ export const mapReviewOutcome = ({ lpaQuestionnaireData, session }) => ({
 					name: 'review-outcome',
 					idPrefix: 'review-outcome',
 					value: lpaQuestionnaireData.validation?.outcome,
+					fieldset: {
+						legend: {
+							text: 'What is the outcome of your review?',
+							classes: 'govuk-fieldset__legend--m'
+						}
+					},
 					items: [
 						{
 							value: 'complete',


### PR DESCRIPTION
## Describe your changes

### Accessibility
Making global use of the `isPageHeading` params in govuk input components to create better relationship between heading and form content. Headings moved into either fieldset legends or labels. Mostly applies to the one-thing-per-page pattern, where the heading is the question.

## Issue ticket number and link

[A2-1504 - Adaptability - Info and relationships - Related Form Elements Not Grouped](https://pins-ds.atlassian.net.mcas.ms/browse/A2-1504)

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)
