### PR TITLE
fix(api): importing duplicate documents

### DIFF
--- a/appeals/api/src/server/endpoints/integrations/integrations.mappers.js
+++ b/appeals/api/src/server/endpoints/integrations/integrations.mappers.js
@@ -32,6 +32,7 @@ import {
 import { APPEAL_CASE_STAGE, SERVICE_USER_TYPE } from 'pins-data-model';
 import { FOLDERS } from '@pins/appeals/constants/documents.js';
 import { mapSiteVisitOut } from './integrations.mappers/site-visit.mapper.js';
+import { renameDuplicateDocuments } from './integrations.utils.js';
 
 /** @typedef {import('@pins/appeals.api').Schema.Appeal} Appeal */
 /** @typedef {import('@pins/appeals.api').Schema.ServiceUser} ServiceUser */
@@ -113,7 +114,7 @@ const mapAppealSubmission = (data) => {
 		}
 	};
 
-	const documentsInput = (documents || []).map((document) =>
+	const documentsInput = (renameDuplicateDocuments(documents) || []).map((document) =>
 		mappers.mapDocumentIn(document, APPEAL_CASE_STAGE.APPELLANT_CASE)
 	);
 
@@ -145,7 +146,7 @@ const mapQuestionnaireSubmission = (data) => {
 		}
 	};
 
-	const documentsInput = (documents || []).map((document) =>
+	const documentsInput = (renameDuplicateDocuments(documents) || []).map((document) =>
 		mappers.mapDocumentIn(document, APPEAL_CASE_STAGE.LPA_QUESTIONNAIRE)
 	);
 

--- a/appeals/api/src/server/endpoints/integrations/integrations.utils.js
+++ b/appeals/api/src/server/endpoints/integrations/integrations.utils.js
@@ -1,0 +1,45 @@
+import Path from 'node:path';
+
+/** @typedef {import('pins-data-model').Schemas.AppellantSubmissionCommand['documents'][number]} AppellantSubmissionDocument */
+/** @typedef {import('pins-data-model').Schemas.LPAQuestionnaireCommand['documents'][number]} LPAQuestionnaireCommandDocument */
+
+/**
+ *
+ * @param {(AppellantSubmissionDocument|LPAQuestionnaireCommandDocument)[]} documents
+ * @returns {(AppellantSubmissionDocument|LPAQuestionnaireCommandDocument)[]}
+ */
+export const renameDuplicateDocuments = (documents) => {
+	const seen = new Set();
+
+	return documents.map((document) => {
+		let key = `${document.documentType}_${document.originalFilename}`;
+
+		if (!seen.has(key)) {
+			seen.add(key);
+			return document;
+		}
+
+		const parsedDocName = Path.parse(document.originalFilename);
+		const extension = parsedDocName.ext;
+		const originalName = parsedDocName.name;
+
+		let counter = 1;
+		let newFilename;
+
+		do {
+			newFilename = `${originalName}_${counter}${extension}`;
+			key = `${document.documentType}_${newFilename}`;
+			counter++;
+
+			if (counter > 1000) {
+				throw new Error('Error processing document names on import, too many iterations...');
+			}
+		} while (seen.has(key));
+
+		seen.add(key);
+		return {
+			...document,
+			originalFilename: newFilename
+		};
+	});
+};


### PR DESCRIPTION
Fixes import of duplicate documents, by appending a `_n` suffix in the file name.

Example input:
`
[
	{ documentType: 'A', originalFilename: 'name.pdf' },
	{ documentType: 'A', originalFilename: 'name.pdf' },
	{ documentType: 'A', originalFilename: 'name.pdf' }
]
`

Expected output:
`
[
	{ documentType: 'A', originalFilename: 'name.pdf' },
	{ documentType: 'A', originalFilename: 'name_1.pdf' },
	{ documentType: 'A', originalFilename: 'name_2.pdf' }
]
`


## Issue ticket number and link

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [ ] I have performed a self-review of my own code
- [ ] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [ ] I have referenced the ticket number above
- [ ] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
