### PR TITLE
feat(web): update summary list row document lists to numbered lists

### DIFF
--- a/appeals/web/src/server/appeals/appeal-details/appellant-case/__tests__/__snapshots__/appellant-case.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/appellant-case/__tests__/__snapshots__/appellant-case.test.js.snap
@@ -259,16 +259,12 @@ exports[`appellant-case GET /appellant-case should render a "Inspector access (a
                     <dl class="govuk-summary-list pins-summary-list--fullwidth-value">
                         <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key govuk-visually-hidden"> Additional documents</dt>
                             <dd                             class="govuk-summary-list__value">
-                                <ul class="govuk-list">
-                                    <li class="govuk-!-margin-bottom-0 govuk-!-padding-bottom-2 pins-border-bottom"><a href='/documents/1/download/00c43c8c-829a-4aa8-883a-fd6fc1f52c3d/ph1.jpeg'
-                                        data-cy='document-00c43c8c-829a-4aa8-883a-fd6fc1f52c3d' target="_blank"
-                                        class="govuk-link">ph1.jpeg</a>
+                                <ol class="govuk-list govuk-list--number pins-file-list">
+                                    <li class="govuk-!-margin-bottom-0 govuk-!-padding-bottom-2 pins-border-bottom"><span><a href='/documents/1/download/00c43c8c-829a-4aa8-883a-fd6fc1f52c3d/ph1.jpeg' data-cy='document-00c43c8c-829a-4aa8-883a-fd6fc1f52c3d' target="_blank" class="govuk-link">ph1.jpeg</a></span>
                                     </li>
-                                    <li class="govuk-!-margin-bottom-0 govuk-!-padding-top-2 govuk-!-padding-bottom-2"><a href='/documents/1/download/a78446aa-167a-4bef-89b7-18bcb0da11c1/ph0.jpeg'
-                                        data-cy='document-a78446aa-167a-4bef-89b7-18bcb0da11c1' target="_blank"
-                                        class="govuk-link">ph0.jpeg</a>
+                                    <li class="govuk-!-margin-bottom-0 govuk-!-padding-top-2 govuk-!-padding-bottom-2"><span><a href='/documents/1/download/a78446aa-167a-4bef-89b7-18bcb0da11c1/ph0.jpeg' data-cy='document-a78446aa-167a-4bef-89b7-18bcb0da11c1' target="_blank" class="govuk-link">ph0.jpeg</a></span>
                                     </li>
-                                </ul>
+                                </ol>
                                 </dd>
                         </div>
                     </dl>
@@ -526,16 +522,12 @@ exports[`appellant-case GET /appellant-case should render a "LPA application ref
                     <dl class="govuk-summary-list pins-summary-list--fullwidth-value">
                         <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key govuk-visually-hidden"> Additional documents</dt>
                             <dd                             class="govuk-summary-list__value">
-                                <ul class="govuk-list">
-                                    <li class="govuk-!-margin-bottom-0 govuk-!-padding-bottom-2 pins-border-bottom"><a href='/documents/1/download/00c43c8c-829a-4aa8-883a-fd6fc1f52c3d/ph1.jpeg'
-                                        data-cy='document-00c43c8c-829a-4aa8-883a-fd6fc1f52c3d' target="_blank"
-                                        class="govuk-link">ph1.jpeg</a>
+                                <ol class="govuk-list govuk-list--number pins-file-list">
+                                    <li class="govuk-!-margin-bottom-0 govuk-!-padding-bottom-2 pins-border-bottom"><span><a href='/documents/1/download/00c43c8c-829a-4aa8-883a-fd6fc1f52c3d/ph1.jpeg' data-cy='document-00c43c8c-829a-4aa8-883a-fd6fc1f52c3d' target="_blank" class="govuk-link">ph1.jpeg</a></span>
                                     </li>
-                                    <li class="govuk-!-margin-bottom-0 govuk-!-padding-top-2 govuk-!-padding-bottom-2"><a href='/documents/1/download/a78446aa-167a-4bef-89b7-18bcb0da11c1/ph0.jpeg'
-                                        data-cy='document-a78446aa-167a-4bef-89b7-18bcb0da11c1' target="_blank"
-                                        class="govuk-link">ph0.jpeg</a>
+                                    <li class="govuk-!-margin-bottom-0 govuk-!-padding-top-2 govuk-!-padding-bottom-2"><span><a href='/documents/1/download/a78446aa-167a-4bef-89b7-18bcb0da11c1/ph0.jpeg' data-cy='document-a78446aa-167a-4bef-89b7-18bcb0da11c1' target="_blank" class="govuk-link">ph0.jpeg</a></span>
                                     </li>
-                                </ul>
+                                </ol>
                                 </dd>
                         </div>
                     </dl>
@@ -805,16 +797,12 @@ exports[`appellant-case GET /appellant-case should render a "Site area updated" 
                     <dl class="govuk-summary-list pins-summary-list--fullwidth-value">
                         <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key govuk-visually-hidden"> Additional documents</dt>
                             <dd                             class="govuk-summary-list__value">
-                                <ul class="govuk-list">
-                                    <li class="govuk-!-margin-bottom-0 govuk-!-padding-bottom-2 pins-border-bottom"><a href='/documents/1/download/00c43c8c-829a-4aa8-883a-fd6fc1f52c3d/ph1.jpeg'
-                                        data-cy='document-00c43c8c-829a-4aa8-883a-fd6fc1f52c3d' target="_blank"
-                                        class="govuk-link">ph1.jpeg</a>
+                                <ol class="govuk-list govuk-list--number pins-file-list">
+                                    <li class="govuk-!-margin-bottom-0 govuk-!-padding-bottom-2 pins-border-bottom"><span><a href='/documents/1/download/00c43c8c-829a-4aa8-883a-fd6fc1f52c3d/ph1.jpeg' data-cy='document-00c43c8c-829a-4aa8-883a-fd6fc1f52c3d' target="_blank" class="govuk-link">ph1.jpeg</a></span>
                                     </li>
-                                    <li class="govuk-!-margin-bottom-0 govuk-!-padding-top-2 govuk-!-padding-bottom-2"><a href='/documents/1/download/a78446aa-167a-4bef-89b7-18bcb0da11c1/ph0.jpeg'
-                                        data-cy='document-a78446aa-167a-4bef-89b7-18bcb0da11c1' target="_blank"
-                                        class="govuk-link">ph0.jpeg</a>
+                                    <li class="govuk-!-margin-bottom-0 govuk-!-padding-top-2 govuk-!-padding-bottom-2"><span><a href='/documents/1/download/a78446aa-167a-4bef-89b7-18bcb0da11c1/ph0.jpeg' data-cy='document-a78446aa-167a-4bef-89b7-18bcb0da11c1' target="_blank" class="govuk-link">ph0.jpeg</a></span>
                                     </li>
-                                </ul>
+                                </ol>
                                 </dd>
                         </div>
                     </dl>
@@ -1072,16 +1060,12 @@ exports[`appellant-case GET /appellant-case should render a "Site health and saf
                     <dl class="govuk-summary-list pins-summary-list--fullwidth-value">
                         <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key govuk-visually-hidden"> Additional documents</dt>
                             <dd                             class="govuk-summary-list__value">
-                                <ul class="govuk-list">
-                                    <li class="govuk-!-margin-bottom-0 govuk-!-padding-bottom-2 pins-border-bottom"><a href='/documents/1/download/00c43c8c-829a-4aa8-883a-fd6fc1f52c3d/ph1.jpeg'
-                                        data-cy='document-00c43c8c-829a-4aa8-883a-fd6fc1f52c3d' target="_blank"
-                                        class="govuk-link">ph1.jpeg</a>
+                                <ol class="govuk-list govuk-list--number pins-file-list">
+                                    <li class="govuk-!-margin-bottom-0 govuk-!-padding-bottom-2 pins-border-bottom"><span><a href='/documents/1/download/00c43c8c-829a-4aa8-883a-fd6fc1f52c3d/ph1.jpeg' data-cy='document-00c43c8c-829a-4aa8-883a-fd6fc1f52c3d' target="_blank" class="govuk-link">ph1.jpeg</a></span>
                                     </li>
-                                    <li class="govuk-!-margin-bottom-0 govuk-!-padding-top-2 govuk-!-padding-bottom-2"><a href='/documents/1/download/a78446aa-167a-4bef-89b7-18bcb0da11c1/ph0.jpeg'
-                                        data-cy='document-a78446aa-167a-4bef-89b7-18bcb0da11c1' target="_blank"
-                                        class="govuk-link">ph0.jpeg</a>
+                                    <li class="govuk-!-margin-bottom-0 govuk-!-padding-top-2 govuk-!-padding-bottom-2"><span><a href='/documents/1/download/a78446aa-167a-4bef-89b7-18bcb0da11c1/ph0.jpeg' data-cy='document-a78446aa-167a-4bef-89b7-18bcb0da11c1' target="_blank" class="govuk-link">ph0.jpeg</a></span>
                                     </li>
-                                </ul>
+                                </ol>
                                 </dd>
                         </div>
                     </dl>
@@ -1339,16 +1323,12 @@ exports[`appellant-case GET /appellant-case should render a "Site updated" notif
                     <dl class="govuk-summary-list pins-summary-list--fullwidth-value">
                         <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key govuk-visually-hidden"> Additional documents</dt>
                             <dd                             class="govuk-summary-list__value">
-                                <ul class="govuk-list">
-                                    <li class="govuk-!-margin-bottom-0 govuk-!-padding-bottom-2 pins-border-bottom"><a href='/documents/1/download/00c43c8c-829a-4aa8-883a-fd6fc1f52c3d/ph1.jpeg'
-                                        data-cy='document-00c43c8c-829a-4aa8-883a-fd6fc1f52c3d' target="_blank"
-                                        class="govuk-link">ph1.jpeg</a>
+                                <ol class="govuk-list govuk-list--number pins-file-list">
+                                    <li class="govuk-!-margin-bottom-0 govuk-!-padding-bottom-2 pins-border-bottom"><span><a href='/documents/1/download/00c43c8c-829a-4aa8-883a-fd6fc1f52c3d/ph1.jpeg' data-cy='document-00c43c8c-829a-4aa8-883a-fd6fc1f52c3d' target="_blank" class="govuk-link">ph1.jpeg</a></span>
                                     </li>
-                                    <li class="govuk-!-margin-bottom-0 govuk-!-padding-top-2 govuk-!-padding-bottom-2"><a href='/documents/1/download/a78446aa-167a-4bef-89b7-18bcb0da11c1/ph0.jpeg'
-                                        data-cy='document-a78446aa-167a-4bef-89b7-18bcb0da11c1' target="_blank"
-                                        class="govuk-link">ph0.jpeg</a>
+                                    <li class="govuk-!-margin-bottom-0 govuk-!-padding-top-2 govuk-!-padding-bottom-2"><span><a href='/documents/1/download/a78446aa-167a-4bef-89b7-18bcb0da11c1/ph0.jpeg' data-cy='document-a78446aa-167a-4bef-89b7-18bcb0da11c1' target="_blank" class="govuk-link">ph0.jpeg</a></span>
                                     </li>
-                                </ul>
+                                </ol>
                                 </dd>
                         </div>
                     </dl>
@@ -1618,16 +1598,12 @@ exports[`appellant-case GET /appellant-case should render a success notification
                     <dl class="govuk-summary-list pins-summary-list--fullwidth-value">
                         <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key govuk-visually-hidden"> Additional documents</dt>
                             <dd                             class="govuk-summary-list__value">
-                                <ul class="govuk-list">
-                                    <li class="govuk-!-margin-bottom-0 govuk-!-padding-bottom-2 pins-border-bottom"><a href='/documents/1/download/00c43c8c-829a-4aa8-883a-fd6fc1f52c3d/ph1.jpeg'
-                                        data-cy='document-00c43c8c-829a-4aa8-883a-fd6fc1f52c3d' target="_blank"
-                                        class="govuk-link">ph1.jpeg</a>
+                                <ol class="govuk-list govuk-list--number pins-file-list">
+                                    <li class="govuk-!-margin-bottom-0 govuk-!-padding-bottom-2 pins-border-bottom"><span><a href='/documents/1/download/00c43c8c-829a-4aa8-883a-fd6fc1f52c3d/ph1.jpeg' data-cy='document-00c43c8c-829a-4aa8-883a-fd6fc1f52c3d' target="_blank" class="govuk-link">ph1.jpeg</a></span>
                                     </li>
-                                    <li class="govuk-!-margin-bottom-0 govuk-!-padding-top-2 govuk-!-padding-bottom-2"><a href='/documents/1/download/a78446aa-167a-4bef-89b7-18bcb0da11c1/ph0.jpeg'
-                                        data-cy='document-a78446aa-167a-4bef-89b7-18bcb0da11c1' target="_blank"
-                                        class="govuk-link">ph0.jpeg</a>
+                                    <li class="govuk-!-margin-bottom-0 govuk-!-padding-top-2 govuk-!-padding-bottom-2"><span><a href='/documents/1/download/a78446aa-167a-4bef-89b7-18bcb0da11c1/ph0.jpeg' data-cy='document-a78446aa-167a-4bef-89b7-18bcb0da11c1' target="_blank" class="govuk-link">ph0.jpeg</a></span>
                                     </li>
-                                </ul>
+                                </ol>
                                 </dd>
                         </div>
                     </dl>
@@ -1967,16 +1943,12 @@ exports[`appellant-case GET /appellant-case should render review outcome form fi
                     <dl class="govuk-summary-list pins-summary-list--fullwidth-value">
                         <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key govuk-visually-hidden"> Additional documents</dt>
                             <dd                             class="govuk-summary-list__value">
-                                <ul class="govuk-list">
-                                    <li class="govuk-!-margin-bottom-0 govuk-!-padding-bottom-2 pins-border-bottom"><a href='/documents/1/download/00c43c8c-829a-4aa8-883a-fd6fc1f52c3d/ph1.jpeg'
-                                        data-cy='document-00c43c8c-829a-4aa8-883a-fd6fc1f52c3d' target="_blank"
-                                        class="govuk-link">ph1.jpeg</a>
+                                <ol class="govuk-list govuk-list--number pins-file-list">
+                                    <li class="govuk-!-margin-bottom-0 govuk-!-padding-bottom-2 pins-border-bottom"><span><a href='/documents/1/download/00c43c8c-829a-4aa8-883a-fd6fc1f52c3d/ph1.jpeg' data-cy='document-00c43c8c-829a-4aa8-883a-fd6fc1f52c3d' target="_blank" class="govuk-link">ph1.jpeg</a></span>
                                     </li>
-                                    <li class="govuk-!-margin-bottom-0 govuk-!-padding-top-2 govuk-!-padding-bottom-2"><a href='/documents/1/download/a78446aa-167a-4bef-89b7-18bcb0da11c1/ph0.jpeg'
-                                        data-cy='document-a78446aa-167a-4bef-89b7-18bcb0da11c1' target="_blank"
-                                        class="govuk-link">ph0.jpeg</a>
+                                    <li class="govuk-!-margin-bottom-0 govuk-!-padding-top-2 govuk-!-padding-bottom-2"><span><a href='/documents/1/download/a78446aa-167a-4bef-89b7-18bcb0da11c1/ph0.jpeg' data-cy='document-a78446aa-167a-4bef-89b7-18bcb0da11c1' target="_blank" class="govuk-link">ph0.jpeg</a></span>
                                     </li>
-                                </ul>
+                                </ol>
                                 </dd>
                         </div>
                     </dl>
@@ -2319,16 +2291,12 @@ exports[`appellant-case GET /appellant-case should render the appellant case pag
                     <dl class="govuk-summary-list pins-summary-list--fullwidth-value">
                         <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key govuk-visually-hidden"> Additional documents</dt>
                             <dd                             class="govuk-summary-list__value">
-                                <ul class="govuk-list">
-                                    <li class="govuk-!-margin-bottom-0 govuk-!-padding-bottom-2 pins-border-bottom"><a href='/documents/1/download/00c43c8c-829a-4aa8-883a-fd6fc1f52c3d/ph1.jpeg'
-                                        data-cy='document-00c43c8c-829a-4aa8-883a-fd6fc1f52c3d' target="_blank"
-                                        class="govuk-link">ph1.jpeg</a>
+                                <ol class="govuk-list govuk-list--number pins-file-list">
+                                    <li class="govuk-!-margin-bottom-0 govuk-!-padding-bottom-2 pins-border-bottom"><span><a href='/documents/1/download/00c43c8c-829a-4aa8-883a-fd6fc1f52c3d/ph1.jpeg' data-cy='document-00c43c8c-829a-4aa8-883a-fd6fc1f52c3d' target="_blank" class="govuk-link">ph1.jpeg</a></span>
                                     </li>
-                                    <li class="govuk-!-margin-bottom-0 govuk-!-padding-top-2 govuk-!-padding-bottom-2"><a href='/documents/1/download/a78446aa-167a-4bef-89b7-18bcb0da11c1/ph0.jpeg'
-                                        data-cy='document-a78446aa-167a-4bef-89b7-18bcb0da11c1' target="_blank"
-                                        class="govuk-link">ph0.jpeg</a>
+                                    <li class="govuk-!-margin-bottom-0 govuk-!-padding-top-2 govuk-!-padding-bottom-2"><span><a href='/documents/1/download/a78446aa-167a-4bef-89b7-18bcb0da11c1/ph0.jpeg' data-cy='document-a78446aa-167a-4bef-89b7-18bcb0da11c1' target="_blank" class="govuk-link">ph0.jpeg</a></span>
                                     </li>
-                                </ul>
+                                </ol>
                                 </dd>
                         </div>
                     </dl>
@@ -2561,16 +2529,12 @@ exports[`appellant-case GET /appellant-case should render the appellant case pag
                     <dl class="govuk-summary-list pins-summary-list--fullwidth-value">
                         <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key govuk-visually-hidden"> Additional documents</dt>
                             <dd                             class="govuk-summary-list__value">
-                                <ul class="govuk-list">
-                                    <li class="govuk-!-margin-bottom-0 govuk-!-padding-bottom-2 pins-border-bottom"><a href='/documents/1/download/00c43c8c-829a-4aa8-883a-fd6fc1f52c3d/ph1.jpeg'
-                                        data-cy='document-00c43c8c-829a-4aa8-883a-fd6fc1f52c3d' target="_blank"
-                                        class="govuk-link">ph1.jpeg</a>
+                                <ol class="govuk-list govuk-list--number pins-file-list">
+                                    <li class="govuk-!-margin-bottom-0 govuk-!-padding-bottom-2 pins-border-bottom"><span><a href='/documents/1/download/00c43c8c-829a-4aa8-883a-fd6fc1f52c3d/ph1.jpeg' data-cy='document-00c43c8c-829a-4aa8-883a-fd6fc1f52c3d' target="_blank" class="govuk-link">ph1.jpeg</a></span>
                                     </li>
-                                    <li class="govuk-!-margin-bottom-0 govuk-!-padding-top-2 govuk-!-padding-bottom-2"><a href='/documents/1/download/a78446aa-167a-4bef-89b7-18bcb0da11c1/ph0.jpeg'
-                                        data-cy='document-a78446aa-167a-4bef-89b7-18bcb0da11c1' target="_blank"
-                                        class="govuk-link">ph0.jpeg</a>
+                                    <li class="govuk-!-margin-bottom-0 govuk-!-padding-top-2 govuk-!-padding-bottom-2"><span><a href='/documents/1/download/a78446aa-167a-4bef-89b7-18bcb0da11c1/ph0.jpeg' data-cy='document-a78446aa-167a-4bef-89b7-18bcb0da11c1' target="_blank" class="govuk-link">ph0.jpeg</a></span>
                                     </li>
-                                </ul>
+                                </ol>
                                 </dd>
                         </div>
                     </dl>
@@ -4964,16 +4928,12 @@ exports[`appellant-case POST /appellant-case should re-render the appellant case
                     <dl class="govuk-summary-list pins-summary-list--fullwidth-value">
                         <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key govuk-visually-hidden"> Additional documents</dt>
                             <dd                             class="govuk-summary-list__value">
-                                <ul class="govuk-list">
-                                    <li class="govuk-!-margin-bottom-0 govuk-!-padding-bottom-2 pins-border-bottom"><a href='/documents/1/download/00c43c8c-829a-4aa8-883a-fd6fc1f52c3d/ph1.jpeg'
-                                        data-cy='document-00c43c8c-829a-4aa8-883a-fd6fc1f52c3d' target="_blank"
-                                        class="govuk-link">ph1.jpeg</a>
+                                <ol class="govuk-list govuk-list--number pins-file-list">
+                                    <li class="govuk-!-margin-bottom-0 govuk-!-padding-bottom-2 pins-border-bottom"><span><a href='/documents/1/download/00c43c8c-829a-4aa8-883a-fd6fc1f52c3d/ph1.jpeg' data-cy='document-00c43c8c-829a-4aa8-883a-fd6fc1f52c3d' target="_blank" class="govuk-link">ph1.jpeg</a></span>
                                     </li>
-                                    <li class="govuk-!-margin-bottom-0 govuk-!-padding-top-2 govuk-!-padding-bottom-2"><a href='/documents/1/download/a78446aa-167a-4bef-89b7-18bcb0da11c1/ph0.jpeg'
-                                        data-cy='document-a78446aa-167a-4bef-89b7-18bcb0da11c1' target="_blank"
-                                        class="govuk-link">ph0.jpeg</a>
+                                    <li class="govuk-!-margin-bottom-0 govuk-!-padding-top-2 govuk-!-padding-bottom-2"><span><a href='/documents/1/download/a78446aa-167a-4bef-89b7-18bcb0da11c1/ph0.jpeg' data-cy='document-a78446aa-167a-4bef-89b7-18bcb0da11c1' target="_blank" class="govuk-link">ph0.jpeg</a></span>
                                     </li>
-                                </ul>
+                                </ol>
                                 </dd>
                         </div>
                     </dl>

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/__tests__/__snapshots__/lpa-questionnaire.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/__tests__/__snapshots__/lpa-questionnaire.test.js.snap
@@ -57,7 +57,7 @@ exports[`LPA Questionnaire review GET / should render review outcome form fields
                         </div>
                         <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Conservation area map and guidance</dt>
                             <dd                             class="govuk-summary-list__value">
-                                <ul class="govuk-list">
+                                <ul class="govuk-list pins-file-list">
                                     <li><span><div class="govuk-body govuk-!-margin-bottom-2">conservationAreaMap.docx</div><strong class="govuk-tag govuk-tag--yellow single-line">Virus scanning</strong></span>
                                     </li>
                                 </ul>
@@ -94,7 +94,7 @@ exports[`LPA Questionnaire review GET / should render review outcome form fields
                     <dl class="govuk-summary-list" id="notifications-summary">
                         <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Who was notified</dt>
                             <dd class="govuk-summary-list__value">
-                                <ul class="govuk-list">
+                                <ul class="govuk-list pins-file-list">
                                     <li><span><div class="govuk-body govuk-!-margin-bottom-2">notifyingParties.docx</div><strong class="govuk-tag govuk-tag--yellow single-line">Virus scanning</strong></span>
                                     </li>
                                 </ul>
@@ -151,7 +151,7 @@ exports[`LPA Questionnaire review GET / should render review outcome form fields
                     <dl class="govuk-summary-list" id="representations-summary">
                         <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Representations from other parties documents</dt>
                             <dd                             class="govuk-summary-list__value">
-                                <ul class="govuk-list">
+                                <ul class="govuk-list pins-file-list">
                                     <li><span><div class="govuk-body govuk-!-margin-bottom-2">representations.docx</div><strong class="govuk-tag govuk-tag--yellow single-line">Virus scanning</strong></span>
                                     </li>
                                 </ul>
@@ -182,7 +182,7 @@ exports[`LPA Questionnaire review GET / should render review outcome form fields
                     <dl class="govuk-summary-list" id="supplementary-documents-summary">
                         <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Planning officer&#39;s report</dt>
                             <dd                             class="govuk-summary-list__value">
-                                <ul class="govuk-list">
+                                <ul class="govuk-list pins-file-list">
                                     <li><span><div class="govuk-body govuk-!-margin-bottom-2">officersReport.docx</div><strong class="govuk-tag govuk-tag--yellow single-line">Virus scanning</strong></span>
                                     </li>
                                 </ul>
@@ -311,17 +311,14 @@ exports[`LPA Questionnaire review GET / should render review outcome form fields
                     <dl class="govuk-summary-list pins-summary-list--fullwidth-value">
                         <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key govuk-visually-hidden"> Additional documents</dt>
                             <dd                             class="govuk-summary-list__value">
-                                <ul class="govuk-list">
-                                    <li class="govuk-!-margin-bottom-0 govuk-!-padding-bottom-2 pins-border-bottom"><a href='/documents/1/download/undefined/ph0.jpg' data-cy='document-undefined'
-                                        target="_blank" class="govuk-link">ph0.jpg</a>
+                                <ol class="govuk-list govuk-list--number pins-file-list">
+                                    <li class="govuk-!-margin-bottom-0 govuk-!-padding-bottom-2 pins-border-bottom"><span><a href='/documents/1/download/undefined/ph0.jpg' data-cy='document-undefined' target="_blank" class="govuk-link">ph0.jpg</a></span>
                                     </li>
-                                    <li class="govuk-!-margin-bottom-0 govuk-!-padding-top-2 govuk-!-padding-bottom-2 pins-border-bottom"><a href='/documents/1/download/undefined/ph1.jpg' data-cy='document-undefined'
-                                        target="_blank" class="govuk-link">ph1.jpg</a>
+                                    <li class="govuk-!-margin-bottom-0 govuk-!-padding-top-2 govuk-!-padding-bottom-2 pins-border-bottom"><span><a href='/documents/1/download/undefined/ph1.jpg' data-cy='document-undefined' target="_blank" class="govuk-link">ph1.jpg</a></span>
                                     </li>
-                                    <li class="govuk-!-margin-bottom-0 govuk-!-padding-top-2 govuk-!-padding-bottom-2"><a href='/documents/1/download/undefined/ph2.jpg' data-cy='document-undefined'
-                                        target="_blank" class="govuk-link">ph2.jpg</a>
+                                    <li class="govuk-!-margin-bottom-0 govuk-!-padding-top-2 govuk-!-padding-bottom-2"><span><a href='/documents/1/download/undefined/ph2.jpg' data-cy='document-undefined' target="_blank" class="govuk-link">ph2.jpg</a></span>
                                     </li>
-                                </ul>
+                                </ol>
                                 </dd>
                         </div>
                     </dl>
@@ -420,7 +417,7 @@ exports[`LPA Questionnaire review GET / should render the LPA Questionnaire page
                         </div>
                         <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Conservation area map and guidance</dt>
                             <dd                             class="govuk-summary-list__value">
-                                <ul class="govuk-list">
+                                <ul class="govuk-list pins-file-list">
                                     <li><span><div class="govuk-body govuk-!-margin-bottom-2">conservationAreaMap.docx</div><strong class="govuk-tag govuk-tag--yellow single-line">Virus scanning</strong></span>
                                     </li>
                                 </ul>
@@ -457,7 +454,7 @@ exports[`LPA Questionnaire review GET / should render the LPA Questionnaire page
                     <dl class="govuk-summary-list" id="notifications-summary">
                         <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Who was notified</dt>
                             <dd class="govuk-summary-list__value">
-                                <ul class="govuk-list">
+                                <ul class="govuk-list pins-file-list">
                                     <li><span><div class="govuk-body govuk-!-margin-bottom-2">notifyingParties.docx</div><strong class="govuk-tag govuk-tag--yellow single-line">Virus scanning</strong></span>
                                     </li>
                                 </ul>
@@ -514,7 +511,7 @@ exports[`LPA Questionnaire review GET / should render the LPA Questionnaire page
                     <dl class="govuk-summary-list" id="representations-summary">
                         <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Representations from other parties documents</dt>
                             <dd                             class="govuk-summary-list__value">
-                                <ul class="govuk-list">
+                                <ul class="govuk-list pins-file-list">
                                     <li><span><div class="govuk-body govuk-!-margin-bottom-2">representations.docx</div><strong class="govuk-tag govuk-tag--yellow single-line">Virus scanning</strong></span>
                                     </li>
                                 </ul>
@@ -545,7 +542,7 @@ exports[`LPA Questionnaire review GET / should render the LPA Questionnaire page
                     <dl class="govuk-summary-list" id="supplementary-documents-summary">
                         <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Planning officer&#39;s report</dt>
                             <dd                             class="govuk-summary-list__value">
-                                <ul class="govuk-list">
+                                <ul class="govuk-list pins-file-list">
                                     <li><span><div class="govuk-body govuk-!-margin-bottom-2">officersReport.docx</div><strong class="govuk-tag govuk-tag--yellow single-line">Virus scanning</strong></span>
                                     </li>
                                 </ul>
@@ -674,17 +671,14 @@ exports[`LPA Questionnaire review GET / should render the LPA Questionnaire page
                     <dl class="govuk-summary-list pins-summary-list--fullwidth-value">
                         <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key govuk-visually-hidden"> Additional documents</dt>
                             <dd                             class="govuk-summary-list__value">
-                                <ul class="govuk-list">
-                                    <li class="govuk-!-margin-bottom-0 govuk-!-padding-bottom-2 pins-border-bottom"><a href='/documents/1/download/undefined/ph0.jpg' data-cy='document-undefined'
-                                        target="_blank" class="govuk-link">ph0.jpg</a>
+                                <ol class="govuk-list govuk-list--number pins-file-list">
+                                    <li class="govuk-!-margin-bottom-0 govuk-!-padding-bottom-2 pins-border-bottom"><span><a href='/documents/1/download/undefined/ph0.jpg' data-cy='document-undefined' target="_blank" class="govuk-link">ph0.jpg</a></span>
                                     </li>
-                                    <li class="govuk-!-margin-bottom-0 govuk-!-padding-top-2 govuk-!-padding-bottom-2 pins-border-bottom"><a href='/documents/1/download/undefined/ph1.jpg' data-cy='document-undefined'
-                                        target="_blank" class="govuk-link">ph1.jpg</a>
+                                    <li class="govuk-!-margin-bottom-0 govuk-!-padding-top-2 govuk-!-padding-bottom-2 pins-border-bottom"><span><a href='/documents/1/download/undefined/ph1.jpg' data-cy='document-undefined' target="_blank" class="govuk-link">ph1.jpg</a></span>
                                     </li>
-                                    <li class="govuk-!-margin-bottom-0 govuk-!-padding-top-2 govuk-!-padding-bottom-2"><a href='/documents/1/download/undefined/ph2.jpg' data-cy='document-undefined'
-                                        target="_blank" class="govuk-link">ph2.jpg</a>
+                                    <li class="govuk-!-margin-bottom-0 govuk-!-padding-top-2 govuk-!-padding-bottom-2"><span><a href='/documents/1/download/undefined/ph2.jpg' data-cy='document-undefined' target="_blank" class="govuk-link">ph2.jpg</a></span>
                                     </li>
-                                </ul>
+                                </ol>
                                 </dd>
                         </div>
                     </dl>
@@ -808,12 +802,12 @@ exports[`LPA Questionnaire review GET / with unchecked documents should render a
                         </div>
                         <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Conservation area map and guidance</dt>
                             <dd                             class="govuk-summary-list__value">
-                                <ul class="govuk-list">
+                                <ol class="govuk-list govuk-list--number pins-file-list">
                                     <li><span><div class="govuk-body govuk-!-margin-bottom-2">conservationAreaMap.docx</div><strong class="govuk-tag govuk-tag--yellow single-line">Virus scanning</strong></span>
                                     </li>
                                     <li><span><div class="govuk-body govuk-!-margin-bottom-2">applicationForm.docx</div><strong class="govuk-tag govuk-tag--yellow single-line">Virus scanning</strong></span>
                                     </li>
-                                </ul>
+                                </ol>
                                 </dd>
                                 <dd class="govuk-summary-list__actions">
                                     <ul class="govuk-summary-list__actions-list">
@@ -847,7 +841,7 @@ exports[`LPA Questionnaire review GET / with unchecked documents should render a
                     <dl class="govuk-summary-list" id="notifications-summary">
                         <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Who was notified</dt>
                             <dd class="govuk-summary-list__value">
-                                <ul class="govuk-list">
+                                <ul class="govuk-list pins-file-list">
                                     <li><span><div class="govuk-body govuk-!-margin-bottom-2">notifyingParties.docx</div><strong class="govuk-tag govuk-tag--yellow single-line">Virus scanning</strong></span>
                                     </li>
                                 </ul>
@@ -904,7 +898,7 @@ exports[`LPA Questionnaire review GET / with unchecked documents should render a
                     <dl class="govuk-summary-list" id="representations-summary">
                         <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Representations from other parties documents</dt>
                             <dd                             class="govuk-summary-list__value">
-                                <ul class="govuk-list">
+                                <ul class="govuk-list pins-file-list">
                                     <li><span><div class="govuk-body govuk-!-margin-bottom-2">representations.docx</div><strong class="govuk-tag govuk-tag--yellow single-line">Virus scanning</strong></span>
                                     </li>
                                 </ul>
@@ -935,7 +929,7 @@ exports[`LPA Questionnaire review GET / with unchecked documents should render a
                     <dl class="govuk-summary-list" id="supplementary-documents-summary">
                         <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Planning officer&#39;s report</dt>
                             <dd                             class="govuk-summary-list__value">
-                                <ul class="govuk-list">
+                                <ul class="govuk-list pins-file-list">
                                     <li><span><div class="govuk-body govuk-!-margin-bottom-2">officersReport.docx</div><strong class="govuk-tag govuk-tag--yellow single-line">Virus scanning</strong></span>
                                     </li>
                                 </ul>
@@ -1064,17 +1058,14 @@ exports[`LPA Questionnaire review GET / with unchecked documents should render a
                     <dl class="govuk-summary-list pins-summary-list--fullwidth-value">
                         <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key govuk-visually-hidden"> Additional documents</dt>
                             <dd                             class="govuk-summary-list__value">
-                                <ul class="govuk-list">
-                                    <li class="govuk-!-margin-bottom-0 govuk-!-padding-bottom-2 pins-border-bottom"><a href='/documents/1/download/undefined/ph0.jpg' data-cy='document-undefined'
-                                        target="_blank" class="govuk-link">ph0.jpg</a>
+                                <ol class="govuk-list govuk-list--number pins-file-list">
+                                    <li class="govuk-!-margin-bottom-0 govuk-!-padding-bottom-2 pins-border-bottom"><span><a href='/documents/1/download/undefined/ph0.jpg' data-cy='document-undefined' target="_blank" class="govuk-link">ph0.jpg</a></span>
                                     </li>
-                                    <li class="govuk-!-margin-bottom-0 govuk-!-padding-top-2 govuk-!-padding-bottom-2 pins-border-bottom"><a href='/documents/1/download/undefined/ph1.jpg' data-cy='document-undefined'
-                                        target="_blank" class="govuk-link">ph1.jpg</a>
+                                    <li class="govuk-!-margin-bottom-0 govuk-!-padding-top-2 govuk-!-padding-bottom-2 pins-border-bottom"><span><a href='/documents/1/download/undefined/ph1.jpg' data-cy='document-undefined' target="_blank" class="govuk-link">ph1.jpg</a></span>
                                     </li>
-                                    <li class="govuk-!-margin-bottom-0 govuk-!-padding-top-2 govuk-!-padding-bottom-2"><a href='/documents/1/download/undefined/ph2.jpg' data-cy='document-undefined'
-                                        target="_blank" class="govuk-link">ph2.jpg</a>
+                                    <li class="govuk-!-margin-bottom-0 govuk-!-padding-top-2 govuk-!-padding-bottom-2"><span><a href='/documents/1/download/undefined/ph2.jpg' data-cy='document-undefined' target="_blank" class="govuk-link">ph2.jpg</a></span>
                                     </li>
-                                </ul>
+                                </ol>
                                 </dd>
                         </div>
                     </dl>
@@ -1157,12 +1148,12 @@ exports[`LPA Questionnaire review GET / with unchecked documents should render a
                         </div>
                         <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Conservation area map and guidance</dt>
                             <dd                             class="govuk-summary-list__value">
-                                <ul class="govuk-list">
+                                <ol class="govuk-list govuk-list--number pins-file-list">
                                     <li><span><div class="govuk-body govuk-!-margin-bottom-2">conservationAreaMap.docx</div><strong class="govuk-tag govuk-tag--yellow single-line">Virus scanning</strong></span>
                                     </li>
                                     <li><span><div class="govuk-body govuk-!-margin-bottom-2">applicationForm.docx</div><strong class="govuk-tag govuk-tag--red single-line">Virus detected</strong></span>
                                     </li>
-                                </ul>
+                                </ol>
                                 </dd>
                                 <dd class="govuk-summary-list__actions">
                                     <ul class="govuk-summary-list__actions-list">
@@ -1196,7 +1187,7 @@ exports[`LPA Questionnaire review GET / with unchecked documents should render a
                     <dl class="govuk-summary-list" id="notifications-summary">
                         <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Who was notified</dt>
                             <dd class="govuk-summary-list__value">
-                                <ul class="govuk-list">
+                                <ul class="govuk-list pins-file-list">
                                     <li><span><div class="govuk-body govuk-!-margin-bottom-2">notifyingParties.docx</div><strong class="govuk-tag govuk-tag--yellow single-line">Virus scanning</strong></span>
                                     </li>
                                 </ul>
@@ -1253,7 +1244,7 @@ exports[`LPA Questionnaire review GET / with unchecked documents should render a
                     <dl class="govuk-summary-list" id="representations-summary">
                         <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Representations from other parties documents</dt>
                             <dd                             class="govuk-summary-list__value">
-                                <ul class="govuk-list">
+                                <ul class="govuk-list pins-file-list">
                                     <li><span><div class="govuk-body govuk-!-margin-bottom-2">representations.docx</div><strong class="govuk-tag govuk-tag--yellow single-line">Virus scanning</strong></span>
                                     </li>
                                 </ul>
@@ -1284,7 +1275,7 @@ exports[`LPA Questionnaire review GET / with unchecked documents should render a
                     <dl class="govuk-summary-list" id="supplementary-documents-summary">
                         <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Planning officer&#39;s report</dt>
                             <dd                             class="govuk-summary-list__value">
-                                <ul class="govuk-list">
+                                <ul class="govuk-list pins-file-list">
                                     <li><span><div class="govuk-body govuk-!-margin-bottom-2">officersReport.docx</div><strong class="govuk-tag govuk-tag--yellow single-line">Virus scanning</strong></span>
                                     </li>
                                 </ul>
@@ -1413,17 +1404,14 @@ exports[`LPA Questionnaire review GET / with unchecked documents should render a
                     <dl class="govuk-summary-list pins-summary-list--fullwidth-value">
                         <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key govuk-visually-hidden"> Additional documents</dt>
                             <dd                             class="govuk-summary-list__value">
-                                <ul class="govuk-list">
-                                    <li class="govuk-!-margin-bottom-0 govuk-!-padding-bottom-2 pins-border-bottom"><a href='/documents/1/download/undefined/ph0.jpg' data-cy='document-undefined'
-                                        target="_blank" class="govuk-link">ph0.jpg</a>
+                                <ol class="govuk-list govuk-list--number pins-file-list">
+                                    <li class="govuk-!-margin-bottom-0 govuk-!-padding-bottom-2 pins-border-bottom"><span><a href='/documents/1/download/undefined/ph0.jpg' data-cy='document-undefined' target="_blank" class="govuk-link">ph0.jpg</a></span>
                                     </li>
-                                    <li class="govuk-!-margin-bottom-0 govuk-!-padding-top-2 govuk-!-padding-bottom-2 pins-border-bottom"><a href='/documents/1/download/undefined/ph1.jpg' data-cy='document-undefined'
-                                        target="_blank" class="govuk-link">ph1.jpg</a>
+                                    <li class="govuk-!-margin-bottom-0 govuk-!-padding-top-2 govuk-!-padding-bottom-2 pins-border-bottom"><span><a href='/documents/1/download/undefined/ph1.jpg' data-cy='document-undefined' target="_blank" class="govuk-link">ph1.jpg</a></span>
                                     </li>
-                                    <li class="govuk-!-margin-bottom-0 govuk-!-padding-top-2 govuk-!-padding-bottom-2"><a href='/documents/1/download/undefined/ph2.jpg' data-cy='document-undefined'
-                                        target="_blank" class="govuk-link">ph2.jpg</a>
+                                    <li class="govuk-!-margin-bottom-0 govuk-!-padding-top-2 govuk-!-padding-bottom-2"><span><a href='/documents/1/download/undefined/ph2.jpg' data-cy='document-undefined' target="_blank" class="govuk-link">ph2.jpg</a></span>
                                     </li>
-                                </ul>
+                                </ol>
                                 </dd>
                         </div>
                     </dl>
@@ -3565,7 +3553,7 @@ exports[`LPA Questionnaire review POST / should render LPA Questionnaire review 
                         </div>
                         <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Conservation area map and guidance</dt>
                             <dd                             class="govuk-summary-list__value">
-                                <ul class="govuk-list">
+                                <ul class="govuk-list pins-file-list">
                                     <li><span><div class="govuk-body govuk-!-margin-bottom-2">conservationAreaMap.docx</div><strong class="govuk-tag govuk-tag--yellow single-line">Virus scanning</strong></span>
                                     </li>
                                 </ul>
@@ -3602,7 +3590,7 @@ exports[`LPA Questionnaire review POST / should render LPA Questionnaire review 
                     <dl class="govuk-summary-list" id="notifications-summary">
                         <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Who was notified</dt>
                             <dd class="govuk-summary-list__value">
-                                <ul class="govuk-list">
+                                <ul class="govuk-list pins-file-list">
                                     <li><span><div class="govuk-body govuk-!-margin-bottom-2">notifyingParties.docx</div><strong class="govuk-tag govuk-tag--yellow single-line">Virus scanning</strong></span>
                                     </li>
                                 </ul>
@@ -3659,7 +3647,7 @@ exports[`LPA Questionnaire review POST / should render LPA Questionnaire review 
                     <dl class="govuk-summary-list" id="representations-summary">
                         <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Representations from other parties documents</dt>
                             <dd                             class="govuk-summary-list__value">
-                                <ul class="govuk-list">
+                                <ul class="govuk-list pins-file-list">
                                     <li><span><div class="govuk-body govuk-!-margin-bottom-2">representations.docx</div><strong class="govuk-tag govuk-tag--yellow single-line">Virus scanning</strong></span>
                                     </li>
                                 </ul>
@@ -3690,7 +3678,7 @@ exports[`LPA Questionnaire review POST / should render LPA Questionnaire review 
                     <dl class="govuk-summary-list" id="supplementary-documents-summary">
                         <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Planning officer&#39;s report</dt>
                             <dd                             class="govuk-summary-list__value">
-                                <ul class="govuk-list">
+                                <ul class="govuk-list pins-file-list">
                                     <li><span><div class="govuk-body govuk-!-margin-bottom-2">officersReport.docx</div><strong class="govuk-tag govuk-tag--yellow single-line">Virus scanning</strong></span>
                                     </li>
                                 </ul>
@@ -3819,17 +3807,14 @@ exports[`LPA Questionnaire review POST / should render LPA Questionnaire review 
                     <dl class="govuk-summary-list pins-summary-list--fullwidth-value">
                         <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key govuk-visually-hidden"> Additional documents</dt>
                             <dd                             class="govuk-summary-list__value">
-                                <ul class="govuk-list">
-                                    <li class="govuk-!-margin-bottom-0 govuk-!-padding-bottom-2 pins-border-bottom"><a href='/documents/1/download/undefined/ph0.jpg' data-cy='document-undefined'
-                                        target="_blank" class="govuk-link">ph0.jpg</a>
+                                <ol class="govuk-list govuk-list--number pins-file-list">
+                                    <li class="govuk-!-margin-bottom-0 govuk-!-padding-bottom-2 pins-border-bottom"><span><a href='/documents/1/download/undefined/ph0.jpg' data-cy='document-undefined' target="_blank" class="govuk-link">ph0.jpg</a></span>
                                     </li>
-                                    <li class="govuk-!-margin-bottom-0 govuk-!-padding-top-2 govuk-!-padding-bottom-2 pins-border-bottom"><a href='/documents/1/download/undefined/ph1.jpg' data-cy='document-undefined'
-                                        target="_blank" class="govuk-link">ph1.jpg</a>
+                                    <li class="govuk-!-margin-bottom-0 govuk-!-padding-top-2 govuk-!-padding-bottom-2 pins-border-bottom"><span><a href='/documents/1/download/undefined/ph1.jpg' data-cy='document-undefined' target="_blank" class="govuk-link">ph1.jpg</a></span>
                                     </li>
-                                    <li class="govuk-!-margin-bottom-0 govuk-!-padding-top-2 govuk-!-padding-bottom-2"><a href='/documents/1/download/undefined/ph2.jpg' data-cy='document-undefined'
-                                        target="_blank" class="govuk-link">ph2.jpg</a>
+                                    <li class="govuk-!-margin-bottom-0 govuk-!-padding-top-2 govuk-!-padding-bottom-2"><span><a href='/documents/1/download/undefined/ph2.jpg' data-cy='document-undefined' target="_blank" class="govuk-link">ph2.jpg</a></span>
                                     </li>
-                                </ul>
+                                </ol>
                                 </dd>
                         </div>
                     </dl>

--- a/appeals/web/src/server/lib/display-page-formatter.js
+++ b/appeals/web/src/server/lib/display-page-formatter.js
@@ -182,10 +182,6 @@ const formatDocumentValuesAsList = ({ appealId, documents, isAdditionalDocuments
 			} else {
 				documentPageComponents.push({
 					type: 'html',
-					wrapperHtml: {
-						opening: '<span>',
-						closing: ''
-					},
 					parameters: {
 						html: '',
 						pageComponents: [
@@ -200,10 +196,6 @@ const formatDocumentValuesAsList = ({ appealId, documents, isAdditionalDocuments
 				});
 				documentPageComponents.push({
 					type: 'html',
-					wrapperHtml: {
-						opening: '',
-						closing: '</span>'
-					},
 					parameters: {
 						html: '',
 						pageComponents: [
@@ -229,12 +221,14 @@ const formatDocumentValuesAsList = ({ appealId, documents, isAdditionalDocuments
 
 			htmlProperty.pageComponents.push({
 				wrapperHtml: {
-					opening: isAdditionalDocuments
-						? `<li class="govuk-!-margin-bottom-0${
-								i > 0 ? ' govuk-!-padding-top-2' : ''
-						  } govuk-!-padding-bottom-2${i < documents.length - 1 ? ' pins-border-bottom' : ''}">`
-						: '<li>',
-					closing: '</li>'
+					opening: `<li${
+						isAdditionalDocuments
+							? ` class="govuk-!-margin-bottom-0${
+									i > 0 ? ' govuk-!-padding-top-2' : ''
+							  } govuk-!-padding-bottom-2${i < documents.length - 1 ? ' pins-border-bottom' : ''}"`
+							: ''
+					}><span>`,
+					closing: '</span></li>'
 				},
 				type: 'html',
 				parameters: {
@@ -244,9 +238,14 @@ const formatDocumentValuesAsList = ({ appealId, documents, isAdditionalDocuments
 			});
 		}
 
-		if (htmlProperty.pageComponents.length > 0) {
+		if (htmlProperty.pageComponents.length > 1) {
 			htmlProperty.wrapperHtml = {
-				opening: '<ul class="govuk-list">',
+				opening: '<ol class="govuk-list govuk-list--number pins-file-list">',
+				closing: '</ol>'
+			};
+		} else if (htmlProperty.pageComponents.length > 0) {
+			htmlProperty.wrapperHtml = {
+				opening: '<ul class="govuk-list pins-file-list">',
 				closing: '</ul>'
 			};
 		}

--- a/appeals/web/src/styles/5-elements/_elements.pins-file-list.scss
+++ b/appeals/web/src/styles/5-elements/_elements.pins-file-list.scss
@@ -1,0 +1,19 @@
+.pins-file-list {
+	> li {
+		> span {
+			display: flex;
+			flex-direction: row;
+			justify-content: flex-start;
+			align-items: baseline;
+			list-style-position: inside;
+
+			> * {
+				margin-left: 5px;
+
+				&:first-child {
+					margin-left: 0;
+				}
+			}
+		}
+	}
+}

--- a/appeals/web/src/styles/7-components/_summary-list.scss
+++ b/appeals/web/src/styles/7-components/_summary-list.scss
@@ -30,12 +30,6 @@
 		.govuk-list {
 			display: block;
 			width: 100%;
-
-			li {
-				display: flex;
-				justify-content: space-between;
-				align-items: flex-start;
-			}
 		}
 	}
 }

--- a/appeals/web/src/styles/main.scss
+++ b/appeals/web/src/styles/main.scss
@@ -31,6 +31,7 @@
 @use "5-elements/elements.page" as elements-page;
 @use "5-elements/elements.images" as elements-images;
 @use "5-elements/elements.form-group" as form-group;
+@use "5-elements/elements.pins-file-list" as pins-file-list;
 
 // 6 - SKELETON
 @use "6-skeleton/container";


### PR DESCRIPTION
## Describe your changes

Update summary list rows which display documents as lists of filename links to ordered lists displaying numbered markers (number is not displayed if there is only one item in the list)

## Issue ticket number and link

A2-859

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [ ] I have performed a self-review of my own code
- [ ] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [ ] I have referenced the ticket number above
- [ ] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
