### PR TITLE
feat(api): increase rep fields storage A2-1893

### DIFF
--- a/appeals/api/src/database/migrations/20241213155447_representations_text_nvarchar_max/migration.sql
+++ b/appeals/api/src/database/migrations/20241213155447_representations_text_nvarchar_max/migration.sql
@@ -1,0 +1,27 @@
+/*
+  Warnings:
+
+  - You are about to alter the column `originalRepresentation` on the `Representation` table. The data in that column could be lost. The data in that column will be cast from `NVarChar(1000)` to `VarChar(Max)`.
+  - You are about to alter the column `redactedRepresentation` on the `Representation` table. The data in that column could be lost. The data in that column will be cast from `NVarChar(1000)` to `VarChar(Max)`.
+
+*/
+BEGIN TRY
+
+BEGIN TRAN;
+
+-- AlterTable
+ALTER TABLE [dbo].[Representation] ALTER COLUMN [originalRepresentation] NVARCHAR(max) NULL;
+ALTER TABLE [dbo].[Representation] ALTER COLUMN [redactedRepresentation] NVARCHAR(max) NULL;
+
+COMMIT TRAN;
+
+END TRY
+BEGIN CATCH
+
+IF @@TRANCOUNT > 0
+BEGIN
+    ROLLBACK TRAN;
+END;
+THROW
+
+END CATCH

--- a/appeals/api/src/database/schema.prisma
+++ b/appeals/api/src/database/schema.prisma
@@ -664,8 +664,8 @@ model Representation {
   representationType                     String
   dateCreated                            DateTime                                 @default(now())
   dateLastUpdated                        DateTime                                 @default(now())
-  originalRepresentation                 String?
-  redactedRepresentation                 String?
+  originalRepresentation                 String?                                  @db.NVarChar(Max)
+  redactedRepresentation                 String?                                  @db.NVarChar(Max)
   represented                            ServiceUser?                             @relation("represented", fields: [representedId], references: [id], onDelete: NoAction, onUpdate: NoAction)
   representedId                          Int?
   representative                         ServiceUser?                             @relation("representative", fields: [representativeId], references: [id], onDelete: NoAction, onUpdate: NoAction)


### PR DESCRIPTION
Increase the `originalRepresentation` and `redactedRepresentation` columns in the `Representation` database table to `nvarchar(max)`.
 

## Issue ticket number and link

[A2-1893](https://pins-ds.atlassian.net/browse/A2-1893)

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [ ] I have performed a self-review of my own code
- [ ] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [ ] I have referenced the ticket number above
- [ ] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes


[A2-1893]: https://pins-ds.atlassian.net/browse/A2-1893?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ