### PR TITLE
fix(appeals): case notes paragraph breaks are formatted correctly (a2-1399)

### DIFF
--- a/appeals/web/src/server/lib/nunjucks-filters/__tests__/format-line-breaks.test.js
+++ b/appeals/web/src/server/lib/nunjucks-filters/__tests__/format-line-breaks.test.js
@@ -1,0 +1,9 @@
+import { formatLineBreaks } from '#lib/nunjucks-filters/index.js';
+
+describe('formatLineBreaks', () => {
+	it('should format line breaks correctly', () => {
+		const text = 'This is a test\r\nThis is another test\r\nThis is a third test';
+		const expected = 'This is a test<br>This is another test<br>This is a third test';
+		expect(formatLineBreaks(text)).toEqual(expected);
+	});
+});

--- a/appeals/web/src/server/lib/nunjucks-filters/format-line-breaks.js
+++ b/appeals/web/src/server/lib/nunjucks-filters/format-line-breaks.js
@@ -1,0 +1,9 @@
+/**
+ * Replaces carriage return line break with br tags
+ *
+ * @param {string} text
+ * @returns {string}
+ */
+export const formatLineBreaks = (text) => {
+	return text.replace(/\n/g, '<br>').replace(/\r/g, '');
+};

--- a/appeals/web/src/server/lib/nunjucks-filters/index.js
+++ b/appeals/web/src/server/lib/nunjucks-filters/index.js
@@ -20,6 +20,7 @@ export { collapse } from './collapse.js';
 export { default as className } from 'classnames';
 export { endsWith } from './ends-with.js';
 export { errorMessage } from './error-message.js';
+export { formatLineBreaks } from './format-line-breaks.js';
 export { json } from './json.js';
 export { mapToErrorSummary } from './error-summary.js';
 export { hasOneOf } from './object.js';

--- a/appeals/web/src/server/views/appeals/components/case-notes.njk
+++ b/appeals/web/src/server/views/appeals/components/case-notes.njk
@@ -24,15 +24,15 @@
 	<div>
 		<hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
 		{%- for caseNote in params.caseNotes -%}
-		<section>
-			<p class="govuk-body govuk-!-margin-bottom-1">
-				{{caseNote.commentText}}
-			</p>
-			<p class="govuk-hint govuk-!-margin-bottom-6">
-				{{ [caseNote.time, ' on ', caseNote.dayOfWeek, ' ', caseNote.date, ' by ', caseNote.userName] | join }}
-			</p>
-			<hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
-		</section>
+			<section>
+				<p class="govuk-body govuk-!-margin-bottom-1">
+					{{caseNote.commentText | formatLineBreaks | safe}}
+				</p>
+				<p class="govuk-hint govuk-!-margin-bottom-6">
+					{{ [caseNote.time, ' on ', caseNote.dayOfWeek, ' ', caseNote.date, ' by ', caseNote.userName] | join }}
+				</p>
+				<hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+			</section>
 		{%- endfor -%}
 	</div>
 {%- endmacro -%}


### PR DESCRIPTION
## Describe your changes

WEB:
 - Added a filter to format the line breaks
 - Applied the filter to the case notes component
   
TESTING:
- Added a unit tests for new filter
- WEB unit tests pass
- Manually tested within browser

## Issue ticket number and link

[A2-1399 As a back office user I want my paragraph breaks to be reflected in the case note](https://pins-ds.atlassian.net/browse/A2-1399)

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [x] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [x] I have included unit tests to cover any testable code changes
