### PR TITLE
fix(web): fix to re-populate submitted text into textareas on s78 lpaq conditional text rows

### DIFF
--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/environmental-impact-assessment/__tests__/environmental-impact-assessment.test.js
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/environmental-impact-assessment/__tests__/environmental-impact-assessment.test.js
@@ -515,7 +515,7 @@ describe('environmental-impact-assessment', () => {
 				);
 			});
 
-			it('should re-render the change sensitive area details page with the expected validation error and the "yes" radio option checked, if "yes" was selected and the text entered in the details textarea exceeds 1000 characters in length', async () => {
+			it('should re-render the change sensitive area details page with the expected validation error, and the "yes" radio option checked, and the details textarea pre-populated with the submitted text, if "yes" was selected and the text entered in the details textarea exceeds 1000 characters in length', async () => {
 				nock('http://test/').get('/appeals/1').reply(200, appealDataFullPlanning);
 				nock('http://test/')
 					.get(`/appeals/1/lpa-questionnaires/${appealDataFullPlanning.lpaQuestionnaireId}`)
@@ -524,13 +524,15 @@ describe('environmental-impact-assessment', () => {
 						eiaSensitiveAreaDetails: null
 					});
 
+				const submittedText = 'a'.repeat(1001);
+
 				const response = await request
 					.post(
 						`${baseUrl}/1/lpa-questionnaire/${appealDataFullPlanning.lpaQuestionnaireId}/environmental-impact-assessment/sensitive-area-details/change`
 					)
 					.send({
 						eiaSensitiveAreaDetailsRadio: 'yes',
-						eiaSensitiveAreaDetails: 'a'.repeat(1001)
+						eiaSensitiveAreaDetails: submittedText
 					});
 
 				expect(response.statusCode).toBe(200);
@@ -546,6 +548,7 @@ describe('environmental-impact-assessment', () => {
 				expect(elementInnerHtml).toContain(
 					'name="eiaSensitiveAreaDetailsRadio" type="radio" value="no"'
 				);
+				expect(elementInnerHtml).toContain(`${submittedText}</textarea>`);
 
 				const unprettifiedErrorSummaryHtml = parseHtml(response.text, {
 					rootElement: '.govuk-error-summary',
@@ -711,7 +714,7 @@ describe('environmental-impact-assessment', () => {
 				);
 			});
 
-			it('should re-render the change consulted bodies details page with the expected validation error and the "yes" radio option checked, if "yes" was selected and the text entered in the details textarea exceeds 1000 characters in length', async () => {
+			it('should re-render the change consulted bodies details page with the expected validation error, and the "yes" radio option checked, and the details textarea pre-populated with the submitted text, if "yes" was selected and the text entered in the details textarea exceeds 1000 characters in length', async () => {
 				nock('http://test/').get('/appeals/1').reply(200, appealDataFullPlanning);
 				nock('http://test/')
 					.get(`/appeals/1/lpa-questionnaires/${appealDataFullPlanning.lpaQuestionnaireId}`)
@@ -720,13 +723,15 @@ describe('environmental-impact-assessment', () => {
 						eiaConsultedBodiesDetails: null
 					});
 
+				const submittedText = 'a'.repeat(1001);
+
 				const response = await request
 					.post(
 						`${baseUrl}/1/lpa-questionnaire/${appealDataFullPlanning.lpaQuestionnaireId}/environmental-impact-assessment/consulted-bodies-details/change`
 					)
 					.send({
 						eiaConsultedBodiesDetailsRadio: 'yes',
-						eiaConsultedBodiesDetails: 'a'.repeat(1001)
+						eiaConsultedBodiesDetails: submittedText
 					});
 
 				expect(response.statusCode).toBe(200);
@@ -740,6 +745,7 @@ describe('environmental-impact-assessment', () => {
 				expect(elementInnerHtml).toContain(
 					'name="eiaConsultedBodiesDetailsRadio" type="radio" value="no"'
 				);
+				expect(elementInnerHtml).toContain(`${submittedText}</textarea>`);
 
 				const unprettifiedErrorSummaryHtml = parseHtml(response.text, {
 					rootElement: '.govuk-error-summary',

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/environmental-impact-assessment/environmental-impact-assessment.controller.js
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/environmental-impact-assessment/environmental-impact-assessment.controller.js
@@ -189,7 +189,8 @@ const renderChangeEiaSensitiveAreaDetails = async (request, response) => {
 	const mappedPageContents = changeEiaSensitiveAreaDetailsPage(
 		request.currentAppeal,
 		lpaQuestionnaire.eiaSensitiveAreaDetails,
-		request.session.eiaSensitiveAreaDetails?.radio
+		request.session.eiaSensitiveAreaDetails?.radio,
+		request.session.eiaSensitiveAreaDetails?.details
 	);
 
 	return response.status(200).render('patterns/change-page.pattern.njk', {
@@ -268,7 +269,8 @@ const renderChangeEiaConsultedBodiesDetails = async (request, response) => {
 	const mappedPageContents = changeEiaConsultedBodiesDetailsPage(
 		request.currentAppeal,
 		lpaQuestionnaire.eiaConsultedBodiesDetails,
-		request.session.eiaConsultedBodiesDetails?.radio
+		request.session.eiaConsultedBodiesDetails?.radio,
+		request.session.eiaConsultedBodiesDetails?.details
 	);
 
 	return response.status(200).render('patterns/change-page.pattern.njk', {

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/environmental-impact-assessment/environmental-impact-assessment.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/environmental-impact-assessment/environmental-impact-assessment.mapper.js
@@ -64,9 +64,15 @@ export function changeEiaRequiresEnvironmentalStatementPage(appealData, existing
  * @param {Appeal} appealData
  * @param {string|null} existingValue
  * @param {string|undefined} [sessionRadioValue]
+ * @param {string|undefined} [sessionDetailsValue]
  * @returns {PageContent}
  */
-export function changeEiaSensitiveAreaDetailsPage(appealData, existingValue, sessionRadioValue) {
+export function changeEiaSensitiveAreaDetailsPage(
+	appealData,
+	existingValue,
+	sessionRadioValue,
+	sessionDetailsValue
+) {
 	const shortAppealReference = appealShortReference(appealData.appealReference);
 
 	/** @type {PageContent} */
@@ -83,7 +89,7 @@ export function changeEiaSensitiveAreaDetailsPage(appealData, existingValue, ses
 					id: 'eia-sensitive-area-details',
 					name: 'eiaSensitiveAreaDetails',
 					hint: 'In, partly in, or likely to affect a sensitive area details',
-					details: existingValue || ''
+					details: sessionDetailsValue || existingValue || ''
 				}
 			})
 		]
@@ -96,9 +102,15 @@ export function changeEiaSensitiveAreaDetailsPage(appealData, existingValue, ses
  * @param {Appeal} appealData
  * @param {string|null} existingValue
  * @param {string|undefined} [sessionRadioValue]
+ * @param {string|undefined} [sessionDetailsValue]
  * @returns {PageContent}
  */
-export function changeEiaConsultedBodiesDetailsPage(appealData, existingValue, sessionRadioValue) {
+export function changeEiaConsultedBodiesDetailsPage(
+	appealData,
+	existingValue,
+	sessionRadioValue,
+	sessionDetailsValue
+) {
 	const shortAppealReference = appealShortReference(appealData.appealReference);
 
 	/** @type {PageContent} */
@@ -115,7 +127,7 @@ export function changeEiaConsultedBodiesDetailsPage(appealData, existingValue, s
 					id: 'eia-consulted-bodies-details',
 					name: 'eiaConsultedBodiesDetails',
 					hint: 'Consulted relevant statutory consultees details',
-					details: existingValue || ''
+					details: sessionDetailsValue || existingValue || ''
 				}
 			})
 		]

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/neighbouring-site-access/__tests__/neighbouring-site-access.test.js
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/neighbouring-site-access/__tests__/neighbouring-site-access.test.js
@@ -190,7 +190,7 @@ describe('neighbouring-site-access', () => {
 				);
 			});
 
-			it('should re-render the change neighbouring site access page with the expected validation error and the "yes" radio option checked, if "yes" was selected and the text entered in the details textarea exceeds 1000 characters in length', async () => {
+			it('should re-render the change neighbouring site access page with the expected validation error, and the "yes" radio option checked, and the details textarea pre-populated with the submitted text, if "yes" was selected and the text entered in the details textarea exceeds 1000 characters in length', async () => {
 				nock('http://test/').get('/appeals/1').reply(200, appealDataFullPlanning);
 				nock('http://test/')
 					.get(`/appeals/1/lpa-questionnaires/${appealDataFullPlanning.lpaQuestionnaireId}`)
@@ -199,13 +199,15 @@ describe('neighbouring-site-access', () => {
 						reasonForNeighbourVisits: null
 					});
 
+				const submittedText = 'a'.repeat(1001);
+
 				const response = await request
 					.post(
 						`${baseUrl}/1/lpa-questionnaire/${appealDataFullPlanning.lpaQuestionnaireId}/neighbouring-site-access/change`
 					)
 					.send({
 						neighbouringSiteAccessRadio: 'yes',
-						neighbouringSiteAccess: 'a'.repeat(1001)
+						neighbouringSiteAccess: submittedText
 					});
 
 				expect(response.statusCode).toBe(200);
@@ -221,6 +223,7 @@ describe('neighbouring-site-access', () => {
 				expect(elementInnerHtml).toContain(
 					'name="neighbouringSiteAccessRadio" type="radio" value="no"'
 				);
+				expect(elementInnerHtml).toContain(`${submittedText}</textarea>`);
 
 				const unprettifiedErrorSummaryHtml = parseHtml(response.text, {
 					rootElement: '.govuk-error-summary',

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/neighbouring-site-access/neighbouring-site-access.controller.js
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/neighbouring-site-access/neighbouring-site-access.controller.js
@@ -28,7 +28,8 @@ const renderChangeNeighbouringSiteAccess = async (request, response) => {
 	const mappedPageContents = changeNeighbouringSiteAccessPage(
 		request.currentAppeal,
 		lpaQuestionnaire.reasonForNeighbourVisits,
-		request.session.neighbouringSiteAccess?.radio
+		request.session.neighbouringSiteAccess?.radio,
+		request.session.neighbouringSiteAccess?.details
 	);
 
 	return response.status(200).render('patterns/change-page.pattern.njk', {

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/neighbouring-site-access/neighbouring-site-access.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/neighbouring-site-access/neighbouring-site-access.mapper.js
@@ -5,9 +5,15 @@ import { yesNoInput } from '#lib/mappers/index.js';
  * @param {import('../../appeal-details.types.js').WebAppeal} appealData
  * @param {string|null} existingValue
  * @param {string|undefined} [sessionRadioValue]
+ * @param {string|undefined} [sessionDetailsValue]
  * @returns {PageContent}
  */
-export function changeNeighbouringSiteAccessPage(appealData, existingValue, sessionRadioValue) {
+export function changeNeighbouringSiteAccessPage(
+	appealData,
+	existingValue,
+	sessionRadioValue,
+	sessionDetailsValue
+) {
 	const shortAppealReference = appealShortReference(appealData.appealReference);
 
 	/** @type {PageContent} */
@@ -24,7 +30,7 @@ export function changeNeighbouringSiteAccessPage(appealData, existingValue, sess
 					id: 'neighbouring-site-access-details',
 					name: 'neighbouringSiteAccess',
 					hint: 'Inspector needs neighbouring site access details',
-					details: existingValue || ''
+					details: sessionDetailsValue || existingValue || ''
 				}
 			})
 		]


### PR DESCRIPTION
## Describe your changes

The following conditional free text rows were recently added to the s78 LPA questionnaire:

- Environmental impact assessment: In, partly in or likely to affect sensitive area
- Consultation responses and representations: Consulted relevant statutory consultees
- Site access: Inspector needs neighbouring site access

This PR fixes an issue where the user-submitted text is cleared from the field if a validation error occurs.

## Issue ticket number and link

A2-1287

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [ ] I have performed a self-review of my own code
- [ ] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [ ] I have referenced the ticket number above
- [ ] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
