### PR TITLE
fix(appeals): error summary should be above heading (a2-1222)

### DIFF
--- a/appeals/web/src/server/appeals/appeal-details/appellant-case/__tests__/__snapshots__/appellant-case.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/appellant-case/__tests__/__snapshots__/appellant-case.test.js.snap
@@ -2600,6 +2600,7 @@ exports[`appellant-case GET /appellant-case/add-document-details/:folderId/:docu
 exports[`appellant-case GET /appellant-case/add-documents/:folderId/ should render a document upload page with a file upload component, and no late entry tag and associated details component, and no additional documents warning text, if the folder is not additional documents 1`] = `
 "<main class="govuk-main-wrapper " id="main-content" role="main">
     <div class="govuk-grid-row">
+        <div class="top-errors-hook govuk-grid-column-two-thirds"></div>
         <div class="govuk-grid-column-full"><span class="govuk-caption-xl">Appeal 351062</span>
             <h1 class="govuk-heading-xl govuk-!-margin-bottom-3">Upload documents</h1>
         </div>
@@ -2611,34 +2612,34 @@ exports[`appellant-case GET /appellant-case/add-documents/:folderId/ should rend
             data-document-type="changedDescription" data-document-stage="appellant-case"
             data-blob-storage-host="https://127.0.0.1:10000/devstoreaccount1" data-blob-storage-container="document-service-uploads"
             data-allowed-types=".pdf,application/pdf,.doc,application/msword,.docx,application/vnd.openxmlformats-officedocument.wordprocessingml.document,.ppt,application/vnd.ms-powerpoint,.pptx,application/vnd.openxmlformats-officedocument.presentationml.presentation,.xls,application/vnd.ms-excel,.xlsx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,.msg,application/vnd.ms-outlook,.jpg,image/jpeg,.jpeg,image/jpeg,.mpeg,video/mpeg,.mp3,audio/mpeg,.mp4,video/mp4,.mov,video/quicktime,.png,image/png,.tif,image/tiff,.tiff,image/tiff,">
-                <div class="top-errors-hook govuk-grid-column-two-thirds"></div>
                 <form method="POST" novalidate="novalidate" class="govuk-grid-column-two-thirds"
                 data-filenames-in-folder="WyJ0ZXN0LXBkZi1kb2N1bWVudEZvbGRlckluZm8ucGRmIiwic2FtcGxlLTIwcy1kb2N1bWVudEZvbGRlckluZm8ubXA0IiwicGgwLWRvY3VtZW50Rm9sZGVySW5mby5qcGVnIiwicGgxLWRvY3VtZW50Rm9sZGVySW5mby5qcGVnIl0=">
                     <div class="pins-file-upload__container">
                         <div class="govuk-body colour--secondary pins-file-upload__instructions">
                             <label for="upload-file-1">Choose a single file or multiple files to upload.</label><span>Each file must be a PDF, DOC, DOCX, PPT, PPTX, XLS, XLSX, MSG, JPG, JPEG, MPEG, MP3, MP4, MOV, PNG, TIF, 	or TIFF.</span><span>The total size of your uploaded files must be smaller than 1GB.</span>
-                            <div                             class="middle-errors-hook"></div>
+                        </div>
+                        <div class="middle-errors-hook">
+                            <div class="pins-file-upload__upload">
+                                <input class="display--none" id="upload-file-1" accept=".pdf,application/pdf,.doc,application/msword,.docx,application/vnd.openxmlformats-officedocument.wordprocessingml.document,.ppt,application/vnd.ms-powerpoint,.pptx,application/vnd.openxmlformats-officedocument.presentationml.presentation,.xls,application/vnd.ms-excel,.xlsx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,.msg,application/vnd.ms-outlook,.jpg,image/jpeg,.jpeg,image/jpeg,.mpeg,video/mpeg,.mp3,audio/mpeg,.mp4,video/mp4,.mov,video/quicktime,.png,image/png,.tif,image/tiff,.tiff,image/tiff,"
+                                type="file" name="files" value="Choose file" aria-controls="file-list-1"
+                                multiple><span class='govuk-body pins-file-upload__dropzone-text'>Drag and drop files here or</span>
+                                <button                                 type='button' class="pins-file-upload__button govuk-button">Select files</button>
+                            </div>
+                            <div id="file-list-1">
+                                <h2 class="display--sr-only" id="file-list-title-1">List of files to upload</h2>
+                                <ul class="pins-file-upload__files-rows" aria-describedby="file-list-title-1"
+                                aria-live="polite"></ul>
+                            </div>
+                        </div>
                     </div>
-                    <div class="pins-file-upload__upload">
-                        <input class="display--none" id="upload-file-1" accept=".pdf,application/pdf,.doc,application/msword,.docx,application/vnd.openxmlformats-officedocument.wordprocessingml.document,.ppt,application/vnd.ms-powerpoint,.pptx,application/vnd.openxmlformats-officedocument.presentationml.presentation,.xls,application/vnd.ms-excel,.xlsx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,.msg,application/vnd.ms-outlook,.jpg,image/jpeg,.jpeg,image/jpeg,.mpeg,video/mpeg,.mp3,audio/mpeg,.mp4,video/mp4,.mov,video/quicktime,.png,image/png,.tif,image/tiff,.tiff,image/tiff,"
-                        type="file" name="files" value="Choose file" aria-controls="file-list-1"
-                        multiple><span class='govuk-body pins-file-upload__dropzone-text'>Drag and drop files here or</span>
-                        <button                         type='button' class="pins-file-upload__button govuk-button">Select files</button>
+                    <div class="display--flex">
+                        <button type="submit" class="govuk-button pins-file-upload__submit" data-module="govuk-button"
+                        id="submit-button-1">Continue</button>
+                        <div class="progress-hook"></div>
                     </div>
-                    <div id="file-list-1">
-                        <h2 class="display--sr-only" id="file-list-title-1">List of files to upload</h2>
-                        <ul class="pins-file-upload__files-rows" aria-describedby="file-list-title-1"
-                        aria-live="polite"></ul>
-                    </div>
+                </form>
             </div>
-            <div class="display--flex">
-                <button type="submit" class="govuk-button pins-file-upload__submit" data-module="govuk-button"
-                id="submit-button-1">Continue</button>
-                <div class="progress-hook"></div>
-            </div>
-            </form>
         </div>
-    </div>
     </div>
 </main>"
 `;
@@ -2646,6 +2647,7 @@ exports[`appellant-case GET /appellant-case/add-documents/:folderId/ should rend
 exports[`appellant-case GET /appellant-case/add-documents/:folderId/ should render document upload page with additional documents warning text, and without late entry status tag and associated details component, if the folder is additional documents, and the appellant case has a validation outcome of incomplete 1`] = `
 "<main class="govuk-main-wrapper " id="main-content" role="main">
     <div class="govuk-grid-row">
+        <div class="top-errors-hook govuk-grid-column-two-thirds"></div>
         <div class="govuk-grid-column-full"><span class="govuk-caption-xl">Appeal 351062</span>
             <h1 class="govuk-heading-xl govuk-!-margin-bottom-3">Upload additional documents</h1>
         </div>
@@ -2657,38 +2659,38 @@ exports[`appellant-case GET /appellant-case/add-documents/:folderId/ should rend
             data-document-type="appellantCaseCorrespondence" data-document-stage="appellant-case"
             data-blob-storage-host="https://127.0.0.1:10000/devstoreaccount1" data-blob-storage-container="document-service-uploads"
             data-allowed-types=".pdf,application/pdf,.doc,application/msword,.docx,application/vnd.openxmlformats-officedocument.wordprocessingml.document,.ppt,application/vnd.ms-powerpoint,.pptx,application/vnd.openxmlformats-officedocument.presentationml.presentation,.xls,application/vnd.ms-excel,.xlsx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,.msg,application/vnd.ms-outlook,.jpg,image/jpeg,.jpeg,image/jpeg,.mpeg,video/mpeg,.mp3,audio/mpeg,.mp4,video/mp4,.mov,video/quicktime,.png,image/png,.tif,image/tiff,.tiff,image/tiff,">
-                <div class="top-errors-hook govuk-grid-column-two-thirds"></div>
                 <form method="POST" novalidate="novalidate" class="govuk-grid-column-two-thirds"
                 data-filenames-in-folder="WyJ0ZXN0LXBkZi1kb2N1bWVudEZvbGRlckluZm8ucGRmIiwic2FtcGxlLTIwcy1kb2N1bWVudEZvbGRlckluZm8ubXA0IiwicGgwLWRvY3VtZW50Rm9sZGVySW5mby5qcGVnIiwicGgxLWRvY3VtZW50Rm9sZGVySW5mby5qcGVnIl0=">
                     <div class="pins-file-upload__container">
                         <div class="govuk-body colour--secondary pins-file-upload__instructions">
                             <label for="upload-file-1">Choose a single file or multiple files to upload.</label><span>Each file must be a PDF, DOC, DOCX, PPT, PPTX, XLS, XLSX, MSG, JPG, JPEG, MPEG, MP3, MP4, MOV, PNG, TIF, 	or TIFF.</span><span>The total size of your uploaded files must be smaller than 1GB.</span>
-                            <div                             class="middle-errors-hook"></div>
+                        </div>
+                        <div class="middle-errors-hook">
+                            <div class="pins-file-upload__upload">
+                                <input class="display--none" id="upload-file-1" accept=".pdf,application/pdf,.doc,application/msword,.docx,application/vnd.openxmlformats-officedocument.wordprocessingml.document,.ppt,application/vnd.ms-powerpoint,.pptx,application/vnd.openxmlformats-officedocument.presentationml.presentation,.xls,application/vnd.ms-excel,.xlsx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,.msg,application/vnd.ms-outlook,.jpg,image/jpeg,.jpeg,image/jpeg,.mpeg,video/mpeg,.mp3,audio/mpeg,.mp4,video/mp4,.mov,video/quicktime,.png,image/png,.tif,image/tiff,.tiff,image/tiff,"
+                                type="file" name="files" value="Choose file" aria-controls="file-list-1"
+                                multiple><span class='govuk-body pins-file-upload__dropzone-text'>Drag and drop files here or</span>
+                                <button                                 type='button' class="pins-file-upload__button govuk-button">Select files</button>
+                            </div>
+                            <div id="file-list-1">
+                                <h2 class="display--sr-only" id="file-list-title-1">List of files to upload</h2>
+                                <ul class="pins-file-upload__files-rows" aria-describedby="file-list-title-1"
+                                aria-live="polite"></ul>
+                            </div>
+                        </div>
                     </div>
-                    <div class="pins-file-upload__upload">
-                        <input class="display--none" id="upload-file-1" accept=".pdf,application/pdf,.doc,application/msword,.docx,application/vnd.openxmlformats-officedocument.wordprocessingml.document,.ppt,application/vnd.ms-powerpoint,.pptx,application/vnd.openxmlformats-officedocument.presentationml.presentation,.xls,application/vnd.ms-excel,.xlsx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,.msg,application/vnd.ms-outlook,.jpg,image/jpeg,.jpeg,image/jpeg,.mpeg,video/mpeg,.mp3,audio/mpeg,.mp4,video/mp4,.mov,video/quicktime,.png,image/png,.tif,image/tiff,.tiff,image/tiff,"
-                        type="file" name="files" value="Choose file" aria-controls="file-list-1"
-                        multiple><span class='govuk-body pins-file-upload__dropzone-text'>Drag and drop files here or</span>
-                        <button                         type='button' class="pins-file-upload__button govuk-button">Select files</button>
+                    <div class="govuk-warning-text"><span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+                        <strong                         class="govuk-warning-text__text"><span class="govuk-warning-text__assistive">Warning</span> Only upload
+                            files to additional documents when no other folder is applicable.</strong>
                     </div>
-                    <div id="file-list-1">
-                        <h2 class="display--sr-only" id="file-list-title-1">List of files to upload</h2>
-                        <ul class="pins-file-upload__files-rows" aria-describedby="file-list-title-1"
-                        aria-live="polite"></ul>
+                    <div class="display--flex">
+                        <button type="submit" class="govuk-button pins-file-upload__submit" data-module="govuk-button"
+                        id="submit-button-1">Continue</button>
+                        <div class="progress-hook"></div>
                     </div>
+                </form>
             </div>
-            <div class="govuk-warning-text"><span class="govuk-warning-text__icon" aria-hidden="true">!</span>
-                <strong                 class="govuk-warning-text__text"><span class="govuk-warning-text__assistive">Warning</span> Only upload
-                    files to additional documents when no other folder is applicable.</strong>
-            </div>
-            <div class="display--flex">
-                <button type="submit" class="govuk-button pins-file-upload__submit" data-module="govuk-button"
-                id="submit-button-1">Continue</button>
-                <div class="progress-hook"></div>
-            </div>
-            </form>
         </div>
-    </div>
     </div>
 </main>"
 `;
@@ -2696,6 +2698,7 @@ exports[`appellant-case GET /appellant-case/add-documents/:folderId/ should rend
 exports[`appellant-case GET /appellant-case/add-documents/:folderId/ should render document upload page with additional documents warning text, and without late entry status tag and associated details component, if the folder is additional documents, and the appellant case has a validation outcome of invalid 1`] = `
 "<main class="govuk-main-wrapper " id="main-content" role="main">
     <div class="govuk-grid-row">
+        <div class="top-errors-hook govuk-grid-column-two-thirds"></div>
         <div class="govuk-grid-column-full"><span class="govuk-caption-xl">Appeal 351062</span>
             <h1 class="govuk-heading-xl govuk-!-margin-bottom-3">Upload additional documents</h1>
         </div>
@@ -2707,38 +2710,38 @@ exports[`appellant-case GET /appellant-case/add-documents/:folderId/ should rend
             data-document-type="appellantCaseCorrespondence" data-document-stage="appellant-case"
             data-blob-storage-host="https://127.0.0.1:10000/devstoreaccount1" data-blob-storage-container="document-service-uploads"
             data-allowed-types=".pdf,application/pdf,.doc,application/msword,.docx,application/vnd.openxmlformats-officedocument.wordprocessingml.document,.ppt,application/vnd.ms-powerpoint,.pptx,application/vnd.openxmlformats-officedocument.presentationml.presentation,.xls,application/vnd.ms-excel,.xlsx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,.msg,application/vnd.ms-outlook,.jpg,image/jpeg,.jpeg,image/jpeg,.mpeg,video/mpeg,.mp3,audio/mpeg,.mp4,video/mp4,.mov,video/quicktime,.png,image/png,.tif,image/tiff,.tiff,image/tiff,">
-                <div class="top-errors-hook govuk-grid-column-two-thirds"></div>
                 <form method="POST" novalidate="novalidate" class="govuk-grid-column-two-thirds"
                 data-filenames-in-folder="WyJ0ZXN0LXBkZi1kb2N1bWVudEZvbGRlckluZm8ucGRmIiwic2FtcGxlLTIwcy1kb2N1bWVudEZvbGRlckluZm8ubXA0IiwicGgwLWRvY3VtZW50Rm9sZGVySW5mby5qcGVnIiwicGgxLWRvY3VtZW50Rm9sZGVySW5mby5qcGVnIl0=">
                     <div class="pins-file-upload__container">
                         <div class="govuk-body colour--secondary pins-file-upload__instructions">
                             <label for="upload-file-1">Choose a single file or multiple files to upload.</label><span>Each file must be a PDF, DOC, DOCX, PPT, PPTX, XLS, XLSX, MSG, JPG, JPEG, MPEG, MP3, MP4, MOV, PNG, TIF, 	or TIFF.</span><span>The total size of your uploaded files must be smaller than 1GB.</span>
-                            <div                             class="middle-errors-hook"></div>
+                        </div>
+                        <div class="middle-errors-hook">
+                            <div class="pins-file-upload__upload">
+                                <input class="display--none" id="upload-file-1" accept=".pdf,application/pdf,.doc,application/msword,.docx,application/vnd.openxmlformats-officedocument.wordprocessingml.document,.ppt,application/vnd.ms-powerpoint,.pptx,application/vnd.openxmlformats-officedocument.presentationml.presentation,.xls,application/vnd.ms-excel,.xlsx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,.msg,application/vnd.ms-outlook,.jpg,image/jpeg,.jpeg,image/jpeg,.mpeg,video/mpeg,.mp3,audio/mpeg,.mp4,video/mp4,.mov,video/quicktime,.png,image/png,.tif,image/tiff,.tiff,image/tiff,"
+                                type="file" name="files" value="Choose file" aria-controls="file-list-1"
+                                multiple><span class='govuk-body pins-file-upload__dropzone-text'>Drag and drop files here or</span>
+                                <button                                 type='button' class="pins-file-upload__button govuk-button">Select files</button>
+                            </div>
+                            <div id="file-list-1">
+                                <h2 class="display--sr-only" id="file-list-title-1">List of files to upload</h2>
+                                <ul class="pins-file-upload__files-rows" aria-describedby="file-list-title-1"
+                                aria-live="polite"></ul>
+                            </div>
+                        </div>
                     </div>
-                    <div class="pins-file-upload__upload">
-                        <input class="display--none" id="upload-file-1" accept=".pdf,application/pdf,.doc,application/msword,.docx,application/vnd.openxmlformats-officedocument.wordprocessingml.document,.ppt,application/vnd.ms-powerpoint,.pptx,application/vnd.openxmlformats-officedocument.presentationml.presentation,.xls,application/vnd.ms-excel,.xlsx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,.msg,application/vnd.ms-outlook,.jpg,image/jpeg,.jpeg,image/jpeg,.mpeg,video/mpeg,.mp3,audio/mpeg,.mp4,video/mp4,.mov,video/quicktime,.png,image/png,.tif,image/tiff,.tiff,image/tiff,"
-                        type="file" name="files" value="Choose file" aria-controls="file-list-1"
-                        multiple><span class='govuk-body pins-file-upload__dropzone-text'>Drag and drop files here or</span>
-                        <button                         type='button' class="pins-file-upload__button govuk-button">Select files</button>
+                    <div class="govuk-warning-text"><span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+                        <strong                         class="govuk-warning-text__text"><span class="govuk-warning-text__assistive">Warning</span> Only upload
+                            files to additional documents when no other folder is applicable.</strong>
                     </div>
-                    <div id="file-list-1">
-                        <h2 class="display--sr-only" id="file-list-title-1">List of files to upload</h2>
-                        <ul class="pins-file-upload__files-rows" aria-describedby="file-list-title-1"
-                        aria-live="polite"></ul>
+                    <div class="display--flex">
+                        <button type="submit" class="govuk-button pins-file-upload__submit" data-module="govuk-button"
+                        id="submit-button-1">Continue</button>
+                        <div class="progress-hook"></div>
                     </div>
+                </form>
             </div>
-            <div class="govuk-warning-text"><span class="govuk-warning-text__icon" aria-hidden="true">!</span>
-                <strong                 class="govuk-warning-text__text"><span class="govuk-warning-text__assistive">Warning</span> Only upload
-                    files to additional documents when no other folder is applicable.</strong>
-            </div>
-            <div class="display--flex">
-                <button type="submit" class="govuk-button pins-file-upload__submit" data-module="govuk-button"
-                id="submit-button-1">Continue</button>
-                <div class="progress-hook"></div>
-            </div>
-            </form>
         </div>
-    </div>
     </div>
 </main>"
 `;
@@ -2746,6 +2749,7 @@ exports[`appellant-case GET /appellant-case/add-documents/:folderId/ should rend
 exports[`appellant-case GET /appellant-case/add-documents/:folderId/ should render document upload page with additional documents warning text, and without late entry status tag and associated details component, if the folder is additional documents, and the appellant case has no validation outcome 1`] = `
 "<main class="govuk-main-wrapper " id="main-content" role="main">
     <div class="govuk-grid-row">
+        <div class="top-errors-hook govuk-grid-column-two-thirds"></div>
         <div class="govuk-grid-column-full"><span class="govuk-caption-xl">Appeal 351062</span>
             <h1 class="govuk-heading-xl govuk-!-margin-bottom-3">Upload additional documents</h1>
         </div>
@@ -2757,38 +2761,38 @@ exports[`appellant-case GET /appellant-case/add-documents/:folderId/ should rend
             data-document-type="appellantCaseCorrespondence" data-document-stage="appellant-case"
             data-blob-storage-host="https://127.0.0.1:10000/devstoreaccount1" data-blob-storage-container="document-service-uploads"
             data-allowed-types=".pdf,application/pdf,.doc,application/msword,.docx,application/vnd.openxmlformats-officedocument.wordprocessingml.document,.ppt,application/vnd.ms-powerpoint,.pptx,application/vnd.openxmlformats-officedocument.presentationml.presentation,.xls,application/vnd.ms-excel,.xlsx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,.msg,application/vnd.ms-outlook,.jpg,image/jpeg,.jpeg,image/jpeg,.mpeg,video/mpeg,.mp3,audio/mpeg,.mp4,video/mp4,.mov,video/quicktime,.png,image/png,.tif,image/tiff,.tiff,image/tiff,">
-                <div class="top-errors-hook govuk-grid-column-two-thirds"></div>
                 <form method="POST" novalidate="novalidate" class="govuk-grid-column-two-thirds"
                 data-filenames-in-folder="WyJ0ZXN0LXBkZi1kb2N1bWVudEZvbGRlckluZm8ucGRmIiwic2FtcGxlLTIwcy1kb2N1bWVudEZvbGRlckluZm8ubXA0IiwicGgwLWRvY3VtZW50Rm9sZGVySW5mby5qcGVnIiwicGgxLWRvY3VtZW50Rm9sZGVySW5mby5qcGVnIl0=">
                     <div class="pins-file-upload__container">
                         <div class="govuk-body colour--secondary pins-file-upload__instructions">
                             <label for="upload-file-1">Choose a single file or multiple files to upload.</label><span>Each file must be a PDF, DOC, DOCX, PPT, PPTX, XLS, XLSX, MSG, JPG, JPEG, MPEG, MP3, MP4, MOV, PNG, TIF, 	or TIFF.</span><span>The total size of your uploaded files must be smaller than 1GB.</span>
-                            <div                             class="middle-errors-hook"></div>
+                        </div>
+                        <div class="middle-errors-hook">
+                            <div class="pins-file-upload__upload">
+                                <input class="display--none" id="upload-file-1" accept=".pdf,application/pdf,.doc,application/msword,.docx,application/vnd.openxmlformats-officedocument.wordprocessingml.document,.ppt,application/vnd.ms-powerpoint,.pptx,application/vnd.openxmlformats-officedocument.presentationml.presentation,.xls,application/vnd.ms-excel,.xlsx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,.msg,application/vnd.ms-outlook,.jpg,image/jpeg,.jpeg,image/jpeg,.mpeg,video/mpeg,.mp3,audio/mpeg,.mp4,video/mp4,.mov,video/quicktime,.png,image/png,.tif,image/tiff,.tiff,image/tiff,"
+                                type="file" name="files" value="Choose file" aria-controls="file-list-1"
+                                multiple><span class='govuk-body pins-file-upload__dropzone-text'>Drag and drop files here or</span>
+                                <button                                 type='button' class="pins-file-upload__button govuk-button">Select files</button>
+                            </div>
+                            <div id="file-list-1">
+                                <h2 class="display--sr-only" id="file-list-title-1">List of files to upload</h2>
+                                <ul class="pins-file-upload__files-rows" aria-describedby="file-list-title-1"
+                                aria-live="polite"></ul>
+                            </div>
+                        </div>
                     </div>
-                    <div class="pins-file-upload__upload">
-                        <input class="display--none" id="upload-file-1" accept=".pdf,application/pdf,.doc,application/msword,.docx,application/vnd.openxmlformats-officedocument.wordprocessingml.document,.ppt,application/vnd.ms-powerpoint,.pptx,application/vnd.openxmlformats-officedocument.presentationml.presentation,.xls,application/vnd.ms-excel,.xlsx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,.msg,application/vnd.ms-outlook,.jpg,image/jpeg,.jpeg,image/jpeg,.mpeg,video/mpeg,.mp3,audio/mpeg,.mp4,video/mp4,.mov,video/quicktime,.png,image/png,.tif,image/tiff,.tiff,image/tiff,"
-                        type="file" name="files" value="Choose file" aria-controls="file-list-1"
-                        multiple><span class='govuk-body pins-file-upload__dropzone-text'>Drag and drop files here or</span>
-                        <button                         type='button' class="pins-file-upload__button govuk-button">Select files</button>
+                    <div class="govuk-warning-text"><span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+                        <strong                         class="govuk-warning-text__text"><span class="govuk-warning-text__assistive">Warning</span> Only upload
+                            files to additional documents when no other folder is applicable.</strong>
                     </div>
-                    <div id="file-list-1">
-                        <h2 class="display--sr-only" id="file-list-title-1">List of files to upload</h2>
-                        <ul class="pins-file-upload__files-rows" aria-describedby="file-list-title-1"
-                        aria-live="polite"></ul>
+                    <div class="display--flex">
+                        <button type="submit" class="govuk-button pins-file-upload__submit" data-module="govuk-button"
+                        id="submit-button-1">Continue</button>
+                        <div class="progress-hook"></div>
                     </div>
+                </form>
             </div>
-            <div class="govuk-warning-text"><span class="govuk-warning-text__icon" aria-hidden="true">!</span>
-                <strong                 class="govuk-warning-text__text"><span class="govuk-warning-text__assistive">Warning</span> Only upload
-                    files to additional documents when no other folder is applicable.</strong>
-            </div>
-            <div class="display--flex">
-                <button type="submit" class="govuk-button pins-file-upload__submit" data-module="govuk-button"
-                id="submit-button-1">Continue</button>
-                <div class="progress-hook"></div>
-            </div>
-            </form>
         </div>
-    </div>
     </div>
 </main>"
 `;
@@ -2796,6 +2800,7 @@ exports[`appellant-case GET /appellant-case/add-documents/:folderId/ should rend
 exports[`appellant-case GET /appellant-case/add-documents/:folderId/ should render document upload page with late entry status tag and associated details component, and without additional documents warning text, if the folder is additional documents, and the appellant case validation outcome is valid 1`] = `
 "<main class="govuk-main-wrapper " id="main-content" role="main">
     <div class="govuk-grid-row">
+        <div class="top-errors-hook govuk-grid-column-two-thirds"></div>
         <div class="govuk-grid-column-full"><span class="govuk-caption-xl">Appeal 351062</span>
             <h1 class="govuk-heading-xl govuk-!-margin-bottom-3">Upload additional documents</h1>
         </div>
@@ -2826,34 +2831,34 @@ exports[`appellant-case GET /appellant-case/add-documents/:folderId/ should rend
             data-document-type="appellantCaseCorrespondence" data-document-stage="appellant-case"
             data-blob-storage-host="https://127.0.0.1:10000/devstoreaccount1" data-blob-storage-container="document-service-uploads"
             data-allowed-types=".pdf,application/pdf,.doc,application/msword,.docx,application/vnd.openxmlformats-officedocument.wordprocessingml.document,.ppt,application/vnd.ms-powerpoint,.pptx,application/vnd.openxmlformats-officedocument.presentationml.presentation,.xls,application/vnd.ms-excel,.xlsx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,.msg,application/vnd.ms-outlook,.jpg,image/jpeg,.jpeg,image/jpeg,.mpeg,video/mpeg,.mp3,audio/mpeg,.mp4,video/mp4,.mov,video/quicktime,.png,image/png,.tif,image/tiff,.tiff,image/tiff,">
-                <div class="top-errors-hook govuk-grid-column-two-thirds"></div>
                 <form method="POST" novalidate="novalidate" class="govuk-grid-column-two-thirds"
                 data-filenames-in-folder="WyJ0ZXN0LXBkZi1kb2N1bWVudEZvbGRlckluZm8ucGRmIiwic2FtcGxlLTIwcy1kb2N1bWVudEZvbGRlckluZm8ubXA0IiwicGgwLWRvY3VtZW50Rm9sZGVySW5mby5qcGVnIiwicGgxLWRvY3VtZW50Rm9sZGVySW5mby5qcGVnIl0=">
                     <div class="pins-file-upload__container">
                         <div class="govuk-body colour--secondary pins-file-upload__instructions">
                             <label for="upload-file-1">Choose a single file or multiple files to upload.</label><span>Each file must be a PDF, DOC, DOCX, PPT, PPTX, XLS, XLSX, MSG, JPG, JPEG, MPEG, MP3, MP4, MOV, PNG, TIF, 	or TIFF.</span><span>The total size of your uploaded files must be smaller than 1GB.</span>
-                            <div                             class="middle-errors-hook"></div>
+                        </div>
+                        <div class="middle-errors-hook">
+                            <div class="pins-file-upload__upload">
+                                <input class="display--none" id="upload-file-1" accept=".pdf,application/pdf,.doc,application/msword,.docx,application/vnd.openxmlformats-officedocument.wordprocessingml.document,.ppt,application/vnd.ms-powerpoint,.pptx,application/vnd.openxmlformats-officedocument.presentationml.presentation,.xls,application/vnd.ms-excel,.xlsx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,.msg,application/vnd.ms-outlook,.jpg,image/jpeg,.jpeg,image/jpeg,.mpeg,video/mpeg,.mp3,audio/mpeg,.mp4,video/mp4,.mov,video/quicktime,.png,image/png,.tif,image/tiff,.tiff,image/tiff,"
+                                type="file" name="files" value="Choose file" aria-controls="file-list-1"
+                                multiple><span class='govuk-body pins-file-upload__dropzone-text'>Drag and drop files here or</span>
+                                <button                                 type='button' class="pins-file-upload__button govuk-button">Select files</button>
+                            </div>
+                            <div id="file-list-1">
+                                <h2 class="display--sr-only" id="file-list-title-1">List of files to upload</h2>
+                                <ul class="pins-file-upload__files-rows" aria-describedby="file-list-title-1"
+                                aria-live="polite"></ul>
+                            </div>
+                        </div>
                     </div>
-                    <div class="pins-file-upload__upload">
-                        <input class="display--none" id="upload-file-1" accept=".pdf,application/pdf,.doc,application/msword,.docx,application/vnd.openxmlformats-officedocument.wordprocessingml.document,.ppt,application/vnd.ms-powerpoint,.pptx,application/vnd.openxmlformats-officedocument.presentationml.presentation,.xls,application/vnd.ms-excel,.xlsx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,.msg,application/vnd.ms-outlook,.jpg,image/jpeg,.jpeg,image/jpeg,.mpeg,video/mpeg,.mp3,audio/mpeg,.mp4,video/mp4,.mov,video/quicktime,.png,image/png,.tif,image/tiff,.tiff,image/tiff,"
-                        type="file" name="files" value="Choose file" aria-controls="file-list-1"
-                        multiple><span class='govuk-body pins-file-upload__dropzone-text'>Drag and drop files here or</span>
-                        <button                         type='button' class="pins-file-upload__button govuk-button">Select files</button>
+                    <div class="display--flex">
+                        <button type="submit" class="govuk-button pins-file-upload__submit" data-module="govuk-button"
+                        id="submit-button-1">Continue</button>
+                        <div class="progress-hook"></div>
                     </div>
-                    <div id="file-list-1">
-                        <h2 class="display--sr-only" id="file-list-title-1">List of files to upload</h2>
-                        <ul class="pins-file-upload__files-rows" aria-describedby="file-list-title-1"
-                        aria-live="polite"></ul>
-                    </div>
+                </form>
             </div>
-            <div class="display--flex">
-                <button type="submit" class="govuk-button pins-file-upload__submit" data-module="govuk-button"
-                id="submit-button-1">Continue</button>
-                <div class="progress-hook"></div>
-            </div>
-            </form>
         </div>
-    </div>
     </div>
 </main>"
 `;
@@ -2861,6 +2866,7 @@ exports[`appellant-case GET /appellant-case/add-documents/:folderId/ should rend
 exports[`appellant-case GET /appellant-case/add-documents/:folderId/:documentId should render a document upload page with a file upload component, and no late entry tag and associated details component, and no additional documents warning text, if the folder is not additional documents 1`] = `
 "<main class="govuk-main-wrapper " id="main-content" role="main">
     <div class="govuk-grid-row">
+        <div class="top-errors-hook govuk-grid-column-two-thirds"></div>
         <div class="govuk-grid-column-full"><span class="govuk-caption-xl">Appeal 351062</span>
             <h1 class="govuk-heading-xl govuk-!-margin-bottom-3">Upload an updated document</h1>
         </div>
@@ -2873,33 +2879,33 @@ exports[`appellant-case GET /appellant-case/add-documents/:folderId/:documentId 
             data-blob-storage-host="https://127.0.0.1:10000/devstoreaccount1" data-blob-storage-container="document-service-uploads"
             data-document-id="1" data-document-original-file-name="test-pdf-documentFileVersionsInfo.pdf"
             data-document-version="1" data-allowed-types=".pdf,application/pdf,.doc,application/msword,.docx,application/vnd.openxmlformats-officedocument.wordprocessingml.document,.ppt,application/vnd.ms-powerpoint,.pptx,application/vnd.openxmlformats-officedocument.presentationml.presentation,.xls,application/vnd.ms-excel,.xlsx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,.msg,application/vnd.ms-outlook,.jpg,image/jpeg,.jpeg,image/jpeg,.mpeg,video/mpeg,.mp3,audio/mpeg,.mp4,video/mp4,.mov,video/quicktime,.png,image/png,.tif,image/tiff,.tiff,image/tiff,">
-                <div class="top-errors-hook govuk-grid-column-two-thirds"></div>
                 <form method="POST" novalidate="novalidate" class="govuk-grid-column-two-thirds"
                 data-filenames-in-folder="WyJ0ZXN0LXBkZi1kb2N1bWVudEZvbGRlckluZm8ucGRmIiwic2FtcGxlLTIwcy1kb2N1bWVudEZvbGRlckluZm8ubXA0IiwicGgwLWRvY3VtZW50Rm9sZGVySW5mby5qcGVnIiwicGgxLWRvY3VtZW50Rm9sZGVySW5mby5qcGVnIl0=">
                     <div class="pins-file-upload__container">
                         <div class="govuk-body colour--secondary pins-file-upload__instructions">
                             <label for="upload-file-1">Choose a single file to upload.</label><span>The file must be a PDF, DOC, DOCX, PPT, PPTX, XLS, XLSX, MSG, JPG, JPEG, MPEG, MP3, MP4, MOV, PNG, TIF, 	or TIFF.</span><span>The file must be smaller than 25MB.</span>
-                            <div                             class="middle-errors-hook"></div>
+                        </div>
+                        <div class="middle-errors-hook">
+                            <div class="pins-file-upload__upload">
+                                <input class="display--none" id="upload-file-1" accept=".pdf,application/pdf,.doc,application/msword,.docx,application/vnd.openxmlformats-officedocument.wordprocessingml.document,.ppt,application/vnd.ms-powerpoint,.pptx,application/vnd.openxmlformats-officedocument.presentationml.presentation,.xls,application/vnd.ms-excel,.xlsx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,.msg,application/vnd.ms-outlook,.jpg,image/jpeg,.jpeg,image/jpeg,.mpeg,video/mpeg,.mp3,audio/mpeg,.mp4,video/mp4,.mov,video/quicktime,.png,image/png,.tif,image/tiff,.tiff,image/tiff,"
+                                type="file" name="files" value="Choose file" aria-controls="file-list-1">
+                                <button type='button' class="pins-file-upload__button govuk-button">Select files</button>
+                            </div>
+                            <div id="file-list-1">
+                                <h2 class="display--sr-only" id="file-list-title-1">List of files to upload</h2>
+                                <ul class="pins-file-upload__files-rows" aria-describedby="file-list-title-1"
+                                aria-live="polite"></ul>
+                            </div>
+                        </div>
                     </div>
-                    <div class="pins-file-upload__upload">
-                        <input class="display--none" id="upload-file-1" accept=".pdf,application/pdf,.doc,application/msword,.docx,application/vnd.openxmlformats-officedocument.wordprocessingml.document,.ppt,application/vnd.ms-powerpoint,.pptx,application/vnd.openxmlformats-officedocument.presentationml.presentation,.xls,application/vnd.ms-excel,.xlsx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,.msg,application/vnd.ms-outlook,.jpg,image/jpeg,.jpeg,image/jpeg,.mpeg,video/mpeg,.mp3,audio/mpeg,.mp4,video/mp4,.mov,video/quicktime,.png,image/png,.tif,image/tiff,.tiff,image/tiff,"
-                        type="file" name="files" value="Choose file" aria-controls="file-list-1">
-                        <button type='button' class="pins-file-upload__button govuk-button">Select files</button>
+                    <div class="display--flex">
+                        <button type="submit" class="govuk-button pins-file-upload__submit" data-module="govuk-button"
+                        id="submit-button-1">Continue</button>
+                        <div class="progress-hook"></div>
                     </div>
-                    <div id="file-list-1">
-                        <h2 class="display--sr-only" id="file-list-title-1">List of files to upload</h2>
-                        <ul class="pins-file-upload__files-rows" aria-describedby="file-list-title-1"
-                        aria-live="polite"></ul>
-                    </div>
+                </form>
             </div>
-            <div class="display--flex">
-                <button type="submit" class="govuk-button pins-file-upload__submit" data-module="govuk-button"
-                id="submit-button-1">Continue</button>
-                <div class="progress-hook"></div>
-            </div>
-            </form>
         </div>
-    </div>
     </div>
 </main>"
 `;
@@ -2907,6 +2913,7 @@ exports[`appellant-case GET /appellant-case/add-documents/:folderId/:documentId 
 exports[`appellant-case GET /appellant-case/add-documents/:folderId/:documentId should render document upload page with additional documents warning text, and without late entry status tag and associated details component, if the folder is additional documents, and the appellant case has a validation outcome of incomplete 1`] = `
 "<main class="govuk-main-wrapper " id="main-content" role="main">
     <div class="govuk-grid-row">
+        <div class="top-errors-hook govuk-grid-column-two-thirds"></div>
         <div class="govuk-grid-column-full"><span class="govuk-caption-xl">Appeal 351062</span>
             <h1 class="govuk-heading-xl govuk-!-margin-bottom-3">Update additional document</h1>
         </div>
@@ -2919,37 +2926,37 @@ exports[`appellant-case GET /appellant-case/add-documents/:folderId/:documentId 
             data-blob-storage-host="https://127.0.0.1:10000/devstoreaccount1" data-blob-storage-container="document-service-uploads"
             data-document-id="1" data-document-original-file-name="test-pdf-documentFileVersionsInfo.pdf"
             data-document-version="1" data-allowed-types=".pdf,application/pdf,.doc,application/msword,.docx,application/vnd.openxmlformats-officedocument.wordprocessingml.document,.ppt,application/vnd.ms-powerpoint,.pptx,application/vnd.openxmlformats-officedocument.presentationml.presentation,.xls,application/vnd.ms-excel,.xlsx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,.msg,application/vnd.ms-outlook,.jpg,image/jpeg,.jpeg,image/jpeg,.mpeg,video/mpeg,.mp3,audio/mpeg,.mp4,video/mp4,.mov,video/quicktime,.png,image/png,.tif,image/tiff,.tiff,image/tiff,">
-                <div class="top-errors-hook govuk-grid-column-two-thirds"></div>
                 <form method="POST" novalidate="novalidate" class="govuk-grid-column-two-thirds"
                 data-filenames-in-folder="WyJ0ZXN0LXBkZi1kb2N1bWVudEZvbGRlckluZm8ucGRmIiwic2FtcGxlLTIwcy1kb2N1bWVudEZvbGRlckluZm8ubXA0IiwicGgwLWRvY3VtZW50Rm9sZGVySW5mby5qcGVnIiwicGgxLWRvY3VtZW50Rm9sZGVySW5mby5qcGVnIl0=">
                     <div class="pins-file-upload__container">
                         <div class="govuk-body colour--secondary pins-file-upload__instructions">
                             <label for="upload-file-1">Choose a single file to upload.</label><span>The file must be a PDF, DOC, DOCX, PPT, PPTX, XLS, XLSX, MSG, JPG, JPEG, MPEG, MP3, MP4, MOV, PNG, TIF, 	or TIFF.</span><span>The file must be smaller than 25MB.</span>
-                            <div                             class="middle-errors-hook"></div>
+                        </div>
+                        <div class="middle-errors-hook">
+                            <div class="pins-file-upload__upload">
+                                <input class="display--none" id="upload-file-1" accept=".pdf,application/pdf,.doc,application/msword,.docx,application/vnd.openxmlformats-officedocument.wordprocessingml.document,.ppt,application/vnd.ms-powerpoint,.pptx,application/vnd.openxmlformats-officedocument.presentationml.presentation,.xls,application/vnd.ms-excel,.xlsx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,.msg,application/vnd.ms-outlook,.jpg,image/jpeg,.jpeg,image/jpeg,.mpeg,video/mpeg,.mp3,audio/mpeg,.mp4,video/mp4,.mov,video/quicktime,.png,image/png,.tif,image/tiff,.tiff,image/tiff,"
+                                type="file" name="files" value="Choose file" aria-controls="file-list-1">
+                                <button type='button' class="pins-file-upload__button govuk-button">Select files</button>
+                            </div>
+                            <div id="file-list-1">
+                                <h2 class="display--sr-only" id="file-list-title-1">List of files to upload</h2>
+                                <ul class="pins-file-upload__files-rows" aria-describedby="file-list-title-1"
+                                aria-live="polite"></ul>
+                            </div>
+                        </div>
                     </div>
-                    <div class="pins-file-upload__upload">
-                        <input class="display--none" id="upload-file-1" accept=".pdf,application/pdf,.doc,application/msword,.docx,application/vnd.openxmlformats-officedocument.wordprocessingml.document,.ppt,application/vnd.ms-powerpoint,.pptx,application/vnd.openxmlformats-officedocument.presentationml.presentation,.xls,application/vnd.ms-excel,.xlsx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,.msg,application/vnd.ms-outlook,.jpg,image/jpeg,.jpeg,image/jpeg,.mpeg,video/mpeg,.mp3,audio/mpeg,.mp4,video/mp4,.mov,video/quicktime,.png,image/png,.tif,image/tiff,.tiff,image/tiff,"
-                        type="file" name="files" value="Choose file" aria-controls="file-list-1">
-                        <button type='button' class="pins-file-upload__button govuk-button">Select files</button>
+                    <div class="govuk-warning-text"><span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+                        <strong                         class="govuk-warning-text__text"><span class="govuk-warning-text__assistive">Warning</span> Only upload
+                            files to additional documents when no other folder is applicable.</strong>
                     </div>
-                    <div id="file-list-1">
-                        <h2 class="display--sr-only" id="file-list-title-1">List of files to upload</h2>
-                        <ul class="pins-file-upload__files-rows" aria-describedby="file-list-title-1"
-                        aria-live="polite"></ul>
+                    <div class="display--flex">
+                        <button type="submit" class="govuk-button pins-file-upload__submit" data-module="govuk-button"
+                        id="submit-button-1">Continue</button>
+                        <div class="progress-hook"></div>
                     </div>
+                </form>
             </div>
-            <div class="govuk-warning-text"><span class="govuk-warning-text__icon" aria-hidden="true">!</span>
-                <strong                 class="govuk-warning-text__text"><span class="govuk-warning-text__assistive">Warning</span> Only upload
-                    files to additional documents when no other folder is applicable.</strong>
-            </div>
-            <div class="display--flex">
-                <button type="submit" class="govuk-button pins-file-upload__submit" data-module="govuk-button"
-                id="submit-button-1">Continue</button>
-                <div class="progress-hook"></div>
-            </div>
-            </form>
         </div>
-    </div>
     </div>
 </main>"
 `;
@@ -2957,6 +2964,7 @@ exports[`appellant-case GET /appellant-case/add-documents/:folderId/:documentId 
 exports[`appellant-case GET /appellant-case/add-documents/:folderId/:documentId should render document upload page with additional documents warning text, and without late entry status tag and associated details component, if the folder is additional documents, and the appellant case has a validation outcome of invalid 1`] = `
 "<main class="govuk-main-wrapper " id="main-content" role="main">
     <div class="govuk-grid-row">
+        <div class="top-errors-hook govuk-grid-column-two-thirds"></div>
         <div class="govuk-grid-column-full"><span class="govuk-caption-xl">Appeal 351062</span>
             <h1 class="govuk-heading-xl govuk-!-margin-bottom-3">Update additional document</h1>
         </div>
@@ -2969,37 +2977,37 @@ exports[`appellant-case GET /appellant-case/add-documents/:folderId/:documentId 
             data-blob-storage-host="https://127.0.0.1:10000/devstoreaccount1" data-blob-storage-container="document-service-uploads"
             data-document-id="1" data-document-original-file-name="test-pdf-documentFileVersionsInfo.pdf"
             data-document-version="1" data-allowed-types=".pdf,application/pdf,.doc,application/msword,.docx,application/vnd.openxmlformats-officedocument.wordprocessingml.document,.ppt,application/vnd.ms-powerpoint,.pptx,application/vnd.openxmlformats-officedocument.presentationml.presentation,.xls,application/vnd.ms-excel,.xlsx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,.msg,application/vnd.ms-outlook,.jpg,image/jpeg,.jpeg,image/jpeg,.mpeg,video/mpeg,.mp3,audio/mpeg,.mp4,video/mp4,.mov,video/quicktime,.png,image/png,.tif,image/tiff,.tiff,image/tiff,">
-                <div class="top-errors-hook govuk-grid-column-two-thirds"></div>
                 <form method="POST" novalidate="novalidate" class="govuk-grid-column-two-thirds"
                 data-filenames-in-folder="WyJ0ZXN0LXBkZi1kb2N1bWVudEZvbGRlckluZm8ucGRmIiwic2FtcGxlLTIwcy1kb2N1bWVudEZvbGRlckluZm8ubXA0IiwicGgwLWRvY3VtZW50Rm9sZGVySW5mby5qcGVnIiwicGgxLWRvY3VtZW50Rm9sZGVySW5mby5qcGVnIl0=">
                     <div class="pins-file-upload__container">
                         <div class="govuk-body colour--secondary pins-file-upload__instructions">
                             <label for="upload-file-1">Choose a single file to upload.</label><span>The file must be a PDF, DOC, DOCX, PPT, PPTX, XLS, XLSX, MSG, JPG, JPEG, MPEG, MP3, MP4, MOV, PNG, TIF, 	or TIFF.</span><span>The file must be smaller than 25MB.</span>
-                            <div                             class="middle-errors-hook"></div>
+                        </div>
+                        <div class="middle-errors-hook">
+                            <div class="pins-file-upload__upload">
+                                <input class="display--none" id="upload-file-1" accept=".pdf,application/pdf,.doc,application/msword,.docx,application/vnd.openxmlformats-officedocument.wordprocessingml.document,.ppt,application/vnd.ms-powerpoint,.pptx,application/vnd.openxmlformats-officedocument.presentationml.presentation,.xls,application/vnd.ms-excel,.xlsx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,.msg,application/vnd.ms-outlook,.jpg,image/jpeg,.jpeg,image/jpeg,.mpeg,video/mpeg,.mp3,audio/mpeg,.mp4,video/mp4,.mov,video/quicktime,.png,image/png,.tif,image/tiff,.tiff,image/tiff,"
+                                type="file" name="files" value="Choose file" aria-controls="file-list-1">
+                                <button type='button' class="pins-file-upload__button govuk-button">Select files</button>
+                            </div>
+                            <div id="file-list-1">
+                                <h2 class="display--sr-only" id="file-list-title-1">List of files to upload</h2>
+                                <ul class="pins-file-upload__files-rows" aria-describedby="file-list-title-1"
+                                aria-live="polite"></ul>
+                            </div>
+                        </div>
                     </div>
-                    <div class="pins-file-upload__upload">
-                        <input class="display--none" id="upload-file-1" accept=".pdf,application/pdf,.doc,application/msword,.docx,application/vnd.openxmlformats-officedocument.wordprocessingml.document,.ppt,application/vnd.ms-powerpoint,.pptx,application/vnd.openxmlformats-officedocument.presentationml.presentation,.xls,application/vnd.ms-excel,.xlsx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,.msg,application/vnd.ms-outlook,.jpg,image/jpeg,.jpeg,image/jpeg,.mpeg,video/mpeg,.mp3,audio/mpeg,.mp4,video/mp4,.mov,video/quicktime,.png,image/png,.tif,image/tiff,.tiff,image/tiff,"
-                        type="file" name="files" value="Choose file" aria-controls="file-list-1">
-                        <button type='button' class="pins-file-upload__button govuk-button">Select files</button>
+                    <div class="govuk-warning-text"><span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+                        <strong                         class="govuk-warning-text__text"><span class="govuk-warning-text__assistive">Warning</span> Only upload
+                            files to additional documents when no other folder is applicable.</strong>
                     </div>
-                    <div id="file-list-1">
-                        <h2 class="display--sr-only" id="file-list-title-1">List of files to upload</h2>
-                        <ul class="pins-file-upload__files-rows" aria-describedby="file-list-title-1"
-                        aria-live="polite"></ul>
+                    <div class="display--flex">
+                        <button type="submit" class="govuk-button pins-file-upload__submit" data-module="govuk-button"
+                        id="submit-button-1">Continue</button>
+                        <div class="progress-hook"></div>
                     </div>
+                </form>
             </div>
-            <div class="govuk-warning-text"><span class="govuk-warning-text__icon" aria-hidden="true">!</span>
-                <strong                 class="govuk-warning-text__text"><span class="govuk-warning-text__assistive">Warning</span> Only upload
-                    files to additional documents when no other folder is applicable.</strong>
-            </div>
-            <div class="display--flex">
-                <button type="submit" class="govuk-button pins-file-upload__submit" data-module="govuk-button"
-                id="submit-button-1">Continue</button>
-                <div class="progress-hook"></div>
-            </div>
-            </form>
         </div>
-    </div>
     </div>
 </main>"
 `;
@@ -3007,6 +3015,7 @@ exports[`appellant-case GET /appellant-case/add-documents/:folderId/:documentId 
 exports[`appellant-case GET /appellant-case/add-documents/:folderId/:documentId should render document upload page with additional documents warning text, and without late entry status tag and associated details component, if the folder is additional documents, and the appellant case has no validation outcome 1`] = `
 "<main class="govuk-main-wrapper " id="main-content" role="main">
     <div class="govuk-grid-row">
+        <div class="top-errors-hook govuk-grid-column-two-thirds"></div>
         <div class="govuk-grid-column-full"><span class="govuk-caption-xl">Appeal 351062</span>
             <h1 class="govuk-heading-xl govuk-!-margin-bottom-3">Update additional document</h1>
         </div>
@@ -3019,37 +3028,37 @@ exports[`appellant-case GET /appellant-case/add-documents/:folderId/:documentId 
             data-blob-storage-host="https://127.0.0.1:10000/devstoreaccount1" data-blob-storage-container="document-service-uploads"
             data-document-id="1" data-document-original-file-name="test-pdf-documentFileVersionsInfo.pdf"
             data-document-version="1" data-allowed-types=".pdf,application/pdf,.doc,application/msword,.docx,application/vnd.openxmlformats-officedocument.wordprocessingml.document,.ppt,application/vnd.ms-powerpoint,.pptx,application/vnd.openxmlformats-officedocument.presentationml.presentation,.xls,application/vnd.ms-excel,.xlsx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,.msg,application/vnd.ms-outlook,.jpg,image/jpeg,.jpeg,image/jpeg,.mpeg,video/mpeg,.mp3,audio/mpeg,.mp4,video/mp4,.mov,video/quicktime,.png,image/png,.tif,image/tiff,.tiff,image/tiff,">
-                <div class="top-errors-hook govuk-grid-column-two-thirds"></div>
                 <form method="POST" novalidate="novalidate" class="govuk-grid-column-two-thirds"
                 data-filenames-in-folder="WyJ0ZXN0LXBkZi1kb2N1bWVudEZvbGRlckluZm8ucGRmIiwic2FtcGxlLTIwcy1kb2N1bWVudEZvbGRlckluZm8ubXA0IiwicGgwLWRvY3VtZW50Rm9sZGVySW5mby5qcGVnIiwicGgxLWRvY3VtZW50Rm9sZGVySW5mby5qcGVnIl0=">
                     <div class="pins-file-upload__container">
                         <div class="govuk-body colour--secondary pins-file-upload__instructions">
                             <label for="upload-file-1">Choose a single file to upload.</label><span>The file must be a PDF, DOC, DOCX, PPT, PPTX, XLS, XLSX, MSG, JPG, JPEG, MPEG, MP3, MP4, MOV, PNG, TIF, 	or TIFF.</span><span>The file must be smaller than 25MB.</span>
-                            <div                             class="middle-errors-hook"></div>
+                        </div>
+                        <div class="middle-errors-hook">
+                            <div class="pins-file-upload__upload">
+                                <input class="display--none" id="upload-file-1" accept=".pdf,application/pdf,.doc,application/msword,.docx,application/vnd.openxmlformats-officedocument.wordprocessingml.document,.ppt,application/vnd.ms-powerpoint,.pptx,application/vnd.openxmlformats-officedocument.presentationml.presentation,.xls,application/vnd.ms-excel,.xlsx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,.msg,application/vnd.ms-outlook,.jpg,image/jpeg,.jpeg,image/jpeg,.mpeg,video/mpeg,.mp3,audio/mpeg,.mp4,video/mp4,.mov,video/quicktime,.png,image/png,.tif,image/tiff,.tiff,image/tiff,"
+                                type="file" name="files" value="Choose file" aria-controls="file-list-1">
+                                <button type='button' class="pins-file-upload__button govuk-button">Select files</button>
+                            </div>
+                            <div id="file-list-1">
+                                <h2 class="display--sr-only" id="file-list-title-1">List of files to upload</h2>
+                                <ul class="pins-file-upload__files-rows" aria-describedby="file-list-title-1"
+                                aria-live="polite"></ul>
+                            </div>
+                        </div>
                     </div>
-                    <div class="pins-file-upload__upload">
-                        <input class="display--none" id="upload-file-1" accept=".pdf,application/pdf,.doc,application/msword,.docx,application/vnd.openxmlformats-officedocument.wordprocessingml.document,.ppt,application/vnd.ms-powerpoint,.pptx,application/vnd.openxmlformats-officedocument.presentationml.presentation,.xls,application/vnd.ms-excel,.xlsx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,.msg,application/vnd.ms-outlook,.jpg,image/jpeg,.jpeg,image/jpeg,.mpeg,video/mpeg,.mp3,audio/mpeg,.mp4,video/mp4,.mov,video/quicktime,.png,image/png,.tif,image/tiff,.tiff,image/tiff,"
-                        type="file" name="files" value="Choose file" aria-controls="file-list-1">
-                        <button type='button' class="pins-file-upload__button govuk-button">Select files</button>
+                    <div class="govuk-warning-text"><span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+                        <strong                         class="govuk-warning-text__text"><span class="govuk-warning-text__assistive">Warning</span> Only upload
+                            files to additional documents when no other folder is applicable.</strong>
                     </div>
-                    <div id="file-list-1">
-                        <h2 class="display--sr-only" id="file-list-title-1">List of files to upload</h2>
-                        <ul class="pins-file-upload__files-rows" aria-describedby="file-list-title-1"
-                        aria-live="polite"></ul>
+                    <div class="display--flex">
+                        <button type="submit" class="govuk-button pins-file-upload__submit" data-module="govuk-button"
+                        id="submit-button-1">Continue</button>
+                        <div class="progress-hook"></div>
                     </div>
+                </form>
             </div>
-            <div class="govuk-warning-text"><span class="govuk-warning-text__icon" aria-hidden="true">!</span>
-                <strong                 class="govuk-warning-text__text"><span class="govuk-warning-text__assistive">Warning</span> Only upload
-                    files to additional documents when no other folder is applicable.</strong>
-            </div>
-            <div class="display--flex">
-                <button type="submit" class="govuk-button pins-file-upload__submit" data-module="govuk-button"
-                id="submit-button-1">Continue</button>
-                <div class="progress-hook"></div>
-            </div>
-            </form>
         </div>
-    </div>
     </div>
 </main>"
 `;
@@ -3057,6 +3066,7 @@ exports[`appellant-case GET /appellant-case/add-documents/:folderId/:documentId 
 exports[`appellant-case GET /appellant-case/add-documents/:folderId/:documentId should render document upload page with late entry status tag and associated details component, and without additional documents warning text, if the folder is additional documents, and the appellant case validation outcome is valid 1`] = `
 "<main class="govuk-main-wrapper " id="main-content" role="main">
     <div class="govuk-grid-row">
+        <div class="top-errors-hook govuk-grid-column-two-thirds"></div>
         <div class="govuk-grid-column-full"><span class="govuk-caption-xl">Appeal 351062</span>
             <h1 class="govuk-heading-xl govuk-!-margin-bottom-3">Update additional document</h1>
         </div>
@@ -3088,33 +3098,33 @@ exports[`appellant-case GET /appellant-case/add-documents/:folderId/:documentId 
             data-blob-storage-host="https://127.0.0.1:10000/devstoreaccount1" data-blob-storage-container="document-service-uploads"
             data-document-id="1" data-document-original-file-name="test-pdf-documentFileVersionsInfo.pdf"
             data-document-version="1" data-allowed-types=".pdf,application/pdf,.doc,application/msword,.docx,application/vnd.openxmlformats-officedocument.wordprocessingml.document,.ppt,application/vnd.ms-powerpoint,.pptx,application/vnd.openxmlformats-officedocument.presentationml.presentation,.xls,application/vnd.ms-excel,.xlsx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,.msg,application/vnd.ms-outlook,.jpg,image/jpeg,.jpeg,image/jpeg,.mpeg,video/mpeg,.mp3,audio/mpeg,.mp4,video/mp4,.mov,video/quicktime,.png,image/png,.tif,image/tiff,.tiff,image/tiff,">
-                <div class="top-errors-hook govuk-grid-column-two-thirds"></div>
                 <form method="POST" novalidate="novalidate" class="govuk-grid-column-two-thirds"
                 data-filenames-in-folder="WyJ0ZXN0LXBkZi1kb2N1bWVudEZvbGRlckluZm8ucGRmIiwic2FtcGxlLTIwcy1kb2N1bWVudEZvbGRlckluZm8ubXA0IiwicGgwLWRvY3VtZW50Rm9sZGVySW5mby5qcGVnIiwicGgxLWRvY3VtZW50Rm9sZGVySW5mby5qcGVnIl0=">
                     <div class="pins-file-upload__container">
                         <div class="govuk-body colour--secondary pins-file-upload__instructions">
                             <label for="upload-file-1">Choose a single file to upload.</label><span>The file must be a PDF, DOC, DOCX, PPT, PPTX, XLS, XLSX, MSG, JPG, JPEG, MPEG, MP3, MP4, MOV, PNG, TIF, 	or TIFF.</span><span>The file must be smaller than 25MB.</span>
-                            <div                             class="middle-errors-hook"></div>
+                        </div>
+                        <div class="middle-errors-hook">
+                            <div class="pins-file-upload__upload">
+                                <input class="display--none" id="upload-file-1" accept=".pdf,application/pdf,.doc,application/msword,.docx,application/vnd.openxmlformats-officedocument.wordprocessingml.document,.ppt,application/vnd.ms-powerpoint,.pptx,application/vnd.openxmlformats-officedocument.presentationml.presentation,.xls,application/vnd.ms-excel,.xlsx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,.msg,application/vnd.ms-outlook,.jpg,image/jpeg,.jpeg,image/jpeg,.mpeg,video/mpeg,.mp3,audio/mpeg,.mp4,video/mp4,.mov,video/quicktime,.png,image/png,.tif,image/tiff,.tiff,image/tiff,"
+                                type="file" name="files" value="Choose file" aria-controls="file-list-1">
+                                <button type='button' class="pins-file-upload__button govuk-button">Select files</button>
+                            </div>
+                            <div id="file-list-1">
+                                <h2 class="display--sr-only" id="file-list-title-1">List of files to upload</h2>
+                                <ul class="pins-file-upload__files-rows" aria-describedby="file-list-title-1"
+                                aria-live="polite"></ul>
+                            </div>
+                        </div>
                     </div>
-                    <div class="pins-file-upload__upload">
-                        <input class="display--none" id="upload-file-1" accept=".pdf,application/pdf,.doc,application/msword,.docx,application/vnd.openxmlformats-officedocument.wordprocessingml.document,.ppt,application/vnd.ms-powerpoint,.pptx,application/vnd.openxmlformats-officedocument.presentationml.presentation,.xls,application/vnd.ms-excel,.xlsx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,.msg,application/vnd.ms-outlook,.jpg,image/jpeg,.jpeg,image/jpeg,.mpeg,video/mpeg,.mp3,audio/mpeg,.mp4,video/mp4,.mov,video/quicktime,.png,image/png,.tif,image/tiff,.tiff,image/tiff,"
-                        type="file" name="files" value="Choose file" aria-controls="file-list-1">
-                        <button type='button' class="pins-file-upload__button govuk-button">Select files</button>
+                    <div class="display--flex">
+                        <button type="submit" class="govuk-button pins-file-upload__submit" data-module="govuk-button"
+                        id="submit-button-1">Continue</button>
+                        <div class="progress-hook"></div>
                     </div>
-                    <div id="file-list-1">
-                        <h2 class="display--sr-only" id="file-list-title-1">List of files to upload</h2>
-                        <ul class="pins-file-upload__files-rows" aria-describedby="file-list-title-1"
-                        aria-live="polite"></ul>
-                    </div>
+                </form>
             </div>
-            <div class="display--flex">
-                <button type="submit" class="govuk-button pins-file-upload__submit" data-module="govuk-button"
-                id="submit-button-1">Continue</button>
-                <div class="progress-hook"></div>
-            </div>
-            </form>
         </div>
-    </div>
     </div>
 </main>"
 `;

--- a/appeals/web/src/server/appeals/appeal-details/costs/__tests__/__snapshots__/costs.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/costs/__tests__/__snapshots__/costs.test.js.snap
@@ -3861,6 +3861,7 @@ exports[`costs application, withdrawal and correspondence GET /costs/:costsCateg
 exports[`costs application, withdrawal and correspondence GET /costs/:costsCategory/:costsDocumentType/upload-documents/:folderId should render the upload documents page (appellant application) 1`] = `
 "<main class="govuk-main-wrapper " id="main-content" role="main">
     <div class="govuk-grid-row">
+        <div class="top-errors-hook govuk-grid-column-two-thirds"></div>
         <div class="govuk-grid-column-full"><span class="govuk-caption-xl">Appeal 351062</span>
             <h1 class="govuk-heading-xl govuk-!-margin-bottom-3">Upload appellant costs application document</h1>
         </div>
@@ -3872,34 +3873,34 @@ exports[`costs application, withdrawal and correspondence GET /costs/:costsCateg
             data-document-type="appellantCostsApplication" data-document-stage="costs"
             data-blob-storage-host="https://127.0.0.1:10000/devstoreaccount1" data-blob-storage-container="document-service-uploads"
             data-allowed-types=".pdf,application/pdf,.doc,application/msword,.docx,application/vnd.openxmlformats-officedocument.wordprocessingml.document,.ppt,application/vnd.ms-powerpoint,.pptx,application/vnd.openxmlformats-officedocument.presentationml.presentation,.xls,application/vnd.ms-excel,.xlsx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,.msg,application/vnd.ms-outlook,.jpg,image/jpeg,.jpeg,image/jpeg,.mpeg,video/mpeg,.mp3,audio/mpeg,.mp4,video/mp4,.mov,video/quicktime,.png,image/png,.tif,image/tiff,.tiff,image/tiff,">
-                <div class="top-errors-hook govuk-grid-column-two-thirds"></div>
                 <form method="POST" novalidate="novalidate" class="govuk-grid-column-two-thirds"
                 data-filenames-in-folder="WyJ0ZXN0LXBkZi1kb2N1bWVudEZvbGRlckluZm8ucGRmIiwic2FtcGxlLTIwcy1kb2N1bWVudEZvbGRlckluZm8ubXA0Il0=">
                     <div class="pins-file-upload__container">
                         <div class="govuk-body colour--secondary pins-file-upload__instructions">
                             <label for="upload-file-1">Choose a single file or multiple files to upload.</label><span>Each file must be a PDF, DOC, DOCX, PPT, PPTX, XLS, XLSX, MSG, JPG, JPEG, MPEG, MP3, MP4, MOV, PNG, TIF, 	or TIFF.</span><span>The total size of your uploaded files must be smaller than 1GB.</span>
-                            <div                             class="middle-errors-hook"></div>
+                        </div>
+                        <div class="middle-errors-hook">
+                            <div class="pins-file-upload__upload">
+                                <input class="display--none" id="upload-file-1" accept=".pdf,application/pdf,.doc,application/msword,.docx,application/vnd.openxmlformats-officedocument.wordprocessingml.document,.ppt,application/vnd.ms-powerpoint,.pptx,application/vnd.openxmlformats-officedocument.presentationml.presentation,.xls,application/vnd.ms-excel,.xlsx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,.msg,application/vnd.ms-outlook,.jpg,image/jpeg,.jpeg,image/jpeg,.mpeg,video/mpeg,.mp3,audio/mpeg,.mp4,video/mp4,.mov,video/quicktime,.png,image/png,.tif,image/tiff,.tiff,image/tiff,"
+                                type="file" name="files" value="Choose file" aria-controls="file-list-1"
+                                multiple><span class='govuk-body pins-file-upload__dropzone-text'>Drag and drop files here or</span>
+                                <button                                 type='button' class="pins-file-upload__button govuk-button">Select files</button>
+                            </div>
+                            <div id="file-list-1">
+                                <h2 class="display--sr-only" id="file-list-title-1">List of files to upload</h2>
+                                <ul class="pins-file-upload__files-rows" aria-describedby="file-list-title-1"
+                                aria-live="polite"></ul>
+                            </div>
+                        </div>
                     </div>
-                    <div class="pins-file-upload__upload">
-                        <input class="display--none" id="upload-file-1" accept=".pdf,application/pdf,.doc,application/msword,.docx,application/vnd.openxmlformats-officedocument.wordprocessingml.document,.ppt,application/vnd.ms-powerpoint,.pptx,application/vnd.openxmlformats-officedocument.presentationml.presentation,.xls,application/vnd.ms-excel,.xlsx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,.msg,application/vnd.ms-outlook,.jpg,image/jpeg,.jpeg,image/jpeg,.mpeg,video/mpeg,.mp3,audio/mpeg,.mp4,video/mp4,.mov,video/quicktime,.png,image/png,.tif,image/tiff,.tiff,image/tiff,"
-                        type="file" name="files" value="Choose file" aria-controls="file-list-1"
-                        multiple><span class='govuk-body pins-file-upload__dropzone-text'>Drag and drop files here or</span>
-                        <button                         type='button' class="pins-file-upload__button govuk-button">Select files</button>
+                    <div class="display--flex">
+                        <button type="submit" class="govuk-button pins-file-upload__submit" data-module="govuk-button"
+                        id="submit-button-1">Continue</button>
+                        <div class="progress-hook"></div>
                     </div>
-                    <div id="file-list-1">
-                        <h2 class="display--sr-only" id="file-list-title-1">List of files to upload</h2>
-                        <ul class="pins-file-upload__files-rows" aria-describedby="file-list-title-1"
-                        aria-live="polite"></ul>
-                    </div>
+                </form>
             </div>
-            <div class="display--flex">
-                <button type="submit" class="govuk-button pins-file-upload__submit" data-module="govuk-button"
-                id="submit-button-1">Continue</button>
-                <div class="progress-hook"></div>
-            </div>
-            </form>
         </div>
-    </div>
     </div>
 </main>"
 `;
@@ -3907,6 +3908,7 @@ exports[`costs application, withdrawal and correspondence GET /costs/:costsCateg
 exports[`costs application, withdrawal and correspondence GET /costs/:costsCategory/:costsDocumentType/upload-documents/:folderId should render the upload documents page (appellant correspondence) 1`] = `
 "<main class="govuk-main-wrapper " id="main-content" role="main">
     <div class="govuk-grid-row">
+        <div class="top-errors-hook govuk-grid-column-two-thirds"></div>
         <div class="govuk-grid-column-full"><span class="govuk-caption-xl">Appeal 351062</span>
             <h1 class="govuk-heading-xl govuk-!-margin-bottom-3">Upload appellant costs correspondence document</h1>
         </div>
@@ -3918,34 +3920,34 @@ exports[`costs application, withdrawal and correspondence GET /costs/:costsCateg
             data-document-type="appellantCostsCorrespondence" data-document-stage="costs"
             data-blob-storage-host="https://127.0.0.1:10000/devstoreaccount1" data-blob-storage-container="document-service-uploads"
             data-allowed-types=".pdf,application/pdf,.doc,application/msword,.docx,application/vnd.openxmlformats-officedocument.wordprocessingml.document,.ppt,application/vnd.ms-powerpoint,.pptx,application/vnd.openxmlformats-officedocument.presentationml.presentation,.xls,application/vnd.ms-excel,.xlsx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,.msg,application/vnd.ms-outlook,.jpg,image/jpeg,.jpeg,image/jpeg,.mpeg,video/mpeg,.mp3,audio/mpeg,.mp4,video/mp4,.mov,video/quicktime,.png,image/png,.tif,image/tiff,.tiff,image/tiff,">
-                <div class="top-errors-hook govuk-grid-column-two-thirds"></div>
                 <form method="POST" novalidate="novalidate" class="govuk-grid-column-two-thirds"
                 data-filenames-in-folder="WyJ0ZXN0LXBkZi1kb2N1bWVudEZvbGRlckluZm8ucGRmIiwic2FtcGxlLTIwcy1kb2N1bWVudEZvbGRlckluZm8ubXA0Il0=">
                     <div class="pins-file-upload__container">
                         <div class="govuk-body colour--secondary pins-file-upload__instructions">
                             <label for="upload-file-1">Choose a single file or multiple files to upload.</label><span>Each file must be a PDF, DOC, DOCX, PPT, PPTX, XLS, XLSX, MSG, JPG, JPEG, MPEG, MP3, MP4, MOV, PNG, TIF, 	or TIFF.</span><span>The total size of your uploaded files must be smaller than 1GB.</span>
-                            <div                             class="middle-errors-hook"></div>
+                        </div>
+                        <div class="middle-errors-hook">
+                            <div class="pins-file-upload__upload">
+                                <input class="display--none" id="upload-file-1" accept=".pdf,application/pdf,.doc,application/msword,.docx,application/vnd.openxmlformats-officedocument.wordprocessingml.document,.ppt,application/vnd.ms-powerpoint,.pptx,application/vnd.openxmlformats-officedocument.presentationml.presentation,.xls,application/vnd.ms-excel,.xlsx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,.msg,application/vnd.ms-outlook,.jpg,image/jpeg,.jpeg,image/jpeg,.mpeg,video/mpeg,.mp3,audio/mpeg,.mp4,video/mp4,.mov,video/quicktime,.png,image/png,.tif,image/tiff,.tiff,image/tiff,"
+                                type="file" name="files" value="Choose file" aria-controls="file-list-1"
+                                multiple><span class='govuk-body pins-file-upload__dropzone-text'>Drag and drop files here or</span>
+                                <button                                 type='button' class="pins-file-upload__button govuk-button">Select files</button>
+                            </div>
+                            <div id="file-list-1">
+                                <h2 class="display--sr-only" id="file-list-title-1">List of files to upload</h2>
+                                <ul class="pins-file-upload__files-rows" aria-describedby="file-list-title-1"
+                                aria-live="polite"></ul>
+                            </div>
+                        </div>
                     </div>
-                    <div class="pins-file-upload__upload">
-                        <input class="display--none" id="upload-file-1" accept=".pdf,application/pdf,.doc,application/msword,.docx,application/vnd.openxmlformats-officedocument.wordprocessingml.document,.ppt,application/vnd.ms-powerpoint,.pptx,application/vnd.openxmlformats-officedocument.presentationml.presentation,.xls,application/vnd.ms-excel,.xlsx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,.msg,application/vnd.ms-outlook,.jpg,image/jpeg,.jpeg,image/jpeg,.mpeg,video/mpeg,.mp3,audio/mpeg,.mp4,video/mp4,.mov,video/quicktime,.png,image/png,.tif,image/tiff,.tiff,image/tiff,"
-                        type="file" name="files" value="Choose file" aria-controls="file-list-1"
-                        multiple><span class='govuk-body pins-file-upload__dropzone-text'>Drag and drop files here or</span>
-                        <button                         type='button' class="pins-file-upload__button govuk-button">Select files</button>
+                    <div class="display--flex">
+                        <button type="submit" class="govuk-button pins-file-upload__submit" data-module="govuk-button"
+                        id="submit-button-1">Continue</button>
+                        <div class="progress-hook"></div>
                     </div>
-                    <div id="file-list-1">
-                        <h2 class="display--sr-only" id="file-list-title-1">List of files to upload</h2>
-                        <ul class="pins-file-upload__files-rows" aria-describedby="file-list-title-1"
-                        aria-live="polite"></ul>
-                    </div>
+                </form>
             </div>
-            <div class="display--flex">
-                <button type="submit" class="govuk-button pins-file-upload__submit" data-module="govuk-button"
-                id="submit-button-1">Continue</button>
-                <div class="progress-hook"></div>
-            </div>
-            </form>
         </div>
-    </div>
     </div>
 </main>"
 `;
@@ -3953,6 +3955,7 @@ exports[`costs application, withdrawal and correspondence GET /costs/:costsCateg
 exports[`costs application, withdrawal and correspondence GET /costs/:costsCategory/:costsDocumentType/upload-documents/:folderId should render the upload documents page (appellant withdrawal) 1`] = `
 "<main class="govuk-main-wrapper " id="main-content" role="main">
     <div class="govuk-grid-row">
+        <div class="top-errors-hook govuk-grid-column-two-thirds"></div>
         <div class="govuk-grid-column-full"><span class="govuk-caption-xl">Appeal 351062</span>
             <h1 class="govuk-heading-xl govuk-!-margin-bottom-3">Upload appellant costs withdrawal document</h1>
         </div>
@@ -3964,34 +3967,34 @@ exports[`costs application, withdrawal and correspondence GET /costs/:costsCateg
             data-document-type="appellantCostsWithdrawal" data-document-stage="costs"
             data-blob-storage-host="https://127.0.0.1:10000/devstoreaccount1" data-blob-storage-container="document-service-uploads"
             data-allowed-types=".pdf,application/pdf,.doc,application/msword,.docx,application/vnd.openxmlformats-officedocument.wordprocessingml.document,.ppt,application/vnd.ms-powerpoint,.pptx,application/vnd.openxmlformats-officedocument.presentationml.presentation,.xls,application/vnd.ms-excel,.xlsx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,.msg,application/vnd.ms-outlook,.jpg,image/jpeg,.jpeg,image/jpeg,.mpeg,video/mpeg,.mp3,audio/mpeg,.mp4,video/mp4,.mov,video/quicktime,.png,image/png,.tif,image/tiff,.tiff,image/tiff,">
-                <div class="top-errors-hook govuk-grid-column-two-thirds"></div>
                 <form method="POST" novalidate="novalidate" class="govuk-grid-column-two-thirds"
                 data-filenames-in-folder="WyJ0ZXN0LXBkZi1kb2N1bWVudEZvbGRlckluZm8ucGRmIiwic2FtcGxlLTIwcy1kb2N1bWVudEZvbGRlckluZm8ubXA0Il0=">
                     <div class="pins-file-upload__container">
                         <div class="govuk-body colour--secondary pins-file-upload__instructions">
                             <label for="upload-file-1">Choose a single file or multiple files to upload.</label><span>Each file must be a PDF, DOC, DOCX, PPT, PPTX, XLS, XLSX, MSG, JPG, JPEG, MPEG, MP3, MP4, MOV, PNG, TIF, 	or TIFF.</span><span>The total size of your uploaded files must be smaller than 1GB.</span>
-                            <div                             class="middle-errors-hook"></div>
+                        </div>
+                        <div class="middle-errors-hook">
+                            <div class="pins-file-upload__upload">
+                                <input class="display--none" id="upload-file-1" accept=".pdf,application/pdf,.doc,application/msword,.docx,application/vnd.openxmlformats-officedocument.wordprocessingml.document,.ppt,application/vnd.ms-powerpoint,.pptx,application/vnd.openxmlformats-officedocument.presentationml.presentation,.xls,application/vnd.ms-excel,.xlsx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,.msg,application/vnd.ms-outlook,.jpg,image/jpeg,.jpeg,image/jpeg,.mpeg,video/mpeg,.mp3,audio/mpeg,.mp4,video/mp4,.mov,video/quicktime,.png,image/png,.tif,image/tiff,.tiff,image/tiff,"
+                                type="file" name="files" value="Choose file" aria-controls="file-list-1"
+                                multiple><span class='govuk-body pins-file-upload__dropzone-text'>Drag and drop files here or</span>
+                                <button                                 type='button' class="pins-file-upload__button govuk-button">Select files</button>
+                            </div>
+                            <div id="file-list-1">
+                                <h2 class="display--sr-only" id="file-list-title-1">List of files to upload</h2>
+                                <ul class="pins-file-upload__files-rows" aria-describedby="file-list-title-1"
+                                aria-live="polite"></ul>
+                            </div>
+                        </div>
                     </div>
-                    <div class="pins-file-upload__upload">
-                        <input class="display--none" id="upload-file-1" accept=".pdf,application/pdf,.doc,application/msword,.docx,application/vnd.openxmlformats-officedocument.wordprocessingml.document,.ppt,application/vnd.ms-powerpoint,.pptx,application/vnd.openxmlformats-officedocument.presentationml.presentation,.xls,application/vnd.ms-excel,.xlsx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,.msg,application/vnd.ms-outlook,.jpg,image/jpeg,.jpeg,image/jpeg,.mpeg,video/mpeg,.mp3,audio/mpeg,.mp4,video/mp4,.mov,video/quicktime,.png,image/png,.tif,image/tiff,.tiff,image/tiff,"
-                        type="file" name="files" value="Choose file" aria-controls="file-list-1"
-                        multiple><span class='govuk-body pins-file-upload__dropzone-text'>Drag and drop files here or</span>
-                        <button                         type='button' class="pins-file-upload__button govuk-button">Select files</button>
+                    <div class="display--flex">
+                        <button type="submit" class="govuk-button pins-file-upload__submit" data-module="govuk-button"
+                        id="submit-button-1">Continue</button>
+                        <div class="progress-hook"></div>
                     </div>
-                    <div id="file-list-1">
-                        <h2 class="display--sr-only" id="file-list-title-1">List of files to upload</h2>
-                        <ul class="pins-file-upload__files-rows" aria-describedby="file-list-title-1"
-                        aria-live="polite"></ul>
-                    </div>
+                </form>
             </div>
-            <div class="display--flex">
-                <button type="submit" class="govuk-button pins-file-upload__submit" data-module="govuk-button"
-                id="submit-button-1">Continue</button>
-                <div class="progress-hook"></div>
-            </div>
-            </form>
         </div>
-    </div>
     </div>
 </main>"
 `;
@@ -3999,6 +4002,7 @@ exports[`costs application, withdrawal and correspondence GET /costs/:costsCateg
 exports[`costs application, withdrawal and correspondence GET /costs/:costsCategory/:costsDocumentType/upload-documents/:folderId should render the upload documents page (lpa application) 1`] = `
 "<main class="govuk-main-wrapper " id="main-content" role="main">
     <div class="govuk-grid-row">
+        <div class="top-errors-hook govuk-grid-column-two-thirds"></div>
         <div class="govuk-grid-column-full"><span class="govuk-caption-xl">Appeal 351062</span>
             <h1 class="govuk-heading-xl govuk-!-margin-bottom-3">Upload LPA costs application document</h1>
         </div>
@@ -4009,34 +4013,34 @@ exports[`costs application, withdrawal and correspondence GET /costs/:costsCateg
             data-case-id="1" data-case-reference="APP/Q9999/D/21/351062" data-folder-id="4"
             data-document-type="lpaCostsApplication" data-document-stage="costs" data-blob-storage-host="https://127.0.0.1:10000/devstoreaccount1"
             data-blob-storage-container="document-service-uploads" data-allowed-types=".pdf,application/pdf,.doc,application/msword,.docx,application/vnd.openxmlformats-officedocument.wordprocessingml.document,.ppt,application/vnd.ms-powerpoint,.pptx,application/vnd.openxmlformats-officedocument.presentationml.presentation,.xls,application/vnd.ms-excel,.xlsx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,.msg,application/vnd.ms-outlook,.jpg,image/jpeg,.jpeg,image/jpeg,.mpeg,video/mpeg,.mp3,audio/mpeg,.mp4,video/mp4,.mov,video/quicktime,.png,image/png,.tif,image/tiff,.tiff,image/tiff,">
-                <div class="top-errors-hook govuk-grid-column-two-thirds"></div>
                 <form method="POST" novalidate="novalidate" class="govuk-grid-column-two-thirds"
                 data-filenames-in-folder="WyJ0ZXN0LXBkZi1kb2N1bWVudEZvbGRlckluZm8ucGRmIiwic2FtcGxlLTIwcy1kb2N1bWVudEZvbGRlckluZm8ubXA0Il0=">
                     <div class="pins-file-upload__container">
                         <div class="govuk-body colour--secondary pins-file-upload__instructions">
                             <label for="upload-file-1">Choose a single file or multiple files to upload.</label><span>Each file must be a PDF, DOC, DOCX, PPT, PPTX, XLS, XLSX, MSG, JPG, JPEG, MPEG, MP3, MP4, MOV, PNG, TIF, 	or TIFF.</span><span>The total size of your uploaded files must be smaller than 1GB.</span>
-                            <div                             class="middle-errors-hook"></div>
+                        </div>
+                        <div class="middle-errors-hook">
+                            <div class="pins-file-upload__upload">
+                                <input class="display--none" id="upload-file-1" accept=".pdf,application/pdf,.doc,application/msword,.docx,application/vnd.openxmlformats-officedocument.wordprocessingml.document,.ppt,application/vnd.ms-powerpoint,.pptx,application/vnd.openxmlformats-officedocument.presentationml.presentation,.xls,application/vnd.ms-excel,.xlsx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,.msg,application/vnd.ms-outlook,.jpg,image/jpeg,.jpeg,image/jpeg,.mpeg,video/mpeg,.mp3,audio/mpeg,.mp4,video/mp4,.mov,video/quicktime,.png,image/png,.tif,image/tiff,.tiff,image/tiff,"
+                                type="file" name="files" value="Choose file" aria-controls="file-list-1"
+                                multiple><span class='govuk-body pins-file-upload__dropzone-text'>Drag and drop files here or</span>
+                                <button                                 type='button' class="pins-file-upload__button govuk-button">Select files</button>
+                            </div>
+                            <div id="file-list-1">
+                                <h2 class="display--sr-only" id="file-list-title-1">List of files to upload</h2>
+                                <ul class="pins-file-upload__files-rows" aria-describedby="file-list-title-1"
+                                aria-live="polite"></ul>
+                            </div>
+                        </div>
                     </div>
-                    <div class="pins-file-upload__upload">
-                        <input class="display--none" id="upload-file-1" accept=".pdf,application/pdf,.doc,application/msword,.docx,application/vnd.openxmlformats-officedocument.wordprocessingml.document,.ppt,application/vnd.ms-powerpoint,.pptx,application/vnd.openxmlformats-officedocument.presentationml.presentation,.xls,application/vnd.ms-excel,.xlsx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,.msg,application/vnd.ms-outlook,.jpg,image/jpeg,.jpeg,image/jpeg,.mpeg,video/mpeg,.mp3,audio/mpeg,.mp4,video/mp4,.mov,video/quicktime,.png,image/png,.tif,image/tiff,.tiff,image/tiff,"
-                        type="file" name="files" value="Choose file" aria-controls="file-list-1"
-                        multiple><span class='govuk-body pins-file-upload__dropzone-text'>Drag and drop files here or</span>
-                        <button                         type='button' class="pins-file-upload__button govuk-button">Select files</button>
+                    <div class="display--flex">
+                        <button type="submit" class="govuk-button pins-file-upload__submit" data-module="govuk-button"
+                        id="submit-button-1">Continue</button>
+                        <div class="progress-hook"></div>
                     </div>
-                    <div id="file-list-1">
-                        <h2 class="display--sr-only" id="file-list-title-1">List of files to upload</h2>
-                        <ul class="pins-file-upload__files-rows" aria-describedby="file-list-title-1"
-                        aria-live="polite"></ul>
-                    </div>
+                </form>
             </div>
-            <div class="display--flex">
-                <button type="submit" class="govuk-button pins-file-upload__submit" data-module="govuk-button"
-                id="submit-button-1">Continue</button>
-                <div class="progress-hook"></div>
-            </div>
-            </form>
         </div>
-    </div>
     </div>
 </main>"
 `;
@@ -4044,6 +4048,7 @@ exports[`costs application, withdrawal and correspondence GET /costs/:costsCateg
 exports[`costs application, withdrawal and correspondence GET /costs/:costsCategory/:costsDocumentType/upload-documents/:folderId should render the upload documents page (lpa correspondence) 1`] = `
 "<main class="govuk-main-wrapper " id="main-content" role="main">
     <div class="govuk-grid-row">
+        <div class="top-errors-hook govuk-grid-column-two-thirds"></div>
         <div class="govuk-grid-column-full"><span class="govuk-caption-xl">Appeal 351062</span>
             <h1 class="govuk-heading-xl govuk-!-margin-bottom-3">Upload LPA costs correspondence document</h1>
         </div>
@@ -4055,34 +4060,34 @@ exports[`costs application, withdrawal and correspondence GET /costs/:costsCateg
             data-document-type="lpaCostsCorrespondence" data-document-stage="costs"
             data-blob-storage-host="https://127.0.0.1:10000/devstoreaccount1" data-blob-storage-container="document-service-uploads"
             data-allowed-types=".pdf,application/pdf,.doc,application/msword,.docx,application/vnd.openxmlformats-officedocument.wordprocessingml.document,.ppt,application/vnd.ms-powerpoint,.pptx,application/vnd.openxmlformats-officedocument.presentationml.presentation,.xls,application/vnd.ms-excel,.xlsx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,.msg,application/vnd.ms-outlook,.jpg,image/jpeg,.jpeg,image/jpeg,.mpeg,video/mpeg,.mp3,audio/mpeg,.mp4,video/mp4,.mov,video/quicktime,.png,image/png,.tif,image/tiff,.tiff,image/tiff,">
-                <div class="top-errors-hook govuk-grid-column-two-thirds"></div>
                 <form method="POST" novalidate="novalidate" class="govuk-grid-column-two-thirds"
                 data-filenames-in-folder="WyJ0ZXN0LXBkZi1kb2N1bWVudEZvbGRlckluZm8ucGRmIiwic2FtcGxlLTIwcy1kb2N1bWVudEZvbGRlckluZm8ubXA0Il0=">
                     <div class="pins-file-upload__container">
                         <div class="govuk-body colour--secondary pins-file-upload__instructions">
                             <label for="upload-file-1">Choose a single file or multiple files to upload.</label><span>Each file must be a PDF, DOC, DOCX, PPT, PPTX, XLS, XLSX, MSG, JPG, JPEG, MPEG, MP3, MP4, MOV, PNG, TIF, 	or TIFF.</span><span>The total size of your uploaded files must be smaller than 1GB.</span>
-                            <div                             class="middle-errors-hook"></div>
+                        </div>
+                        <div class="middle-errors-hook">
+                            <div class="pins-file-upload__upload">
+                                <input class="display--none" id="upload-file-1" accept=".pdf,application/pdf,.doc,application/msword,.docx,application/vnd.openxmlformats-officedocument.wordprocessingml.document,.ppt,application/vnd.ms-powerpoint,.pptx,application/vnd.openxmlformats-officedocument.presentationml.presentation,.xls,application/vnd.ms-excel,.xlsx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,.msg,application/vnd.ms-outlook,.jpg,image/jpeg,.jpeg,image/jpeg,.mpeg,video/mpeg,.mp3,audio/mpeg,.mp4,video/mp4,.mov,video/quicktime,.png,image/png,.tif,image/tiff,.tiff,image/tiff,"
+                                type="file" name="files" value="Choose file" aria-controls="file-list-1"
+                                multiple><span class='govuk-body pins-file-upload__dropzone-text'>Drag and drop files here or</span>
+                                <button                                 type='button' class="pins-file-upload__button govuk-button">Select files</button>
+                            </div>
+                            <div id="file-list-1">
+                                <h2 class="display--sr-only" id="file-list-title-1">List of files to upload</h2>
+                                <ul class="pins-file-upload__files-rows" aria-describedby="file-list-title-1"
+                                aria-live="polite"></ul>
+                            </div>
+                        </div>
                     </div>
-                    <div class="pins-file-upload__upload">
-                        <input class="display--none" id="upload-file-1" accept=".pdf,application/pdf,.doc,application/msword,.docx,application/vnd.openxmlformats-officedocument.wordprocessingml.document,.ppt,application/vnd.ms-powerpoint,.pptx,application/vnd.openxmlformats-officedocument.presentationml.presentation,.xls,application/vnd.ms-excel,.xlsx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,.msg,application/vnd.ms-outlook,.jpg,image/jpeg,.jpeg,image/jpeg,.mpeg,video/mpeg,.mp3,audio/mpeg,.mp4,video/mp4,.mov,video/quicktime,.png,image/png,.tif,image/tiff,.tiff,image/tiff,"
-                        type="file" name="files" value="Choose file" aria-controls="file-list-1"
-                        multiple><span class='govuk-body pins-file-upload__dropzone-text'>Drag and drop files here or</span>
-                        <button                         type='button' class="pins-file-upload__button govuk-button">Select files</button>
+                    <div class="display--flex">
+                        <button type="submit" class="govuk-button pins-file-upload__submit" data-module="govuk-button"
+                        id="submit-button-1">Continue</button>
+                        <div class="progress-hook"></div>
                     </div>
-                    <div id="file-list-1">
-                        <h2 class="display--sr-only" id="file-list-title-1">List of files to upload</h2>
-                        <ul class="pins-file-upload__files-rows" aria-describedby="file-list-title-1"
-                        aria-live="polite"></ul>
-                    </div>
+                </form>
             </div>
-            <div class="display--flex">
-                <button type="submit" class="govuk-button pins-file-upload__submit" data-module="govuk-button"
-                id="submit-button-1">Continue</button>
-                <div class="progress-hook"></div>
-            </div>
-            </form>
         </div>
-    </div>
     </div>
 </main>"
 `;
@@ -4090,6 +4095,7 @@ exports[`costs application, withdrawal and correspondence GET /costs/:costsCateg
 exports[`costs application, withdrawal and correspondence GET /costs/:costsCategory/:costsDocumentType/upload-documents/:folderId should render the upload documents page (lpa withdrawal) 1`] = `
 "<main class="govuk-main-wrapper " id="main-content" role="main">
     <div class="govuk-grid-row">
+        <div class="top-errors-hook govuk-grid-column-two-thirds"></div>
         <div class="govuk-grid-column-full"><span class="govuk-caption-xl">Appeal 351062</span>
             <h1 class="govuk-heading-xl govuk-!-margin-bottom-3">Upload LPA costs withdrawal document</h1>
         </div>
@@ -4100,34 +4106,34 @@ exports[`costs application, withdrawal and correspondence GET /costs/:costsCateg
             data-case-id="1" data-case-reference="APP/Q9999/D/21/351062" data-folder-id="5"
             data-document-type="lpaCostsWithdrawal" data-document-stage="costs" data-blob-storage-host="https://127.0.0.1:10000/devstoreaccount1"
             data-blob-storage-container="document-service-uploads" data-allowed-types=".pdf,application/pdf,.doc,application/msword,.docx,application/vnd.openxmlformats-officedocument.wordprocessingml.document,.ppt,application/vnd.ms-powerpoint,.pptx,application/vnd.openxmlformats-officedocument.presentationml.presentation,.xls,application/vnd.ms-excel,.xlsx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,.msg,application/vnd.ms-outlook,.jpg,image/jpeg,.jpeg,image/jpeg,.mpeg,video/mpeg,.mp3,audio/mpeg,.mp4,video/mp4,.mov,video/quicktime,.png,image/png,.tif,image/tiff,.tiff,image/tiff,">
-                <div class="top-errors-hook govuk-grid-column-two-thirds"></div>
                 <form method="POST" novalidate="novalidate" class="govuk-grid-column-two-thirds"
                 data-filenames-in-folder="WyJ0ZXN0LXBkZi1kb2N1bWVudEZvbGRlckluZm8ucGRmIiwic2FtcGxlLTIwcy1kb2N1bWVudEZvbGRlckluZm8ubXA0Il0=">
                     <div class="pins-file-upload__container">
                         <div class="govuk-body colour--secondary pins-file-upload__instructions">
                             <label for="upload-file-1">Choose a single file or multiple files to upload.</label><span>Each file must be a PDF, DOC, DOCX, PPT, PPTX, XLS, XLSX, MSG, JPG, JPEG, MPEG, MP3, MP4, MOV, PNG, TIF, 	or TIFF.</span><span>The total size of your uploaded files must be smaller than 1GB.</span>
-                            <div                             class="middle-errors-hook"></div>
+                        </div>
+                        <div class="middle-errors-hook">
+                            <div class="pins-file-upload__upload">
+                                <input class="display--none" id="upload-file-1" accept=".pdf,application/pdf,.doc,application/msword,.docx,application/vnd.openxmlformats-officedocument.wordprocessingml.document,.ppt,application/vnd.ms-powerpoint,.pptx,application/vnd.openxmlformats-officedocument.presentationml.presentation,.xls,application/vnd.ms-excel,.xlsx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,.msg,application/vnd.ms-outlook,.jpg,image/jpeg,.jpeg,image/jpeg,.mpeg,video/mpeg,.mp3,audio/mpeg,.mp4,video/mp4,.mov,video/quicktime,.png,image/png,.tif,image/tiff,.tiff,image/tiff,"
+                                type="file" name="files" value="Choose file" aria-controls="file-list-1"
+                                multiple><span class='govuk-body pins-file-upload__dropzone-text'>Drag and drop files here or</span>
+                                <button                                 type='button' class="pins-file-upload__button govuk-button">Select files</button>
+                            </div>
+                            <div id="file-list-1">
+                                <h2 class="display--sr-only" id="file-list-title-1">List of files to upload</h2>
+                                <ul class="pins-file-upload__files-rows" aria-describedby="file-list-title-1"
+                                aria-live="polite"></ul>
+                            </div>
+                        </div>
                     </div>
-                    <div class="pins-file-upload__upload">
-                        <input class="display--none" id="upload-file-1" accept=".pdf,application/pdf,.doc,application/msword,.docx,application/vnd.openxmlformats-officedocument.wordprocessingml.document,.ppt,application/vnd.ms-powerpoint,.pptx,application/vnd.openxmlformats-officedocument.presentationml.presentation,.xls,application/vnd.ms-excel,.xlsx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,.msg,application/vnd.ms-outlook,.jpg,image/jpeg,.jpeg,image/jpeg,.mpeg,video/mpeg,.mp3,audio/mpeg,.mp4,video/mp4,.mov,video/quicktime,.png,image/png,.tif,image/tiff,.tiff,image/tiff,"
-                        type="file" name="files" value="Choose file" aria-controls="file-list-1"
-                        multiple><span class='govuk-body pins-file-upload__dropzone-text'>Drag and drop files here or</span>
-                        <button                         type='button' class="pins-file-upload__button govuk-button">Select files</button>
+                    <div class="display--flex">
+                        <button type="submit" class="govuk-button pins-file-upload__submit" data-module="govuk-button"
+                        id="submit-button-1">Continue</button>
+                        <div class="progress-hook"></div>
                     </div>
-                    <div id="file-list-1">
-                        <h2 class="display--sr-only" id="file-list-title-1">List of files to upload</h2>
-                        <ul class="pins-file-upload__files-rows" aria-describedby="file-list-title-1"
-                        aria-live="polite"></ul>
-                    </div>
+                </form>
             </div>
-            <div class="display--flex">
-                <button type="submit" class="govuk-button pins-file-upload__submit" data-module="govuk-button"
-                id="submit-button-1">Continue</button>
-                <div class="progress-hook"></div>
-            </div>
-            </form>
         </div>
-    </div>
     </div>
 </main>"
 `;
@@ -4135,6 +4141,7 @@ exports[`costs application, withdrawal and correspondence GET /costs/:costsCateg
 exports[`costs application, withdrawal and correspondence GET /costs/:costsCategory/:costsDocumentType/upload-documents/:folderId/:documentId should render the upload document version page (appellant application) 1`] = `
 "<main class="govuk-main-wrapper " id="main-content" role="main">
     <div class="govuk-grid-row">
+        <div class="top-errors-hook govuk-grid-column-two-thirds"></div>
         <div class="govuk-grid-column-full"><span class="govuk-caption-xl">Appeal 351062</span>
             <h1 class="govuk-heading-xl govuk-!-margin-bottom-3">Upload an updated document</h1>
         </div>
@@ -4147,33 +4154,33 @@ exports[`costs application, withdrawal and correspondence GET /costs/:costsCateg
             data-blob-storage-host="https://127.0.0.1:10000/devstoreaccount1" data-blob-storage-container="document-service-uploads"
             data-document-id="1" data-document-original-file-name="test-pdf-documentFileVersionsInfo.pdf"
             data-document-version="1" data-allowed-types=".pdf,application/pdf,.doc,application/msword,.docx,application/vnd.openxmlformats-officedocument.wordprocessingml.document,.ppt,application/vnd.ms-powerpoint,.pptx,application/vnd.openxmlformats-officedocument.presentationml.presentation,.xls,application/vnd.ms-excel,.xlsx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,.msg,application/vnd.ms-outlook,.jpg,image/jpeg,.jpeg,image/jpeg,.mpeg,video/mpeg,.mp3,audio/mpeg,.mp4,video/mp4,.mov,video/quicktime,.png,image/png,.tif,image/tiff,.tiff,image/tiff,">
-                <div class="top-errors-hook govuk-grid-column-two-thirds"></div>
                 <form method="POST" novalidate="novalidate" class="govuk-grid-column-two-thirds"
                 data-filenames-in-folder="WyJ0ZXN0LXBkZi1kb2N1bWVudEZvbGRlckluZm8ucGRmIiwic2FtcGxlLTIwcy1kb2N1bWVudEZvbGRlckluZm8ubXA0Il0=">
                     <div class="pins-file-upload__container">
                         <div class="govuk-body colour--secondary pins-file-upload__instructions">
                             <label for="upload-file-1">Choose a single file to upload.</label><span>The file must be a PDF, DOC, DOCX, PPT, PPTX, XLS, XLSX, MSG, JPG, JPEG, MPEG, MP3, MP4, MOV, PNG, TIF, 	or TIFF.</span><span>The file must be smaller than 25MB.</span>
-                            <div                             class="middle-errors-hook"></div>
+                        </div>
+                        <div class="middle-errors-hook">
+                            <div class="pins-file-upload__upload">
+                                <input class="display--none" id="upload-file-1" accept=".pdf,application/pdf,.doc,application/msword,.docx,application/vnd.openxmlformats-officedocument.wordprocessingml.document,.ppt,application/vnd.ms-powerpoint,.pptx,application/vnd.openxmlformats-officedocument.presentationml.presentation,.xls,application/vnd.ms-excel,.xlsx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,.msg,application/vnd.ms-outlook,.jpg,image/jpeg,.jpeg,image/jpeg,.mpeg,video/mpeg,.mp3,audio/mpeg,.mp4,video/mp4,.mov,video/quicktime,.png,image/png,.tif,image/tiff,.tiff,image/tiff,"
+                                type="file" name="files" value="Choose file" aria-controls="file-list-1">
+                                <button type='button' class="pins-file-upload__button govuk-button">Select files</button>
+                            </div>
+                            <div id="file-list-1">
+                                <h2 class="display--sr-only" id="file-list-title-1">List of files to upload</h2>
+                                <ul class="pins-file-upload__files-rows" aria-describedby="file-list-title-1"
+                                aria-live="polite"></ul>
+                            </div>
+                        </div>
                     </div>
-                    <div class="pins-file-upload__upload">
-                        <input class="display--none" id="upload-file-1" accept=".pdf,application/pdf,.doc,application/msword,.docx,application/vnd.openxmlformats-officedocument.wordprocessingml.document,.ppt,application/vnd.ms-powerpoint,.pptx,application/vnd.openxmlformats-officedocument.presentationml.presentation,.xls,application/vnd.ms-excel,.xlsx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,.msg,application/vnd.ms-outlook,.jpg,image/jpeg,.jpeg,image/jpeg,.mpeg,video/mpeg,.mp3,audio/mpeg,.mp4,video/mp4,.mov,video/quicktime,.png,image/png,.tif,image/tiff,.tiff,image/tiff,"
-                        type="file" name="files" value="Choose file" aria-controls="file-list-1">
-                        <button type='button' class="pins-file-upload__button govuk-button">Select files</button>
+                    <div class="display--flex">
+                        <button type="submit" class="govuk-button pins-file-upload__submit" data-module="govuk-button"
+                        id="submit-button-1">Continue</button>
+                        <div class="progress-hook"></div>
                     </div>
-                    <div id="file-list-1">
-                        <h2 class="display--sr-only" id="file-list-title-1">List of files to upload</h2>
-                        <ul class="pins-file-upload__files-rows" aria-describedby="file-list-title-1"
-                        aria-live="polite"></ul>
-                    </div>
+                </form>
             </div>
-            <div class="display--flex">
-                <button type="submit" class="govuk-button pins-file-upload__submit" data-module="govuk-button"
-                id="submit-button-1">Continue</button>
-                <div class="progress-hook"></div>
-            </div>
-            </form>
         </div>
-    </div>
     </div>
 </main>"
 `;
@@ -4181,6 +4188,7 @@ exports[`costs application, withdrawal and correspondence GET /costs/:costsCateg
 exports[`costs application, withdrawal and correspondence GET /costs/:costsCategory/:costsDocumentType/upload-documents/:folderId/:documentId should render the upload document version page (appellant correspondence) 1`] = `
 "<main class="govuk-main-wrapper " id="main-content" role="main">
     <div class="govuk-grid-row">
+        <div class="top-errors-hook govuk-grid-column-two-thirds"></div>
         <div class="govuk-grid-column-full"><span class="govuk-caption-xl">Appeal 351062</span>
             <h1 class="govuk-heading-xl govuk-!-margin-bottom-3">Upload an updated document</h1>
         </div>
@@ -4193,33 +4201,33 @@ exports[`costs application, withdrawal and correspondence GET /costs/:costsCateg
             data-blob-storage-host="https://127.0.0.1:10000/devstoreaccount1" data-blob-storage-container="document-service-uploads"
             data-document-id="1" data-document-original-file-name="test-pdf-documentFileVersionsInfo.pdf"
             data-document-version="1" data-allowed-types=".pdf,application/pdf,.doc,application/msword,.docx,application/vnd.openxmlformats-officedocument.wordprocessingml.document,.ppt,application/vnd.ms-powerpoint,.pptx,application/vnd.openxmlformats-officedocument.presentationml.presentation,.xls,application/vnd.ms-excel,.xlsx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,.msg,application/vnd.ms-outlook,.jpg,image/jpeg,.jpeg,image/jpeg,.mpeg,video/mpeg,.mp3,audio/mpeg,.mp4,video/mp4,.mov,video/quicktime,.png,image/png,.tif,image/tiff,.tiff,image/tiff,">
-                <div class="top-errors-hook govuk-grid-column-two-thirds"></div>
                 <form method="POST" novalidate="novalidate" class="govuk-grid-column-two-thirds"
                 data-filenames-in-folder="WyJ0ZXN0LXBkZi1kb2N1bWVudEZvbGRlckluZm8ucGRmIiwic2FtcGxlLTIwcy1kb2N1bWVudEZvbGRlckluZm8ubXA0Il0=">
                     <div class="pins-file-upload__container">
                         <div class="govuk-body colour--secondary pins-file-upload__instructions">
                             <label for="upload-file-1">Choose a single file to upload.</label><span>The file must be a PDF, DOC, DOCX, PPT, PPTX, XLS, XLSX, MSG, JPG, JPEG, MPEG, MP3, MP4, MOV, PNG, TIF, 	or TIFF.</span><span>The file must be smaller than 25MB.</span>
-                            <div                             class="middle-errors-hook"></div>
+                        </div>
+                        <div class="middle-errors-hook">
+                            <div class="pins-file-upload__upload">
+                                <input class="display--none" id="upload-file-1" accept=".pdf,application/pdf,.doc,application/msword,.docx,application/vnd.openxmlformats-officedocument.wordprocessingml.document,.ppt,application/vnd.ms-powerpoint,.pptx,application/vnd.openxmlformats-officedocument.presentationml.presentation,.xls,application/vnd.ms-excel,.xlsx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,.msg,application/vnd.ms-outlook,.jpg,image/jpeg,.jpeg,image/jpeg,.mpeg,video/mpeg,.mp3,audio/mpeg,.mp4,video/mp4,.mov,video/quicktime,.png,image/png,.tif,image/tiff,.tiff,image/tiff,"
+                                type="file" name="files" value="Choose file" aria-controls="file-list-1">
+                                <button type='button' class="pins-file-upload__button govuk-button">Select files</button>
+                            </div>
+                            <div id="file-list-1">
+                                <h2 class="display--sr-only" id="file-list-title-1">List of files to upload</h2>
+                                <ul class="pins-file-upload__files-rows" aria-describedby="file-list-title-1"
+                                aria-live="polite"></ul>
+                            </div>
+                        </div>
                     </div>
-                    <div class="pins-file-upload__upload">
-                        <input class="display--none" id="upload-file-1" accept=".pdf,application/pdf,.doc,application/msword,.docx,application/vnd.openxmlformats-officedocument.wordprocessingml.document,.ppt,application/vnd.ms-powerpoint,.pptx,application/vnd.openxmlformats-officedocument.presentationml.presentation,.xls,application/vnd.ms-excel,.xlsx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,.msg,application/vnd.ms-outlook,.jpg,image/jpeg,.jpeg,image/jpeg,.mpeg,video/mpeg,.mp3,audio/mpeg,.mp4,video/mp4,.mov,video/quicktime,.png,image/png,.tif,image/tiff,.tiff,image/tiff,"
-                        type="file" name="files" value="Choose file" aria-controls="file-list-1">
-                        <button type='button' class="pins-file-upload__button govuk-button">Select files</button>
+                    <div class="display--flex">
+                        <button type="submit" class="govuk-button pins-file-upload__submit" data-module="govuk-button"
+                        id="submit-button-1">Continue</button>
+                        <div class="progress-hook"></div>
                     </div>
-                    <div id="file-list-1">
-                        <h2 class="display--sr-only" id="file-list-title-1">List of files to upload</h2>
-                        <ul class="pins-file-upload__files-rows" aria-describedby="file-list-title-1"
-                        aria-live="polite"></ul>
-                    </div>
+                </form>
             </div>
-            <div class="display--flex">
-                <button type="submit" class="govuk-button pins-file-upload__submit" data-module="govuk-button"
-                id="submit-button-1">Continue</button>
-                <div class="progress-hook"></div>
-            </div>
-            </form>
         </div>
-    </div>
     </div>
 </main>"
 `;
@@ -4227,6 +4235,7 @@ exports[`costs application, withdrawal and correspondence GET /costs/:costsCateg
 exports[`costs application, withdrawal and correspondence GET /costs/:costsCategory/:costsDocumentType/upload-documents/:folderId/:documentId should render the upload document version page (appellant withdrawal) 1`] = `
 "<main class="govuk-main-wrapper " id="main-content" role="main">
     <div class="govuk-grid-row">
+        <div class="top-errors-hook govuk-grid-column-two-thirds"></div>
         <div class="govuk-grid-column-full"><span class="govuk-caption-xl">Appeal 351062</span>
             <h1 class="govuk-heading-xl govuk-!-margin-bottom-3">Upload an updated document</h1>
         </div>
@@ -4239,33 +4248,33 @@ exports[`costs application, withdrawal and correspondence GET /costs/:costsCateg
             data-blob-storage-host="https://127.0.0.1:10000/devstoreaccount1" data-blob-storage-container="document-service-uploads"
             data-document-id="1" data-document-original-file-name="test-pdf-documentFileVersionsInfo.pdf"
             data-document-version="1" data-allowed-types=".pdf,application/pdf,.doc,application/msword,.docx,application/vnd.openxmlformats-officedocument.wordprocessingml.document,.ppt,application/vnd.ms-powerpoint,.pptx,application/vnd.openxmlformats-officedocument.presentationml.presentation,.xls,application/vnd.ms-excel,.xlsx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,.msg,application/vnd.ms-outlook,.jpg,image/jpeg,.jpeg,image/jpeg,.mpeg,video/mpeg,.mp3,audio/mpeg,.mp4,video/mp4,.mov,video/quicktime,.png,image/png,.tif,image/tiff,.tiff,image/tiff,">
-                <div class="top-errors-hook govuk-grid-column-two-thirds"></div>
                 <form method="POST" novalidate="novalidate" class="govuk-grid-column-two-thirds"
                 data-filenames-in-folder="WyJ0ZXN0LXBkZi1kb2N1bWVudEZvbGRlckluZm8ucGRmIiwic2FtcGxlLTIwcy1kb2N1bWVudEZvbGRlckluZm8ubXA0Il0=">
                     <div class="pins-file-upload__container">
                         <div class="govuk-body colour--secondary pins-file-upload__instructions">
                             <label for="upload-file-1">Choose a single file to upload.</label><span>The file must be a PDF, DOC, DOCX, PPT, PPTX, XLS, XLSX, MSG, JPG, JPEG, MPEG, MP3, MP4, MOV, PNG, TIF, 	or TIFF.</span><span>The file must be smaller than 25MB.</span>
-                            <div                             class="middle-errors-hook"></div>
+                        </div>
+                        <div class="middle-errors-hook">
+                            <div class="pins-file-upload__upload">
+                                <input class="display--none" id="upload-file-1" accept=".pdf,application/pdf,.doc,application/msword,.docx,application/vnd.openxmlformats-officedocument.wordprocessingml.document,.ppt,application/vnd.ms-powerpoint,.pptx,application/vnd.openxmlformats-officedocument.presentationml.presentation,.xls,application/vnd.ms-excel,.xlsx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,.msg,application/vnd.ms-outlook,.jpg,image/jpeg,.jpeg,image/jpeg,.mpeg,video/mpeg,.mp3,audio/mpeg,.mp4,video/mp4,.mov,video/quicktime,.png,image/png,.tif,image/tiff,.tiff,image/tiff,"
+                                type="file" name="files" value="Choose file" aria-controls="file-list-1">
+                                <button type='button' class="pins-file-upload__button govuk-button">Select files</button>
+                            </div>
+                            <div id="file-list-1">
+                                <h2 class="display--sr-only" id="file-list-title-1">List of files to upload</h2>
+                                <ul class="pins-file-upload__files-rows" aria-describedby="file-list-title-1"
+                                aria-live="polite"></ul>
+                            </div>
+                        </div>
                     </div>
-                    <div class="pins-file-upload__upload">
-                        <input class="display--none" id="upload-file-1" accept=".pdf,application/pdf,.doc,application/msword,.docx,application/vnd.openxmlformats-officedocument.wordprocessingml.document,.ppt,application/vnd.ms-powerpoint,.pptx,application/vnd.openxmlformats-officedocument.presentationml.presentation,.xls,application/vnd.ms-excel,.xlsx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,.msg,application/vnd.ms-outlook,.jpg,image/jpeg,.jpeg,image/jpeg,.mpeg,video/mpeg,.mp3,audio/mpeg,.mp4,video/mp4,.mov,video/quicktime,.png,image/png,.tif,image/tiff,.tiff,image/tiff,"
-                        type="file" name="files" value="Choose file" aria-controls="file-list-1">
-                        <button type='button' class="pins-file-upload__button govuk-button">Select files</button>
+                    <div class="display--flex">
+                        <button type="submit" class="govuk-button pins-file-upload__submit" data-module="govuk-button"
+                        id="submit-button-1">Continue</button>
+                        <div class="progress-hook"></div>
                     </div>
-                    <div id="file-list-1">
-                        <h2 class="display--sr-only" id="file-list-title-1">List of files to upload</h2>
-                        <ul class="pins-file-upload__files-rows" aria-describedby="file-list-title-1"
-                        aria-live="polite"></ul>
-                    </div>
+                </form>
             </div>
-            <div class="display--flex">
-                <button type="submit" class="govuk-button pins-file-upload__submit" data-module="govuk-button"
-                id="submit-button-1">Continue</button>
-                <div class="progress-hook"></div>
-            </div>
-            </form>
         </div>
-    </div>
     </div>
 </main>"
 `;
@@ -4273,6 +4282,7 @@ exports[`costs application, withdrawal and correspondence GET /costs/:costsCateg
 exports[`costs application, withdrawal and correspondence GET /costs/:costsCategory/:costsDocumentType/upload-documents/:folderId/:documentId should render the upload document version page (lpa application) 1`] = `
 "<main class="govuk-main-wrapper " id="main-content" role="main">
     <div class="govuk-grid-row">
+        <div class="top-errors-hook govuk-grid-column-two-thirds"></div>
         <div class="govuk-grid-column-full"><span class="govuk-caption-xl">Appeal 351062</span>
             <h1 class="govuk-heading-xl govuk-!-margin-bottom-3">Upload an updated document</h1>
         </div>
@@ -4285,33 +4295,33 @@ exports[`costs application, withdrawal and correspondence GET /costs/:costsCateg
             data-blob-storage-host="https://127.0.0.1:10000/devstoreaccount1" data-blob-storage-container="document-service-uploads"
             data-document-id="1" data-document-original-file-name="test-pdf-documentFileVersionsInfo.pdf"
             data-document-version="1" data-allowed-types=".pdf,application/pdf,.doc,application/msword,.docx,application/vnd.openxmlformats-officedocument.wordprocessingml.document,.ppt,application/vnd.ms-powerpoint,.pptx,application/vnd.openxmlformats-officedocument.presentationml.presentation,.xls,application/vnd.ms-excel,.xlsx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,.msg,application/vnd.ms-outlook,.jpg,image/jpeg,.jpeg,image/jpeg,.mpeg,video/mpeg,.mp3,audio/mpeg,.mp4,video/mp4,.mov,video/quicktime,.png,image/png,.tif,image/tiff,.tiff,image/tiff,">
-                <div class="top-errors-hook govuk-grid-column-two-thirds"></div>
                 <form method="POST" novalidate="novalidate" class="govuk-grid-column-two-thirds"
                 data-filenames-in-folder="WyJ0ZXN0LXBkZi1kb2N1bWVudEZvbGRlckluZm8ucGRmIiwic2FtcGxlLTIwcy1kb2N1bWVudEZvbGRlckluZm8ubXA0Il0=">
                     <div class="pins-file-upload__container">
                         <div class="govuk-body colour--secondary pins-file-upload__instructions">
                             <label for="upload-file-1">Choose a single file to upload.</label><span>The file must be a PDF, DOC, DOCX, PPT, PPTX, XLS, XLSX, MSG, JPG, JPEG, MPEG, MP3, MP4, MOV, PNG, TIF, 	or TIFF.</span><span>The file must be smaller than 25MB.</span>
-                            <div                             class="middle-errors-hook"></div>
+                        </div>
+                        <div class="middle-errors-hook">
+                            <div class="pins-file-upload__upload">
+                                <input class="display--none" id="upload-file-1" accept=".pdf,application/pdf,.doc,application/msword,.docx,application/vnd.openxmlformats-officedocument.wordprocessingml.document,.ppt,application/vnd.ms-powerpoint,.pptx,application/vnd.openxmlformats-officedocument.presentationml.presentation,.xls,application/vnd.ms-excel,.xlsx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,.msg,application/vnd.ms-outlook,.jpg,image/jpeg,.jpeg,image/jpeg,.mpeg,video/mpeg,.mp3,audio/mpeg,.mp4,video/mp4,.mov,video/quicktime,.png,image/png,.tif,image/tiff,.tiff,image/tiff,"
+                                type="file" name="files" value="Choose file" aria-controls="file-list-1">
+                                <button type='button' class="pins-file-upload__button govuk-button">Select files</button>
+                            </div>
+                            <div id="file-list-1">
+                                <h2 class="display--sr-only" id="file-list-title-1">List of files to upload</h2>
+                                <ul class="pins-file-upload__files-rows" aria-describedby="file-list-title-1"
+                                aria-live="polite"></ul>
+                            </div>
+                        </div>
                     </div>
-                    <div class="pins-file-upload__upload">
-                        <input class="display--none" id="upload-file-1" accept=".pdf,application/pdf,.doc,application/msword,.docx,application/vnd.openxmlformats-officedocument.wordprocessingml.document,.ppt,application/vnd.ms-powerpoint,.pptx,application/vnd.openxmlformats-officedocument.presentationml.presentation,.xls,application/vnd.ms-excel,.xlsx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,.msg,application/vnd.ms-outlook,.jpg,image/jpeg,.jpeg,image/jpeg,.mpeg,video/mpeg,.mp3,audio/mpeg,.mp4,video/mp4,.mov,video/quicktime,.png,image/png,.tif,image/tiff,.tiff,image/tiff,"
-                        type="file" name="files" value="Choose file" aria-controls="file-list-1">
-                        <button type='button' class="pins-file-upload__button govuk-button">Select files</button>
+                    <div class="display--flex">
+                        <button type="submit" class="govuk-button pins-file-upload__submit" data-module="govuk-button"
+                        id="submit-button-1">Continue</button>
+                        <div class="progress-hook"></div>
                     </div>
-                    <div id="file-list-1">
-                        <h2 class="display--sr-only" id="file-list-title-1">List of files to upload</h2>
-                        <ul class="pins-file-upload__files-rows" aria-describedby="file-list-title-1"
-                        aria-live="polite"></ul>
-                    </div>
+                </form>
             </div>
-            <div class="display--flex">
-                <button type="submit" class="govuk-button pins-file-upload__submit" data-module="govuk-button"
-                id="submit-button-1">Continue</button>
-                <div class="progress-hook"></div>
-            </div>
-            </form>
         </div>
-    </div>
     </div>
 </main>"
 `;
@@ -4319,6 +4329,7 @@ exports[`costs application, withdrawal and correspondence GET /costs/:costsCateg
 exports[`costs application, withdrawal and correspondence GET /costs/:costsCategory/:costsDocumentType/upload-documents/:folderId/:documentId should render the upload document version page (lpa correspondence) 1`] = `
 "<main class="govuk-main-wrapper " id="main-content" role="main">
     <div class="govuk-grid-row">
+        <div class="top-errors-hook govuk-grid-column-two-thirds"></div>
         <div class="govuk-grid-column-full"><span class="govuk-caption-xl">Appeal 351062</span>
             <h1 class="govuk-heading-xl govuk-!-margin-bottom-3">Upload an updated document</h1>
         </div>
@@ -4331,33 +4342,33 @@ exports[`costs application, withdrawal and correspondence GET /costs/:costsCateg
             data-blob-storage-host="https://127.0.0.1:10000/devstoreaccount1" data-blob-storage-container="document-service-uploads"
             data-document-id="1" data-document-original-file-name="test-pdf-documentFileVersionsInfo.pdf"
             data-document-version="1" data-allowed-types=".pdf,application/pdf,.doc,application/msword,.docx,application/vnd.openxmlformats-officedocument.wordprocessingml.document,.ppt,application/vnd.ms-powerpoint,.pptx,application/vnd.openxmlformats-officedocument.presentationml.presentation,.xls,application/vnd.ms-excel,.xlsx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,.msg,application/vnd.ms-outlook,.jpg,image/jpeg,.jpeg,image/jpeg,.mpeg,video/mpeg,.mp3,audio/mpeg,.mp4,video/mp4,.mov,video/quicktime,.png,image/png,.tif,image/tiff,.tiff,image/tiff,">
-                <div class="top-errors-hook govuk-grid-column-two-thirds"></div>
                 <form method="POST" novalidate="novalidate" class="govuk-grid-column-two-thirds"
                 data-filenames-in-folder="WyJ0ZXN0LXBkZi1kb2N1bWVudEZvbGRlckluZm8ucGRmIiwic2FtcGxlLTIwcy1kb2N1bWVudEZvbGRlckluZm8ubXA0Il0=">
                     <div class="pins-file-upload__container">
                         <div class="govuk-body colour--secondary pins-file-upload__instructions">
                             <label for="upload-file-1">Choose a single file to upload.</label><span>The file must be a PDF, DOC, DOCX, PPT, PPTX, XLS, XLSX, MSG, JPG, JPEG, MPEG, MP3, MP4, MOV, PNG, TIF, 	or TIFF.</span><span>The file must be smaller than 25MB.</span>
-                            <div                             class="middle-errors-hook"></div>
+                        </div>
+                        <div class="middle-errors-hook">
+                            <div class="pins-file-upload__upload">
+                                <input class="display--none" id="upload-file-1" accept=".pdf,application/pdf,.doc,application/msword,.docx,application/vnd.openxmlformats-officedocument.wordprocessingml.document,.ppt,application/vnd.ms-powerpoint,.pptx,application/vnd.openxmlformats-officedocument.presentationml.presentation,.xls,application/vnd.ms-excel,.xlsx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,.msg,application/vnd.ms-outlook,.jpg,image/jpeg,.jpeg,image/jpeg,.mpeg,video/mpeg,.mp3,audio/mpeg,.mp4,video/mp4,.mov,video/quicktime,.png,image/png,.tif,image/tiff,.tiff,image/tiff,"
+                                type="file" name="files" value="Choose file" aria-controls="file-list-1">
+                                <button type='button' class="pins-file-upload__button govuk-button">Select files</button>
+                            </div>
+                            <div id="file-list-1">
+                                <h2 class="display--sr-only" id="file-list-title-1">List of files to upload</h2>
+                                <ul class="pins-file-upload__files-rows" aria-describedby="file-list-title-1"
+                                aria-live="polite"></ul>
+                            </div>
+                        </div>
                     </div>
-                    <div class="pins-file-upload__upload">
-                        <input class="display--none" id="upload-file-1" accept=".pdf,application/pdf,.doc,application/msword,.docx,application/vnd.openxmlformats-officedocument.wordprocessingml.document,.ppt,application/vnd.ms-powerpoint,.pptx,application/vnd.openxmlformats-officedocument.presentationml.presentation,.xls,application/vnd.ms-excel,.xlsx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,.msg,application/vnd.ms-outlook,.jpg,image/jpeg,.jpeg,image/jpeg,.mpeg,video/mpeg,.mp3,audio/mpeg,.mp4,video/mp4,.mov,video/quicktime,.png,image/png,.tif,image/tiff,.tiff,image/tiff,"
-                        type="file" name="files" value="Choose file" aria-controls="file-list-1">
-                        <button type='button' class="pins-file-upload__button govuk-button">Select files</button>
+                    <div class="display--flex">
+                        <button type="submit" class="govuk-button pins-file-upload__submit" data-module="govuk-button"
+                        id="submit-button-1">Continue</button>
+                        <div class="progress-hook"></div>
                     </div>
-                    <div id="file-list-1">
-                        <h2 class="display--sr-only" id="file-list-title-1">List of files to upload</h2>
-                        <ul class="pins-file-upload__files-rows" aria-describedby="file-list-title-1"
-                        aria-live="polite"></ul>
-                    </div>
+                </form>
             </div>
-            <div class="display--flex">
-                <button type="submit" class="govuk-button pins-file-upload__submit" data-module="govuk-button"
-                id="submit-button-1">Continue</button>
-                <div class="progress-hook"></div>
-            </div>
-            </form>
         </div>
-    </div>
     </div>
 </main>"
 `;
@@ -4365,6 +4376,7 @@ exports[`costs application, withdrawal and correspondence GET /costs/:costsCateg
 exports[`costs application, withdrawal and correspondence GET /costs/:costsCategory/:costsDocumentType/upload-documents/:folderId/:documentId should render the upload document version page (lpa withdrawal) 1`] = `
 "<main class="govuk-main-wrapper " id="main-content" role="main">
     <div class="govuk-grid-row">
+        <div class="top-errors-hook govuk-grid-column-two-thirds"></div>
         <div class="govuk-grid-column-full"><span class="govuk-caption-xl">Appeal 351062</span>
             <h1 class="govuk-heading-xl govuk-!-margin-bottom-3">Upload an updated document</h1>
         </div>
@@ -4377,33 +4389,33 @@ exports[`costs application, withdrawal and correspondence GET /costs/:costsCateg
             data-blob-storage-host="https://127.0.0.1:10000/devstoreaccount1" data-blob-storage-container="document-service-uploads"
             data-document-id="1" data-document-original-file-name="test-pdf-documentFileVersionsInfo.pdf"
             data-document-version="1" data-allowed-types=".pdf,application/pdf,.doc,application/msword,.docx,application/vnd.openxmlformats-officedocument.wordprocessingml.document,.ppt,application/vnd.ms-powerpoint,.pptx,application/vnd.openxmlformats-officedocument.presentationml.presentation,.xls,application/vnd.ms-excel,.xlsx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,.msg,application/vnd.ms-outlook,.jpg,image/jpeg,.jpeg,image/jpeg,.mpeg,video/mpeg,.mp3,audio/mpeg,.mp4,video/mp4,.mov,video/quicktime,.png,image/png,.tif,image/tiff,.tiff,image/tiff,">
-                <div class="top-errors-hook govuk-grid-column-two-thirds"></div>
                 <form method="POST" novalidate="novalidate" class="govuk-grid-column-two-thirds"
                 data-filenames-in-folder="WyJ0ZXN0LXBkZi1kb2N1bWVudEZvbGRlckluZm8ucGRmIiwic2FtcGxlLTIwcy1kb2N1bWVudEZvbGRlckluZm8ubXA0Il0=">
                     <div class="pins-file-upload__container">
                         <div class="govuk-body colour--secondary pins-file-upload__instructions">
                             <label for="upload-file-1">Choose a single file to upload.</label><span>The file must be a PDF, DOC, DOCX, PPT, PPTX, XLS, XLSX, MSG, JPG, JPEG, MPEG, MP3, MP4, MOV, PNG, TIF, 	or TIFF.</span><span>The file must be smaller than 25MB.</span>
-                            <div                             class="middle-errors-hook"></div>
+                        </div>
+                        <div class="middle-errors-hook">
+                            <div class="pins-file-upload__upload">
+                                <input class="display--none" id="upload-file-1" accept=".pdf,application/pdf,.doc,application/msword,.docx,application/vnd.openxmlformats-officedocument.wordprocessingml.document,.ppt,application/vnd.ms-powerpoint,.pptx,application/vnd.openxmlformats-officedocument.presentationml.presentation,.xls,application/vnd.ms-excel,.xlsx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,.msg,application/vnd.ms-outlook,.jpg,image/jpeg,.jpeg,image/jpeg,.mpeg,video/mpeg,.mp3,audio/mpeg,.mp4,video/mp4,.mov,video/quicktime,.png,image/png,.tif,image/tiff,.tiff,image/tiff,"
+                                type="file" name="files" value="Choose file" aria-controls="file-list-1">
+                                <button type='button' class="pins-file-upload__button govuk-button">Select files</button>
+                            </div>
+                            <div id="file-list-1">
+                                <h2 class="display--sr-only" id="file-list-title-1">List of files to upload</h2>
+                                <ul class="pins-file-upload__files-rows" aria-describedby="file-list-title-1"
+                                aria-live="polite"></ul>
+                            </div>
+                        </div>
                     </div>
-                    <div class="pins-file-upload__upload">
-                        <input class="display--none" id="upload-file-1" accept=".pdf,application/pdf,.doc,application/msword,.docx,application/vnd.openxmlformats-officedocument.wordprocessingml.document,.ppt,application/vnd.ms-powerpoint,.pptx,application/vnd.openxmlformats-officedocument.presentationml.presentation,.xls,application/vnd.ms-excel,.xlsx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,.msg,application/vnd.ms-outlook,.jpg,image/jpeg,.jpeg,image/jpeg,.mpeg,video/mpeg,.mp3,audio/mpeg,.mp4,video/mp4,.mov,video/quicktime,.png,image/png,.tif,image/tiff,.tiff,image/tiff,"
-                        type="file" name="files" value="Choose file" aria-controls="file-list-1">
-                        <button type='button' class="pins-file-upload__button govuk-button">Select files</button>
+                    <div class="display--flex">
+                        <button type="submit" class="govuk-button pins-file-upload__submit" data-module="govuk-button"
+                        id="submit-button-1">Continue</button>
+                        <div class="progress-hook"></div>
                     </div>
-                    <div id="file-list-1">
-                        <h2 class="display--sr-only" id="file-list-title-1">List of files to upload</h2>
-                        <ul class="pins-file-upload__files-rows" aria-describedby="file-list-title-1"
-                        aria-live="polite"></ul>
-                    </div>
+                </form>
             </div>
-            <div class="display--flex">
-                <button type="submit" class="govuk-button pins-file-upload__submit" data-module="govuk-button"
-                id="submit-button-1">Continue</button>
-                <div class="progress-hook"></div>
-            </div>
-            </form>
         </div>
-    </div>
     </div>
 </main>"
 `;
@@ -5864,6 +5876,7 @@ exports[`costs decision GET /costs/decision/manage-documents/:folderId/:document
 exports[`costs decision GET /costs/decision/upload-documents/:folderId should render the upload documents page 1`] = `
 "<main class="govuk-main-wrapper " id="main-content" role="main">
     <div class="govuk-grid-row">
+        <div class="top-errors-hook govuk-grid-column-two-thirds"></div>
         <div class="govuk-grid-column-full"><span class="govuk-caption-xl">Appeal 351062</span>
             <h1 class="govuk-heading-xl govuk-!-margin-bottom-3">Upload costs decision</h1>
         </div>
@@ -5874,34 +5887,34 @@ exports[`costs decision GET /costs/decision/upload-documents/:folderId should re
             data-case-id="1" data-case-reference="APP/Q9999/D/21/351062" data-folder-id="7"
             data-document-type="costsDecisionLetter" data-document-stage="costs" data-blob-storage-host="https://127.0.0.1:10000/devstoreaccount1"
             data-blob-storage-container="document-service-uploads" data-allowed-types=".pdf,application/pdf,.doc,application/msword,.docx,application/vnd.openxmlformats-officedocument.wordprocessingml.document,.ppt,application/vnd.ms-powerpoint,.pptx,application/vnd.openxmlformats-officedocument.presentationml.presentation,.xls,application/vnd.ms-excel,.xlsx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,.msg,application/vnd.ms-outlook,.jpg,image/jpeg,.jpeg,image/jpeg,.mpeg,video/mpeg,.mp3,audio/mpeg,.mp4,video/mp4,.mov,video/quicktime,.png,image/png,.tif,image/tiff,.tiff,image/tiff,">
-                <div class="top-errors-hook govuk-grid-column-two-thirds"></div>
                 <form method="POST" novalidate="novalidate" class="govuk-grid-column-two-thirds"
                 data-filenames-in-folder="WyJ0ZXN0LXBkZi1kb2N1bWVudEZvbGRlckluZm8ucGRmIiwic2FtcGxlLTIwcy1kb2N1bWVudEZvbGRlckluZm8ubXA0Il0=">
                     <div class="pins-file-upload__container">
                         <div class="govuk-body colour--secondary pins-file-upload__instructions">
                             <label for="upload-file-1">Choose a single file or multiple files to upload.</label><span>Each file must be a PDF, DOC, DOCX, PPT, PPTX, XLS, XLSX, MSG, JPG, JPEG, MPEG, MP3, MP4, MOV, PNG, TIF, 	or TIFF.</span><span>The total size of your uploaded files must be smaller than 1GB.</span>
-                            <div                             class="middle-errors-hook"></div>
+                        </div>
+                        <div class="middle-errors-hook">
+                            <div class="pins-file-upload__upload">
+                                <input class="display--none" id="upload-file-1" accept=".pdf,application/pdf,.doc,application/msword,.docx,application/vnd.openxmlformats-officedocument.wordprocessingml.document,.ppt,application/vnd.ms-powerpoint,.pptx,application/vnd.openxmlformats-officedocument.presentationml.presentation,.xls,application/vnd.ms-excel,.xlsx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,.msg,application/vnd.ms-outlook,.jpg,image/jpeg,.jpeg,image/jpeg,.mpeg,video/mpeg,.mp3,audio/mpeg,.mp4,video/mp4,.mov,video/quicktime,.png,image/png,.tif,image/tiff,.tiff,image/tiff,"
+                                type="file" name="files" value="Choose file" aria-controls="file-list-1"
+                                multiple><span class='govuk-body pins-file-upload__dropzone-text'>Drag and drop files here or</span>
+                                <button                                 type='button' class="pins-file-upload__button govuk-button">Select files</button>
+                            </div>
+                            <div id="file-list-1">
+                                <h2 class="display--sr-only" id="file-list-title-1">List of files to upload</h2>
+                                <ul class="pins-file-upload__files-rows" aria-describedby="file-list-title-1"
+                                aria-live="polite"></ul>
+                            </div>
+                        </div>
                     </div>
-                    <div class="pins-file-upload__upload">
-                        <input class="display--none" id="upload-file-1" accept=".pdf,application/pdf,.doc,application/msword,.docx,application/vnd.openxmlformats-officedocument.wordprocessingml.document,.ppt,application/vnd.ms-powerpoint,.pptx,application/vnd.openxmlformats-officedocument.presentationml.presentation,.xls,application/vnd.ms-excel,.xlsx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,.msg,application/vnd.ms-outlook,.jpg,image/jpeg,.jpeg,image/jpeg,.mpeg,video/mpeg,.mp3,audio/mpeg,.mp4,video/mp4,.mov,video/quicktime,.png,image/png,.tif,image/tiff,.tiff,image/tiff,"
-                        type="file" name="files" value="Choose file" aria-controls="file-list-1"
-                        multiple><span class='govuk-body pins-file-upload__dropzone-text'>Drag and drop files here or</span>
-                        <button                         type='button' class="pins-file-upload__button govuk-button">Select files</button>
+                    <div class="display--flex">
+                        <button type="submit" class="govuk-button pins-file-upload__submit" data-module="govuk-button"
+                        id="submit-button-1">Continue</button>
+                        <div class="progress-hook"></div>
                     </div>
-                    <div id="file-list-1">
-                        <h2 class="display--sr-only" id="file-list-title-1">List of files to upload</h2>
-                        <ul class="pins-file-upload__files-rows" aria-describedby="file-list-title-1"
-                        aria-live="polite"></ul>
-                    </div>
+                </form>
             </div>
-            <div class="display--flex">
-                <button type="submit" class="govuk-button pins-file-upload__submit" data-module="govuk-button"
-                id="submit-button-1">Continue</button>
-                <div class="progress-hook"></div>
-            </div>
-            </form>
         </div>
-    </div>
     </div>
 </main>"
 `;
@@ -5909,6 +5922,7 @@ exports[`costs decision GET /costs/decision/upload-documents/:folderId should re
 exports[`costs decision GET /costs/decision/upload-documents/:folderId/:documentId should render the upload document version page 1`] = `
 "<main class="govuk-main-wrapper " id="main-content" role="main">
     <div class="govuk-grid-row">
+        <div class="top-errors-hook govuk-grid-column-two-thirds"></div>
         <div class="govuk-grid-column-full"><span class="govuk-caption-xl">Appeal 351062</span>
             <h1 class="govuk-heading-xl govuk-!-margin-bottom-3">Upload an updated document</h1>
         </div>
@@ -5921,33 +5935,33 @@ exports[`costs decision GET /costs/decision/upload-documents/:folderId/:document
             data-blob-storage-host="https://127.0.0.1:10000/devstoreaccount1" data-blob-storage-container="document-service-uploads"
             data-document-id="1" data-document-original-file-name="test-pdf-documentFileVersionsInfo.pdf"
             data-document-version="1" data-allowed-types=".pdf,application/pdf,.doc,application/msword,.docx,application/vnd.openxmlformats-officedocument.wordprocessingml.document,.ppt,application/vnd.ms-powerpoint,.pptx,application/vnd.openxmlformats-officedocument.presentationml.presentation,.xls,application/vnd.ms-excel,.xlsx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,.msg,application/vnd.ms-outlook,.jpg,image/jpeg,.jpeg,image/jpeg,.mpeg,video/mpeg,.mp3,audio/mpeg,.mp4,video/mp4,.mov,video/quicktime,.png,image/png,.tif,image/tiff,.tiff,image/tiff,">
-                <div class="top-errors-hook govuk-grid-column-two-thirds"></div>
                 <form method="POST" novalidate="novalidate" class="govuk-grid-column-two-thirds"
                 data-filenames-in-folder="WyJ0ZXN0LXBkZi1kb2N1bWVudEZvbGRlckluZm8ucGRmIiwic2FtcGxlLTIwcy1kb2N1bWVudEZvbGRlckluZm8ubXA0Il0=">
                     <div class="pins-file-upload__container">
                         <div class="govuk-body colour--secondary pins-file-upload__instructions">
                             <label for="upload-file-1">Choose a single file to upload.</label><span>The file must be a PDF, DOC, DOCX, PPT, PPTX, XLS, XLSX, MSG, JPG, JPEG, MPEG, MP3, MP4, MOV, PNG, TIF, 	or TIFF.</span><span>The file must be smaller than 25MB.</span>
-                            <div                             class="middle-errors-hook"></div>
+                        </div>
+                        <div class="middle-errors-hook">
+                            <div class="pins-file-upload__upload">
+                                <input class="display--none" id="upload-file-1" accept=".pdf,application/pdf,.doc,application/msword,.docx,application/vnd.openxmlformats-officedocument.wordprocessingml.document,.ppt,application/vnd.ms-powerpoint,.pptx,application/vnd.openxmlformats-officedocument.presentationml.presentation,.xls,application/vnd.ms-excel,.xlsx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,.msg,application/vnd.ms-outlook,.jpg,image/jpeg,.jpeg,image/jpeg,.mpeg,video/mpeg,.mp3,audio/mpeg,.mp4,video/mp4,.mov,video/quicktime,.png,image/png,.tif,image/tiff,.tiff,image/tiff,"
+                                type="file" name="files" value="Choose file" aria-controls="file-list-1">
+                                <button type='button' class="pins-file-upload__button govuk-button">Select files</button>
+                            </div>
+                            <div id="file-list-1">
+                                <h2 class="display--sr-only" id="file-list-title-1">List of files to upload</h2>
+                                <ul class="pins-file-upload__files-rows" aria-describedby="file-list-title-1"
+                                aria-live="polite"></ul>
+                            </div>
+                        </div>
                     </div>
-                    <div class="pins-file-upload__upload">
-                        <input class="display--none" id="upload-file-1" accept=".pdf,application/pdf,.doc,application/msword,.docx,application/vnd.openxmlformats-officedocument.wordprocessingml.document,.ppt,application/vnd.ms-powerpoint,.pptx,application/vnd.openxmlformats-officedocument.presentationml.presentation,.xls,application/vnd.ms-excel,.xlsx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,.msg,application/vnd.ms-outlook,.jpg,image/jpeg,.jpeg,image/jpeg,.mpeg,video/mpeg,.mp3,audio/mpeg,.mp4,video/mp4,.mov,video/quicktime,.png,image/png,.tif,image/tiff,.tiff,image/tiff,"
-                        type="file" name="files" value="Choose file" aria-controls="file-list-1">
-                        <button type='button' class="pins-file-upload__button govuk-button">Select files</button>
+                    <div class="display--flex">
+                        <button type="submit" class="govuk-button pins-file-upload__submit" data-module="govuk-button"
+                        id="submit-button-1">Continue</button>
+                        <div class="progress-hook"></div>
                     </div>
-                    <div id="file-list-1">
-                        <h2 class="display--sr-only" id="file-list-title-1">List of files to upload</h2>
-                        <ul class="pins-file-upload__files-rows" aria-describedby="file-list-title-1"
-                        aria-live="polite"></ul>
-                    </div>
+                </form>
             </div>
-            <div class="display--flex">
-                <button type="submit" class="govuk-button pins-file-upload__submit" data-module="govuk-button"
-                id="submit-button-1">Continue</button>
-                <div class="progress-hook"></div>
-            </div>
-            </form>
         </div>
-    </div>
     </div>
 </main>"
 `;

--- a/appeals/web/src/server/appeals/appeal-details/internal-correspondence/__tests__/__snapshots__/internal-correspondence.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/internal-correspondence/__tests__/__snapshots__/internal-correspondence.test.js.snap
@@ -1445,6 +1445,7 @@ exports[`internal correspondence GET /internal-correspondence/:correspondenceCat
 exports[`internal correspondence GET /internal-correspondence/:correspondenceCategory/upload-documents/:folderId should render the upload documents page (cross-team) 1`] = `
 "<main class="govuk-main-wrapper " id="main-content" role="main">
     <div class="govuk-grid-row">
+        <div class="top-errors-hook govuk-grid-column-two-thirds"></div>
         <div class="govuk-grid-column-full"><span class="govuk-caption-xl">Appeal 351062</span>
             <h1 class="govuk-heading-xl govuk-!-margin-bottom-3">Upload cross-team correspondence</h1>
         </div>
@@ -1456,34 +1457,34 @@ exports[`internal correspondence GET /internal-correspondence/:correspondenceCat
             data-document-type="crossTeamCorrespondence" data-document-stage="internal"
             data-blob-storage-host="https://127.0.0.1:10000/devstoreaccount1" data-blob-storage-container="document-service-uploads"
             data-allowed-types=".pdf,application/pdf,.doc,application/msword,.docx,application/vnd.openxmlformats-officedocument.wordprocessingml.document,.ppt,application/vnd.ms-powerpoint,.pptx,application/vnd.openxmlformats-officedocument.presentationml.presentation,.xls,application/vnd.ms-excel,.xlsx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,.msg,application/vnd.ms-outlook,.jpg,image/jpeg,.jpeg,image/jpeg,.mpeg,video/mpeg,.mp3,audio/mpeg,.mp4,video/mp4,.mov,video/quicktime,.png,image/png,.tif,image/tiff,.tiff,image/tiff,">
-                <div class="top-errors-hook govuk-grid-column-two-thirds"></div>
                 <form method="POST" novalidate="novalidate" class="govuk-grid-column-two-thirds"
                 data-filenames-in-folder="WyJ0ZXN0LXBkZi1kb2N1bWVudEZvbGRlckluZm8ucGRmIiwic2FtcGxlLTIwcy1kb2N1bWVudEZvbGRlckluZm8ubXA0Il0=">
                     <div class="pins-file-upload__container">
                         <div class="govuk-body colour--secondary pins-file-upload__instructions">
                             <label for="upload-file-1">Choose a single file or multiple files to upload.</label><span>Each file must be a PDF, DOC, DOCX, PPT, PPTX, XLS, XLSX, MSG, JPG, JPEG, MPEG, MP3, MP4, MOV, PNG, TIF, 	or TIFF.</span><span>The total size of your uploaded files must be smaller than 1GB.</span>
-                            <div                             class="middle-errors-hook"></div>
+                        </div>
+                        <div class="middle-errors-hook">
+                            <div class="pins-file-upload__upload">
+                                <input class="display--none" id="upload-file-1" accept=".pdf,application/pdf,.doc,application/msword,.docx,application/vnd.openxmlformats-officedocument.wordprocessingml.document,.ppt,application/vnd.ms-powerpoint,.pptx,application/vnd.openxmlformats-officedocument.presentationml.presentation,.xls,application/vnd.ms-excel,.xlsx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,.msg,application/vnd.ms-outlook,.jpg,image/jpeg,.jpeg,image/jpeg,.mpeg,video/mpeg,.mp3,audio/mpeg,.mp4,video/mp4,.mov,video/quicktime,.png,image/png,.tif,image/tiff,.tiff,image/tiff,"
+                                type="file" name="files" value="Choose file" aria-controls="file-list-1"
+                                multiple><span class='govuk-body pins-file-upload__dropzone-text'>Drag and drop files here or</span>
+                                <button                                 type='button' class="pins-file-upload__button govuk-button">Select files</button>
+                            </div>
+                            <div id="file-list-1">
+                                <h2 class="display--sr-only" id="file-list-title-1">List of files to upload</h2>
+                                <ul class="pins-file-upload__files-rows" aria-describedby="file-list-title-1"
+                                aria-live="polite"></ul>
+                            </div>
+                        </div>
                     </div>
-                    <div class="pins-file-upload__upload">
-                        <input class="display--none" id="upload-file-1" accept=".pdf,application/pdf,.doc,application/msword,.docx,application/vnd.openxmlformats-officedocument.wordprocessingml.document,.ppt,application/vnd.ms-powerpoint,.pptx,application/vnd.openxmlformats-officedocument.presentationml.presentation,.xls,application/vnd.ms-excel,.xlsx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,.msg,application/vnd.ms-outlook,.jpg,image/jpeg,.jpeg,image/jpeg,.mpeg,video/mpeg,.mp3,audio/mpeg,.mp4,video/mp4,.mov,video/quicktime,.png,image/png,.tif,image/tiff,.tiff,image/tiff,"
-                        type="file" name="files" value="Choose file" aria-controls="file-list-1"
-                        multiple><span class='govuk-body pins-file-upload__dropzone-text'>Drag and drop files here or</span>
-                        <button                         type='button' class="pins-file-upload__button govuk-button">Select files</button>
+                    <div class="display--flex">
+                        <button type="submit" class="govuk-button pins-file-upload__submit" data-module="govuk-button"
+                        id="submit-button-1">Continue</button>
+                        <div class="progress-hook"></div>
                     </div>
-                    <div id="file-list-1">
-                        <h2 class="display--sr-only" id="file-list-title-1">List of files to upload</h2>
-                        <ul class="pins-file-upload__files-rows" aria-describedby="file-list-title-1"
-                        aria-live="polite"></ul>
-                    </div>
+                </form>
             </div>
-            <div class="display--flex">
-                <button type="submit" class="govuk-button pins-file-upload__submit" data-module="govuk-button"
-                id="submit-button-1">Continue</button>
-                <div class="progress-hook"></div>
-            </div>
-            </form>
         </div>
-    </div>
     </div>
 </main>"
 `;
@@ -1491,6 +1492,7 @@ exports[`internal correspondence GET /internal-correspondence/:correspondenceCat
 exports[`internal correspondence GET /internal-correspondence/:correspondenceCategory/upload-documents/:folderId should render the upload documents page (inspector) 1`] = `
 "<main class="govuk-main-wrapper " id="main-content" role="main">
     <div class="govuk-grid-row">
+        <div class="top-errors-hook govuk-grid-column-two-thirds"></div>
         <div class="govuk-grid-column-full"><span class="govuk-caption-xl">Appeal 351062</span>
             <h1 class="govuk-heading-xl govuk-!-margin-bottom-3">Upload inspector correspondence</h1>
         </div>
@@ -1502,34 +1504,34 @@ exports[`internal correspondence GET /internal-correspondence/:correspondenceCat
             data-document-type="inspectorCorrespondence" data-document-stage="internal"
             data-blob-storage-host="https://127.0.0.1:10000/devstoreaccount1" data-blob-storage-container="document-service-uploads"
             data-allowed-types=".pdf,application/pdf,.doc,application/msword,.docx,application/vnd.openxmlformats-officedocument.wordprocessingml.document,.ppt,application/vnd.ms-powerpoint,.pptx,application/vnd.openxmlformats-officedocument.presentationml.presentation,.xls,application/vnd.ms-excel,.xlsx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,.msg,application/vnd.ms-outlook,.jpg,image/jpeg,.jpeg,image/jpeg,.mpeg,video/mpeg,.mp3,audio/mpeg,.mp4,video/mp4,.mov,video/quicktime,.png,image/png,.tif,image/tiff,.tiff,image/tiff,">
-                <div class="top-errors-hook govuk-grid-column-two-thirds"></div>
                 <form method="POST" novalidate="novalidate" class="govuk-grid-column-two-thirds"
                 data-filenames-in-folder="WyJ0ZXN0LXBkZi1kb2N1bWVudEZvbGRlckluZm8ucGRmIiwic2FtcGxlLTIwcy1kb2N1bWVudEZvbGRlckluZm8ubXA0Il0=">
                     <div class="pins-file-upload__container">
                         <div class="govuk-body colour--secondary pins-file-upload__instructions">
                             <label for="upload-file-1">Choose a single file or multiple files to upload.</label><span>Each file must be a PDF, DOC, DOCX, PPT, PPTX, XLS, XLSX, MSG, JPG, JPEG, MPEG, MP3, MP4, MOV, PNG, TIF, 	or TIFF.</span><span>The total size of your uploaded files must be smaller than 1GB.</span>
-                            <div                             class="middle-errors-hook"></div>
+                        </div>
+                        <div class="middle-errors-hook">
+                            <div class="pins-file-upload__upload">
+                                <input class="display--none" id="upload-file-1" accept=".pdf,application/pdf,.doc,application/msword,.docx,application/vnd.openxmlformats-officedocument.wordprocessingml.document,.ppt,application/vnd.ms-powerpoint,.pptx,application/vnd.openxmlformats-officedocument.presentationml.presentation,.xls,application/vnd.ms-excel,.xlsx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,.msg,application/vnd.ms-outlook,.jpg,image/jpeg,.jpeg,image/jpeg,.mpeg,video/mpeg,.mp3,audio/mpeg,.mp4,video/mp4,.mov,video/quicktime,.png,image/png,.tif,image/tiff,.tiff,image/tiff,"
+                                type="file" name="files" value="Choose file" aria-controls="file-list-1"
+                                multiple><span class='govuk-body pins-file-upload__dropzone-text'>Drag and drop files here or</span>
+                                <button                                 type='button' class="pins-file-upload__button govuk-button">Select files</button>
+                            </div>
+                            <div id="file-list-1">
+                                <h2 class="display--sr-only" id="file-list-title-1">List of files to upload</h2>
+                                <ul class="pins-file-upload__files-rows" aria-describedby="file-list-title-1"
+                                aria-live="polite"></ul>
+                            </div>
+                        </div>
                     </div>
-                    <div class="pins-file-upload__upload">
-                        <input class="display--none" id="upload-file-1" accept=".pdf,application/pdf,.doc,application/msword,.docx,application/vnd.openxmlformats-officedocument.wordprocessingml.document,.ppt,application/vnd.ms-powerpoint,.pptx,application/vnd.openxmlformats-officedocument.presentationml.presentation,.xls,application/vnd.ms-excel,.xlsx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,.msg,application/vnd.ms-outlook,.jpg,image/jpeg,.jpeg,image/jpeg,.mpeg,video/mpeg,.mp3,audio/mpeg,.mp4,video/mp4,.mov,video/quicktime,.png,image/png,.tif,image/tiff,.tiff,image/tiff,"
-                        type="file" name="files" value="Choose file" aria-controls="file-list-1"
-                        multiple><span class='govuk-body pins-file-upload__dropzone-text'>Drag and drop files here or</span>
-                        <button                         type='button' class="pins-file-upload__button govuk-button">Select files</button>
+                    <div class="display--flex">
+                        <button type="submit" class="govuk-button pins-file-upload__submit" data-module="govuk-button"
+                        id="submit-button-1">Continue</button>
+                        <div class="progress-hook"></div>
                     </div>
-                    <div id="file-list-1">
-                        <h2 class="display--sr-only" id="file-list-title-1">List of files to upload</h2>
-                        <ul class="pins-file-upload__files-rows" aria-describedby="file-list-title-1"
-                        aria-live="polite"></ul>
-                    </div>
+                </form>
             </div>
-            <div class="display--flex">
-                <button type="submit" class="govuk-button pins-file-upload__submit" data-module="govuk-button"
-                id="submit-button-1">Continue</button>
-                <div class="progress-hook"></div>
-            </div>
-            </form>
         </div>
-    </div>
     </div>
 </main>"
 `;
@@ -1537,6 +1539,7 @@ exports[`internal correspondence GET /internal-correspondence/:correspondenceCat
 exports[`internal correspondence GET /internal-correspondence/:correspondenceCategory/upload-documents/:folderId/:documentId should render the upload document version page (cross-team) 1`] = `
 "<main class="govuk-main-wrapper " id="main-content" role="main">
     <div class="govuk-grid-row">
+        <div class="top-errors-hook govuk-grid-column-two-thirds"></div>
         <div class="govuk-grid-column-full"><span class="govuk-caption-xl">Appeal 351062</span>
             <h1 class="govuk-heading-xl govuk-!-margin-bottom-3">Upload an updated document</h1>
         </div>
@@ -1549,33 +1552,33 @@ exports[`internal correspondence GET /internal-correspondence/:correspondenceCat
             data-blob-storage-host="https://127.0.0.1:10000/devstoreaccount1" data-blob-storage-container="document-service-uploads"
             data-document-id="1" data-document-original-file-name="test-pdf-documentFileVersionsInfo.pdf"
             data-document-version="1" data-allowed-types=".pdf,application/pdf,.doc,application/msword,.docx,application/vnd.openxmlformats-officedocument.wordprocessingml.document,.ppt,application/vnd.ms-powerpoint,.pptx,application/vnd.openxmlformats-officedocument.presentationml.presentation,.xls,application/vnd.ms-excel,.xlsx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,.msg,application/vnd.ms-outlook,.jpg,image/jpeg,.jpeg,image/jpeg,.mpeg,video/mpeg,.mp3,audio/mpeg,.mp4,video/mp4,.mov,video/quicktime,.png,image/png,.tif,image/tiff,.tiff,image/tiff,">
-                <div class="top-errors-hook govuk-grid-column-two-thirds"></div>
                 <form method="POST" novalidate="novalidate" class="govuk-grid-column-two-thirds"
                 data-filenames-in-folder="WyJ0ZXN0LXBkZi1kb2N1bWVudEZvbGRlckluZm8ucGRmIiwic2FtcGxlLTIwcy1kb2N1bWVudEZvbGRlckluZm8ubXA0Il0=">
                     <div class="pins-file-upload__container">
                         <div class="govuk-body colour--secondary pins-file-upload__instructions">
                             <label for="upload-file-1">Choose a single file to upload.</label><span>The file must be a PDF, DOC, DOCX, PPT, PPTX, XLS, XLSX, MSG, JPG, JPEG, MPEG, MP3, MP4, MOV, PNG, TIF, 	or TIFF.</span><span>The file must be smaller than 25MB.</span>
-                            <div                             class="middle-errors-hook"></div>
+                        </div>
+                        <div class="middle-errors-hook">
+                            <div class="pins-file-upload__upload">
+                                <input class="display--none" id="upload-file-1" accept=".pdf,application/pdf,.doc,application/msword,.docx,application/vnd.openxmlformats-officedocument.wordprocessingml.document,.ppt,application/vnd.ms-powerpoint,.pptx,application/vnd.openxmlformats-officedocument.presentationml.presentation,.xls,application/vnd.ms-excel,.xlsx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,.msg,application/vnd.ms-outlook,.jpg,image/jpeg,.jpeg,image/jpeg,.mpeg,video/mpeg,.mp3,audio/mpeg,.mp4,video/mp4,.mov,video/quicktime,.png,image/png,.tif,image/tiff,.tiff,image/tiff,"
+                                type="file" name="files" value="Choose file" aria-controls="file-list-1">
+                                <button type='button' class="pins-file-upload__button govuk-button">Select files</button>
+                            </div>
+                            <div id="file-list-1">
+                                <h2 class="display--sr-only" id="file-list-title-1">List of files to upload</h2>
+                                <ul class="pins-file-upload__files-rows" aria-describedby="file-list-title-1"
+                                aria-live="polite"></ul>
+                            </div>
+                        </div>
                     </div>
-                    <div class="pins-file-upload__upload">
-                        <input class="display--none" id="upload-file-1" accept=".pdf,application/pdf,.doc,application/msword,.docx,application/vnd.openxmlformats-officedocument.wordprocessingml.document,.ppt,application/vnd.ms-powerpoint,.pptx,application/vnd.openxmlformats-officedocument.presentationml.presentation,.xls,application/vnd.ms-excel,.xlsx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,.msg,application/vnd.ms-outlook,.jpg,image/jpeg,.jpeg,image/jpeg,.mpeg,video/mpeg,.mp3,audio/mpeg,.mp4,video/mp4,.mov,video/quicktime,.png,image/png,.tif,image/tiff,.tiff,image/tiff,"
-                        type="file" name="files" value="Choose file" aria-controls="file-list-1">
-                        <button type='button' class="pins-file-upload__button govuk-button">Select files</button>
+                    <div class="display--flex">
+                        <button type="submit" class="govuk-button pins-file-upload__submit" data-module="govuk-button"
+                        id="submit-button-1">Continue</button>
+                        <div class="progress-hook"></div>
                     </div>
-                    <div id="file-list-1">
-                        <h2 class="display--sr-only" id="file-list-title-1">List of files to upload</h2>
-                        <ul class="pins-file-upload__files-rows" aria-describedby="file-list-title-1"
-                        aria-live="polite"></ul>
-                    </div>
+                </form>
             </div>
-            <div class="display--flex">
-                <button type="submit" class="govuk-button pins-file-upload__submit" data-module="govuk-button"
-                id="submit-button-1">Continue</button>
-                <div class="progress-hook"></div>
-            </div>
-            </form>
         </div>
-    </div>
     </div>
 </main>"
 `;
@@ -1583,6 +1586,7 @@ exports[`internal correspondence GET /internal-correspondence/:correspondenceCat
 exports[`internal correspondence GET /internal-correspondence/:correspondenceCategory/upload-documents/:folderId/:documentId should render the upload document version page (inspector) 1`] = `
 "<main class="govuk-main-wrapper " id="main-content" role="main">
     <div class="govuk-grid-row">
+        <div class="top-errors-hook govuk-grid-column-two-thirds"></div>
         <div class="govuk-grid-column-full"><span class="govuk-caption-xl">Appeal 351062</span>
             <h1 class="govuk-heading-xl govuk-!-margin-bottom-3">Upload an updated document</h1>
         </div>
@@ -1595,33 +1599,33 @@ exports[`internal correspondence GET /internal-correspondence/:correspondenceCat
             data-blob-storage-host="https://127.0.0.1:10000/devstoreaccount1" data-blob-storage-container="document-service-uploads"
             data-document-id="1" data-document-original-file-name="test-pdf-documentFileVersionsInfo.pdf"
             data-document-version="1" data-allowed-types=".pdf,application/pdf,.doc,application/msword,.docx,application/vnd.openxmlformats-officedocument.wordprocessingml.document,.ppt,application/vnd.ms-powerpoint,.pptx,application/vnd.openxmlformats-officedocument.presentationml.presentation,.xls,application/vnd.ms-excel,.xlsx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,.msg,application/vnd.ms-outlook,.jpg,image/jpeg,.jpeg,image/jpeg,.mpeg,video/mpeg,.mp3,audio/mpeg,.mp4,video/mp4,.mov,video/quicktime,.png,image/png,.tif,image/tiff,.tiff,image/tiff,">
-                <div class="top-errors-hook govuk-grid-column-two-thirds"></div>
                 <form method="POST" novalidate="novalidate" class="govuk-grid-column-two-thirds"
                 data-filenames-in-folder="WyJ0ZXN0LXBkZi1kb2N1bWVudEZvbGRlckluZm8ucGRmIiwic2FtcGxlLTIwcy1kb2N1bWVudEZvbGRlckluZm8ubXA0Il0=">
                     <div class="pins-file-upload__container">
                         <div class="govuk-body colour--secondary pins-file-upload__instructions">
                             <label for="upload-file-1">Choose a single file to upload.</label><span>The file must be a PDF, DOC, DOCX, PPT, PPTX, XLS, XLSX, MSG, JPG, JPEG, MPEG, MP3, MP4, MOV, PNG, TIF, 	or TIFF.</span><span>The file must be smaller than 25MB.</span>
-                            <div                             class="middle-errors-hook"></div>
+                        </div>
+                        <div class="middle-errors-hook">
+                            <div class="pins-file-upload__upload">
+                                <input class="display--none" id="upload-file-1" accept=".pdf,application/pdf,.doc,application/msword,.docx,application/vnd.openxmlformats-officedocument.wordprocessingml.document,.ppt,application/vnd.ms-powerpoint,.pptx,application/vnd.openxmlformats-officedocument.presentationml.presentation,.xls,application/vnd.ms-excel,.xlsx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,.msg,application/vnd.ms-outlook,.jpg,image/jpeg,.jpeg,image/jpeg,.mpeg,video/mpeg,.mp3,audio/mpeg,.mp4,video/mp4,.mov,video/quicktime,.png,image/png,.tif,image/tiff,.tiff,image/tiff,"
+                                type="file" name="files" value="Choose file" aria-controls="file-list-1">
+                                <button type='button' class="pins-file-upload__button govuk-button">Select files</button>
+                            </div>
+                            <div id="file-list-1">
+                                <h2 class="display--sr-only" id="file-list-title-1">List of files to upload</h2>
+                                <ul class="pins-file-upload__files-rows" aria-describedby="file-list-title-1"
+                                aria-live="polite"></ul>
+                            </div>
+                        </div>
                     </div>
-                    <div class="pins-file-upload__upload">
-                        <input class="display--none" id="upload-file-1" accept=".pdf,application/pdf,.doc,application/msword,.docx,application/vnd.openxmlformats-officedocument.wordprocessingml.document,.ppt,application/vnd.ms-powerpoint,.pptx,application/vnd.openxmlformats-officedocument.presentationml.presentation,.xls,application/vnd.ms-excel,.xlsx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,.msg,application/vnd.ms-outlook,.jpg,image/jpeg,.jpeg,image/jpeg,.mpeg,video/mpeg,.mp3,audio/mpeg,.mp4,video/mp4,.mov,video/quicktime,.png,image/png,.tif,image/tiff,.tiff,image/tiff,"
-                        type="file" name="files" value="Choose file" aria-controls="file-list-1">
-                        <button type='button' class="pins-file-upload__button govuk-button">Select files</button>
+                    <div class="display--flex">
+                        <button type="submit" class="govuk-button pins-file-upload__submit" data-module="govuk-button"
+                        id="submit-button-1">Continue</button>
+                        <div class="progress-hook"></div>
                     </div>
-                    <div id="file-list-1">
-                        <h2 class="display--sr-only" id="file-list-title-1">List of files to upload</h2>
-                        <ul class="pins-file-upload__files-rows" aria-describedby="file-list-title-1"
-                        aria-live="polite"></ul>
-                    </div>
+                </form>
             </div>
-            <div class="display--flex">
-                <button type="submit" class="govuk-button pins-file-upload__submit" data-module="govuk-button"
-                id="submit-button-1">Continue</button>
-                <div class="progress-hook"></div>
-            </div>
-            </form>
         </div>
-    </div>
     </div>
 </main>"
 `;

--- a/appeals/web/src/server/appeals/appeal-details/issue-decision/__tests__/__snapshots__/issue-decision.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/issue-decision/__tests__/__snapshots__/issue-decision.test.js.snap
@@ -162,6 +162,7 @@ exports[`issue-decision GET /decision-letter-date should render the decision let
 exports[`issue-decision GET /decision-letter-upload should render the decision letter upload page with a file upload component 1`] = `
 "<main class="govuk-main-wrapper " id="main-content" role="main">
     <div class="govuk-grid-row">
+        <div class="top-errors-hook govuk-grid-column-two-thirds"></div>
         <div class="govuk-grid-column-full"><span class="govuk-caption-xl">Appeal 351062</span>
             <h1 class="govuk-heading-xl govuk-!-margin-bottom-3">Upload decision letter</h1>
         </div>
@@ -184,33 +185,33 @@ exports[`issue-decision GET /decision-letter-upload should render the decision l
             data-document-type="caseDecisionLetter" data-document-stage="appeal-decision"
             data-blob-storage-host="https://127.0.0.1:10000/devstoreaccount1" data-blob-storage-container="document-service-uploads"
             data-allowed-types=".pdf,application/pdf,.doc,application/msword,.docx,application/vnd.openxmlformats-officedocument.wordprocessingml.document,.ppt,application/vnd.ms-powerpoint,.pptx,application/vnd.openxmlformats-officedocument.presentationml.presentation,.xls,application/vnd.ms-excel,.xlsx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,.msg,application/vnd.ms-outlook,.jpg,image/jpeg,.jpeg,image/jpeg,.mpeg,video/mpeg,.mp3,audio/mpeg,.mp4,video/mp4,.mov,video/quicktime,.png,image/png,.tif,image/tiff,.tiff,image/tiff,">
-                <div class="top-errors-hook govuk-grid-column-two-thirds"></div>
                 <form method="POST" novalidate="novalidate" class="govuk-grid-column-two-thirds"
                 data-filenames-in-folder="">
                     <div class="pins-file-upload__container">
                         <div class="govuk-body colour--secondary pins-file-upload__instructions">
                             <label for="upload-file-1">Choose a single file to upload.</label><span>The file must be a PDF, DOC, DOCX, PPT, PPTX, XLS, XLSX, MSG, JPG, JPEG, MPEG, MP3, MP4, MOV, PNG, TIF, 	or TIFF.</span><span>The file must be smaller than 25MB.</span>
-                            <div                             class="middle-errors-hook"></div>
+                        </div>
+                        <div class="middle-errors-hook">
+                            <div class="pins-file-upload__upload">
+                                <input class="display--none" id="upload-file-1" accept=".pdf,application/pdf,.doc,application/msword,.docx,application/vnd.openxmlformats-officedocument.wordprocessingml.document,.ppt,application/vnd.ms-powerpoint,.pptx,application/vnd.openxmlformats-officedocument.presentationml.presentation,.xls,application/vnd.ms-excel,.xlsx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,.msg,application/vnd.ms-outlook,.jpg,image/jpeg,.jpeg,image/jpeg,.mpeg,video/mpeg,.mp3,audio/mpeg,.mp4,video/mp4,.mov,video/quicktime,.png,image/png,.tif,image/tiff,.tiff,image/tiff,"
+                                type="file" name="files" value="Choose file" aria-controls="file-list-1">
+                                <button type='button' class="pins-file-upload__button govuk-button">Select files</button>
+                            </div>
+                            <div id="file-list-1">
+                                <h2 class="display--sr-only" id="file-list-title-1">List of files to upload</h2>
+                                <ul class="pins-file-upload__files-rows" aria-describedby="file-list-title-1"
+                                aria-live="polite"></ul>
+                            </div>
+                        </div>
                     </div>
-                    <div class="pins-file-upload__upload">
-                        <input class="display--none" id="upload-file-1" accept=".pdf,application/pdf,.doc,application/msword,.docx,application/vnd.openxmlformats-officedocument.wordprocessingml.document,.ppt,application/vnd.ms-powerpoint,.pptx,application/vnd.openxmlformats-officedocument.presentationml.presentation,.xls,application/vnd.ms-excel,.xlsx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,.msg,application/vnd.ms-outlook,.jpg,image/jpeg,.jpeg,image/jpeg,.mpeg,video/mpeg,.mp3,audio/mpeg,.mp4,video/mp4,.mov,video/quicktime,.png,image/png,.tif,image/tiff,.tiff,image/tiff,"
-                        type="file" name="files" value="Choose file" aria-controls="file-list-1">
-                        <button type='button' class="pins-file-upload__button govuk-button">Select files</button>
+                    <div class="display--flex">
+                        <button type="submit" class="govuk-button pins-file-upload__submit" data-module="govuk-button"
+                        id="submit-button-1">Continue</button>
+                        <div class="progress-hook"></div>
                     </div>
-                    <div id="file-list-1">
-                        <h2 class="display--sr-only" id="file-list-title-1">List of files to upload</h2>
-                        <ul class="pins-file-upload__files-rows" aria-describedby="file-list-title-1"
-                        aria-live="polite"></ul>
-                    </div>
+                </form>
             </div>
-            <div class="display--flex">
-                <button type="submit" class="govuk-button pins-file-upload__submit" data-module="govuk-button"
-                id="submit-button-1">Continue</button>
-                <div class="progress-hook"></div>
-            </div>
-            </form>
         </div>
-    </div>
     </div>
 </main>"
 `;

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/__tests__/__snapshots__/lpa-questionnaire.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/__tests__/__snapshots__/lpa-questionnaire.test.js.snap
@@ -1766,6 +1766,7 @@ exports[`LPA Questionnaire review GET /lpa-questionnaire/1/add-document-details/
 exports[`LPA Questionnaire review GET /lpa-questionnaire/1/add-documents/:folderId/ should render document upload page with a file upload component, and no late entry status tag and associated details component, and no additional documents warning text, if the folder is not additional documents 1`] = `
 "<main class="govuk-main-wrapper " id="main-content" role="main">
     <div class="govuk-grid-row">
+        <div class="top-errors-hook govuk-grid-column-two-thirds"></div>
         <div class="govuk-grid-column-full"><span class="govuk-caption-xl">Appeal 351062</span>
             <h1 class="govuk-heading-xl govuk-!-margin-bottom-3">Upload documents</h1>
         </div>
@@ -1777,34 +1778,34 @@ exports[`LPA Questionnaire review GET /lpa-questionnaire/1/add-documents/:folder
             data-document-type="changedDescription" data-document-stage="appellant-case"
             data-blob-storage-host="https://127.0.0.1:10000/devstoreaccount1" data-blob-storage-container="document-service-uploads"
             data-allowed-types=".pdf,application/pdf,.doc,application/msword,.docx,application/vnd.openxmlformats-officedocument.wordprocessingml.document,.ppt,application/vnd.ms-powerpoint,.pptx,application/vnd.openxmlformats-officedocument.presentationml.presentation,.xls,application/vnd.ms-excel,.xlsx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,.msg,application/vnd.ms-outlook,.jpg,image/jpeg,.jpeg,image/jpeg,.mpeg,video/mpeg,.mp3,audio/mpeg,.mp4,video/mp4,.mov,video/quicktime,.png,image/png,.tif,image/tiff,.tiff,image/tiff,">
-                <div class="top-errors-hook govuk-grid-column-two-thirds"></div>
                 <form method="POST" novalidate="novalidate" class="govuk-grid-column-two-thirds"
                 data-filenames-in-folder="WyJ0ZXN0LXBkZi1kb2N1bWVudEZvbGRlckluZm8ucGRmIiwic2FtcGxlLTIwcy1kb2N1bWVudEZvbGRlckluZm8ubXA0IiwicGgwLWRvY3VtZW50Rm9sZGVySW5mby5qcGVnIiwicGgxLWRvY3VtZW50Rm9sZGVySW5mby5qcGVnIl0=">
                     <div class="pins-file-upload__container">
                         <div class="govuk-body colour--secondary pins-file-upload__instructions">
                             <label for="upload-file-1">Choose a single file or multiple files to upload.</label><span>Each file must be a PDF, DOC, DOCX, PPT, PPTX, XLS, XLSX, MSG, JPG, JPEG, MPEG, MP3, MP4, MOV, PNG, TIF, 	or TIFF.</span><span>The total size of your uploaded files must be smaller than 1GB.</span>
-                            <div                             class="middle-errors-hook"></div>
+                        </div>
+                        <div class="middle-errors-hook">
+                            <div class="pins-file-upload__upload">
+                                <input class="display--none" id="upload-file-1" accept=".pdf,application/pdf,.doc,application/msword,.docx,application/vnd.openxmlformats-officedocument.wordprocessingml.document,.ppt,application/vnd.ms-powerpoint,.pptx,application/vnd.openxmlformats-officedocument.presentationml.presentation,.xls,application/vnd.ms-excel,.xlsx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,.msg,application/vnd.ms-outlook,.jpg,image/jpeg,.jpeg,image/jpeg,.mpeg,video/mpeg,.mp3,audio/mpeg,.mp4,video/mp4,.mov,video/quicktime,.png,image/png,.tif,image/tiff,.tiff,image/tiff,"
+                                type="file" name="files" value="Choose file" aria-controls="file-list-1"
+                                multiple><span class='govuk-body pins-file-upload__dropzone-text'>Drag and drop files here or</span>
+                                <button                                 type='button' class="pins-file-upload__button govuk-button">Select files</button>
+                            </div>
+                            <div id="file-list-1">
+                                <h2 class="display--sr-only" id="file-list-title-1">List of files to upload</h2>
+                                <ul class="pins-file-upload__files-rows" aria-describedby="file-list-title-1"
+                                aria-live="polite"></ul>
+                            </div>
+                        </div>
                     </div>
-                    <div class="pins-file-upload__upload">
-                        <input class="display--none" id="upload-file-1" accept=".pdf,application/pdf,.doc,application/msword,.docx,application/vnd.openxmlformats-officedocument.wordprocessingml.document,.ppt,application/vnd.ms-powerpoint,.pptx,application/vnd.openxmlformats-officedocument.presentationml.presentation,.xls,application/vnd.ms-excel,.xlsx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,.msg,application/vnd.ms-outlook,.jpg,image/jpeg,.jpeg,image/jpeg,.mpeg,video/mpeg,.mp3,audio/mpeg,.mp4,video/mp4,.mov,video/quicktime,.png,image/png,.tif,image/tiff,.tiff,image/tiff,"
-                        type="file" name="files" value="Choose file" aria-controls="file-list-1"
-                        multiple><span class='govuk-body pins-file-upload__dropzone-text'>Drag and drop files here or</span>
-                        <button                         type='button' class="pins-file-upload__button govuk-button">Select files</button>
+                    <div class="display--flex">
+                        <button type="submit" class="govuk-button pins-file-upload__submit" data-module="govuk-button"
+                        id="submit-button-1">Continue</button>
+                        <div class="progress-hook"></div>
                     </div>
-                    <div id="file-list-1">
-                        <h2 class="display--sr-only" id="file-list-title-1">List of files to upload</h2>
-                        <ul class="pins-file-upload__files-rows" aria-describedby="file-list-title-1"
-                        aria-live="polite"></ul>
-                    </div>
+                </form>
             </div>
-            <div class="display--flex">
-                <button type="submit" class="govuk-button pins-file-upload__submit" data-module="govuk-button"
-                id="submit-button-1">Continue</button>
-                <div class="progress-hook"></div>
-            </div>
-            </form>
         </div>
-    </div>
     </div>
 </main>"
 `;
@@ -1812,6 +1813,7 @@ exports[`LPA Questionnaire review GET /lpa-questionnaire/1/add-documents/:folder
 exports[`LPA Questionnaire review GET /lpa-questionnaire/1/add-documents/:folderId/ should render document upload page with additional documents warning text, and without late entry status tag and associated details component, if the folder is additional documents, and the lpa questionnaire has a validation outcome of incomplete 1`] = `
 "<main class="govuk-main-wrapper " id="main-content" role="main">
     <div class="govuk-grid-row">
+        <div class="top-errors-hook govuk-grid-column-two-thirds"></div>
         <div class="govuk-grid-column-full"><span class="govuk-caption-xl">Appeal 351062</span>
             <h1 class="govuk-heading-xl govuk-!-margin-bottom-3">Upload additional documents</h1>
         </div>
@@ -1823,38 +1825,38 @@ exports[`LPA Questionnaire review GET /lpa-questionnaire/1/add-documents/:folder
             data-document-type="appellantCaseCorrespondence" data-document-stage="appellant-case"
             data-blob-storage-host="https://127.0.0.1:10000/devstoreaccount1" data-blob-storage-container="document-service-uploads"
             data-allowed-types=".pdf,application/pdf,.doc,application/msword,.docx,application/vnd.openxmlformats-officedocument.wordprocessingml.document,.ppt,application/vnd.ms-powerpoint,.pptx,application/vnd.openxmlformats-officedocument.presentationml.presentation,.xls,application/vnd.ms-excel,.xlsx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,.msg,application/vnd.ms-outlook,.jpg,image/jpeg,.jpeg,image/jpeg,.mpeg,video/mpeg,.mp3,audio/mpeg,.mp4,video/mp4,.mov,video/quicktime,.png,image/png,.tif,image/tiff,.tiff,image/tiff,">
-                <div class="top-errors-hook govuk-grid-column-two-thirds"></div>
                 <form method="POST" novalidate="novalidate" class="govuk-grid-column-two-thirds"
                 data-filenames-in-folder="WyJ0ZXN0LXBkZi1kb2N1bWVudEZvbGRlckluZm8ucGRmIiwic2FtcGxlLTIwcy1kb2N1bWVudEZvbGRlckluZm8ubXA0IiwicGgwLWRvY3VtZW50Rm9sZGVySW5mby5qcGVnIiwicGgxLWRvY3VtZW50Rm9sZGVySW5mby5qcGVnIl0=">
                     <div class="pins-file-upload__container">
                         <div class="govuk-body colour--secondary pins-file-upload__instructions">
                             <label for="upload-file-1">Choose a single file or multiple files to upload.</label><span>Each file must be a PDF, DOC, DOCX, PPT, PPTX, XLS, XLSX, MSG, JPG, JPEG, MPEG, MP3, MP4, MOV, PNG, TIF, 	or TIFF.</span><span>The total size of your uploaded files must be smaller than 1GB.</span>
-                            <div                             class="middle-errors-hook"></div>
+                        </div>
+                        <div class="middle-errors-hook">
+                            <div class="pins-file-upload__upload">
+                                <input class="display--none" id="upload-file-1" accept=".pdf,application/pdf,.doc,application/msword,.docx,application/vnd.openxmlformats-officedocument.wordprocessingml.document,.ppt,application/vnd.ms-powerpoint,.pptx,application/vnd.openxmlformats-officedocument.presentationml.presentation,.xls,application/vnd.ms-excel,.xlsx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,.msg,application/vnd.ms-outlook,.jpg,image/jpeg,.jpeg,image/jpeg,.mpeg,video/mpeg,.mp3,audio/mpeg,.mp4,video/mp4,.mov,video/quicktime,.png,image/png,.tif,image/tiff,.tiff,image/tiff,"
+                                type="file" name="files" value="Choose file" aria-controls="file-list-1"
+                                multiple><span class='govuk-body pins-file-upload__dropzone-text'>Drag and drop files here or</span>
+                                <button                                 type='button' class="pins-file-upload__button govuk-button">Select files</button>
+                            </div>
+                            <div id="file-list-1">
+                                <h2 class="display--sr-only" id="file-list-title-1">List of files to upload</h2>
+                                <ul class="pins-file-upload__files-rows" aria-describedby="file-list-title-1"
+                                aria-live="polite"></ul>
+                            </div>
+                        </div>
                     </div>
-                    <div class="pins-file-upload__upload">
-                        <input class="display--none" id="upload-file-1" accept=".pdf,application/pdf,.doc,application/msword,.docx,application/vnd.openxmlformats-officedocument.wordprocessingml.document,.ppt,application/vnd.ms-powerpoint,.pptx,application/vnd.openxmlformats-officedocument.presentationml.presentation,.xls,application/vnd.ms-excel,.xlsx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,.msg,application/vnd.ms-outlook,.jpg,image/jpeg,.jpeg,image/jpeg,.mpeg,video/mpeg,.mp3,audio/mpeg,.mp4,video/mp4,.mov,video/quicktime,.png,image/png,.tif,image/tiff,.tiff,image/tiff,"
-                        type="file" name="files" value="Choose file" aria-controls="file-list-1"
-                        multiple><span class='govuk-body pins-file-upload__dropzone-text'>Drag and drop files here or</span>
-                        <button                         type='button' class="pins-file-upload__button govuk-button">Select files</button>
+                    <div class="govuk-warning-text"><span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+                        <strong                         class="govuk-warning-text__text"><span class="govuk-warning-text__assistive">Warning</span> Only upload
+                            files to additional documents when no other folder is applicable.</strong>
                     </div>
-                    <div id="file-list-1">
-                        <h2 class="display--sr-only" id="file-list-title-1">List of files to upload</h2>
-                        <ul class="pins-file-upload__files-rows" aria-describedby="file-list-title-1"
-                        aria-live="polite"></ul>
+                    <div class="display--flex">
+                        <button type="submit" class="govuk-button pins-file-upload__submit" data-module="govuk-button"
+                        id="submit-button-1">Continue</button>
+                        <div class="progress-hook"></div>
                     </div>
+                </form>
             </div>
-            <div class="govuk-warning-text"><span class="govuk-warning-text__icon" aria-hidden="true">!</span>
-                <strong                 class="govuk-warning-text__text"><span class="govuk-warning-text__assistive">Warning</span> Only upload
-                    files to additional documents when no other folder is applicable.</strong>
-            </div>
-            <div class="display--flex">
-                <button type="submit" class="govuk-button pins-file-upload__submit" data-module="govuk-button"
-                id="submit-button-1">Continue</button>
-                <div class="progress-hook"></div>
-            </div>
-            </form>
         </div>
-    </div>
     </div>
 </main>"
 `;
@@ -1862,6 +1864,7 @@ exports[`LPA Questionnaire review GET /lpa-questionnaire/1/add-documents/:folder
 exports[`LPA Questionnaire review GET /lpa-questionnaire/1/add-documents/:folderId/ should render document upload page with additional documents warning text, and without late entry status tag and associated details component, if the folder is additional documents, and the lpa questionnaire has no validation outcome 1`] = `
 "<main class="govuk-main-wrapper " id="main-content" role="main">
     <div class="govuk-grid-row">
+        <div class="top-errors-hook govuk-grid-column-two-thirds"></div>
         <div class="govuk-grid-column-full"><span class="govuk-caption-xl">Appeal 351062</span>
             <h1 class="govuk-heading-xl govuk-!-margin-bottom-3">Upload additional documents</h1>
         </div>
@@ -1873,38 +1876,38 @@ exports[`LPA Questionnaire review GET /lpa-questionnaire/1/add-documents/:folder
             data-document-type="appellantCaseCorrespondence" data-document-stage="appellant-case"
             data-blob-storage-host="https://127.0.0.1:10000/devstoreaccount1" data-blob-storage-container="document-service-uploads"
             data-allowed-types=".pdf,application/pdf,.doc,application/msword,.docx,application/vnd.openxmlformats-officedocument.wordprocessingml.document,.ppt,application/vnd.ms-powerpoint,.pptx,application/vnd.openxmlformats-officedocument.presentationml.presentation,.xls,application/vnd.ms-excel,.xlsx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,.msg,application/vnd.ms-outlook,.jpg,image/jpeg,.jpeg,image/jpeg,.mpeg,video/mpeg,.mp3,audio/mpeg,.mp4,video/mp4,.mov,video/quicktime,.png,image/png,.tif,image/tiff,.tiff,image/tiff,">
-                <div class="top-errors-hook govuk-grid-column-two-thirds"></div>
                 <form method="POST" novalidate="novalidate" class="govuk-grid-column-two-thirds"
                 data-filenames-in-folder="WyJ0ZXN0LXBkZi1kb2N1bWVudEZvbGRlckluZm8ucGRmIiwic2FtcGxlLTIwcy1kb2N1bWVudEZvbGRlckluZm8ubXA0IiwicGgwLWRvY3VtZW50Rm9sZGVySW5mby5qcGVnIiwicGgxLWRvY3VtZW50Rm9sZGVySW5mby5qcGVnIl0=">
                     <div class="pins-file-upload__container">
                         <div class="govuk-body colour--secondary pins-file-upload__instructions">
                             <label for="upload-file-1">Choose a single file or multiple files to upload.</label><span>Each file must be a PDF, DOC, DOCX, PPT, PPTX, XLS, XLSX, MSG, JPG, JPEG, MPEG, MP3, MP4, MOV, PNG, TIF, 	or TIFF.</span><span>The total size of your uploaded files must be smaller than 1GB.</span>
-                            <div                             class="middle-errors-hook"></div>
+                        </div>
+                        <div class="middle-errors-hook">
+                            <div class="pins-file-upload__upload">
+                                <input class="display--none" id="upload-file-1" accept=".pdf,application/pdf,.doc,application/msword,.docx,application/vnd.openxmlformats-officedocument.wordprocessingml.document,.ppt,application/vnd.ms-powerpoint,.pptx,application/vnd.openxmlformats-officedocument.presentationml.presentation,.xls,application/vnd.ms-excel,.xlsx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,.msg,application/vnd.ms-outlook,.jpg,image/jpeg,.jpeg,image/jpeg,.mpeg,video/mpeg,.mp3,audio/mpeg,.mp4,video/mp4,.mov,video/quicktime,.png,image/png,.tif,image/tiff,.tiff,image/tiff,"
+                                type="file" name="files" value="Choose file" aria-controls="file-list-1"
+                                multiple><span class='govuk-body pins-file-upload__dropzone-text'>Drag and drop files here or</span>
+                                <button                                 type='button' class="pins-file-upload__button govuk-button">Select files</button>
+                            </div>
+                            <div id="file-list-1">
+                                <h2 class="display--sr-only" id="file-list-title-1">List of files to upload</h2>
+                                <ul class="pins-file-upload__files-rows" aria-describedby="file-list-title-1"
+                                aria-live="polite"></ul>
+                            </div>
+                        </div>
                     </div>
-                    <div class="pins-file-upload__upload">
-                        <input class="display--none" id="upload-file-1" accept=".pdf,application/pdf,.doc,application/msword,.docx,application/vnd.openxmlformats-officedocument.wordprocessingml.document,.ppt,application/vnd.ms-powerpoint,.pptx,application/vnd.openxmlformats-officedocument.presentationml.presentation,.xls,application/vnd.ms-excel,.xlsx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,.msg,application/vnd.ms-outlook,.jpg,image/jpeg,.jpeg,image/jpeg,.mpeg,video/mpeg,.mp3,audio/mpeg,.mp4,video/mp4,.mov,video/quicktime,.png,image/png,.tif,image/tiff,.tiff,image/tiff,"
-                        type="file" name="files" value="Choose file" aria-controls="file-list-1"
-                        multiple><span class='govuk-body pins-file-upload__dropzone-text'>Drag and drop files here or</span>
-                        <button                         type='button' class="pins-file-upload__button govuk-button">Select files</button>
+                    <div class="govuk-warning-text"><span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+                        <strong                         class="govuk-warning-text__text"><span class="govuk-warning-text__assistive">Warning</span> Only upload
+                            files to additional documents when no other folder is applicable.</strong>
                     </div>
-                    <div id="file-list-1">
-                        <h2 class="display--sr-only" id="file-list-title-1">List of files to upload</h2>
-                        <ul class="pins-file-upload__files-rows" aria-describedby="file-list-title-1"
-                        aria-live="polite"></ul>
+                    <div class="display--flex">
+                        <button type="submit" class="govuk-button pins-file-upload__submit" data-module="govuk-button"
+                        id="submit-button-1">Continue</button>
+                        <div class="progress-hook"></div>
                     </div>
+                </form>
             </div>
-            <div class="govuk-warning-text"><span class="govuk-warning-text__icon" aria-hidden="true">!</span>
-                <strong                 class="govuk-warning-text__text"><span class="govuk-warning-text__assistive">Warning</span> Only upload
-                    files to additional documents when no other folder is applicable.</strong>
-            </div>
-            <div class="display--flex">
-                <button type="submit" class="govuk-button pins-file-upload__submit" data-module="govuk-button"
-                id="submit-button-1">Continue</button>
-                <div class="progress-hook"></div>
-            </div>
-            </form>
         </div>
-    </div>
     </div>
 </main>"
 `;
@@ -1912,6 +1915,7 @@ exports[`LPA Questionnaire review GET /lpa-questionnaire/1/add-documents/:folder
 exports[`LPA Questionnaire review GET /lpa-questionnaire/1/add-documents/:folderId/ should render document upload page with late entry status tag and associated details component, and without additional documents warning text, if the folder is additional documents, and the lpa questionnaire validation outcome is complete 1`] = `
 "<main class="govuk-main-wrapper " id="main-content" role="main">
     <div class="govuk-grid-row">
+        <div class="top-errors-hook govuk-grid-column-two-thirds"></div>
         <div class="govuk-grid-column-full"><span class="govuk-caption-xl">Appeal 351062</span>
             <h1 class="govuk-heading-xl govuk-!-margin-bottom-3">Upload additional documents</h1>
         </div>
@@ -1942,34 +1946,34 @@ exports[`LPA Questionnaire review GET /lpa-questionnaire/1/add-documents/:folder
             data-document-type="appellantCaseCorrespondence" data-document-stage="appellant-case"
             data-blob-storage-host="https://127.0.0.1:10000/devstoreaccount1" data-blob-storage-container="document-service-uploads"
             data-allowed-types=".pdf,application/pdf,.doc,application/msword,.docx,application/vnd.openxmlformats-officedocument.wordprocessingml.document,.ppt,application/vnd.ms-powerpoint,.pptx,application/vnd.openxmlformats-officedocument.presentationml.presentation,.xls,application/vnd.ms-excel,.xlsx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,.msg,application/vnd.ms-outlook,.jpg,image/jpeg,.jpeg,image/jpeg,.mpeg,video/mpeg,.mp3,audio/mpeg,.mp4,video/mp4,.mov,video/quicktime,.png,image/png,.tif,image/tiff,.tiff,image/tiff,">
-                <div class="top-errors-hook govuk-grid-column-two-thirds"></div>
                 <form method="POST" novalidate="novalidate" class="govuk-grid-column-two-thirds"
                 data-filenames-in-folder="WyJ0ZXN0LXBkZi1kb2N1bWVudEZvbGRlckluZm8ucGRmIiwic2FtcGxlLTIwcy1kb2N1bWVudEZvbGRlckluZm8ubXA0IiwicGgwLWRvY3VtZW50Rm9sZGVySW5mby5qcGVnIiwicGgxLWRvY3VtZW50Rm9sZGVySW5mby5qcGVnIl0=">
                     <div class="pins-file-upload__container">
                         <div class="govuk-body colour--secondary pins-file-upload__instructions">
                             <label for="upload-file-1">Choose a single file or multiple files to upload.</label><span>Each file must be a PDF, DOC, DOCX, PPT, PPTX, XLS, XLSX, MSG, JPG, JPEG, MPEG, MP3, MP4, MOV, PNG, TIF, 	or TIFF.</span><span>The total size of your uploaded files must be smaller than 1GB.</span>
-                            <div                             class="middle-errors-hook"></div>
+                        </div>
+                        <div class="middle-errors-hook">
+                            <div class="pins-file-upload__upload">
+                                <input class="display--none" id="upload-file-1" accept=".pdf,application/pdf,.doc,application/msword,.docx,application/vnd.openxmlformats-officedocument.wordprocessingml.document,.ppt,application/vnd.ms-powerpoint,.pptx,application/vnd.openxmlformats-officedocument.presentationml.presentation,.xls,application/vnd.ms-excel,.xlsx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,.msg,application/vnd.ms-outlook,.jpg,image/jpeg,.jpeg,image/jpeg,.mpeg,video/mpeg,.mp3,audio/mpeg,.mp4,video/mp4,.mov,video/quicktime,.png,image/png,.tif,image/tiff,.tiff,image/tiff,"
+                                type="file" name="files" value="Choose file" aria-controls="file-list-1"
+                                multiple><span class='govuk-body pins-file-upload__dropzone-text'>Drag and drop files here or</span>
+                                <button                                 type='button' class="pins-file-upload__button govuk-button">Select files</button>
+                            </div>
+                            <div id="file-list-1">
+                                <h2 class="display--sr-only" id="file-list-title-1">List of files to upload</h2>
+                                <ul class="pins-file-upload__files-rows" aria-describedby="file-list-title-1"
+                                aria-live="polite"></ul>
+                            </div>
+                        </div>
                     </div>
-                    <div class="pins-file-upload__upload">
-                        <input class="display--none" id="upload-file-1" accept=".pdf,application/pdf,.doc,application/msword,.docx,application/vnd.openxmlformats-officedocument.wordprocessingml.document,.ppt,application/vnd.ms-powerpoint,.pptx,application/vnd.openxmlformats-officedocument.presentationml.presentation,.xls,application/vnd.ms-excel,.xlsx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,.msg,application/vnd.ms-outlook,.jpg,image/jpeg,.jpeg,image/jpeg,.mpeg,video/mpeg,.mp3,audio/mpeg,.mp4,video/mp4,.mov,video/quicktime,.png,image/png,.tif,image/tiff,.tiff,image/tiff,"
-                        type="file" name="files" value="Choose file" aria-controls="file-list-1"
-                        multiple><span class='govuk-body pins-file-upload__dropzone-text'>Drag and drop files here or</span>
-                        <button                         type='button' class="pins-file-upload__button govuk-button">Select files</button>
+                    <div class="display--flex">
+                        <button type="submit" class="govuk-button pins-file-upload__submit" data-module="govuk-button"
+                        id="submit-button-1">Continue</button>
+                        <div class="progress-hook"></div>
                     </div>
-                    <div id="file-list-1">
-                        <h2 class="display--sr-only" id="file-list-title-1">List of files to upload</h2>
-                        <ul class="pins-file-upload__files-rows" aria-describedby="file-list-title-1"
-                        aria-live="polite"></ul>
-                    </div>
+                </form>
             </div>
-            <div class="display--flex">
-                <button type="submit" class="govuk-button pins-file-upload__submit" data-module="govuk-button"
-                id="submit-button-1">Continue</button>
-                <div class="progress-hook"></div>
-            </div>
-            </form>
         </div>
-    </div>
     </div>
 </main>"
 `;
@@ -1977,6 +1981,7 @@ exports[`LPA Questionnaire review GET /lpa-questionnaire/1/add-documents/:folder
 exports[`LPA Questionnaire review GET /lpa-questionnaire/1/add-documents/:folderId/:documentId should render a document upload page with a file upload component, and no late entry tag and associated details component, and no additional documents warning text, if the folder is not additional documents 1`] = `
 "<main class="govuk-main-wrapper " id="main-content" role="main">
     <div class="govuk-grid-row">
+        <div class="top-errors-hook govuk-grid-column-two-thirds"></div>
         <div class="govuk-grid-column-full"><span class="govuk-caption-xl">Appeal 351062</span>
             <h1 class="govuk-heading-xl govuk-!-margin-bottom-3">Upload an updated document</h1>
         </div>
@@ -1989,33 +1994,33 @@ exports[`LPA Questionnaire review GET /lpa-questionnaire/1/add-documents/:folder
             data-blob-storage-host="https://127.0.0.1:10000/devstoreaccount1" data-blob-storage-container="document-service-uploads"
             data-document-id="1" data-document-original-file-name="test-pdf-documentFileVersionsInfo.pdf"
             data-document-version="1" data-allowed-types=".pdf,application/pdf,.doc,application/msword,.docx,application/vnd.openxmlformats-officedocument.wordprocessingml.document,.ppt,application/vnd.ms-powerpoint,.pptx,application/vnd.openxmlformats-officedocument.presentationml.presentation,.xls,application/vnd.ms-excel,.xlsx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,.msg,application/vnd.ms-outlook,.jpg,image/jpeg,.jpeg,image/jpeg,.mpeg,video/mpeg,.mp3,audio/mpeg,.mp4,video/mp4,.mov,video/quicktime,.png,image/png,.tif,image/tiff,.tiff,image/tiff,">
-                <div class="top-errors-hook govuk-grid-column-two-thirds"></div>
                 <form method="POST" novalidate="novalidate" class="govuk-grid-column-two-thirds"
                 data-filenames-in-folder="WyJ0ZXN0LXBkZi1kb2N1bWVudEZvbGRlckluZm8ucGRmIiwic2FtcGxlLTIwcy1kb2N1bWVudEZvbGRlckluZm8ubXA0IiwicGgwLWRvY3VtZW50Rm9sZGVySW5mby5qcGVnIiwicGgxLWRvY3VtZW50Rm9sZGVySW5mby5qcGVnIl0=">
                     <div class="pins-file-upload__container">
                         <div class="govuk-body colour--secondary pins-file-upload__instructions">
                             <label for="upload-file-1">Choose a single file to upload.</label><span>The file must be a PDF, DOC, DOCX, PPT, PPTX, XLS, XLSX, MSG, JPG, JPEG, MPEG, MP3, MP4, MOV, PNG, TIF, 	or TIFF.</span><span>The file must be smaller than 25MB.</span>
-                            <div                             class="middle-errors-hook"></div>
+                        </div>
+                        <div class="middle-errors-hook">
+                            <div class="pins-file-upload__upload">
+                                <input class="display--none" id="upload-file-1" accept=".pdf,application/pdf,.doc,application/msword,.docx,application/vnd.openxmlformats-officedocument.wordprocessingml.document,.ppt,application/vnd.ms-powerpoint,.pptx,application/vnd.openxmlformats-officedocument.presentationml.presentation,.xls,application/vnd.ms-excel,.xlsx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,.msg,application/vnd.ms-outlook,.jpg,image/jpeg,.jpeg,image/jpeg,.mpeg,video/mpeg,.mp3,audio/mpeg,.mp4,video/mp4,.mov,video/quicktime,.png,image/png,.tif,image/tiff,.tiff,image/tiff,"
+                                type="file" name="files" value="Choose file" aria-controls="file-list-1">
+                                <button type='button' class="pins-file-upload__button govuk-button">Select files</button>
+                            </div>
+                            <div id="file-list-1">
+                                <h2 class="display--sr-only" id="file-list-title-1">List of files to upload</h2>
+                                <ul class="pins-file-upload__files-rows" aria-describedby="file-list-title-1"
+                                aria-live="polite"></ul>
+                            </div>
+                        </div>
                     </div>
-                    <div class="pins-file-upload__upload">
-                        <input class="display--none" id="upload-file-1" accept=".pdf,application/pdf,.doc,application/msword,.docx,application/vnd.openxmlformats-officedocument.wordprocessingml.document,.ppt,application/vnd.ms-powerpoint,.pptx,application/vnd.openxmlformats-officedocument.presentationml.presentation,.xls,application/vnd.ms-excel,.xlsx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,.msg,application/vnd.ms-outlook,.jpg,image/jpeg,.jpeg,image/jpeg,.mpeg,video/mpeg,.mp3,audio/mpeg,.mp4,video/mp4,.mov,video/quicktime,.png,image/png,.tif,image/tiff,.tiff,image/tiff,"
-                        type="file" name="files" value="Choose file" aria-controls="file-list-1">
-                        <button type='button' class="pins-file-upload__button govuk-button">Select files</button>
+                    <div class="display--flex">
+                        <button type="submit" class="govuk-button pins-file-upload__submit" data-module="govuk-button"
+                        id="submit-button-1">Continue</button>
+                        <div class="progress-hook"></div>
                     </div>
-                    <div id="file-list-1">
-                        <h2 class="display--sr-only" id="file-list-title-1">List of files to upload</h2>
-                        <ul class="pins-file-upload__files-rows" aria-describedby="file-list-title-1"
-                        aria-live="polite"></ul>
-                    </div>
+                </form>
             </div>
-            <div class="display--flex">
-                <button type="submit" class="govuk-button pins-file-upload__submit" data-module="govuk-button"
-                id="submit-button-1">Continue</button>
-                <div class="progress-hook"></div>
-            </div>
-            </form>
         </div>
-    </div>
     </div>
 </main>"
 `;
@@ -2023,6 +2028,7 @@ exports[`LPA Questionnaire review GET /lpa-questionnaire/1/add-documents/:folder
 exports[`LPA Questionnaire review GET /lpa-questionnaire/1/add-documents/:folderId/:documentId should render document upload page with additional documents warning text, and without late entry status tag and associated details component, if the folder is additional documents, and the lpa questionnaire has a validation outcome of incomplete 1`] = `
 "<main class="govuk-main-wrapper " id="main-content" role="main">
     <div class="govuk-grid-row">
+        <div class="top-errors-hook govuk-grid-column-two-thirds"></div>
         <div class="govuk-grid-column-full"><span class="govuk-caption-xl">Appeal 351062</span>
             <h1 class="govuk-heading-xl govuk-!-margin-bottom-3">Update additional document</h1>
         </div>
@@ -2035,37 +2041,37 @@ exports[`LPA Questionnaire review GET /lpa-questionnaire/1/add-documents/:folder
             data-blob-storage-host="https://127.0.0.1:10000/devstoreaccount1" data-blob-storage-container="document-service-uploads"
             data-document-id="1" data-document-original-file-name="test-pdf-documentFileVersionsInfo.pdf"
             data-document-version="1" data-allowed-types=".pdf,application/pdf,.doc,application/msword,.docx,application/vnd.openxmlformats-officedocument.wordprocessingml.document,.ppt,application/vnd.ms-powerpoint,.pptx,application/vnd.openxmlformats-officedocument.presentationml.presentation,.xls,application/vnd.ms-excel,.xlsx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,.msg,application/vnd.ms-outlook,.jpg,image/jpeg,.jpeg,image/jpeg,.mpeg,video/mpeg,.mp3,audio/mpeg,.mp4,video/mp4,.mov,video/quicktime,.png,image/png,.tif,image/tiff,.tiff,image/tiff,">
-                <div class="top-errors-hook govuk-grid-column-two-thirds"></div>
                 <form method="POST" novalidate="novalidate" class="govuk-grid-column-two-thirds"
                 data-filenames-in-folder="WyJ0ZXN0LXBkZi1kb2N1bWVudEZvbGRlckluZm8ucGRmIiwic2FtcGxlLTIwcy1kb2N1bWVudEZvbGRlckluZm8ubXA0IiwicGgwLWRvY3VtZW50Rm9sZGVySW5mby5qcGVnIiwicGgxLWRvY3VtZW50Rm9sZGVySW5mby5qcGVnIl0=">
                     <div class="pins-file-upload__container">
                         <div class="govuk-body colour--secondary pins-file-upload__instructions">
                             <label for="upload-file-1">Choose a single file to upload.</label><span>The file must be a PDF, DOC, DOCX, PPT, PPTX, XLS, XLSX, MSG, JPG, JPEG, MPEG, MP3, MP4, MOV, PNG, TIF, 	or TIFF.</span><span>The file must be smaller than 25MB.</span>
-                            <div                             class="middle-errors-hook"></div>
+                        </div>
+                        <div class="middle-errors-hook">
+                            <div class="pins-file-upload__upload">
+                                <input class="display--none" id="upload-file-1" accept=".pdf,application/pdf,.doc,application/msword,.docx,application/vnd.openxmlformats-officedocument.wordprocessingml.document,.ppt,application/vnd.ms-powerpoint,.pptx,application/vnd.openxmlformats-officedocument.presentationml.presentation,.xls,application/vnd.ms-excel,.xlsx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,.msg,application/vnd.ms-outlook,.jpg,image/jpeg,.jpeg,image/jpeg,.mpeg,video/mpeg,.mp3,audio/mpeg,.mp4,video/mp4,.mov,video/quicktime,.png,image/png,.tif,image/tiff,.tiff,image/tiff,"
+                                type="file" name="files" value="Choose file" aria-controls="file-list-1">
+                                <button type='button' class="pins-file-upload__button govuk-button">Select files</button>
+                            </div>
+                            <div id="file-list-1">
+                                <h2 class="display--sr-only" id="file-list-title-1">List of files to upload</h2>
+                                <ul class="pins-file-upload__files-rows" aria-describedby="file-list-title-1"
+                                aria-live="polite"></ul>
+                            </div>
+                        </div>
                     </div>
-                    <div class="pins-file-upload__upload">
-                        <input class="display--none" id="upload-file-1" accept=".pdf,application/pdf,.doc,application/msword,.docx,application/vnd.openxmlformats-officedocument.wordprocessingml.document,.ppt,application/vnd.ms-powerpoint,.pptx,application/vnd.openxmlformats-officedocument.presentationml.presentation,.xls,application/vnd.ms-excel,.xlsx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,.msg,application/vnd.ms-outlook,.jpg,image/jpeg,.jpeg,image/jpeg,.mpeg,video/mpeg,.mp3,audio/mpeg,.mp4,video/mp4,.mov,video/quicktime,.png,image/png,.tif,image/tiff,.tiff,image/tiff,"
-                        type="file" name="files" value="Choose file" aria-controls="file-list-1">
-                        <button type='button' class="pins-file-upload__button govuk-button">Select files</button>
+                    <div class="govuk-warning-text"><span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+                        <strong                         class="govuk-warning-text__text"><span class="govuk-warning-text__assistive">Warning</span> Only upload
+                            files to additional documents when no other folder is applicable.</strong>
                     </div>
-                    <div id="file-list-1">
-                        <h2 class="display--sr-only" id="file-list-title-1">List of files to upload</h2>
-                        <ul class="pins-file-upload__files-rows" aria-describedby="file-list-title-1"
-                        aria-live="polite"></ul>
+                    <div class="display--flex">
+                        <button type="submit" class="govuk-button pins-file-upload__submit" data-module="govuk-button"
+                        id="submit-button-1">Continue</button>
+                        <div class="progress-hook"></div>
                     </div>
+                </form>
             </div>
-            <div class="govuk-warning-text"><span class="govuk-warning-text__icon" aria-hidden="true">!</span>
-                <strong                 class="govuk-warning-text__text"><span class="govuk-warning-text__assistive">Warning</span> Only upload
-                    files to additional documents when no other folder is applicable.</strong>
-            </div>
-            <div class="display--flex">
-                <button type="submit" class="govuk-button pins-file-upload__submit" data-module="govuk-button"
-                id="submit-button-1">Continue</button>
-                <div class="progress-hook"></div>
-            </div>
-            </form>
         </div>
-    </div>
     </div>
 </main>"
 `;
@@ -2073,6 +2079,7 @@ exports[`LPA Questionnaire review GET /lpa-questionnaire/1/add-documents/:folder
 exports[`LPA Questionnaire review GET /lpa-questionnaire/1/add-documents/:folderId/:documentId should render document upload page with additional documents warning text, and without late entry status tag and associated details component, if the folder is additional documents, and the lpa questionnaire has no validation outcome 1`] = `
 "<main class="govuk-main-wrapper " id="main-content" role="main">
     <div class="govuk-grid-row">
+        <div class="top-errors-hook govuk-grid-column-two-thirds"></div>
         <div class="govuk-grid-column-full"><span class="govuk-caption-xl">Appeal 351062</span>
             <h1 class="govuk-heading-xl govuk-!-margin-bottom-3">Update additional document</h1>
         </div>
@@ -2085,37 +2092,37 @@ exports[`LPA Questionnaire review GET /lpa-questionnaire/1/add-documents/:folder
             data-blob-storage-host="https://127.0.0.1:10000/devstoreaccount1" data-blob-storage-container="document-service-uploads"
             data-document-id="1" data-document-original-file-name="test-pdf-documentFileVersionsInfo.pdf"
             data-document-version="1" data-allowed-types=".pdf,application/pdf,.doc,application/msword,.docx,application/vnd.openxmlformats-officedocument.wordprocessingml.document,.ppt,application/vnd.ms-powerpoint,.pptx,application/vnd.openxmlformats-officedocument.presentationml.presentation,.xls,application/vnd.ms-excel,.xlsx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,.msg,application/vnd.ms-outlook,.jpg,image/jpeg,.jpeg,image/jpeg,.mpeg,video/mpeg,.mp3,audio/mpeg,.mp4,video/mp4,.mov,video/quicktime,.png,image/png,.tif,image/tiff,.tiff,image/tiff,">
-                <div class="top-errors-hook govuk-grid-column-two-thirds"></div>
                 <form method="POST" novalidate="novalidate" class="govuk-grid-column-two-thirds"
                 data-filenames-in-folder="WyJ0ZXN0LXBkZi1kb2N1bWVudEZvbGRlckluZm8ucGRmIiwic2FtcGxlLTIwcy1kb2N1bWVudEZvbGRlckluZm8ubXA0IiwicGgwLWRvY3VtZW50Rm9sZGVySW5mby5qcGVnIiwicGgxLWRvY3VtZW50Rm9sZGVySW5mby5qcGVnIl0=">
                     <div class="pins-file-upload__container">
                         <div class="govuk-body colour--secondary pins-file-upload__instructions">
                             <label for="upload-file-1">Choose a single file to upload.</label><span>The file must be a PDF, DOC, DOCX, PPT, PPTX, XLS, XLSX, MSG, JPG, JPEG, MPEG, MP3, MP4, MOV, PNG, TIF, 	or TIFF.</span><span>The file must be smaller than 25MB.</span>
-                            <div                             class="middle-errors-hook"></div>
+                        </div>
+                        <div class="middle-errors-hook">
+                            <div class="pins-file-upload__upload">
+                                <input class="display--none" id="upload-file-1" accept=".pdf,application/pdf,.doc,application/msword,.docx,application/vnd.openxmlformats-officedocument.wordprocessingml.document,.ppt,application/vnd.ms-powerpoint,.pptx,application/vnd.openxmlformats-officedocument.presentationml.presentation,.xls,application/vnd.ms-excel,.xlsx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,.msg,application/vnd.ms-outlook,.jpg,image/jpeg,.jpeg,image/jpeg,.mpeg,video/mpeg,.mp3,audio/mpeg,.mp4,video/mp4,.mov,video/quicktime,.png,image/png,.tif,image/tiff,.tiff,image/tiff,"
+                                type="file" name="files" value="Choose file" aria-controls="file-list-1">
+                                <button type='button' class="pins-file-upload__button govuk-button">Select files</button>
+                            </div>
+                            <div id="file-list-1">
+                                <h2 class="display--sr-only" id="file-list-title-1">List of files to upload</h2>
+                                <ul class="pins-file-upload__files-rows" aria-describedby="file-list-title-1"
+                                aria-live="polite"></ul>
+                            </div>
+                        </div>
                     </div>
-                    <div class="pins-file-upload__upload">
-                        <input class="display--none" id="upload-file-1" accept=".pdf,application/pdf,.doc,application/msword,.docx,application/vnd.openxmlformats-officedocument.wordprocessingml.document,.ppt,application/vnd.ms-powerpoint,.pptx,application/vnd.openxmlformats-officedocument.presentationml.presentation,.xls,application/vnd.ms-excel,.xlsx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,.msg,application/vnd.ms-outlook,.jpg,image/jpeg,.jpeg,image/jpeg,.mpeg,video/mpeg,.mp3,audio/mpeg,.mp4,video/mp4,.mov,video/quicktime,.png,image/png,.tif,image/tiff,.tiff,image/tiff,"
-                        type="file" name="files" value="Choose file" aria-controls="file-list-1">
-                        <button type='button' class="pins-file-upload__button govuk-button">Select files</button>
+                    <div class="govuk-warning-text"><span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+                        <strong                         class="govuk-warning-text__text"><span class="govuk-warning-text__assistive">Warning</span> Only upload
+                            files to additional documents when no other folder is applicable.</strong>
                     </div>
-                    <div id="file-list-1">
-                        <h2 class="display--sr-only" id="file-list-title-1">List of files to upload</h2>
-                        <ul class="pins-file-upload__files-rows" aria-describedby="file-list-title-1"
-                        aria-live="polite"></ul>
+                    <div class="display--flex">
+                        <button type="submit" class="govuk-button pins-file-upload__submit" data-module="govuk-button"
+                        id="submit-button-1">Continue</button>
+                        <div class="progress-hook"></div>
                     </div>
+                </form>
             </div>
-            <div class="govuk-warning-text"><span class="govuk-warning-text__icon" aria-hidden="true">!</span>
-                <strong                 class="govuk-warning-text__text"><span class="govuk-warning-text__assistive">Warning</span> Only upload
-                    files to additional documents when no other folder is applicable.</strong>
-            </div>
-            <div class="display--flex">
-                <button type="submit" class="govuk-button pins-file-upload__submit" data-module="govuk-button"
-                id="submit-button-1">Continue</button>
-                <div class="progress-hook"></div>
-            </div>
-            </form>
         </div>
-    </div>
     </div>
 </main>"
 `;
@@ -2123,6 +2130,7 @@ exports[`LPA Questionnaire review GET /lpa-questionnaire/1/add-documents/:folder
 exports[`LPA Questionnaire review GET /lpa-questionnaire/1/add-documents/:folderId/:documentId should render document upload page with late entry status tag and associated details component, and without additional documents warning text, if the folder is additional documents, and the lpa questionnaire validation outcome is complete 1`] = `
 "<main class="govuk-main-wrapper " id="main-content" role="main">
     <div class="govuk-grid-row">
+        <div class="top-errors-hook govuk-grid-column-two-thirds"></div>
         <div class="govuk-grid-column-full"><span class="govuk-caption-xl">Appeal 351062</span>
             <h1 class="govuk-heading-xl govuk-!-margin-bottom-3">Update additional document</h1>
         </div>
@@ -2154,33 +2162,33 @@ exports[`LPA Questionnaire review GET /lpa-questionnaire/1/add-documents/:folder
             data-blob-storage-host="https://127.0.0.1:10000/devstoreaccount1" data-blob-storage-container="document-service-uploads"
             data-document-id="1" data-document-original-file-name="test-pdf-documentFileVersionsInfo.pdf"
             data-document-version="1" data-allowed-types=".pdf,application/pdf,.doc,application/msword,.docx,application/vnd.openxmlformats-officedocument.wordprocessingml.document,.ppt,application/vnd.ms-powerpoint,.pptx,application/vnd.openxmlformats-officedocument.presentationml.presentation,.xls,application/vnd.ms-excel,.xlsx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,.msg,application/vnd.ms-outlook,.jpg,image/jpeg,.jpeg,image/jpeg,.mpeg,video/mpeg,.mp3,audio/mpeg,.mp4,video/mp4,.mov,video/quicktime,.png,image/png,.tif,image/tiff,.tiff,image/tiff,">
-                <div class="top-errors-hook govuk-grid-column-two-thirds"></div>
                 <form method="POST" novalidate="novalidate" class="govuk-grid-column-two-thirds"
                 data-filenames-in-folder="WyJ0ZXN0LXBkZi1kb2N1bWVudEZvbGRlckluZm8ucGRmIiwic2FtcGxlLTIwcy1kb2N1bWVudEZvbGRlckluZm8ubXA0IiwicGgwLWRvY3VtZW50Rm9sZGVySW5mby5qcGVnIiwicGgxLWRvY3VtZW50Rm9sZGVySW5mby5qcGVnIl0=">
                     <div class="pins-file-upload__container">
                         <div class="govuk-body colour--secondary pins-file-upload__instructions">
                             <label for="upload-file-1">Choose a single file to upload.</label><span>The file must be a PDF, DOC, DOCX, PPT, PPTX, XLS, XLSX, MSG, JPG, JPEG, MPEG, MP3, MP4, MOV, PNG, TIF, 	or TIFF.</span><span>The file must be smaller than 25MB.</span>
-                            <div                             class="middle-errors-hook"></div>
+                        </div>
+                        <div class="middle-errors-hook">
+                            <div class="pins-file-upload__upload">
+                                <input class="display--none" id="upload-file-1" accept=".pdf,application/pdf,.doc,application/msword,.docx,application/vnd.openxmlformats-officedocument.wordprocessingml.document,.ppt,application/vnd.ms-powerpoint,.pptx,application/vnd.openxmlformats-officedocument.presentationml.presentation,.xls,application/vnd.ms-excel,.xlsx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,.msg,application/vnd.ms-outlook,.jpg,image/jpeg,.jpeg,image/jpeg,.mpeg,video/mpeg,.mp3,audio/mpeg,.mp4,video/mp4,.mov,video/quicktime,.png,image/png,.tif,image/tiff,.tiff,image/tiff,"
+                                type="file" name="files" value="Choose file" aria-controls="file-list-1">
+                                <button type='button' class="pins-file-upload__button govuk-button">Select files</button>
+                            </div>
+                            <div id="file-list-1">
+                                <h2 class="display--sr-only" id="file-list-title-1">List of files to upload</h2>
+                                <ul class="pins-file-upload__files-rows" aria-describedby="file-list-title-1"
+                                aria-live="polite"></ul>
+                            </div>
+                        </div>
                     </div>
-                    <div class="pins-file-upload__upload">
-                        <input class="display--none" id="upload-file-1" accept=".pdf,application/pdf,.doc,application/msword,.docx,application/vnd.openxmlformats-officedocument.wordprocessingml.document,.ppt,application/vnd.ms-powerpoint,.pptx,application/vnd.openxmlformats-officedocument.presentationml.presentation,.xls,application/vnd.ms-excel,.xlsx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,.msg,application/vnd.ms-outlook,.jpg,image/jpeg,.jpeg,image/jpeg,.mpeg,video/mpeg,.mp3,audio/mpeg,.mp4,video/mp4,.mov,video/quicktime,.png,image/png,.tif,image/tiff,.tiff,image/tiff,"
-                        type="file" name="files" value="Choose file" aria-controls="file-list-1">
-                        <button type='button' class="pins-file-upload__button govuk-button">Select files</button>
+                    <div class="display--flex">
+                        <button type="submit" class="govuk-button pins-file-upload__submit" data-module="govuk-button"
+                        id="submit-button-1">Continue</button>
+                        <div class="progress-hook"></div>
                     </div>
-                    <div id="file-list-1">
-                        <h2 class="display--sr-only" id="file-list-title-1">List of files to upload</h2>
-                        <ul class="pins-file-upload__files-rows" aria-describedby="file-list-title-1"
-                        aria-live="polite"></ul>
-                    </div>
+                </form>
             </div>
-            <div class="display--flex">
-                <button type="submit" class="govuk-button pins-file-upload__submit" data-module="govuk-button"
-                id="submit-button-1">Continue</button>
-                <div class="progress-hook"></div>
-            </div>
-            </form>
         </div>
-    </div>
     </div>
 </main>"
 `;

--- a/appeals/web/src/server/appeals/appeal-details/withdrawal/__tests__/__snapshots__/withdrawal.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/withdrawal/__tests__/__snapshots__/withdrawal.test.js.snap
@@ -48,6 +48,7 @@ exports[`withdrawal GET /redaction-status should render the redaction status pag
 exports[`withdrawal GET /start should render the withdrawal request upload page with a file upload component 1`] = `
 "<main class="govuk-main-wrapper " id="main-content" role="main">
     <div class="govuk-grid-row">
+        <div class="top-errors-hook govuk-grid-column-two-thirds"></div>
         <div class="govuk-grid-column-full"><span class="govuk-caption-xl">Appeal 351062</span>
             <h1 class="govuk-heading-xl govuk-!-margin-bottom-3">Upload appellant&#39;s withdrawal request</h1>
         </div>
@@ -59,33 +60,33 @@ exports[`withdrawal GET /start should render the withdrawal request upload page 
             data-document-type="appellantCaseWithdrawalLetter" data-document-stage="appellant-case"
             data-blob-storage-host="https://127.0.0.1:10000/devstoreaccount1" data-blob-storage-container="document-service-uploads"
             data-allowed-types=".pdf,application/pdf,.doc,application/msword,.docx,application/vnd.openxmlformats-officedocument.wordprocessingml.document,.ppt,application/vnd.ms-powerpoint,.pptx,application/vnd.openxmlformats-officedocument.presentationml.presentation,.xls,application/vnd.ms-excel,.xlsx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,.msg,application/vnd.ms-outlook,.jpg,image/jpeg,.jpeg,image/jpeg,.mpeg,video/mpeg,.mp3,audio/mpeg,.mp4,video/mp4,.mov,video/quicktime,.png,image/png,.tif,image/tiff,.tiff,image/tiff,">
-                <div class="top-errors-hook govuk-grid-column-two-thirds"></div>
                 <form method="POST" novalidate="novalidate" class="govuk-grid-column-two-thirds"
                 data-filenames-in-folder="">
                     <div class="pins-file-upload__container">
                         <div class="govuk-body colour--secondary pins-file-upload__instructions">
                             <label for="upload-file-1">Choose a single file to upload.</label><span>The file must be a PDF, DOC, DOCX, PPT, PPTX, XLS, XLSX, MSG, JPG, JPEG, MPEG, MP3, MP4, MOV, PNG, TIF, 	or TIFF.</span><span>The file must be smaller than 25MB.</span>
-                            <div                             class="middle-errors-hook"></div>
+                        </div>
+                        <div class="middle-errors-hook">
+                            <div class="pins-file-upload__upload">
+                                <input class="display--none" id="upload-file-1" accept=".pdf,application/pdf,.doc,application/msword,.docx,application/vnd.openxmlformats-officedocument.wordprocessingml.document,.ppt,application/vnd.ms-powerpoint,.pptx,application/vnd.openxmlformats-officedocument.presentationml.presentation,.xls,application/vnd.ms-excel,.xlsx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,.msg,application/vnd.ms-outlook,.jpg,image/jpeg,.jpeg,image/jpeg,.mpeg,video/mpeg,.mp3,audio/mpeg,.mp4,video/mp4,.mov,video/quicktime,.png,image/png,.tif,image/tiff,.tiff,image/tiff,"
+                                type="file" name="files" value="Choose file" aria-controls="file-list-1">
+                                <button type='button' class="pins-file-upload__button govuk-button">Select files</button>
+                            </div>
+                            <div id="file-list-1">
+                                <h2 class="display--sr-only" id="file-list-title-1">List of files to upload</h2>
+                                <ul class="pins-file-upload__files-rows" aria-describedby="file-list-title-1"
+                                aria-live="polite"></ul>
+                            </div>
+                        </div>
                     </div>
-                    <div class="pins-file-upload__upload">
-                        <input class="display--none" id="upload-file-1" accept=".pdf,application/pdf,.doc,application/msword,.docx,application/vnd.openxmlformats-officedocument.wordprocessingml.document,.ppt,application/vnd.ms-powerpoint,.pptx,application/vnd.openxmlformats-officedocument.presentationml.presentation,.xls,application/vnd.ms-excel,.xlsx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,.msg,application/vnd.ms-outlook,.jpg,image/jpeg,.jpeg,image/jpeg,.mpeg,video/mpeg,.mp3,audio/mpeg,.mp4,video/mp4,.mov,video/quicktime,.png,image/png,.tif,image/tiff,.tiff,image/tiff,"
-                        type="file" name="files" value="Choose file" aria-controls="file-list-1">
-                        <button type='button' class="pins-file-upload__button govuk-button">Select files</button>
+                    <div class="display--flex">
+                        <button type="submit" class="govuk-button pins-file-upload__submit" data-module="govuk-button"
+                        id="submit-button-1">Continue</button>
+                        <div class="progress-hook"></div>
                     </div>
-                    <div id="file-list-1">
-                        <h2 class="display--sr-only" id="file-list-title-1">List of files to upload</h2>
-                        <ul class="pins-file-upload__files-rows" aria-describedby="file-list-title-1"
-                        aria-live="polite"></ul>
-                    </div>
+                </form>
             </div>
-            <div class="display--flex">
-                <button type="submit" class="govuk-button pins-file-upload__submit" data-module="govuk-button"
-                id="submit-button-1">Continue</button>
-                <div class="progress-hook"></div>
-            </div>
-            </form>
         </div>
-    </div>
     </div>
 </main>"
 `;

--- a/appeals/web/src/server/appeals/appeal-documents/__tests__/__snapshots__/appeal-documents.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-documents/__tests__/__snapshots__/appeal-documents.test.js.snap
@@ -3,6 +3,7 @@
 exports[`appeal-documents upload should render upload form if appeal ID and folder ID are found 1`] = `
 "<main class="govuk-main-wrapper " id="main-content" role="main">
     <div class="govuk-grid-row">
+        <div class="top-errors-hook govuk-grid-column-two-thirds"></div>
         <div class="govuk-grid-column-full"><span class="govuk-caption-xl">Appeal 351062</span>
             <h1 class="govuk-heading-xl govuk-!-margin-bottom-3">Upload documents</h1>
         </div>
@@ -14,34 +15,34 @@ exports[`appeal-documents upload should render upload form if appeal ID and fold
             data-document-type="newSupportingDocuments" data-document-stage="appellantCase"
             data-blob-storage-host="https://127.0.0.1:10000/devstoreaccount1" data-blob-storage-container="document-service-uploads"
             data-allowed-types=".pdf,application/pdf,.doc,application/msword,.docx,application/vnd.openxmlformats-officedocument.wordprocessingml.document,.ppt,application/vnd.ms-powerpoint,.pptx,application/vnd.openxmlformats-officedocument.presentationml.presentation,.xls,application/vnd.ms-excel,.xlsx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,.msg,application/vnd.ms-outlook,.jpg,image/jpeg,.jpeg,image/jpeg,.mpeg,video/mpeg,.mp3,audio/mpeg,.mp4,video/mp4,.mov,video/quicktime,.png,image/png,.tif,image/tiff,.tiff,image/tiff,">
-                <div class="top-errors-hook govuk-grid-column-two-thirds"></div>
                 <form method="POST" novalidate="novalidate" class="govuk-grid-column-two-thirds"
                 data-filenames-in-folder="">
                     <div class="pins-file-upload__container">
                         <div class="govuk-body colour--secondary pins-file-upload__instructions">
                             <label for="upload-file-1">Choose a single file or multiple files to upload.</label><span>Each file must be a PDF, DOC, DOCX, PPT, PPTX, XLS, XLSX, MSG, JPG, JPEG, MPEG, MP3, MP4, MOV, PNG, TIF, 	or TIFF.</span><span>The total size of your uploaded files must be smaller than 1GB.</span>
-                            <div                             class="middle-errors-hook"></div>
+                        </div>
+                        <div class="middle-errors-hook">
+                            <div class="pins-file-upload__upload">
+                                <input class="display--none" id="upload-file-1" accept=".pdf,application/pdf,.doc,application/msword,.docx,application/vnd.openxmlformats-officedocument.wordprocessingml.document,.ppt,application/vnd.ms-powerpoint,.pptx,application/vnd.openxmlformats-officedocument.presentationml.presentation,.xls,application/vnd.ms-excel,.xlsx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,.msg,application/vnd.ms-outlook,.jpg,image/jpeg,.jpeg,image/jpeg,.mpeg,video/mpeg,.mp3,audio/mpeg,.mp4,video/mp4,.mov,video/quicktime,.png,image/png,.tif,image/tiff,.tiff,image/tiff,"
+                                type="file" name="files" value="Choose file" aria-controls="file-list-1"
+                                multiple><span class='govuk-body pins-file-upload__dropzone-text'>Drag and drop files here or</span>
+                                <button                                 type='button' class="pins-file-upload__button govuk-button">Select files</button>
+                            </div>
+                            <div id="file-list-1">
+                                <h2 class="display--sr-only" id="file-list-title-1">List of files to upload</h2>
+                                <ul class="pins-file-upload__files-rows" aria-describedby="file-list-title-1"
+                                aria-live="polite"></ul>
+                            </div>
+                        </div>
                     </div>
-                    <div class="pins-file-upload__upload">
-                        <input class="display--none" id="upload-file-1" accept=".pdf,application/pdf,.doc,application/msword,.docx,application/vnd.openxmlformats-officedocument.wordprocessingml.document,.ppt,application/vnd.ms-powerpoint,.pptx,application/vnd.openxmlformats-officedocument.presentationml.presentation,.xls,application/vnd.ms-excel,.xlsx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,.msg,application/vnd.ms-outlook,.jpg,image/jpeg,.jpeg,image/jpeg,.mpeg,video/mpeg,.mp3,audio/mpeg,.mp4,video/mp4,.mov,video/quicktime,.png,image/png,.tif,image/tiff,.tiff,image/tiff,"
-                        type="file" name="files" value="Choose file" aria-controls="file-list-1"
-                        multiple><span class='govuk-body pins-file-upload__dropzone-text'>Drag and drop files here or</span>
-                        <button                         type='button' class="pins-file-upload__button govuk-button">Select files</button>
+                    <div class="display--flex">
+                        <button type="submit" class="govuk-button pins-file-upload__submit" data-module="govuk-button"
+                        id="submit-button-1">Continue</button>
+                        <div class="progress-hook"></div>
                     </div>
-                    <div id="file-list-1">
-                        <h2 class="display--sr-only" id="file-list-title-1">List of files to upload</h2>
-                        <ul class="pins-file-upload__files-rows" aria-describedby="file-list-title-1"
-                        aria-live="polite"></ul>
-                    </div>
+                </form>
             </div>
-            <div class="display--flex">
-                <button type="submit" class="govuk-button pins-file-upload__submit" data-module="govuk-button"
-                id="submit-button-1">Continue</button>
-                <div class="progress-hook"></div>
-            </div>
-            </form>
         </div>
-    </div>
     </div>
 </main>"
 `;
@@ -49,6 +50,7 @@ exports[`appeal-documents upload should render upload form if appeal ID and fold
 exports[`appeal-documents upload should render upload form if appeal ID, folder ID and document ID are found 1`] = `
 "<main class="govuk-main-wrapper " id="main-content" role="main">
     <div class="govuk-grid-row">
+        <div class="top-errors-hook govuk-grid-column-two-thirds"></div>
         <div class="govuk-grid-column-full"><span class="govuk-caption-xl">Appeal 351062</span>
             <h1 class="govuk-heading-xl govuk-!-margin-bottom-3">Upload an updated document</h1>
         </div>
@@ -61,33 +63,33 @@ exports[`appeal-documents upload should render upload form if appeal ID, folder 
             data-blob-storage-host="https://127.0.0.1:10000/devstoreaccount1" data-blob-storage-container="document-service-uploads"
             data-document-id="0e4ce48f-2d67-4659-9082-e80a15182386" data-document-original-file-name="test-pdf-documentFileVersionsInfo.pdf"
             data-document-version="1" data-allowed-types=".pdf,application/pdf,.doc,application/msword,.docx,application/vnd.openxmlformats-officedocument.wordprocessingml.document,.ppt,application/vnd.ms-powerpoint,.pptx,application/vnd.openxmlformats-officedocument.presentationml.presentation,.xls,application/vnd.ms-excel,.xlsx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,.msg,application/vnd.ms-outlook,.jpg,image/jpeg,.jpeg,image/jpeg,.mpeg,video/mpeg,.mp3,audio/mpeg,.mp4,video/mp4,.mov,video/quicktime,.png,image/png,.tif,image/tiff,.tiff,image/tiff,">
-                <div class="top-errors-hook govuk-grid-column-two-thirds"></div>
                 <form method="POST" novalidate="novalidate" class="govuk-grid-column-two-thirds"
                 data-filenames-in-folder="">
                     <div class="pins-file-upload__container">
                         <div class="govuk-body colour--secondary pins-file-upload__instructions">
                             <label for="upload-file-1">Choose a single file to upload.</label><span>The file must be a PDF, DOC, DOCX, PPT, PPTX, XLS, XLSX, MSG, JPG, JPEG, MPEG, MP3, MP4, MOV, PNG, TIF, 	or TIFF.</span><span>The file must be smaller than 25MB.</span>
-                            <div                             class="middle-errors-hook"></div>
+                        </div>
+                        <div class="middle-errors-hook">
+                            <div class="pins-file-upload__upload">
+                                <input class="display--none" id="upload-file-1" accept=".pdf,application/pdf,.doc,application/msword,.docx,application/vnd.openxmlformats-officedocument.wordprocessingml.document,.ppt,application/vnd.ms-powerpoint,.pptx,application/vnd.openxmlformats-officedocument.presentationml.presentation,.xls,application/vnd.ms-excel,.xlsx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,.msg,application/vnd.ms-outlook,.jpg,image/jpeg,.jpeg,image/jpeg,.mpeg,video/mpeg,.mp3,audio/mpeg,.mp4,video/mp4,.mov,video/quicktime,.png,image/png,.tif,image/tiff,.tiff,image/tiff,"
+                                type="file" name="files" value="Choose file" aria-controls="file-list-1">
+                                <button type='button' class="pins-file-upload__button govuk-button">Select files</button>
+                            </div>
+                            <div id="file-list-1">
+                                <h2 class="display--sr-only" id="file-list-title-1">List of files to upload</h2>
+                                <ul class="pins-file-upload__files-rows" aria-describedby="file-list-title-1"
+                                aria-live="polite"></ul>
+                            </div>
+                        </div>
                     </div>
-                    <div class="pins-file-upload__upload">
-                        <input class="display--none" id="upload-file-1" accept=".pdf,application/pdf,.doc,application/msword,.docx,application/vnd.openxmlformats-officedocument.wordprocessingml.document,.ppt,application/vnd.ms-powerpoint,.pptx,application/vnd.openxmlformats-officedocument.presentationml.presentation,.xls,application/vnd.ms-excel,.xlsx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,.msg,application/vnd.ms-outlook,.jpg,image/jpeg,.jpeg,image/jpeg,.mpeg,video/mpeg,.mp3,audio/mpeg,.mp4,video/mp4,.mov,video/quicktime,.png,image/png,.tif,image/tiff,.tiff,image/tiff,"
-                        type="file" name="files" value="Choose file" aria-controls="file-list-1">
-                        <button type='button' class="pins-file-upload__button govuk-button">Select files</button>
+                    <div class="display--flex">
+                        <button type="submit" class="govuk-button pins-file-upload__submit" data-module="govuk-button"
+                        id="submit-button-1">Continue</button>
+                        <div class="progress-hook"></div>
                     </div>
-                    <div id="file-list-1">
-                        <h2 class="display--sr-only" id="file-list-title-1">List of files to upload</h2>
-                        <ul class="pins-file-upload__files-rows" aria-describedby="file-list-title-1"
-                        aria-live="polite"></ul>
-                    </div>
+                </form>
             </div>
-            <div class="display--flex">
-                <button type="submit" class="govuk-button pins-file-upload__submit" data-module="govuk-button"
-                id="submit-button-1">Continue</button>
-                <div class="progress-hook"></div>
-            </div>
-            </form>
         </div>
-    </div>
     </div>
 </main>"
 `;

--- a/appeals/web/src/server/views/app/components/file-uploader.component.njk
+++ b/appeals/web/src/server/views/app/components/file-uploader.component.njk
@@ -24,7 +24,6 @@
 		 {% if params.accessToken %} data-access-token="{{ params.accessToken }}"{% endif %}
 		 {% if params.uncommittedFiles %} data-uncommitted-files="{{ params.uncommittedFiles }}"{% endif %}
 		 data-allowed-types="{% for value in params.allowedTypes %}{{ value|MIME }}{% endfor %}">
-		<div class="top-errors-hook govuk-grid-column-two-thirds"></div>
 		{% if params.formTitle %}
 			<h1 class="govuk-heading-m govuk-grid-column-full">{{ params.formTitle }}</h1>
 		{% endif %}
@@ -36,26 +35,27 @@
 					<label for="upload-file-{{ params.formId }}">{{ hintText }}</label>
 					{{ extensionsHtml(params) }}
 					<span>{{ totalSizeText }}</span>
-					<div class="middle-errors-hook"></div>
 				</div>
-				<div class="pins-file-upload__upload">
-					<input class="display--none"
-						   id="upload-file-{{ params.formId }}"
-						   accept="{% for value in params.allowedTypes %}{{ value|MIME }}{% endfor %}"
-						   type="file" name="files" value="Choose file"
-						   aria-controls="file-list-{{ params.formId }}"
-						   {% if params.multiple %}multiple{% endif %}>
-					{% if params.multiple %}
-						<span class='govuk-body pins-file-upload__dropzone-text'>Drag and drop files here or</span>
-					{% endif %}
-					<button type='button' class="pins-file-upload__button govuk-button">
-						Select files
-					</button>
-				</div>
-				<div id="file-list-{{ params.formId }}">
-					<h2 class="display--sr-only" id="file-list-title-{{ params.formId }}">List of files to upload</h2>
-					<ul class="pins-file-upload__files-rows"
-						aria-describedby="file-list-title-{{ params.formId }}" aria-live="polite"></ul>
+				<div class="middle-errors-hook">
+					<div class="pins-file-upload__upload">
+						<input class="display--none"
+							   id="upload-file-{{ params.formId }}"
+							   accept="{% for value in params.allowedTypes %}{{ value|MIME }}{% endfor %}"
+							   type="file" name="files" value="Choose file"
+							   aria-controls="file-list-{{ params.formId }}"
+							   {% if params.multiple %}multiple{% endif %}>
+						{% if params.multiple %}
+							<span class='govuk-body pins-file-upload__dropzone-text'>Drag and drop files here or</span>
+						{% endif %}
+						<button type='button' class="pins-file-upload__button govuk-button">
+							Select files
+						</button>
+					</div>
+					<div id="file-list-{{ params.formId }}">
+						<h2 class="display--sr-only" id="file-list-title-{{ params.formId }}">List of files to upload</h2>
+						<ul class="pins-file-upload__files-rows"
+							aria-describedby="file-list-title-{{ params.formId }}" aria-live="polite"></ul>
+					</div>
 				</div>
 			</div>
 			{% if params.disclaimerText %}

--- a/appeals/web/src/server/views/appeals/documents/decision-letter-upload.njk
+++ b/appeals/web/src/server/views/appeals/documents/decision-letter-upload.njk
@@ -10,6 +10,7 @@
 
 {%- block pageHeading -%}
 	<div class="govuk-grid-row">
+		<div class="top-errors-hook govuk-grid-column-two-thirds"></div>
 		<div class="govuk-grid-column-full">
 			<span class="govuk-caption-l govuk-!-margin-bottom-3">{{ caseInfoText }}</span>
 			<h1 class="govuk-heading-l govuk-!-margin-bottom-3">{{ pageHeadingText }}</h1>

--- a/appeals/web/src/server/views/appeals/documents/document-upload.njk
+++ b/appeals/web/src/server/views/appeals/documents/document-upload.njk
@@ -10,6 +10,7 @@
 
 {%- block pageHeading -%}
 	<div class="govuk-grid-row">
+		<div class="top-errors-hook govuk-grid-column-two-thirds"></div>
 		<div class="govuk-grid-column-full">
 			<span class="govuk-caption-xl">Appeal {{ appealShortReference }}</span>
 			<h1 class="govuk-heading-xl govuk-!-margin-bottom-3">


### PR DESCRIPTION
## Describe your changes

WEB:
 - Moved the error summary hook outside the file-uploader-component and above the page heading
 - Changed the client-side JavaScript to cope with above and added the logic to create the standard error messages around the upload component as requested by design
   
TESTING:
- WEB unit tests pass
- Manually tested within browser

## Issue ticket number and link

[A2-1222 WEB - File upload component - error summary should be above the H1](https://pins-ds.atlassian.net/browse/A2-1222)

**Note there is a screenshot of the new design seen in a comment in the ticket above**

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [x] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [x] I have included unit tests to cover any testable code changes
