### PR TITLE
fix(web): make show more wait for inner text

### DIFF
--- a/appeals/web/src/client/components/show-more/show-more.js
+++ b/appeals/web/src/client/components/show-more/show-more.js
@@ -123,8 +123,6 @@ const awaitInnerText = async (
 const initialiseTextMode = async (/** @type {ShowMoreComponentInstance} */ componentInstance) => {
 	await awaitInnerText(componentInstance);
 
-	console.log('Setting attrs');
-
 	componentInstance.elements.root.setAttribute(
 		ATTRIBUTES.fullText,
 		componentInstance.elements.root.innerText

--- a/appeals/web/src/client/components/show-more/show-more.js
+++ b/appeals/web/src/client/components/show-more/show-more.js
@@ -103,7 +103,28 @@ const bindEvents = (/** @type {ShowMoreComponentInstance} */ componentInstance) 
 		});
 };
 
-const initialiseTextMode = (/** @type {ShowMoreComponentInstance} */ componentInstance) => {
+const awaitInnerText = async (
+	/** @type {ShowMoreComponentInstance} */ componentInstance,
+	depth = 0
+) => {
+	if (componentInstance.elements.root.innerText || depth > 100) {
+		if (depth > 100 && !componentInstance.elements.root.innerText) {
+			console.warn('Failed to find inner text when initialising show more');
+		}
+		return;
+	}
+	await (() =>
+		new Promise((resolve) => {
+			setTimeout(resolve, 50);
+		}))();
+	return awaitInnerText(componentInstance, depth + 1);
+};
+
+const initialiseTextMode = async (/** @type {ShowMoreComponentInstance} */ componentInstance) => {
+	await awaitInnerText(componentInstance);
+
+	console.log('Setting attrs');
+
 	componentInstance.elements.root.setAttribute(
 		ATTRIBUTES.fullText,
 		componentInstance.elements.root.innerText
@@ -154,7 +175,7 @@ const initialiseOptions = (/** @type {ShowMoreComponentInstance} */ componentIns
 	};
 };
 
-const initialiseComponentInstance = (
+const initialiseComponentInstance = async (
 	/** @type {ShowMoreComponentInstance} */ componentInstance
 ) => {
 	initialiseOptions(componentInstance);
@@ -162,7 +183,7 @@ const initialiseComponentInstance = (
 	if (isHtmlMode(componentInstance)) {
 		htmlModeToggleExpanded(componentInstance);
 	} else {
-		initialiseTextMode(componentInstance);
+		await initialiseTextMode(componentInstance);
 	}
 
 	const button = document.createElement('button');
@@ -191,7 +212,7 @@ const initialiseShowMore = () => {
 	/** @type {NodeListOf<HTMLElement>} */
 	const componentElementInstances = document.querySelectorAll(SELECTORS.container);
 
-	componentElementInstances.forEach((componentElementInstance) => {
+	componentElementInstances.forEach(async (componentElementInstance) => {
 		/** @type {ShowMoreComponentInstance} */
 		const componentInstance = {
 			mode: 'text',
@@ -203,7 +224,7 @@ const initialiseShowMore = () => {
 				expanded: false
 			}
 		};
-		initialiseComponentInstance(componentInstance);
+		await initialiseComponentInstance(componentInstance);
 	});
 };
 

--- a/appeals/web/src/client/components/show-more/show-more.js
+++ b/appeals/web/src/client/components/show-more/show-more.js
@@ -106,10 +106,13 @@ const bindEvents = (/** @type {ShowMoreComponentInstance} */ componentInstance) 
 // N.B. maximum total timeout will be the product of these
 const INNER_TEXT_TIMEOUT = 50;
 const INNER_TEXT_DEPTH = 100;
-const awaitInnerText = async (
-	/** @type {ShowMoreComponentInstance} */ componentInstance,
-	depth = 0
-) => {
+/**
+ *
+ * @param {ShowMoreComponentInstance} componentInstance
+ * @param {number} [depth]
+ * @returns {Promise<void>}
+ */
+const awaitInnerText = async (componentInstance, depth = 0) => {
 	if (componentInstance.elements.root.innerText || depth > INNER_TEXT_DEPTH) {
 		if (depth > 100 && !componentInstance.elements.root.innerText) {
 			console.warn('Failed to find inner text when initialising show more');

--- a/appeals/web/src/client/components/show-more/show-more.js
+++ b/appeals/web/src/client/components/show-more/show-more.js
@@ -103,11 +103,14 @@ const bindEvents = (/** @type {ShowMoreComponentInstance} */ componentInstance) 
 		});
 };
 
+// N.B. maximum total timeout will be the product of these
+const INNER_TEXT_TIMEOUT = 50;
+const INNER_TEXT_DEPTH = 100;
 const awaitInnerText = async (
 	/** @type {ShowMoreComponentInstance} */ componentInstance,
 	depth = 0
 ) => {
-	if (componentInstance.elements.root.innerText || depth > 100) {
+	if (componentInstance.elements.root.innerText || depth > INNER_TEXT_DEPTH) {
 		if (depth > 100 && !componentInstance.elements.root.innerText) {
 			console.warn('Failed to find inner text when initialising show more');
 		}
@@ -115,7 +118,7 @@ const awaitInnerText = async (
 	}
 	await (() =>
 		new Promise((resolve) => {
-			setTimeout(resolve, 50);
+			setTimeout(resolve, INNER_TEXT_TIMEOUT);
 		}))();
 	return awaitInnerText(componentInstance, depth + 1);
 };

--- a/appeals/web/src/client/components/show-more/show-more.js
+++ b/appeals/web/src/client/components/show-more/show-more.js
@@ -114,7 +114,7 @@ const INNER_TEXT_DEPTH = 100;
  */
 const awaitInnerText = async (componentInstance, depth = 0) => {
 	if (componentInstance.elements.root.innerText || depth > INNER_TEXT_DEPTH) {
-		if (depth > 100 && !componentInstance.elements.root.innerText) {
+		if (depth > INNER_TEXT_DEPTH && !componentInstance.elements.root.innerText) {
 			console.warn('Failed to find inner text when initialising show more');
 		}
 		return;


### PR DESCRIPTION
Still not totally sure why this bug happens but like a lot of those sorts of bugs it can be fixed by waiting for a bit 🤷🏻‍♀️

Adds a recursive timeout to the show more script that waits for inner text to appear in the target before proceeding. 