### PR TITLE
fix(web): redirect to review on review error

### DIFF
--- a/appeals/web/src/server/appeals/appeal-details/interested-party-comments/view-and-review/view-and-review.controller.js
+++ b/appeals/web/src/server/appeals/appeal-details/interested-party-comments/view-and-review/view-and-review.controller.js
@@ -45,7 +45,7 @@ export const postReviewInterestedPartyComment = async (request, response, next) 
 		} = request;
 
 		if (errors) {
-			return renderViewInterestedPartyComment(request, response, next);
+			return renderReviewInterestedPartyComment(request, response, next);
 		}
 
 		if (status === COMMENT_STATUS.VALID_REQUIRES_REDACTION) {


### PR DESCRIPTION
Fixes a bug where the user would be redirected to the view IP comment page if an error occurred on the review IP comment page