### PR TITLE
feat(appeals): address eia screening scenario 3 back link (a2-1882)

### DIFF
--- a/appeals/web/src/server/appeals/appeal-details/appeal-details.controller.js
+++ b/appeals/web/src/server/appeals/appeal-details/appeal-details.controller.js
@@ -19,6 +19,8 @@ export const viewAppealDetails = async (request, response) => {
 		return response.status(404).render('app/404.njk');
 	}
 
+	delete session.reviewOutcome;
+
 	try {
 		/** @type {import('./accordions/index.js').RepresentationTypesAwaitingReview} */
 		const representationTypesAwaitingReview = await (async () => {

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/__tests__/lpa-questionnaire.test.js
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/__tests__/lpa-questionnaire.test.js
@@ -770,12 +770,6 @@ describe('LPA Questionnaire review', () => {
 		});
 
 		it('should redirect to the complete page if no errors are present and posted outcome is "complete"', async () => {
-			nock('http://test/')
-				.get('/appeals/1/lpa-questionnaires/2')
-				.reply(200, lpaQuestionnaireDataIncompleteOutcome)
-				.patch('/appeals/1/lpa-questionnaires/2')
-				.reply(200, { validationOutcome: 'complete' });
-
 			const response = await request.post(baseUrl).send({
 				'review-outcome': 'complete'
 			});
@@ -3360,6 +3354,11 @@ describe('LPA Questionnaire review', () => {
 
 		it('should save the eia-screening-required value and redirect successfully', async () => {
 			nock('http://test/').patch(`/appeals/1/eia-screening-required`).reply(200, {});
+			nock('http://test/')
+				.get('/appeals/1/lpa-questionnaires/2')
+				.reply(200, lpaQuestionnaireDataIncompleteOutcome)
+				.patch('/appeals/1/lpa-questionnaires/2')
+				.reply(200, { validationOutcome: 'complete' });
 			const response = await request
 				.post(`${baseUrl}/environment-service-team-review-case`)
 				.send({ eiaScreeningRequired: 'yes' });

--- a/appeals/web/src/server/lib/mappers/data/lpa-questionnaire/mapper.js
+++ b/appeals/web/src/server/lib/mappers/data/lpa-questionnaire/mapper.js
@@ -5,7 +5,7 @@ import { submaps as hasSubmaps } from './has.js';
 import { submaps as s78Submaps } from './s78.js';
 /**
  * @typedef {import('#appeals/appeal-details/appeal-details.types.js').WebAppeal} WebAppeal
- * @typedef {import('../../../../app/auth/auth-session.service.js').SessionWithAuth} SessionWithAuth
+ * @typedef {import('../../../../app/auth/auth-session.service.js').SessionWithAuth & Express.Request["session"]} SessionWithAuth
  * @typedef {import('@pins/appeals.api').Appeals.SingleLPAQuestionnaireResponse} SingleLPAQuestionnaireResponse
  */
 

--- a/appeals/web/src/server/lib/mappers/data/lpa-questionnaire/submappers/map-review-outcome.js
+++ b/appeals/web/src/server/lib/mappers/data/lpa-questionnaire/submappers/map-review-outcome.js
@@ -32,7 +32,8 @@ export const mapReviewOutcome = ({ lpaQuestionnaireData, session }) => ({
 				properties: {
 					name: 'review-outcome',
 					idPrefix: 'review-outcome',
-					value: lpaQuestionnaireData.validation?.outcome,
+					// @ts-ignore
+					value: lpaQuestionnaireData.validation?.outcome ?? session.reviewOutcome,
 					fieldset: {
 						legend: {
 							text: 'What is the outcome of your review?',

--- a/appeals/web/src/server/lib/mappers/data/lpa-questionnaire/submappers/map-review-outcome.js
+++ b/appeals/web/src/server/lib/mappers/data/lpa-questionnaire/submappers/map-review-outcome.js
@@ -32,7 +32,6 @@ export const mapReviewOutcome = ({ lpaQuestionnaireData, session }) => ({
 				properties: {
 					name: 'review-outcome',
 					idPrefix: 'review-outcome',
-					// @ts-ignore
 					value: lpaQuestionnaireData.validation?.outcome ?? session.reviewOutcome,
 					fieldset: {
 						legend: {


### PR DESCRIPTION
## Describe your changes

**Please note that these changes now mean all Acceptance Criteria on the ticket A2-1882 are satisfied whether the ticket itself is correct or not.**

Please also note that in this PR, a fix has been made to make sure the LPA Questionnaire will now **only complete** after the new  environmental impact assessment screening required page is confirmed.

WEB:
 - Moved the logic to "complete" the LPA Questionnaire to the post of the new  environmental impact assessment screening required page.
 - Added a session variable to allow the complete or incomplete radio buttons to show as checked when the back link is clicked from the environmental impact assessment screening required page.
   
TESTING:
- WEB fixed unit tests and checked all other tests pass.
- API checked all tests pass
- Manually tested within browser

## Issue ticket number and link

[A2-1882 Boolean - Does the environmental services team need to review the case?](https://pins-ds.atlassian.net/browse/A2-1882)

**Note there is a screenshot of the new design seen in a comment in the ticket above**

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [x] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [x] I have included unit tests to cover any testable code changes
