### PR TITLE
feat(appeals): fix complete when householder (a2-1882)

### DIFF
--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/__tests__/lpa-questionnaire.test.js
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/__tests__/lpa-questionnaire.test.js
@@ -770,6 +770,12 @@ describe('LPA Questionnaire review', () => {
 		});
 
 		it('should redirect to the complete page if no errors are present and posted outcome is "complete"', async () => {
+			nock('http://test/')
+				.get('/appeals/1/lpa-questionnaires/2')
+				.reply(200, lpaQuestionnaireDataIncompleteOutcome)
+				.patch('/appeals/1/lpa-questionnaires/2')
+				.reply(200, { validationOutcome: 'complete' });
+
 			const response = await request.post(baseUrl).send({
 				'review-outcome': 'complete'
 			});

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/lpa-questionnaire.controller.js
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/lpa-questionnaire.controller.js
@@ -96,6 +96,12 @@ export const postLpaQuestionnaire = async (request, response) => {
 		if (currentAppeal) {
 			if (reviewOutcome === 'complete') {
 				if (currentAppeal.appealType === APPEAL_TYPE.D) {
+					await lpaQuestionnaireService.setReviewOutcomeForLpaQuestionnaire(
+						request.apiClient,
+						appealId,
+						lpaQuestionnaireId,
+						mapWebValidationOutcomeToApiValidationOutcome('complete')
+					);
 					return response.redirect(
 						`/appeals-service/appeal-details/${appealId}/lpa-questionnaire/${lpaQuestionnaireId}/confirmation`
 					);


### PR DESCRIPTION
## Describe your changes
This PR is to fix the issue caused by the previous PR which meant that HAS LPA Questionnaires  did not "complete" correctly.

WEB:
 - Put the logic back to "complete" the LPA Questionnaire when HAS.  This is because the new environmental impact assessment screening required page is not in the flow when HAS.
   
TESTING:
- WEB fixed unit tests and checked all other tests pass.
- API checked all tests pass
- Manually tested both HAS and S78 within browser

## Issue ticket number and link

[A2-1882 Boolean - Does the environmental services team need to review the case?](https://pins-ds.atlassian.net/browse/A2-1882)

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [x] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [x] I have included unit tests to cover any testable code changes
