### PR TITLE
fix(api): associate uploaded documents with an existing statement

### DIFF
--- a/appeals/api/setup-tests.js
+++ b/appeals/api/setup-tests.js
@@ -99,6 +99,7 @@ const mockCaseNotesFindMany = jest.fn().mockResolvedValue({});
 const mockCaseNotesFindUnique = jest.fn().mockResolvedValue({});
 const mockCaseNotesCreate = jest.fn().mockResolvedValue({});
 const mockRepresentationRejectionReasonFindMany = jest.fn().mockResolvedValue({});
+const mockRepresentationCreate = jest.fn().mockResolvedValue({});
 
 class MockPrismaClient {
 	get representation() {
@@ -106,6 +107,11 @@ class MockPrismaClient {
 			update: mockRepUpdateById,
 			findUnique: mockRepGetById,
 			groupBy: mockRepGroupBy
+		};
+	}
+	get representationAttachment() {
+		return {
+			create: mockRepresentationCreate
 		};
 	}
 

--- a/appeals/api/src/server/endpoints/representations/representations.controller.js
+++ b/appeals/api/src/server/endpoints/representations/representations.controller.js
@@ -212,3 +212,30 @@ export const updateRejectionReasons = async (req, res) => {
 		});
 	}
 };
+
+/**
+ * @param {Request} req
+ * @param {Response} res
+ * @returns {Promise<Response>}
+ */
+export const updateRepresentationAttachments = async (req, res) => {
+	const { repId } = req.params;
+	const { attachments } = req.body;
+
+	if (!Array.isArray(attachments) || !attachments.every((id) => typeof id === 'string')) {
+		return res.status(400).send({ errors: { attachments: 'must be an array of strings' } });
+	}
+
+	const rep = await representationService.getRepresentation(parseInt(repId));
+
+	if (!rep) {
+		return res.status(404).send({ errors: { repId: 'Representation not found' } });
+	}
+
+	const updatedRepresentation = await representationService.updateAttachments(
+		Number(repId),
+		attachments
+	);
+
+	return res.status(200).send(updatedRepresentation);
+};

--- a/appeals/api/src/server/endpoints/representations/representations.routes.js
+++ b/appeals/api/src/server/endpoints/representations/representations.routes.js
@@ -219,4 +219,39 @@ router.patch(
 	asyncHandler(controller.updateRejectionReasons)
 );
 
+router.patch(
+	'/:appealId/reps/:repId/attachments',
+	/*
+	#swagger.tags = ['Representations']
+	#swagger.path = '/appeals/{appealId}/reps/{repId}/attachments'
+	#swagger.description = Update attachments for a representation
+	#swagger.parameters['azureAdUserId'] = {
+		in: 'header',
+		required: true,
+		example: '434bff4e-8191-4ce0-9a0a-91e5d6cdd882'
+	}
+	#swagger.requestBody = {
+		in: 'body',
+		required: true,
+		schema: { type: 'object', properties: { attachments: { type: 'array', items: { type: 'string' } } } },
+		example: {
+			"attachments": [
+				"39ad6cd8-60ab-43f0-a995-4854db8f12c6",
+				"b6f15730-2d7f-4fa0-8752-2d26a62474de",
+				"7919b64d-acca-4b6d-9793-97a0dd786139"
+			]
+		}
+	}
+	#swagger.responses[200] = {
+		description: 'Attachments updated successfully',
+		schema: { $ref: '#/components/schemas/RepResponse' }
+	}
+	#swagger.responses[400] = {
+		description: 'Invalid payload',
+		schema: { errors: { attachments: 'must be an array of strings' } }
+	}
+	*/
+	asyncHandler(controller.updateRepresentationAttachments)
+);
+
 export { router as representationRoutes };

--- a/appeals/api/src/server/endpoints/representations/representations.service.js
+++ b/appeals/api/src/server/endpoints/representations/representations.service.js
@@ -221,3 +221,23 @@ export const notifyRejection = async (notifyClient, appeal, comment, allowResubm
 		throw new Error(ERROR_FAILED_TO_SEND_NOTIFICATION_EMAIL);
 	}
 };
+
+/**
+ * @param {number} repId
+ * @param {string[]} attachments
+ * @returns {Promise<import('@pins/appeals.api').Schema.Representation>}
+ */
+export const updateAttachments = async (repId, attachments) => {
+	const documents = await documentRepository.getDocumentsByIds(attachments);
+
+	const mappedDocuments = documents.map((d) => ({
+		documentGuid: d.guid,
+		version: d.latestDocumentVersion?.version ?? 1
+	}));
+
+	const updatedRepresentation = await representationRepository.addAttachments(
+		repId,
+		mappedDocuments
+	);
+	return updatedRepresentation;
+};

--- a/appeals/api/src/server/openapi-types.ts
+++ b/appeals/api/src/server/openapi-types.ts
@@ -139,7 +139,7 @@ export interface AddBusinessDays {
 
 export interface AppellantCaseData {
 	casedata?: {
-		/** @example "14960baa-3d0f-4db9-9e84-0c75be891560" */
+		/** @example "ab35047f-753f-48d7-a738-05388a316586" */
 		submissionId?: string;
 		/** @example true */
 		advertisedAppeal?: boolean;

--- a/appeals/api/src/server/openapi.json
+++ b/appeals/api/src/server/openapi.json
@@ -1019,6 +1019,43 @@
 				}
 			}
 		},
+		"/appeals/lpa-designated-sites": {
+			"get": {
+				"tags": ["LPA Designated Sites"],
+				"description": "Gets LPA designated sites",
+				"parameters": [
+					{
+						"name": "azureAdUserId",
+						"in": "header",
+						"required": true,
+						"example": "434bff4e-8191-4ce0-9a0a-91e5d6cdd882",
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "LPA designated sites",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/DesignatedSiteName"
+								}
+							},
+							"application/xml": {
+								"schema": {
+									"$ref": "#/components/schemas/DesignatedSiteName"
+								}
+							}
+						}
+					},
+					"400": {
+						"description": "Bad Request"
+					}
+				}
+			}
+		},
 		"/appeals/lpa-questionnaire-incomplete-reasons": {
 			"get": {
 				"tags": ["LPA Questionnaire Incomplete Reasons"],
@@ -3916,6 +3953,138 @@
 				}
 			}
 		},
+		"/appeals/{appealId}/reps/{repId}/attachments": {
+			"patch": {
+				"tags": ["Representations"],
+				"description": "Update attachments for a representation",
+				"parameters": [
+					{
+						"name": "appealId",
+						"in": "path",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"name": "repId",
+						"in": "path",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"name": "azureAdUserId",
+						"in": "header",
+						"required": true,
+						"example": "434bff4e-8191-4ce0-9a0a-91e5d6cdd882",
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "Attachments updated successfully",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/RepResponse"
+								}
+							},
+							"application/xml": {
+								"schema": {
+									"$ref": "#/components/schemas/RepResponse"
+								}
+							}
+						}
+					},
+					"400": {
+						"description": "Invalid payload",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"errors": {
+											"type": "object",
+											"properties": {
+												"attachments": {
+													"type": "string",
+													"example": "must be an array of strings"
+												}
+											}
+										}
+									},
+									"xml": {
+										"name": "main"
+									}
+								}
+							},
+							"application/xml": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"errors": {
+											"type": "object",
+											"properties": {
+												"attachments": {
+													"type": "string",
+													"example": "must be an array of strings"
+												}
+											}
+										}
+									},
+									"xml": {
+										"name": "main"
+									}
+								}
+							}
+						}
+					}
+				},
+				"requestBody": {
+					"in": "body",
+					"required": true,
+					"example": {
+						"attachments": [
+							"39ad6cd8-60ab-43f0-a995-4854db8f12c6",
+							"b6f15730-2d7f-4fa0-8752-2d26a62474de",
+							"7919b64d-acca-4b6d-9793-97a0dd786139"
+						]
+					},
+					"content": {
+						"application/json": {
+							"schema": {
+								"type": "object",
+								"properties": {
+									"attachments": {
+										"type": "array",
+										"items": {
+											"type": "string"
+										}
+									}
+								}
+							}
+						},
+						"application/xml": {
+							"schema": {
+								"type": "object",
+								"properties": {
+									"attachments": {
+										"type": "array",
+										"items": {
+											"type": "string"
+										}
+									}
+								}
+							}
+						}
+					}
+				}
+			}
+		},
 		"/appeals/{appealId}/listed-buildings": {
 			"post": {
 				"tags": ["Listed buildings"],
@@ -4325,43 +4494,6 @@
 					}
 				}
 			}
-		},
-		"/appeals/lpa-designated-sites": {
-			"get": {
-				"tags": ["LPA Designated Sites"],
-				"description": "Gets LPA designated sites",
-				"parameters": [
-					{
-						"name": "azureAdUserId",
-						"in": "header",
-						"required": true,
-						"example": "434bff4e-8191-4ce0-9a0a-91e5d6cdd882",
-						"schema": {
-							"type": "string"
-						}
-					}
-				],
-				"responses": {
-					"200": {
-						"description": "LPA designated sites",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/DesignatedSiteName"
-								}
-							},
-							"application/xml": {
-								"schema": {
-									"$ref": "#/components/schemas/DesignatedSiteName"
-								}
-							}
-						}
-					},
-					"400": {
-						"description": "Bad Request"
-					}
-				}
-			}
 		}
 	},
 	"components": {
@@ -4692,7 +4824,7 @@
 						"properties": {
 							"submissionId": {
 								"type": "string",
-								"example": "14960baa-3d0f-4db9-9e84-0c75be891560"
+								"example": "ab35047f-753f-48d7-a738-05388a316586"
 							},
 							"advertisedAppeal": {
 								"type": "boolean",


### PR DESCRIPTION
## Describe your changes

Developed a new API endpoint to enable the association of uploaded documents with an existing statement.

## Issue ticket number and link
[A2-2004](https://pins-ds.atlassian.net/browse/A2-2004)


[A2-2004]: https://pins-ds.atlassian.net/browse/A2-2004?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ