### PR TITLE
Feature/a2 766 site visit

### DIFF
--- a/appeals/api/src/database/migrations/20250114125418_address_unique/migration.sql
+++ b/appeals/api/src/database/migrations/20250114125418_address_unique/migration.sql
@@ -1,0 +1,25 @@
+/*
+  Warnings:
+
+  - A unique constraint covering the columns `[appealId,addressId]` on the table `NeighbouringSite` will be added. If there are existing duplicate values, this will fail.
+
+*/
+BEGIN TRY
+
+BEGIN TRAN;
+
+-- CreateIndex
+ALTER TABLE [dbo].[NeighbouringSite] ADD CONSTRAINT [NeighbouringSite_appealId_addressId_key] UNIQUE NONCLUSTERED ([appealId], [addressId]);
+
+COMMIT TRAN;
+
+END TRY
+BEGIN CATCH
+
+IF @@TRANCOUNT > 0
+BEGIN
+    ROLLBACK TRAN;
+END;
+THROW
+
+END CATCH

--- a/appeals/api/src/database/schema.prisma
+++ b/appeals/api/src/database/schema.prisma
@@ -228,6 +228,8 @@ model NeighbouringSite {
   address   Address @relation(fields: [addressId], references: [id], onDelete: NoAction, onUpdate: NoAction)
   addressId Int
   source    String  @default("back-office")
+
+  @@unique([appealId, addressId])
 }
 
 /// AppellantCase model

--- a/appeals/api/src/server/endpoints/representations/__tests__/representations.test.js
+++ b/appeals/api/src/server/endpoints/representations/__tests__/representations.test.js
@@ -78,7 +78,7 @@ describe('/appeals/:id/representations', () => {
 			databaseConnector.appeal.findUnique.mockResolvedValue(householdAppeal);
 
 			const response = await request
-				.patch('/appeals/1/reps/1/status')
+				.patch('/appeals/1/reps/1')
 				.send({ status: 'an_invalid_val' })
 				.set('azureAdUserId', '732652365');
 
@@ -95,7 +95,7 @@ describe('/appeals/:id/representations', () => {
 			databaseConnector.appeal.findUnique.mockResolvedValue(householdAppeal);
 
 			const response = await request
-				.patch('/appeals/1/reps/1/status')
+				.patch('/appeals/1/reps/1')
 				.send({ status: 0 })
 				.set('azureAdUserId', '732652365');
 
@@ -112,7 +112,7 @@ describe('/appeals/:id/representations', () => {
 			databaseConnector.appeal.findUnique.mockResolvedValue(householdAppeal);
 
 			const response = await request
-				.patch('/appeals/1/reps/1/redaction')
+				.patch('/appeals/1/reps/1')
 				.send({ redactedRepresentation: false })
 				.set('azureAdUserId', '732652365');
 
@@ -157,7 +157,7 @@ describe('/appeals/:id/representations', () => {
 			databaseConnector.representation.update.mockResolvedValue(mockRepresentation);
 
 			const response = await request
-				.patch('/appeals/1/reps/1/status')
+				.patch('/appeals/1/reps/1')
 				.send({
 					status: 'valid',
 					notes: 'Some notes',
@@ -166,27 +166,6 @@ describe('/appeals/:id/representations', () => {
 				.set('azureAdUserId', '732652365');
 
 			expect(response.status).toEqual(200);
-
-			// eslint-disable-next-line no-undef
-			expect(mockSendEmail).toHaveBeenCalledTimes(1);
-
-			// eslint-disable-next-line no-undef
-			expect(mockSendEmail).toHaveBeenCalledWith(
-				config.govNotify.template.commentRejected.id,
-				'test@136s7.com',
-				{
-					emailReplyToId: null,
-					personalisation: {
-						appeal_reference_number: '1345264',
-						lpa_reference: '48269/APP/2021/1482',
-						site_address: '96 The Avenue, Leftfield, Maidstone, Kent, MD21 5XY, United Kingdom',
-						deadline_date: '',
-						reasons: ['Invalid submission'],
-						url: 'https://www.gov.uk/appeal-planning-inspectorate'
-					},
-					reference: null
-				}
-			);
 		});
 
 		test('200 when representation status is successfully updated with extended deadline template selected', async () => {
@@ -197,7 +176,7 @@ describe('/appeals/:id/representations', () => {
 			const mockRepresentation = {
 				id: 1,
 				lpa: false,
-				status: 'valid',
+				status: 'invalid',
 				originalRepresentation: 'Original text of the representation',
 				redactedRepresentation: 'Redacted text of the representation',
 				dateCreated: new Date('2024-12-11T12:00:00Z'),
@@ -234,9 +213,9 @@ describe('/appeals/:id/representations', () => {
 			databaseConnector.representation.update.mockResolvedValue(mockRepresentation);
 
 			const response = await request
-				.patch('/appeals/1/reps/1/status')
+				.patch('/appeals/1/reps/1')
 				.send({
-					status: 'valid',
+					status: 'invalid',
 					notes: 'Some notes',
 					allowResubmit: true,
 					extendedDeadline: true

--- a/appeals/api/src/server/endpoints/representations/representations.controller.js
+++ b/appeals/api/src/server/endpoints/representations/representations.controller.js
@@ -151,7 +151,7 @@ export async function updateRepresentation(request, response) {
 		return response.status(400).send({ errors: { status: ERROR_REP_ONLY_STATEMENT_INCOMPLETE } });
 	}
 
-	const updatedRep = await representationRepository.updateRepresentationById(
+	const updatedRep = await representationService.updateRepresentation(
 		parseInt(repId),
 		request.body
 	);

--- a/appeals/api/src/server/endpoints/representations/representations.routes.js
+++ b/appeals/api/src/server/endpoints/representations/representations.routes.js
@@ -107,11 +107,11 @@ router.get(
 );
 
 router.patch(
-	'/:appealId/reps/:repId/status',
+	'/:appealId/reps/:repId',
 	/*
 	#swagger.tags = ['Representations']
-	#swagger.path = '/appeals/{appealId}/reps/{repId}/status'
-	#swagger.description = Get a single representation
+	#swagger.path = '/appeals/{appealId}/reps/{repId}'
+	#swagger.description = "Update a representation"
 	#swagger.parameters['azureAdUserId'] = {
 		in: 'header',
 		required: true,
@@ -120,7 +120,7 @@ router.patch(
 	#swagger.requestBody = {
 		in: 'body',
 		required: true,
-		schema: { $ref: '#/components/schemas/RepStatusUpdateRequest' },
+		schema: { $ref: '#/components/schemas/RepUpdateRequest' },
 	}
 	#swagger.responses[200] = {
 		description: 'Get a single representation for an appeal',
@@ -132,35 +132,7 @@ router.patch(
 	getRepresentationUpdateValidator,
 	checkAppealExistsByIdAndAddToRequest,
 	checkRepresentationExistsById,
-	asyncHandler(controller.changeRepresentationStatus)
-);
-
-router.patch(
-	'/:appealId/reps/:repId/redaction',
-	/*
-	#swagger.tags = ['Representations']
-	#swagger.path = '/appeals/{appealId}/reps/{repId}/redaction'
-	#swagger.description = Get a single representation
-	#swagger.parameters['azureAdUserId'] = {
-		in: 'header',
-		required: true,
-		example: '434bff4e-8191-4ce0-9a0a-91e5d6cdd882'
-	}
-	#swagger.requestBody = {
-		in: 'body',
-		required: true,
-		schema: { $ref: '#/components/schemas/RepRedactionRequest' },
-	}
-	#swagger.responses[200] = {
-		description: 'Get a single representation for an appeal',
-		schema: { $ref: '#/components/schemas/RepResponse' }
-	}
-	#swagger.responses[400] = {}
-	#swagger.responses[404] = {}
- */
-	getRepresentationUpdateValidator,
-	checkAppealExistsByIdAndAddToRequest,
-	asyncHandler(controller.addRedactedRepresentation)
+	asyncHandler(controller.updateRepresentation)
 );
 
 router.post(

--- a/appeals/api/src/server/endpoints/representations/representations.service.js
+++ b/appeals/api/src/server/endpoints/representations/representations.service.js
@@ -76,31 +76,6 @@ export const addRepresentation = async (appealId, pageNumber = 0, pageSize = 30,
 };
 
 /**
- *
- * @param {number} id
- * @param {string} status //APPEAL_REPRESENTATION_STATUS
- * @param {string} notes
- * @param {string} reviewer
- */
-export const updateRepresentationStatus = async (id, status, notes, reviewer) => {
-	const rep = await representationRepository.updateRepresentationById(id, {
-		status,
-		notes,
-		reviewer
-	});
-	return rep;
-};
-
-/**
- *
- * @param {number} id
- * @param {string} redactedRepresentation
- * @param {string} reviewer
- */
-export const redactRepresentation = (id, redactedRepresentation, reviewer) =>
-	representationRepository.updateRepresentationById(id, { redactedRepresentation, reviewer });
-
-/**
  * @typedef {Object} CreateRepresentationInput
  * @param {'comment' | 'lpa_statement' | 'appellant_statement' | 'lpa_final_comment' | 'appellant_final_comment'} representationType
  * @property {{ firstName: string, lastName: string, email: string }} ipDetails

--- a/appeals/api/src/server/openapi-types.ts
+++ b/appeals/api/src/server/openapi-types.ts
@@ -27,18 +27,17 @@ export interface UnlinkAppealRequest {
 	relationshipId?: number;
 }
 
-export interface RepRedactionRequest {
-	/** @example "Some redacted text" */
-	redactedRepresentation?: string;
-}
-
-export interface RepStatusUpdateRequest {
+export interface RepUpdateRequest {
 	/** @example "valid" */
 	status?: string;
 	/** @example "Some notes" */
 	notes?: string;
 	/** @example true */
 	allowResubmit?: boolean;
+	/** @example "Some redacted text" */
+	redactedRepresentation?: string;
+	/** @example true */
+	siteVisitedRequest?: boolean;
 }
 
 export interface CreateRepRequest {

--- a/appeals/api/src/server/openapi.json
+++ b/appeals/api/src/server/openapi.json
@@ -3674,12 +3674,10 @@
 						"description": "Not Found"
 					}
 				}
-			}
-		},
-		"/appeals/{appealId}/reps/{repId}/status": {
+			},
 			"patch": {
 				"tags": ["Representations"],
-				"description": "Get a single representation",
+				"description": "Update a representation",
 				"parameters": [
 					{
 						"name": "appealId",
@@ -3736,84 +3734,12 @@
 					"content": {
 						"application/json": {
 							"schema": {
-								"$ref": "#/components/schemas/RepStatusUpdateRequest"
+								"$ref": "#/components/schemas/RepUpdateRequest"
 							}
 						},
 						"application/xml": {
 							"schema": {
-								"$ref": "#/components/schemas/RepStatusUpdateRequest"
-							}
-						}
-					}
-				}
-			}
-		},
-		"/appeals/{appealId}/reps/{repId}/redaction": {
-			"patch": {
-				"tags": ["Representations"],
-				"description": "Get a single representation",
-				"parameters": [
-					{
-						"name": "appealId",
-						"in": "path",
-						"required": true,
-						"schema": {
-							"type": "string"
-						}
-					},
-					{
-						"name": "repId",
-						"in": "path",
-						"required": true,
-						"schema": {
-							"type": "string"
-						}
-					},
-					{
-						"name": "azureAdUserId",
-						"in": "header",
-						"required": true,
-						"example": "434bff4e-8191-4ce0-9a0a-91e5d6cdd882",
-						"schema": {
-							"type": "string"
-						}
-					}
-				],
-				"responses": {
-					"200": {
-						"description": "Get a single representation for an appeal",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/RepResponse"
-								}
-							},
-							"application/xml": {
-								"schema": {
-									"$ref": "#/components/schemas/RepResponse"
-								}
-							}
-						}
-					},
-					"400": {
-						"description": "Bad Request"
-					},
-					"404": {
-						"description": "Not Found"
-					}
-				},
-				"requestBody": {
-					"in": "body",
-					"required": true,
-					"content": {
-						"application/json": {
-							"schema": {
-								"$ref": "#/components/schemas/RepRedactionRequest"
-							}
-						},
-						"application/xml": {
-							"schema": {
-								"$ref": "#/components/schemas/RepRedactionRequest"
+								"$ref": "#/components/schemas/RepUpdateRequest"
 							}
 						}
 					}
@@ -4566,19 +4492,7 @@
 					"name": "UnlinkAppealRequest"
 				}
 			},
-			"RepRedactionRequest": {
-				"type": "object",
-				"properties": {
-					"redactedRepresentation": {
-						"type": "string",
-						"example": "Some redacted text"
-					}
-				},
-				"xml": {
-					"name": "RepRedactionRequest"
-				}
-			},
-			"RepStatusUpdateRequest": {
+			"RepUpdateRequest": {
 				"type": "object",
 				"properties": {
 					"status": {
@@ -4592,10 +4506,18 @@
 					"allowResubmit": {
 						"type": "boolean",
 						"example": true
+					},
+					"redactedRepresentation": {
+						"type": "string",
+						"example": "Some redacted text"
+					},
+					"siteVisitedRequest": {
+						"type": "boolean",
+						"example": true
 					}
 				},
 				"xml": {
-					"name": "RepStatusUpdateRequest"
+					"name": "RepUpdateRequest"
 				}
 			},
 			"CreateRepRequest": {

--- a/appeals/api/src/server/repositories/neighbouring-sites.repository.js
+++ b/appeals/api/src/server/repositories/neighbouring-sites.repository.js
@@ -34,6 +34,50 @@ const addSite = async (appealId, source, address) => {
 };
 
 /**
+ * @param {number} appealId
+ * @param {number} addressId
+ * @returns {Promise<NeighbouringSite>}
+ */
+const connectSite = (appealId, addressId) =>
+	databaseConnector.neighbouringSite.upsert({
+		where: {
+			appealId_addressId: {
+				appealId,
+				addressId
+			}
+		},
+		create: {
+			appeal: {
+				connect: {
+					id: appealId
+				}
+			},
+			address: {
+				connect: {
+					id: addressId
+				}
+			},
+			source: 'back-office'
+		},
+		update: {
+			appeal: {
+				connect: {
+					id: appealId
+				}
+			},
+			address: {
+				connect: {
+					id: addressId
+				}
+			},
+			source: 'back-office'
+		},
+		include: {
+			address: true
+		}
+	});
+
+/**
  * Updates the address of a neighbouring site
  * @param {number} siteId
  * @param {{addressLine1: string, addressLine2?: string | null, postcode: string, addressCounty?: string | null, addressTown: string}} address
@@ -92,5 +136,6 @@ const removeSite = async (siteId) => {
 export default {
 	addSite,
 	updateSite,
-	removeSite
+	removeSite,
+	connectSite
 };

--- a/appeals/api/src/server/repositories/representation.repository.js
+++ b/appeals/api/src/server/repositories/representation.repository.js
@@ -118,7 +118,7 @@ const getRepresentationCounts = async (appealId, options) => {
  * @returns {Promise<import('@pins/appeals.api').Schema.Representation>}
  */
 const updateRepresentationById = (id, data) => {
-	const { status, redactedRepresentation, notes, reviewer } = data;
+	const { status, redactedRepresentation, notes, reviewer, siteVisitRequested } = data;
 
 	return databaseConnector.representation.update({
 		where: {
@@ -129,7 +129,8 @@ const updateRepresentationById = (id, data) => {
 			...(redactedRepresentation && { redactedRepresentation }),
 			...(notes && { notes }),
 			reviewer,
-			dateLastUpdated: new Date()
+			dateLastUpdated: new Date(),
+			siteVisitRequested
 		},
 		include: {
 			representative: true,

--- a/appeals/api/src/server/swagger.js
+++ b/appeals/api/src/server/swagger.js
@@ -1,10 +1,5 @@
 import { validAppellantCase, validLpaQuestionnaire } from '#tests/integrations/mocks.js';
-import {
-	createRepRequest,
-	repRedactionRequest,
-	repStatusUpdateRequest,
-	repResponse
-} from '#tests/representations/mocks.js';
+import { createRepRequest, repUpdateRequest, repResponse } from '#tests/representations/mocks.js';
 import {
 	folder,
 	addDocumentsRequest,
@@ -78,11 +73,8 @@ export const spec = {
 		UnlinkAppealRequest: {
 			...unlinkAppealRequest
 		},
-		RepRedactionRequest: {
-			...repRedactionRequest
-		},
-		RepStatusUpdateRequest: {
-			...repStatusUpdateRequest
+		RepUpdateRequest: {
+			...repUpdateRequest
 		},
 		CreateRepRequest: {
 			...createRepRequest

--- a/appeals/api/src/server/tests/representations/mocks.js
+++ b/appeals/api/src/server/tests/representations/mocks.js
@@ -13,14 +13,12 @@ export const createRepRequest = {
 	redactionStatus: 'unredacted'
 };
 
-export const repRedactionRequest = {
-	redactedRepresentation: 'Some redacted text'
-};
-
-export const repStatusUpdateRequest = {
+export const repUpdateRequest = {
 	status: 'valid',
 	notes: 'Some notes',
-  allowResubmit: true
+	allowResubmit: true,
+	redactedRepresentation: 'Some redacted text',
+	siteVisitedRequest: true
 };
 
 export const repResponse = {

--- a/appeals/web/src/server/appeals/appeal-details/final-comments/redact/redact.service.js
+++ b/appeals/web/src/server/appeals/appeal-details/final-comments/redact/redact.service.js
@@ -11,7 +11,7 @@ export const patchFinalCommentRedaction = (
 	redactedRepresentation
 ) =>
 	apiClient
-		.patch(`appeals/${appealId}/reps/${commentId}/redaction`, {
+		.patch(`appeals/${appealId}/reps/${commentId}`, {
 			json: {
 				redactedRepresentation
 			}

--- a/appeals/web/src/server/appeals/appeal-details/interested-party-comments/redact/redact.controller.js
+++ b/appeals/web/src/server/appeals/appeal-details/interested-party-comments/redact/redact.controller.js
@@ -1,7 +1,7 @@
 import { redactInterestedPartyCommentPage } from './redact.mapper.js';
 import { confirmRedactInterestedPartyCommentPage } from './confirm.mapper.js';
 import { addNotificationBannerToSession } from '#lib/session-utilities.js';
-import { redactAndRejectComment } from './redact.service.js';
+import { redactAndAcceptComment } from './redact.service.js';
 import { render } from '#appeals/appeal-details/representations/common/render.js';
 
 /** @typedef {import("../../appeal-details.types.js").WebAppeal} Appeal */
@@ -46,7 +46,7 @@ export const postConfirmRedactInterestedPartyComment = async (request, response)
 		apiClient
 	} = request;
 
-	await redactAndRejectComment(
+	await redactAndAcceptComment(
 		apiClient,
 		appealId,
 		commentId,

--- a/appeals/web/src/server/appeals/appeal-details/interested-party-comments/redact/redact.service.js
+++ b/appeals/web/src/server/appeals/appeal-details/interested-party-comments/redact/redact.service.js
@@ -1,20 +1,25 @@
+import { COMMENT_STATUS } from '@pins/appeals/constants/common.js';
+
 /**
  * @param {import('got').Got} apiClient
  * @param {string} appealId
  * @param {string} commentId
  * @param {string} redactedRepresentation
+ * @param {boolean} [siteVisitRequested]
  * */
-export const patchInterestedPartyCommentRedaction = (
+export const redactAndRejectComment = (
 	apiClient,
 	appealId,
 	commentId,
-	redactedRepresentation
+	redactedRepresentation,
+	siteVisitRequested
 ) =>
 	apiClient
 		.patch(`appeals/${appealId}/reps/${commentId}`, {
 			json: {
 				redactedRepresentation,
-				test: 'test'
+				siteVisitRequested,
+				status: COMMENT_STATUS.VALID
 			}
 		})
 		.json();

--- a/appeals/web/src/server/appeals/appeal-details/interested-party-comments/redact/redact.service.js
+++ b/appeals/web/src/server/appeals/appeal-details/interested-party-comments/redact/redact.service.js
@@ -7,7 +7,7 @@ import { COMMENT_STATUS } from '@pins/appeals/constants/common.js';
  * @param {string} redactedRepresentation
  * @param {boolean} [siteVisitRequested]
  * */
-export const redactAndRejectComment = (
+export const redactAndAcceptComment = (
 	apiClient,
 	appealId,
 	commentId,

--- a/appeals/web/src/server/appeals/appeal-details/interested-party-comments/redact/redact.service.js
+++ b/appeals/web/src/server/appeals/appeal-details/interested-party-comments/redact/redact.service.js
@@ -11,7 +11,7 @@ export const patchInterestedPartyCommentRedaction = (
 	redactedRepresentation
 ) =>
 	apiClient
-		.patch(`appeals/${appealId}/reps/${commentId}/redaction`, {
+		.patch(`appeals/${appealId}/reps/${commentId}`, {
 			json: {
 				redactedRepresentation,
 				test: 'test'

--- a/appeals/web/src/server/appeals/appeal-details/interested-party-comments/view-and-review/__tests__/__snapshots__/view-and-review.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/interested-party-comments/view-and-review/__tests__/__snapshots__/view-and-review.test.js.snap
@@ -359,9 +359,9 @@ exports[`interested-party-comments GET /review-comment with data should render r
                         <div class="govuk-form-group">
                             <div class="govuk-checkboxes" data-module="govuk-checkboxes">
                                 <div class="govuk-checkboxes__item">
-                                    <input class="govuk-checkboxes__input" id="site-visit-request" name="site-visit-request"
+                                    <input class="govuk-checkboxes__input" id="site-visit-request" name="siteVisitRequested"
                                     type="checkbox" value="site-visit">
-                                    <label class="govuk-label govuk-checkboxes__label" for="site-visit-request">The comment includes a site visit request</label>
+                                    <label class="govuk-label govuk-checkboxes__label" for="site-visit-request">Comment includes a site visit request</label>
                                 </div>
                             </div>
                         </div>
@@ -414,7 +414,7 @@ exports[`interested-party-comments GET /view-comment with data should render vie
                     <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/interested-party-comments/3670/edit/address?review=false&amp;editAddress=false"> Add<span class="govuk-visually-hidden"> address</span></a>
                     </dd>
                 </div>
-                <div class="govuk-summary-list__row govuk-summary-list__row--no-actions"><dt class="govuk-summary-list__key"> Site visit requested</dt>
+                <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Site visit requested</dt>
                     <dd class="govuk-summary-list__value">No</dd>
                 </div>
                 <div class="govuk-summary-list__row govuk-summary-list__row--no-actions"><dt class="govuk-summary-list__key"> When did the interested party submit the comment?</dt>

--- a/appeals/web/src/server/appeals/appeal-details/interested-party-comments/view-and-review/__tests__/view-and-review.test.js
+++ b/appeals/web/src/server/appeals/appeal-details/interested-party-comments/view-and-review/__tests__/view-and-review.test.js
@@ -128,10 +128,10 @@ describe('interested-party-comments', () => {
 	describe('POST /review', () => {
 		beforeEach(() => {
 			nock('http://test/').get('/appeals/2/reps/5').reply(200, interestedPartyCommentForReview);
-			nock('http://test/').patch('/appeals/2/reps/5/status').reply(200, {});
+			nock('http://test/').patch('/appeals/2/reps/5').reply(200, {});
 		});
 
-		it('should set represnetation status to valid', async () => {
+		it('should set representation status to valid', async () => {
 			const response = await request
 				.post(`${baseUrl}/2/interested-party-comments/5/review`)
 				.send({ status: 'valid' });

--- a/appeals/web/src/server/appeals/appeal-details/interested-party-comments/view-and-review/page-components/common.js
+++ b/appeals/web/src/server/appeals/appeal-details/interested-party-comments/view-and-review/page-components/common.js
@@ -102,7 +102,18 @@ export function generateCommentSummaryList(
 			: [
 					{
 						key: { text: 'Site visit requested' },
-						value: { text: comment.siteVisitRequested ? 'Yes' : 'No' }
+						value: { text: comment.siteVisitRequested ? 'Yes' : 'No' },
+						actions: {
+							items: comment.siteVisitRequested
+								? [
+										{
+											text: 'Change',
+											href: `/appeals-service/appeal-details/${appealId}/interested-party-comments/${comment.id}/edit/site-visit-requested`,
+											visuallyHiddenText: 'site visited requested'
+										}
+								  ]
+								: []
+						}
 					}
 			  ]),
 		{

--- a/appeals/web/src/server/appeals/appeal-details/interested-party-comments/view-and-review/page-components/review.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/interested-party-comments/view-and-review/page-components/review.mapper.js
@@ -23,7 +23,7 @@ export function reviewInterestedPartyCommentPage(appealDetails, comment, session
 	const siteVisitRequestCheckbox = {
 		type: 'checkboxes',
 		parameters: {
-			name: 'site-visit-request',
+			name: 'siteVisitRequest',
 			idPrefix: 'site-visit-request',
 			items: [
 				{

--- a/appeals/web/src/server/appeals/appeal-details/interested-party-comments/view-and-review/page-components/review.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/interested-party-comments/view-and-review/page-components/review.mapper.js
@@ -23,7 +23,7 @@ export function reviewInterestedPartyCommentPage(appealDetails, comment, session
 	const siteVisitRequestCheckbox = {
 		type: 'checkboxes',
 		parameters: {
-			name: 'siteVisitRequest',
+			name: 'siteVisitRequested',
 			idPrefix: 'site-visit-request',
 			items: [
 				{

--- a/appeals/web/src/server/appeals/appeal-details/interested-party-comments/view-and-review/page-components/review.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/interested-party-comments/view-and-review/page-components/review.mapper.js
@@ -27,7 +27,7 @@ export function reviewInterestedPartyCommentPage(appealDetails, comment, session
 			idPrefix: 'site-visit-request',
 			items: [
 				{
-					text: 'The comment includes a site visit request',
+					text: 'Comment includes a site visit request',
 					value: 'site-visit',
 					checked: comment?.siteVisitRequested
 				}

--- a/appeals/web/src/server/appeals/appeal-details/interested-party-comments/view-and-review/reject/reject.controller.js
+++ b/appeals/web/src/server/appeals/appeal-details/interested-party-comments/view-and-review/reject/reject.controller.js
@@ -57,26 +57,21 @@ export const postRejectInterestedPartyComment = async (request, response) => {
 
 	const rejectionReasons = mapRejectionReasonPayload(session.rejectIpComment);
 
-	try {
-		await updateRejectionReasons(apiClient, appealId, commentId, rejectionReasons);
-		await rejectInterestedPartyComment(
-			apiClient,
-			appealId,
-			commentId,
-			session.rejectIpComment.allowResubmit === 'yes'
-		);
+	await updateRejectionReasons(apiClient, appealId, commentId, rejectionReasons);
+	await rejectInterestedPartyComment(
+		apiClient,
+		appealId,
+		commentId,
+		session.rejectIpComment.allowResubmit === 'yes',
+		session.siteVisitRequested === 'site-visit'
+	);
 
-		addNotificationBannerToSession(session, 'interestedPartyCommentsRejectedSuccess', appealId);
+	addNotificationBannerToSession(session, 'interestedPartyCommentsRejectedSuccess', appealId);
 
-		delete session.rejectIpComment;
+	delete session.rejectIpComment;
+	delete session.siteVisitRequested;
 
-		return response.redirect(
-			`/appeals-service/appeal-details/${appealId}/interested-party-comments`
-		);
-	} catch (error) {
-		logger.error(error);
-		return response.status(500).render('app/500.njk');
-	}
+	return response.redirect(`/appeals-service/appeal-details/${appealId}/interested-party-comments`);
 };
 
 /**

--- a/appeals/web/src/server/appeals/appeal-details/interested-party-comments/view-and-review/reject/reject.service.js
+++ b/appeals/web/src/server/appeals/appeal-details/interested-party-comments/view-and-review/reject/reject.service.js
@@ -20,13 +20,21 @@ export const updateRejectionReasons = (apiClient, appealId, commentId, rejection
  * @param {string} appealId
  * @param {string} commentId
  * @param {boolean} allowResubmit
+ * @param {boolean} [siteVisitRequested]
  * */
-export const rejectInterestedPartyComment = (apiClient, appealId, commentId, allowResubmit) =>
+export const rejectInterestedPartyComment = (
+	apiClient,
+	appealId,
+	commentId,
+	allowResubmit,
+	siteVisitRequested
+) =>
 	apiClient
 		.patch(`appeals/${appealId}/reps/${commentId}`, {
 			json: {
 				status: COMMENT_STATUS.INVALID,
-				allowResubmit
+				allowResubmit,
+				siteVisitRequested
 			}
 		})
 		.json();

--- a/appeals/web/src/server/appeals/appeal-details/interested-party-comments/view-and-review/reject/reject.service.js
+++ b/appeals/web/src/server/appeals/appeal-details/interested-party-comments/view-and-review/reject/reject.service.js
@@ -23,7 +23,7 @@ export const updateRejectionReasons = (apiClient, appealId, commentId, rejection
  * */
 export const rejectInterestedPartyComment = (apiClient, appealId, commentId, allowResubmit) =>
 	apiClient
-		.patch(`appeals/${appealId}/reps/${commentId}/status`, {
+		.patch(`appeals/${appealId}/reps/${commentId}`, {
 			json: {
 				status: COMMENT_STATUS.INVALID,
 				allowResubmit

--- a/appeals/web/src/server/appeals/appeal-details/interested-party-comments/view-and-review/view-and-review.controller.js
+++ b/appeals/web/src/server/appeals/appeal-details/interested-party-comments/view-and-review/view-and-review.controller.js
@@ -47,7 +47,7 @@ export const postReviewInterestedPartyComment = async (request, response, next) 
 		return renderReviewInterestedPartyComment(request, response, next);
 	}
 
-	session.siteVisitRequest = body.siteVisitRequest;
+	session.siteVisitRequested = body.siteVisitRequested;
 
 	if (status === COMMENT_STATUS.VALID_REQUIRES_REDACTION) {
 		return response.redirect(
@@ -66,7 +66,7 @@ export const postReviewInterestedPartyComment = async (request, response, next) 
 		appealId,
 		commentId,
 		status,
-		body.siteVisitRequest === 'site-visit'
+		body.siteVisitRequested === 'site-visit'
 	);
 
 	addNotificationBannerToSession(session, 'interestedPartyCommentsValidSuccess', appealId);

--- a/appeals/web/src/server/appeals/appeal-details/interested-party-comments/view-and-review/view-and-review.controller.js
+++ b/appeals/web/src/server/appeals/appeal-details/interested-party-comments/view-and-review/view-and-review.controller.js
@@ -1,4 +1,3 @@
-import logger from '#lib/logger.js';
 import { addNotificationBannerToSession } from '#lib/session-utilities.js';
 import { COMMENT_STATUS } from '@pins/appeals/constants/common.js';
 import {
@@ -35,42 +34,35 @@ export const renderReviewInterestedPartyComment = render(
  * @type {import('@pins/express').RenderHandler<any, any, any>}
  */
 export const postReviewInterestedPartyComment = async (request, response, next) => {
-	try {
-		const {
-			errors,
-			params: { appealId, commentId },
-			body: { status },
-			apiClient,
-			session
-		} = request;
+	const {
+		errors,
+		params: { appealId, commentId },
+		body: { status },
+		apiClient,
+		session
+	} = request;
 
-		if (errors) {
-			return renderReviewInterestedPartyComment(request, response, next);
-		}
-
-		if (status === COMMENT_STATUS.VALID_REQUIRES_REDACTION) {
-			return response.redirect(
-				`/appeals-service/appeal-details/${appealId}/interested-party-comments/${commentId}/redact`
-			);
-		}
-
-		if (status === COMMENT_STATUS.INVALID) {
-			return response.redirect(
-				`/appeals-service/appeal-details/${appealId}/interested-party-comments/${commentId}/reject/select-reason`
-			);
-		}
-
-		await patchInterestedPartyCommentStatus(apiClient, appealId, commentId, status);
-
-		addNotificationBannerToSession(session, 'interestedPartyCommentsValidSuccess', appealId);
-
-		return response.redirect(
-			`/appeals-service/appeal-details/${appealId}/interested-party-comments`
-		);
-	} catch (error) {
-		logger.error(error);
-		return response.status(500).render('app/500.njk');
+	if (errors) {
+		return renderReviewInterestedPartyComment(request, response, next);
 	}
+
+	if (status === COMMENT_STATUS.VALID_REQUIRES_REDACTION) {
+		return response.redirect(
+			`/appeals-service/appeal-details/${appealId}/interested-party-comments/${commentId}/redact`
+		);
+	}
+
+	if (status === COMMENT_STATUS.INVALID) {
+		return response.redirect(
+			`/appeals-service/appeal-details/${appealId}/interested-party-comments/${commentId}/reject/select-reason`
+		);
+	}
+
+	await patchInterestedPartyCommentStatus(apiClient, appealId, commentId, status);
+
+	addNotificationBannerToSession(session, 'interestedPartyCommentsValidSuccess', appealId);
+
+	return response.redirect(`/appeals-service/appeal-details/${appealId}/interested-party-comments`);
 };
 
 /** @type {import('@pins/express').RequestHandler<Response>} */

--- a/appeals/web/src/server/appeals/appeal-details/interested-party-comments/view-and-review/view-and-review.controller.js
+++ b/appeals/web/src/server/appeals/appeal-details/interested-party-comments/view-and-review/view-and-review.controller.js
@@ -61,7 +61,13 @@ export const postReviewInterestedPartyComment = async (request, response, next) 
 		);
 	}
 
-	await patchInterestedPartyCommentStatus(apiClient, appealId, commentId, status);
+	await patchInterestedPartyCommentStatus(
+		apiClient,
+		appealId,
+		commentId,
+		status,
+		body.siteVisitRequest === 'site-visit'
+	);
 
 	addNotificationBannerToSession(session, 'interestedPartyCommentsValidSuccess', appealId);
 

--- a/appeals/web/src/server/appeals/appeal-details/interested-party-comments/view-and-review/view-and-review.controller.js
+++ b/appeals/web/src/server/appeals/appeal-details/interested-party-comments/view-and-review/view-and-review.controller.js
@@ -39,12 +39,15 @@ export const postReviewInterestedPartyComment = async (request, response, next) 
 		params: { appealId, commentId },
 		body: { status },
 		apiClient,
-		session
+		session,
+		body
 	} = request;
 
 	if (errors) {
 		return renderReviewInterestedPartyComment(request, response, next);
 	}
+
+	session.siteVisitRequest = body.siteVisitRequest;
 
 	if (status === COMMENT_STATUS.VALID_REQUIRES_REDACTION) {
 		return response.redirect(

--- a/appeals/web/src/server/appeals/appeal-details/interested-party-comments/view-and-review/view-and-review.service.js
+++ b/appeals/web/src/server/appeals/appeal-details/interested-party-comments/view-and-review/view-and-review.service.js
@@ -3,17 +3,17 @@
  * @param {string} appealId
  * @param {string} commentId
  * @param {string} status
- * @param {boolean} [siteVisitRequest]
+ * @param {boolean} [siteVisitRequested]
  * */
 export const patchInterestedPartyCommentStatus = (
 	apiClient,
 	appealId,
 	commentId,
 	status,
-	siteVisitRequest
+	siteVisitRequested
 ) =>
 	apiClient
 		.patch(`appeals/${appealId}/reps/${commentId}`, {
-			json: { status, siteVisitRequest }
+			json: { status, siteVisitRequested }
 		})
 		.json();

--- a/appeals/web/src/server/appeals/appeal-details/interested-party-comments/view-and-review/view-and-review.service.js
+++ b/appeals/web/src/server/appeals/appeal-details/interested-party-comments/view-and-review/view-and-review.service.js
@@ -3,12 +3,17 @@
  * @param {string} appealId
  * @param {string} commentId
  * @param {string} status
+ * @param {boolean} [siteVisitRequest]
  * */
-export const patchInterestedPartyCommentStatus = (apiClient, appealId, commentId, status) =>
+export const patchInterestedPartyCommentStatus = (
+	apiClient,
+	appealId,
+	commentId,
+	status,
+	siteVisitRequest
+) =>
 	apiClient
-		.patch(`appeals/${appealId}/reps/${commentId}/status`, {
-			json: {
-				status
-			}
+		.patch(`appeals/${appealId}/reps/${commentId}`, {
+			json: { status, siteVisitRequest }
 		})
 		.json();

--- a/appeals/web/src/server/appeals/appeal-details/representations/representations.service.js
+++ b/appeals/web/src/server/appeals/appeal-details/representations/representations.service.js
@@ -48,7 +48,7 @@ export const getSingularRepresentationByType = async (apiClient, appealId, type)
  * @returns {Promise<Representation>}
  * */
 export const setRepresentationStatus = (apiClient, appealId, repId, status) =>
-	apiClient.patch(`appeals/${appealId}/reps/${repId}/status`, { json: { status } }).json();
+	apiClient.patch(`appeals/${appealId}/reps/${repId}`, { json: { status } }).json();
 
 /**
  * @param {import('got').Got} apiClient


### PR DESCRIPTION
## Describe your changes

* refactor(api): use a single patch endpoint for representations
* refactor(web): change consumers of representation API to use new patch
* refactor(web): remove try-catch block from postReviewInterestedPartyComment
* feat(web): save siteVisitRequest selection to session
* feat(web): pass siteVisitRequest value to the API when updating status
* feat(web): set siteVisitedRequested in redact and accept flow
* fix(web): update site visit input copy to match design
* test(api): update unit tests to match new representation patch endpoint
* feat(api): create compound unique constraint for address/appeal
* feat(api): connect IP comment address as neighbouring site
* test(web): update test snapshots
* test(web): update test API mocks to match new patch endpoint

Try-catch blocks can be removed as errors are handled in the same way in a middleware at the top level of the app.

## Issue ticket number and link
[A2-766](https://pins-ds.atlassian.net/browse/A2-766)


[A2-766]: https://pins-ds.atlassian.net/browse/A2-766?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ