### PR TITLE
fix(web): Read redaction status and date submitted from session

### DIFF
--- a/appeals/web/src/server/appeals/appeal-details/interested-party-comments/add-document/add-document.router.js
+++ b/appeals/web/src/server/appeals/appeal-details/interested-party-comments/add-document/add-document.router.js
@@ -36,7 +36,7 @@ router.post(
 	createDateInputFieldsValidator('', '', 'day', 'month', 'year'),
 	createDateInputDateValidityValidator('', '', 'day', 'month', 'year'),
 	createDateInputDateInPastOrTodayValidator('', '', 'day', 'month', 'year'),
-	saveBodyToSession('addDocument'),
+	saveBodyToSession('/'),
 	asyncHandler(postDateSubmitted)
 );
 

--- a/appeals/web/src/server/appeals/appeal-details/interested-party-comments/add-document/controller/date-submitted.js
+++ b/appeals/web/src/server/appeals/appeal-details/interested-party-comments/add-document/controller/date-submitted.js
@@ -2,7 +2,8 @@ import { postDateSubmittedFactory, renderDateSubmittedFactory } from '../../comm
 
 export const renderDateSubmitted = renderDateSubmittedFactory({
 	getBackLinkUrl: (appealDetails, comment) =>
-		`/appeals-service/appeal-details/${appealDetails.appealId}/interested-party-comments/${comment.id}/add-document/redaction-status`
+		`/appeals-service/appeal-details/${appealDetails.appealId}/interested-party-comments/${comment.id}/add-document/redaction-status`,
+	getValue: (request) => request.session.addDocument || request.body
 });
 
 export const postDateSubmitted = postDateSubmittedFactory({

--- a/appeals/web/src/server/appeals/appeal-details/interested-party-comments/add-document/controller/redaction-status.js
+++ b/appeals/web/src/server/appeals/appeal-details/interested-party-comments/add-document/controller/redaction-status.js
@@ -1,8 +1,13 @@
 import { postRedactionStatusFactory, renderRedactionStatusFactory } from '../../common/index.js';
+import { APPEAL_REDACTED_STATUS } from 'pins-data-model';
 
 export const renderRedactionStatus = renderRedactionStatusFactory({
 	getBackLinkUrl: (appealDetails, comment) =>
-		`/appeals-service/appeal-details/${appealDetails.appealId}/interested-party-comments/${comment.id}/add-document`
+		`/appeals-service/appeal-details/${appealDetails.appealId}/interested-party-comments/${comment.id}/add-document`,
+	getValue: (request) =>
+		request.session.addDocument?.redactionStatus ||
+		request.body.redactionStatus ||
+		APPEAL_REDACTED_STATUS.NO_REDACTION_REQUIRED
 });
 
 export const postRedactionStatus = postRedactionStatusFactory({

--- a/appeals/web/src/server/appeals/appeal-details/interested-party-comments/add-ip-comment/add-ip-comment.controller.js
+++ b/appeals/web/src/server/appeals/appeal-details/interested-party-comments/add-ip-comment/add-ip-comment.controller.js
@@ -114,7 +114,11 @@ export async function postUpload(request, response) {
 
 export const renderRedactionStatus = renderRedactionStatusFactory({
 	getBackLinkUrl: (appealDetails) =>
-		`/appeals-service/appeal-details/${appealDetails.appealId}/interested-party-comments/add/upload`
+		`/appeals-service/appeal-details/${appealDetails.appealId}/interested-party-comments/add/upload`,
+	getValue: (request) =>
+		request.session.addIpComment?.redactionStatus ||
+		request.body.redactionStatus ||
+		APPEAL_REDACTED_STATUS.NO_REDACTION_REQUIRED
 });
 
 export const postRedactionStatus = postRedactionStatusFactory({
@@ -125,7 +129,8 @@ export const postRedactionStatus = postRedactionStatusFactory({
 
 export const renderDateSubmitted = renderDateSubmittedFactory({
 	getBackLinkUrl: (appealDetails) =>
-		`/appeals-service/appeal-details/${appealDetails.appealId}/interested-party-comments/add/redaction-status`
+		`/appeals-service/appeal-details/${appealDetails.appealId}/interested-party-comments/add/redaction-status`,
+	getValue: (request) => request.session.addIpComment || request.body
 });
 
 export const postDateSubmitted = postDateSubmittedFactory({

--- a/appeals/web/src/server/appeals/appeal-details/interested-party-comments/common/date-submitted.js
+++ b/appeals/web/src/server/appeals/appeal-details/interested-party-comments/common/date-submitted.js
@@ -3,7 +3,8 @@ import { dateInput } from '#lib/mappers/index.js';
 
 /** @typedef {import("../../appeal-details.types.js").WebAppeal} Appeal */
 /** @typedef {import('#appeals/appeal-details/representations/types.js').Representation} Representation */
-/** @typedef {{ 'day': string, 'month': string, 'year': string }} ReqBody */
+/** @typedef {{ 'day': string, 'month': string, 'year': string }} RequestDate */
+/** @typedef {RequestDate} ReqBody */
 
 /**
  * @param {Appeal} appealDetails
@@ -31,14 +32,16 @@ export const mapper = (appealDetails, errors, date, backLinkUrl) => ({
 /**
  * @param {object} options
  * @param {(appealDetails: Appeal, comment: Representation) => string} options.getBackLinkUrl
+ * @param {(request: import('@pins/express').Request) => RequestDate} options.getValue
  * @returns {import('@pins/express').RenderHandler<{}, {}, ReqBody>}
  */
 export const renderDateSubmittedFactory =
-	({ getBackLinkUrl }) =>
+	({ getBackLinkUrl, getValue }) =>
 	(request, response) => {
 		const backLinkUrl = getBackLinkUrl(request.currentAppeal, request.currentRepresentation);
+		const value = getValue(request);
 
-		const pageContent = mapper(request.currentAppeal, request.errors, request.body, backLinkUrl);
+		const pageContent = mapper(request.currentAppeal, request.errors, value, backLinkUrl);
 
 		return response.status(request.errors ? 400 : 200).render('patterns/change-page.pattern.njk', {
 			errors: request.errors,

--- a/appeals/web/src/server/appeals/appeal-details/interested-party-comments/common/redaction-status.js
+++ b/appeals/web/src/server/appeals/appeal-details/interested-party-comments/common/redaction-status.js
@@ -16,17 +16,18 @@ export const name = 'redactionStatus';
 
 /**
  * @param {any} maybeRedactionStatus
- *	@returns {maybeRedactionStatus is keyof APPEAL_REDACTED_STATUS}
+ * @returns {maybeRedactionStatus is keyof APPEAL_REDACTED_STATUS}
  */
 export const isValidRedactionStatus = (maybeRedactionStatus) =>
 	Object.keys(statusFormatMap).includes(maybeRedactionStatus);
 /**
  * @param {Appeal} appealDetails
  * @param {import('@pins/express').ValidationErrors | undefined} errors
+ * @param {string} value
  * @param {string} backLinkUrl
  * @returns {PageContent}
  */
-const mapper = (appealDetails, errors, backLinkUrl) => ({
+const mapper = (appealDetails, errors, value, backLinkUrl) => ({
 	title: 'Redaction status',
 	backLinkUrl,
 	preHeading: `Appeal ${appealShortReference(appealDetails.appealReference)}`,
@@ -36,22 +37,24 @@ const mapper = (appealDetails, errors, backLinkUrl) => ({
 			legendText: 'Redaction status',
 			legendIsPageHeading: true,
 			items: Object.entries(statusFormatMap).map(([value, text]) => ({ value, text })),
-			value: APPEAL_REDACTED_STATUS.NO_REDACTION_REQUIRED
+			value
 		})
 	]
 });
 
 /**
  * @param {object} options
- * @param {(appealDetails: Appeal, comment: Representation) => string} options.getBackLinkUrl
+ * @param {(appealDetails: Appeal, comment: Representation) => string} options.getBackLinkUrl,
+ * @param {(request: import('@pins/express').Request) => string} options.getValue
  * @returns {import('@pins/express').RenderHandler<{}, {}, ReqBody>}
  */
 export const renderRedactionStatusFactory =
-	({ getBackLinkUrl }) =>
+	({ getBackLinkUrl, getValue }) =>
 	(request, response) => {
 		const backLinkUrl = getBackLinkUrl(request.currentAppeal, request.currentRepresentation);
+		const value = getValue(request);
 
-		const pageContent = mapper(request.currentAppeal, request.errors, backLinkUrl);
+		const pageContent = mapper(request.currentAppeal, request.errors, value, backLinkUrl);
 
 		return response.status(request.errors ? 400 : 200).render('patterns/change-page.pattern.njk', {
 			errors: request.errors,

--- a/appeals/web/src/server/appeals/appeal-details/interested-party-comments/interested-party-comments.router.js
+++ b/appeals/web/src/server/appeals/appeal-details/interested-party-comments/interested-party-comments.router.js
@@ -3,7 +3,7 @@ import { Router as createRouter } from 'express';
 import { validateAppeal } from '../appeal-details.middleware.js';
 import addIpCommentRouter from './add-ip-comment/add-ip-comment.router.js';
 import editIpCommentRouter from './edit-ip-comment/edit-ip-comment.router.js';
-import addDocumentRouter from './add-document/router.js';
+import addDocumentRouter from './add-document/add-document.router.js';
 import viewAndReviewIpCommentRouter from './view-and-review/view-and-review.router.js';
 import redactIpCommentRouter from './redact/redact.router.js';
 import * as controller from './interested-party-comments.controller.js';


### PR DESCRIPTION
## Describe your changes

Fixes a bug in IP doc flows that use the date submitted and redaction status components where session values were not displayed in the inputs.

## Issue ticket number and link
[Ticket](https://pins-ds.atlassian.net/browse/A2-1748)
