### PR TITLE
feat(appeals): amend copy on notifying relevant parties (a2-2047)

### DIFF
--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/__tests__/__snapshots__/lpa-questionnaire.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/__tests__/__snapshots__/lpa-questionnaire.test.js.snap
@@ -88,27 +88,38 @@ exports[`LPA Questionnaire review GET / should render review outcome form fields
         <div class="govuk-grid-column-full">
             <div class="govuk-summary-card">
                 <div class="govuk-summary-card__title-wrapper">
-                    <h2 class="govuk-summary-card__title">2. Notifying relevant parties of the application</h2>
+                    <h2 class="govuk-summary-card__title">2. Notifying relevant parties</h2>
                 </div>
                 <div class="govuk-summary-card__content">
                     <dl class="govuk-summary-list" id="notifications-summary">
-                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Who was notified</dt>
-                            <dd class="govuk-summary-list__value">
+                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Who was notified about the application</dt>
+                            <dd                             class="govuk-summary-list__value">
                                 <ul class="govuk-list pins-file-list">
                                     <li><span><div class="govuk-body govuk-!-margin-bottom-2">notifyingParties.docx</div><strong class="govuk-tag govuk-tag--yellow single-line">Virus scanning</strong></span>
                                     </li>
                                 </ul>
-                            </dd>
-                            <dd class="govuk-summary-list__actions">
-                                <ul class="govuk-summary-list__actions-list">
-                                    <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/manage-documents/2/"
-                                        data-cy="manage-notifying-parties"> Manage<span class="govuk-visually-hidden"> Who was notified</span></a>
-                                    </li>
-                                    <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/add-documents/2"
-                                        data-cy="add-notifying-parties"> Add<span class="govuk-visually-hidden"> Who was notified</span></a>
-                                    </li>
+                                </dd>
+                                <dd class="govuk-summary-list__actions">
+                                    <ul class="govuk-summary-list__actions-list">
+                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/manage-documents/2/"
+                                            data-cy="manage-notifying-parties"> Manage<span class="govuk-visually-hidden"> Who was notified about the application</span></a>
+                                        </li>
+                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/add-documents/2"
+                                            data-cy="add-notifying-parties"> Add<span class="govuk-visually-hidden"> Who was notified about the application</span></a>
+                                        </li>
+                                    </ul>
+                                </dd>
+                        </div>
+                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> How did you notify relevant parties about the application?</dt>
+                            <dd                             class="govuk-summary-list__value">
+                                <ul class="pins-summary-list-sublist">
+                                    <li>A site notice</li>
+                                    <li>Letter/email to interested parties</li>
                                 </ul>
-                            </dd>
+                                </dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/lpa-questionnaire/2/notification-methods/change"
+                                    data-cy="change-notification-methods"> Change<span class="govuk-visually-hidden"> How did you notify relevant parties about the application?</span></a>
+                                </dd>
                         </div>
                         <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Site notice</dt>
                             <dd class="govuk-summary-list__value">Not provided</dd>
@@ -124,17 +135,6 @@ exports[`LPA Questionnaire review GET / should render review outcome form fields
                             <dd                             class="govuk-summary-list__value">Not provided</dd>
                                 <dd class="govuk-summary-list__actions"><a class="govuk-link" href="#" data-cy="add-press-advert-notification"> Add<span class="govuk-visually-hidden"> Press advert notification</span></a>
                                 </dd>
-                        </div>
-                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Notification methods</dt>
-                            <dd class="govuk-summary-list__value">
-                                <ul>
-                                    <li>A site notice</li>
-                                    <li>Letter/email to interested parties</li>
-                                </ul>
-                            </dd>
-                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/lpa-questionnaire/2/notification-methods/change"
-                                data-cy="change-notification-methods"> Change<span class="govuk-visually-hidden"> Notification methods</span></a>
-                            </dd>
                         </div>
                     </dl>
                 </div>
@@ -446,27 +446,38 @@ exports[`LPA Questionnaire review GET / should render the LPA Questionnaire page
         <div class="govuk-grid-column-full">
             <div class="govuk-summary-card">
                 <div class="govuk-summary-card__title-wrapper">
-                    <h2 class="govuk-summary-card__title">2. Notifying relevant parties of the application</h2>
+                    <h2 class="govuk-summary-card__title">2. Notifying relevant parties</h2>
                 </div>
                 <div class="govuk-summary-card__content">
                     <dl class="govuk-summary-list" id="notifications-summary">
-                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Who was notified</dt>
-                            <dd class="govuk-summary-list__value">
+                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Who was notified about the application</dt>
+                            <dd                             class="govuk-summary-list__value">
                                 <ul class="govuk-list pins-file-list">
                                     <li><span><div class="govuk-body govuk-!-margin-bottom-2">notifyingParties.docx</div><strong class="govuk-tag govuk-tag--yellow single-line">Virus scanning</strong></span>
                                     </li>
                                 </ul>
-                            </dd>
-                            <dd class="govuk-summary-list__actions">
-                                <ul class="govuk-summary-list__actions-list">
-                                    <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/manage-documents/2/"
-                                        data-cy="manage-notifying-parties"> Manage<span class="govuk-visually-hidden"> Who was notified</span></a>
-                                    </li>
-                                    <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/add-documents/2"
-                                        data-cy="add-notifying-parties"> Add<span class="govuk-visually-hidden"> Who was notified</span></a>
-                                    </li>
+                                </dd>
+                                <dd class="govuk-summary-list__actions">
+                                    <ul class="govuk-summary-list__actions-list">
+                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/manage-documents/2/"
+                                            data-cy="manage-notifying-parties"> Manage<span class="govuk-visually-hidden"> Who was notified about the application</span></a>
+                                        </li>
+                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/add-documents/2"
+                                            data-cy="add-notifying-parties"> Add<span class="govuk-visually-hidden"> Who was notified about the application</span></a>
+                                        </li>
+                                    </ul>
+                                </dd>
+                        </div>
+                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> How did you notify relevant parties about the application?</dt>
+                            <dd                             class="govuk-summary-list__value">
+                                <ul class="pins-summary-list-sublist">
+                                    <li>A site notice</li>
+                                    <li>Letter/email to interested parties</li>
                                 </ul>
-                            </dd>
+                                </dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/notification-methods/change"
+                                    data-cy="change-notification-methods"> Change<span class="govuk-visually-hidden"> How did you notify relevant parties about the application?</span></a>
+                                </dd>
                         </div>
                         <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Site notice</dt>
                             <dd class="govuk-summary-list__value">Not provided</dd>
@@ -482,17 +493,6 @@ exports[`LPA Questionnaire review GET / should render the LPA Questionnaire page
                             <dd                             class="govuk-summary-list__value">Not provided</dd>
                                 <dd class="govuk-summary-list__actions"><a class="govuk-link" href="#" data-cy="add-press-advert-notification"> Add<span class="govuk-visually-hidden"> Press advert notification</span></a>
                                 </dd>
-                        </div>
-                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Notification methods</dt>
-                            <dd class="govuk-summary-list__value">
-                                <ul>
-                                    <li>A site notice</li>
-                                    <li>Letter/email to interested parties</li>
-                                </ul>
-                            </dd>
-                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/notification-methods/change"
-                                data-cy="change-notification-methods"> Change<span class="govuk-visually-hidden"> Notification methods</span></a>
-                            </dd>
                         </div>
                     </dl>
                 </div>
@@ -831,27 +831,38 @@ exports[`LPA Questionnaire review GET / with unchecked documents should render a
         <div class="govuk-grid-column-full">
             <div class="govuk-summary-card">
                 <div class="govuk-summary-card__title-wrapper">
-                    <h2 class="govuk-summary-card__title">2. Notifying relevant parties of the application</h2>
+                    <h2 class="govuk-summary-card__title">2. Notifying relevant parties</h2>
                 </div>
                 <div class="govuk-summary-card__content">
                     <dl class="govuk-summary-list" id="notifications-summary">
-                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Who was notified</dt>
-                            <dd class="govuk-summary-list__value">
+                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Who was notified about the application</dt>
+                            <dd                             class="govuk-summary-list__value">
                                 <ul class="govuk-list pins-file-list">
                                     <li><span><div class="govuk-body govuk-!-margin-bottom-2">notifyingParties.docx</div><strong class="govuk-tag govuk-tag--yellow single-line">Virus scanning</strong></span>
                                     </li>
                                 </ul>
-                            </dd>
-                            <dd class="govuk-summary-list__actions">
-                                <ul class="govuk-summary-list__actions-list">
-                                    <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/manage-documents/2/"
-                                        data-cy="manage-notifying-parties"> Manage<span class="govuk-visually-hidden"> Who was notified</span></a>
-                                    </li>
-                                    <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/add-documents/2"
-                                        data-cy="add-notifying-parties"> Add<span class="govuk-visually-hidden"> Who was notified</span></a>
-                                    </li>
+                                </dd>
+                                <dd class="govuk-summary-list__actions">
+                                    <ul class="govuk-summary-list__actions-list">
+                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/manage-documents/2/"
+                                            data-cy="manage-notifying-parties"> Manage<span class="govuk-visually-hidden"> Who was notified about the application</span></a>
+                                        </li>
+                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/add-documents/2"
+                                            data-cy="add-notifying-parties"> Add<span class="govuk-visually-hidden"> Who was notified about the application</span></a>
+                                        </li>
+                                    </ul>
+                                </dd>
+                        </div>
+                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> How did you notify relevant parties about the application?</dt>
+                            <dd                             class="govuk-summary-list__value">
+                                <ul class="pins-summary-list-sublist">
+                                    <li>A site notice</li>
+                                    <li>Letter/email to interested parties</li>
                                 </ul>
-                            </dd>
+                                </dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/notification-methods/change"
+                                    data-cy="change-notification-methods"> Change<span class="govuk-visually-hidden"> How did you notify relevant parties about the application?</span></a>
+                                </dd>
                         </div>
                         <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Site notice</dt>
                             <dd class="govuk-summary-list__value">Not provided</dd>
@@ -867,17 +878,6 @@ exports[`LPA Questionnaire review GET / with unchecked documents should render a
                             <dd                             class="govuk-summary-list__value">Not provided</dd>
                                 <dd class="govuk-summary-list__actions"><a class="govuk-link" href="#" data-cy="add-press-advert-notification"> Add<span class="govuk-visually-hidden"> Press advert notification</span></a>
                                 </dd>
-                        </div>
-                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Notification methods</dt>
-                            <dd class="govuk-summary-list__value">
-                                <ul>
-                                    <li>A site notice</li>
-                                    <li>Letter/email to interested parties</li>
-                                </ul>
-                            </dd>
-                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/notification-methods/change"
-                                data-cy="change-notification-methods"> Change<span class="govuk-visually-hidden"> Notification methods</span></a>
-                            </dd>
                         </div>
                     </dl>
                 </div>
@@ -1175,27 +1175,38 @@ exports[`LPA Questionnaire review GET / with unchecked documents should render a
         <div class="govuk-grid-column-full">
             <div class="govuk-summary-card">
                 <div class="govuk-summary-card__title-wrapper">
-                    <h2 class="govuk-summary-card__title">2. Notifying relevant parties of the application</h2>
+                    <h2 class="govuk-summary-card__title">2. Notifying relevant parties</h2>
                 </div>
                 <div class="govuk-summary-card__content">
                     <dl class="govuk-summary-list" id="notifications-summary">
-                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Who was notified</dt>
-                            <dd class="govuk-summary-list__value">
+                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Who was notified about the application</dt>
+                            <dd                             class="govuk-summary-list__value">
                                 <ul class="govuk-list pins-file-list">
                                     <li><span><div class="govuk-body govuk-!-margin-bottom-2">notifyingParties.docx</div><strong class="govuk-tag govuk-tag--yellow single-line">Virus scanning</strong></span>
                                     </li>
                                 </ul>
-                            </dd>
-                            <dd class="govuk-summary-list__actions">
-                                <ul class="govuk-summary-list__actions-list">
-                                    <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/manage-documents/2/"
-                                        data-cy="manage-notifying-parties"> Manage<span class="govuk-visually-hidden"> Who was notified</span></a>
-                                    </li>
-                                    <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/add-documents/2"
-                                        data-cy="add-notifying-parties"> Add<span class="govuk-visually-hidden"> Who was notified</span></a>
-                                    </li>
+                                </dd>
+                                <dd class="govuk-summary-list__actions">
+                                    <ul class="govuk-summary-list__actions-list">
+                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/manage-documents/2/"
+                                            data-cy="manage-notifying-parties"> Manage<span class="govuk-visually-hidden"> Who was notified about the application</span></a>
+                                        </li>
+                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/add-documents/2"
+                                            data-cy="add-notifying-parties"> Add<span class="govuk-visually-hidden"> Who was notified about the application</span></a>
+                                        </li>
+                                    </ul>
+                                </dd>
+                        </div>
+                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> How did you notify relevant parties about the application?</dt>
+                            <dd                             class="govuk-summary-list__value">
+                                <ul class="pins-summary-list-sublist">
+                                    <li>A site notice</li>
+                                    <li>Letter/email to interested parties</li>
                                 </ul>
-                            </dd>
+                                </dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/notification-methods/change"
+                                    data-cy="change-notification-methods"> Change<span class="govuk-visually-hidden"> How did you notify relevant parties about the application?</span></a>
+                                </dd>
                         </div>
                         <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Site notice</dt>
                             <dd class="govuk-summary-list__value">Not provided</dd>
@@ -1211,17 +1222,6 @@ exports[`LPA Questionnaire review GET / with unchecked documents should render a
                             <dd                             class="govuk-summary-list__value">Not provided</dd>
                                 <dd class="govuk-summary-list__actions"><a class="govuk-link" href="#" data-cy="add-press-advert-notification"> Add<span class="govuk-visually-hidden"> Press advert notification</span></a>
                                 </dd>
-                        </div>
-                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Notification methods</dt>
-                            <dd class="govuk-summary-list__value">
-                                <ul>
-                                    <li>A site notice</li>
-                                    <li>Letter/email to interested parties</li>
-                                </ul>
-                            </dd>
-                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/notification-methods/change"
-                                data-cy="change-notification-methods"> Change<span class="govuk-visually-hidden"> Notification methods</span></a>
-                            </dd>
                         </div>
                     </dl>
                 </div>
@@ -3588,27 +3588,38 @@ exports[`LPA Questionnaire review POST / should render LPA Questionnaire review 
         <div class="govuk-grid-column-full">
             <div class="govuk-summary-card">
                 <div class="govuk-summary-card__title-wrapper">
-                    <h2 class="govuk-summary-card__title">2. Notifying relevant parties of the application</h2>
+                    <h2 class="govuk-summary-card__title">2. Notifying relevant parties</h2>
                 </div>
                 <div class="govuk-summary-card__content">
                     <dl class="govuk-summary-list" id="notifications-summary">
-                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Who was notified</dt>
-                            <dd class="govuk-summary-list__value">
+                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Who was notified about the application</dt>
+                            <dd                             class="govuk-summary-list__value">
                                 <ul class="govuk-list pins-file-list">
                                     <li><span><div class="govuk-body govuk-!-margin-bottom-2">notifyingParties.docx</div><strong class="govuk-tag govuk-tag--yellow single-line">Virus scanning</strong></span>
                                     </li>
                                 </ul>
-                            </dd>
-                            <dd class="govuk-summary-list__actions">
-                                <ul class="govuk-summary-list__actions-list">
-                                    <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/manage-documents/2/"
-                                        data-cy="manage-notifying-parties"> Manage<span class="govuk-visually-hidden"> Who was notified</span></a>
-                                    </li>
-                                    <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/add-documents/2"
-                                        data-cy="add-notifying-parties"> Add<span class="govuk-visually-hidden"> Who was notified</span></a>
-                                    </li>
+                                </dd>
+                                <dd class="govuk-summary-list__actions">
+                                    <ul class="govuk-summary-list__actions-list">
+                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/manage-documents/2/"
+                                            data-cy="manage-notifying-parties"> Manage<span class="govuk-visually-hidden"> Who was notified about the application</span></a>
+                                        </li>
+                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/add-documents/2"
+                                            data-cy="add-notifying-parties"> Add<span class="govuk-visually-hidden"> Who was notified about the application</span></a>
+                                        </li>
+                                    </ul>
+                                </dd>
+                        </div>
+                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> How did you notify relevant parties about the application?</dt>
+                            <dd                             class="govuk-summary-list__value">
+                                <ul class="pins-summary-list-sublist">
+                                    <li>A site notice</li>
+                                    <li>Letter/email to interested parties</li>
                                 </ul>
-                            </dd>
+                                </dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/notification-methods/change"
+                                    data-cy="change-notification-methods"> Change<span class="govuk-visually-hidden"> How did you notify relevant parties about the application?</span></a>
+                                </dd>
                         </div>
                         <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Site notice</dt>
                             <dd class="govuk-summary-list__value">Not provided</dd>
@@ -3624,17 +3635,6 @@ exports[`LPA Questionnaire review POST / should render LPA Questionnaire review 
                             <dd                             class="govuk-summary-list__value">Not provided</dd>
                                 <dd class="govuk-summary-list__actions"><a class="govuk-link" href="#" data-cy="add-press-advert-notification"> Add<span class="govuk-visually-hidden"> Press advert notification</span></a>
                                 </dd>
-                        </div>
-                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Notification methods</dt>
-                            <dd class="govuk-summary-list__value">
-                                <ul>
-                                    <li>A site notice</li>
-                                    <li>Letter/email to interested parties</li>
-                                </ul>
-                            </dd>
-                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/notification-methods/change"
-                                data-cy="change-notification-methods"> Change<span class="govuk-visually-hidden"> Notification methods</span></a>
-                            </dd>
                         </div>
                     </dl>
                 </div>

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/__tests__/lpa-questionnaire.test.js
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/__tests__/lpa-questionnaire.test.js
@@ -476,7 +476,7 @@ describe('LPA Questionnaire review', () => {
 			expect(element.innerHTML).toMatchSnapshot();
 			expect(element.innerHTML).toContain('LPA questionnaire</h1>');
 			expect(element.innerHTML).toContain('1. Constraints, designations and other issues</h2>');
-			expect(element.innerHTML).toContain('2. Notifying relevant parties of the application</h2>');
+			expect(element.innerHTML).toContain('2. Notifying relevant parties</h2>');
 			expect(element.innerHTML).toContain('3. Consultation responses and representations</h2>');
 			expect(element.innerHTML).toContain(
 				'4. Planning officer’s report and supplementary documents</h2>'

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/lpa-questionnaire.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/lpa-questionnaire.mapper.js
@@ -815,7 +815,7 @@ const generateHASLpaQuestionnaireComponents = (mappedLPAQData, mappedAppealDetai
 		parameters: {
 			card: {
 				title: {
-					text: '2. Notifying relevant parties of the application'
+					text: '2. Notifying relevant parties'
 				}
 			},
 			attributes: {
@@ -823,10 +823,10 @@ const generateHASLpaQuestionnaireComponents = (mappedLPAQData, mappedAppealDetai
 			},
 			rows: [
 				mappedLPAQData.lpaq?.notifyingParties?.display.summaryListItem,
+				mappedLPAQData.lpaq?.notificationMethods?.display.summaryListItem,
 				mappedLPAQData.lpaq?.siteNotice?.display.summaryListItem,
 				mappedLPAQData.lpaq?.lettersToNeighbours?.display.summaryListItem,
-				mappedLPAQData.lpaq?.pressAdvert?.display.summaryListItem,
-				mappedLPAQData.lpaq?.notificationMethods?.display.summaryListItem
+				mappedLPAQData.lpaq?.pressAdvert?.display.summaryListItem
 			].filter(isDefined)
 		}
 	});
@@ -1004,15 +1004,15 @@ const generateS78LpaQuestionnaireComponents = (mappedLPAQData, mappedAppealDetai
 		parameters: {
 			card: {
 				title: {
-					text: '3. Notifying relevant parties of the application'
+					text: '3. Notifying relevant parties'
 				}
 			},
 			rows: [
 				mappedLPAQData.lpaq?.notifyingParties?.display.summaryListItem,
+				mappedLPAQData.lpaq?.notificationMethods?.display.summaryListItem,
 				mappedLPAQData.lpaq?.siteNotice?.display.summaryListItem,
 				mappedLPAQData.lpaq?.lettersToNeighbours?.display.summaryListItem,
-				mappedLPAQData.lpaq?.pressAdvert?.display.summaryListItem,
-				mappedLPAQData.lpaq?.notificationMethods?.display.summaryListItem
+				mappedLPAQData.lpaq?.pressAdvert?.display.summaryListItem
 			].filter(isDefined)
 		}
 	});

--- a/appeals/web/src/server/lib/display-page-formatter.js
+++ b/appeals/web/src/server/lib/display-page-formatter.js
@@ -45,8 +45,10 @@ export const formatListOfNotificationMethodsToHtml = (notificationMethods) => {
 		return '';
 	}
 	// TODO: check LPANotificationMethodDetails in SingleAppellantCaseResponse
-	// @ts-ignore
-	return `<ul>${notificationMethods.map((method) => `<li>${method.name}</li>`).join('')}</ul>`;
+	return `<ul class="pins-summary-list-sublist">${notificationMethods
+		// @ts-ignore
+		.map((method) => `<li>${method.name}</li>`)
+		.join('')}</ul>`;
 };
 
 /**

--- a/appeals/web/src/server/lib/mappers/data/lpa-questionnaire/submappers/map-notification-methods.js
+++ b/appeals/web/src/server/lib/mappers/data/lpa-questionnaire/submappers/map-notification-methods.js
@@ -5,7 +5,7 @@ import { formatListOfNotificationMethodsToHtml } from '#lib/display-page-formatt
 export const mapNotificationMethods = ({ lpaQuestionnaireData, currentRoute, userHasUpdateCase }) =>
 	textSummaryListItem({
 		id: 'notification-methods',
-		text: 'Notification methods',
+		text: 'How did you notify relevant parties about the application?',
 		value: {
 			html: formatListOfNotificationMethodsToHtml(lpaQuestionnaireData.lpaNotificationMethods)
 		},

--- a/appeals/web/src/server/lib/mappers/data/lpa-questionnaire/submappers/map-notify-parties.js
+++ b/appeals/web/src/server/lib/mappers/data/lpa-questionnaire/submappers/map-notify-parties.js
@@ -4,7 +4,7 @@ import { documentInstruction } from '../common.js';
 export const mapNotifyingParties = ({ lpaQuestionnaireData, session }) =>
 	documentInstruction({
 		id: 'notifying-parties',
-		text: 'Who was notified',
+		text: 'Who was notified about the application',
 		folderInfo: lpaQuestionnaireData.documents.whoNotified,
 		lpaQuestionnaireData,
 		session

--- a/appeals/web/src/styles/7-components/_summary-list.scss
+++ b/appeals/web/src/styles/7-components/_summary-list.scss
@@ -33,3 +33,9 @@
 		}
 	}
 }
+
+.govuk-summary-list__value {
+	.pins-summary-list-sublist {
+		margin-block: auto;
+	}
+}


### PR DESCRIPTION
## Describe your changes

Please note that this affects section 2 for HAS and section 3 for S78.  (They are the same section)

WEB:
 - Amended copy in mappers as described within the ticket
 - Cleaned up padding around the unordered list in the "Notification methods" row
   
TESTING:
- WEB snapshots updated
- All WEB unit tests pass
- Manually tested within browser

## Issue ticket number and link

[A2-2047 WEB/API -Amend copy on section 2. Notifying relevant parties of the application of the LPA questionnaire](https://pins-ds.atlassian.net/browse/A2-2047)

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [x] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [x] I have included unit tests to cover any testable code changes
