### PR TITLE
feat(appeals): use data-model 1.9.6 for reps

### DIFF
--- a/appeals/api/package.json
+++ b/appeals/api/package.json
@@ -70,7 +70,7 @@
     "rhea": "3.0.1",
     "swagger-ui-express": "^5.0.1",
     "xstate": "4.32.1",
-    "pins-data-model": "github:Planning-Inspectorate/data-model#1.9.4"
+    "pins-data-model": "github:Planning-Inspectorate/data-model#1.9.6"
   },
   "devDependencies": {
     "@types/express": "^4.17.13",

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
 				"joi": "^17.7.0",
 				"node-cache": "^5.1.2",
 				"nodemon": "3.0.3",
-				"pins-data-model": "github:Planning-Inspectorate/data-model#1.9.4"
+				"pins-data-model": "github:Planning-Inspectorate/data-model#1.9.6"
 			},
 			"devDependencies": {
 				"@commitlint/cli": "17.0.1",
@@ -77,7 +77,7 @@
 				"pino": "^8.1.0",
 				"pino-http": "^8.1.0",
 				"pino-pretty": "^8.1.0",
-				"pins-data-model": "github:Planning-Inspectorate/data-model#1.9.4",
+				"pins-data-model": "github:Planning-Inspectorate/data-model#1.9.6",
 				"rhea": "3.0.1",
 				"swagger-ui-express": "^5.0.1",
 				"xstate": "4.32.1"
@@ -21066,8 +21066,8 @@
 			"license": "MIT"
 		},
 		"node_modules/pins-data-model": {
-			"version": "1.9.4",
-			"resolved": "git+ssh://git@github.com/Planning-Inspectorate/data-model.git#b41c388375519b6f6645106c5ff5ce1eb856587b",
+			"version": "1.9.6",
+			"resolved": "git+ssh://git@github.com/Planning-Inspectorate/data-model.git#5086a6e3ebb0843de413eb11b8e6fa2cafbb8b8e",
 			"integrity": "sha512-xk2gyAS0kAzFkiOWmo2pKvKAkQno2nER/buABJbmyVgIBsBGNSb7gQ91TmZOyn4aNEI90Q4Gxcq5w9q4+RyMpw==",
 			"license": "MIT",
 			"dependencies": {
@@ -30518,7 +30518,7 @@
 				"pino": "^8.1.0",
 				"pino-http": "^8.1.0",
 				"pino-pretty": "^8.1.0",
-				"pins-data-model": "github:Planning-Inspectorate/data-model#1.9.4",
+				"pins-data-model": "github:Planning-Inspectorate/data-model#1.9.6",
 				"prisma": "4.16.1",
 				"rhea": "3.0.1",
 				"rimraf": "^3.0.2",
@@ -41878,9 +41878,9 @@
 			"version": "4.0.0"
 		},
 		"pins-data-model": {
-			"version": "git+ssh://git@github.com/Planning-Inspectorate/data-model.git#b41c388375519b6f6645106c5ff5ce1eb856587b",
+			"version": "git+ssh://git@github.com/Planning-Inspectorate/data-model.git#5086a6e3ebb0843de413eb11b8e6fa2cafbb8b8e",
 			"integrity": "sha512-xk2gyAS0kAzFkiOWmo2pKvKAkQno2nER/buABJbmyVgIBsBGNSb7gQ91TmZOyn4aNEI90Q4Gxcq5w9q4+RyMpw==",
-			"from": "pins-data-model@github:Planning-Inspectorate/data-model#1.9.4",
+			"from": "pins-data-model@github:Planning-Inspectorate/data-model#1.9.6",
 			"requires": {
 				"jsonc-parser": "^3.2.0"
 			}

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
 		"joi": "^17.7.0",
 		"node-cache": "^5.1.2",
 		"nodemon": "3.0.3",
-		"pins-data-model": "github:Planning-Inspectorate/data-model#1.9.4"
+		"pins-data-model": "github:Planning-Inspectorate/data-model#1.9.6"
 	},
 	"devDependencies": {
 		"@commitlint/cli": "17.0.1",


### PR DESCRIPTION
Upgrades the data model version used to 1.9.6.
This version include schemas for representation entities.
