### PR TITLE
feat(web): lpa statements set new date page addition

### DIFF
--- a/appeals/web/src/server/appeals/appeal-details/representations/lpa-statement/incomplete/incomplete.controller.js
+++ b/appeals/web/src/server/appeals/appeal-details/representations/lpa-statement/incomplete/incomplete.controller.js
@@ -8,6 +8,7 @@ import { getRepresentationRejectionReasonOptions } from '../../representations.s
 import { ensureArray } from '#lib/array-utilities.js';
 import { buildHtmUnorderedList } from '#lib/nunjucks-template-builders/tag-builders.js';
 import { simpleHtmlComponent } from '#lib/mappers/index.js';
+import { dateISOStringToDisplayDate, addBusinessDays } from '#lib/dates.js';
 
 const statusFormatMap = {
 	[COMMENT_STATUS.INCOMPLETE]: 'Statement incomplete'
@@ -41,7 +42,9 @@ export const postReasons = async (request, response, next) => {
  * @param {import('@pins/express/types/express.js').RenderedResponse<any, any, Number>} response
  */
 export async function renderSetNewDate(request, response) {
-	const pageContent = await setNewDatePage(request.apiClient, request.currentAppeal);
+	const extendedDeadline = await addBusinessDays(request.apiClient, new Date(), 7);
+	const deadlineString = dateISOStringToDisplayDate(extendedDeadline.toISOString());
+	const pageContent = setNewDatePage(request.currentAppeal, deadlineString);
 
 	return response
 		.status(request.errors ? 400 : 200)

--- a/appeals/web/src/server/appeals/appeal-details/representations/lpa-statement/incomplete/incomplete.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/representations/lpa-statement/incomplete/incomplete.mapper.js
@@ -1,5 +1,4 @@
 import { appealShortReference } from '#lib/appeals-formatter.js';
-import { dateISOStringToDisplayDate, addBusinessDays } from '#lib/dates.js';
 import { yesNoInput } from '#lib/mappers/index.js';
 
 /** @typedef {import("#appeals/appeal-details/appeal-details.types.js").WebAppeal} Appeal */
@@ -23,14 +22,11 @@ export function rejectLpaStatementPage(appealDetails) {
 }
 
 /**
- * @param {import('got').Got} apiClient
  * @param {Appeal} appealDetails
- * @returns {Promise<PageContent>}
+ * @param {string} deadlineString
+ * @returns {PageContent}
  * */
-export async function setNewDatePage(apiClient, appealDetails) {
-	const extendedDeadline = await addBusinessDays(apiClient, new Date(), 7);
-	const deadlineString = dateISOStringToDisplayDate(extendedDeadline.toISOString());
-
+export function setNewDatePage(appealDetails, deadlineString) {
 	/** @type {PageContent} */
 	const pageContent = {
 		backLinkUrl: `/appeals-service/appeal-details/${appealDetails.appealId}/lpa-statement/incomplete/reasons`,

--- a/appeals/web/src/server/appeals/appeal-details/representations/lpa-statement/incomplete/incomplete.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/representations/lpa-statement/incomplete/incomplete.mapper.js
@@ -1,5 +1,6 @@
 import { appealShortReference } from '#lib/appeals-formatter.js';
 import { dateISOStringToDisplayDate, addBusinessDays } from '#lib/dates.js';
+import { yesNoInput } from '#lib/mappers/index.js';
 
 /** @typedef {import("#appeals/appeal-details/appeal-details.types.js").WebAppeal} Appeal */
 
@@ -33,31 +34,16 @@ export async function setNewDatePage(apiClient, appealDetails) {
 	/** @type {PageContent} */
 	const pageContent = {
 		backLinkUrl: `/appeals-service/appeal-details/${appealDetails.appealId}/lpa-statement/incomplete/reasons`,
-		heading: 'Do you want to allow the LPA to resubmit their statement?',
-		headingClasses: 'govuk-heading-l',
 		hint: `The LPA can resubmit their comments by ${deadlineString}`,
 		preHeading: `Appeal ${appealShortReference(appealDetails.appealReference)}`,
 		submitButtonProperties: {
 			text: 'Continue'
 		},
 		pageComponents: [
-			{
-				type: 'radios',
-				parameters: {
-					name: 'setNewDate',
-					idPrefix: 'set-new-date',
-					items: [
-						{
-							value: 'yes',
-							text: 'Yes'
-						},
-						{
-							value: 'no',
-							text: 'No'
-						}
-					]
-				}
-			}
+			yesNoInput({
+				name: 'setNewDate',
+				legendText: 'Do you want to allow the LPA to resubmit their statement?'
+			})
 		]
 	};
 

--- a/appeals/web/src/server/appeals/appeal-details/representations/lpa-statement/incomplete/incomplete.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/representations/lpa-statement/incomplete/incomplete.mapper.js
@@ -1,4 +1,5 @@
 import { appealShortReference } from '#lib/appeals-formatter.js';
+import { dateISOStringToDisplayDate, addBusinessDays } from '#lib/dates.js';
 
 /** @typedef {import("#appeals/appeal-details/appeal-details.types.js").WebAppeal} Appeal */
 
@@ -11,10 +12,53 @@ export function rejectLpaStatementPage(appealDetails) {
 
 	const pageContent = {
 		heading: 'Why is the statement incomplete?',
-		backLinkUrl: `/appeals-service/appeal-details/${appealDetails.appealId}/lpa-statement/incomplete/confirm`,
+		backLinkUrl: `/appeals-service/appeal-details/${appealDetails.appealId}/lpa-statement`,
 		preHeading: `Appeal ${shortReference}`,
 		hint: 'Select all that apply.',
 		headingClasses: 'govuk-heading-l'
+	};
+
+	return pageContent;
+}
+
+/**
+ * @param {import('got').Got} apiClient
+ * @param {Appeal} appealDetails
+ * @returns {Promise<PageContent>}
+ * */
+export async function setNewDatePage(apiClient, appealDetails) {
+	const extendedDeadline = await addBusinessDays(apiClient, new Date(), 7);
+	const deadlineString = dateISOStringToDisplayDate(extendedDeadline.toISOString());
+
+	/** @type {PageContent} */
+	const pageContent = {
+		backLinkUrl: `/appeals-service/appeal-details/${appealDetails.appealId}/lpa-statement/incomplete/reasons`,
+		heading: 'Do you want to allow the LPA to resubmit their statement?',
+		headingClasses: 'govuk-heading-l',
+		hint: `The LPA can resubmit their comments by ${deadlineString}`,
+		preHeading: `Appeal ${appealShortReference(appealDetails.appealReference)}`,
+		submitButtonProperties: {
+			text: 'Continue'
+		},
+		pageComponents: [
+			{
+				type: 'radios',
+				parameters: {
+					name: 'setNewDate',
+					idPrefix: 'set-new-date',
+					items: [
+						{
+							value: 'yes',
+							text: 'Yes'
+						},
+						{
+							value: 'no',
+							text: 'No'
+						}
+					]
+				}
+			}
+		]
 	};
 
 	return pageContent;

--- a/appeals/web/src/server/appeals/appeal-details/representations/lpa-statement/incomplete/incomplete.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/representations/lpa-statement/incomplete/incomplete.mapper.js
@@ -34,7 +34,6 @@ export async function setNewDatePage(apiClient, appealDetails) {
 	/** @type {PageContent} */
 	const pageContent = {
 		backLinkUrl: `/appeals-service/appeal-details/${appealDetails.appealId}/lpa-statement/incomplete/reasons`,
-		hint: `The LPA can resubmit their comments by ${deadlineString}`,
 		preHeading: `Appeal ${appealShortReference(appealDetails.appealReference)}`,
 		submitButtonProperties: {
 			text: 'Continue'
@@ -42,7 +41,8 @@ export async function setNewDatePage(apiClient, appealDetails) {
 		pageComponents: [
 			yesNoInput({
 				name: 'setNewDate',
-				legendText: 'Do you want to allow the LPA to resubmit their statement?'
+				legendText: 'Do you want to allow the LPA to resubmit their statement?',
+				hint: `The LPA can resubmit their comments by ${deadlineString}`
 			})
 		]
 	};

--- a/appeals/web/src/server/appeals/appeal-details/representations/lpa-statement/incomplete/incomplete.router.js
+++ b/appeals/web/src/server/appeals/appeal-details/representations/lpa-statement/incomplete/incomplete.router.js
@@ -1,14 +1,24 @@
 import { Router } from 'express';
-import { postReasons, renderCheckYourAnswers, renderReasons } from './incomplete.controller.js';
+import {
+	postReasons,
+	renderCheckYourAnswers,
+	renderReasons,
+	renderSetNewDate,
+	postSetNewDate
+} from './incomplete.controller.js';
 import {
 	validateRejectionReasonTextItems,
 	validateRejectReason
 } from '../../common/validators/reject.validators.js';
+import { validateSetNewDate } from './incomplete.validator.js';
 
 const router = Router({ mergeParams: true });
 
 router.get('/reasons', renderReasons);
 router.post('/reasons', validateRejectReason, validateRejectionReasonTextItems, postReasons);
+
+router.get('/date', renderSetNewDate);
+router.post('/date', validateSetNewDate, postSetNewDate);
 
 router.get('/confirm', renderCheckYourAnswers);
 

--- a/appeals/web/src/server/appeals/appeal-details/representations/lpa-statement/incomplete/incomplete.validator.js
+++ b/appeals/web/src/server/appeals/appeal-details/representations/lpa-statement/incomplete/incomplete.validator.js
@@ -1,12 +1,6 @@
-import { createValidator } from '@pins/express';
-import { body } from 'express-validator';
+import { createYesNoRadioValidator } from '#lib/validators/radio.validator.js';
 
-export const validateSetNewDate = createValidator(
-	body('setNewDate')
-		.notEmpty()
-		.withMessage('Select yes if you want to allow the LPA to resubmit their statement')
-		.bail()
-		.isString()
-		.isAlpha()
-		.withMessage('Something went wrong')
+export const validateSetNewDate = createYesNoRadioValidator(
+	'setNewDate',
+	'Select yes if you want to allow the LPA to resubmit their statement'
 );

--- a/appeals/web/src/server/appeals/appeal-details/representations/lpa-statement/incomplete/incomplete.validator.js
+++ b/appeals/web/src/server/appeals/appeal-details/representations/lpa-statement/incomplete/incomplete.validator.js
@@ -1,0 +1,12 @@
+import { createValidator } from '@pins/express';
+import { body } from 'express-validator';
+
+export const validateSetNewDate = createValidator(
+	body('setNewDate')
+		.notEmpty()
+		.withMessage('Select yes if you want to allow the LPA to resubmit their statement')
+		.bail()
+		.isString()
+		.isAlpha()
+		.withMessage('Something went wrong')
+);


### PR DESCRIPTION
## Describe your changes
Implementation of the set new date page within the incomplete lpa statements journey. 
Also a few tweaks to routing of other pages on confirm / back links. 



fyi that while the success banner design (for when the CYA page is submitted) is included in this ticket the cya confirm will be part of ticket part 4. 
<!--
    Please include a summary of the change along with any relevant context.
    List any dependencies that are required for this change.
-->

## Issue ticket number and link

https://pins-ds.atlassian.net/browse/A2-1743