### PR TITLE
feat(appeals): add appeal notification letter row (a2-1985)

### DIFF
--- a/appeals/api/src/server/endpoints/appeals.d.ts
+++ b/appeals/api/src/server/endpoints/appeals.d.ts
@@ -302,6 +302,7 @@ interface SingleLPAQuestionnaireResponse {
 		eiaScreeningOpinion?: FolderInfo | null;
 		eiaScreeningDirection?: FolderInfo | null;
 		otherRelevantPolicies?: FolderInfo | null;
+		appealNotification?: FolderInfo | null;
 	};
 	validation: ValidationOutcomeResponse | null;
 	lpaNotificationMethods?: LPANotificationMethodDetails[] | null;

--- a/appeals/api/src/server/openapi-types.ts
+++ b/appeals/api/src/server/openapi-types.ts
@@ -402,6 +402,7 @@ export interface Folder {
 			redactionStatus: 'no_redaction_required' | 'not_redacted' | 'redacted';
 			virusCheckStatus: 'affected' | 'not_scanned' | 'scanned';
 			documentType?:
+				| 'appealNotification'
 				| 'appellantCaseCorrespondence'
 				| 'appellantCaseWithdrawalLetter'
 				| 'appellantCostsApplication'
@@ -496,6 +497,7 @@ export interface Folder {
 			redactionStatus: 'no_redaction_required' | 'not_redacted' | 'redacted';
 			virusCheckStatus: 'affected' | 'not_scanned' | 'scanned';
 			documentType?:
+				| 'appealNotification'
 				| 'appellantCaseCorrespondence'
 				| 'appellantCaseWithdrawalLetter'
 				| 'appellantCostsApplication'
@@ -2464,6 +2466,7 @@ export interface AppealDecision {
 			redactionStatus: 'no_redaction_required' | 'not_redacted' | 'redacted';
 			virusCheckStatus: 'affected' | 'not_scanned' | 'scanned';
 			documentType?:
+				| 'appealNotification'
 				| 'appellantCaseCorrespondence'
 				| 'appellantCaseWithdrawalLetter'
 				| 'appellantCostsApplication'
@@ -2558,6 +2561,7 @@ export interface AppealDecision {
 			redactionStatus: 'no_redaction_required' | 'not_redacted' | 'redacted';
 			virusCheckStatus: 'affected' | 'not_scanned' | 'scanned';
 			documentType?:
+				| 'appealNotification'
 				| 'appellantCaseCorrespondence'
 				| 'appellantCaseWithdrawalLetter'
 				| 'appellantCostsApplication'
@@ -2675,6 +2679,7 @@ export interface AppealWithdrawal {
 				redactionStatus: 'no_redaction_required' | 'not_redacted' | 'redacted';
 				virusCheckStatus: 'affected' | 'not_scanned' | 'scanned';
 				documentType?:
+					| 'appealNotification'
 					| 'appellantCaseCorrespondence'
 					| 'appellantCaseWithdrawalLetter'
 					| 'appellantCostsApplication'
@@ -2769,6 +2774,7 @@ export interface AppealWithdrawal {
 				redactionStatus: 'no_redaction_required' | 'not_redacted' | 'redacted';
 				virusCheckStatus: 'affected' | 'not_scanned' | 'scanned';
 				documentType?:
+					| 'appealNotification'
 					| 'appellantCaseCorrespondence'
 					| 'appellantCaseWithdrawalLetter'
 					| 'appellantCostsApplication'
@@ -2890,6 +2896,7 @@ export interface Document {
 		redactionStatus: 'no_redaction_required' | 'not_redacted' | 'redacted';
 		virusCheckStatus: 'affected' | 'not_scanned' | 'scanned';
 		documentType?:
+			| 'appealNotification'
 			| 'appellantCaseCorrespondence'
 			| 'appellantCaseWithdrawalLetter'
 			| 'appellantCostsApplication'
@@ -2984,6 +2991,7 @@ export interface Document {
 		redactionStatus: 'no_redaction_required' | 'not_redacted' | 'redacted';
 		virusCheckStatus: 'affected' | 'not_scanned' | 'scanned';
 		documentType?:
+			| 'appealNotification'
 			| 'appellantCaseCorrespondence'
 			| 'appellantCaseWithdrawalLetter'
 			| 'appellantCostsApplication'
@@ -3080,6 +3088,7 @@ export interface DocumentVersion {
 	redactionStatus: 'no_redaction_required' | 'not_redacted' | 'redacted';
 	virusCheckStatus: 'affected' | 'not_scanned' | 'scanned';
 	documentType?:
+		| 'appealNotification'
 		| 'appellantCaseCorrespondence'
 		| 'appellantCaseWithdrawalLetter'
 		| 'appellantCostsApplication'
@@ -3321,6 +3330,7 @@ export type AppellantCase = {
 					redactionStatus: 'no_redaction_required' | 'not_redacted' | 'redacted';
 					virusCheckStatus: 'affected' | 'not_scanned' | 'scanned';
 					documentType?:
+						| 'appealNotification'
 						| 'appellantCaseCorrespondence'
 						| 'appellantCaseWithdrawalLetter'
 						| 'appellantCostsApplication'
@@ -3415,6 +3425,7 @@ export type AppellantCase = {
 					redactionStatus: 'no_redaction_required' | 'not_redacted' | 'redacted';
 					virusCheckStatus: 'affected' | 'not_scanned' | 'scanned';
 					documentType?:
+						| 'appealNotification'
 						| 'appellantCaseCorrespondence'
 						| 'appellantCaseWithdrawalLetter'
 						| 'appellantCostsApplication'
@@ -3523,6 +3534,7 @@ export type AppellantCase = {
 					redactionStatus: 'no_redaction_required' | 'not_redacted' | 'redacted';
 					virusCheckStatus: 'affected' | 'not_scanned' | 'scanned';
 					documentType?:
+						| 'appealNotification'
 						| 'appellantCaseCorrespondence'
 						| 'appellantCaseWithdrawalLetter'
 						| 'appellantCostsApplication'
@@ -3617,6 +3629,7 @@ export type AppellantCase = {
 					redactionStatus: 'no_redaction_required' | 'not_redacted' | 'redacted';
 					virusCheckStatus: 'affected' | 'not_scanned' | 'scanned';
 					documentType?:
+						| 'appealNotification'
 						| 'appellantCaseCorrespondence'
 						| 'appellantCaseWithdrawalLetter'
 						| 'appellantCostsApplication'
@@ -3725,6 +3738,7 @@ export type AppellantCase = {
 					redactionStatus: 'no_redaction_required' | 'not_redacted' | 'redacted';
 					virusCheckStatus: 'affected' | 'not_scanned' | 'scanned';
 					documentType?:
+						| 'appealNotification'
 						| 'appellantCaseCorrespondence'
 						| 'appellantCaseWithdrawalLetter'
 						| 'appellantCostsApplication'
@@ -3819,6 +3833,7 @@ export type AppellantCase = {
 					redactionStatus: 'no_redaction_required' | 'not_redacted' | 'redacted';
 					virusCheckStatus: 'affected' | 'not_scanned' | 'scanned';
 					documentType?:
+						| 'appealNotification'
 						| 'appellantCaseCorrespondence'
 						| 'appellantCaseWithdrawalLetter'
 						| 'appellantCostsApplication'
@@ -3927,6 +3942,7 @@ export type AppellantCase = {
 					redactionStatus: 'no_redaction_required' | 'not_redacted' | 'redacted';
 					virusCheckStatus: 'affected' | 'not_scanned' | 'scanned';
 					documentType?:
+						| 'appealNotification'
 						| 'appellantCaseCorrespondence'
 						| 'appellantCaseWithdrawalLetter'
 						| 'appellantCostsApplication'
@@ -4021,6 +4037,7 @@ export type AppellantCase = {
 					redactionStatus: 'no_redaction_required' | 'not_redacted' | 'redacted';
 					virusCheckStatus: 'affected' | 'not_scanned' | 'scanned';
 					documentType?:
+						| 'appealNotification'
 						| 'appellantCaseCorrespondence'
 						| 'appellantCaseWithdrawalLetter'
 						| 'appellantCostsApplication'
@@ -4129,6 +4146,7 @@ export type AppellantCase = {
 					redactionStatus: 'no_redaction_required' | 'not_redacted' | 'redacted';
 					virusCheckStatus: 'affected' | 'not_scanned' | 'scanned';
 					documentType?:
+						| 'appealNotification'
 						| 'appellantCaseCorrespondence'
 						| 'appellantCaseWithdrawalLetter'
 						| 'appellantCostsApplication'
@@ -4223,6 +4241,7 @@ export type AppellantCase = {
 					redactionStatus: 'no_redaction_required' | 'not_redacted' | 'redacted';
 					virusCheckStatus: 'affected' | 'not_scanned' | 'scanned';
 					documentType?:
+						| 'appealNotification'
 						| 'appellantCaseCorrespondence'
 						| 'appellantCaseWithdrawalLetter'
 						| 'appellantCostsApplication'
@@ -4331,6 +4350,7 @@ export type AppellantCase = {
 					redactionStatus: 'no_redaction_required' | 'not_redacted' | 'redacted';
 					virusCheckStatus: 'affected' | 'not_scanned' | 'scanned';
 					documentType?:
+						| 'appealNotification'
 						| 'appellantCaseCorrespondence'
 						| 'appellantCaseWithdrawalLetter'
 						| 'appellantCostsApplication'
@@ -4425,6 +4445,7 @@ export type AppellantCase = {
 					redactionStatus: 'no_redaction_required' | 'not_redacted' | 'redacted';
 					virusCheckStatus: 'affected' | 'not_scanned' | 'scanned';
 					documentType?:
+						| 'appealNotification'
 						| 'appellantCaseCorrespondence'
 						| 'appellantCaseWithdrawalLetter'
 						| 'appellantCostsApplication'
@@ -4533,6 +4554,7 @@ export type AppellantCase = {
 					redactionStatus: 'no_redaction_required' | 'not_redacted' | 'redacted';
 					virusCheckStatus: 'affected' | 'not_scanned' | 'scanned';
 					documentType?:
+						| 'appealNotification'
 						| 'appellantCaseCorrespondence'
 						| 'appellantCaseWithdrawalLetter'
 						| 'appellantCostsApplication'
@@ -4627,6 +4649,7 @@ export type AppellantCase = {
 					redactionStatus: 'no_redaction_required' | 'not_redacted' | 'redacted';
 					virusCheckStatus: 'affected' | 'not_scanned' | 'scanned';
 					documentType?:
+						| 'appealNotification'
 						| 'appellantCaseCorrespondence'
 						| 'appellantCaseWithdrawalLetter'
 						| 'appellantCostsApplication'
@@ -4735,6 +4758,7 @@ export type AppellantCase = {
 					redactionStatus: 'no_redaction_required' | 'not_redacted' | 'redacted';
 					virusCheckStatus: 'affected' | 'not_scanned' | 'scanned';
 					documentType?:
+						| 'appealNotification'
 						| 'appellantCaseCorrespondence'
 						| 'appellantCaseWithdrawalLetter'
 						| 'appellantCostsApplication'
@@ -4829,6 +4853,7 @@ export type AppellantCase = {
 					redactionStatus: 'no_redaction_required' | 'not_redacted' | 'redacted';
 					virusCheckStatus: 'affected' | 'not_scanned' | 'scanned';
 					documentType?:
+						| 'appealNotification'
 						| 'appellantCaseCorrespondence'
 						| 'appellantCaseWithdrawalLetter'
 						| 'appellantCostsApplication'
@@ -4937,6 +4962,7 @@ export type AppellantCase = {
 					redactionStatus: 'no_redaction_required' | 'not_redacted' | 'redacted';
 					virusCheckStatus: 'affected' | 'not_scanned' | 'scanned';
 					documentType?:
+						| 'appealNotification'
 						| 'appellantCaseCorrespondence'
 						| 'appellantCaseWithdrawalLetter'
 						| 'appellantCostsApplication'
@@ -5031,6 +5057,7 @@ export type AppellantCase = {
 					redactionStatus: 'no_redaction_required' | 'not_redacted' | 'redacted';
 					virusCheckStatus: 'affected' | 'not_scanned' | 'scanned';
 					documentType?:
+						| 'appealNotification'
 						| 'appellantCaseCorrespondence'
 						| 'appellantCaseWithdrawalLetter'
 						| 'appellantCostsApplication'
@@ -5139,6 +5166,7 @@ export type AppellantCase = {
 					redactionStatus: 'no_redaction_required' | 'not_redacted' | 'redacted';
 					virusCheckStatus: 'affected' | 'not_scanned' | 'scanned';
 					documentType?:
+						| 'appealNotification'
 						| 'appellantCaseCorrespondence'
 						| 'appellantCaseWithdrawalLetter'
 						| 'appellantCostsApplication'
@@ -5233,6 +5261,7 @@ export type AppellantCase = {
 					redactionStatus: 'no_redaction_required' | 'not_redacted' | 'redacted';
 					virusCheckStatus: 'affected' | 'not_scanned' | 'scanned';
 					documentType?:
+						| 'appealNotification'
 						| 'appellantCaseCorrespondence'
 						| 'appellantCaseWithdrawalLetter'
 						| 'appellantCostsApplication'
@@ -5341,6 +5370,7 @@ export type AppellantCase = {
 					redactionStatus: 'no_redaction_required' | 'not_redacted' | 'redacted';
 					virusCheckStatus: 'affected' | 'not_scanned' | 'scanned';
 					documentType?:
+						| 'appealNotification'
 						| 'appellantCaseCorrespondence'
 						| 'appellantCaseWithdrawalLetter'
 						| 'appellantCostsApplication'
@@ -5435,6 +5465,7 @@ export type AppellantCase = {
 					redactionStatus: 'no_redaction_required' | 'not_redacted' | 'redacted';
 					virusCheckStatus: 'affected' | 'not_scanned' | 'scanned';
 					documentType?:
+						| 'appealNotification'
 						| 'appellantCaseCorrespondence'
 						| 'appellantCaseWithdrawalLetter'
 						| 'appellantCostsApplication'
@@ -5543,6 +5574,7 @@ export type AppellantCase = {
 					redactionStatus: 'no_redaction_required' | 'not_redacted' | 'redacted';
 					virusCheckStatus: 'affected' | 'not_scanned' | 'scanned';
 					documentType?:
+						| 'appealNotification'
 						| 'appellantCaseCorrespondence'
 						| 'appellantCaseWithdrawalLetter'
 						| 'appellantCostsApplication'
@@ -5637,6 +5669,7 @@ export type AppellantCase = {
 					redactionStatus: 'no_redaction_required' | 'not_redacted' | 'redacted';
 					virusCheckStatus: 'affected' | 'not_scanned' | 'scanned';
 					documentType?:
+						| 'appealNotification'
 						| 'appellantCaseCorrespondence'
 						| 'appellantCaseWithdrawalLetter'
 						| 'appellantCostsApplication'
@@ -5856,6 +5889,7 @@ export type LpaQuestionnaire = {
 					redactionStatus: 'no_redaction_required' | 'not_redacted' | 'redacted';
 					virusCheckStatus: 'affected' | 'not_scanned' | 'scanned';
 					documentType?:
+						| 'appealNotification'
 						| 'appellantCaseCorrespondence'
 						| 'appellantCaseWithdrawalLetter'
 						| 'appellantCostsApplication'
@@ -5950,6 +5984,7 @@ export type LpaQuestionnaire = {
 					redactionStatus: 'no_redaction_required' | 'not_redacted' | 'redacted';
 					virusCheckStatus: 'affected' | 'not_scanned' | 'scanned';
 					documentType?:
+						| 'appealNotification'
 						| 'appellantCaseCorrespondence'
 						| 'appellantCaseWithdrawalLetter'
 						| 'appellantCostsApplication'
@@ -6058,6 +6093,7 @@ export type LpaQuestionnaire = {
 					redactionStatus: 'no_redaction_required' | 'not_redacted' | 'redacted';
 					virusCheckStatus: 'affected' | 'not_scanned' | 'scanned';
 					documentType?:
+						| 'appealNotification'
 						| 'appellantCaseCorrespondence'
 						| 'appellantCaseWithdrawalLetter'
 						| 'appellantCostsApplication'
@@ -6152,6 +6188,7 @@ export type LpaQuestionnaire = {
 					redactionStatus: 'no_redaction_required' | 'not_redacted' | 'redacted';
 					virusCheckStatus: 'affected' | 'not_scanned' | 'scanned';
 					documentType?:
+						| 'appealNotification'
 						| 'appellantCaseCorrespondence'
 						| 'appellantCaseWithdrawalLetter'
 						| 'appellantCostsApplication'
@@ -6260,6 +6297,7 @@ export type LpaQuestionnaire = {
 					redactionStatus: 'no_redaction_required' | 'not_redacted' | 'redacted';
 					virusCheckStatus: 'affected' | 'not_scanned' | 'scanned';
 					documentType?:
+						| 'appealNotification'
 						| 'appellantCaseCorrespondence'
 						| 'appellantCaseWithdrawalLetter'
 						| 'appellantCostsApplication'
@@ -6354,6 +6392,7 @@ export type LpaQuestionnaire = {
 					redactionStatus: 'no_redaction_required' | 'not_redacted' | 'redacted';
 					virusCheckStatus: 'affected' | 'not_scanned' | 'scanned';
 					documentType?:
+						| 'appealNotification'
 						| 'appellantCaseCorrespondence'
 						| 'appellantCaseWithdrawalLetter'
 						| 'appellantCostsApplication'
@@ -6462,6 +6501,7 @@ export type LpaQuestionnaire = {
 					redactionStatus: 'no_redaction_required' | 'not_redacted' | 'redacted';
 					virusCheckStatus: 'affected' | 'not_scanned' | 'scanned';
 					documentType?:
+						| 'appealNotification'
 						| 'appellantCaseCorrespondence'
 						| 'appellantCaseWithdrawalLetter'
 						| 'appellantCostsApplication'
@@ -6556,6 +6596,7 @@ export type LpaQuestionnaire = {
 					redactionStatus: 'no_redaction_required' | 'not_redacted' | 'redacted';
 					virusCheckStatus: 'affected' | 'not_scanned' | 'scanned';
 					documentType?:
+						| 'appealNotification'
 						| 'appellantCaseCorrespondence'
 						| 'appellantCaseWithdrawalLetter'
 						| 'appellantCostsApplication'
@@ -6664,6 +6705,7 @@ export type LpaQuestionnaire = {
 					redactionStatus: 'no_redaction_required' | 'not_redacted' | 'redacted';
 					virusCheckStatus: 'affected' | 'not_scanned' | 'scanned';
 					documentType?:
+						| 'appealNotification'
 						| 'appellantCaseCorrespondence'
 						| 'appellantCaseWithdrawalLetter'
 						| 'appellantCostsApplication'
@@ -6758,6 +6800,7 @@ export type LpaQuestionnaire = {
 					redactionStatus: 'no_redaction_required' | 'not_redacted' | 'redacted';
 					virusCheckStatus: 'affected' | 'not_scanned' | 'scanned';
 					documentType?:
+						| 'appealNotification'
 						| 'appellantCaseCorrespondence'
 						| 'appellantCaseWithdrawalLetter'
 						| 'appellantCostsApplication'
@@ -6866,6 +6909,7 @@ export type LpaQuestionnaire = {
 					redactionStatus: 'no_redaction_required' | 'not_redacted' | 'redacted';
 					virusCheckStatus: 'affected' | 'not_scanned' | 'scanned';
 					documentType?:
+						| 'appealNotification'
 						| 'appellantCaseCorrespondence'
 						| 'appellantCaseWithdrawalLetter'
 						| 'appellantCostsApplication'
@@ -6960,6 +7004,7 @@ export type LpaQuestionnaire = {
 					redactionStatus: 'no_redaction_required' | 'not_redacted' | 'redacted';
 					virusCheckStatus: 'affected' | 'not_scanned' | 'scanned';
 					documentType?:
+						| 'appealNotification'
 						| 'appellantCaseCorrespondence'
 						| 'appellantCaseWithdrawalLetter'
 						| 'appellantCostsApplication'
@@ -7068,6 +7113,7 @@ export type LpaQuestionnaire = {
 					redactionStatus: 'no_redaction_required' | 'not_redacted' | 'redacted';
 					virusCheckStatus: 'affected' | 'not_scanned' | 'scanned';
 					documentType?:
+						| 'appealNotification'
 						| 'appellantCaseCorrespondence'
 						| 'appellantCaseWithdrawalLetter'
 						| 'appellantCostsApplication'
@@ -7162,6 +7208,7 @@ export type LpaQuestionnaire = {
 					redactionStatus: 'no_redaction_required' | 'not_redacted' | 'redacted';
 					virusCheckStatus: 'affected' | 'not_scanned' | 'scanned';
 					documentType?:
+						| 'appealNotification'
 						| 'appellantCaseCorrespondence'
 						| 'appellantCaseWithdrawalLetter'
 						| 'appellantCostsApplication'
@@ -7270,6 +7317,7 @@ export type LpaQuestionnaire = {
 					redactionStatus: 'no_redaction_required' | 'not_redacted' | 'redacted';
 					virusCheckStatus: 'affected' | 'not_scanned' | 'scanned';
 					documentType?:
+						| 'appealNotification'
 						| 'appellantCaseCorrespondence'
 						| 'appellantCaseWithdrawalLetter'
 						| 'appellantCostsApplication'
@@ -7364,6 +7412,7 @@ export type LpaQuestionnaire = {
 					redactionStatus: 'no_redaction_required' | 'not_redacted' | 'redacted';
 					virusCheckStatus: 'affected' | 'not_scanned' | 'scanned';
 					documentType?:
+						| 'appealNotification'
 						| 'appellantCaseCorrespondence'
 						| 'appellantCaseWithdrawalLetter'
 						| 'appellantCostsApplication'
@@ -7472,6 +7521,7 @@ export type LpaQuestionnaire = {
 					redactionStatus: 'no_redaction_required' | 'not_redacted' | 'redacted';
 					virusCheckStatus: 'affected' | 'not_scanned' | 'scanned';
 					documentType?:
+						| 'appealNotification'
 						| 'appellantCaseCorrespondence'
 						| 'appellantCaseWithdrawalLetter'
 						| 'appellantCostsApplication'
@@ -7566,6 +7616,7 @@ export type LpaQuestionnaire = {
 					redactionStatus: 'no_redaction_required' | 'not_redacted' | 'redacted';
 					virusCheckStatus: 'affected' | 'not_scanned' | 'scanned';
 					documentType?:
+						| 'appealNotification'
 						| 'appellantCaseCorrespondence'
 						| 'appellantCaseWithdrawalLetter'
 						| 'appellantCostsApplication'
@@ -7674,6 +7725,7 @@ export type LpaQuestionnaire = {
 					redactionStatus: 'no_redaction_required' | 'not_redacted' | 'redacted';
 					virusCheckStatus: 'affected' | 'not_scanned' | 'scanned';
 					documentType?:
+						| 'appealNotification'
 						| 'appellantCaseCorrespondence'
 						| 'appellantCaseWithdrawalLetter'
 						| 'appellantCostsApplication'
@@ -7768,6 +7820,7 @@ export type LpaQuestionnaire = {
 					redactionStatus: 'no_redaction_required' | 'not_redacted' | 'redacted';
 					virusCheckStatus: 'affected' | 'not_scanned' | 'scanned';
 					documentType?:
+						| 'appealNotification'
 						| 'appellantCaseCorrespondence'
 						| 'appellantCaseWithdrawalLetter'
 						| 'appellantCostsApplication'
@@ -7876,6 +7929,7 @@ export type LpaQuestionnaire = {
 					redactionStatus: 'no_redaction_required' | 'not_redacted' | 'redacted';
 					virusCheckStatus: 'affected' | 'not_scanned' | 'scanned';
 					documentType?:
+						| 'appealNotification'
 						| 'appellantCaseCorrespondence'
 						| 'appellantCaseWithdrawalLetter'
 						| 'appellantCostsApplication'
@@ -7970,6 +8024,7 @@ export type LpaQuestionnaire = {
 					redactionStatus: 'no_redaction_required' | 'not_redacted' | 'redacted';
 					virusCheckStatus: 'affected' | 'not_scanned' | 'scanned';
 					documentType?:
+						| 'appealNotification'
 						| 'appellantCaseCorrespondence'
 						| 'appellantCaseWithdrawalLetter'
 						| 'appellantCostsApplication'
@@ -8078,6 +8133,7 @@ export type LpaQuestionnaire = {
 					redactionStatus: 'no_redaction_required' | 'not_redacted' | 'redacted';
 					virusCheckStatus: 'affected' | 'not_scanned' | 'scanned';
 					documentType?:
+						| 'appealNotification'
 						| 'appellantCaseCorrespondence'
 						| 'appellantCaseWithdrawalLetter'
 						| 'appellantCostsApplication'
@@ -8172,6 +8228,7 @@ export type LpaQuestionnaire = {
 					redactionStatus: 'no_redaction_required' | 'not_redacted' | 'redacted';
 					virusCheckStatus: 'affected' | 'not_scanned' | 'scanned';
 					documentType?:
+						| 'appealNotification'
 						| 'appellantCaseCorrespondence'
 						| 'appellantCaseWithdrawalLetter'
 						| 'appellantCostsApplication'
@@ -8280,6 +8337,7 @@ export type LpaQuestionnaire = {
 					redactionStatus: 'no_redaction_required' | 'not_redacted' | 'redacted';
 					virusCheckStatus: 'affected' | 'not_scanned' | 'scanned';
 					documentType?:
+						| 'appealNotification'
 						| 'appellantCaseCorrespondence'
 						| 'appellantCaseWithdrawalLetter'
 						| 'appellantCostsApplication'
@@ -8374,6 +8432,7 @@ export type LpaQuestionnaire = {
 					redactionStatus: 'no_redaction_required' | 'not_redacted' | 'redacted';
 					virusCheckStatus: 'affected' | 'not_scanned' | 'scanned';
 					documentType?:
+						| 'appealNotification'
 						| 'appellantCaseCorrespondence'
 						| 'appellantCaseWithdrawalLetter'
 						| 'appellantCostsApplication'
@@ -8482,6 +8541,7 @@ export type LpaQuestionnaire = {
 					redactionStatus: 'no_redaction_required' | 'not_redacted' | 'redacted';
 					virusCheckStatus: 'affected' | 'not_scanned' | 'scanned';
 					documentType?:
+						| 'appealNotification'
 						| 'appellantCaseCorrespondence'
 						| 'appellantCaseWithdrawalLetter'
 						| 'appellantCostsApplication'
@@ -8576,6 +8636,7 @@ export type LpaQuestionnaire = {
 					redactionStatus: 'no_redaction_required' | 'not_redacted' | 'redacted';
 					virusCheckStatus: 'affected' | 'not_scanned' | 'scanned';
 					documentType?:
+						| 'appealNotification'
 						| 'appellantCaseCorrespondence'
 						| 'appellantCaseWithdrawalLetter'
 						| 'appellantCostsApplication'
@@ -8684,6 +8745,7 @@ export type LpaQuestionnaire = {
 					redactionStatus: 'no_redaction_required' | 'not_redacted' | 'redacted';
 					virusCheckStatus: 'affected' | 'not_scanned' | 'scanned';
 					documentType?:
+						| 'appealNotification'
 						| 'appellantCaseCorrespondence'
 						| 'appellantCaseWithdrawalLetter'
 						| 'appellantCostsApplication'
@@ -8778,6 +8840,7 @@ export type LpaQuestionnaire = {
 					redactionStatus: 'no_redaction_required' | 'not_redacted' | 'redacted';
 					virusCheckStatus: 'affected' | 'not_scanned' | 'scanned';
 					documentType?:
+						| 'appealNotification'
 						| 'appellantCaseCorrespondence'
 						| 'appellantCaseWithdrawalLetter'
 						| 'appellantCostsApplication'
@@ -8886,6 +8949,7 @@ export type LpaQuestionnaire = {
 					redactionStatus: 'no_redaction_required' | 'not_redacted' | 'redacted';
 					virusCheckStatus: 'affected' | 'not_scanned' | 'scanned';
 					documentType?:
+						| 'appealNotification'
 						| 'appellantCaseCorrespondence'
 						| 'appellantCaseWithdrawalLetter'
 						| 'appellantCostsApplication'
@@ -8980,6 +9044,7 @@ export type LpaQuestionnaire = {
 					redactionStatus: 'no_redaction_required' | 'not_redacted' | 'redacted';
 					virusCheckStatus: 'affected' | 'not_scanned' | 'scanned';
 					documentType?:
+						| 'appealNotification'
 						| 'appellantCaseCorrespondence'
 						| 'appellantCaseWithdrawalLetter'
 						| 'appellantCostsApplication'
@@ -9088,6 +9153,7 @@ export type LpaQuestionnaire = {
 					redactionStatus: 'no_redaction_required' | 'not_redacted' | 'redacted';
 					virusCheckStatus: 'affected' | 'not_scanned' | 'scanned';
 					documentType?:
+						| 'appealNotification'
 						| 'appellantCaseCorrespondence'
 						| 'appellantCaseWithdrawalLetter'
 						| 'appellantCostsApplication'
@@ -9182,6 +9248,7 @@ export type LpaQuestionnaire = {
 					redactionStatus: 'no_redaction_required' | 'not_redacted' | 'redacted';
 					virusCheckStatus: 'affected' | 'not_scanned' | 'scanned';
 					documentType?:
+						| 'appealNotification'
 						| 'appellantCaseCorrespondence'
 						| 'appellantCaseWithdrawalLetter'
 						| 'appellantCostsApplication'
@@ -9290,6 +9357,7 @@ export type LpaQuestionnaire = {
 					redactionStatus: 'no_redaction_required' | 'not_redacted' | 'redacted';
 					virusCheckStatus: 'affected' | 'not_scanned' | 'scanned';
 					documentType?:
+						| 'appealNotification'
 						| 'appellantCaseCorrespondence'
 						| 'appellantCaseWithdrawalLetter'
 						| 'appellantCostsApplication'
@@ -9384,6 +9452,7 @@ export type LpaQuestionnaire = {
 					redactionStatus: 'no_redaction_required' | 'not_redacted' | 'redacted';
 					virusCheckStatus: 'affected' | 'not_scanned' | 'scanned';
 					documentType?:
+						| 'appealNotification'
 						| 'appellantCaseCorrespondence'
 						| 'appellantCaseWithdrawalLetter'
 						| 'appellantCostsApplication'
@@ -9492,6 +9561,7 @@ export type LpaQuestionnaire = {
 					redactionStatus: 'no_redaction_required' | 'not_redacted' | 'redacted';
 					virusCheckStatus: 'affected' | 'not_scanned' | 'scanned';
 					documentType?:
+						| 'appealNotification'
 						| 'appellantCaseCorrespondence'
 						| 'appellantCaseWithdrawalLetter'
 						| 'appellantCostsApplication'
@@ -9586,6 +9656,7 @@ export type LpaQuestionnaire = {
 					redactionStatus: 'no_redaction_required' | 'not_redacted' | 'redacted';
 					virusCheckStatus: 'affected' | 'not_scanned' | 'scanned';
 					documentType?:
+						| 'appealNotification'
 						| 'appellantCaseCorrespondence'
 						| 'appellantCaseWithdrawalLetter'
 						| 'appellantCostsApplication'
@@ -9694,6 +9765,7 @@ export type LpaQuestionnaire = {
 					redactionStatus: 'no_redaction_required' | 'not_redacted' | 'redacted';
 					virusCheckStatus: 'affected' | 'not_scanned' | 'scanned';
 					documentType?:
+						| 'appealNotification'
 						| 'appellantCaseCorrespondence'
 						| 'appellantCaseWithdrawalLetter'
 						| 'appellantCostsApplication'
@@ -9788,6 +9860,7 @@ export type LpaQuestionnaire = {
 					redactionStatus: 'no_redaction_required' | 'not_redacted' | 'redacted';
 					virusCheckStatus: 'affected' | 'not_scanned' | 'scanned';
 					documentType?:
+						| 'appealNotification'
 						| 'appellantCaseCorrespondence'
 						| 'appellantCaseWithdrawalLetter'
 						| 'appellantCostsApplication'
@@ -10041,6 +10114,7 @@ export interface Appeal {
 				redactionStatus: 'no_redaction_required' | 'not_redacted' | 'redacted';
 				virusCheckStatus: 'affected' | 'not_scanned' | 'scanned';
 				documentType?:
+					| 'appealNotification'
 					| 'appellantCaseCorrespondence'
 					| 'appellantCaseWithdrawalLetter'
 					| 'appellantCostsApplication'
@@ -10135,6 +10209,7 @@ export interface Appeal {
 				redactionStatus: 'no_redaction_required' | 'not_redacted' | 'redacted';
 				virusCheckStatus: 'affected' | 'not_scanned' | 'scanned';
 				documentType?:
+					| 'appealNotification'
 					| 'appellantCaseCorrespondence'
 					| 'appellantCaseWithdrawalLetter'
 					| 'appellantCostsApplication'
@@ -10252,6 +10327,7 @@ export interface Appeal {
 				redactionStatus: 'no_redaction_required' | 'not_redacted' | 'redacted';
 				virusCheckStatus: 'affected' | 'not_scanned' | 'scanned';
 				documentType?:
+					| 'appealNotification'
 					| 'appellantCaseCorrespondence'
 					| 'appellantCaseWithdrawalLetter'
 					| 'appellantCostsApplication'
@@ -10346,6 +10422,7 @@ export interface Appeal {
 				redactionStatus: 'no_redaction_required' | 'not_redacted' | 'redacted';
 				virusCheckStatus: 'affected' | 'not_scanned' | 'scanned';
 				documentType?:
+					| 'appealNotification'
 					| 'appellantCaseCorrespondence'
 					| 'appellantCaseWithdrawalLetter'
 					| 'appellantCostsApplication'

--- a/appeals/api/src/server/openapi.json
+++ b/appeals/api/src/server/openapi.json
@@ -5464,6 +5464,7 @@
 										"documentType": {
 											"type": "string",
 											"enum": [
+												"appealNotification",
 												"appellantCaseCorrespondence",
 												"appellantCaseWithdrawalLetter",
 												"appellantCostsApplication",
@@ -5621,6 +5622,7 @@
 											"documentType": {
 												"type": "string",
 												"enum": [
+													"appealNotification",
 													"appellantCaseCorrespondence",
 													"appellantCaseWithdrawalLetter",
 													"appellantCostsApplication",
@@ -9949,6 +9951,7 @@
 										"documentType": {
 											"type": "string",
 											"enum": [
+												"appealNotification",
 												"appellantCaseCorrespondence",
 												"appellantCaseWithdrawalLetter",
 												"appellantCostsApplication",
@@ -10106,6 +10109,7 @@
 											"documentType": {
 												"type": "string",
 												"enum": [
+													"appealNotification",
 													"appellantCaseCorrespondence",
 													"appellantCaseWithdrawalLetter",
 													"appellantCostsApplication",
@@ -10329,6 +10333,7 @@
 												"documentType": {
 													"type": "string",
 													"enum": [
+														"appealNotification",
 														"appellantCaseCorrespondence",
 														"appellantCaseWithdrawalLetter",
 														"appellantCostsApplication",
@@ -10486,6 +10491,7 @@
 													"documentType": {
 														"type": "string",
 														"enum": [
+															"appealNotification",
 															"appellantCaseCorrespondence",
 															"appellantCaseWithdrawalLetter",
 															"appellantCostsApplication",
@@ -10715,6 +10721,7 @@
 							"documentType": {
 								"type": "string",
 								"enum": [
+									"appealNotification",
 									"appellantCaseCorrespondence",
 									"appellantCaseWithdrawalLetter",
 									"appellantCostsApplication",
@@ -10866,6 +10873,7 @@
 								"documentType": {
 									"type": "string",
 									"enum": [
+										"appealNotification",
 										"appellantCaseCorrespondence",
 										"appellantCaseWithdrawalLetter",
 										"appellantCostsApplication",
@@ -11018,6 +11026,7 @@
 					"documentType": {
 						"type": "string",
 						"enum": [
+							"appealNotification",
 							"appellantCaseCorrespondence",
 							"appellantCaseWithdrawalLetter",
 							"appellantCostsApplication",
@@ -11649,6 +11658,7 @@
 														"documentType": {
 															"type": "string",
 															"enum": [
+																"appealNotification",
 																"appellantCaseCorrespondence",
 																"appellantCaseWithdrawalLetter",
 																"appellantCostsApplication",
@@ -11806,6 +11816,7 @@
 															"documentType": {
 																"type": "string",
 																"enum": [
+																	"appealNotification",
 																	"appellantCaseCorrespondence",
 																	"appellantCaseWithdrawalLetter",
 																	"appellantCostsApplication",
@@ -12004,6 +12015,7 @@
 														"documentType": {
 															"type": "string",
 															"enum": [
+																"appealNotification",
 																"appellantCaseCorrespondence",
 																"appellantCaseWithdrawalLetter",
 																"appellantCostsApplication",
@@ -12161,6 +12173,7 @@
 															"documentType": {
 																"type": "string",
 																"enum": [
+																	"appealNotification",
 																	"appellantCaseCorrespondence",
 																	"appellantCaseWithdrawalLetter",
 																	"appellantCostsApplication",
@@ -12359,6 +12372,7 @@
 														"documentType": {
 															"type": "string",
 															"enum": [
+																"appealNotification",
 																"appellantCaseCorrespondence",
 																"appellantCaseWithdrawalLetter",
 																"appellantCostsApplication",
@@ -12516,6 +12530,7 @@
 															"documentType": {
 																"type": "string",
 																"enum": [
+																	"appealNotification",
 																	"appellantCaseCorrespondence",
 																	"appellantCaseWithdrawalLetter",
 																	"appellantCostsApplication",
@@ -12714,6 +12729,7 @@
 														"documentType": {
 															"type": "string",
 															"enum": [
+																"appealNotification",
 																"appellantCaseCorrespondence",
 																"appellantCaseWithdrawalLetter",
 																"appellantCostsApplication",
@@ -12871,6 +12887,7 @@
 															"documentType": {
 																"type": "string",
 																"enum": [
+																	"appealNotification",
 																	"appellantCaseCorrespondence",
 																	"appellantCaseWithdrawalLetter",
 																	"appellantCostsApplication",
@@ -13069,6 +13086,7 @@
 														"documentType": {
 															"type": "string",
 															"enum": [
+																"appealNotification",
 																"appellantCaseCorrespondence",
 																"appellantCaseWithdrawalLetter",
 																"appellantCostsApplication",
@@ -13226,6 +13244,7 @@
 															"documentType": {
 																"type": "string",
 																"enum": [
+																	"appealNotification",
 																	"appellantCaseCorrespondence",
 																	"appellantCaseWithdrawalLetter",
 																	"appellantCostsApplication",
@@ -13424,6 +13443,7 @@
 														"documentType": {
 															"type": "string",
 															"enum": [
+																"appealNotification",
 																"appellantCaseCorrespondence",
 																"appellantCaseWithdrawalLetter",
 																"appellantCostsApplication",
@@ -13581,6 +13601,7 @@
 															"documentType": {
 																"type": "string",
 																"enum": [
+																	"appealNotification",
 																	"appellantCaseCorrespondence",
 																	"appellantCaseWithdrawalLetter",
 																	"appellantCostsApplication",
@@ -13779,6 +13800,7 @@
 														"documentType": {
 															"type": "string",
 															"enum": [
+																"appealNotification",
 																"appellantCaseCorrespondence",
 																"appellantCaseWithdrawalLetter",
 																"appellantCostsApplication",
@@ -13936,6 +13958,7 @@
 															"documentType": {
 																"type": "string",
 																"enum": [
+																	"appealNotification",
 																	"appellantCaseCorrespondence",
 																	"appellantCaseWithdrawalLetter",
 																	"appellantCostsApplication",
@@ -14134,6 +14157,7 @@
 														"documentType": {
 															"type": "string",
 															"enum": [
+																"appealNotification",
 																"appellantCaseCorrespondence",
 																"appellantCaseWithdrawalLetter",
 																"appellantCostsApplication",
@@ -14291,6 +14315,7 @@
 															"documentType": {
 																"type": "string",
 																"enum": [
+																	"appealNotification",
 																	"appellantCaseCorrespondence",
 																	"appellantCaseWithdrawalLetter",
 																	"appellantCostsApplication",
@@ -14489,6 +14514,7 @@
 														"documentType": {
 															"type": "string",
 															"enum": [
+																"appealNotification",
 																"appellantCaseCorrespondence",
 																"appellantCaseWithdrawalLetter",
 																"appellantCostsApplication",
@@ -14646,6 +14672,7 @@
 															"documentType": {
 																"type": "string",
 																"enum": [
+																	"appealNotification",
 																	"appellantCaseCorrespondence",
 																	"appellantCaseWithdrawalLetter",
 																	"appellantCostsApplication",
@@ -14844,6 +14871,7 @@
 														"documentType": {
 															"type": "string",
 															"enum": [
+																"appealNotification",
 																"appellantCaseCorrespondence",
 																"appellantCaseWithdrawalLetter",
 																"appellantCostsApplication",
@@ -15001,6 +15029,7 @@
 															"documentType": {
 																"type": "string",
 																"enum": [
+																	"appealNotification",
 																	"appellantCaseCorrespondence",
 																	"appellantCaseWithdrawalLetter",
 																	"appellantCostsApplication",
@@ -15199,6 +15228,7 @@
 														"documentType": {
 															"type": "string",
 															"enum": [
+																"appealNotification",
 																"appellantCaseCorrespondence",
 																"appellantCaseWithdrawalLetter",
 																"appellantCostsApplication",
@@ -15356,6 +15386,7 @@
 															"documentType": {
 																"type": "string",
 																"enum": [
+																	"appealNotification",
 																	"appellantCaseCorrespondence",
 																	"appellantCaseWithdrawalLetter",
 																	"appellantCostsApplication",
@@ -15554,6 +15585,7 @@
 														"documentType": {
 															"type": "string",
 															"enum": [
+																"appealNotification",
 																"appellantCaseCorrespondence",
 																"appellantCaseWithdrawalLetter",
 																"appellantCostsApplication",
@@ -15711,6 +15743,7 @@
 															"documentType": {
 																"type": "string",
 																"enum": [
+																	"appealNotification",
 																	"appellantCaseCorrespondence",
 																	"appellantCaseWithdrawalLetter",
 																	"appellantCostsApplication",
@@ -16272,6 +16305,7 @@
 														"documentType": {
 															"type": "string",
 															"enum": [
+																"appealNotification",
 																"appellantCaseCorrespondence",
 																"appellantCaseWithdrawalLetter",
 																"appellantCostsApplication",
@@ -16429,6 +16463,7 @@
 															"documentType": {
 																"type": "string",
 																"enum": [
+																	"appealNotification",
 																	"appellantCaseCorrespondence",
 																	"appellantCaseWithdrawalLetter",
 																	"appellantCostsApplication",
@@ -16627,6 +16662,7 @@
 														"documentType": {
 															"type": "string",
 															"enum": [
+																"appealNotification",
 																"appellantCaseCorrespondence",
 																"appellantCaseWithdrawalLetter",
 																"appellantCostsApplication",
@@ -16784,6 +16820,7 @@
 															"documentType": {
 																"type": "string",
 																"enum": [
+																	"appealNotification",
 																	"appellantCaseCorrespondence",
 																	"appellantCaseWithdrawalLetter",
 																	"appellantCostsApplication",
@@ -16982,6 +17019,7 @@
 														"documentType": {
 															"type": "string",
 															"enum": [
+																"appealNotification",
 																"appellantCaseCorrespondence",
 																"appellantCaseWithdrawalLetter",
 																"appellantCostsApplication",
@@ -17139,6 +17177,7 @@
 															"documentType": {
 																"type": "string",
 																"enum": [
+																	"appealNotification",
 																	"appellantCaseCorrespondence",
 																	"appellantCaseWithdrawalLetter",
 																	"appellantCostsApplication",
@@ -17337,6 +17376,7 @@
 														"documentType": {
 															"type": "string",
 															"enum": [
+																"appealNotification",
 																"appellantCaseCorrespondence",
 																"appellantCaseWithdrawalLetter",
 																"appellantCostsApplication",
@@ -17494,6 +17534,7 @@
 															"documentType": {
 																"type": "string",
 																"enum": [
+																	"appealNotification",
 																	"appellantCaseCorrespondence",
 																	"appellantCaseWithdrawalLetter",
 																	"appellantCostsApplication",
@@ -17692,6 +17733,7 @@
 														"documentType": {
 															"type": "string",
 															"enum": [
+																"appealNotification",
 																"appellantCaseCorrespondence",
 																"appellantCaseWithdrawalLetter",
 																"appellantCostsApplication",
@@ -17849,6 +17891,7 @@
 															"documentType": {
 																"type": "string",
 																"enum": [
+																	"appealNotification",
 																	"appellantCaseCorrespondence",
 																	"appellantCaseWithdrawalLetter",
 																	"appellantCostsApplication",
@@ -18047,6 +18090,7 @@
 														"documentType": {
 															"type": "string",
 															"enum": [
+																"appealNotification",
 																"appellantCaseCorrespondence",
 																"appellantCaseWithdrawalLetter",
 																"appellantCostsApplication",
@@ -18204,6 +18248,7 @@
 															"documentType": {
 																"type": "string",
 																"enum": [
+																	"appealNotification",
 																	"appellantCaseCorrespondence",
 																	"appellantCaseWithdrawalLetter",
 																	"appellantCostsApplication",
@@ -18402,6 +18447,7 @@
 														"documentType": {
 															"type": "string",
 															"enum": [
+																"appealNotification",
 																"appellantCaseCorrespondence",
 																"appellantCaseWithdrawalLetter",
 																"appellantCostsApplication",
@@ -18559,6 +18605,7 @@
 															"documentType": {
 																"type": "string",
 																"enum": [
+																	"appealNotification",
 																	"appellantCaseCorrespondence",
 																	"appellantCaseWithdrawalLetter",
 																	"appellantCostsApplication",
@@ -18757,6 +18804,7 @@
 														"documentType": {
 															"type": "string",
 															"enum": [
+																"appealNotification",
 																"appellantCaseCorrespondence",
 																"appellantCaseWithdrawalLetter",
 																"appellantCostsApplication",
@@ -18914,6 +18962,7 @@
 															"documentType": {
 																"type": "string",
 																"enum": [
+																	"appealNotification",
 																	"appellantCaseCorrespondence",
 																	"appellantCaseWithdrawalLetter",
 																	"appellantCostsApplication",
@@ -19112,6 +19161,7 @@
 														"documentType": {
 															"type": "string",
 															"enum": [
+																"appealNotification",
 																"appellantCaseCorrespondence",
 																"appellantCaseWithdrawalLetter",
 																"appellantCostsApplication",
@@ -19269,6 +19319,7 @@
 															"documentType": {
 																"type": "string",
 																"enum": [
+																	"appealNotification",
 																	"appellantCaseCorrespondence",
 																	"appellantCaseWithdrawalLetter",
 																	"appellantCostsApplication",
@@ -19467,6 +19518,7 @@
 														"documentType": {
 															"type": "string",
 															"enum": [
+																"appealNotification",
 																"appellantCaseCorrespondence",
 																"appellantCaseWithdrawalLetter",
 																"appellantCostsApplication",
@@ -19624,6 +19676,7 @@
 															"documentType": {
 																"type": "string",
 																"enum": [
+																	"appealNotification",
 																	"appellantCaseCorrespondence",
 																	"appellantCaseWithdrawalLetter",
 																	"appellantCostsApplication",
@@ -19822,6 +19875,7 @@
 														"documentType": {
 															"type": "string",
 															"enum": [
+																"appealNotification",
 																"appellantCaseCorrespondence",
 																"appellantCaseWithdrawalLetter",
 																"appellantCostsApplication",
@@ -19979,6 +20033,7 @@
 															"documentType": {
 																"type": "string",
 																"enum": [
+																	"appealNotification",
 																	"appellantCaseCorrespondence",
 																	"appellantCaseWithdrawalLetter",
 																	"appellantCostsApplication",
@@ -20177,6 +20232,7 @@
 														"documentType": {
 															"type": "string",
 															"enum": [
+																"appealNotification",
 																"appellantCaseCorrespondence",
 																"appellantCaseWithdrawalLetter",
 																"appellantCostsApplication",
@@ -20334,6 +20390,7 @@
 															"documentType": {
 																"type": "string",
 																"enum": [
+																	"appealNotification",
 																	"appellantCaseCorrespondence",
 																	"appellantCaseWithdrawalLetter",
 																	"appellantCostsApplication",
@@ -20532,6 +20589,7 @@
 														"documentType": {
 															"type": "string",
 															"enum": [
+																"appealNotification",
 																"appellantCaseCorrespondence",
 																"appellantCaseWithdrawalLetter",
 																"appellantCostsApplication",
@@ -20689,6 +20747,7 @@
 															"documentType": {
 																"type": "string",
 																"enum": [
+																	"appealNotification",
 																	"appellantCaseCorrespondence",
 																	"appellantCaseWithdrawalLetter",
 																	"appellantCostsApplication",
@@ -20887,6 +20946,7 @@
 														"documentType": {
 															"type": "string",
 															"enum": [
+																"appealNotification",
 																"appellantCaseCorrespondence",
 																"appellantCaseWithdrawalLetter",
 																"appellantCostsApplication",
@@ -21044,6 +21104,7 @@
 															"documentType": {
 																"type": "string",
 																"enum": [
+																	"appealNotification",
 																	"appellantCaseCorrespondence",
 																	"appellantCaseWithdrawalLetter",
 																	"appellantCostsApplication",
@@ -21242,6 +21303,7 @@
 														"documentType": {
 															"type": "string",
 															"enum": [
+																"appealNotification",
 																"appellantCaseCorrespondence",
 																"appellantCaseWithdrawalLetter",
 																"appellantCostsApplication",
@@ -21399,6 +21461,7 @@
 															"documentType": {
 																"type": "string",
 																"enum": [
+																	"appealNotification",
 																	"appellantCaseCorrespondence",
 																	"appellantCaseWithdrawalLetter",
 																	"appellantCostsApplication",
@@ -21597,6 +21660,7 @@
 														"documentType": {
 															"type": "string",
 															"enum": [
+																"appealNotification",
 																"appellantCaseCorrespondence",
 																"appellantCaseWithdrawalLetter",
 																"appellantCostsApplication",
@@ -21754,6 +21818,7 @@
 															"documentType": {
 																"type": "string",
 																"enum": [
+																	"appealNotification",
 																	"appellantCaseCorrespondence",
 																	"appellantCaseWithdrawalLetter",
 																	"appellantCostsApplication",
@@ -21952,6 +22017,7 @@
 														"documentType": {
 															"type": "string",
 															"enum": [
+																"appealNotification",
 																"appellantCaseCorrespondence",
 																"appellantCaseWithdrawalLetter",
 																"appellantCostsApplication",
@@ -22109,6 +22175,7 @@
 															"documentType": {
 																"type": "string",
 																"enum": [
+																	"appealNotification",
 																	"appellantCaseCorrespondence",
 																	"appellantCaseWithdrawalLetter",
 																	"appellantCostsApplication",
@@ -22307,6 +22374,7 @@
 														"documentType": {
 															"type": "string",
 															"enum": [
+																"appealNotification",
 																"appellantCaseCorrespondence",
 																"appellantCaseWithdrawalLetter",
 																"appellantCostsApplication",
@@ -22464,6 +22532,7 @@
 															"documentType": {
 																"type": "string",
 																"enum": [
+																	"appealNotification",
 																	"appellantCaseCorrespondence",
 																	"appellantCaseWithdrawalLetter",
 																	"appellantCostsApplication",
@@ -22662,6 +22731,7 @@
 														"documentType": {
 															"type": "string",
 															"enum": [
+																"appealNotification",
 																"appellantCaseCorrespondence",
 																"appellantCaseWithdrawalLetter",
 																"appellantCostsApplication",
@@ -22819,6 +22889,7 @@
 															"documentType": {
 																"type": "string",
 																"enum": [
+																	"appealNotification",
 																	"appellantCaseCorrespondence",
 																	"appellantCaseWithdrawalLetter",
 																	"appellantCostsApplication",
@@ -23017,6 +23088,7 @@
 														"documentType": {
 															"type": "string",
 															"enum": [
+																"appealNotification",
 																"appellantCaseCorrespondence",
 																"appellantCaseWithdrawalLetter",
 																"appellantCostsApplication",
@@ -23174,6 +23246,7 @@
 															"documentType": {
 																"type": "string",
 																"enum": [
+																	"appealNotification",
 																	"appellantCaseCorrespondence",
 																	"appellantCaseWithdrawalLetter",
 																	"appellantCostsApplication",
@@ -23882,6 +23955,7 @@
 												"documentType": {
 													"type": "string",
 													"enum": [
+														"appealNotification",
 														"appellantCaseCorrespondence",
 														"appellantCaseWithdrawalLetter",
 														"appellantCostsApplication",
@@ -24039,6 +24113,7 @@
 													"documentType": {
 														"type": "string",
 														"enum": [
+															"appealNotification",
 															"appellantCaseCorrespondence",
 															"appellantCaseWithdrawalLetter",
 															"appellantCostsApplication",
@@ -24259,6 +24334,7 @@
 													"documentType": {
 														"type": "string",
 														"enum": [
+															"appealNotification",
 															"appellantCaseCorrespondence",
 															"appellantCaseWithdrawalLetter",
 															"appellantCostsApplication",
@@ -24416,6 +24492,7 @@
 														"documentType": {
 															"type": "string",
 															"enum": [
+																"appealNotification",
 																"appellantCaseCorrespondence",
 																"appellantCaseWithdrawalLetter",
 																"appellantCostsApplication",
@@ -24613,6 +24690,7 @@
 													"documentType": {
 														"type": "string",
 														"enum": [
+															"appealNotification",
 															"appellantCaseCorrespondence",
 															"appellantCaseWithdrawalLetter",
 															"appellantCostsApplication",
@@ -24770,6 +24848,7 @@
 														"documentType": {
 															"type": "string",
 															"enum": [
+																"appealNotification",
 																"appellantCaseCorrespondence",
 																"appellantCaseWithdrawalLetter",
 																"appellantCostsApplication",
@@ -24967,6 +25046,7 @@
 													"documentType": {
 														"type": "string",
 														"enum": [
+															"appealNotification",
 															"appellantCaseCorrespondence",
 															"appellantCaseWithdrawalLetter",
 															"appellantCostsApplication",
@@ -25124,6 +25204,7 @@
 														"documentType": {
 															"type": "string",
 															"enum": [
+																"appealNotification",
 																"appellantCaseCorrespondence",
 																"appellantCaseWithdrawalLetter",
 																"appellantCostsApplication",
@@ -25321,6 +25402,7 @@
 													"documentType": {
 														"type": "string",
 														"enum": [
+															"appealNotification",
 															"appellantCaseCorrespondence",
 															"appellantCaseWithdrawalLetter",
 															"appellantCostsApplication",
@@ -25478,6 +25560,7 @@
 														"documentType": {
 															"type": "string",
 															"enum": [
+																"appealNotification",
 																"appellantCaseCorrespondence",
 																"appellantCaseWithdrawalLetter",
 																"appellantCostsApplication",
@@ -25675,6 +25758,7 @@
 													"documentType": {
 														"type": "string",
 														"enum": [
+															"appealNotification",
 															"appellantCaseCorrespondence",
 															"appellantCaseWithdrawalLetter",
 															"appellantCostsApplication",
@@ -25832,6 +25916,7 @@
 														"documentType": {
 															"type": "string",
 															"enum": [
+																"appealNotification",
 																"appellantCaseCorrespondence",
 																"appellantCaseWithdrawalLetter",
 																"appellantCostsApplication",
@@ -26029,6 +26114,7 @@
 													"documentType": {
 														"type": "string",
 														"enum": [
+															"appealNotification",
 															"appellantCaseCorrespondence",
 															"appellantCaseWithdrawalLetter",
 															"appellantCostsApplication",
@@ -26186,6 +26272,7 @@
 														"documentType": {
 															"type": "string",
 															"enum": [
+																"appealNotification",
 																"appellantCaseCorrespondence",
 																"appellantCaseWithdrawalLetter",
 																"appellantCostsApplication",
@@ -26383,6 +26470,7 @@
 													"documentType": {
 														"type": "string",
 														"enum": [
+															"appealNotification",
 															"appellantCaseCorrespondence",
 															"appellantCaseWithdrawalLetter",
 															"appellantCostsApplication",
@@ -26540,6 +26628,7 @@
 														"documentType": {
 															"type": "string",
 															"enum": [
+																"appealNotification",
 																"appellantCaseCorrespondence",
 																"appellantCaseWithdrawalLetter",
 																"appellantCostsApplication",
@@ -26739,6 +26828,7 @@
 													"documentType": {
 														"type": "string",
 														"enum": [
+															"appealNotification",
 															"appellantCaseCorrespondence",
 															"appellantCaseWithdrawalLetter",
 															"appellantCostsApplication",
@@ -26896,6 +26986,7 @@
 														"documentType": {
 															"type": "string",
 															"enum": [
+																"appealNotification",
 																"appellantCaseCorrespondence",
 																"appellantCaseWithdrawalLetter",
 																"appellantCostsApplication",
@@ -27093,6 +27184,7 @@
 													"documentType": {
 														"type": "string",
 														"enum": [
+															"appealNotification",
 															"appellantCaseCorrespondence",
 															"appellantCaseWithdrawalLetter",
 															"appellantCostsApplication",
@@ -27250,6 +27342,7 @@
 														"documentType": {
 															"type": "string",
 															"enum": [
+																"appealNotification",
 																"appellantCaseCorrespondence",
 																"appellantCaseWithdrawalLetter",
 																"appellantCostsApplication",
@@ -27448,6 +27541,7 @@
 												"documentType": {
 													"type": "string",
 													"enum": [
+														"appealNotification",
 														"appellantCaseCorrespondence",
 														"appellantCaseWithdrawalLetter",
 														"appellantCostsApplication",
@@ -27605,6 +27699,7 @@
 													"documentType": {
 														"type": "string",
 														"enum": [
+															"appealNotification",
 															"appellantCaseCorrespondence",
 															"appellantCaseWithdrawalLetter",
 															"appellantCostsApplication",

--- a/appeals/api/src/server/utils/mapping/map-enums.js
+++ b/appeals/api/src/server/utils/mapping/map-enums.js
@@ -35,7 +35,7 @@ export const isValidStage = (stage) => Object.values(APPEAL_CASE_STAGE).includes
  *
  * @param {string} documentType
  * @returns {documentType is
- * 	'appellantCaseCorrespondence'|'appellantCaseWithdrawalLetter'|'appellantCostsApplication'|
+ * 	    'appealNotification'|'appellantCaseCorrespondence'|'appellantCaseWithdrawalLetter'|'appellantCostsApplication'|
  *		'appellantStatement'|'applicationDecisionLetter'|'caseDecisionLetter'|
  *		'changedDescription'|'communityInfrastructureLevy'|'conservationMap'|'consultationResponses'|'costsDecisionLetter'|
  *		'crossTeamCorrespondence'|'definitiveMapStatement'|'designAccessStatement'|'developmentPlanPolicies'|'eiaEnvironmentalStatement'|

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/__tests__/__snapshots__/lpa-questionnaire.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/__tests__/__snapshots__/lpa-questionnaire.test.js.snap
@@ -136,6 +136,11 @@ exports[`LPA Questionnaire review GET / should render review outcome form fields
                                 <dd class="govuk-summary-list__actions"><a class="govuk-link" href="#" data-cy="add-press-advert-notification"> Add<span class="govuk-visually-hidden"> Press advert notification</span></a>
                                 </dd>
                         </div>
+                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Appeal notification letter</dt>
+                            <dd                             class="govuk-summary-list__value">Not provided</dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="#" data-cy="add-appeal-notification-letter"> Add<span class="govuk-visually-hidden"> Appeal notification letter</span></a>
+                                </dd>
+                        </div>
                     </dl>
                 </div>
             </div>
@@ -496,6 +501,11 @@ exports[`LPA Questionnaire review GET / should render the LPA Questionnaire page
                         <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Press advert notification</dt>
                             <dd                             class="govuk-summary-list__value">Not provided</dd>
                                 <dd class="govuk-summary-list__actions"><a class="govuk-link" href="#" data-cy="add-press-advert-notification"> Add<span class="govuk-visually-hidden"> Press advert notification</span></a>
+                                </dd>
+                        </div>
+                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Appeal notification letter</dt>
+                            <dd                             class="govuk-summary-list__value">Not provided</dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="#" data-cy="add-appeal-notification-letter"> Add<span class="govuk-visually-hidden"> Appeal notification letter</span></a>
                                 </dd>
                         </div>
                     </dl>
@@ -883,6 +893,11 @@ exports[`LPA Questionnaire review GET / with unchecked documents should render a
                                 <dd class="govuk-summary-list__actions"><a class="govuk-link" href="#" data-cy="add-press-advert-notification"> Add<span class="govuk-visually-hidden"> Press advert notification</span></a>
                                 </dd>
                         </div>
+                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Appeal notification letter</dt>
+                            <dd                             class="govuk-summary-list__value">Not provided</dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="#" data-cy="add-appeal-notification-letter"> Add<span class="govuk-visually-hidden"> Appeal notification letter</span></a>
+                                </dd>
+                        </div>
                     </dl>
                 </div>
             </div>
@@ -1225,6 +1240,11 @@ exports[`LPA Questionnaire review GET / with unchecked documents should render a
                         <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Press advert notification</dt>
                             <dd                             class="govuk-summary-list__value">Not provided</dd>
                                 <dd class="govuk-summary-list__actions"><a class="govuk-link" href="#" data-cy="add-press-advert-notification"> Add<span class="govuk-visually-hidden"> Press advert notification</span></a>
+                                </dd>
+                        </div>
+                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Appeal notification letter</dt>
+                            <dd                             class="govuk-summary-list__value">Not provided</dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="#" data-cy="add-appeal-notification-letter"> Add<span class="govuk-visually-hidden"> Appeal notification letter</span></a>
                                 </dd>
                         </div>
                     </dl>
@@ -3638,6 +3658,11 @@ exports[`LPA Questionnaire review POST / should render LPA Questionnaire review 
                         <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Press advert notification</dt>
                             <dd                             class="govuk-summary-list__value">Not provided</dd>
                                 <dd class="govuk-summary-list__actions"><a class="govuk-link" href="#" data-cy="add-press-advert-notification"> Add<span class="govuk-visually-hidden"> Press advert notification</span></a>
+                                </dd>
+                        </div>
+                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Appeal notification letter</dt>
+                            <dd                             class="govuk-summary-list__value">Not provided</dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="#" data-cy="add-appeal-notification-letter"> Add<span class="govuk-visually-hidden"> Appeal notification letter</span></a>
                                 </dd>
                         </div>
                     </dl>

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/lpa-questionnaire.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/lpa-questionnaire.mapper.js
@@ -823,7 +823,8 @@ const generateHASLpaQuestionnaireComponents = (mappedLPAQData, mappedAppealDetai
 				mappedLPAQData.lpaq?.notificationMethods?.display.summaryListItem,
 				mappedLPAQData.lpaq?.siteNotice?.display.summaryListItem,
 				mappedLPAQData.lpaq?.lettersToNeighbours?.display.summaryListItem,
-				mappedLPAQData.lpaq?.pressAdvert?.display.summaryListItem
+				mappedLPAQData.lpaq?.pressAdvert?.display.summaryListItem,
+				mappedLPAQData.lpaq?.appealNotification?.display.summaryListItem
 			].filter(isDefined)
 		}
 	});
@@ -1009,7 +1010,8 @@ const generateS78LpaQuestionnaireComponents = (mappedLPAQData, mappedAppealDetai
 				mappedLPAQData.lpaq?.notificationMethods?.display.summaryListItem,
 				mappedLPAQData.lpaq?.siteNotice?.display.summaryListItem,
 				mappedLPAQData.lpaq?.lettersToNeighbours?.display.summaryListItem,
-				mappedLPAQData.lpaq?.pressAdvert?.display.summaryListItem
+				mappedLPAQData.lpaq?.pressAdvert?.display.summaryListItem,
+				mappedLPAQData.lpaq?.appealNotification?.display.summaryListItem
 			].filter(isDefined)
 		}
 	});

--- a/appeals/web/src/server/lib/mappers/data/lpa-questionnaire/has.js
+++ b/appeals/web/src/server/lib/mappers/data/lpa-questionnaire/has.js
@@ -20,6 +20,7 @@ import { mapSiteAccess } from './submappers/map-site-access.js';
 import { mapSiteNotice } from './submappers/map-site-notice.js';
 import { mapSiteWithinGreenBelt } from './submappers/map-site-within-green-belt.js';
 import { mapSupplementaryPlanning } from './submappers/map-supplementary-planning.js';
+import { mapAppealNotification } from './submappers/map-appeal-notification.js';
 
 export const submaps = {
 	affectsListedBuildingDetails: mapAffectsListedBuildingDetails,
@@ -30,6 +31,7 @@ export const submaps = {
 	siteNotice: mapSiteNotice,
 	lettersToNeighbours: mapLettersToNeighbours,
 	pressAdvert: mapPressAdvert,
+	appealNotification: mapAppealNotification,
 	notificationMethods: mapNotificationMethods,
 	representations: mapRepresentations,
 	officersReport: mapOfficersReport,

--- a/appeals/web/src/server/lib/mappers/data/lpa-questionnaire/submappers/map-appeal-notification.js
+++ b/appeals/web/src/server/lib/mappers/data/lpa-questionnaire/submappers/map-appeal-notification.js
@@ -1,0 +1,12 @@
+import { documentInstruction } from '../common.js';
+
+/** @type {import("../mapper.js").SubMapper} */
+export const mapAppealNotification = ({ lpaQuestionnaireData, session }) =>
+	documentInstruction({
+		id: 'appeal-notification',
+		text: 'Appeal notification letter',
+		folderInfo: lpaQuestionnaireData.documents.appealNotification,
+		cypressDataName: 'appeal-notification-letter',
+		lpaQuestionnaireData,
+		session
+	});


### PR DESCRIPTION
## Describe your changes
### Add appeal notification letter row (a2-1985)

WEB:
 - Added the submapper for the Appeal notification letter row
 - Included the submapper in the Notifying relevant parties section for both HAS and S78
 - hooked up the functionality to add and manage documents for this row
 
API:
 - Updated SingleLPAQuestionnaireResponse interface to include appealNotification
 - Regenerated APIspec
   
TESTING:
- WEB snapshots updated
- All WEB unit tests pass
- All API unit tests pass
- Manually tested within browser

## Issue ticket number and link

[A2-1985 Remove an agent](https://pins-ds.atlassian.net/browse/A2-1985)

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [x] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [x] I have included unit tests to cover any testable code changes
