### PR TITLE
feat(appeals): fix change link for final comments due date (a2-83)

### DIFF
--- a/appeals/web/src/server/lib/mappers/data/appeal/submappers/appellant-final-comment-due-date.mapper.js
+++ b/appeals/web/src/server/lib/mappers/data/appeal/submappers/appellant-final-comment-due-date.mapper.js
@@ -9,14 +9,13 @@ export const mapAppellantFinalCommentDueDate = ({
 	userHasUpdateCasePermission,
 	appellantFinalComments
 }) => {
-	const commentNotAccepted = appellantFinalComments?.status !== APPEAL_REPRESENTATION_STATUS.VALID
+	const commentNotAccepted = appellantFinalComments?.status !== APPEAL_REPRESENTATION_STATUS.VALID;
 	return textSummaryListItem({
 		id: 'appellant-final-comment-due-date',
 		text: 'Appellant final comments due',
 		value: dateISOStringToDisplayDate(appealDetails.appealTimetable?.appellantFinalCommentsDueDate),
-		link: `${currentRoute}/appeal-timetables/final-comments/appellants`,
+		link: `${currentRoute}/appeal-timetables/appellant-final-comments`,
 		editable: Boolean(commentNotAccepted && userHasUpdateCasePermission && appealDetails.startedAt),
 		classes: 'appeal-final-comments-due-date'
 	});
-
-}
+};

--- a/appeals/web/src/server/lib/mappers/data/appeal/submappers/lpa-final-comment-due-date.mapper.js
+++ b/appeals/web/src/server/lib/mappers/data/appeal/submappers/lpa-final-comment-due-date.mapper.js
@@ -9,13 +9,13 @@ export const mapLpaFinalCommentDueDate = ({
 	userHasUpdateCasePermission,
 	lpaFinalComments
 }) => {
-	const commentNotAccepted = lpaFinalComments?.status !== APPEAL_REPRESENTATION_STATUS.VALID
+	const commentNotAccepted = lpaFinalComments?.status !== APPEAL_REPRESENTATION_STATUS.VALID;
 	return textSummaryListItem({
 		id: 'lpa-final-comment-due-date',
 		text: 'LPA final comments due',
 		value: dateISOStringToDisplayDate(appealDetails.appealTimetable?.lpaFinalCommentsDueDate),
-		link: `${currentRoute}/appeal-timetables/final-comments/lpas`,
+		link: `${currentRoute}/appeal-timetables/lpa-final-comments`,
 		editable: Boolean(commentNotAccepted && userHasUpdateCasePermission && appealDetails.startedAt),
 		classes: 'appeal-lpa-final-comment-due-date'
 	});
-}
+};


### PR DESCRIPTION
## Describe your changes
### Fix the change link in the timetables section for the final comments due date (a2-83)

WEB:
 - Corrected the link in both the lpa and appellant final comments due date submappers so the common processing for appeal-timetables routes can be used without having to change anything else.
    
TESTING:
- All WEB unit tests pass
- Manually tested within browser

## Issue ticket number and link

[A2-83 WEB - S78w - Appellant/LPA - Case Details - As a Case Officer, I need to extend the Final Comment deadline](https://pins-ds.atlassian.net/browse/A2-83)

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [x] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [x] I have included unit tests to cover any testable code changes
