### PR TITLE
Feat/a2 1141 notify final comment rejected

### DIFF
--- a/appeals/api/src/server/config/config.js
+++ b/appeals/api/src/server/config/config.js
@@ -235,7 +235,14 @@ const { value, error } = schema.validate({
 				id: environment.GOV_NOTIFY_VALID_APPELLANT_CASE_ID || 'mock-valid-appellant-case-id'
 			},
 			commentRejected: {
-				id: environment.GOV_NOTIFY_COMMENT_REJECTED || 'mock-comment-rejected-id'
+				appellant: {
+					id:
+						environment.GOV_NOTIFY_COMMENT_REJECTED_APPELLANT_ID ||
+						'mock-comment-rejected-appellant-id'
+				},
+				lpa: {
+					id: environment.GOV_NOTIFY_COMMENT_REJECTED_LPA_ID || 'mock-comment-rejected-lpa-id'
+				}
 			},
 			commentRejectedDeadlineExtended: {
 				id:

--- a/appeals/api/src/server/config/schema.js
+++ b/appeals/api/src/server/config/schema.js
@@ -176,7 +176,12 @@ export default joi
 							id: joi.string().required()
 						}),
 						commentRejected: joi.object({
-							id: joi.string().required()
+							appellant: joi.object({
+								id: joi.string().required()
+							}),
+							lpa: joi.object({
+								id: joi.string().required()
+							})
 						}),
 						commentRejectedDeadlineExtended: joi.object({
 							id: joi.string().required()

--- a/appeals/api/src/server/endpoints/representations/representations.controller.js
+++ b/appeals/api/src/server/endpoints/representations/representations.controller.js
@@ -159,26 +159,30 @@ export async function updateRepresentation(request, response) {
 		return response.status(400).send({ errors: { status: ERROR_REP_ONLY_STATEMENT_INCOMPLETE } });
 	}
 
-	const updatedRep = await representationService.updateRepresentation(
-		parseInt(repId),
-		request.body
-	);
+	await representationService.updateRepresentation(parseInt(repId), request.body);
 
-	if(status !== rep.status){
+	const updatedRep = await representationService.getRepresentation(parseInt(repId));
+
+	if (status !== rep.status) {
 		await createAuditTrail({
 			appealId: parseInt(appealId),
 			azureAdUserId: String(request.get('azureAdUserId')),
 			details:
 				// @ts-ignore
-				stringTokenReplacement(CONSTANTS[`AUDIT_TRAIL_REP_${camelToScreamingSnake(updatedRep.representationType)}_STATUS_UPDATED`], [status])
-		})
+				stringTokenReplacement(
+					CONSTANTS[
+						`AUDIT_TRAIL_REP_${camelToScreamingSnake(updatedRep.representationType)}_STATUS_UPDATED`
+					],
+					[status]
+				)
+		});
 	}
 
 	if (status === APPEAL_REPRESENTATION_STATUS.INVALID) {
 		await representationService.notifyRejection(
 			request.notifyClient,
 			request.appeal,
-			rep,
+			updatedRep,
 			allowResubmit
 		);
 	}

--- a/infrastructure/app-api.tf
+++ b/infrastructure/app-api.tf
@@ -93,6 +93,8 @@ module "app_api" {
     GOV_NOTIFY_SITE_VISIT_SCHEDULE_UNACCOMPANIED_APPELLANT_ID                  = var.apps_config.integrations.notify_template_ids.site_visit_schedule_unaccompanied_appellant_id
     GOV_NOTIFY_VALID_APPELLANT_CASE_ID                                         = var.apps_config.integrations.notify_template_ids.valid_appellant_case_id
     GOV_NOTIFY_COMMENT_REJECTED                                                = var.apps_config.integrations.notify_template_ids.comment_rejected_id
+    GOV_NOTIFY_COMMENT_REJECTED_APPELLANT_ID                                   = var.apps_config.integrations.notify_template_ids.comment_rejected_appellant_id
+    GOV_NOTIFY_COMMENT_REJECTED_LPA_ID                                         = var.apps_config.integrations.notify_template_ids.comment_rejected_lpa_id
     GOV_NOTIFY_COMMENT_REJECTED_DEADLINE_EXTENDED                              = var.apps_config.integrations.notify_template_ids.comment_rejected_deadline_extended_id
 
     #feature flags

--- a/infrastructure/environments/dev.tfvars
+++ b/infrastructure/environments/dev.tfvars
@@ -60,6 +60,8 @@ apps_config = {
       site_visit_schedule_unaccompanied_appellant_id                  = "a33bb800-56d9-46a4-ba64-35d9d0263666"
       valid_appellant_case_id                                         = "3b4b74b4-b604-411b-9c98-5be2c6f3bdfd"
       comment_rejected_id                                             = "13924f23-8b50-4e2e-86f2-70b92360889b"
+      comment_rejected_appellant_id                                   = "3165d99e-f628-4623-95e4-acdebf6d700c"
+      comment_rejected_lpa_id                                         = "ebb2d0e0-2146-43a5-a6f5-d45e9ee0ca3f"
       comment_rejected_deadline_extended_id                           = "ccffeb37-c7e0-4c38-888c-6cf2755f6703"
     }
   }

--- a/infrastructure/environments/test.tfvars
+++ b/infrastructure/environments/test.tfvars
@@ -60,6 +60,8 @@ apps_config = {
       site_visit_schedule_unaccompanied_appellant_id                  = "a33bb800-56d9-46a4-ba64-35d9d0263666"
       valid_appellant_case_id                                         = "3b4b74b4-b604-411b-9c98-5be2c6f3bdfd"
       comment_rejected_id                                             = "13924f23-8b50-4e2e-86f2-70b92360889b"
+      comment_rejected_appellant_id                                   = "3165d99e-f628-4623-95e4-acdebf6d700c"
+      comment_rejected_lpa_id                                         = "ebb2d0e0-2146-43a5-a6f5-d45e9ee0ca3f"
       comment_rejected_deadline_extended_id                           = "ccffeb37-c7e0-4c38-888c-6cf2755f6703"
     }
   }


### PR DESCRIPTION
### Notify final comment rejected (a2-1141)

#### API:
 - Made sure the rejection reasons are populated when sending the rejection notify
 - Identify the representative type and use the appropriate notify template id and email when sending the rejection notify
 
#### INFRA: (Only for TEST and DEV)
- GOV_NOTIFY_COMMENT_REJECTED_APPELLANT_ID
- GOV_NOTIFY_COMMENT_REJECTED_LPA_ID
(Please note PROD and TEST will need to be in another ticket when available)
   
#### TESTING:
- API unit tests updated
- All API unit tests pass
- Manually tested within browser for both lpa and appellant 
- Confirmed in Notify portal for both lpa and appellant

#### NOTES:
 - Make sure Infra is deployed on DEV and TEST

## Issue ticket number and link

[A2-1141 Notify: Final comment rejected (all main parties)](https://pins-ds.atlassian.net/browse/A2-1141)

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [x] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [x] I have included unit tests to cover any testable code changes