### PR TITLE
fix(api): fixes the appeal broadcast when updating deadlines

### DIFF
--- a/appeals/api/src/server/endpoints/appeal-timetables/appeal-timetables.service.js
+++ b/appeals/api/src/server/endpoints/appeal-timetables/appeal-timetables.service.js
@@ -78,6 +78,7 @@ const startCase = async (appeal, startDate, notifyClient, siteAddress, azureAdUs
 
 		if (timetable) {
 			await Promise.all([
+				// @ts-ignore
 				appealTimetableRepository.upsertAppealTimetableById(appeal.id, timetable),
 				appealRepository.updateAppealById(appeal.id, {
 					caseStartedDate: startDateWithTimeCorrection.toISOString()
@@ -158,6 +159,7 @@ const updateAppealTimetable = async (appealId, appealTimetableId, body, azureAdU
 		])
 	);
 
+	// @ts-ignore
 	await appealTimetableRepository.updateAppealTimetableById(appealTimetableId, processedBody);
 
 	await createAuditTrail({
@@ -166,7 +168,7 @@ const updateAppealTimetable = async (appealId, appealTimetableId, body, azureAdU
 		details: AUDIT_TRAIL_CASE_TIMELINE_UPDATED
 	});
 
-	await broadcasters.broadcastAppeal(appealTimetableId);
+	await broadcasters.broadcastAppeal(appealId);
 };
 
 export { checkAppealTimetableExists, startCase, updateAppealTimetable };


### PR DESCRIPTION
Tiny PR, fixes the broadcast of appeal data when updating timetable deadlines.

## Issue ticket number and link
[Ticket](<!--Paste your ticket link here-->)
