### PR TITLE
feat(appeals): final comments success banner (a2-2194)

### DIFF
--- a/appeals/web/src/server/appeals/appeal-details/appeal-timetables/appeal-timetables.controller.js
+++ b/appeals/web/src/server/appeals/appeal-details/appeal-timetables/appeal-timetables.controller.js
@@ -104,7 +104,19 @@ const processUpdateDueDate = async (request, response) => {
 				return response.status(500).render('app/500.njk');
 			}
 		}
-		addNotificationBannerToSession(request.session, 'timetableDueDateUpdated', appealId);
+
+		let bannerDefinitionKey = 'timetableDueDateUpdated';
+
+		switch (timetableType) {
+			case 'lpa-final-comments':
+				bannerDefinitionKey = 'lpaFinalCommentsDueDateUpdated';
+				break;
+			case 'appellant-final-comments':
+				bannerDefinitionKey = 'appellantFinalCommentsDueDateUpdated';
+				break;
+		}
+
+		addNotificationBannerToSession(request.session, bannerDefinitionKey, appealId);
 
 		return response.redirect(`/appeals-service/appeal-details/${appealId}`);
 	} catch (error) {

--- a/appeals/web/src/server/lib/mappers/components/page-components/notification-banners.mapper.js
+++ b/appeals/web/src/server/lib/mappers/components/page-components/notification-banners.mapper.js
@@ -181,6 +181,16 @@ export const notificationBannerDefinitions = {
 		pages: ['appealDetails'],
 		text: 'Timetable updated'
 	},
+	appellantFinalCommentsDueDateUpdated: {
+		type: 'success',
+		pages: ['appealDetails'],
+		text: 'Appellant final comments due date changed'
+	},
+	lpaFinalCommentsDueDateUpdated: {
+		type: 'success',
+		pages: ['appealDetails'],
+		text: 'LPA final comments due date changed'
+	},
 	changePage: {
 		type: 'success',
 		pages: ['appealDetails', 'appellantCase', 'lpaQuestionnaire', 'ipComments']


### PR DESCRIPTION
## Describe your changes
### Fix the change final comments due date success banners (a2-2194)

Please note that the bulk of the A2-2194 ticket was completed in a previous ticket a2-83

WEB:
 - Corrected the success banners to match those in the ACs of this ticket.
    
TESTING:
- All WEB unit tests pass
- Manually tested within browser

## Issue ticket number and link

[A2-2194 Timetable - Appellant/LPA Final Comment Due 'Change'](https://pins-ds.atlassian.net/browse/A2-2194)

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [x] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [x] I have included unit tests to cover any testable code changes
