### PR TITLE
Fix/a2 75 bugs

### DIFF
--- a/appeals/api/src/server/endpoints/appeal-details/__tests__/appeals-details.test.js
+++ b/appeals/api/src/server/endpoints/appeal-details/__tests__/appeals-details.test.js
@@ -175,7 +175,8 @@ const s78AppealDto = {
 		},
 		lpaStatement: {
 			status: 'not_received',
-			receivedAt: null
+			receivedAt: null,
+			representationStatus: null
 		}
 	},
 	healthAndSafety: {

--- a/appeals/api/src/server/mappers/api/definitions/documentation-summary.js
+++ b/appeals/api/src/server/mappers/api/definitions/documentation-summary.js
@@ -11,6 +11,10 @@ const commonDocumentationSummaryProperties = {
 		type: 'string',
 		format: 'date-time',
 		nullable: true
+	},
+	representationStatus: {
+		type: 'string',
+		nullable: true
 	}
 };
 

--- a/appeals/api/src/server/mappers/api/shared/map-documentation-summary.js
+++ b/appeals/api/src/server/mappers/api/shared/map-documentation-summary.js
@@ -1,7 +1,6 @@
 import {
 	formatAppellantCaseDocumentationStatus,
-	formatLpaQuestionnaireDocumentationStatus,
-	formatLpaStatementStatus
+	formatLpaQuestionnaireDocumentationStatus
 } from '#utils/format-documentation-status.js';
 import { APPEAL_REPRESENTATION_TYPE } from '@pins/appeals/constants/common.js';
 import { DOCUMENT_STATUS_NOT_RECEIVED, DOCUMENT_STATUS_RECEIVED } from '#endpoints/constants.js';
@@ -54,22 +53,23 @@ export const mapDocumentationSummary = (data) => {
 						: DOCUMENT_STATUS_NOT_RECEIVED
 			},
 			lpaStatement: {
-				status: formatLpaStatementStatus(lpaStatement),
-				receivedAt: lpaStatement?.dateCreated.toISOString() ?? null
+				status: lpaStatement ? DOCUMENT_STATUS_RECEIVED : DOCUMENT_STATUS_NOT_RECEIVED,
+				receivedAt: lpaStatement?.dateCreated.toISOString() ?? null,
+				representationStatus: lpaStatement?.status ?? null
 			},
 			lpaFinalComments: {
 				status: lpaFinalComments ? DOCUMENT_STATUS_RECEIVED : DOCUMENT_STATUS_NOT_RECEIVED,
 				receivedAt: lpaFinalComments
 					? lpaFinalComments?.dateCreated && lpaFinalComments?.dateCreated.toISOString()
 					: null,
-				representationStatus: lpaFinalComments ? lpaFinalComments.status : null
+				representationStatus: lpaFinalComments?.status ?? null
 			},
 			appellantFinalComments: {
 				status: appellantFinalComments ? DOCUMENT_STATUS_RECEIVED : DOCUMENT_STATUS_NOT_RECEIVED,
 				receivedAt: appellantFinalComments
 					? appellantFinalComments?.dateCreated && appellantFinalComments?.dateCreated.toISOString()
 					: null,
-				representationStatus: appellantFinalComments ? appellantFinalComments.status : null
+				representationStatus: appellantFinalComments?.status ?? null
 			}
 		})
 	};

--- a/appeals/api/src/server/openapi-types.ts
+++ b/appeals/api/src/server/openapi-types.ts
@@ -2493,6 +2493,7 @@ export interface DocumentationSummary {
 		dueDate?: string | null;
 		/** @format date-time */
 		receivedAt?: string | null;
+		representationStatus?: string | null;
 	};
 	lpaQuestionnaire?: {
 		status?: string;
@@ -2500,6 +2501,7 @@ export interface DocumentationSummary {
 		dueDate?: string | null;
 		/** @format date-time */
 		receivedAt?: string | null;
+		representationStatus?: string | null;
 	};
 	ipComments?: {
 		status?: string;
@@ -2507,6 +2509,7 @@ export interface DocumentationSummary {
 		dueDate?: string | null;
 		/** @format date-time */
 		receivedAt?: string | null;
+		representationStatus?: string | null;
 	};
 	lpaStatement?: {
 		status?: string;
@@ -2514,6 +2517,7 @@ export interface DocumentationSummary {
 		dueDate?: string | null;
 		/** @format date-time */
 		receivedAt?: string | null;
+		representationStatus?: string | null;
 	};
 }
 

--- a/appeals/api/src/server/openapi.json
+++ b/appeals/api/src/server/openapi.json
@@ -10073,6 +10073,10 @@
 								"type": "string",
 								"format": "date-time",
 								"nullable": true
+							},
+							"representationStatus": {
+								"type": "string",
+								"nullable": true
 							}
 						}
 					},
@@ -10090,6 +10094,10 @@
 							"receivedAt": {
 								"type": "string",
 								"format": "date-time",
+								"nullable": true
+							},
+							"representationStatus": {
+								"type": "string",
 								"nullable": true
 							}
 						}
@@ -10109,6 +10117,10 @@
 								"type": "string",
 								"format": "date-time",
 								"nullable": true
+							},
+							"representationStatus": {
+								"type": "string",
+								"nullable": true
 							}
 						}
 					},
@@ -10126,6 +10138,10 @@
 							"receivedAt": {
 								"type": "string",
 								"format": "date-time",
+								"nullable": true
+							},
+							"representationStatus": {
+								"type": "string",
 								"nullable": true
 							}
 						}

--- a/appeals/web/src/server/appeals/appeal-details/representations/lpa-statement/redact/redact.controller.js
+++ b/appeals/web/src/server/appeals/appeal-details/representations/lpa-statement/redact/redact.controller.js
@@ -48,5 +48,5 @@ export async function postConfirm(request, response) {
 
 	addNotificationBannerToSession(session, 'lpaStatementRedactedAndAccepted', appealId);
 
-	return response.redirect(`/appeals-service/appeal-details/${appealId}/lpa-statement`);
+	return response.redirect(`/appeals-service/appeal-details/${appealId}`);
 }

--- a/appeals/web/src/server/appeals/appeal-details/representations/lpa-statement/redact/redact.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/representations/lpa-statement/redact/redact.mapper.js
@@ -86,17 +86,50 @@ export function redactConfirmPage(appealDetails, lpaStatement, session) {
 				rows: [
 					{
 						key: { text: 'Original statement' },
-						value: { text: lpaStatement.originalRepresentation }
+						value: {
+							html: '',
+							pageComponents: [
+								{
+									type: 'show-more',
+									parameters: {
+										text: lpaStatement.originalRepresentation
+									}
+								}
+							]
+						}
 					},
 					{
 						key: { text: 'Redacted statement' },
-						value: { text: session?.redactedRepresentation },
+						value: {
+							html: '',
+							pageComponents: [
+								{
+									type: 'show-more',
+									parameters: {
+										text: session?.redactedRepresentation
+									}
+								}
+							]
+						},
 						actions: {
 							items: [
 								{
 									href: `/appeals-service/appeal-details/${appealDetails.appealId}/lpa-statement/redact`,
 									text: 'Change',
 									visuallyHiddenText: 'redacted statement'
+								}
+							]
+						}
+					},
+					{
+						key: { text: 'Review decision' },
+						value: { text: 'Redact and accept statement' },
+						actions: {
+							items: [
+								{
+									href: `/appeals-service/appeal-details/${appealDetails.appealId}/lpa-statement`,
+									text: 'Change',
+									visuallyHiddenText: 'review decision'
 								}
 							]
 						}
@@ -110,7 +143,7 @@ export function redactConfirmPage(appealDetails, lpaStatement, session) {
 
 	return {
 		title: 'Check details and accept statement',
-		backLinkUrl: `/appeals-service/appeal-details/${appealDetails.appealId}/lpa-statement/${lpaStatement.id}/redact`,
+		backLinkUrl: `/appeals-service/appeal-details/${appealDetails.appealId}/lpa-statement/redact`,
 		preHeading: `Appeal ${shortReference}`,
 		heading: 'Check details and accept statement',
 		forceRenderSubmitButton: true,

--- a/appeals/web/src/server/lib/mappers/components/page-components/notification-banners.mapper.js
+++ b/appeals/web/src/server/lib/mappers/components/page-components/notification-banners.mapper.js
@@ -255,7 +255,7 @@ export const notificationBannerDefinitions = {
 	},
 	lpaStatementRedactedAndAccepted: {
 		type: 'success',
-		pages: ['lpaStatement'],
+		pages: ['appealDetails'],
 		text: 'LPA statement redacted and accepted'
 	},
 	shareCommentsAndLpaStatement: {

--- a/appeals/web/src/server/lib/mappers/data/appeal/submappers/lpa-statement.mapper.js
+++ b/appeals/web/src/server/lib/mappers/data/appeal/submappers/lpa-statement.mapper.js
@@ -1,5 +1,5 @@
 import { dateISOStringToDisplayDate } from '#lib/dates.js';
-import { mapDocumentStatus } from '#lib/display-page-formatter.js';
+import { mapRepresentationDocumentSummaryStatus } from '#lib/representation-utilities.js';
 import { documentationFolderTableItem } from '#lib/mappers/index.js';
 
 /** @type {import('../mapper.js').SubMapper} */
@@ -7,14 +7,17 @@ export const mapLpaStatement = ({ appealDetails, currentRoute }) =>
 	documentationFolderTableItem({
 		id: 'lpa-statement',
 		text: 'LPA statement',
-		statusText: mapDocumentStatus(appealDetails?.documentationSummary?.lpaStatement?.status),
+		statusText: mapRepresentationDocumentSummaryStatus(
+			appealDetails?.documentationSummary?.lpaStatement?.status,
+			appealDetails?.documentationSummary?.lpaStatement?.representationStatus
+		),
 		receivedText: dateISOStringToDisplayDate(
 			appealDetails?.documentationSummary?.lpaStatement?.receivedAt instanceof Date
 				? appealDetails?.documentationSummary?.lpaStatement?.receivedAt.toDateString()
 				: appealDetails?.documentationSummary?.lpaStatement?.receivedAt
 		),
 		actionHtml:
-			appealDetails?.documentationSummary?.lpaStatement?.status === 'received'
+			appealDetails?.documentationSummary?.lpaStatement?.representationStatus === 'received'
 				? `<a href="${currentRoute}/lpa-statement" data-cy="review-lpa-statement" class="govuk-link">Review<span class="govuk-visually-hidden">LPA statement</span></a>`
 				: `<a href="${currentRoute}/lpa-statement" data-cy="view-lpa-statement" class="govuk-link">View<span class="govuk-visually-hidden">LPA statement</span></a>`
 	});


### PR DESCRIPTION
## Describe your changes

* fix(web): fix back link on lpa-statement redact confirm page
* fix(web): add Review decision row to lpa-statement redact confirm page
* feat(web): implement show-more component on redact confirm page
* fix(web): redirect to case details page after redact and accept
* fix(api): add representationStatus to lpa statement summary entry
* fix(web): use correct function to map LPA statement status text
* fix(web): use new representationStatus field for change link logic

## Issue ticket number and link
[A2-75](https://pins-ds.atlassian.net/browse/A2-75)


[A2-75]: https://pins-ds.atlassian.net/browse/A2-75?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ