### PR TITLE
fix(api): returns only attachments to a rep in that folder

### DIFF
--- a/appeals/api/src/server/endpoints/documents/documents.controller.js
+++ b/appeals/api/src/server/endpoints/documents/documents.controller.js
@@ -33,7 +33,8 @@ import { EventType } from '@pins/event-client';
 const getFolder = async (req, res) => {
 	const { appeal } = req;
 	const { folderId } = req.params;
-	const folder = await service.getFolderForAppeal(appeal.id, folderId);
+	const repId = Number(req.query.repId) || null;
+	const folder = await service.getFolderForAppeal(appeal.id, folderId, repId);
 
 	return res.send(folder);
 };

--- a/appeals/api/src/server/endpoints/documents/documents.routes.js
+++ b/appeals/api/src/server/endpoints/documents/documents.routes.js
@@ -50,6 +50,11 @@ router.get(
 			required: true,
 			example: '434bff4e-8191-4ce0-9a0a-91e5d6cdd882'
 		}
+		#swagger.parameters['repId'] = {
+			in: 'query',
+			description: 'The ID of a representation to filter attachments to',
+			example: 1,
+		}
 		#swagger.responses[200] = {
 			description: 'Returns the contents of a single appeal folder, by id',
 			schema: { $ref: '#/components/schemas/Folder' }

--- a/appeals/api/src/server/mappers/integration/map-document-entity.js
+++ b/appeals/api/src/server/mappers/integration/map-document-entity.js
@@ -26,6 +26,11 @@ import { APPEAL_REPRESENTATION_TYPE as INTERNAL_REPRESENTATION_TYPE } from '@pin
  */
 export const mapDocumentEntity = (data) => {
 	const latestDocumentVersion = data.versions?.length === 1 ? data.versions[0] : null;
+	const docFriendlyName =
+		latestDocumentVersion?.representation !== null
+			? data.name.replace(/[a-f\d-]{36}_/, '')
+			: data.name;
+
 	const documentInput = {
 		...data,
 		latestDocumentVersion
@@ -47,7 +52,7 @@ export const mapDocumentEntity = (data) => {
 		caseId: documentInput.caseId,
 		caseReference: documentInput.case?.reference || '',
 		version: documentInput.latestDocumentVersion.version,
-		filename: documentInput.latestDocumentVersion.fileName || '',
+		filename: docFriendlyName || '',
 		originalFilename: documentInput.latestDocumentVersion.originalFilename || '',
 		size: documentInput.latestDocumentVersion.size ?? 0,
 		mime: documentInput.latestDocumentVersion.mime || '',

--- a/appeals/api/src/server/openapi.json
+++ b/appeals/api/src/server/openapi.json
@@ -1828,6 +1828,15 @@
 						"schema": {
 							"type": "string"
 						}
+					},
+					{
+						"name": "repId",
+						"in": "query",
+						"description": "The ID of a representation to filter attachments to",
+						"example": 1,
+						"schema": {
+							"type": "string"
+						}
 					}
 				],
 				"responses": {

--- a/appeals/api/src/server/repositories/appeal.repository.js
+++ b/appeals/api/src/server/repositories/appeal.repository.js
@@ -368,7 +368,7 @@ const getAppealsByIds = async (linkedAppealIds) => {
  *
  * @param {number} appealId
  * @param {Object<string, number>} data
- * @returns {Promise<AppealRelationship>}
+ * @returns {Promise<import('#db-client').ServiceUser>}
  */
 const removeAppealServiceUser = async (appealId, data) => {
 	const { userType, serviceUserId } = data;

--- a/appeals/api/src/server/repositories/folder.repository.js
+++ b/appeals/api/src/server/repositories/folder.repository.js
@@ -11,6 +11,7 @@ import { databaseConnector } from '#utils/database-connector.js';
  * @returns {PrismaPromise<Folder|null>}
  */
 export const getById = (id) => {
+	// @ts-ignore
 	return databaseConnector.folder.findUnique({
 		where: { id },
 		include: {
@@ -18,7 +19,8 @@ export const getById = (id) => {
 				include: {
 					latestDocumentVersion: {
 						include: {
-							redactionStatus: true
+							redactionStatus: true,
+							representation: true
 						}
 					}
 				},


### PR DESCRIPTION
Adds an optional `repId` querystring param when loading a single folder. If the folder is for representation attachments, it will only return the documents that are attachment of the representation ID provided.

Also, removed any GUID prefixes in the document name (used to avoid folder constraints) when showing the data back to the user.

