### PR TITLE
fix(api): check visitDate is in the past if visitEndTime is not present

### DIFF
--- a/appeals/api/src/server/repositories/appeal.repository.js
+++ b/appeals/api/src/server/repositories/appeal.repository.js
@@ -390,9 +390,19 @@ const getAppealsWithCompletedEvents = () =>
 				}
 			},
 			siteVisit: {
-				visitEndTime: {
-					lte: new Date()
-				}
+				OR: [
+					{
+						visitEndTime: {
+							lte: new Date()
+						}
+					},
+					{
+						visitEndTime: null,
+						visitDate: {
+							lte: new Date()
+						}
+					}
+				]
 			}
 		},
 		include: appealDetailsInclude


### PR DESCRIPTION
A2-1832

## Describe your changes

In the endpoint used by the new cron job, check `visitDate` column is in the past if `visitEndTime` is not present.

## Issue ticket number and link
[A2-1832](https://pins-ds.atlassian.net/browse/A2-1832)


[A2-1832]: https://pins-ds.atlassian.net/browse/A2-1832?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ