### PR TITLE
feat(appeals): progress the case even if no statements, or ipcomments, have been received (a2-1954)

### DIFF
--- a/appeals/web/src/server/appeals/appeal-details/accordions/utils/map-status-dependent-notifications.js
+++ b/appeals/web/src/server/appeals/appeal-details/accordions/utils/map-status-dependent-notifications.js
@@ -88,7 +88,17 @@ export function mapStatusDependentNotifications(
 			removeAccordionComponentsActions(accordionComponents);
 			break;
 		case APPEAL_CASE_STATUS.STATEMENTS: {
-			const isDueDatePassed = (() => {
+			const isIpCommentsDueDatePassed = (() => {
+				if (!appealDetails.appealTimetable?.ipCommentsDueDate) {
+					return false;
+				}
+
+				return dateIsInThePast(
+					dateISOStringToDayMonthYearHourMinute(appealDetails.appealTimetable.ipCommentsDueDate)
+				);
+			})();
+
+			const isLpaStatementDueDatePassed = (() => {
 				if (!appealDetails.appealTimetable?.lpaStatementDueDate) {
 					return false;
 				}
@@ -99,7 +109,7 @@ export function mapStatusDependentNotifications(
 			})();
 
 			if (
-				isDueDatePassed &&
+				isLpaStatementDueDatePassed &&
 				!representationTypesAwaitingReview?.ipComments &&
 				!representationTypesAwaitingReview?.lpaStatement
 			) {
@@ -108,6 +118,23 @@ export function mapStatusDependentNotifications(
 					'shareCommentsAndLpaStatement',
 					appealDetails.appealId,
 					`<a href="/appeals-service/appeal-details/${appealDetails.appealId}/share" class="govuk-heading-s govuk-notification-banner__link">Share IP comments and LPA statement</a>`
+				);
+				break;
+			}
+
+			if (
+				isLpaStatementDueDatePassed &&
+				isIpCommentsDueDatePassed &&
+				!(
+					representationTypesAwaitingReview?.ipComments &&
+					representationTypesAwaitingReview?.lpaStatement
+				)
+			) {
+				addNotificationBannerToSession(
+					session,
+					'progressToFinalComments',
+					appealDetails.appealId,
+					`<a href="/appeals-service/appeal-details/${appealDetails.appealId}/share" class="govuk-heading-s govuk-notification-banner__link">Progress to final comments</a>`
 				);
 				break;
 			}

--- a/appeals/web/src/server/appeals/appeal-details/representations/representations.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/representations/representations.mapper.js
@@ -152,11 +152,14 @@ export function statementAndCommentsSharePage(appeal) {
 					}
 			  };
 
+	const heading =
+		valueTexts.length > 0 ? 'Share IP comments and statements' : 'Progress to final comments';
+
 	return {
-		title: 'Share IP comments and statements',
+		title: heading,
 		backLinkUrl: `/appeals-service/appeal-details/${appeal.appealId}`,
 		preHeading: `Appeal ${shortAppealReference}`,
-		heading: 'Share IP comments and statements',
+		heading,
 		pageComponents: [
 			textComponent,
 			{

--- a/appeals/web/src/server/appeals/appeal-details/representations/representations.validators.js
+++ b/appeals/web/src/server/appeals/appeal-details/representations/representations.validators.js
@@ -5,9 +5,10 @@ import { APPEAL_REPRESENTATION_STATUS } from '@pins/appeals/constants/common.js'
 export function validateReadyToShare(request, response, next) {
 	const { currentAppeal } = request;
 
+	const { representationStatus, status } = currentAppeal.documentationSummary?.lpaStatement || {};
+
 	const statementValid =
-		currentAppeal.documentationSummary?.lpaStatement?.representationStatus ===
-		APPEAL_REPRESENTATION_STATUS.VALID;
+		representationStatus === APPEAL_REPRESENTATION_STATUS.VALID || status === 'not_received';
 
 	if (currentAppeal.appealStatus !== APPEAL_CASE_STATUS.STATEMENTS || !statementValid) {
 		return response.status(404).render('app/404.njk');

--- a/appeals/web/src/server/appeals/personal-list/__tests__/personal-list.test.js
+++ b/appeals/web/src/server/appeals/personal-list/__tests__/personal-list.test.js
@@ -343,25 +343,16 @@ describe('personal-list', () => {
 describe('mapAppealStatusToActionRequiredHtml', () => {
 	const appealId = 123;
 	const lpaQuestionnaireId = 456;
+	const appeal = {
+		appealId,
+		lpaQuestionnaireId,
+		appealStatus: 'validation',
+		appealType: 'appeal',
+		appealSubtype: 'protection'
+	};
 
 	it('should return "Review appellant case" link for validation status with unvalidated appellant case', () => {
-		const result = mapAppealStatusToActionRequiredHtml(
-			appealId,
-			'validation',
-			false,
-			lpaQuestionnaireId,
-			{
-				appellantCase: '',
-				lpaQuestionnaire: '',
-				lpaStatement: '',
-				lpaFinalComments: '',
-				lpaFinalCommentsRepresentationStatus: '',
-				appellantFinalComments: '',
-				appellantFinalCommentsRepresentationStatus: ''
-			},
-			'',
-			true
-		);
+		const result = mapAppealStatusToActionRequiredHtml(appeal, true);
 		expect(result).toEqual(
 			`<a class="govuk-link" href="/appeals-service/appeal-details/${appealId}/appellant-case">Review appellant case<span class="govuk-visually-hidden"> for appeal 123</span></a>`
 		);
@@ -369,20 +360,10 @@ describe('mapAppealStatusToActionRequiredHtml', () => {
 
 	it('should return "Awaiting appellant update" link for validation status with incomplete appellant case', () => {
 		const result = mapAppealStatusToActionRequiredHtml(
-			appealId,
-			'validation',
-			false,
-			lpaQuestionnaireId,
 			{
-				appellantCase: 'Incomplete',
-				lpaQuestionnaire: '',
-				lpaStatement: '',
-				lpaFinalComments: '',
-				lpaFinalCommentsRepresentationStatus: '',
-				appellantFinalComments: '',
-				appellantFinalCommentsRepresentationStatus: ''
+				...appeal,
+				documentationSummary: { appellantCase: { status: 'Incomplete' } }
 			},
-			'',
 			true
 		);
 		expect(result).toEqual(
@@ -392,20 +373,10 @@ describe('mapAppealStatusToActionRequiredHtml', () => {
 
 	it('should return "Awaiting appellant update" text for validation status with incomplete appellant case and isCaseOfficer false', () => {
 		const result = mapAppealStatusToActionRequiredHtml(
-			appealId,
-			'validation',
-			false,
-			lpaQuestionnaireId,
 			{
-				appellantCase: 'Incomplete',
-				lpaQuestionnaire: '',
-				lpaStatement: '',
-				lpaFinalComments: '',
-				lpaFinalCommentsRepresentationStatus: '',
-				appellantFinalComments: '',
-				appellantFinalCommentsRepresentationStatus: ''
+				...appeal,
+				documentationSummary: { appellantCase: { status: 'Incomplete' } }
 			},
-			'',
 			false
 		);
 		expect(result).toEqual('Awaiting appellant update');
@@ -413,20 +384,11 @@ describe('mapAppealStatusToActionRequiredHtml', () => {
 
 	it('should return "Start case" link for ready_to_start status', () => {
 		const result = mapAppealStatusToActionRequiredHtml(
-			appealId,
-			'ready_to_start',
-			false,
-			lpaQuestionnaireId,
 			{
-				appellantCase: '',
-				lpaQuestionnaire: '',
-				lpaStatement: '',
-				lpaFinalComments: '',
-				lpaFinalCommentsRepresentationStatus: '',
-				appellantFinalComments: '',
-				appellantFinalCommentsRepresentationStatus: ''
+				...appeal,
+				appealStatus: 'ready_to_start',
+				documentationSummary: { appellantCase: { status: 'Incomplete' } }
 			},
-			'',
 			true
 		);
 		expect(result).toEqual(
@@ -436,20 +398,11 @@ describe('mapAppealStatusToActionRequiredHtml', () => {
 
 	it('should return "Start case" text for ready_to_start status and isCaseOfficer false', () => {
 		const result = mapAppealStatusToActionRequiredHtml(
-			appealId,
-			'ready_to_start',
-			false,
-			lpaQuestionnaireId,
 			{
-				appellantCase: '',
-				lpaQuestionnaire: '',
-				lpaStatement: '',
-				lpaFinalComments: '',
-				lpaFinalCommentsRepresentationStatus: '',
-				appellantFinalComments: '',
-				appellantFinalCommentsRepresentationStatus: ''
+				...appeal,
+				appealStatus: 'ready_to_start',
+				documentationSummary: { appellantCase: { status: 'Incomplete' } }
 			},
-			'',
 			false
 		);
 		expect(result).toEqual('Start case');
@@ -457,20 +410,12 @@ describe('mapAppealStatusToActionRequiredHtml', () => {
 
 	it('should return "Awaiting LPA questionnaire" for lpa_questionnaire status with no LPA questionnaire ID', () => {
 		const result = mapAppealStatusToActionRequiredHtml(
-			appealId,
-			'lpa_questionnaire',
-			false,
-			null,
 			{
-				appellantCase: '',
-				lpaQuestionnaire: '',
-				lpaStatement: '',
-				lpaFinalComments: '',
-				lpaFinalCommentsRepresentationStatus: '',
-				appellantFinalComments: '',
-				appellantFinalCommentsRepresentationStatus: ''
+				...appeal,
+				appealStatus: 'lpa_questionnaire',
+				lpaQuestionnaireId: null,
+				documentationSummary: { appellantCase: { status: 'Incomplete' } }
 			},
-			'',
 			true
 		);
 		expect(result).toEqual('Awaiting LPA questionnaire');
@@ -478,20 +423,11 @@ describe('mapAppealStatusToActionRequiredHtml', () => {
 
 	it('should return "Awaiting LPA update" link for lpa_questionnaire status with incomplete LPA questionnaire', () => {
 		const result = mapAppealStatusToActionRequiredHtml(
-			appealId,
-			'lpa_questionnaire',
-			false,
-			lpaQuestionnaireId,
 			{
-				appellantCase: '',
-				lpaQuestionnaire: 'Incomplete',
-				lpaStatement: '',
-				lpaFinalComments: '',
-				lpaFinalCommentsRepresentationStatus: '',
-				appellantFinalComments: '',
-				appellantFinalCommentsRepresentationStatus: ''
+				...appeal,
+				appealStatus: 'lpa_questionnaire',
+				documentationSummary: { lpaQuestionnaire: { status: 'Incomplete' } }
 			},
-			'',
 			true
 		);
 		expect(result).toEqual(
@@ -501,20 +437,11 @@ describe('mapAppealStatusToActionRequiredHtml', () => {
 
 	it('should return "Awaiting LPA update" text for lpa_questionnaire status with incomplete LPA questionnaire and isCaseOfficer false', () => {
 		const result = mapAppealStatusToActionRequiredHtml(
-			appealId,
-			'lpa_questionnaire',
-			false,
-			lpaQuestionnaireId,
 			{
-				appellantCase: '',
-				lpaQuestionnaire: 'Incomplete',
-				lpaStatement: '',
-				lpaFinalComments: '',
-				lpaFinalCommentsRepresentationStatus: '',
-				appellantFinalComments: '',
-				appellantFinalCommentsRepresentationStatus: ''
+				...appeal,
+				appealStatus: 'lpa_questionnaire',
+				documentationSummary: { lpaQuestionnaire: { status: 'Incomplete' } }
 			},
-			'',
 			false
 		);
 		expect(result).toEqual('Awaiting LPA update');
@@ -522,20 +449,11 @@ describe('mapAppealStatusToActionRequiredHtml', () => {
 
 	it('should return "Review LPA questionnaire" for lpa_questionnaire status with LPA questionnaire', () => {
 		const result = mapAppealStatusToActionRequiredHtml(
-			appealId,
-			'lpa_questionnaire',
-			false,
-			lpaQuestionnaireId,
 			{
-				appellantCase: '',
-				lpaQuestionnaire: '',
-				lpaStatement: '',
-				lpaFinalComments: '',
-				lpaFinalCommentsRepresentationStatus: '',
-				appellantFinalComments: '',
-				appellantFinalCommentsRepresentationStatus: ''
+				...appeal,
+				appealStatus: 'lpa_questionnaire',
+				documentationSummary: { appellantCase: { status: 'Incomplete' } }
 			},
-			'',
 			true
 		);
 		expect(result).toEqual(
@@ -545,20 +463,11 @@ describe('mapAppealStatusToActionRequiredHtml', () => {
 
 	it('should return "Review LPA questionnaire" for lpa_questionnaire status with LPA questionnaire and isCaseOfficer false', () => {
 		const result = mapAppealStatusToActionRequiredHtml(
-			appealId,
-			'lpa_questionnaire',
-			false,
-			lpaQuestionnaireId,
 			{
-				appellantCase: '',
-				lpaQuestionnaire: '',
-				lpaStatement: '',
-				lpaFinalComments: '',
-				lpaFinalCommentsRepresentationStatus: '',
-				appellantFinalComments: '',
-				appellantFinalCommentsRepresentationStatus: ''
+				...appeal,
+				appealStatus: 'lpa_questionnaire',
+				documentationSummary: { appellantCase: { status: 'Incomplete' } }
 			},
-			'',
 			false
 		);
 		expect(result).toEqual('Review LPA questionnaire');
@@ -566,20 +475,13 @@ describe('mapAppealStatusToActionRequiredHtml', () => {
 
 	it('should return "LPA questionnaire overdue" for lpa_questionnaire status with LPA questionnaire overdue', () => {
 		const result = mapAppealStatusToActionRequiredHtml(
-			appealId,
-			'lpa_questionnaire',
-			false,
-			null,
 			{
-				appellantCase: '',
-				lpaQuestionnaire: '',
-				lpaStatement: '',
-				lpaFinalComments: '',
-				lpaFinalCommentsRepresentationStatus: '',
-				appellantFinalComments: '',
-				appellantFinalCommentsRepresentationStatus: ''
+				...appeal,
+				appealStatus: 'lpa_questionnaire',
+				lpaQuestionnaireId: null,
+				dueDate: '2024-01-01',
+				documentationSummary: { appellantCase: { status: 'Incomplete' } }
 			},
-			'2024-01-01',
 			true
 		);
 		expect(result).toEqual('LPA questionnaire overdue');
@@ -587,20 +489,12 @@ describe('mapAppealStatusToActionRequiredHtml', () => {
 
 	it('should return "Set up site visit" link for event status', () => {
 		const result = mapAppealStatusToActionRequiredHtml(
-			appealId,
-			'event',
-			false,
-			null,
 			{
-				appellantCase: '',
-				lpaQuestionnaire: '',
-				lpaStatement: '',
-				lpaFinalComments: '',
-				lpaFinalCommentsRepresentationStatus: '',
-				appellantFinalComments: '',
-				appellantFinalCommentsRepresentationStatus: ''
+				...appeal,
+				appealStatus: 'event',
+				lpaQuestionnaireId: null,
+				documentationSummary: { appellantCase: { status: 'Incomplete' } }
 			},
-			'',
 			true
 		);
 		expect(result).toEqual(
@@ -610,20 +504,11 @@ describe('mapAppealStatusToActionRequiredHtml', () => {
 
 	it('should return "Issue decision" link for issue_determination status', () => {
 		const result = mapAppealStatusToActionRequiredHtml(
-			appealId,
-			'issue_determination',
-			false,
-			null,
 			{
-				appellantCase: '',
-				lpaQuestionnaire: '',
-				lpaStatement: '',
-				lpaFinalComments: '',
-				lpaFinalCommentsRepresentationStatus: '',
-				appellantFinalComments: '',
-				appellantFinalCommentsRepresentationStatus: ''
+				...appeal,
+				appealStatus: 'issue_determination',
+				lpaQuestionnaireId: null
 			},
-			'',
 			true
 		);
 		expect(result).toEqual(
@@ -633,20 +518,11 @@ describe('mapAppealStatusToActionRequiredHtml', () => {
 
 	it('should return "Update Horizon reference" link for awaiting_transfer status', () => {
 		const result = mapAppealStatusToActionRequiredHtml(
-			appealId,
-			'awaiting_transfer',
-			false,
-			null,
 			{
-				appellantCase: '',
-				lpaQuestionnaire: '',
-				lpaStatement: '',
-				lpaFinalComments: '',
-				lpaFinalCommentsRepresentationStatus: '',
-				appellantFinalComments: '',
-				appellantFinalCommentsRepresentationStatus: ''
+				...appeal,
+				appealStatus: 'awaiting_transfer',
+				lpaQuestionnaireId: null
 			},
-			'',
 			true
 		);
 		expect(result).toEqual(
@@ -656,20 +532,11 @@ describe('mapAppealStatusToActionRequiredHtml', () => {
 
 	it('should return "View case" link for any other status', () => {
 		const result = mapAppealStatusToActionRequiredHtml(
-			appealId,
-			'some_other_status',
-			false,
-			null,
 			{
-				appellantCase: '',
-				lpaQuestionnaire: '',
-				lpaStatement: '',
-				lpaFinalComments: '',
-				lpaFinalCommentsRepresentationStatus: '',
-				appellantFinalComments: '',
-				appellantFinalCommentsRepresentationStatus: ''
+				...appeal,
+				appealStatus: 'some_other_status',
+				lpaQuestionnaireId: null
 			},
-			'',
 			true
 		);
 		expect(result).toEqual(

--- a/appeals/web/src/server/lib/mappers/components/page-components/notification-banners.mapper.js
+++ b/appeals/web/src/server/lib/mappers/components/page-components/notification-banners.mapper.js
@@ -92,6 +92,9 @@ export const notificationBannerDefinitions = {
 	readyForLpaQuestionnaireReview: {
 		pages: ['appealDetails']
 	},
+	progressToFinalComments: {
+		pages: ['appealDetails']
+	},
 	lpaQuestionnaireNotValid: {
 		pages: ['lpaQuestionnaire'],
 		persist: true


### PR DESCRIPTION
## Describe your changes
### Progress the case on even if no Statements/IP comments have been received (a2-1954)

#### WEB:
 - Added "Progress to final comments" banner in case details page
 - Added "Progress to final comments" action link in personal list
 - Simplified parameters passed into "mapAppealStatusToActionRequiredHtml" function to pass in the appeal object to reduce the number of parameters required.
    
#### TESTING:
- Simplified WEB tests for personal list now the number of parameters are far less when calling "mapAppealStatusToActionRequiredHtml"
- All WEB unit tests pass
- Manually tested within browser

## Issue ticket number and link

[A2-1954 Progress the case on even if no Statements/IP comments have been received](https://pins-ds.atlassian.net/browse/A2-1954)

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [x] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [x] I have included unit tests to cover any testable code changes
