### PR TITLE
fix(infrastructure): updating module version to 1.38

### DIFF
--- a/infrastructure/app-api.tf
+++ b/infrastructure/app-api.tf
@@ -1,6 +1,6 @@
 module "app_api" {
   #checkov:skip=CKV_TF_1: Use of commit hash are not required for our Terraform modules
-  source = "github.com/Planning-Inspectorate/infrastructure-modules.git//modules/node-app-service?ref=1.31"
+  source = "github.com/Planning-Inspectorate/infrastructure-modules.git//modules/node-app-service?ref=1.38"
 
   resource_group_name = azurerm_resource_group.primary.name
   location            = module.primary_region.location
@@ -26,6 +26,7 @@ module "app_api" {
   inbound_vnet_connectivity       = var.apps_config.private_endpoint_enabled
   integration_subnet_id           = azurerm_subnet.apps.id
   outbound_vnet_connectivity      = true
+  public_network_access           = false
 
   # monitoring
   action_group_ids                  = local.action_group_ids

--- a/infrastructure/app-web.tf
+++ b/infrastructure/app-web.tf
@@ -1,6 +1,6 @@
 module "app_web" {
   #checkov:skip=CKV_TF_1: Use of commit hash are not required for our Terraform modules
-  source = "github.com/Planning-Inspectorate/infrastructure-modules.git//modules/node-app-service?ref=1.31"
+  source = "github.com/Planning-Inspectorate/infrastructure-modules.git//modules/node-app-service?ref=1.38"
 
   resource_group_name = azurerm_resource_group.primary.name
   location            = module.primary_region.location
@@ -26,6 +26,7 @@ module "app_web" {
   inbound_vnet_connectivity       = false
   integration_subnet_id           = azurerm_subnet.apps.id
   outbound_vnet_connectivity      = true
+  public_network_access           = true
 
   # monitoring
   action_group_ids                  = local.action_group_ids


### PR DESCRIPTION
## Describe your changes
With infrastructure module v1.38, 
- Uses new public_network_access setting to ensure staging slots have the same networking rules set as the prod slot
- Deny all public network access for Api's
- Allow only front door access for Web Apps
- All site_config changes were ignored due to a incorrect ignore_changes entry. This has been updated to only ignore  the docker image name/tag.

This ensures IP restrictions allowing only front_door and default action settings will apply.
<!--
    Please include a summary of the change along with any relevant context.
    List any dependencies that are required for this change.
-->

## Issue ticket number and link
[Ticket-slot-access](https://pins-ds.atlassian.net/browse/DEV-308)
[Ticket-ignore-changes](https://pins-ds.atlassian.net/browse/DEV-351)

