### PR TITLE
Feature/a2 2050 share

### DIFF
--- a/appeals/api/src/server/endpoints/constants.js
+++ b/appeals/api/src/server/endpoints/constants.js
@@ -13,6 +13,7 @@ export const CASE_OUTCOME_DISMISSED = 'dismissed';
 export const CASE_OUTCOME_SPLIT_DECISION = 'split decision';
 export const CASE_OUTCOME_INVALID = 'invalid';
 
+export const AUDIT_TRAIL_REP_SHARED = '{replacement0} shared';
 export const AUDIT_TRAIL_REP_LPA_STATEMENT_STATUS_UPDATED =
 	'LPA statement status updated to {replacement0}';
 export const AUDIT_TRAIL_REP_LPA_STATEMENT_REDACTED_AND_ACCEPTED =

--- a/appeals/api/src/server/endpoints/representations/representations.controller.js
+++ b/appeals/api/src/server/endpoints/representations/representations.controller.js
@@ -303,6 +303,18 @@ export async function publish(req, res) {
 
 	const updatedReps = await publish(appeal, azureAdUserId);
 
+	if (updatedReps.length > 0) {
+		const details = stringTokenReplacement(CONSTANTS.AUDIT_TRAIL_REP_SHARED, [
+			'Statements and IP comments'
+		]);
+
+		await createAuditTrail({
+			appealId: appeal.id,
+			azureAdUserId: req.get('azureAdUserId'),
+			details
+		});
+	}
+
 	await Promise.all(
 		updatedReps.map((rep) => broadcasters.broadcastRepresentation(rep.id, EventType.Update))
 	);

--- a/appeals/web/src/server/appeals/appeal-details/representations/representations.controller.js
+++ b/appeals/web/src/server/appeals/appeal-details/representations/representations.controller.js
@@ -1,3 +1,4 @@
+import { addNotificationBannerToSession } from '#lib/session-utilities.js';
 import { statementAndCommentsSharePage } from './representations.mapper.js';
 import { publishRepresentations } from './representations.service.js';
 
@@ -15,9 +16,11 @@ export function renderShareRepresentations(request, response) {
 
 /** @type {import('@pins/express').RequestHandler<{}>} */
 export async function postShareRepresentations(request, response) {
-	const { apiClient, currentAppeal } = request;
+	const { apiClient, currentAppeal, session } = request;
 
 	await publishRepresentations(apiClient, currentAppeal.appealId, 'lpa_statement');
+
+	addNotificationBannerToSession(session, 'commentsAndLpaStatementShared', currentAppeal.appealId);
 
 	return response.redirect(`/appeals-service/appeal-details/${currentAppeal.appealId}`);
 }

--- a/appeals/web/src/server/appeals/appeal-details/representations/representations.controller.js
+++ b/appeals/web/src/server/appeals/appeal-details/representations/representations.controller.js
@@ -18,9 +18,17 @@ export function renderShareRepresentations(request, response) {
 export async function postShareRepresentations(request, response) {
 	const { apiClient, currentAppeal, session } = request;
 
-	await publishRepresentations(apiClient, currentAppeal.appealId, 'lpa_statement');
+	const publishedReps = await publishRepresentations(
+		apiClient,
+		currentAppeal.appealId,
+		'lpa_statement'
+	);
 
-	addNotificationBannerToSession(session, 'commentsAndLpaStatementShared', currentAppeal.appealId);
+	addNotificationBannerToSession(
+		session,
+		publishedReps.length > 0 ? 'commentsAndLpaStatementShared' : 'progressedToFinalComments',
+		currentAppeal.appealId
+	);
 
 	return response.redirect(`/appeals-service/appeal-details/${currentAppeal.appealId}`);
 }

--- a/appeals/web/src/server/appeals/appeal-details/representations/representations.service.js
+++ b/appeals/web/src/server/appeals/appeal-details/representations/representations.service.js
@@ -107,6 +107,7 @@ export const updateRejectionReasons = (apiClient, appealId, commentId, rejection
  * @param {import('got').Got} apiClient
  * @param {number} appealId
  * @param {'lpa_statement' | 'final_comment'} type
+ * @returns {Promise<Representation[]>}
  * */
 export const publishRepresentations = (apiClient, appealId, type) =>
 	apiClient.post(`appeals/${appealId}/reps/publish?type=${type}`).json();

--- a/appeals/web/src/server/appeals/personal-list/personal-list.mapper.js
+++ b/appeals/web/src/server/appeals/personal-list/personal-list.mapper.js
@@ -316,10 +316,13 @@ export function mapAppealStatusToActionRequiredHtml(appeal, isCaseOfficer = fals
 		case APPEAL_CASE_STATUS.AWAITING_TRANSFER:
 			return `<a class="govuk-link" href="/appeals-service/appeal-details/${appealId}/change-appeal-type/add-horizon-reference">Update Horizon reference<span class="govuk-visually-hidden"> for appeal ${appealId}</span></a>`;
 		case APPEAL_CASE_STATUS.STATEMENTS: {
-			if (lpaStatementStatus === 'not_received' && ipCommentsStatus === 'not_received') {
-				if (lpaStatementDueDatePassed && ipCommentsDueDatePassed) {
-					return `<a class="govuk-link" href="/appeals-service/appeal-details/${appealId}/share">Progress to final comments<span class="govuk-visually-hidden"> for appeal ${appealId}</span></a>`;
-				}
+			if (
+				lpaStatementStatus === 'not_received' &&
+				ipCommentsStatus === 'not_received' &&
+				lpaStatementDueDatePassed &&
+				ipCommentsDueDatePassed
+			) {
+				return `<a class="govuk-link" href="/appeals-service/appeal-details/${appealId}/share">Progress to final comments<span class="govuk-visually-hidden"> for appeal ${appealId}</span></a>`;
 			}
 
 			if (appealDueDatePassed && !hasAwaitingComments) {

--- a/appeals/web/src/server/lib/mappers/components/page-components/notification-banners.mapper.js
+++ b/appeals/web/src/server/lib/mappers/components/page-components/notification-banners.mapper.js
@@ -274,6 +274,11 @@ export const notificationBannerDefinitions = {
 		pages: ['appealDetails'],
 		text: 'Statements and IP comments shared'
 	},
+	progressedToFinalComments: {
+		type: 'success',
+		pages: ['appealDetails'],
+		text: 'Progressed to Final Comments'
+	},
 	finalCommentsDocumentAddedSuccess: {
 		type: 'success',
 		pages: ['viewFinalComments'],

--- a/appeals/web/src/server/lib/mappers/components/page-components/notification-banners.mapper.js
+++ b/appeals/web/src/server/lib/mappers/components/page-components/notification-banners.mapper.js
@@ -269,6 +269,11 @@ export const notificationBannerDefinitions = {
 	shareCommentsAndLpaStatement: {
 		pages: ['appealDetails']
 	},
+	commentsAndLpaStatementShared: {
+		type: 'success',
+		pages: ['appealDetails'],
+		text: 'Statements and IP comments shared'
+	},
 	finalCommentsDocumentAddedSuccess: {
 		type: 'success',
 		pages: ['viewFinalComments'],

--- a/appeals/web/src/server/lib/mappers/data/appeal/submappers/lpa-statement-due-date.mapper.js
+++ b/appeals/web/src/server/lib/mappers/data/appeal/submappers/lpa-statement-due-date.mapper.js
@@ -1,3 +1,4 @@
+import { APPEAL_REPRESENTATION_STATUS } from 'pins-data-model';
 import { dateISOStringToDisplayDate } from '#lib/dates.js';
 import { textSummaryListItem } from '#lib/mappers/index.js';
 
@@ -12,6 +13,10 @@ export const mapLpaStatementDueDate = ({
 		text: 'LPA statement due',
 		value: dateISOStringToDisplayDate(appealDetails.appealTimetable?.lpaStatementDueDate),
 		link: `${currentRoute}/appeal-timetables/lpa-statement`,
-		editable: Boolean(userHasUpdateCasePermission && appealDetails.validAt),
+		editable:
+			userHasUpdateCasePermission &&
+			Boolean(appealDetails.validAt) &&
+			appealDetails.documentationSummary?.lpaStatement?.representationStatus !==
+				APPEAL_REPRESENTATION_STATUS.PUBLISHED,
 		classes: 'appeal-lpa-statement-due-date'
 	});

--- a/appeals/web/src/server/lib/representation-utilities.js
+++ b/appeals/web/src/server/lib/representation-utilities.js
@@ -42,13 +42,16 @@ export function mapRepresentationDocumentSummaryActionLink(
  * @returns {string}
  */
 export function mapRepresentationDocumentSummaryStatus(documentationStatus, representationStatus) {
-	if (documentationStatus === 'received' && representationStatus) {
-		if (representationStatus === APPEAL_REPRESENTATION_STATUS.VALID) {
-			return 'Accepted';
-		}
-
-		return 'Received';
+	if (documentationStatus !== 'received' || !representationStatus) {
+		return 'Not received';
 	}
 
-	return 'Not received';
+	switch (representationStatus) {
+		case APPEAL_REPRESENTATION_STATUS.VALID:
+			return 'Accepted';
+		case APPEAL_REPRESENTATION_STATUS.PUBLISHED:
+			return 'Shared';
+		default:
+			return 'Received';
+	}
 }


### PR DESCRIPTION
## Describe your changes

* feat(api): add an audit trail log when publishing LPA statement
* feat(web): render a success banner on sharing LPA statement and comments
* feat(web): display 'Shared' status in documentation table
* feat(web): change success banner if progressing without sharing
* feat(web): hide the LPA Statement Change link once published
* refactor(web): change nested if-statement to a single if-statement
* fix(web): correct logic for rendering notification banners in STATEMENTS

## Issue ticket number and link
[A2-2050](https://pins-ds.atlassian.net/browse/A2-2050)


[A2-2050]: https://pins-ds.atlassian.net/browse/A2-2050?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ