### PR TITLE
Feature/a2 2051 ip comments

### DIFF
--- a/appeals/api/src/server/endpoints/appeal-details/__tests__/appeals-details.test.js
+++ b/appeals/api/src/server/endpoints/appeal-details/__tests__/appeals-details.test.js
@@ -167,7 +167,10 @@ const s78AppealDto = {
 		},
 		ipComments: {
 			status: 'received',
-			validCount: 4
+			counts: {
+				valid: 4,
+				published: 0
+			}
 		},
 		lpaFinalComments: {
 			receivedAt: null,

--- a/appeals/api/src/server/endpoints/appeals.d.ts
+++ b/appeals/api/src/server/endpoints/appeals.d.ts
@@ -522,7 +522,7 @@ interface AppealListResponse {
 interface DocumentationSummary {
 	appellantCase?: DocumentationSummaryEntry;
 	lpaQuestionnaire?: DocumentationSummaryEntry;
-	ipComments?: IPCommentsDocumentationSummary;
+	ipComments?: DocumentationSummaryEntry;
 	lpaStatement?: DocumentationSummaryEntry;
 	lpaFinalComments?: DocumentationSummaryEntry;
 	appellantFinalComments?: DocumentationSummaryEntry;
@@ -533,10 +533,7 @@ interface DocumentationSummaryEntry {
 	dueDate?: Date | string | undefined | null;
 	receivedAt?: Date | string | undefined | null;
 	representationStatus?: string | undefined | null;
-}
-
-interface IPCommentsDocumentationSummary extends DocumentationSummaryEntry {
-	validCount: number;
+	counts: Record<string, number>;
 }
 
 interface FolderInfo {

--- a/appeals/api/src/server/endpoints/appeals/__tests__/appeals.test.js
+++ b/appeals/api/src/server/endpoints/appeals/__tests__/appeals.test.js
@@ -81,7 +81,10 @@ describe('appeals list routes', () => {
 								},
 								ipComments: {
 									status: 'not_received',
-									validCount: 0
+									counts: {
+										valid: 0,
+										published: 0
+									}
 								},
 								lpaQuestionnaire: {
 									receivedAt: '2024-06-24T00:00:00.000Z',
@@ -127,7 +130,10 @@ describe('appeals list routes', () => {
 								},
 								ipComments: {
 									status: 'not_received',
-									validCount: 0
+									counts: {
+										valid: 0,
+										published: 0
+									}
 								},
 								lpaQuestionnaire: {
 									receivedAt: '2024-06-24T00:00:00.000Z',
@@ -196,7 +202,10 @@ describe('appeals list routes', () => {
 								},
 								ipComments: {
 									status: 'not_received',
-									validCount: 0
+									counts: {
+										valid: 0,
+										published: 0
+									}
 								},
 								lpaQuestionnaire: {
 									receivedAt: '2024-06-24T00:00:00.000Z',
@@ -293,7 +302,10 @@ describe('appeals list routes', () => {
 								},
 								ipComments: {
 									status: 'not_received',
-									validCount: 0
+									counts: {
+										valid: 0,
+										published: 0
+									}
 								},
 								lpaQuestionnaire: {
 									receivedAt: '2024-06-24T00:00:00.000Z',
@@ -390,7 +402,10 @@ describe('appeals list routes', () => {
 								},
 								ipComments: {
 									status: 'not_received',
-									validCount: 0
+									counts: {
+										valid: 0,
+										published: 0
+									}
 								},
 								lpaQuestionnaire: {
 									receivedAt: '2024-06-24T00:00:00.000Z',
@@ -487,7 +502,10 @@ describe('appeals list routes', () => {
 								},
 								ipComments: {
 									status: 'not_received',
-									validCount: 0
+									counts: {
+										valid: 0,
+										published: 0
+									}
 								},
 								lpaQuestionnaire: {
 									receivedAt: '2024-06-24T00:00:00.000Z',
@@ -571,7 +589,10 @@ describe('appeals list routes', () => {
 								},
 								ipComments: {
 									status: 'not_received',
-									validCount: 0
+									counts: {
+										valid: 0,
+										published: 0
+									}
 								},
 								lpaQuestionnaire: {
 									receivedAt: '2024-06-24T00:00:00.000Z',
@@ -657,7 +678,10 @@ describe('appeals list routes', () => {
 								},
 								ipComments: {
 									status: 'not_received',
-									validCount: 0
+									counts: {
+										valid: 0,
+										published: 0
+									}
 								},
 								lpaQuestionnaire: {
 									receivedAt: '2024-06-24T00:00:00.000Z',
@@ -740,7 +764,10 @@ describe('appeals list routes', () => {
 								},
 								ipComments: {
 									status: 'not_received',
-									validCount: 0
+									counts: {
+										valid: 0,
+										published: 0
+									}
 								},
 								lpaQuestionnaire: {
 									receivedAt: '2024-06-24T00:00:00.000Z',

--- a/appeals/api/src/server/endpoints/appeals/appeals.formatter.js
+++ b/appeals/api/src/server/endpoints/appeals/appeals.formatter.js
@@ -1,10 +1,10 @@
-import { sumBy } from 'lodash-es';
 import {
 	APPEAL_REPRESENTATION_TYPE,
 	APPEAL_REPRESENTATION_STATUS
 } from '@pins/appeals/constants/common.js';
 import formatAddress from '#utils/format-address.js';
 import isFPA from '#utils/is-fpa.js';
+import count from '#utils/count-array.js';
 import {
 	formatAppellantCaseDocumentationStatus,
 	formatLpaQuestionnaireDocumentationStatus,
@@ -137,9 +137,16 @@ const formatDocumentationSummary = (appeal) => {
 		},
 		ipComments: {
 			status: ipComments.length > 0 ? DOCUMENT_STATUS_RECEIVED : DOCUMENT_STATUS_NOT_RECEIVED,
-			validCount: sumBy(ipComments, (rep) =>
-				rep.status === APPEAL_REPRESENTATION_STATUS.VALID ? 1 : 0
-			)
+			counts: {
+				[APPEAL_REPRESENTATION_STATUS.VALID]: count(
+					ipComments,
+					(rep) => rep.status === APPEAL_REPRESENTATION_STATUS.VALID
+				),
+				[APPEAL_REPRESENTATION_STATUS.PUBLISHED]: count(
+					ipComments,
+					(rep) => rep.status === APPEAL_REPRESENTATION_STATUS.PUBLISHED
+				)
+			}
 		},
 		lpaStatement: {
 			status: formatLpaStatementStatus(lpaStatement ?? null),

--- a/appeals/api/src/server/mappers/api/definitions/documentation-summary.js
+++ b/appeals/api/src/server/mappers/api/definitions/documentation-summary.js
@@ -15,6 +15,10 @@ const commonDocumentationSummaryProperties = {
 	representationStatus: {
 		type: 'string',
 		nullable: true
+	},
+	counts: {
+		type: 'object',
+		nullable: true
 	}
 };
 
@@ -37,11 +41,7 @@ const documentationSummary = {
 		ipComments: {
 			type: 'object',
 			properties: {
-				...commonDocumentationSummaryProperties,
-				validCount: {
-					type: 'number',
-					nullable: true
-				}
+				...commonDocumentationSummaryProperties
 			}
 		},
 		lpaStatement: {

--- a/appeals/api/src/server/mappers/api/shared/map-documentation-summary.js
+++ b/appeals/api/src/server/mappers/api/shared/map-documentation-summary.js
@@ -1,4 +1,3 @@
-import { sumBy } from 'lodash-es';
 import {
 	formatAppellantCaseDocumentationStatus,
 	formatLpaQuestionnaireDocumentationStatus
@@ -9,6 +8,7 @@ import {
 } from '@pins/appeals/constants/common.js';
 import { DOCUMENT_STATUS_NOT_RECEIVED, DOCUMENT_STATUS_RECEIVED } from '#endpoints/constants.js';
 import isFPA from '#utils/is-fpa.js';
+import count from '#utils/count-array.js';
 
 /** @typedef {import('@pins/appeals.api').Schema.Appeal} Appeal */
 /** @typedef {import('@pins/appeals.api').Api.DocumentationSummary} DocumentationSummary */
@@ -57,9 +57,16 @@ export const mapDocumentationSummary = (data) => {
 		...(isFPA(appeal.appealType?.key || '') && {
 			ipComments: {
 				status: ipComments.length > 0 ? DOCUMENT_STATUS_RECEIVED : DOCUMENT_STATUS_NOT_RECEIVED,
-				validCount: sumBy(ipComments, (rep) =>
-					rep.status === APPEAL_REPRESENTATION_STATUS.VALID ? 1 : 0
-				)
+				counts: {
+					[APPEAL_REPRESENTATION_STATUS.VALID]: count(
+						ipComments,
+						(rep) => rep.status === APPEAL_REPRESENTATION_STATUS.VALID
+					),
+					[APPEAL_REPRESENTATION_STATUS.PUBLISHED]: count(
+						ipComments,
+						(rep) => rep.status === APPEAL_REPRESENTATION_STATUS.PUBLISHED
+					)
+				}
 			},
 			lpaStatement: {
 				status: lpaStatement ? DOCUMENT_STATUS_RECEIVED : DOCUMENT_STATUS_NOT_RECEIVED,

--- a/appeals/api/src/server/openapi-types.ts
+++ b/appeals/api/src/server/openapi-types.ts
@@ -2494,6 +2494,7 @@ export interface DocumentationSummary {
 		/** @format date-time */
 		receivedAt?: string | null;
 		representationStatus?: string | null;
+		counts?: object | null;
 	};
 	lpaQuestionnaire?: {
 		status?: string;
@@ -2502,6 +2503,7 @@ export interface DocumentationSummary {
 		/** @format date-time */
 		receivedAt?: string | null;
 		representationStatus?: string | null;
+		counts?: object | null;
 	};
 	ipComments?: {
 		status?: string;
@@ -2510,7 +2512,7 @@ export interface DocumentationSummary {
 		/** @format date-time */
 		receivedAt?: string | null;
 		representationStatus?: string | null;
-		validCount?: number | null;
+		counts?: object | null;
 	};
 	lpaStatement?: {
 		status?: string;
@@ -2519,6 +2521,7 @@ export interface DocumentationSummary {
 		/** @format date-time */
 		receivedAt?: string | null;
 		representationStatus?: string | null;
+		counts?: object | null;
 	};
 }
 

--- a/appeals/api/src/server/openapi.json
+++ b/appeals/api/src/server/openapi.json
@@ -10077,6 +10077,10 @@
 							"representationStatus": {
 								"type": "string",
 								"nullable": true
+							},
+							"counts": {
+								"type": "object",
+								"nullable": true
 							}
 						}
 					},
@@ -10098,6 +10102,10 @@
 							},
 							"representationStatus": {
 								"type": "string",
+								"nullable": true
+							},
+							"counts": {
+								"type": "object",
 								"nullable": true
 							}
 						}
@@ -10122,8 +10130,8 @@
 								"type": "string",
 								"nullable": true
 							},
-							"validCount": {
-								"type": "number",
+							"counts": {
+								"type": "object",
 								"nullable": true
 							}
 						}
@@ -10146,6 +10154,10 @@
 							},
 							"representationStatus": {
 								"type": "string",
+								"nullable": true
+							},
+							"counts": {
+								"type": "object",
 								"nullable": true
 							}
 						}

--- a/appeals/api/src/server/utils/count-array.js
+++ b/appeals/api/src/server/utils/count-array.js
@@ -1,0 +1,9 @@
+/**
+ * @template T
+ * @param {T[]} array
+ * @param {(item: T) => boolean} predicate
+ * @returns {number}
+ * */
+const count = (array, predicate) => array.reduce((sum, item) => sum + (predicate(item) ? 1 : 0), 0);
+
+export default count;

--- a/appeals/web/src/server/appeals/appeal-details/accordions/utils/map-status-dependent-notifications.js
+++ b/appeals/web/src/server/appeals/appeal-details/accordions/utils/map-status-dependent-notifications.js
@@ -97,7 +97,7 @@ export function mapStatusDependentNotifications(
 			const hasItemsToShare =
 				appealDetails.documentationSummary?.lpaStatement?.representationStatus ===
 					APPEAL_REPRESENTATION_STATUS.VALID ||
-				(appealDetails.documentationSummary?.ipComments?.validCount ?? 0) > 0;
+				(appealDetails.documentationSummary?.ipComments?.counts?.valid ?? 0) > 0;
 
 			if (isLpaStatementDueDatePassed && hasItemsToShare) {
 				addNotificationBannerToSession(

--- a/appeals/web/src/server/appeals/appeal-details/appeal-details.types.d.ts
+++ b/appeals/web/src/server/appeals/appeal-details/appeal-details.types.d.ts
@@ -368,7 +368,7 @@ export interface WebDocumentationSummaryEntry extends DocumentationSummaryEntry 
 	dueDate: string | undefined | null;
 	receivedAt: string | undefined | null;
 	representationStatus: string | undefined | null;
-	validCount?: number;
+	counts?: Record<string, number>;
 }
 
 export interface WebDocumentationSummary extends DocumentationSummary {

--- a/appeals/web/src/server/appeals/appeal-details/representations/interested-party-comments/interested-party-comments.controller.js
+++ b/appeals/web/src/server/appeals/appeal-details/representations/interested-party-comments/interested-party-comments.controller.js
@@ -1,4 +1,3 @@
-import logger from '#lib/logger.js';
 import { interestedPartyCommentsPage } from './interested-party-comments.mapper.js';
 import * as interestedPartyCommentsService from './interested-party-comments.service.js';
 
@@ -18,45 +17,40 @@ export const renderInterestedPartyComments = async (request, response) => {
 		return response.status(404).render('app/404.njk');
 	}
 
-	try {
-		const [awaitingReviewComments, invalidComments, validComments] = await Promise.all([
-			interestedPartyCommentsService.getInterestedPartyComments(
-				request.apiClient,
-				currentAppeal.appealId,
-				'awaiting_review',
-				paginationParameters.pageNumber,
-				paginationParameters.pageSize
-			),
-			interestedPartyCommentsService.getInterestedPartyComments(
-				request.apiClient,
-				currentAppeal.appealId,
-				'invalid',
-				paginationParameters.pageNumber,
-				paginationParameters.pageSize
-			),
-			interestedPartyCommentsService.getInterestedPartyComments(
-				request.apiClient,
-				currentAppeal.appealId,
-				'valid',
-				paginationParameters.pageNumber,
-				paginationParameters.pageSize
-			)
-		]);
+	const [awaitingReviewComments, invalidComments, validComments] = await Promise.all([
+		interestedPartyCommentsService.getInterestedPartyComments(
+			request.apiClient,
+			currentAppeal.appealId,
+			'awaiting_review',
+			paginationParameters.pageNumber,
+			paginationParameters.pageSize
+		),
+		interestedPartyCommentsService.getInterestedPartyComments(
+			request.apiClient,
+			currentAppeal.appealId,
+			'invalid',
+			paginationParameters.pageNumber,
+			paginationParameters.pageSize
+		),
+		interestedPartyCommentsService.getInterestedPartyComments(
+			request.apiClient,
+			currentAppeal.appealId,
+			'valid',
+			paginationParameters.pageNumber,
+			paginationParameters.pageSize
+		)
+	]);
 
-		const mappedPageContent = await interestedPartyCommentsPage(
-			currentAppeal,
-			awaitingReviewComments,
-			validComments,
-			invalidComments,
-			session
-		);
+	const mappedPageContent = await interestedPartyCommentsPage(
+		currentAppeal,
+		awaitingReviewComments,
+		validComments,
+		invalidComments,
+		session
+	);
 
-		return response.status(200).render('appeals/appeal/interested-party-comments.njk', {
-			pageContent: mappedPageContent,
-			errors
-		});
-	} catch (error) {
-		logger.error(error);
-		return response.status(500).render('app/500.njk');
-	}
+	return response.status(200).render('appeals/appeal/interested-party-comments.njk', {
+		pageContent: mappedPageContent,
+		errors
+	});
 };

--- a/appeals/web/src/server/appeals/appeal-details/representations/interested-party-comments/interested-party-comments.router.js
+++ b/appeals/web/src/server/appeals/appeal-details/representations/interested-party-comments/interested-party-comments.router.js
@@ -21,6 +21,6 @@ router.use('/:commentId/add-document', validateAppeal, validateComment, addDocum
 
 router.use('/:commentId', validateAppeal, validateComment, viewAndReviewIpCommentRouter);
 
-router.route('/').get(validateAppeal, asyncHandler(controller.renderInterestedPartyComments));
+router.route('/').get(validateAppeal, asyncHandler(controller.handleInterestedPartyComments));
 
 export default router;

--- a/appeals/web/src/server/appeals/appeal-details/representations/representations.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/representations/representations.mapper.js
@@ -119,7 +119,7 @@ export function statementAndCommentsSharePage(appeal) {
 	const shortAppealReference = appealShortReference(appeal.appealReference);
 
 	const ipCommentsText = (() => {
-		const numIpComments = appeal.documentationSummary?.ipComments?.validCount ?? 0;
+		const numIpComments = appeal.documentationSummary?.ipComments?.counts?.valid ?? 0;
 
 		return numIpComments > 0
 			? `<a href="/appeals-service/appeal-details/${appeal.appealId}/interested-party-comments" class="govuk-link">${numIpComments} interested party comments</a>`

--- a/appeals/web/src/server/lib/mappers/data/appeal/submappers/ip-comments.mapper.js
+++ b/appeals/web/src/server/lib/mappers/data/appeal/submappers/ip-comments.mapper.js
@@ -2,13 +2,26 @@ import { mapDocumentStatus } from '#lib/display-page-formatter.js';
 import { documentationFolderTableItem } from '#lib/mappers/index.js';
 
 /** @type {import('../mapper.js').SubMapper} */
-export const mapIpComments = ({ appealDetails, currentRoute }) =>
-	documentationFolderTableItem({
+export const mapIpComments = ({ appealDetails, currentRoute }) => {
+	const actionText = (() => {
+		const { status, counts } = appealDetails?.documentationSummary?.ipComments ?? {};
+
+		if (status !== 'received') {
+			return 'Add';
+		}
+
+		if (counts?.published === 0) {
+			return 'Review';
+		}
+
+		return 'View';
+	})();
+
+	return documentationFolderTableItem({
 		id: 'ip-comments',
 		text: 'Interested party comments',
 		statusText: mapDocumentStatus(appealDetails?.documentationSummary?.ipComments?.status),
 		receivedText: 'Not applicable',
-		actionHtml: `<a href="${currentRoute}/interested-party-comments" data-cy="review-ip-comments" class="govuk-link">${
-			appealDetails?.documentationSummary?.ipComments?.status === 'received' ? 'Review' : 'Add'
-		} <span class="govuk-visually-hidden">Interested party comments</span></a>`
+		actionHtml: `<a href="${currentRoute}/interested-party-comments" data-cy="review-ip-comments" class="govuk-link">${actionText}<span class="govuk-visually-hidden"> interested party comments</span></a>`
 	});
+};


### PR DESCRIPTION
## Describe your changes

* feat(api): optionally return a counts object in DocumentationSummary
* refactor(web): expect a counts object instead of validCount property
* feat(web): render 'View' link once IP comments are published
* refactor(web): remove redundant try-catch block
* feat(web): render different page once IP comments are published

## Issue ticket number and link
[A2-2051](https://pins-ds.atlassian.net/browse/A2-2051)


[A2-2051]: https://pins-ds.atlassian.net/browse/A2-2051?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ