### PR TITLE
fix(web): notification banners refactoring

### DIFF
--- a/appeals/web/src/server/appeals/appeal-details/accordions/has.js
+++ b/appeals/web/src/server/appeals/appeal-details/accordions/has.js
@@ -7,20 +7,16 @@ import { getCaseManagement } from './common/case-management.js';
 import { getCaseOverview } from './common/case-overview.js';
 import { getCaseTeam } from './common/case-team.js';
 import { getSiteDetails } from './common/site-details.js';
-import {
-	mapStatusDependentNotifications,
-	removeAccordionComponentsActions
-} from './utils/index.js';
+import { removeAccordionComponentsActions } from './utils/index.js';
+import { APPEAL_CASE_STATUS } from 'pins-data-model';
 
 /**
- *
  * @param {import('../appeal-details.types.js').WebAppeal} appealDetails
  * @param {{appeal: MappedInstructions}} mappedData
  * @param {import("express-session").Session & Partial<import("express-session").SessionData>} session
- * @param {boolean} [ipCommentsAwaitingReview]
- * @returns
+ * @returns {SharedPageComponentProperties & AccordionPageComponent}
  */
-export function generateAccordion(appealDetails, mappedData, session, ipCommentsAwaitingReview) {
+export function generateAccordion(appealDetails, mappedData, session) {
 	const caseOverview = getCaseOverview(mappedData);
 
 	const siteDetails = getSiteDetails(mappedData);
@@ -89,14 +85,10 @@ export function generateAccordion(appealDetails, mappedData, session, ipComments
 		caseManagement
 	];
 
-	mapStatusDependentNotifications(appealDetails, session, accordionComponents, {
-		ipComments: ipCommentsAwaitingReview || false,
-		appellantFinalComments: false,
-		lpaFinalComments: false,
-		lpaStatement: false
-	});
-
-	if (!userHasPermission(permissionNames.viewCaseDetails, session)) {
+	if (
+		!userHasPermission(permissionNames.viewCaseDetails, session) ||
+		appealDetails.appealStatus === APPEAL_CASE_STATUS.AWAITING_TRANSFER
+	) {
 		removeAccordionComponentsActions(accordionComponents);
 	}
 

--- a/appeals/web/src/server/appeals/appeal-details/accordions/index.js
+++ b/appeals/web/src/server/appeals/appeal-details/accordions/index.js
@@ -17,15 +17,9 @@ import { FEATURE_FLAG_NAMES } from '@pins/appeals/constants/common.js';
  * @param {import('../appeal-details.types.js').WebAppeal} appealDetails
  * @param {{appeal: MappedInstructions}} mappedData
  * @param {import('express-session').Session & Partial<import('express-session').SessionData>} session
- * @param {RepresentationTypesAwaitingReview} [representationsAwaitingReview]
  * @returns {PageComponent}
  */
-export function generateAccordionItems(
-	appealDetails,
-	mappedData,
-	session,
-	representationsAwaitingReview
-) {
+export function generateAccordionItems(appealDetails, mappedData, session) {
 	switch (appealDetails.appealType) {
 		case APPEAL_TYPE.D:
 			return generateHasAccordion(appealDetails, mappedData, session);
@@ -33,12 +27,7 @@ export function generateAccordionItems(
 			if (!isFeatureActive(FEATURE_FLAG_NAMES.SECTION_78)) {
 				throw new Error('Feature flag inactive for S78');
 			}
-			return generateS78Accordion(
-				appealDetails,
-				mappedData,
-				session,
-				representationsAwaitingReview
-			);
+			return generateS78Accordion(appealDetails, mappedData, session);
 		default:
 			throw new Error('Invalid appealType, unable to generate display page');
 	}

--- a/appeals/web/src/server/appeals/appeal-details/accordions/s78.js
+++ b/appeals/web/src/server/appeals/appeal-details/accordions/s78.js
@@ -7,25 +7,17 @@ import { getCaseManagement } from './common/case-management.js';
 import { getCaseOverview } from './common/case-overview.js';
 import { getCaseTeam } from './common/case-team.js';
 import { getSiteDetails } from './common/site-details.js';
-import {
-	mapStatusDependentNotifications,
-	removeAccordionComponentsActions
-} from './utils/index.js';
+import { removeAccordionComponentsActions } from './utils/index.js';
+import { APPEAL_CASE_STATUS } from 'pins-data-model';
 
 /**
  *
  * @param {import('../appeal-details.types.js').WebAppeal} appealDetails
  * @param {{appeal: MappedInstructions}} mappedData
  * @param {import("express-session").Session & Partial<import("express-session").SessionData>} session
- * @param {import('./index.js').RepresentationTypesAwaitingReview} [representationTypesAwaitingReview]
  * @returns {SharedPageComponentProperties & AccordionPageComponent}
  */
-export function generateAccordion(
-	appealDetails,
-	mappedData,
-	session,
-	representationTypesAwaitingReview
-) {
+export function generateAccordion(appealDetails, mappedData, session) {
 	const caseOverview = getCaseOverview(mappedData);
 
 	const siteDetails = getSiteDetails(mappedData);
@@ -90,14 +82,10 @@ export function generateAccordion(
 		caseManagement
 	];
 
-	mapStatusDependentNotifications(
-		appealDetails,
-		session,
-		accordionComponents,
-		representationTypesAwaitingReview
-	);
-
-	if (!userHasPermission(permissionNames.viewCaseDetails, session)) {
+	if (
+		!userHasPermission(permissionNames.viewCaseDetails, session) ||
+		appealDetails.appealStatus === APPEAL_CASE_STATUS.AWAITING_TRANSFER
+	) {
 		removeAccordionComponentsActions(accordionComponents);
 	}
 

--- a/appeals/web/src/server/appeals/appeal-details/accordions/utils/map-status-dependent-notifications.js
+++ b/appeals/web/src/server/appeals/appeal-details/accordions/utils/map-status-dependent-notifications.js
@@ -1,234 +1,294 @@
 import { dateIsInThePast, dateISOStringToDayMonthYearHourMinute } from '#lib/dates.js';
-import {
-	addNotificationBannerToSession,
-	clearNotificationBannerFromSession
-} from '#lib/session-utilities.js';
 import { APPEAL_CASE_STATUS } from 'pins-data-model';
 import { APPEAL_REPRESENTATION_STATUS } from '@pins/appeals/constants/common.js';
-import { removeAccordionComponentsActions } from './remove-accordion-components-actions.js';
 import {
 	generateIssueDecisionUrl,
 	generateStartTimetableUrl
 } from '../../issue-decision/issue-decision.mapper.js';
+import { createNotificationBanner } from '#lib/mappers/index.js';
 
 /**
  * @param {import('../../appeal-details.types.js').WebAppeal} appealDetails
- * @param {import("express-session").Session & Partial<import("express-session").SessionData>} session
- * @param {PageComponent[]} accordionComponents
  * @param {import('../index.js').RepresentationTypesAwaitingReview} [representationTypesAwaitingReview]
- * @returns {void}
+ * @returns {PageComponent[]}
  */
-export function mapStatusDependentNotifications(
+export function mapStatusDependentNotifications(appealDetails, representationTypesAwaitingReview) {
+	/** @type {PageComponent[]} */
+	const notifications = [];
+
+	switch (appealDetails.appealStatus) {
+		case APPEAL_CASE_STATUS.ASSIGN_CASE_OFFICER:
+			return mapStatusDependentNotificationsForAssignCaseOfficer(appealDetails.appealId);
+		case APPEAL_CASE_STATUS.VALIDATION:
+			return mapStatusDependentNotificationsForValidation(appealDetails.appealId);
+		case APPEAL_CASE_STATUS.LPA_QUESTIONNAIRE:
+			return mapStatusDependentNotificationsForLPAQuestionnaire(
+				appealDetails.appealId,
+				appealDetails.lpaQuestionnaireId
+			);
+		case APPEAL_CASE_STATUS.EVENT:
+			return mapStatusDependentNotificationsForEvent(appealDetails.appealId);
+		case APPEAL_CASE_STATUS.ISSUE_DETERMINATION:
+			return mapStatusDependentNotificationsForIssueDetermination(appealDetails.appealId);
+		case APPEAL_CASE_STATUS.READY_TO_START:
+			return mapStatusDependentNotificationsForReadyToStart(appealDetails.appealId);
+		case APPEAL_CASE_STATUS.AWAITING_TRANSFER:
+			return mapStatusDependentNotificationsForAwaitingTransfer(appealDetails.appealId);
+		case APPEAL_CASE_STATUS.STATEMENTS:
+			return mapStatusDependentNotificationsForStatements(
+				appealDetails,
+				representationTypesAwaitingReview
+			);
+		case APPEAL_CASE_STATUS.FINAL_COMMENTS:
+			return mapStatusDependentNotificationsForFinalComments(
+				appealDetails,
+				representationTypesAwaitingReview
+			);
+		default:
+			break;
+	}
+
+	return notifications;
+}
+
+/**
+ * @param {number} appealId
+ * @returns {PageComponent[]}
+ */
+function mapStatusDependentNotificationsForAssignCaseOfficer(appealId) {
+	return [
+		createNotificationBanner({
+			bannerDefinitionKey: 'assignCaseOfficer',
+			html: `<p class="govuk-notification-banner__heading">Appeal ready to be assigned to case officer</p><p><a class="govuk-notification-banner__link" href="/appeals-service/appeal-details/${appealId}/assign-user/case-officer" data-cy="banner-assign-case-officer">Assign case officer</a></p>`
+		})
+	];
+}
+
+/**
+ * @param {number} appealId
+ * @returns {PageComponent[]}
+ */
+function mapStatusDependentNotificationsForValidation(appealId) {
+	return [
+		createNotificationBanner({
+			bannerDefinitionKey: 'readyForValidation',
+			html: `<p class="govuk-notification-banner__heading">Appeal ready for validation</p><p><a class="govuk-notification-banner__link" data-cy="validate-appeal" href="/appeals-service/appeal-details/${appealId}/appellant-case">Validate <span class="govuk-visually-hidden">appeal</span></a></p>`
+		})
+	];
+}
+
+/**
+ * @param {number} appealId
+ * @param {number|null|undefined} lpaQuestionnaireId
+ * @returns {PageComponent[]}
+ */
+function mapStatusDependentNotificationsForLPAQuestionnaire(appealId, lpaQuestionnaireId) {
+	if (typeof lpaQuestionnaireId === 'number') {
+		return [
+			createNotificationBanner({
+				bannerDefinitionKey: 'readyForLpaQuestionnaireReview',
+				html: `<p class="govuk-notification-banner__heading">LPA questionnaire ready for review</p><p><a class="govuk-notification-banner__link" data-cy="review-lpa-questionnaire-banner" href="/appeals-service/appeal-details/${appealId}/lpa-questionnaire/${lpaQuestionnaireId}">Review <span class="govuk-visually-hidden">LPA questionnaire</span></a></p>`
+			})
+		];
+	}
+
+	return [];
+}
+
+/**
+ * @param {number} appealId
+ * @returns {PageComponent[]}
+ */
+function mapStatusDependentNotificationsForEvent(appealId) {
+	return [
+		createNotificationBanner({
+			bannerDefinitionKey: 'readyForSetUpSiteVisit',
+			html: `<p class="govuk-notification-banner__heading">Site visit ready to set up</p><p><a class="govuk-notification-banner__link" data-cy="set-up-site-visit-banner" href="/appeals-service/appeal-details/${appealId}/site-visit/schedule-visit">Set up site visit</a></p>`
+		})
+	];
+}
+
+/**
+ * @param {number} appealId
+ * @returns {PageComponent[]}
+ */
+function mapStatusDependentNotificationsForIssueDetermination(appealId) {
+	return [
+		createNotificationBanner({
+			bannerDefinitionKey: 'readyForDecision',
+			html: `<p class="govuk-notification-banner__heading">Ready for decision</p><p><a class="govuk-notification-banner__link" data-cy="issue-determination" href="${generateIssueDecisionUrl(
+				appealId
+			)}">Issue decision</a></p>`
+		})
+	];
+}
+
+/**
+ * @param {number} appealId
+ * @returns {PageComponent[]}
+ */
+function mapStatusDependentNotificationsForReadyToStart(appealId) {
+	return [
+		createNotificationBanner({
+			bannerDefinitionKey: 'appealValidAndReadyToStart',
+			html: `<p class="govuk-notification-banner__heading">Appeal valid</p><p><a class="govuk-notification-banner__link" data-cy="ready-to-start" href="${generateStartTimetableUrl(
+				appealId
+			)}">Start case</a></p>`
+		})
+	];
+}
+
+/**
+ * @param {number} appealId
+ * @returns {PageComponent[]}
+ */
+function mapStatusDependentNotificationsForAwaitingTransfer(appealId) {
+	return [
+		createNotificationBanner({
+			bannerDefinitionKey: 'appealAwaitingTransfer',
+			html: `<p class="govuk-notification-banner__heading">This appeal is awaiting transfer</p><p class="govuk-body">The appeal must be transferred to Horizon. When this is done, <a class="govuk-link" data-cy="awaiting-transfer" href="/appeals-service/appeal-details/${appealId}/change-appeal-type/add-horizon-reference">update the appeal with the new horizon reference</a>.</p>`
+		})
+	];
+}
+
+/**
+ * @param {import('../../appeal-details.types.js').WebAppeal} appealDetails
+ * @param {import('../index.js').RepresentationTypesAwaitingReview} [representationTypesAwaitingReview]
+ * @returns {PageComponent[]}
+ */
+function mapStatusDependentNotificationsForStatements(
 	appealDetails,
-	session,
-	accordionComponents,
 	representationTypesAwaitingReview
 ) {
-	const finalCommentsDueDate = appealDetails.appealTimetable?.finalCommentsDueDate;
+	const isLpaStatementDueDatePassed = appealDetails.appealTimetable?.lpaStatementDueDate
+		? dateIsInThePast(
+				dateISOStringToDayMonthYearHourMinute(appealDetails.appealTimetable.lpaStatementDueDate)
+		  )
+		: false;
 
+	const hasItemsToShare =
+		appealDetails.documentationSummary?.lpaStatement?.representationStatus ===
+			APPEAL_REPRESENTATION_STATUS.VALID ||
+		(appealDetails.documentationSummary?.ipComments?.counts?.valid ?? 0) > 0;
+
+	const lpaStatementIncomplete =
+		appealDetails.documentationSummary?.lpaStatement?.representationStatus ===
+		APPEAL_REPRESENTATION_STATUS.INCOMPLETE;
+
+	if (lpaStatementIncomplete) {
+		return [
+			createNotificationBanner({
+				bannerDefinitionKey: 'shareCommentsAndLpaStatement',
+				html: `<p class="govuk-notification-banner__heading">LPA statement incomplete</p> <a href="/appeals-service/appeal-details/${appealDetails.appealId}/lpa-statement" class="govuk-heading-s govuk-notification-banner__link">Update LPA statement</a>`
+			})
+		];
+	}
+
+	if (isLpaStatementDueDatePassed && !hasItemsToShare) {
+		return [
+			createNotificationBanner({
+				bannerDefinitionKey: 'progressToFinalComments',
+				html: `<a href="/appeals-service/appeal-details/${appealDetails.appealId}/share" class="govuk-heading-s govuk-notification-banner__link">Progress to final comments</a>`
+			})
+		];
+	}
+
+	/** @type {PageComponent[]} */
+	const banners = [];
+
+	if (representationTypesAwaitingReview?.ipComments && !lpaStatementIncomplete) {
+		banners.push(
+			createNotificationBanner({
+				bannerDefinitionKey: 'interestedPartyCommentsAwaitingReview',
+				html: `<p class="govuk-notification-banner__heading">Interested party comments awaiting review</p><p><a class="govuk-notification-banner__link" href="/appeals-service/appeal-details/${appealDetails.appealId}/interested-party-comments" data-cy="banner-review-ip-comments">Review <span class="govuk-visually-hidden">interested party comments</span></a></p>`
+			})
+		);
+	}
+
+	if (representationTypesAwaitingReview?.lpaStatement) {
+		banners.push(
+			createNotificationBanner({
+				bannerDefinitionKey: 'lpaStatementAwaitingReview',
+				html: `<p class="govuk-notification-banner__heading">LPA statement awaiting review</p><p><a class="govuk-notification-banner__link" href="/appeals-service/appeal-details/${appealDetails.appealId}/lpa-statement" data-cy="banner-review-lpa-statement">Review <span class="govuk-visually-hidden">LPA statement</span></a></p>`
+			})
+		);
+	}
+	if (representationTypesAwaitingReview?.lpaStatement) {
+		banners.push(
+			createNotificationBanner({
+				bannerDefinitionKey: 'lpaStatementIncomplete',
+				html: `<p class="govuk-notification-banner__heading">LPA statement incomplete</p><p><a class="govuk-notification-banner__link" href="/appeals-service/appeal-details/${appealDetails.appealId}/lpa-statement" data-cy="banner-review-lpa-statement">Update LPA statement <span class="govuk-visually-hidden">Update LPA statement</span></a></p>`
+			})
+		);
+	}
+
+	return banners;
+}
+
+/**
+ * @param {import('../../appeal-details.types.js').WebAppeal} appealDetails
+ * @param {import('../index.js').RepresentationTypesAwaitingReview} [representationTypesAwaitingReview]
+ * @returns {PageComponent[]}
+ */
+function mapStatusDependentNotificationsForFinalComments(
+	appealDetails,
+	representationTypesAwaitingReview
+) {
+	/** @type {PageComponent[]} */
+	const banners = [];
+
+	const finalCommentsDueDate = appealDetails.appealTimetable?.finalCommentsDueDate;
 	const isFinalCommentsDueDatePassed =
 		appealDetails.appealStatus === APPEAL_CASE_STATUS.FINAL_COMMENTS && finalCommentsDueDate
 			? dateIsInThePast(dateISOStringToDayMonthYearHourMinute(finalCommentsDueDate))
 			: false;
 
-	switch (appealDetails.appealStatus) {
-		case APPEAL_CASE_STATUS.ASSIGN_CASE_OFFICER:
-			addNotificationBannerToSession(
-				session,
-				'assignCaseOfficer',
-				appealDetails.appealId,
-				`<p class="govuk-notification-banner__heading">Appeal ready to be assigned to case officer</p><p><a class="govuk-notification-banner__link" href="/appeals-service/appeal-details/${appealDetails.appealId}/assign-user/case-officer" data-cy="banner-assign-case-officer">Assign case officer</a></p>`
-			);
-			break;
-		case APPEAL_CASE_STATUS.VALIDATION:
-			addNotificationBannerToSession(
-				session,
-				'readyForValidation',
-				appealDetails.appealId,
-				`<p class="govuk-notification-banner__heading">Appeal ready for validation</p><p><a class="govuk-notification-banner__link" data-cy="validate-appeal" href="/appeals-service/appeal-details/${appealDetails.appealId}/appellant-case">Validate <span class="govuk-visually-hidden">appeal</span></a></p>`
-			);
-			break;
-		case APPEAL_CASE_STATUS.LPA_QUESTIONNAIRE:
-			if (appealDetails.lpaQuestionnaireId) {
-				addNotificationBannerToSession(
-					session,
-					'readyForLpaQuestionnaireReview',
-					appealDetails.appealId,
-					`<p class="govuk-notification-banner__heading">LPA questionnaire ready for review</p><p><a class="govuk-notification-banner__link" data-cy="review-lpa-questionnaire-banner" href="/appeals-service/appeal-details/${appealDetails.appealId}/lpa-questionnaire/${appealDetails.lpaQuestionnaireId}">Review <span class="govuk-visually-hidden">LPA questionnaire</span></a></p>`
-				);
-			}
-			break;
-		case APPEAL_CASE_STATUS.EVENT:
-			addNotificationBannerToSession(
-				session,
-				'readyForSetUpSiteVisit',
-				appealDetails.appealId,
-				`<p class="govuk-notification-banner__heading">Site visit ready to set up</p><p><a class="govuk-notification-banner__link" data-cy="set-up-site-visit-banner" href="/appeals-service/appeal-details/${appealDetails.appealId}/site-visit/schedule-visit">Set up site visit</a></p>`
-			);
-			break;
-		case APPEAL_CASE_STATUS.ISSUE_DETERMINATION:
-			addNotificationBannerToSession(
-				session,
-				'readyForDecision',
-				appealDetails.appealId,
-				`<p class="govuk-notification-banner__heading">Ready for decision</p><p><a class="govuk-notification-banner__link" data-cy="issue-determination" href="${generateIssueDecisionUrl(
-					appealDetails.appealId
-				)}">Issue decision</a></p>`
-			);
-			break;
-		case APPEAL_CASE_STATUS.READY_TO_START:
-			addNotificationBannerToSession(
-				session,
-				'appealValidAndReadyToStart',
-				appealDetails.appealId,
-				`<p class="govuk-notification-banner__heading">Appeal valid</p><p><a class="govuk-notification-banner__link" data-cy="ready-to-start" href="${generateStartTimetableUrl(
-					appealDetails.appealId
-				)}">Start case</a></p>`
-			);
-			break;
-		case APPEAL_CASE_STATUS.AWAITING_TRANSFER:
-			addNotificationBannerToSession(
-				session,
-				'appealAwaitingTransfer',
-				appealDetails.appealId,
-				`<p class="govuk-notification-banner__heading">This appeal is awaiting transfer</p><p class="govuk-body">The appeal must be transferred to Horizon. When this is done, <a class="govuk-link" data-cy="awaiting-transfer" href="/appeals-service/appeal-details/${appealDetails.appealId}/change-appeal-type/add-horizon-reference">update the appeal with the new horizon reference</a>.</p>`
-			);
-			removeAccordionComponentsActions(accordionComponents);
-			break;
-		case APPEAL_CASE_STATUS.STATEMENTS: {
-			const isLpaStatementDueDatePassed = appealDetails.appealTimetable?.lpaStatementDueDate
-				? dateIsInThePast(
-						dateISOStringToDayMonthYearHourMinute(appealDetails.appealTimetable.lpaStatementDueDate)
-				  )
+	if (isFinalCommentsDueDatePassed) {
+		const { documentationSummary } = appealDetails;
+
+		const hasValidFinalCommentsAppellant =
+			documentationSummary.appellantFinalComments?.representationStatus &&
+			documentationSummary.appellantFinalComments?.representationStatus ===
+				APPEAL_REPRESENTATION_STATUS.VALID
+				? true
+				: false;
+		const hasValidFinalCommentsLPA =
+			documentationSummary.lpaFinalComments?.representationStatus &&
+			documentationSummary.lpaFinalComments?.representationStatus ===
+				APPEAL_REPRESENTATION_STATUS.VALID
+				? true
 				: false;
 
-			const hasItemsToShare =
-				appealDetails.documentationSummary?.lpaStatement?.representationStatus ===
-					APPEAL_REPRESENTATION_STATUS.VALID ||
-				(appealDetails.documentationSummary?.ipComments?.counts?.valid ?? 0) > 0;
+		let bannerText = 'Progress case';
 
-			const lpaStatementIncomplete =
-				appealDetails.documentationSummary?.lpaStatement?.representationStatus ===
-				APPEAL_REPRESENTATION_STATUS.INCOMPLETE;
-
-			if (lpaStatementIncomplete) {
-				addNotificationBannerToSession(
-					session,
-					'shareCommentsAndLpaStatement',
-					appealDetails.appealId,
-					`<p class="govuk-notification-banner__heading">LPA statement incomplete</p> <a href="/appeals-service/appeal-details/${appealDetails.appealId}/lpa-statement" class="govuk-heading-s govuk-notification-banner__link">Update LPA statement</a>`
-				);
-				break;
-			}
-
-			if (isLpaStatementDueDatePassed && !hasItemsToShare) {
-				addNotificationBannerToSession(
-					session,
-					'progressToFinalComments',
-					appealDetails.appealId,
-					`<a href="/appeals-service/appeal-details/${appealDetails.appealId}/share" class="govuk-heading-s govuk-notification-banner__link">Progress to final comments</a>`
-				);
-				break;
-			}
-
-			if (representationTypesAwaitingReview?.ipComments && !lpaStatementIncomplete) {
-				addNotificationBannerToSession(
-					session,
-					'interestedPartyCommentsAwaitingReview',
-					appealDetails.appealId,
-					`<p class="govuk-notification-banner__heading">Interested party comments awaiting review</p><p><a class="govuk-notification-banner__link" href="/appeals-service/appeal-details/${appealDetails.appealId}/interested-party-comments" data-cy="banner-review-ip-comments">Review <span class="govuk-visually-hidden">interested party comments</span></a></p>`
-				);
-			}
-
-			if (representationTypesAwaitingReview?.lpaStatement) {
-				addNotificationBannerToSession(
-					session,
-					'lpaStatementAwaitingReview',
-					appealDetails.appealId,
-					`<p class="govuk-notification-banner__heading">LPA statement awaiting review</p><p><a class="govuk-notification-banner__link" href="/appeals-service/appeal-details/${appealDetails.appealId}/lpa-statement" data-cy="banner-review-lpa-statement">Review <span class="govuk-visually-hidden">LPA statement</span></a></p>`
-				);
-			}
-			if (representationTypesAwaitingReview?.lpaStatement) {
-				addNotificationBannerToSession(
-					session,
-					'lpaStatementIncomplete',
-					appealDetails.appealId,
-					`<p class="govuk-notification-banner__heading">LPA statement incomplete</p><p><a class="govuk-notification-banner__link" href="/appeals-service/appeal-details/${appealDetails.appealId}/lpa-statement" data-cy="banner-review-lpa-statement">Update LPA statement <span class="govuk-visually-hidden">Update LPA statement</span></a></p>`
-				);
-			}
-			break;
+		if (hasValidFinalCommentsAppellant || hasValidFinalCommentsLPA) {
+			bannerText = 'Share final comments';
 		}
-		case APPEAL_CASE_STATUS.FINAL_COMMENTS:
-			if (isFinalCommentsDueDatePassed) {
-				const { documentationSummary } = appealDetails;
 
-				const hasValidFinalCommentsAppellant =
-					documentationSummary.appellantFinalComments?.representationStatus &&
-					documentationSummary.appellantFinalComments?.representationStatus ===
-						APPEAL_REPRESENTATION_STATUS.VALID
-						? true
-						: false;
-				const hasValidFinalCommentsLPA =
-					documentationSummary.lpaFinalComments?.representationStatus &&
-					documentationSummary.lpaFinalComments?.representationStatus ===
-						APPEAL_REPRESENTATION_STATUS.VALID
-						? true
-						: false;
-
-				let bannerText = 'Progress case';
-				if (hasValidFinalCommentsAppellant || hasValidFinalCommentsLPA) {
-					bannerText = 'Share final comments';
-				}
-
-				addNotificationBannerToSession(
-					session,
-					'shareFinalComments',
-					appealDetails.appealId,
-					`<a href="/appeals-service/appeal-details/${appealDetails.appealId}/share" class="govuk-heading-s govuk-notification-banner__link">${bannerText}</a>`
-				);
-			} else {
-				clearNotificationBannerFromSession(session, appealDetails.appealId, 'shareFinalComments');
-
-				if (representationTypesAwaitingReview?.appellantFinalComments) {
-					addNotificationBannerToSession(
-						session,
-						'appellantFinalCommentsAwaitingReview',
-						appealDetails.appealId,
-						`<p class="govuk-notification-banner__heading">Appellant final comments awaiting review</p><p><a class="govuk-notification-banner__link" href="/appeals-service/appeal-details/${appealDetails.appealId}/final-comments/appellant" data-cy="banner-review-appellant-final-comments">Review <span class="govuk-visually-hidden">appellant final comments</span></a></p>`
-					);
-				} else {
-					clearNotificationBannerFromSession(
-						session,
-						appealDetails.appealId,
-						'appellantFinalCommentsAwaitingReview'
-					);
-				}
-				if (representationTypesAwaitingReview?.lpaFinalComments) {
-					addNotificationBannerToSession(
-						session,
-						'lpaFinalCommentsAwaitingReview',
-						appealDetails.appealId,
-						`<p class="govuk-notification-banner__heading">LPA final comments awaiting review</p><p><a class="govuk-notification-banner__link" href="/appeals-service/appeal-details/${appealDetails.appealId}/final-comments/lpa" data-cy="banner-review-lpa-final-comments">Review <span class="govuk-visually-hidden">L P A final comments</span></a></p>`
-					);
-				} else {
-					clearNotificationBannerFromSession(
-						session,
-						appealDetails.appealId,
-						'lpaFinalCommentsAwaitingReview'
-					);
-				}
-			}
-
-			break;
-		default:
-			break;
+		banners.push(
+			createNotificationBanner({
+				bannerDefinitionKey: 'shareFinalComments',
+				html: `<a href="/appeals-service/appeal-details/${appealDetails.appealId}/share" class="govuk-heading-s govuk-notification-banner__link">${bannerText}</a>`
+			})
+		);
+	} else {
+		if (representationTypesAwaitingReview?.appellantFinalComments) {
+			banners.push(
+				createNotificationBanner({
+					bannerDefinitionKey: 'appellantFinalCommentsAwaitingReview',
+					html: `<p class="govuk-notification-banner__heading">Appellant final comments awaiting review</p><p><a class="govuk-notification-banner__link" href="/appeals-service/appeal-details/${appealDetails.appealId}/final-comments/appellant" data-cy="banner-review-appellant-final-comments">Review <span class="govuk-visually-hidden">appellant final comments</span></a></p>`
+				})
+			);
+		}
+		if (representationTypesAwaitingReview?.lpaFinalComments) {
+			banners.push(
+				createNotificationBanner({
+					bannerDefinitionKey: 'lpaFinalCommentsAwaitingReview',
+					html: `<p class="govuk-notification-banner__heading">LPA final comments awaiting review</p><p><a class="govuk-notification-banner__link" href="/appeals-service/appeal-details/${appealDetails.appealId}/final-comments/lpa" data-cy="banner-review-lpa-final-comments">Review <span class="govuk-visually-hidden">L P A final comments</span></a></p>`
+				})
+			);
+		}
 	}
 
-	if (
-		'notificationBanners' in session &&
-		'appealAwaitingTransfer' in session.notificationBanners &&
-		appealDetails.appealStatus !== 'awaiting_transfer'
-	) {
-		delete session.notificationBanners.appealAwaitingTransfer;
-	}
+	return banners;
 }

--- a/appeals/web/src/server/appeals/appeal-details/allocation-details/allocation-details.controller.js
+++ b/appeals/web/src/server/appeals/appeal-details/allocation-details/allocation-details.controller.js
@@ -244,11 +244,11 @@ export const postAllocationDetailsCheckAnswers = async (request, response) => {
 		delete request.session.allocationLevel;
 		delete request.session.allocationSpecialisms;
 
-		addNotificationBannerToSession(
-			request.session,
-			'allocationDetailsUpdated',
-			appealDetails.appealId
-		);
+		addNotificationBannerToSession({
+			session: request.session,
+			bannerDefinitionKey: 'allocationDetailsUpdated',
+			appealId: appealDetails.appealId
+		});
 
 		return response.redirect(`/appeals-service/appeal-details/${appealDetails.appealId}`);
 	} catch (error) {

--- a/appeals/web/src/server/appeals/appeal-details/appeal-details.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/appeal-details.mapper.js
@@ -1,11 +1,12 @@
 import { appealShortReference } from '#lib/appeals-formatter.js';
 import { initialiseAndMapAppealData } from '#lib/mappers/data/appeal/mapper.js';
-import { buildNotificationBanners } from '#lib/mappers/index.js';
+import { mapNotificationBannersFromSession } from '#lib/mappers/index.js';
 import { preRenderPageComponents } from '#lib/nunjucks-template-builders/page-component-rendering.js';
 import { generateAccordionItems } from './accordions/index.js';
 import { generateCaseNotes } from './case-notes/case-notes.mapper.js';
 import { generateCaseSummary } from './case-summary/case-summary.mapper.js';
 import { generateStatusTags } from './status-tags/status-tags.mapper.js';
+import { mapStatusDependentNotifications } from './accordions/utils/map-status-dependent-notifications.js';
 
 export const pageHeading = 'Case details';
 
@@ -47,15 +48,11 @@ export async function appealDetailsPage(
 		? [mappedData.appeal.downloadCaseFiles.display.htmlItem]
 		: [];
 
-	const accordion = generateAccordionItems(
-		appealDetails,
-		mappedData,
-		session,
-		representationTypesAwaitingReview
-	);
+	const accordion = generateAccordionItems(appealDetails, mappedData, session);
 
 	const pageComponents = [
-		...buildNotificationBanners(session, 'appealDetails', appealDetails.appealId),
+		...mapStatusDependentNotifications(appealDetails, representationTypesAwaitingReview),
+		...mapNotificationBannersFromSession(session, 'appealDetails', appealDetails.appealId),
 		...(await generateStatusTags(mappedData, appealDetails, request)),
 		generateCaseSummary(mappedData),
 		...caseDownload,

--- a/appeals/web/src/server/appeals/appeal-details/appeal-timetables/appeal-timetables.controller.js
+++ b/appeals/web/src/server/appeals/appeal-details/appeal-timetables/appeal-timetables.controller.js
@@ -104,7 +104,11 @@ const processUpdateDueDate = async (request, response) => {
 				return response.status(500).render('app/500.njk');
 			}
 		}
-		addNotificationBannerToSession(request.session, 'timetableDueDateUpdated', appealId);
+		addNotificationBannerToSession({
+			session: request.session,
+			bannerDefinitionKey: 'timetableDueDateUpdated',
+			appealId
+		});
 
 		return response.redirect(`/appeals-service/appeal-details/${appealId}`);
 	} catch (error) {

--- a/appeals/web/src/server/appeals/appeal-details/appellant-case/__tests__/__snapshots__/appellant-case.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/appellant-case/__tests__/__snapshots__/appellant-case.test.js.snap
@@ -2556,7 +2556,8 @@ aria-labelledby="govuk-notification-banner-title" data-module="govuk-notificatio
         <h3 class="govuk-notification-banner__title" id="govuk-notification-banner-title"> Important</h3>
     </div>
     <div class="govuk-notification-banner__content">
-        <p class="govuk-notification-banner__heading">Virus scan in progress</p><a class="govuk-notification-banner__link" href="/appeals-service/appeal-details/1/appellant-case">Refresh page to see if scan has finished</a>
+        <p class="govuk-notification-banner__heading">Virus scan in progress</p><a class="govuk-notification-banner__link" href=""
+        data-cy="refresh-page">Refresh page to see if scan has finished</a>
     </div>
 </div>"
 `;
@@ -3716,7 +3717,8 @@ exports[`appellant-case GET /appellant-case/manage-documents/:folderId/ should r
                     <h3 class="govuk-notification-banner__title" id="govuk-notification-banner-title"> Important</h3>
                 </div>
                 <div class="govuk-notification-banner__content">
-                    <p class="govuk-notification-banner__heading">Virus scan in progress</p><a class="govuk-notification-banner__link" href="/appeals-service/appeal-details/1/appellant-case/manage-documents/1/">Refresh page to see if scan has finished</a>
+                    <p class="govuk-notification-banner__heading">Virus scan in progress</p><a class="govuk-notification-banner__link" href=""
+                    data-cy="refresh-page">Refresh page to see if scan has finished</a>
                 </div>
             </div>
         </div>
@@ -3833,7 +3835,8 @@ exports[`appellant-case GET /appellant-case/manage-documents/:folderId/ should r
                     <h3 class="govuk-notification-banner__title" id="govuk-notification-banner-title"> Important</h3>
                 </div>
                 <div class="govuk-notification-banner__content">
-                    <p class="govuk-notification-banner__heading">Virus scan in progress</p><a class="govuk-notification-banner__link" href="/appeals-service/appeal-details/1/appellant-case/manage-documents/2/">Refresh page to see if scan has finished</a>
+                    <p class="govuk-notification-banner__heading">Virus scan in progress</p><a class="govuk-notification-banner__link" href=""
+                    data-cy="refresh-page">Refresh page to see if scan has finished</a>
                 </div>
             </div>
         </div>
@@ -3979,7 +3982,8 @@ exports[`appellant-case GET /appellant-case/manage-documents/:folderId/:document
                     <h3 class="govuk-notification-banner__title" id="govuk-notification-banner-title"> Important</h3>
                 </div>
                 <div class="govuk-notification-banner__content">
-                    <p class="govuk-notification-banner__heading">Virus scan in progress</p><a class="govuk-notification-banner__link" href="/appeals-service/appeal-details/1/appellant-case/manage-documents/1/1">Refresh page to see if scan has finished</a>
+                    <p class="govuk-notification-banner__heading">Virus scan in progress</p><a class="govuk-notification-banner__link" href=""
+                    data-cy="refresh-page">Refresh page to see if scan has finished</a>
                 </div>
             </div>
         </div>
@@ -4192,7 +4196,8 @@ exports[`appellant-case GET /appellant-case/manage-documents/:folderId/:document
                     <h3 class="govuk-notification-banner__title" id="govuk-notification-banner-title"> Important</h3>
                 </div>
                 <div class="govuk-notification-banner__content">
-                    <p class="govuk-notification-banner__heading">Virus scan in progress</p><a class="govuk-notification-banner__link" href="/appeals-service/appeal-details/1/appellant-case/manage-documents/1/1">Refresh page to see if scan has finished</a>
+                    <p class="govuk-notification-banner__heading">Virus scan in progress</p><a class="govuk-notification-banner__link" href=""
+                    data-cy="refresh-page">Refresh page to see if scan has finished</a>
                 </div>
             </div>
         </div>
@@ -4374,7 +4379,8 @@ exports[`appellant-case GET /appellant-case/manage-documents/:folderId/:document
                     <h3 class="govuk-notification-banner__title" id="govuk-notification-banner-title"> Important</h3>
                 </div>
                 <div class="govuk-notification-banner__content">
-                    <p class="govuk-notification-banner__heading">Virus scan in progress</p><a class="govuk-notification-banner__link" href="/appeals-service/appeal-details/1/appellant-case/manage-documents/1/1">Refresh page to see if scan has finished</a>
+                    <p class="govuk-notification-banner__heading">Virus scan in progress</p><a class="govuk-notification-banner__link" href=""
+                    data-cy="refresh-page">Refresh page to see if scan has finished</a>
                 </div>
             </div>
         </div>
@@ -4467,7 +4473,8 @@ exports[`appellant-case GET /appellant-case/manage-documents/:folderId/:document
                     <h3 class="govuk-notification-banner__title" id="govuk-notification-banner-title"> Important</h3>
                 </div>
                 <div class="govuk-notification-banner__content">
-                    <p class="govuk-notification-banner__heading">Virus scan in progress</p><a class="govuk-notification-banner__link" href="/appeals-service/appeal-details/1/appellant-case/manage-documents/1/1">Refresh page to see if scan has finished</a>
+                    <p class="govuk-notification-banner__heading">Virus scan in progress</p><a class="govuk-notification-banner__link" href=""
+                    data-cy="refresh-page">Refresh page to see if scan has finished</a>
                 </div>
             </div>
         </div>

--- a/appeals/web/src/server/appeals/appeal-details/appellant-case/address/address.controller.js
+++ b/appeals/web/src/server/appeals/appeal-details/appellant-case/address/address.controller.js
@@ -68,7 +68,11 @@ export const postChangeSiteAddress = async (request, response) => {
 	try {
 		await changeSiteAddress(request.apiClient, appealId, request.session.siteAddress, addressId);
 
-		addNotificationBannerToSession(request.session, 'siteAddressUpdated', appealId);
+		addNotificationBannerToSession({
+			session: request.session,
+			bannerDefinitionKey: 'siteAddressUpdated',
+			appealId
+		});
 
 		delete request.session.siteAddress;
 

--- a/appeals/web/src/server/appeals/appeal-details/appellant-case/agricultural-holding/agricultural-holding.controller.js
+++ b/appeals/web/src/server/appeals/appeal-details/appellant-case/agricultural-holding/agricultural-holding.controller.js
@@ -84,13 +84,12 @@ export const postChangePartOfAgriculturalHolding = async (request, response) => 
 			request.session.partOfAgriculturalHolding.radio
 		);
 
-		addNotificationBannerToSession(
-			request.session,
-			'changePage',
+		addNotificationBannerToSession({
+			session: request.session,
+			bannerDefinitionKey: 'changePage',
 			appealId,
-			'',
-			'Part of agricultural holding updated'
-		);
+			text: 'Part of agricultural holding updated'
+		});
 
 		delete request.session.partOfAgriculturalHolding;
 
@@ -175,13 +174,12 @@ export const postChangeTenantOfAgriculturalHolding = async (request, response) =
 			request.session.tenantOfAgriculturalHolding.radio
 		);
 
-		addNotificationBannerToSession(
-			request.session,
-			'changePage',
+		addNotificationBannerToSession({
+			session: request.session,
+			bannerDefinitionKey: 'changePage',
 			appealId,
-			'',
-			'Tenant of agricultural holding updated'
-		);
+			text: 'Tenant of agricultural holding updated'
+		});
 
 		delete request.session.tenantOfAgriculturalHolding;
 
@@ -266,13 +264,12 @@ export const postChangeOtherTenantsOfAgriculturalHolding = async (request, respo
 			request.session.otherTenantsOfAgriculturalHolding.radio
 		);
 
-		addNotificationBannerToSession(
-			request.session,
-			'changePage',
+		addNotificationBannerToSession({
+			session: request.session,
+			bannerDefinitionKey: 'changePage',
 			appealId,
-			'',
-			'Other tenants of agricultural holding updated'
-		);
+			text: 'Other tenants of agricultural holding updated'
+		});
 
 		delete request.session.otherTenantsOfAgriculturalHolding;
 

--- a/appeals/web/src/server/appeals/appeal-details/appellant-case/appellant-case.controller.js
+++ b/appeals/web/src/server/appeals/appeal-details/appellant-case/appellant-case.controller.js
@@ -350,7 +350,11 @@ export const postAddDocumentsCheckAndConfirm = async (request, response) => {
 			response,
 			nextPageUrl: `/appeals-service/appeal-details/${currentAppeal.appealId}/appellant-case`,
 			successCallback: () => {
-				addNotificationBannerToSession(request.session, 'documentAdded', currentAppeal.appealId);
+				addNotificationBannerToSession({
+					session: request.session,
+					bannerDefinitionKey: 'documentAdded',
+					appealId: currentAppeal.appealId
+				});
 			}
 		});
 	} catch (error) {

--- a/appeals/web/src/server/appeals/appeal-details/appellant-case/application-decision-date/application-decision-date.controller.js
+++ b/appeals/web/src/server/appeals/appeal-details/appellant-case/application-decision-date/application-decision-date.controller.js
@@ -91,13 +91,12 @@ export const postChangeApplicationDecisionDate = async (request, response) => {
 			})
 		);
 
-		addNotificationBannerToSession(
-			request.session,
-			'changePage',
+		addNotificationBannerToSession({
+			session: request.session,
+			bannerDefinitionKey: 'changePage',
 			appealId,
-			'',
-			'Application decision date changed'
-		);
+			text: 'Application decision date changed'
+		});
 
 		delete request.session.applicationDecisionDate;
 

--- a/appeals/web/src/server/appeals/appeal-details/appellant-case/application-outcome/application-outcome.controller.js
+++ b/appeals/web/src/server/appeals/appeal-details/appellant-case/application-outcome/application-outcome.controller.js
@@ -65,13 +65,12 @@ export const postChangeApplicationOutcome = async (request, response) => {
 
 		await changeApplicationOutcome(apiClient, appealId, appellantCaseId, applicationOutcome);
 
-		addNotificationBannerToSession(
-			request.session,
-			'changePage',
+		addNotificationBannerToSession({
+			session: request.session,
+			bannerDefinitionKey: 'changePage',
 			appealId,
-			'',
-			'Application decision outcome changed'
-		);
+			text: 'Application decision outcome changed'
+		});
 
 		delete request.session.applicationOutcome;
 

--- a/appeals/web/src/server/appeals/appeal-details/appellant-case/application-submission-date/application-submission-date.controller.js
+++ b/appeals/web/src/server/appeals/appeal-details/appellant-case/application-submission-date/application-submission-date.controller.js
@@ -103,13 +103,12 @@ export const postChangeApplicationSubmissionDate = async (request, response) => 
 			})
 		);
 
-		addNotificationBannerToSession(
-			request.session,
-			'changePage',
+		addNotificationBannerToSession({
+			session: request.session,
+			bannerDefinitionKey: 'changePage',
 			appealId,
-			'',
-			'Date application submitted updated'
-		);
+			text: 'Date application submitted updated'
+		});
 
 		return response.redirect(
 			`/appeals-service/appeal-details/${currentAppeal.appealId}/appellant-case`

--- a/appeals/web/src/server/appeals/appeal-details/appellant-case/development-description/development-description.controller.js
+++ b/appeals/web/src/server/appeals/appeal-details/appellant-case/development-description/development-description.controller.js
@@ -57,13 +57,12 @@ export const postChangeDevelopmentDescription = async (request, response) => {
 			request.session.developmentDescription
 		);
 
-		addNotificationBannerToSession(
-			request.session,
-			'changePage',
+		addNotificationBannerToSession({
+			session: request.session,
+			bannerDefinitionKey: 'changePage',
 			appealId,
-			'',
-			'Original development description has been updated'
-		);
+			text: 'Original development description has been updated'
+		});
 		delete request.session.developmentDescription;
 		return response.redirect(`/appeals-service/appeal-details/${appealId}/appellant-case`);
 	} catch (error) {

--- a/appeals/web/src/server/appeals/appeal-details/appellant-case/owners-known/owners-known.controller.js
+++ b/appeals/web/src/server/appeals/appeal-details/appellant-case/owners-known/owners-known.controller.js
@@ -79,13 +79,12 @@ export const postChangeOwnersKnown = async (request, response) => {
 			request.session.ownersKnown
 		);
 
-		addNotificationBannerToSession(
-			request.session,
-			'changePage',
+		addNotificationBannerToSession({
+			session: request.session,
+			bannerDefinitionKey: 'changePage',
 			appealId,
-			'',
-			'Owners known updated'
-		);
+			text: 'Owners known updated'
+		});
 
 		delete request.session.ownersKnown;
 

--- a/appeals/web/src/server/appeals/appeal-details/appellant-case/planning-obligation/planning-obligation.controller.js
+++ b/appeals/web/src/server/appeals/appeal-details/appellant-case/planning-obligation/planning-obligation.controller.js
@@ -79,13 +79,12 @@ export const postChangePlanningObligationStatus = async (request, response) => {
 			request.session.planningObligationStatus.radio
 		);
 
-		addNotificationBannerToSession(
-			request.session,
-			'changePage',
+		addNotificationBannerToSession({
+			session: request.session,
+			bannerDefinitionKey: 'changePage',
 			appealId,
-			'',
-			'Planning obligation status updated'
-		);
+			text: 'Planning obligation status updated'
+		});
 
 		delete request.session.planningObligationStatus;
 

--- a/appeals/web/src/server/appeals/appeal-details/appellant-case/procedure-preference/procedure-preference.controller.js
+++ b/appeals/web/src/server/appeals/appeal-details/appellant-case/procedure-preference/procedure-preference.controller.js
@@ -84,13 +84,12 @@ export const postChangeProcedurePreference = async (request, response) => {
 			request.session.procedurePreference.radio
 		);
 
-		addNotificationBannerToSession(
-			request.session,
-			'changePage',
+		addNotificationBannerToSession({
+			session: request.session,
+			bannerDefinitionKey: 'changePage',
 			appealId,
-			'',
-			'Procedure preference updated'
-		);
+			text: 'Procedure preference updated'
+		});
 
 		delete request.session.procedurePreference;
 
@@ -173,13 +172,12 @@ export const postChangeProcedurePreferenceDetails = async (request, response) =>
 			request.session.procedurePreferenceDetails.textarea
 		);
 
-		addNotificationBannerToSession(
-			request.session,
-			'changePage',
+		addNotificationBannerToSession({
+			session: request.session,
+			bannerDefinitionKey: 'changePage',
 			appealId,
-			'',
-			'Reason for preference updated'
-		);
+			text: 'Reason for preference updated'
+		});
 
 		delete request.session.procedurePreferenceDetails;
 
@@ -269,13 +267,12 @@ export const postChangeProcedurePreferenceDuration = async (request, response) =
 			request.session.procedurePreferenceDuration.input
 		);
 
-		addNotificationBannerToSession(
-			request.session,
-			'changePage',
+		addNotificationBannerToSession({
+			session: request.session,
+			bannerDefinitionKey: 'changePage',
 			appealId,
-			'',
-			'Expected length of procedure updated'
-		);
+			text: 'Expected length of procedure updated'
+		});
 
 		delete request.session.procedurePreferenceDuration;
 
@@ -358,13 +355,12 @@ export const postChangeInquiryNumberOfWitnesses = async (request, response) => {
 			request.session.inquiryNumberOfWitnesses.input
 		);
 
-		addNotificationBannerToSession(
-			request.session,
-			'changePage',
+		addNotificationBannerToSession({
+			session: request.session,
+			bannerDefinitionKey: 'changePage',
 			appealId,
-			'',
-			'Expected number of witnesses updated'
-		);
+			text: 'Expected number of witnesses updated'
+		});
 
 		delete request.session.inquiryNumberOfWitnesses;
 

--- a/appeals/web/src/server/appeals/appeal-details/appellant-case/site-area/site-area.controller.js
+++ b/appeals/web/src/server/appeals/appeal-details/appellant-case/site-area/site-area.controller.js
@@ -71,13 +71,12 @@ export const postChangeSiteArea = async (request, response) => {
 	try {
 		await changeSiteArea(request.apiClient, appealId, appellantCaseId, request.session.siteArea);
 
-		addNotificationBannerToSession(
-			request.session,
-			'changePage',
+		addNotificationBannerToSession({
+			session: request.session,
+			bannerDefinitionKey: 'changePage',
 			appealId,
-			'',
-			'Site area updated'
-		);
+			text: 'Site area updated'
+		});
 
 		delete request.session.siteArea;
 

--- a/appeals/web/src/server/appeals/appeal-details/appellant-case/site-ownership/site-ownership.controller.js
+++ b/appeals/web/src/server/appeals/appeal-details/appellant-case/site-ownership/site-ownership.controller.js
@@ -78,13 +78,12 @@ export const postChangeSiteOwnership = async (request, response) => {
 			request.session.siteOwnership
 		);
 
-		addNotificationBannerToSession(
-			request.session,
-			'changePage',
+		addNotificationBannerToSession({
+			session: request.session,
+			bannerDefinitionKey: 'changePage',
 			appealId,
-			'',
-			'Site ownership updated'
-		);
+			text: 'Site ownership updated'
+		});
 
 		delete request.session.siteOwnership;
 

--- a/appeals/web/src/server/appeals/appeal-details/assign-user/assign-user.controller.js
+++ b/appeals/web/src/server/appeals/appeal-details/assign-user/assign-user.controller.js
@@ -197,11 +197,13 @@ export const postAssignOrUnassignUserCheckAndConfirm = async (
 				isInspector
 			);
 
-			addNotificationBannerToSession(
-				request.session,
-				`${isInspector ? 'inspector' : 'caseOfficer'}${isUnassign ? 'Removed' : 'Added'}`,
-				Number.parseInt(appealId, 10)
-			);
+			addNotificationBannerToSession({
+				session: request.session,
+				bannerDefinitionKey: `${isInspector ? 'inspector' : 'caseOfficer'}${
+					isUnassign ? 'Removed' : 'Added'
+				}`,
+				appealId
+			});
 
 			return response.redirect(
 				isUnassign

--- a/appeals/web/src/server/appeals/appeal-details/change-appeal-type/change-appeal-type.controller.js
+++ b/appeals/web/src/server/appeals/appeal-details/change-appeal-type/change-appeal-type.controller.js
@@ -367,7 +367,11 @@ export const postCheckTransfer = async (request, response) => {
 		/** @type {import('./change-appeal-type.types.js').ChangeAppealTypeRequest} */
 		request.session.changeAppealType = {};
 
-		addNotificationBannerToSession(request.session, 'horizonReferenceAdded', appealId);
+		addNotificationBannerToSession({
+			session: request.session,
+			bannerDefinitionKey: 'horizonReferenceAdded',
+			appealId
+		});
 
 		return response.redirect(`/appeals-service/appeal-details/${appealId}`);
 	} catch (error) {

--- a/appeals/web/src/server/appeals/appeal-details/costs/__tests__/__snapshots__/costs.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/costs/__tests__/__snapshots__/costs.test.js.snap
@@ -1882,7 +1882,8 @@ exports[`costs application, withdrawal and correspondence GET /costs/:costsCateg
                     <h3 class="govuk-notification-banner__title" id="govuk-notification-banner-title"> Important</h3>
                 </div>
                 <div class="govuk-notification-banner__content">
-                    <p class="govuk-notification-banner__heading">Virus scan in progress</p><a class="govuk-notification-banner__link" href="/appeals-service/appeal-details/1/costs/appellant/application/manage-documents/1/1">Refresh page to see if scan has finished</a>
+                    <p class="govuk-notification-banner__heading">Virus scan in progress</p><a class="govuk-notification-banner__link" href=""
+                    data-cy="refresh-page">Refresh page to see if scan has finished</a>
                 </div>
             </div>
         </div>
@@ -1975,7 +1976,8 @@ exports[`costs application, withdrawal and correspondence GET /costs/:costsCateg
                     <h3 class="govuk-notification-banner__title" id="govuk-notification-banner-title"> Important</h3>
                 </div>
                 <div class="govuk-notification-banner__content">
-                    <p class="govuk-notification-banner__heading">Virus scan in progress</p><a class="govuk-notification-banner__link" href="/appeals-service/appeal-details/1/costs/appellant/correspondence/manage-documents/3/1">Refresh page to see if scan has finished</a>
+                    <p class="govuk-notification-banner__heading">Virus scan in progress</p><a class="govuk-notification-banner__link" href=""
+                    data-cy="refresh-page">Refresh page to see if scan has finished</a>
                 </div>
             </div>
         </div>
@@ -2068,7 +2070,8 @@ exports[`costs application, withdrawal and correspondence GET /costs/:costsCateg
                     <h3 class="govuk-notification-banner__title" id="govuk-notification-banner-title"> Important</h3>
                 </div>
                 <div class="govuk-notification-banner__content">
-                    <p class="govuk-notification-banner__heading">Virus scan in progress</p><a class="govuk-notification-banner__link" href="/appeals-service/appeal-details/1/costs/appellant/withdrawal/manage-documents/2/1">Refresh page to see if scan has finished</a>
+                    <p class="govuk-notification-banner__heading">Virus scan in progress</p><a class="govuk-notification-banner__link" href=""
+                    data-cy="refresh-page">Refresh page to see if scan has finished</a>
                 </div>
             </div>
         </div>
@@ -2161,7 +2164,8 @@ exports[`costs application, withdrawal and correspondence GET /costs/:costsCateg
                     <h3 class="govuk-notification-banner__title" id="govuk-notification-banner-title"> Important</h3>
                 </div>
                 <div class="govuk-notification-banner__content">
-                    <p class="govuk-notification-banner__heading">Virus scan in progress</p><a class="govuk-notification-banner__link" href="/appeals-service/appeal-details/1/costs/lpa/application/manage-documents/4/1">Refresh page to see if scan has finished</a>
+                    <p class="govuk-notification-banner__heading">Virus scan in progress</p><a class="govuk-notification-banner__link" href=""
+                    data-cy="refresh-page">Refresh page to see if scan has finished</a>
                 </div>
             </div>
         </div>
@@ -2254,7 +2258,8 @@ exports[`costs application, withdrawal and correspondence GET /costs/:costsCateg
                     <h3 class="govuk-notification-banner__title" id="govuk-notification-banner-title"> Important</h3>
                 </div>
                 <div class="govuk-notification-banner__content">
-                    <p class="govuk-notification-banner__heading">Virus scan in progress</p><a class="govuk-notification-banner__link" href="/appeals-service/appeal-details/1/costs/lpa/correspondence/manage-documents/6/1">Refresh page to see if scan has finished</a>
+                    <p class="govuk-notification-banner__heading">Virus scan in progress</p><a class="govuk-notification-banner__link" href=""
+                    data-cy="refresh-page">Refresh page to see if scan has finished</a>
                 </div>
             </div>
         </div>
@@ -2347,7 +2352,8 @@ exports[`costs application, withdrawal and correspondence GET /costs/:costsCateg
                     <h3 class="govuk-notification-banner__title" id="govuk-notification-banner-title"> Important</h3>
                 </div>
                 <div class="govuk-notification-banner__content">
-                    <p class="govuk-notification-banner__heading">Virus scan in progress</p><a class="govuk-notification-banner__link" href="/appeals-service/appeal-details/1/costs/lpa/withdrawal/manage-documents/5/1">Refresh page to see if scan has finished</a>
+                    <p class="govuk-notification-banner__heading">Virus scan in progress</p><a class="govuk-notification-banner__link" href=""
+                    data-cy="refresh-page">Refresh page to see if scan has finished</a>
                 </div>
             </div>
         </div>
@@ -2974,7 +2980,8 @@ exports[`costs application, withdrawal and correspondence GET /costs/:costsCateg
                     <h3 class="govuk-notification-banner__title" id="govuk-notification-banner-title"> Important</h3>
                 </div>
                 <div class="govuk-notification-banner__content">
-                    <p class="govuk-notification-banner__heading">Virus scan in progress</p><a class="govuk-notification-banner__link" href="/appeals-service/appeal-details/1/costs/appellant/application/manage-documents/1/1">Refresh page to see if scan has finished</a>
+                    <p class="govuk-notification-banner__heading">Virus scan in progress</p><a class="govuk-notification-banner__link" href=""
+                    data-cy="refresh-page">Refresh page to see if scan has finished</a>
                 </div>
             </div>
         </div>
@@ -3067,7 +3074,8 @@ exports[`costs application, withdrawal and correspondence GET /costs/:costsCateg
                     <h3 class="govuk-notification-banner__title" id="govuk-notification-banner-title"> Important</h3>
                 </div>
                 <div class="govuk-notification-banner__content">
-                    <p class="govuk-notification-banner__heading">Virus scan in progress</p><a class="govuk-notification-banner__link" href="/appeals-service/appeal-details/1/costs/appellant/correspondence/manage-documents/3/1">Refresh page to see if scan has finished</a>
+                    <p class="govuk-notification-banner__heading">Virus scan in progress</p><a class="govuk-notification-banner__link" href=""
+                    data-cy="refresh-page">Refresh page to see if scan has finished</a>
                 </div>
             </div>
         </div>
@@ -3160,7 +3168,8 @@ exports[`costs application, withdrawal and correspondence GET /costs/:costsCateg
                     <h3 class="govuk-notification-banner__title" id="govuk-notification-banner-title"> Important</h3>
                 </div>
                 <div class="govuk-notification-banner__content">
-                    <p class="govuk-notification-banner__heading">Virus scan in progress</p><a class="govuk-notification-banner__link" href="/appeals-service/appeal-details/1/costs/appellant/withdrawal/manage-documents/2/1">Refresh page to see if scan has finished</a>
+                    <p class="govuk-notification-banner__heading">Virus scan in progress</p><a class="govuk-notification-banner__link" href=""
+                    data-cy="refresh-page">Refresh page to see if scan has finished</a>
                 </div>
             </div>
         </div>
@@ -3253,7 +3262,8 @@ exports[`costs application, withdrawal and correspondence GET /costs/:costsCateg
                     <h3 class="govuk-notification-banner__title" id="govuk-notification-banner-title"> Important</h3>
                 </div>
                 <div class="govuk-notification-banner__content">
-                    <p class="govuk-notification-banner__heading">Virus scan in progress</p><a class="govuk-notification-banner__link" href="/appeals-service/appeal-details/1/costs/lpa/application/manage-documents/4/1">Refresh page to see if scan has finished</a>
+                    <p class="govuk-notification-banner__heading">Virus scan in progress</p><a class="govuk-notification-banner__link" href=""
+                    data-cy="refresh-page">Refresh page to see if scan has finished</a>
                 </div>
             </div>
         </div>
@@ -3346,7 +3356,8 @@ exports[`costs application, withdrawal and correspondence GET /costs/:costsCateg
                     <h3 class="govuk-notification-banner__title" id="govuk-notification-banner-title"> Important</h3>
                 </div>
                 <div class="govuk-notification-banner__content">
-                    <p class="govuk-notification-banner__heading">Virus scan in progress</p><a class="govuk-notification-banner__link" href="/appeals-service/appeal-details/1/costs/lpa/correspondence/manage-documents/6/1">Refresh page to see if scan has finished</a>
+                    <p class="govuk-notification-banner__heading">Virus scan in progress</p><a class="govuk-notification-banner__link" href=""
+                    data-cy="refresh-page">Refresh page to see if scan has finished</a>
                 </div>
             </div>
         </div>
@@ -3439,7 +3450,8 @@ exports[`costs application, withdrawal and correspondence GET /costs/:costsCateg
                     <h3 class="govuk-notification-banner__title" id="govuk-notification-banner-title"> Important</h3>
                 </div>
                 <div class="govuk-notification-banner__content">
-                    <p class="govuk-notification-banner__heading">Virus scan in progress</p><a class="govuk-notification-banner__link" href="/appeals-service/appeal-details/1/costs/lpa/withdrawal/manage-documents/5/1">Refresh page to see if scan has finished</a>
+                    <p class="govuk-notification-banner__heading">Virus scan in progress</p><a class="govuk-notification-banner__link" href=""
+                    data-cy="refresh-page">Refresh page to see if scan has finished</a>
                 </div>
             </div>
         </div>
@@ -5892,7 +5904,8 @@ exports[`costs decision GET /costs/decision/manage-documents/:folderId/:document
                     <h3 class="govuk-notification-banner__title" id="govuk-notification-banner-title"> Important</h3>
                 </div>
                 <div class="govuk-notification-banner__content">
-                    <p class="govuk-notification-banner__heading">Virus scan in progress</p><a class="govuk-notification-banner__link" href="/appeals-service/appeal-details/1/costs/decision/manage-documents/7/1">Refresh page to see if scan has finished</a>
+                    <p class="govuk-notification-banner__heading">Virus scan in progress</p><a class="govuk-notification-banner__link" href=""
+                    data-cy="refresh-page">Refresh page to see if scan has finished</a>
                 </div>
             </div>
         </div>
@@ -6074,7 +6087,8 @@ exports[`costs decision GET /costs/decision/manage-documents/:folderId/:document
                     <h3 class="govuk-notification-banner__title" id="govuk-notification-banner-title"> Important</h3>
                 </div>
                 <div class="govuk-notification-banner__content">
-                    <p class="govuk-notification-banner__heading">Virus scan in progress</p><a class="govuk-notification-banner__link" href="/appeals-service/appeal-details/1/costs/decision/manage-documents/7/1">Refresh page to see if scan has finished</a>
+                    <p class="govuk-notification-banner__heading">Virus scan in progress</p><a class="govuk-notification-banner__link" href=""
+                    data-cy="refresh-page">Refresh page to see if scan has finished</a>
                 </div>
             </div>
         </div>

--- a/appeals/web/src/server/appeals/appeal-details/costs/costs.controller.js
+++ b/appeals/web/src/server/appeals/appeal-details/costs/costs.controller.js
@@ -274,15 +274,14 @@ export const postAddDocumentsCheckAndConfirm = async (request, response) => {
 					delete request.session.costsDocumentType;
 				}
 
-				addNotificationBannerToSession(
+				addNotificationBannerToSession({
 					session,
-					'costsDocumentAdded',
-					currentAppeal.appealId,
-					'',
-					`${
+					bannerDefinitionKey: 'costsDocumentAdded',
+					appealId: currentAppeal.appealId,
+					text: `${
 						costsCategory === 'lpa' ? 'LPA' : capitalize(costsCategory)
 					} costs ${costsDocumentType} documents uploaded`
-				);
+				});
 			}
 		});
 	} catch (error) {
@@ -592,13 +591,12 @@ export const postDecisionCheckAndConfirm = async (request, response) => {
 		await postUploadDocumentsCheckAndConfirm({ request, response });
 	}
 
-	addNotificationBannerToSession(
+	addNotificationBannerToSession({
 		session,
-		'costsDocumentAdded',
-		currentAppeal.appealId,
-		'',
-		`Costs decision ${documentId ? 'updated' : 'uploaded'}`
-	);
+		bannerDefinitionKey: 'costsDocumentAdded',
+		appealId: currentAppeal.appealId,
+		text: `Costs decision ${documentId ? 'updated' : 'uploaded'}`
+	});
 
 	return response.redirect(`/appeals-service/appeal-details/${currentAppeal.appealId}`);
 };

--- a/appeals/web/src/server/appeals/appeal-details/environmental-assessment/environmental-assessment.controller.js
+++ b/appeals/web/src/server/appeals/appeal-details/environmental-assessment/environmental-assessment.controller.js
@@ -248,13 +248,12 @@ export const postAddDocumentsCheckAndConfirm = async (request, response) => {
 			response,
 			nextPageUrl: appealUrl(currentAppeal.appealId),
 			successCallback: () => {
-				addNotificationBannerToSession(
+				addNotificationBannerToSession({
 					session,
-					'environmentalAssessmentDocumentAdded',
-					currentAppeal.appealId,
-					'',
-					`Environmental assessment documents uploaded`
-				);
+					bannerDefinitionKey: 'documentAdded',
+					appealId: currentAppeal.appealId,
+					text: 'Environmental assessment documents uploaded'
+				});
 			}
 		});
 	} catch (error) {

--- a/appeals/web/src/server/appeals/appeal-details/final-comments/accept/accept.controller.js
+++ b/appeals/web/src/server/appeals/appeal-details/final-comments/accept/accept.controller.js
@@ -44,7 +44,11 @@ export const postConfirmAcceptFinalComment = async (request, response) => {
 			'valid'
 		);
 
-		addNotificationBannerToSession(session, 'finalCommentsAcceptSuccess', appealId);
+		addNotificationBannerToSession({
+			session,
+			bannerDefinitionKey: 'finalCommentsAcceptSuccess',
+			appealId
+		});
 
 		return response.redirect(`/appeals-service/appeal-details/${appealId}`);
 	} catch (error) {

--- a/appeals/web/src/server/appeals/appeal-details/final-comments/redact/redact.controller.js
+++ b/appeals/web/src/server/appeals/appeal-details/final-comments/redact/redact.controller.js
@@ -95,13 +95,15 @@ export const postConfirmRedactFinalComment = async (request, response) => {
 
 		delete session.redactedRepresentation;
 
-		addNotificationBannerToSession(
+		addNotificationBannerToSession({
 			session,
-			'finalCommentsRedactionSuccess',
+			bannerDefinitionKey: 'finalCommentsRedactionSuccess',
 			appealId,
-			undefined,
-			`${formatFinalCommentsTypeText(finalCommentsType, true)} final comments redacted and accepted`
-		);
+			text: `${formatFinalCommentsTypeText(
+				finalCommentsType,
+				true
+			)} final comments redacted and accepted`
+		});
 
 		return response.redirect(`/appeals-service/appeal-details/${appealId}`);
 	} catch (error) {

--- a/appeals/web/src/server/appeals/appeal-details/final-comments/reject/reject.controller.js
+++ b/appeals/web/src/server/appeals/appeal-details/final-comments/reject/reject.controller.js
@@ -143,12 +143,14 @@ export const postConfirmRejectFinalComment = async (request, response) => {
 
 	delete session.rejectFinalComments;
 
-	const notificationBannerKey =
-		finalCommentsType === 'appellant'
-			? 'finalCommentsAppellantRejectionSuccess'
-			: 'finalCommentsLPARejectionSuccess';
-
-	addNotificationBannerToSession(session, notificationBannerKey, appealId);
+	addNotificationBannerToSession({
+		session,
+		bannerDefinitionKey:
+			finalCommentsType === 'appellant'
+				? 'finalCommentsAppellantRejectionSuccess'
+				: 'finalCommentsLPARejectionSuccess',
+		appealId
+	});
 
 	return response.redirect(`/appeals-service/appeal-details/${appealId}`);
 };

--- a/appeals/web/src/server/appeals/appeal-details/final-comments/view-and-review/__tests__/__snapshots__/view-and-review.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/final-comments/view-and-review/__tests__/__snapshots__/view-and-review.test.js.snap
@@ -102,7 +102,8 @@ exports[`final-comments GET /manage-documents/:folderId/:documentId should rende
                     <h3 class="govuk-notification-banner__title" id="govuk-notification-banner-title"> Important</h3>
                 </div>
                 <div class="govuk-notification-banner__content">
-                    <p class="govuk-notification-banner__heading">Virus scan in progress</p><a class="govuk-notification-banner__link" href="/appeals-service/appeal-details/2/final-comments/lpa/manage-documents/1/1">Refresh page to see if scan has finished</a>
+                    <p class="govuk-notification-banner__heading">Virus scan in progress</p><a class="govuk-notification-banner__link" href=""
+                    data-cy="refresh-page">Refresh page to see if scan has finished</a>
                 </div>
             </div>
         </div>

--- a/appeals/web/src/server/appeals/appeal-details/final-comments/view-and-review/view-and-review.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/final-comments/view-and-review/view-and-review.mapper.js
@@ -1,7 +1,7 @@
 import { appealShortReference } from '#lib/appeals-formatter.js';
 import { COMMENT_STATUS } from '@pins/appeals/constants/common.js';
 import { generateCommentsSummaryList } from './page-components/common.js';
-import { buildNotificationBanners } from '#lib/mappers/index.js';
+import { mapNotificationBannersFromSession } from '#lib/mappers/index.js';
 import { isRepresentationReviewRequired } from '#lib/representation-utilities.js';
 
 /** @typedef {import("#appeals/appeal-details/appeal-details.types.js").WebAppeal} Appeal */
@@ -18,7 +18,7 @@ export function reviewFinalCommentsPage(appealDetails, finalCommentsType, commen
 	const shortReference = appealShortReference(appealDetails.appealReference);
 	const commentSummaryList = generateCommentsSummaryList(appealDetails.appealId, comment);
 
-	const notificationBanners = buildNotificationBanners(
+	const notificationBanners = mapNotificationBannersFromSession(
 		session,
 		'viewFinalComments',
 		appealDetails.appealId

--- a/appeals/web/src/server/appeals/appeal-details/green-belt/green-belt.controller.js
+++ b/appeals/web/src/server/appeals/appeal-details/green-belt/green-belt.controller.js
@@ -102,13 +102,12 @@ export const postGreenBelt = async (request, response) => {
 			);
 		}
 
-		addNotificationBannerToSession(
+		addNotificationBannerToSession({
 			session,
-			'changePage',
+			bannerDefinitionKey: 'changePage',
 			appealId,
-			'',
-			'Green belt status updated'
-		);
+			text: 'Green belt status updated'
+		});
 
 		delete request.session.isGreenBelt;
 

--- a/appeals/web/src/server/appeals/appeal-details/inspector-access/inspector-access.controller.js
+++ b/appeals/web/src/server/appeals/appeal-details/inspector-access/inspector-access.controller.js
@@ -99,12 +99,12 @@ export const postChangeInspectorAccess = async (request, response) => {
 			);
 		}
 
-		addNotificationBannerToSession(
-			request.session,
-			'changePage',
+		addNotificationBannerToSession({
+			session: request.session,
+			bannerDefinitionKey: 'changePage',
 			appealId,
-			`<p class="govuk-notification-banner__heading">Inspector access (${source}) updated</p>`
-		);
+			text: `Inspector access (${source}) updated`
+		});
 
 		delete request.session.inspectorAccess;
 

--- a/appeals/web/src/server/appeals/appeal-details/internal-correspondence/__tests__/__snapshots__/internal-correspondence.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/internal-correspondence/__tests__/__snapshots__/internal-correspondence.test.js.snap
@@ -790,7 +790,8 @@ exports[`internal correspondence GET /internal-correspondence/:correspondenceCat
                     <h3 class="govuk-notification-banner__title" id="govuk-notification-banner-title"> Important</h3>
                 </div>
                 <div class="govuk-notification-banner__content">
-                    <p class="govuk-notification-banner__heading">Virus scan in progress</p><a class="govuk-notification-banner__link" href="/appeals-service/appeal-details/1/internal-correspondence/cross-team/manage-documents/10/1">Refresh page to see if scan has finished</a>
+                    <p class="govuk-notification-banner__heading">Virus scan in progress</p><a class="govuk-notification-banner__link" href=""
+                    data-cy="refresh-page">Refresh page to see if scan has finished</a>
                 </div>
             </div>
         </div>
@@ -883,7 +884,8 @@ exports[`internal correspondence GET /internal-correspondence/:correspondenceCat
                     <h3 class="govuk-notification-banner__title" id="govuk-notification-banner-title"> Important</h3>
                 </div>
                 <div class="govuk-notification-banner__content">
-                    <p class="govuk-notification-banner__heading">Virus scan in progress</p><a class="govuk-notification-banner__link" href="/appeals-service/appeal-details/1/internal-correspondence/inspector/manage-documents/11/1">Refresh page to see if scan has finished</a>
+                    <p class="govuk-notification-banner__heading">Virus scan in progress</p><a class="govuk-notification-banner__link" href=""
+                    data-cy="refresh-page">Refresh page to see if scan has finished</a>
                 </div>
             </div>
         </div>
@@ -1154,7 +1156,8 @@ exports[`internal correspondence GET /internal-correspondence/:correspondenceCat
                     <h3 class="govuk-notification-banner__title" id="govuk-notification-banner-title"> Important</h3>
                 </div>
                 <div class="govuk-notification-banner__content">
-                    <p class="govuk-notification-banner__heading">Virus scan in progress</p><a class="govuk-notification-banner__link" href="/appeals-service/appeal-details/1/internal-correspondence/cross-team/manage-documents/10/1">Refresh page to see if scan has finished</a>
+                    <p class="govuk-notification-banner__heading">Virus scan in progress</p><a class="govuk-notification-banner__link" href=""
+                    data-cy="refresh-page">Refresh page to see if scan has finished</a>
                 </div>
             </div>
         </div>
@@ -1247,7 +1250,8 @@ exports[`internal correspondence GET /internal-correspondence/:correspondenceCat
                     <h3 class="govuk-notification-banner__title" id="govuk-notification-banner-title"> Important</h3>
                 </div>
                 <div class="govuk-notification-banner__content">
-                    <p class="govuk-notification-banner__heading">Virus scan in progress</p><a class="govuk-notification-banner__link" href="/appeals-service/appeal-details/1/internal-correspondence/inspector/manage-documents/11/1">Refresh page to see if scan has finished</a>
+                    <p class="govuk-notification-banner__heading">Virus scan in progress</p><a class="govuk-notification-banner__link" href=""
+                    data-cy="refresh-page">Refresh page to see if scan has finished</a>
                 </div>
             </div>
         </div>

--- a/appeals/web/src/server/appeals/appeal-details/internal-correspondence/internal-correspondence.controller.js
+++ b/appeals/web/src/server/appeals/appeal-details/internal-correspondence/internal-correspondence.controller.js
@@ -209,13 +209,12 @@ export const postAddDocumentsCheckAndConfirm = async (request, response) => {
 			response,
 			nextPageUrl: `/appeals-service/appeal-details/${currentAppeal.appealId}`,
 			successCallback: () => {
-				addNotificationBannerToSession(
+				addNotificationBannerToSession({
 					session,
-					'internalCorrespondenceDocumentAdded',
-					currentAppeal.appealId,
-					'',
-					`${capitalize(correspondenceCategory)} correspondence documents uploaded`
-				);
+					bannerDefinitionKey: 'internalCorrespondenceDocumentAdded',
+					appealId: currentAppeal.appealId,
+					text: `${capitalize(correspondenceCategory)} correspondence documents uploaded`
+				});
 			}
 		});
 	} catch (error) {

--- a/appeals/web/src/server/appeals/appeal-details/linked-appeals/linked-appeals.controller.js
+++ b/appeals/web/src/server/appeals/appeal-details/linked-appeals/linked-appeals.controller.js
@@ -207,14 +207,14 @@ export const postAddLinkedAppealCheckAndConfirm = async (request, response) => {
 			);
 		}
 
-		addNotificationBannerToSession(
-			request.session,
-			'appealLinked',
+		addNotificationBannerToSession({
+			session: request.session,
+			bannerDefinitionKey: 'appealLinked',
 			appealId,
-			`<p class="govuk-notification-banner__heading">This appeal is now ${
-				targetIsLead ? 'the lead for' : 'a child of'
-			} appeal ${request.session.linkableAppeal?.linkableAppealSummary.appealReference}</p>`
-		);
+			text: `This appeal is now ${targetIsLead ? 'the lead for' : 'a child of'} appeal ${
+				request.session.linkableAppeal?.linkableAppealSummary.appealReference
+			}`
+		});
 
 		delete request.session.linkableAppeal;
 
@@ -268,14 +268,14 @@ export const postUnlinkAppeal = async (request, response) => {
 
 			await postUnlinkRequest(request.apiClient, appealId, appealRelationshipId);
 
-			addNotificationBannerToSession(
-				request.session,
-				'appealUnlinked',
-				backLinkAppealId,
-				`<p class="govuk-notification-banner__heading">You have unlinked this appeal from appeal ${
+			addNotificationBannerToSession({
+				session: request.session,
+				bannerDefinitionKey: 'appealUnlinked',
+				appealId: backLinkAppealId,
+				text: `You have unlinked this appeal from appeal ${
 					appealId === backLinkAppealId ? childRef : appealData.appealReference
-				}</p>`
-			);
+				}`
+			});
 
 			return response.redirect(`/appeals-service/appeal-details/${backLinkAppealId}`);
 		}

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/__tests__/__snapshots__/lpa-questionnaire.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/__tests__/__snapshots__/lpa-questionnaire.test.js.snap
@@ -706,15 +706,6 @@ exports[`LPA Questionnaire review GET / with unchecked documents should render a
             <div class="govuk-notification-banner govuk-!-margin-bottom-5" role="region"
             aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
                 <div class="govuk-notification-banner__header">
-                    <h3 class="govuk-notification-banner__title" id="govuk-notification-banner-title"> Important</h3>
-                </div>
-                <div class="govuk-notification-banner__content">
-                    <p class="govuk-notification-banner__heading">Virus scan in progress</p><a class="govuk-notification-banner__link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2">Refresh page to see if scan has finished</a>
-                </div>
-            </div>
-            <div class="govuk-notification-banner govuk-!-margin-bottom-5" role="region"
-            aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
-                <div class="govuk-notification-banner__header">
                     <h3 class="govuk-notification-banner__title" id="govuk-notification-banner-title"> LPA Questionnaire is incomplete</h3>
                 </div>
                 <div class="govuk-notification-banner__content">
@@ -753,6 +744,16 @@ exports[`LPA Questionnaire review GET / with unchecked documents should render a
                             </ul>
                         </div>
                     </details>
+                </div>
+            </div>
+            <div class="govuk-notification-banner govuk-!-margin-bottom-5" role="region"
+            aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
+                <div class="govuk-notification-banner__header">
+                    <h3 class="govuk-notification-banner__title" id="govuk-notification-banner-title"> Important</h3>
+                </div>
+                <div class="govuk-notification-banner__content">
+                    <p class="govuk-notification-banner__heading">Virus scan in progress</p><a class="govuk-notification-banner__link" href=""
+                    data-cy="refresh-page">Refresh page to see if scan has finished</a>
                 </div>
             </div>
         </div>
@@ -2365,7 +2366,8 @@ exports[`LPA Questionnaire review GET /lpa-questionnaire/1/manage-documents/:fol
                     <h3 class="govuk-notification-banner__title" id="govuk-notification-banner-title"> Important</h3>
                 </div>
                 <div class="govuk-notification-banner__content">
-                    <p class="govuk-notification-banner__heading">Virus scan in progress</p><a class="govuk-notification-banner__link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/manage-documents/1/">Refresh page to see if scan has finished</a>
+                    <p class="govuk-notification-banner__heading">Virus scan in progress</p><a class="govuk-notification-banner__link" href=""
+                    data-cy="refresh-page">Refresh page to see if scan has finished</a>
                 </div>
             </div>
         </div>
@@ -2482,7 +2484,8 @@ exports[`LPA Questionnaire review GET /lpa-questionnaire/1/manage-documents/:fol
                     <h3 class="govuk-notification-banner__title" id="govuk-notification-banner-title"> Important</h3>
                 </div>
                 <div class="govuk-notification-banner__content">
-                    <p class="govuk-notification-banner__heading">Virus scan in progress</p><a class="govuk-notification-banner__link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/manage-documents/2/">Refresh page to see if scan has finished</a>
+                    <p class="govuk-notification-banner__heading">Virus scan in progress</p><a class="govuk-notification-banner__link" href=""
+                    data-cy="refresh-page">Refresh page to see if scan has finished</a>
                 </div>
             </div>
         </div>
@@ -2628,7 +2631,8 @@ exports[`LPA Questionnaire review GET /lpa-questionnaire/1/manage-documents/:fol
                     <h3 class="govuk-notification-banner__title" id="govuk-notification-banner-title"> Important</h3>
                 </div>
                 <div class="govuk-notification-banner__content">
-                    <p class="govuk-notification-banner__heading">Virus scan in progress</p><a class="govuk-notification-banner__link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/manage-documents/1/1">Refresh page to see if scan has finished</a>
+                    <p class="govuk-notification-banner__heading">Virus scan in progress</p><a class="govuk-notification-banner__link" href=""
+                    data-cy="refresh-page">Refresh page to see if scan has finished</a>
                 </div>
             </div>
         </div>
@@ -2841,7 +2845,8 @@ exports[`LPA Questionnaire review GET /lpa-questionnaire/1/manage-documents/:fol
                     <h3 class="govuk-notification-banner__title" id="govuk-notification-banner-title"> Important</h3>
                 </div>
                 <div class="govuk-notification-banner__content">
-                    <p class="govuk-notification-banner__heading">Virus scan in progress</p><a class="govuk-notification-banner__link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/manage-documents/1/1">Refresh page to see if scan has finished</a>
+                    <p class="govuk-notification-banner__heading">Virus scan in progress</p><a class="govuk-notification-banner__link" href=""
+                    data-cy="refresh-page">Refresh page to see if scan has finished</a>
                 </div>
             </div>
         </div>
@@ -3023,7 +3028,8 @@ exports[`LPA Questionnaire review GET /lpa-questionnaire/1/manage-documents/:fol
                     <h3 class="govuk-notification-banner__title" id="govuk-notification-banner-title"> Important</h3>
                 </div>
                 <div class="govuk-notification-banner__content">
-                    <p class="govuk-notification-banner__heading">Virus scan in progress</p><a class="govuk-notification-banner__link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/manage-documents/1/1">Refresh page to see if scan has finished</a>
+                    <p class="govuk-notification-banner__heading">Virus scan in progress</p><a class="govuk-notification-banner__link" href=""
+                    data-cy="refresh-page">Refresh page to see if scan has finished</a>
                 </div>
             </div>
         </div>
@@ -3116,7 +3122,8 @@ exports[`LPA Questionnaire review GET /lpa-questionnaire/1/manage-documents/:fol
                     <h3 class="govuk-notification-banner__title" id="govuk-notification-banner-title"> Important</h3>
                 </div>
                 <div class="govuk-notification-banner__content">
-                    <p class="govuk-notification-banner__heading">Virus scan in progress</p><a class="govuk-notification-banner__link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/manage-documents/1/1">Refresh page to see if scan has finished</a>
+                    <p class="govuk-notification-banner__heading">Virus scan in progress</p><a class="govuk-notification-banner__link" href=""
+                    data-cy="refresh-page">Refresh page to see if scan has finished</a>
                 </div>
             </div>
         </div>

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/__tests__/lpa-questionnaire.test.js
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/__tests__/lpa-questionnaire.test.js
@@ -941,7 +941,6 @@ describe('LPA Questionnaire review', () => {
 			expect(element.innerHTML).toMatchSnapshot();
 
 			const notificationBannerElementHTML = parseHtml(response.text, {
-				rootElement: notificationBannerElement,
 				skipPrettyPrint: true
 			}).innerHTML;
 
@@ -3216,7 +3215,7 @@ describe('LPA Questionnaire review', () => {
 			expect(lpaqResponse.statusCode).toBe(200);
 
 			const notificationBannerElementHTML = parseHtml(lpaqResponse.text, {
-				rootElement: notificationBannerElement
+				rootElement: '.govuk-notification-banner--success'
 			}).innerHTML;
 
 			expect(notificationBannerElementHTML).toContain('Success</h3>');

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/affected-listed-buildings/affected-listed-buildings.controller.js
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/affected-listed-buildings/affected-listed-buildings.controller.js
@@ -123,13 +123,12 @@ export const postAddAffectedListedBuildingCheckAndConfirm = async (request, resp
 			request.session.affectedListedBuilding
 		);
 
-		addNotificationBannerToSession(
-			request.session,
-			'changePage',
+		addNotificationBannerToSession({
+			session: request.session,
+			bannerDefinitionKey: 'changePage',
 			appealId,
-			'',
-			'Listed building added'
-		);
+			text: 'Listed building added'
+		});
 
 		delete request.session.affectedListedBuilding;
 
@@ -233,13 +232,12 @@ export const postRemoveAffectedListedBuilding = async (request, response) => {
 		);
 	} else if (body['removeAffectedListedBuilding'] === 'yes') {
 		await removeAffectedListedBuilding(apiClient, appealId, listedBuildingId);
-		addNotificationBannerToSession(
-			request.session,
-			'changePage',
+		addNotificationBannerToSession({
+			session: request.session,
+			bannerDefinitionKey: 'changePage',
 			appealId,
-			'',
-			'Listed building removed'
-		);
+			text: 'Listed building removed'
+		});
 
 		return response.redirect(
 			`/appeals-service/appeal-details/${appealId}/lpa-questionnaire/${lpaQuestionnaireId}`
@@ -363,13 +361,12 @@ export const postChangeAffectedListedBuildingCheckAndConfirm = async (request, r
 			listedBuildingId,
 			request.session.affectedListedBuilding
 		);
-		addNotificationBannerToSession(
-			request.session,
-			'changePage',
+		addNotificationBannerToSession({
+			session: request.session,
+			bannerDefinitionKey: 'changePage',
 			appealId,
-			'',
-			'Listed building updated'
-		);
+			text: 'Listed building updated'
+		});
 
 		delete request.session.affectedListedBuilding;
 

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/affects-scheduled-monument/affects-scheduled-monument.controller.js
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/affects-scheduled-monument/affects-scheduled-monument.controller.js
@@ -76,13 +76,12 @@ export const postChangeAffectsScheduledMonument = async (request, response) => {
 			session.affectsScheduledMonument
 		);
 
-		addNotificationBannerToSession(
+		addNotificationBannerToSession({
 			session,
-			'changePage',
+			bannerDefinitionKey: 'changePage',
 			appealId,
-			'',
-			'Scheduled monument status changed '
-		);
+			text: 'Scheduled monument status changed'
+		});
 
 		delete request.session.affectsScheduledMonument;
 

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/correct-appeal-type/correct-appeal-type.controller.js
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/correct-appeal-type/correct-appeal-type.controller.js
@@ -69,7 +69,12 @@ export const postChangeCorrectAppealType = async (request, response) => {
 			request.session.isCorrectType
 		);
 
-		addNotificationBannerToSession(request.session, 'isAppealTypeCorrectUpdated', appealId);
+		addNotificationBannerToSession({
+			session: request.session,
+			bannerDefinitionKey: 'changePage',
+			appealId,
+			text: 'Correct appeal type (LPA response) has been updated'
+		});
 
 		delete request.session.isCorrectType;
 

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/designated-sites/designated-sites.controller.js
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/designated-sites/designated-sites.controller.js
@@ -95,13 +95,12 @@ export const postChangeInNearOrLikelyToAffectDesignatedSites = async (request, r
 			mappedInputData
 		);
 
-		addNotificationBannerToSession(
+		addNotificationBannerToSession({
 			session,
-			'changePage',
+			bannerDefinitionKey: 'changePage',
 			appealId,
-			'',
-			'In, near or likely to effect designated sites changed'
-		);
+			text: 'In, near or likely to effect designated sites changed'
+		});
 
 		delete request.session.inNearOrLikelyToAffectDesignatedSites;
 

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/eia-development-description/eia-development-description.controller.js
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/eia-development-description/eia-development-description.controller.js
@@ -58,13 +58,12 @@ export const postChangeEiaDevelopmentDescription = async (request, response) => 
 			request.session.eiaDevelopmentDescription
 		);
 
-		addNotificationBannerToSession(
-			request.session,
-			'changePage',
+		addNotificationBannerToSession({
+			session: request.session,
+			bannerDefinitionKey: 'changePage',
 			appealId,
-			'',
-			'Description of development updated'
-		);
+			text: 'Description of development updated'
+		});
 
 		delete request.session.eiaDevelopmentDescription;
 

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/eia-environmental-impact-schedule/eia-environmental-impact-schedule.controller.js
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/eia-environmental-impact-schedule/eia-environmental-impact-schedule.controller.js
@@ -63,13 +63,12 @@ export const postChangeEiaEnvironmentalImpactSchedule = async (request, response
 			)
 		);
 
-		addNotificationBannerToSession(
-			request.session,
-			'changePage',
+		addNotificationBannerToSession({
+			session: request.session,
+			bannerDefinitionKey: 'changePage',
 			appealId,
-			'',
-			'Development category updated'
-		);
+			text: 'Development category updated'
+		});
 
 		delete request.session.eiaEnvironmentalImpactSchedule;
 

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/environmental-impact-assessment/environmental-impact-assessment.controller.js
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/environmental-impact-assessment/environmental-impact-assessment.controller.js
@@ -70,13 +70,12 @@ export const postChangeEiaColumnTwoThreshold = async (request, response) => {
 			request.session.eiaColumnTwoThreshold
 		);
 
-		addNotificationBannerToSession(
-			request.session,
-			'changePage',
+		addNotificationBannerToSession({
+			session: request.session,
+			bannerDefinitionKey: 'changePage',
 			appealId,
-			'',
-			'Column 2 threshold criteria status changed'
-		);
+			text: 'Column 2 threshold criteria status changed'
+		});
 
 		delete request.session.eiaColumnTwoThreshold;
 
@@ -146,13 +145,12 @@ export const postChangeEiaRequiresEnvironmentalStatement = async (request, respo
 			request.session.eiaRequiresEnvironmentalStatement
 		);
 
-		addNotificationBannerToSession(
-			request.session,
-			'changePage',
+		addNotificationBannerToSession({
+			session: request.session,
+			bannerDefinitionKey: 'changePage',
 			appealId,
-			'',
-			'Environmental statement status changed'
-		);
+			text: 'Environmental statement status changed'
+		});
 
 		delete request.session.eiaRequiresEnvironmentalStatement;
 
@@ -226,13 +224,12 @@ export const postChangeEiaSensitiveAreaDetails = async (request, response) => {
 			request.session.eiaSensitiveAreaDetails
 		);
 
-		addNotificationBannerToSession(
-			request.session,
-			'changePage',
+		addNotificationBannerToSession({
+			session: request.session,
+			bannerDefinitionKey: 'changePage',
 			appealId,
-			'',
-			'In, partly in, or likely to affect a sensitive area changed'
-		);
+			text: 'In, partly in, or likely to affect a sensitive area changed'
+		});
 
 		delete request.session.eiaSensitiveAreaDetails;
 
@@ -306,13 +303,12 @@ export const postChangeEiaConsultedBodiesDetails = async (request, response) => 
 			request.session.eiaConsultedBodiesDetails
 		);
 
-		addNotificationBannerToSession(
-			request.session,
-			'changePage',
+		addNotificationBannerToSession({
+			session: request.session,
+			bannerDefinitionKey: 'changePage',
 			appealId,
-			'',
-			'Consulted relevant statutory consultees changed'
-		);
+			text: 'Consulted relevant statutory consultees changed'
+		});
 
 		delete request.session.eiaConsultedBodiesDetails;
 

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/extra-conditions/extra-conditions.controller.js
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/extra-conditions/extra-conditions.controller.js
@@ -82,12 +82,12 @@ export const postChangeExtraConditions = async (request, response) => {
 			request.session.extraConditions
 		);
 
-		addNotificationBannerToSession(
-			request.session,
-			'changePage',
+		addNotificationBannerToSession({
+			session: request.session,
+			bannerDefinitionKey: 'changePage',
 			appealId,
-			`<p class="govuk-notification-banner__heading">Extra conditions updated</p>`
-		);
+			text: `Extra conditions updated`
+		});
 
 		delete request.session.extraConditions;
 

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/has-community-infrastructure-levy/has-community-infrastructure-levy.controller.js
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/has-community-infrastructure-levy/has-community-infrastructure-levy.controller.js
@@ -80,13 +80,12 @@ export const postChangeHasCommunityInfrastructureLevy = async (request, response
 			session.hasCommunityInfrastructureLevy
 		);
 
-		addNotificationBannerToSession(
+		addNotificationBannerToSession({
 			session,
-			'changePage',
+			bannerDefinitionKey: 'changePage',
 			appealId,
-			'',
-			'Community infrastructure levy status changed'
-		);
+			text: 'Community infrastructure levy status changed'
+		});
 
 		delete request.session.hasCommunityInfrastructureLevy;
 

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/has-protected-species/has-protected-species.controller.js
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/has-protected-species/has-protected-species.controller.js
@@ -81,13 +81,12 @@ export const postChangeHasProtectedSpecies = async (request, response) => {
 			session.hasProtectedSpecies
 		);
 
-		addNotificationBannerToSession(
+		addNotificationBannerToSession({
 			session,
-			'changePage',
+			bannerDefinitionKey: 'changePage',
 			appealId,
-			'',
-			'Protected species status changed'
-		);
+			text: 'Protected species status changed'
+		});
 
 		delete request.session.hasProtectedSpecies;
 

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/infrastructure-levy-adopted-date/infrastructure-levy-adopted-date.controller.js
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/infrastructure-levy-adopted-date/infrastructure-levy-adopted-date.controller.js
@@ -86,13 +86,12 @@ export const postChangeInfrastructureLevyAdoptedDate = async (request, response)
 			session.infrastructureLevyAdoptedDate
 		);
 
-		addNotificationBannerToSession(
+		addNotificationBannerToSession({
 			session,
-			'changePage',
+			bannerDefinitionKey: 'changePage',
 			appealId,
-			'',
-			'Levy adoption date changed'
-		);
+			text: 'Levy adoption date changed'
+		});
 
 		delete request.session.infrastructureLevyAdoptedDate;
 

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/infrastructure-levy-expected-date/infrastructure-levy-expected-date.controller.js
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/infrastructure-levy-expected-date/infrastructure-levy-expected-date.controller.js
@@ -86,13 +86,12 @@ export const postChangeInfrastructureLevyExpectedDate = async (request, response
 			session.infrastructureLevyExpectedDate
 		);
 
-		addNotificationBannerToSession(
+		addNotificationBannerToSession({
 			session,
-			'changePage',
+			bannerDefinitionKey: 'changePage',
 			appealId,
-			'',
-			'Expected levy adoption date changed'
-		);
+			text: 'Expected levy adoption date changed'
+		});
 
 		delete request.session.infrastructureLevyExpectedDate;
 

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/is-aonb-national-landscape/is-aonb-national-landscape.controller.js
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/is-aonb-national-landscape/is-aonb-national-landscape.controller.js
@@ -82,13 +82,12 @@ export const postChangeIsAonbNationalLandscape = async (request, response) => {
 			session.isAonbNationalLandscape
 		);
 
-		addNotificationBannerToSession(
+		addNotificationBannerToSession({
 			session,
-			'changePage',
+			bannerDefinitionKey: 'changePage',
 			appealId,
-			'',
-			'Outstanding natural beauty area status changed'
-		);
+			text: 'Outstanding natural beauty area status changed'
+		});
 
 		delete request.session.isAonbNationalLandscape;
 

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/is-gypsy-or-traveller-site/is-gypsy-or-traveller-site.controller.js
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/is-gypsy-or-traveller-site/is-gypsy-or-traveller-site.controller.js
@@ -82,13 +82,12 @@ export const postChangeIsGypsyOrTravellerSite = async (request, response) => {
 			session.isGypsyOrTravellerSite
 		);
 
-		addNotificationBannerToSession(
+		addNotificationBannerToSession({
 			session,
-			'changePage',
+			bannerDefinitionKey: 'changePage',
 			appealId,
-			'',
-			'Gypsy or Traveller communities status changed'
-		);
+			text: 'Gypsy or Traveller communities status changed'
+		});
 
 		delete request.session.isGypsyOrTravellerSite;
 

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/is-infrastructure-levy-formally-adopted/is-infrastructure-levy-formally-adopted.controller.js
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/is-infrastructure-levy-formally-adopted/is-infrastructure-levy-formally-adopted.controller.js
@@ -82,13 +82,12 @@ export const postChangeIsInfrastructureLevyFormallyAdopted = async (request, res
 			session.isInfrastructureLevyFormallyAdopted
 		);
 
-		addNotificationBannerToSession(
+		addNotificationBannerToSession({
 			session,
-			'changePage',
+			bannerDefinitionKey: 'changePage',
 			appealId,
-			'',
-			'Levy formally adopted status changed'
-		);
+			text: 'Levy formally adopted status changed'
+		});
 
 		delete request.session.isInfrastructureLevyFormallyAdopted;
 

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/lpa-questionnaire.controller.js
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/lpa-questionnaire.controller.js
@@ -474,7 +474,11 @@ export const postAddDocumentsCheckAndConfirm = async (request, response) => {
 			response,
 			nextPageUrl: `/appeals-service/appeal-details/${currentAppeal.appealId}/lpa-questionnaire/${request.params.lpaQuestionnaireId}`,
 			successCallback: () => {
-				addNotificationBannerToSession(request.session, 'documentAdded', currentAppeal.appealId);
+				addNotificationBannerToSession({
+					session: request.session,
+					bannerDefinitionKey: 'documentAdded',
+					appealId: currentAppeal.appealId
+				});
 			}
 		});
 	} catch (error) {

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/neighbouring-site-access/neighbouring-site-access.controller.js
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/neighbouring-site-access/neighbouring-site-access.controller.js
@@ -65,13 +65,12 @@ export const postChangeNeighbouringSiteAccess = async (request, response) => {
 			request.session.neighbouringSiteAccess
 		);
 
-		addNotificationBannerToSession(
-			request.session,
-			'changePage',
+		addNotificationBannerToSession({
+			session: request.session,
+			bannerDefinitionKey: 'changePage',
 			appealId,
-			'',
-			'Inspector needs neighbouring site access changed'
-		);
+			text: 'Inspector needs neighbouring site access changed'
+		});
 
 		delete request.session.neighbouringSiteAccess;
 

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/notification-methods/notification-methods.controller.js
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/notification-methods/notification-methods.controller.js
@@ -105,12 +105,12 @@ export const postChangeNotificationMethods = async (request, response) => {
 			request.session.notificationMethods
 		);
 
-		addNotificationBannerToSession(
-			request.session,
-			'changePage',
+		addNotificationBannerToSession({
+			session: request.session,
+			bannerDefinitionKey: 'changePage',
 			appealId,
-			`<p class="govuk-notification-banner__heading">Notification methods updated</p>`
-		);
+			text: `Notification methods updated`
+		});
 
 		delete request.session.notificationMethods;
 

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/procedure-preference/procedure-preference.controller.js
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/procedure-preference/procedure-preference.controller.js
@@ -80,13 +80,12 @@ export const postChangeProcedurePreference = async (request, response) => {
 			request.session.lpaProcedurePreference.radio
 		);
 
-		addNotificationBannerToSession(
-			request.session,
-			'changePage',
+		addNotificationBannerToSession({
+			session: request.session,
+			bannerDefinitionKey: 'changePage',
 			appealId,
-			'',
-			'Procedure preference updated'
-		);
+			text: 'Procedure preference updated'
+		});
 
 		delete request.session.lpaProcedurePreference;
 
@@ -167,13 +166,12 @@ export const postChangeProcedurePreferenceDetails = async (request, response) =>
 			request.session.lpaProcedurePreferenceDetails.textarea
 		);
 
-		addNotificationBannerToSession(
-			request.session,
-			'changePage',
+		addNotificationBannerToSession({
+			session: request.session,
+			bannerDefinitionKey: 'changePage',
 			appealId,
-			'',
-			'Reason for preference updated'
-		);
+			text: 'Reason for preference updated'
+		});
 
 		delete request.session.lpaProcedurePreferenceDetails;
 
@@ -254,13 +252,12 @@ export const postChangeProcedurePreferenceDuration = async (request, response) =
 			request.session.procedurePreferenceDuration.input
 		);
 
-		addNotificationBannerToSession(
-			request.session,
-			'changePage',
+		addNotificationBannerToSession({
+			session: request.session,
+			bannerDefinitionKey: 'changePage',
 			appealId,
-			'',
-			'Expected length of procedure updated'
-		);
+			text: 'Expected length of procedure updated'
+		});
 
 		delete request.session.procedurePreferenceDuration;
 

--- a/appeals/web/src/server/appeals/appeal-details/lpa-reference/lpa-reference.controller.js
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-reference/lpa-reference.controller.js
@@ -73,12 +73,12 @@ export const postChangeLpaReference = async (request, response) => {
 			request.session.planningApplicationReference
 		);
 
-		addNotificationBannerToSession(
-			request.session,
-			'changePage',
+		addNotificationBannerToSession({
+			session: request.session,
+			bannerDefinitionKey: 'changePage',
 			appealId,
-			`<p class="govuk-notification-banner__heading">LPA application reference updated</p>`
-		);
+			text: `LPA application reference updated`
+		});
 
 		delete request.session.planningApplicationReference;
 

--- a/appeals/web/src/server/appeals/appeal-details/neighbouring-sites/neighbouring-sites.controller.js
+++ b/appeals/web/src/server/appeals/appeal-details/neighbouring-sites/neighbouring-sites.controller.js
@@ -175,12 +175,11 @@ export const postAddNeighbouringSiteCheckAndConfirm = async (request, response) 
 			source,
 			request.session.neighbouringSite
 		);
-		addNotificationBannerToSession(
-			request.session,
-			'neighbouringSiteAdded',
-			appealId,
-			`<p class="govuk-notification-banner__heading">Neighbouring site added</p>`
-		);
+		addNotificationBannerToSession({
+			session: request.session,
+			bannerDefinitionKey: 'neighbouringSiteAdded',
+			appealId
+		});
 
 		delete request.session.neighbouringSite;
 
@@ -289,12 +288,12 @@ export const postRemoveNeighbouringSite = async (request, response) => {
 		return response.redirect(`${origin}/neighbouring-sites/manage`);
 	} else if (body['remove-neighbouring-site'] === 'yes') {
 		await removeNeighbouringSite(request.apiClient, appealId, siteId);
-		addNotificationBannerToSession(
-			request.session,
-			'neighbouringSiteRemoved',
-			appealId,
-			`<p class="govuk-notification-banner__heading">Neighbouring site removed</p>`
-		);
+
+		addNotificationBannerToSession({
+			session: request.session,
+			bannerDefinitionKey: 'neighbouringSiteRemoved',
+			appealId
+		});
 
 		const redirectUrl =
 			currentAppeal?.neighbouringSites?.length > 1 ? `${origin}/neighbouring-sites/manage` : origin;
@@ -426,12 +425,11 @@ export const postChangeNeighbouringSiteCheckAndConfirm = async (request, respons
 			request.session.neighbouringSite,
 			siteId
 		);
-		addNotificationBannerToSession(
-			request.session,
-			'neighbouringSiteUpdated',
-			appealId,
-			`<p class="govuk-notification-banner__heading">Neighbouring site updated</p>`
-		);
+		addNotificationBannerToSession({
+			session: request.session,
+			bannerDefinitionKey: 'neighbouringSiteUpdated',
+			appealId
+		});
 
 		delete request.session.neighbouringSite;
 
@@ -512,12 +510,11 @@ export const postChangeNeighbouringSiteAffected = async (request, response) => {
 			neighbouringSiteAffected
 		);
 
-		addNotificationBannerToSession(
-			request.session,
-			'neighbouringSiteAffected',
-			appealId,
-			`<p class="govuk-notification-banner__heading">Neighbouring site affected status updated</p>`
-		);
+		addNotificationBannerToSession({
+			session: request.session,
+			bannerDefinitionKey: 'neighbouringSiteAffected',
+			appealId
+		});
 
 		delete request.session.neighbouringSite;
 

--- a/appeals/web/src/server/appeals/appeal-details/neighbouring-sites/neighbouring-sites.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/neighbouring-sites/neighbouring-sites.mapper.js
@@ -3,7 +3,7 @@ import {
 	appealSiteToMultilineAddressStringHtml
 } from '#lib/address-formatter.js';
 import { appealShortReference } from '#lib/appeals-formatter.js';
-import { buildNotificationBanners } from '#lib/mappers/index.js';
+import { mapNotificationBannersFromSession } from '#lib/mappers/index.js';
 import { addressInputs } from '#lib/mappers/index.js';
 import { yesNoInput } from '#lib/mappers/index.js';
 
@@ -97,7 +97,7 @@ export function addNeighbouringSiteCheckAndConfirmPage(
 export function manageNeighbouringSitesPage(request, appealData) {
 	const shortAppealReference = appealShortReference(appealData.appealReference);
 
-	const notificationBanners = buildNotificationBanners(
+	const notificationBanners = mapNotificationBannersFromSession(
 		request.session,
 		'manageNeighbouringSites',
 		request.currentAppeal.appealId

--- a/appeals/web/src/server/appeals/appeal-details/other-appeals/other-appeals.controller.js
+++ b/appeals/web/src/server/appeals/appeal-details/other-appeals/other-appeals.controller.js
@@ -176,12 +176,12 @@ export const postConfirmOtherAppeals = async (request, response) => {
 				);
 			}
 
-			addNotificationBannerToSession(
-				request.session,
-				'otherAppeal',
-				request.session.appealId,
-				`<p class="govuk-notification-banner__heading">This appeal is now related to ${request.session.relatedAppealReference}</p>`
-			);
+			addNotificationBannerToSession({
+				session: request.session,
+				bannerDefinitionKey: 'relatedAppeal',
+				appealId: request.session.appealId,
+				text: `This appeal is now related to ${request.session.relatedAppealReference}`
+			});
 		} catch (error) {
 			let errorMessage = 'Something went wrong when posting related appeal';
 			if (error instanceof Error) {
@@ -326,12 +326,12 @@ export const postRemoveOtherAppeals = async (request, response) => {
 
 			await postUnlinkRequest(request.apiClient, appealId, appealRelationshipId);
 
-			addNotificationBannerToSession(
-				request.session,
-				'otherAppealRemoved',
+			addNotificationBannerToSession({
+				session: request.session,
+				bannerDefinitionKey: 'relatedAppeal',
 				appealId,
-				`<p class="govuk-notification-banner__heading">You have removed the relationship between this appeal and appeal ${relatedAppealShortReference}</p>`
-			);
+				text: `You have removed the relationship between this appeal and appeal ${relatedAppealShortReference}`
+			});
 
 			const appealData = request.currentAppeal;
 

--- a/appeals/web/src/server/appeals/appeal-details/other-appeals/other-appeals.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/other-appeals/other-appeals.mapper.js
@@ -1,7 +1,7 @@
 import { addressToString } from '#lib/address-formatter.js';
 import { numberToAccessibleDigitLabel } from '#lib/accessibility.js';
 import { appealShortReference } from '#lib/appeals-formatter.js';
-import { buildNotificationBanners } from '#lib/mappers/index.js';
+import { mapNotificationBannersFromSession } from '#lib/mappers/index.js';
 import { generateHorizonAppealUrl } from '#lib/display-page-formatter.js';
 
 /**
@@ -232,7 +232,7 @@ export function confirmOtherAppealsPage(currentAppeal, relatedAppeal, origin) {
  * @returns {PageContent}
  */
 export function manageOtherAppealsPage(appealData, request, origin) {
-	const notificationBanners = buildNotificationBanners(
+	const notificationBanners = mapNotificationBannersFromSession(
 		request.session,
 		'manageRelatedAppeals',
 		request.currentAppeal.appealId

--- a/appeals/web/src/server/appeals/appeal-details/representations/document-attachments/controller/check-your-answers.js
+++ b/appeals/web/src/server/appeals/appeal-details/representations/document-attachments/controller/check-your-answers.js
@@ -136,7 +136,11 @@ export const postCheckYourAnswers = async (request, response) => {
 
 	delete session.fileUploadInfo;
 
-	addNotificationBannerToSession(session, 'finalCommentsDocumentAddedSuccess', appealId);
+	addNotificationBannerToSession({
+		session,
+		bannerDefinitionKey: 'finalCommentsDocumentAddedSuccess',
+		appealId
+	});
 
 	const nextPageUrl = request.baseUrl.split('/').slice(0, -1).join('/');
 	return response.redirect(nextPageUrl);

--- a/appeals/web/src/server/appeals/appeal-details/representations/interested-party-comments/add-document/controller/check-your-answers.js
+++ b/appeals/web/src/server/appeals/appeal-details/representations/interested-party-comments/add-document/controller/check-your-answers.js
@@ -128,7 +128,11 @@ export const postCheckYourAnswers = async (
 
 	delete session.fileUploadInfo;
 
-	addNotificationBannerToSession(session, 'interestedPartyCommentsDocumentAddedSuccess', appealId);
+	addNotificationBannerToSession({
+		session,
+		bannerDefinitionKey: 'interestedPartyCommentsDocumentAddedSuccess',
+		appealId
+	});
 
 	return response.redirect(
 		`/appeals-service/appeal-details/${appealId}/interested-party-comments/${commentId}/review`

--- a/appeals/web/src/server/appeals/appeal-details/representations/interested-party-comments/add-ip-comment/add-ip-comment.controller.js
+++ b/appeals/web/src/server/appeals/appeal-details/representations/interested-party-comments/add-ip-comment/add-ip-comment.controller.js
@@ -227,13 +227,11 @@ export async function postIPComment(request, response) {
 		delete request.session.addIpComment;
 		delete request.session.fileUploadInfo;
 
-		addNotificationBannerToSession(
-			request.session,
-			'changePage',
-			currentAppeal.appealId,
-			'',
-			'Interested party comment added'
-		);
+		addNotificationBannerToSession({
+			session: request.session,
+			bannerDefinitionKey: 'interestedPartyCommentAdded',
+			appealId: currentAppeal.appealId
+		});
 
 		redirectToIPComments(request, response);
 	} catch (error) {

--- a/appeals/web/src/server/appeals/appeal-details/representations/interested-party-comments/edit-ip-comment/edit-ip-comment.controller.js
+++ b/appeals/web/src/server/appeals/appeal-details/representations/interested-party-comments/edit-ip-comment/edit-ip-comment.controller.js
@@ -83,11 +83,14 @@ export async function postCheckPage(request, response) {
 	const redirectPath = request.query.review === 'true' ? 'review' : 'view';
 
 	if (request.session.editIpComment.operationType) {
-		const bannerKey =
-			request.session.editIpComment.operationType === 'add'
-				? 'interestedPartyCommentsAddressAddedSuccess'
-				: 'interestedPartyCommentsAddressUpdatedSuccess';
-		addNotificationBannerToSession(session, bannerKey, currentAppeal.appealId);
+		addNotificationBannerToSession({
+			session,
+			bannerDefinitionKey:
+				request.session.editIpComment.operationType === 'add'
+					? 'interestedPartyCommentsAddressAddedSuccess'
+					: 'interestedPartyCommentsAddressUpdatedSuccess',
+			appealId: currentAppeal.appealId
+		});
 	}
 
 	return response

--- a/appeals/web/src/server/appeals/appeal-details/representations/interested-party-comments/interested-party-comments.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/representations/interested-party-comments/interested-party-comments.mapper.js
@@ -1,7 +1,7 @@
 import { appealShortReference } from '#lib/appeals-formatter.js';
 import { addressToString } from '#lib/address-formatter.js';
 import { dateISOStringToDisplayDate } from '#lib/dates.js';
-import { buildNotificationBanners } from '#lib/mappers/index.js';
+import { mapNotificationBannersFromSession } from '#lib/mappers/index.js';
 import { addressInputs } from '#lib/mappers/index.js';
 import { simpleHtmlComponent } from '#lib/mappers/index.js';
 import { preRenderPageComponents } from '#lib/nunjucks-template-builders/page-component-rendering.js';
@@ -31,7 +31,7 @@ export async function interestedPartyCommentsPage(
 ) {
 	const shortReference = appealShortReference(appealDetails.appealReference);
 
-	const notificationBanners = buildNotificationBanners(
+	const notificationBanners = mapNotificationBannersFromSession(
 		session,
 		'ipComments',
 		appealDetails.appealId

--- a/appeals/web/src/server/appeals/appeal-details/representations/interested-party-comments/redact/redact.controller.js
+++ b/appeals/web/src/server/appeals/appeal-details/representations/interested-party-comments/redact/redact.controller.js
@@ -57,7 +57,11 @@ export const postConfirmRedactInterestedPartyComment = async (request, response)
 	delete session.redactedRepresentation;
 	delete session.siteVisitRequested;
 
-	addNotificationBannerToSession(session, 'interestedPartyCommentsRedactionSuccess', appealId);
+	addNotificationBannerToSession({
+		session,
+		bannerDefinitionKey: 'interestedPartyCommentsRedactionSuccess',
+		appealId
+	});
 
 	return response.redirect(
 		`/appeals-service/appeal-details/${appealId}/interested-party-comments/${commentId}/view`

--- a/appeals/web/src/server/appeals/appeal-details/representations/interested-party-comments/view-and-review/__tests__/__snapshots__/view-and-review.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/representations/interested-party-comments/view-and-review/__tests__/__snapshots__/view-and-review.test.js.snap
@@ -102,7 +102,8 @@ exports[`interested-party-comments GET /manage-documents/:folderId/:documentId s
                     <h3 class="govuk-notification-banner__title" id="govuk-notification-banner-title"> Important</h3>
                 </div>
                 <div class="govuk-notification-banner__content">
-                    <p class="govuk-notification-banner__heading">Virus scan in progress</p><a class="govuk-notification-banner__link" href="/appeals-service/appeal-details/2/interested-party-comments/5/manage-documents/1/1">Refresh page to see if scan has finished</a>
+                    <p class="govuk-notification-banner__heading">Virus scan in progress</p><a class="govuk-notification-banner__link" href=""
+                    data-cy="refresh-page">Refresh page to see if scan has finished</a>
                 </div>
             </div>
         </div>

--- a/appeals/web/src/server/appeals/appeal-details/representations/interested-party-comments/view-and-review/page-components/review.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/representations/interested-party-comments/view-and-review/page-components/review.mapper.js
@@ -1,7 +1,7 @@
 import { appealShortReference } from '#lib/appeals-formatter.js';
 import { COMMENT_STATUS } from '@pins/appeals/constants/common.js';
 import { generateCommentSummaryList, generateWithdrawLink } from './common.js';
-import { buildNotificationBanners } from '#lib/mappers/index.js';
+import { mapNotificationBannersFromSession } from '#lib/mappers/index.js';
 
 /** @typedef {import("#appeals/appeal-details/appeal-details.types.js").WebAppeal} Appeal */
 /** @typedef {import('#appeals/appeal-details/representations/types.js').Representation} Representation */
@@ -82,7 +82,7 @@ export function reviewInterestedPartyCommentPage(appealDetails, comment, session
 		heading: 'Review comment',
 		submitButtonText: 'Confirm',
 		pageComponents: [
-			...buildNotificationBanners(session, 'reviewIpComment', appealDetails.appealId),
+			...mapNotificationBannersFromSession(session, 'reviewIpComment', appealDetails.appealId),
 			commentSummaryList,
 			siteVisitRequestCheckbox,
 			commentValidityRadioButtons,

--- a/appeals/web/src/server/appeals/appeal-details/representations/interested-party-comments/view-and-review/page-components/view.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/representations/interested-party-comments/view-and-review/page-components/view.mapper.js
@@ -1,5 +1,5 @@
 import { appealShortReference } from '#lib/appeals-formatter.js';
-import { buildNotificationBanners } from '#lib/mappers/index.js';
+import { mapNotificationBannersFromSession } from '#lib/mappers/index.js';
 import { generateCommentSummaryList, generateWithdrawLink } from './common.js';
 import { preRenderPageComponents } from '#lib/nunjucks-template-builders/page-component-rendering.js';
 
@@ -16,7 +16,7 @@ export function viewInterestedPartyCommentPage(appealDetails, comment, session) 
 	const shortReference = appealShortReference(appealDetails.appealReference);
 	const commentSummaryList = generateCommentSummaryList(appealDetails.appealId, comment);
 	const withdrawLink = generateWithdrawLink();
-	const notificationBanners = buildNotificationBanners(
+	const notificationBanners = mapNotificationBannersFromSession(
 		session,
 		'viewIpComment',
 		appealDetails.appealId

--- a/appeals/web/src/server/appeals/appeal-details/representations/interested-party-comments/view-and-review/reject/reject.controller.js
+++ b/appeals/web/src/server/appeals/appeal-details/representations/interested-party-comments/view-and-review/reject/reject.controller.js
@@ -70,7 +70,11 @@ export const postRejectInterestedPartyComment = async (request, response) => {
 		session.siteVisitRequested === 'site-visit'
 	);
 
-	addNotificationBannerToSession(session, 'interestedPartyCommentsRejectedSuccess', appealId);
+	addNotificationBannerToSession({
+		session,
+		bannerDefinitionKey: 'interestedPartyCommentsRejectedSuccess',
+		appealId
+	});
 
 	delete session.rejectIpComment;
 	delete session.siteVisitRequested;

--- a/appeals/web/src/server/appeals/appeal-details/representations/interested-party-comments/view-and-review/view-and-review.controller.js
+++ b/appeals/web/src/server/appeals/appeal-details/representations/interested-party-comments/view-and-review/view-and-review.controller.js
@@ -69,7 +69,11 @@ export const postReviewInterestedPartyComment = async (request, response, next) 
 		body.siteVisitRequested === 'site-visit'
 	);
 
-	addNotificationBannerToSession(session, 'interestedPartyCommentsValidSuccess', appealId);
+	addNotificationBannerToSession({
+		session,
+		bannerDefinitionKey: 'interestedPartyCommentsValidSuccess',
+		appealId
+	});
 
 	return response.redirect(`/appeals-service/appeal-details/${appealId}/interested-party-comments`);
 };

--- a/appeals/web/src/server/appeals/appeal-details/representations/lpa-statement/__tests__/__snapshots__/lpa-statement.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/representations/lpa-statement/__tests__/__snapshots__/lpa-statement.test.js.snap
@@ -102,7 +102,8 @@ exports[`lpa-statements GET /manage-documents/:folderId/:documentId should rende
                     <h3 class="govuk-notification-banner__title" id="govuk-notification-banner-title"> Important</h3>
                 </div>
                 <div class="govuk-notification-banner__content">
-                    <p class="govuk-notification-banner__heading">Virus scan in progress</p><a class="govuk-notification-banner__link" href="/appeals-service/appeal-details/2/lpa-statement/manage-documents/1/1">Refresh page to see if scan has finished</a>
+                    <p class="govuk-notification-banner__heading">Virus scan in progress</p><a class="govuk-notification-banner__link" href=""
+                    data-cy="refresh-page">Refresh page to see if scan has finished</a>
                 </div>
             </div>
         </div>

--- a/appeals/web/src/server/appeals/appeal-details/representations/lpa-statement/incomplete/incomplete.controller.js
+++ b/appeals/web/src/server/appeals/appeal-details/representations/lpa-statement/incomplete/incomplete.controller.js
@@ -201,7 +201,11 @@ export const postCheckYourAnswers = async (request, response) => {
 
 	await representationIncomplete(apiClient, parseInt(appealId), currentRepresentation.id);
 
-	addNotificationBannerToSession(session, 'lpaStatementIncomplete', appealId);
+	addNotificationBannerToSession({
+		session,
+		bannerDefinitionKey: 'lpaStatementIncomplete',
+		appealId
+	});
 
 	return response.status(200).redirect(`/appeals-service/appeal-details/${appealId}`);
 };

--- a/appeals/web/src/server/appeals/appeal-details/representations/lpa-statement/lpa-statement.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/representations/lpa-statement/lpa-statement.mapper.js
@@ -1,7 +1,7 @@
 import { appealShortReference } from '#lib/appeals-formatter.js';
 import { preRenderPageComponents } from '#lib/nunjucks-template-builders/page-component-rendering.js';
 import { buildHtmUnorderedList } from '#lib/nunjucks-template-builders/tag-builders.js';
-import { buildNotificationBanners } from '#lib/mappers/index.js';
+import { mapNotificationBannersFromSession } from '#lib/mappers/index.js';
 import { COMMENT_STATUS } from '@pins/appeals/constants/common.js';
 
 /** @typedef {import("#appeals/appeal-details/appeal-details.types.js").WebAppeal} Appeal */
@@ -105,7 +105,7 @@ export function viewLpaStatementPage(appealDetails, lpaStatement, session) {
 	});
 
 	const pageComponents = [
-		...buildNotificationBanners(session, 'lpaStatement', appealDetails.appealId),
+		...mapNotificationBannersFromSession(session, 'lpaStatement', appealDetails.appealId),
 		lpaStatementSummaryList
 	];
 	preRenderPageComponents(pageComponents);
@@ -168,7 +168,7 @@ export function reviewLpaStatementPage(appealDetails, lpaStatement, session) {
 	};
 
 	const pageComponents = [
-		...buildNotificationBanners(session, 'lpaStatement', appealDetails.appealId),
+		...mapNotificationBannersFromSession(session, 'lpaStatement', appealDetails.appealId),
 		lpaStatementSummaryList,
 		lpaStatementValidityRadioButtons
 	];

--- a/appeals/web/src/server/appeals/appeal-details/representations/lpa-statement/redact/redact.controller.js
+++ b/appeals/web/src/server/appeals/appeal-details/representations/lpa-statement/redact/redact.controller.js
@@ -199,7 +199,11 @@ export async function postConfirm(request, response) {
 
 	delete session.redactLPAStatement;
 
-	addNotificationBannerToSession(session, 'lpaStatementRedactedAndAccepted', appealId);
+	addNotificationBannerToSession({
+		session,
+		bannerDefinitionKey: 'lpaStatementRedactedAndAccepted',
+		appealId
+	});
 
 	return response.redirect(`/appeals-service/appeal-details/${appealId}`);
 }

--- a/appeals/web/src/server/appeals/appeal-details/representations/lpa-statement/valid/valid.controller.js
+++ b/appeals/web/src/server/appeals/appeal-details/representations/lpa-statement/valid/valid.controller.js
@@ -177,7 +177,11 @@ export async function postAcceptStatement(request, response) {
 
 	await acceptRepresentation(apiClient, parseInt(appealId), currentRepresentation.id);
 
-	addNotificationBannerToSession(session, 'lpaStatementAccepted', appealId);
+	addNotificationBannerToSession({
+		session,
+		bannerDefinitionKey: 'lpaStatementAccepted',
+		appealId
+	});
 
 	return response.redirect(`/appeals-service/appeal-details/${appealId}`);
 }

--- a/appeals/web/src/server/appeals/appeal-details/representations/representations.controller.js
+++ b/appeals/web/src/server/appeals/appeal-details/representations/representations.controller.js
@@ -42,7 +42,7 @@ export async function postShareRepresentations(request, response) {
 
 	const publishedReps = await publishRepresentations(apiClient, currentAppeal.appealId);
 
-	const bannerKey = (() => {
+	const bannerDefinitionKey = (() => {
 		switch (currentAppeal.appealStatus) {
 			case APPEAL_CASE_STATUS.STATEMENTS:
 				return publishedReps.length > 0
@@ -53,8 +53,12 @@ export async function postShareRepresentations(request, response) {
 		}
 	})();
 
-	if (bannerKey) {
-		addNotificationBannerToSession(session, bannerKey, currentAppeal.appealId);
+	if (bannerDefinitionKey) {
+		addNotificationBannerToSession({
+			session,
+			bannerDefinitionKey,
+			appealId: currentAppeal.appealId
+		});
 	}
 
 	return response.redirect(`/appeals-service/appeal-details/${currentAppeal.appealId}`);

--- a/appeals/web/src/server/appeals/appeal-details/safety-risks/safety-risks.controller.js
+++ b/appeals/web/src/server/appeals/appeal-details/safety-risks/safety-risks.controller.js
@@ -92,12 +92,12 @@ export const postChangeSafetyRisks = async (request, response) => {
 			);
 		}
 
-		addNotificationBannerToSession(
-			request.session,
-			'changePage',
+		addNotificationBannerToSession({
+			session: request.session,
+			bannerDefinitionKey: 'changePage',
 			appealId,
-			`<p class="govuk-notification-banner__heading">Site health and safety risks (${formattedSource} answer) updated</p>`
-		);
+			text: `Site health and safety risks (${formattedSource} answer) updated`
+		});
 
 		delete request.session.safetyRisks;
 

--- a/appeals/web/src/server/appeals/appeal-details/service-user/service-user.controller.js
+++ b/appeals/web/src/server/appeals/appeal-details/service-user/service-user.controller.js
@@ -110,14 +110,12 @@ export const postChangeServiceUser = async (request, response) => {
 			);
 		}
 
-		addNotificationBannerToSession(
-			request.session,
-			'changePage',
+		addNotificationBannerToSession({
+			session: request.session,
+			bannerDefinitionKey: 'changePage',
 			appealId,
-			`<p class="govuk-notification-banner__heading">${capitalize(userType)} details ${
-				isUpdate ? 'updated' : 'added'
-			}</p>`
-		);
+			text: `${capitalize(userType)} details ${isUpdate ? 'updated' : 'added'}`
+		});
 
 		delete request.session.updatedServiceUser;
 
@@ -194,12 +192,12 @@ export const postRemoveServiceUser = async (request, response) => {
 	try {
 		await removeServiceUser(request.apiClient, appealId, serviceUserId, userType);
 
-		addNotificationBannerToSession(
-			request.session,
-			'changePage',
+		addNotificationBannerToSession({
+			session: request.session,
+			bannerDefinitionKey: 'changePage',
 			appealId,
-			`<p class="govuk-notification-banner__heading">${capitalize(userType)} removed</p>`
-		);
+			text: `${capitalize(userType)} removed`
+		});
 
 		delete request.session.updatedServiceUser;
 

--- a/appeals/web/src/server/appeals/appeal-details/site-visit/site-visit.controller.js
+++ b/appeals/web/src/server/appeals/appeal-details/site-visit/site-visit.controller.js
@@ -209,11 +209,11 @@ export const postScheduleOrManageSiteVisit = async (request, response, pageType)
 					confirmationPageTypeToRender
 				);
 
-				addNotificationBannerToSession(
-					request.session,
-					'siteVisitArranged',
-					appealDetails.appealId
-				);
+				addNotificationBannerToSession({
+					session: request.session,
+					bannerDefinitionKey: 'siteVisitArranged',
+					appealId: appealDetails.appealId
+				});
 
 				return response.redirect(
 					`/appeals-service/appeal-details/${appealDetails.appealId}/site-visit/visit-scheduled/${confirmationPageTypeToRender}`
@@ -228,11 +228,11 @@ export const postScheduleOrManageSiteVisit = async (request, response, pageType)
 					mappedUpdateOrCreateSiteVisitParameters.visitEndTime
 				);
 
-				addNotificationBannerToSession(
-					request.session,
-					'siteVisitArranged',
-					appealDetails.appealId
-				);
+				addNotificationBannerToSession({
+					session: request.session,
+					bannerDefinitionKey: 'siteVisitArranged',
+					appealId: appealDetails.appealId
+				});
 
 				return response.redirect(
 					`/appeals-service/appeal-details/${appealDetails.appealId}/site-visit/visit-scheduled/new`

--- a/appeals/web/src/server/appeals/appeal-documents/appeal-documents.controller.js
+++ b/appeals/web/src/server/appeals/appeal-documents/appeal-documents.controller.js
@@ -627,11 +627,11 @@ export const postUploadDocumentVersionCheckAndConfirm = async ({
 
 		delete request.session.fileUploadInfo;
 
-		addNotificationBannerToSession(
-			request.session,
-			'documentVersionAdded',
-			Number.parseInt(currentAppeal.appealId, 10)
-		);
+		addNotificationBannerToSession({
+			session: request.session,
+			bannerDefinitionKey: 'documentVersionAdded',
+			appealId: currentAppeal.appealId
+		});
 
 		if (nextPageUrl) {
 			return response.redirect(nextPageUrl);
@@ -723,11 +723,11 @@ export const postChangeDocumentFileName = async ({
 		const updateDocumentsResult = await updateDocument(apiClient, appealId, apiRequest);
 
 		if (updateDocumentsResult) {
-			addNotificationBannerToSession(
-				request.session,
-				'documentFilenameUpdated',
-				Number.parseInt(appealId, 10)
-			);
+			addNotificationBannerToSession({
+				session: request.session,
+				bannerDefinitionKey: 'documentFilenameUpdated',
+				appealId
+			});
 			return response.redirect(nextPageUrl || `/appeals-service/appeal-details/${appealId}/`);
 		}
 
@@ -816,11 +816,11 @@ export const postChangeDocumentDetails = async ({
 			const updateDocumentsResult = await updateDocuments(apiClient, appealId, apiRequest);
 
 			if (updateDocumentsResult) {
-				addNotificationBannerToSession(
-					request.session,
-					'documentDetailsUpdated',
-					Number.parseInt(appealId, 10)
-				);
+				addNotificationBannerToSession({
+					session: request.session,
+					bannerDefinitionKey: 'documentDetailsUpdated',
+					appealId
+				});
 				return response.redirect(nextPageUrl || `/appeals-service/appeal-details/${appealId}/`);
 			}
 		}
@@ -937,11 +937,11 @@ export const postDeleteDocument = async ({
 		return safeRedirect(request, response, cancelUrlProcessed);
 	} else if (body['delete-file-answer'] === 'yes') {
 		await deleteDocument(apiClient, appealId, documentId, versionId);
-		addNotificationBannerToSession(
-			request.session,
-			'documentDeleted',
-			Number.parseInt(appealId, 10)
-		);
+		addNotificationBannerToSession({
+			session: request.session,
+			bannerDefinitionKey: 'documentDeleted',
+			appealId
+		});
 		return response.redirect(returnUrl);
 	}
 

--- a/appeals/web/src/server/lib/__tests__/libraries.test.js
+++ b/appeals/web/src/server/lib/__tests__/libraries.test.js
@@ -1028,77 +1028,146 @@ describe('Libraries', () => {
 			it('should return false without modifying the session notificationBanners object if an unrecognised bannerDefinitionKey is provided', () => {
 				const testSession = { ...baseSession };
 
-				const result = addNotificationBannerToSession(testSession, 'anUnrecognisedKey', 1);
+				const result = addNotificationBannerToSession({
+					session: testSession,
+					// @ts-ignore
+					bannerDefinitionKey: 'anUnrecognisedKey',
+					appealId: 1
+				});
 
 				expect(result).toBe(false);
 				expect(testSession).toEqual(baseSession);
 			});
 
-			it('should return true and add a notificationBanners property to the session and add a property with name matching the bannerDefinitionKey and value of an object containing the provided appealId to the session notificationBanners object if a recognised bannerDefinitionKey is provided and there is no notificationBanners property in the session already', () => {
+			it('should return true and add the expected notification banner data to the session (scoped by stringified appealId) if a recognised bannerDefinitionKey is provided and there is no notificationBanners property in the session already', () => {
 				const testSession = { ...baseSession };
 
-				const result = addNotificationBannerToSession(testSession, 'siteVisitTypeSelected', 1);
+				const result = addNotificationBannerToSession({
+					session: testSession,
+					bannerDefinitionKey: 'caseOfficerAdded',
+					appealId: 1
+				});
 
 				expect(result).toBe(true);
 				expect(testSession).toEqual({
 					...baseSession,
 					notificationBanners: {
-						siteVisitTypeSelected: {
-							appealId: 1,
-							html: ''
-						}
+						1: [
+							{
+								key: 'caseOfficerAdded'
+							}
+						]
 					}
 				});
 			});
 
-			it('should return true and add a property with name matching the bannerDefinitionKey and value of an object containing the provided appealId to the session notificationBanners object if a recognised bannerDefinitionKey is provided and there is already a notificationBanners property in the session', () => {
+			it('should return true and add the expected notification banner data to the session (scoped by stringified appealId) if a recognised bannerDefinitionKey is provided and there is already a notificationBanners property in the session which is empty', () => {
+				const testSession = {
+					...baseSession,
+					notificationBanners: {}
+				};
+
+				const result = addNotificationBannerToSession({
+					session: testSession,
+					bannerDefinitionKey: 'caseOfficerAdded',
+					appealId: 1
+				});
+
+				expect(result).toBe(true);
+				expect(testSession).toEqual({
+					...baseSession,
+					notificationBanners: {
+						1: [
+							{
+								key: 'caseOfficerAdded'
+							}
+						]
+					}
+				});
+			});
+
+			it('should return true and add the expected notification banner data to the session (scoped by stringified appealId) if a recognised bannerDefinitionKey is provided and there is already a notificationBanners property in the session which is populated with existing banner data', () => {
 				const testSession = {
 					...baseSession,
 					notificationBanners: {
-						allocationDetailsUpdated: {
-							appealId: 1
-						}
+						1: [
+							{
+								key: 'documentAdded'
+							}
+						]
 					}
 				};
 
-				const result = addNotificationBannerToSession(testSession, 'siteVisitTypeSelected', 1);
+				const result = addNotificationBannerToSession({
+					session: testSession,
+					bannerDefinitionKey: 'caseOfficerAdded',
+					appealId: 1
+				});
 
 				expect(result).toBe(true);
 				expect(testSession).toEqual({
 					...baseSession,
 					notificationBanners: {
-						allocationDetailsUpdated: {
-							appealId: 1
-						},
-						siteVisitTypeSelected: {
-							appealId: 1,
-							html: ''
-						}
+						1: [
+							{
+								key: 'documentAdded'
+							},
+							{
+								key: 'caseOfficerAdded'
+							}
+						]
 					}
 				});
 			});
-		});
 
-		it('should return true and correctly handle the html parameter when adding a banner to the session', () => {
-			const testSession = { ...baseSession };
-			const customHtml = '<p>Custom banner content</p>';
+			it('should return true and correctly handle the text parameter when adding a banner to the session', () => {
+				const testSession = { ...baseSession };
+				const customText = 'Custom banner content';
 
-			const result = addNotificationBannerToSession(
-				testSession,
-				'siteVisitTypeSelected',
-				1,
-				customHtml
-			);
+				const result = addNotificationBannerToSession({
+					session: testSession,
+					bannerDefinitionKey: 'documentAdded',
+					appealId: 1,
+					text: customText
+				});
 
-			expect(result).toBe(true);
-			expect(testSession).toEqual({
-				...baseSession,
-				notificationBanners: {
-					siteVisitTypeSelected: {
-						appealId: 1,
-						html: customHtml
+				expect(result).toBe(true);
+				expect(testSession).toEqual({
+					...baseSession,
+					notificationBanners: {
+						1: [
+							{
+								key: 'documentAdded',
+								text: customText
+							}
+						]
 					}
-				}
+				});
+			});
+
+			it('should return true and correctly handle the html parameter when adding a banner to the session', () => {
+				const testSession = { ...baseSession };
+				const customHtml = '<p>Custom banner content</p>';
+
+				const result = addNotificationBannerToSession({
+					session: testSession,
+					bannerDefinitionKey: 'documentAdded',
+					appealId: 1,
+					html: customHtml
+				});
+
+				expect(result).toBe(true);
+				expect(testSession).toEqual({
+					...baseSession,
+					notificationBanners: {
+						1: [
+							{
+								key: 'documentAdded',
+								html: customHtml
+							}
+						]
+					}
+				});
 			});
 		});
 	});

--- a/appeals/web/src/server/lib/mappers/__tests__/mappers.test.js
+++ b/appeals/web/src/server/lib/mappers/__tests__/mappers.test.js
@@ -1,17 +1,12 @@
 import {
 	appealData,
-	baseSession,
 	lpaQuestionnaireDataIncompleteOutcome
 } from '#testing/app/fixtures/referencedata.js';
 import { createAccountInfo } from '#testing/app/app.js';
 import { initialiseAndMapAppealData } from '../data/appeal/mapper.js';
 import { initialiseAndMapLPAQData } from '../data/lpa-questionnaire/mapper.js';
 import { areIdsDefinedAndUnique } from '#testing/lib/testMappers.js';
-import {
-	buildNotificationBanners,
-	notificationBannerDefinitions,
-	mapPagination
-} from '../index.js';
+import { mapPagination } from '../index.js';
 
 /** @typedef {import('../../../app/auth/auth-session.service').SessionWithAuth} SessionWithAuth */
 
@@ -107,166 +102,6 @@ describe('lpaQuestionnaire-mapper', () => {
 		it('should have an id that is unique', async () => {
 			expect(areIdsDefinedAndUnique(validMappedData.lpaq)).toBe(true);
 		});
-	});
-});
-
-describe('notification banners mapper', () => {
-	it('should return an empty array if notificationBanners object is not present in the session', () => {
-		expect(buildNotificationBanners(baseSession, 'appealDetails', 1)).toEqual([]);
-	});
-
-	it('should not return a notification banner page component object if the notification type is not configured to display on the provided servicePage', () => {
-		expect(
-			buildNotificationBanners(
-				{
-					...baseSession,
-					notificationBanners: {
-						siteVisitTypeSelected: {
-							appealId: 1
-						}
-					}
-				},
-				'lpaQuestionnaire',
-				1
-			)
-		).toEqual([]);
-	});
-
-	it('should not return a notification banner page component object if the notification does not belong to the provided appealId', () => {
-		expect(
-			buildNotificationBanners(
-				{
-					...baseSession,
-					notificationBanners: {
-						siteVisitTypeSelected: {
-							appealId: 1
-						}
-					}
-				},
-				'appealDetails',
-				2
-			)
-		).toEqual([]);
-	});
-
-	it('should return a notification banner page component object with the expected shape and property values if the notification type is configured to show on the provided servicePage and the notification belongs to the provided appealId and overriding values are not present in the session notification object', () => {
-		expect(
-			buildNotificationBanners(
-				{
-					...baseSession,
-					notificationBanners: {
-						siteVisitTypeSelected: {
-							appealId: 1
-						}
-					}
-				},
-				'appealDetails',
-				1
-			)
-		).toEqual([
-			{
-				type: 'notification-banner',
-				parameters: {
-					titleText: 'Success',
-					titleHeadingLevel: 3,
-					type: notificationBannerDefinitions.siteVisitTypeSelected.type,
-					text: notificationBannerDefinitions.siteVisitTypeSelected.text
-				}
-			}
-		]);
-	});
-
-	it('should return a notification banner page component object with the expected shape and property values if the notification type is configured to show on the provided servicePage and the notification belongs to the provided appealId and overriding values are present in the session notification object', () => {
-		expect(
-			buildNotificationBanners(
-				{
-					...baseSession,
-					notificationBanners: {
-						siteVisitTypeSelected: {
-							appealId: 1,
-							titleText: 'overriding title text',
-							type: 'important',
-							text: 'overriding text',
-							html: '<span>overriding html</span>'
-						}
-					}
-				},
-				'appealDetails',
-				1
-			)
-		).toEqual([
-			{
-				type: 'notification-banner',
-				parameters: {
-					titleText: 'overriding title text',
-					titleHeadingLevel: 3,
-					type: 'important',
-					text: 'overriding text',
-					html: '<span>overriding html</span>'
-				}
-			}
-		]);
-	});
-
-	it('should delete the notification banner from the session if the notification type is configured to show on the provided servicePage and the notification belongs to the provided appealId and the notification type is configured to not persist', () => {
-		const testSession = {
-			...baseSession,
-			notificationBanners: {
-				siteVisitTypeSelected: {
-					appealId: 1
-				}
-			}
-		};
-
-		buildNotificationBanners(testSession, 'appealDetails', 1);
-
-		expect(testSession.notificationBanners).toEqual({});
-	});
-
-	it('should not delete the notification banner from the session if the notification type is configured to show on the provided servicePage and the notification belongs to the provided appealId and the notification type is configured to persist', () => {
-		const testSession = {
-			...baseSession,
-			notificationBanners: {
-				appellantCaseNotValid: {
-					appealId: 1
-				}
-			}
-		};
-
-		buildNotificationBanners(testSession, 'appellantCase', 1);
-
-		expect(testSession.notificationBanners).toEqual({
-			appellantCaseNotValid: {
-				appealId: 1
-			}
-		});
-	});
-
-	it('should return a notification banner page component object with the correct appealId in the URL for readyForDecision notification', () => {
-		expect(
-			buildNotificationBanners(
-				{
-					...baseSession,
-					notificationBanners: {
-						readyForDecision: {
-							appealId: 1,
-							html: '<p class="govuk-notification-banner__heading">The appeal is ready for a decision.</p><p class="govuk-notification-banner__heading"><a class="govuk-notification-banner__link" href="/appeals-service/appeal-details/1/issue-decision/decision">Issue a decision</a>.</p>'
-						}
-					}
-				},
-				'appealDetails',
-				1
-			)
-		).toEqual([
-			{
-				type: 'notification-banner',
-				parameters: {
-					titleHeadingLevel: 3,
-					html: '<p class="govuk-notification-banner__heading">The appeal is ready for a decision.</p><p class="govuk-notification-banner__heading"><a class="govuk-notification-banner__link" href="/appeals-service/appeal-details/1/issue-decision/decision">Issue a decision</a>.</p>',
-					titleText: 'Important'
-				}
-			}
-		]);
 	});
 });
 

--- a/appeals/web/src/server/lib/mappers/components/page-components/notification-banners.mapper.js
+++ b/appeals/web/src/server/lib/mappers/components/page-components/notification-banners.mapper.js
@@ -2,190 +2,175 @@
  * @typedef {import('#appeals/appeal.constants.js').ServicePageName} ServicePageName
  */
 
+/** @typedef {'allocationDetailsUpdated'|'appealAwaitingTransfer'|'appealLinked'|'appealUnlinked'|'appealValidAndReadyToStart'|'appellantCaseNotValid'|'appellantFinalCommentsAwaitingReview'|'assignCaseOfficer'|'caseOfficerAdded'|'caseOfficerRemoved'|'caseProgressed'|'changePage'|'commentsAndLpaStatementShared'|'costsDocumentAdded'|'documentAdded'|'documentDeleted'|'documentDetailsUpdated'|'documentFilenameUpdated'|'documentVersionAdded'|'finalCommentsAcceptSuccess'|'finalCommentsAppellantRejectionSuccess'|'finalCommentsDocumentAddedSuccess'|'finalCommentsLPARejectionSuccess'|'finalCommentsRedactionSuccess'|'finalCommentsShared'|'horizonReferenceAdded'|'inspectorAdded'|'inspectorRemoved'|'interestedPartyCommentAdded'|'interestedPartyCommentsAddressAddedSuccess'|'interestedPartyCommentsAddressUpdatedSuccess'|'interestedPartyCommentsAwaitingReview'|'interestedPartyCommentsDocumentAddedSuccess'|'interestedPartyCommentsRedactionSuccess'|'interestedPartyCommentsRejectedSuccess'|'interestedPartyCommentsValidSuccess'|'internalCorrespondenceDocumentAdded'|'lpaFinalCommentsAwaitingReview'|'lpaQuestionnaireNotValid'|'lpaStatementAccepted'|'lpaStatementAwaitingReview'|'lpaStatementIncomplete'|'lpaStatementRedactedAndAccepted'|'neighbouringSiteAdded'|'neighbouringSiteAffected'|'neighbouringSiteRemoved'|'neighbouringSiteUpdated'|'notCheckedDocument'|'progressedToFinalComments'|'progressToFinalComments'|'readyForDecision'|'readyForLpaQuestionnaireReview'|'readyForSetUpSiteVisit'|'readyForValidation'|'relatedAppeal'|'shareCommentsAndLpaStatement'|'shareFinalComments'|'siteAddressUpdated'|'siteVisitArranged'|'timetableDueDateUpdated'} NotificationBannerDefinitionKey  */
+
 /**
  * @typedef {Object} NotificationBannerDefinition
+ * @property {'success'|'important'} type default is 'important'
  * @property {ServicePageName[]} pages
- * @property {'success'} [type] default is 'important'
  * @property {string} [text]
  * @property {string} [html]
- * @property {PageComponent[]} [pageComponents]
- * @property {boolean} [persist] default is false
  */
 
 /**
- * @type {Object<string, NotificationBannerDefinition>}
+ * @type {Object<NotificationBannerDefinitionKey, NotificationBannerDefinition>}
  */
 export const notificationBannerDefinitions = {
-	siteVisitTypeSelected: {
-		pages: ['appealDetails'],
-		type: 'success',
-		text: 'Site visit type has been selected'
-	},
 	siteVisitArranged: {
-		pages: ['appealDetails'],
 		type: 'success',
+		pages: ['appealDetails'],
 		text: 'Site visit has been arranged'
 	},
 	allocationDetailsUpdated: {
-		pages: ['appealDetails'],
 		type: 'success',
+		pages: ['appealDetails'],
 		text: 'Allocation details added'
 	},
 	caseOfficerAdded: {
-		pages: ['appealDetails'],
 		type: 'success',
+		pages: ['appealDetails'],
 		text: 'Case officer has been assigned'
 	},
 	inspectorAdded: {
-		pages: ['appealDetails'],
 		type: 'success',
+		pages: ['appealDetails'],
 		text: 'Inspector has been assigned'
 	},
 	caseOfficerRemoved: {
-		pages: ['appealDetails'],
 		type: 'success',
+		pages: ['appealDetails'],
 		text: 'Case officer has been removed'
 	},
 	inspectorRemoved: {
-		pages: ['appealDetails'],
 		type: 'success',
+		pages: ['appealDetails'],
 		text: 'Inspector has been removed'
 	},
 	documentAdded: {
-		pages: ['appellantCase', 'lpaQuestionnaire', 'manageDocuments', 'viewFinalComments'],
 		type: 'success',
+		pages: ['appellantCase', 'lpaQuestionnaire', 'manageDocuments', 'viewFinalComments'],
 		text: 'Document added'
 	},
 	documentVersionAdded: {
-		pages: ['appealDetails', 'appellantCase', 'lpaQuestionnaire', 'manageDocuments'],
 		type: 'success',
+		pages: ['appealDetails', 'appellantCase', 'lpaQuestionnaire', 'manageDocuments'],
 		text: 'Document updated'
 	},
 	documentDetailsUpdated: {
-		pages: ['appellantCase', 'lpaQuestionnaire', 'manageDocuments'],
 		type: 'success',
+		pages: ['appellantCase', 'lpaQuestionnaire', 'manageDocuments'],
 		text: 'Document details updated'
 	},
 	documentFilenameUpdated: {
-		pages: ['appellantCase', 'lpaQuestionnaire', 'manageDocuments'],
 		type: 'success',
+		pages: ['appellantCase', 'lpaQuestionnaire', 'manageDocuments'],
 		text: 'Document filename updated'
 	},
 	documentDeleted: {
-		pages: ['appealDetails', 'appellantCase', 'lpaQuestionnaire'],
 		type: 'success',
+		pages: ['appealDetails', 'appellantCase', 'lpaQuestionnaire'],
 		text: 'Document removed'
 	},
 	appellantCaseNotValid: {
-		pages: ['appellantCase'],
-		persist: true
+		type: 'important',
+		pages: ['appellantCase']
 	},
 	readyForDecision: {
+		type: 'important',
 		pages: ['appealDetails']
 	},
 	readyForValidation: {
+		type: 'important',
 		pages: ['appealDetails']
 	},
 	readyForSetUpSiteVisit: {
+		type: 'important',
 		pages: ['appealDetails']
 	},
 	readyForLpaQuestionnaireReview: {
+		type: 'important',
 		pages: ['appealDetails']
 	},
 	progressToFinalComments: {
+		type: 'important',
 		pages: ['appealDetails']
 	},
 	lpaQuestionnaireNotValid: {
-		pages: ['lpaQuestionnaire'],
-		persist: true
+		type: 'important',
+		pages: ['lpaQuestionnaire']
 	},
 	notCheckedDocument: {
+		type: 'important',
 		pages: ['lpaQuestionnaire', 'manageDocuments', 'appellantCase', 'manageFolder'],
-		html: '<p class="govuk-notification-banner__heading">Virus scan in progress</p></br><a class="govuk-notification-banner__link" href="./" data-cy/"refresh-page/" >Refresh page to see if scan has finished</a>'
+		html: '<p class="govuk-notification-banner__heading">Virus scan in progress</p></br><a class="govuk-notification-banner__link" href="" data-cy="refresh-page" >Refresh page to see if scan has finished</a>'
 	},
 	appealAwaitingTransfer: {
+		type: 'important',
 		pages: ['appealDetails'],
 		html: '<p class="govuk-notification-banner__heading">This appeal is awaiting transfer</p><p class="govuk-body">The appeal must be transferred to Horizon. When this is done, update the appeal with the new horizon reference.</p>'
 	},
 	horizonReferenceAdded: {
-		pages: ['appealDetails', 'appellantCase', 'lpaQuestionnaire'],
 		type: 'success',
+		pages: ['appealDetails', 'appellantCase', 'lpaQuestionnaire'],
 		text: 'Horizon reference added'
 	},
 	assignCaseOfficer: {
+		type: 'important',
 		pages: ['appealDetails']
 	},
 	appealLinked: {
 		type: 'success',
-		pages: ['appealDetails', 'appellantCase', 'lpaQuestionnaire']
+		pages: ['appealDetails', 'appellantCase', 'lpaQuestionnaire'],
+		text: 'Appeals linked'
 	},
 	appealUnlinked: {
+		type: 'success',
 		pages: ['appealDetails', 'appellantCase', 'lpaQuestionnaire'],
-		type: 'success'
+		text: 'Appeals unlinked'
 	},
-	otherAppeal: {
-		pages: ['appealDetails', 'appellantCase', 'lpaQuestionnaire'],
-		type: 'success'
-	},
-	otherAppealRemoved: {
+	relatedAppeal: {
+		type: 'success',
 		pages: ['appealDetails', 'manageRelatedAppeals', 'appellantCase', 'lpaQuestionnaire'],
-		type: 'success'
+		text: 'Appeal relationship updated'
 	},
 	neighbouringSiteAdded: {
 		type: 'success',
-		pages: ['appealDetails', 'lpaQuestionnaire']
+		pages: ['appealDetails', 'lpaQuestionnaire'],
+		text: 'Neighbouring site added'
 	},
 	neighbouringSiteUpdated: {
 		type: 'success',
-		pages: ['appealDetails', 'lpaQuestionnaire']
+		pages: ['appealDetails', 'lpaQuestionnaire'],
+		text: 'Neighbouring site updated'
 	},
 	neighbouringSiteRemoved: {
 		type: 'success',
-		pages: ['appealDetails', 'lpaQuestionnaire', 'manageNeighbouringSites']
+		pages: ['appealDetails', 'lpaQuestionnaire', 'manageNeighbouringSites'],
+		text: 'Neighbouring site removed'
 	},
 	appealValidAndReadyToStart: {
+		type: 'important',
 		pages: ['appealDetails']
 	},
 	costsDocumentAdded: {
-		pages: ['appealDetails'],
 		type: 'success',
+		pages: ['appealDetails'],
 		text: 'Costs document uploaded'
 	},
 	internalCorrespondenceDocumentAdded: {
+		type: 'success',
 		pages: ['appealDetails'],
-		type: 'success',
 		text: 'Internal correspondence document uploaded'
-	},
-	serviceUserUpdated: {
-		pages: ['appealDetails', 'appellantCase'],
-		type: 'success'
-	},
-	lpaReferenceUpdated: {
-		type: 'success',
-		pages: ['appealDetails', 'appellantCase', 'lpaQuestionnaire']
-	},
-	inspectorAccessUpdated: {
-		type: 'success',
-		pages: ['appealDetails', 'appellantCase', 'lpaQuestionnaire']
 	},
 	neighbouringSiteAffected: {
 		type: 'success',
-		pages: ['appealDetails', 'lpaQuestionnaire']
+		pages: ['appealDetails', 'lpaQuestionnaire'],
+		text: 'Neighbouring site affected status updated'
 	},
 	siteAddressUpdated: {
 		type: 'success',
 		pages: ['appellantCase'],
 		text: 'Site address updated'
-	},
-	isAppealTypeCorrectUpdated: {
-		type: 'success',
-		pages: ['lpaQuestionnaire'],
-		text: 'Correct appeal type (LPA response) has been updated'
-	},
-	lpaqDueDateUpdated: {
-		type: 'success',
-		pages: ['appealDetails'],
-		text: 'LPA questionnaire due date changed'
 	},
 	timetableDueDateUpdated: {
 		type: 'success',
@@ -197,11 +182,12 @@ export const notificationBannerDefinitions = {
 		pages: ['appealDetails', 'appellantCase', 'lpaQuestionnaire', 'ipComments']
 	},
 	lpaStatementAwaitingReview: {
+		type: 'important',
 		pages: ['appealDetails']
 	},
 	interestedPartyCommentsAwaitingReview: {
-		pages: ['appealDetails'],
-		persist: true
+		type: 'important',
+		pages: ['appealDetails']
 	},
 	interestedPartyCommentsValidSuccess: {
 		type: 'success',
@@ -217,6 +203,11 @@ export const notificationBannerDefinitions = {
 		type: 'success',
 		pages: ['viewIpComment'],
 		text: 'Comment redacted and accepted'
+	},
+	interestedPartyCommentAdded: {
+		type: 'success',
+		pages: ['viewIpComment'],
+		text: 'Comment added'
 	},
 	interestedPartyCommentsAddressAddedSuccess: {
 		type: 'success',
@@ -234,12 +225,12 @@ export const notificationBannerDefinitions = {
 		text: 'Supporting document added'
 	},
 	appellantFinalCommentsAwaitingReview: {
-		pages: ['appealDetails'],
-		persist: true
+		type: 'important',
+		pages: ['appealDetails']
 	},
 	lpaFinalCommentsAwaitingReview: {
-		pages: ['appealDetails'],
-		persist: true
+		type: 'important',
+		pages: ['appealDetails']
 	},
 	finalCommentsRedactionSuccess: {
 		type: 'success',
@@ -272,6 +263,7 @@ export const notificationBannerDefinitions = {
 		text: 'Statement incomplete'
 	},
 	shareCommentsAndLpaStatement: {
+		type: 'important',
 		pages: ['appealDetails']
 	},
 	commentsAndLpaStatementShared: {
@@ -313,63 +305,101 @@ export const notificationBannerDefinitions = {
  *
  * @param {import("express-session").Session & Partial<import("express-session").SessionData>} session
  * @param {ServicePageName} servicePage
- * @param {number|undefined} appealId
+ * @param {number} appealId
  * @returns {PageComponent[]}
  */
-export function buildNotificationBanners(session, servicePage, appealId) {
-	if (appealId === undefined || !('notificationBanners' in session)) {
+export function mapNotificationBannersFromSession(session, servicePage, appealId) {
+	const appealIdAsString = typeof appealId === 'number' ? appealId.toString() : appealId;
+
+	if (!('notificationBanners' in session) || !(appealIdAsString in session.notificationBanners)) {
 		return [];
 	}
+
+	/** @type {NotificationBannerDefinitionKey[]} */
+	const displayedBannerKeys = [];
 
 	/**
 	 * @type {PageComponent[]}
 	 */
-	const notificationBanners = Object.keys(session.notificationBanners).flatMap((key) => {
-		if (!Object.keys(notificationBannerDefinitions).includes(key)) {
-			return [];
-		}
+	const notificationBanners = session.notificationBanners[appealIdAsString].flatMap(
+		(
+			/** @type {import('#lib/session-utilities.js').NotificationBannerSessionData} */ bannerData
+		) => {
+			if (!Object.keys(notificationBannerDefinitions).includes(bannerData.key)) {
+				return [];
+			}
 
-		const bannerDefinition = notificationBannerDefinitions[key];
-		const bannerData = session.notificationBanners[key];
+			const bannerDefinition = notificationBannerDefinitions[bannerData.key];
 
-		if (!bannerDefinition.persist) {
-			delete session.notificationBanners[key];
-		}
+			if (!bannerDefinition.pages.includes(servicePage)) {
+				return [];
+			}
 
-		if (!bannerDefinition.pages.includes(servicePage) || bannerData.appealId !== appealId) {
-			return [];
-		}
+			const bannerText = bannerData?.text || bannerDefinition.text;
+			const bannerHtml = bannerData?.html || bannerDefinition.html;
 
-		const titleText = bannerDefinition.type === 'success' ? 'Success' : 'Important';
+			displayedBannerKeys.push(bannerData.key);
 
-		const bannerType = bannerData?.type || bannerDefinition.type;
-		const bannerText = bannerData?.text || bannerDefinition.text;
-		const bannerHtml = bannerData?.html || bannerDefinition.html;
-		const bannerPageComponents = bannerData?.pageComponents || bannerDefinition.pageComponents;
-
-		return [
-			{
-				type: 'notification-banner',
-				parameters: {
-					titleText: bannerData?.titleText || titleText,
-					titleHeadingLevel: 3,
-					...(bannerType && {
-						type: bannerType
-					}),
+			return [
+				createNotificationBanner({
+					bannerDefinitionKey: bannerData.key,
 					...(bannerText && {
 						text: bannerText
 					}),
 					...(bannerHtml && {
 						html: bannerHtml
-					}),
-					...(bannerPageComponents && {
-						html: bannerHtml || '',
-						pageComponents: bannerPageComponents
 					})
-				}
-			}
-		];
-	});
+				})
+			];
+		}
+	);
+
+	session.notificationBanners[appealIdAsString] = session.notificationBanners[
+		appealIdAsString
+	].filter(
+		(/** @type {import('#lib/session-utilities.js').NotificationBannerSessionData} */ bannerData) =>
+			!displayedBannerKeys.includes(bannerData.key)
+	);
 
 	return notificationBanners;
+}
+
+/**
+ * @param {Object} options
+ * @param {NotificationBannerDefinitionKey} options.bannerDefinitionKey
+ * @param {string} [options.titleText]
+ * @param {string} [options.text]
+ * @param {string} [options.html]
+ * @param {PageComponent[]} [options.pageComponents]
+ * @returns {PageComponent}
+ */
+export function createNotificationBanner({
+	bannerDefinitionKey,
+	titleText,
+	text,
+	html,
+	pageComponents
+}) {
+	const bannerDefinition = notificationBannerDefinitions[bannerDefinitionKey];
+
+	return {
+		type: 'notification-banner',
+		parameters: {
+			titleText:
+				titleText ||
+				('type' in bannerDefinition && bannerDefinition.type === 'success'
+					? 'Success'
+					: 'Important'),
+			titleHeadingLevel: 3,
+			...('type' in bannerDefinition && {
+				type: bannerDefinition.type
+			}),
+			text: text || bannerDefinition.text,
+			html: html || bannerDefinition.html,
+			...(pageComponents && {
+				html: '',
+				pageComponents: pageComponents
+			})
+		}
+	};
 }

--- a/appeals/web/src/server/lib/session-utilities.js
+++ b/appeals/web/src/server/lib/session-utilities.js
@@ -1,20 +1,27 @@
 import { notificationBannerDefinitions } from './mappers/index.js';
 
 /**
- *
- * @param {import('../app/auth/auth-session.service').SessionWithAuth & Object<string, any>} session
- * @param {keyof import('./mappers/index.js').notificationBannerDefinitions} bannerDefinitionKey
- * @param {number|string} appealId
- * @param {string} [html]
- * @param {string} [text]
+ * @typedef {Object} NotificationBannerSessionData
+ * @property {import('./mappers/index.js').NotificationBannerDefinitionKey} key
+ * @property {string} [html]
+ * @property {string} [text]
  */
-export const addNotificationBannerToSession = (
+
+/**
+ * @param {Object} options
+ * @param {import('../app/auth/auth-session.service').SessionWithAuth & Object<string, any>} options.session
+ * @param {import('./mappers/index.js').NotificationBannerDefinitionKey} options.bannerDefinitionKey
+ * @param {number|string} options.appealId
+ * @param {string} [options.html]
+ * @param {string} [options.text]
+ */
+export const addNotificationBannerToSession = ({
 	session,
 	bannerDefinitionKey,
 	appealId,
 	html = '',
 	text = ''
-) => {
+}) => {
 	if (!(bannerDefinitionKey in notificationBannerDefinitions)) {
 		return false;
 	}
@@ -23,32 +30,21 @@ export const addNotificationBannerToSession = (
 		session.notificationBanners = {};
 	}
 
-	session.notificationBanners[bannerDefinitionKey] = {
-		appealId: typeof appealId === 'string' ? parseInt(appealId) : appealId,
-		html,
+	const appealIdAsString = appealId.toString();
+
+	if (!(appealIdAsString in session.notificationBanners)) {
+		/** @type {NotificationBannerSessionData[]} */
+		session.notificationBanners[appealIdAsString] = [];
+	}
+
+	/** @type {NotificationBannerSessionData} */
+	const notificationBannerSessionData = {
+		key: bannerDefinitionKey,
+		...(html && { html }),
 		...(text && { text })
 	};
 
-	return true;
-};
+	session.notificationBanners[appealIdAsString].push(notificationBannerSessionData);
 
-/**
- * @param {import('../app/auth/auth-session.service').SessionWithAuth & Object<string, any>} session
- * @param {number|string} appealId
- * @param {keyof import('./mappers/index.js').notificationBannerDefinitions} bannerDefinitionKey
- */
-export const clearNotificationBannerFromSession = (session, appealId, bannerDefinitionKey) => {
-	if (!(bannerDefinitionKey in notificationBannerDefinitions)) {
-		return false;
-	}
-	if (!('notificationBanners' in session)) {
-		return false;
-	}
-	if (!(bannerDefinitionKey in session.notificationBanners)) {
-		return false;
-	}
-	if (session.notificationBanners[bannerDefinitionKey]?.appealId !== appealId) {
-		return false;
-	}
-	delete session.notificationBanners[bannerDefinitionKey];
+	return true;
 };


### PR DESCRIPTION
## Describe your changes

Refactoring of notification banner code to fix the following issues:

- notification banners not scoped by appealId
- important banners unnecessarily stored in the session

The changes made differ somewhat from those outlined in the ticket, as a result of improved understanding of the issues gained during implementation, but they still address the two main points mentioned above. The main differences are:

- Did not restrict the existing session-based banner system to work only with success banners, instead preserving support for important banners in case there is a future need for this. Although there is no current use-case for storing important banners in the session, my view is the benefits of the flexibility afforded by preserving support for them outweigh the benefits of removing it, particularly as it emerged the code would not necessarily become simpler or cleaner as a result
- Did not separate notificationBannerDefinitions into successBannerDefinitions and importantBannerDefinitions (it became apparent this would complicate the code and reduce clarity for no obvious benefit)

Summary of changes:

- moved mapStatusDependentNotifications out of accordion mapping code into main appeal-details mapper
- refactored addNotificationBannerToSession to accept parameters as an object (avoids need to pass unused params in some situations)
- renamed several notification banner related functions to improve clarity
- updated notCheckedDocument banner definition html to avoid callers having to pass it to addNotificationBannerToSession
- refactored all important banners to use the new createNotificationBanner function directly instead of the session
- fixed instances of changePage banner type being used outside change pages
- fixed instances of flow-specific banners passing text/html content unnecessarily (these options only exist if there is a need to override the default content specified in the banner definition)
- refactored notification banner code to ensure banners stored in the session are always scoped by appealId, which also adds support for multiple banners of the same type existing in the session simultaneously (even within the same appealId)
- removed duplicate unit tests from mappers tests in favour of updated and improved notification banners mapper tests
- fixed unit tests and updated snapshots
- removed unused banner definitions
- removed now-obsolete "persist" flag from banner definitions
- made "type" mandatory in notification banner definitions, and updated "important" banner definitions with the corresponding type value, for improved clarity

## Issue ticket number and link
https://pins-ds.atlassian.net/browse/A2-2102
