### PR TITLE
fix(api): update doc before broadcast

### DIFF
--- a/appeals/api/src/server/endpoints/documents/documents.controller.js
+++ b/appeals/api/src/server/endpoints/documents/documents.controller.js
@@ -286,7 +286,9 @@ const updateDocumentFileName = async (req, res) => {
 
 	try {
 		const latestDocument = await documentRepository.getDocumentById(documentId);
+
 		if (latestDocument && latestDocument.name && latestDocument.latestDocumentVersion) {
+			await documentRepository.updateDocumentById(latestDocument.guid, document);
 			if (document.fileName && document.fileName !== latestDocument.name) {
 				const nameChangedMessage = stringTokenReplacement(AUDIT_TRAIL_DOCUMENT_NAME_CHANGED, [
 					latestDocument.name,
@@ -308,8 +310,6 @@ const updateDocumentFileName = async (req, res) => {
 					EventType.Update
 				);
 			}
-
-			await documentRepository.updateDocumentById(latestDocument.guid, document);
 		}
 	} catch (error) {
 		if (error) {


### PR DESCRIPTION
## Describe your changes

(Attempts) to fix an issue where updating the name of a doc on back office appears (at first) not to update the name of the doc on front office

## Issue ticket number and link
[Ticket](https://pins-ds.atlassian.net/browse/A2-2281)
