### PR TITLE
Refactor/share representations

### DIFF
--- a/appeals/api/src/server/endpoints/representations/__tests__/representations.test.js
+++ b/appeals/api/src/server/endpoints/representations/__tests__/representations.test.js
@@ -527,18 +527,6 @@ describe('/appeals/:id/reps', () => {
 });
 
 describe('/appeals/:id/reps/publish', () => {
-	test('400 when type parameter is invalid', async () => {
-		// @ts-ignore
-		databaseConnector.appeal.findUnique.mockResolvedValue(appealHas);
-
-		const response = await request
-			.post('/appeals/1/reps/publish')
-			.query({ type: 'invalid' })
-			.set('azureAdUserId', '732652365');
-
-		expect(response.status).toEqual(400);
-	});
-
 	describe('publish LPA statements', () => {
 		test('409 if case is not in STATEMENTS state', async () => {
 			// @ts-ignore

--- a/appeals/api/src/server/endpoints/representations/representations.routes.js
+++ b/appeals/api/src/server/endpoints/representations/representations.routes.js
@@ -237,11 +237,6 @@ router.post(
 		required: true,
 		example: '434bff4e-8191-4ce0-9a0a-91e5d6cdd882'
 	}
-  #swagger.parameters['type'] = {
-    in: 'query',
-    required: false,
-    example: 'lpa_statement'
-  }
 	#swagger.responses[200] = {
 		schema: { $ref: '#/components/schemas/RepResponse' }
 	}

--- a/appeals/api/src/server/openapi.json
+++ b/appeals/api/src/server/openapi.json
@@ -4176,15 +4176,6 @@
 						"schema": {
 							"type": "string"
 						}
-					},
-					{
-						"name": "type",
-						"in": "query",
-						"required": false,
-						"example": "lpa_statement",
-						"schema": {
-							"type": "string"
-						}
 					}
 				],
 				"responses": {

--- a/appeals/web/src/server/appeals/appeal-details/representations/representations.controller.js
+++ b/appeals/web/src/server/appeals/appeal-details/representations/representations.controller.js
@@ -40,23 +40,7 @@ export function renderShareRepresentations(request, response) {
 export async function postShareRepresentations(request, response) {
 	const { apiClient, currentAppeal, session } = request;
 
-	const apiTypeKeys = {
-		[APPEAL_CASE_STATUS.STATEMENTS]: 'lpa_statement',
-		[APPEAL_CASE_STATUS.FINAL_COMMENTS]: 'final_comment'
-	};
-
-	const typeToPublish = /** @type {'lpa_statement' | 'final_comment' | undefined} */ (
-		apiTypeKeys[currentAppeal.appealStatus]
-	);
-	if (!typeToPublish) {
-		throw new Error(`Cannot share when in the ${currentAppeal.appealStatus} state`);
-	}
-
-	const publishedReps = await publishRepresentations(
-		apiClient,
-		currentAppeal.appealId,
-		typeToPublish
-	);
+	const publishedReps = await publishRepresentations(apiClient, currentAppeal.appealId);
 
 	const bannerKey = (() => {
 		switch (currentAppeal.appealStatus) {

--- a/appeals/web/src/server/appeals/appeal-details/representations/representations.service.js
+++ b/appeals/web/src/server/appeals/appeal-details/representations/representations.service.js
@@ -119,8 +119,7 @@ export const updateRejectionReasons = (apiClient, appealId, commentId, rejection
 /**
  * @param {import('got').Got} apiClient
  * @param {number} appealId
- * @param {'lpa_statement' | 'final_comment'} type
  * @returns {Promise<Representation[]>}
  * */
-export const publishRepresentations = (apiClient, appealId, type) =>
-	apiClient.post(`appeals/${appealId}/reps/publish?type=${type}`).json();
+export const publishRepresentations = (apiClient, appealId) =>
+	apiClient.post(`appeals/${appealId}/reps/publish`).json();


### PR DESCRIPTION
## Describe your changes

* refactor(api): use appeal state to decide what to share
This will mean an argument does not need to be passed to the API to tell
it what to share.
* test(api): remove test that checks for `type` query parameter
* refactor(web): remove `type` query parameter when calling share API
