### PR TITLE
fix(web): enable allocation mappers to use session regardless of context

### DIFF
--- a/appeals/web/src/server/appeals/appeal-details/representations/lpa-statement/allocation/allocation.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/representations/lpa-statement/allocation/allocation.mapper.js
@@ -8,10 +8,10 @@ import { ensureArray } from '#lib/array-utilities.js';
 
 /**
  * @param {Appeal} appealDetails
- * @param {SessionWithAuth & { acceptLPAStatement?: Record<string, string> }} session
+ * @param {Record<string, string>} [sessionData]
  * @returns {PageContent}
  */
-export function allocationCheckPage(appealDetails, session) {
+export function allocationCheckPage(appealDetails, sessionData) {
 	const shortReference = appealShortReference(appealDetails.appealReference);
 
 	/** @type {PageComponent} */
@@ -35,7 +35,7 @@ export function allocationCheckPage(appealDetails, session) {
 			name: 'allocationLevelAndSpecialisms',
 			id: 'allocationLevelAndSpecialisms',
 			legendText: 'Do you need to update the allocation level and specialisms?',
-			value: session.acceptLPAStatement?.allocationLevelAndSpecialisms
+			value: sessionData?.allocationLevelAndSpecialisms
 		})
 	];
 
@@ -53,10 +53,10 @@ export function allocationCheckPage(appealDetails, session) {
  * @param {Appeal} appealDetails
  * @param {Representation} lpaStatement
  * @param {string[]} allocationLevels
- * @param {SessionWithAuth & { acceptLPAStatement?: Record<string, string> }} session
+ * @param {Record<string, string>} sessionData
  * @returns {PageContent}
  * */
-export function allocationLevelPage(appealDetails, lpaStatement, allocationLevels, session) {
+export function allocationLevelPage(appealDetails, lpaStatement, allocationLevels, sessionData) {
 	const shortReference = appealShortReference(appealDetails.appealReference);
 
 	/** @type {PageComponent[]} */
@@ -64,7 +64,7 @@ export function allocationLevelPage(appealDetails, lpaStatement, allocationLevel
 		radiosInput({
 			name: 'allocationLevel',
 			items: allocationLevels.map((l) => ({ text: l, value: l })),
-			value: session.acceptLPAStatement?.allocationLevel
+			value: sessionData?.allocationLevel
 		})
 	];
 
@@ -81,13 +81,14 @@ export function allocationLevelPage(appealDetails, lpaStatement, allocationLevel
 /**
  * @param {Appeal} appealDetails
  * @param {{ id: number, name: string }[]} specialisms
- * @param {SessionWithAuth & { acceptLPAStatement?: Record<string, string> }} session
+ * @param {Record<string, string>} sessionData
+ * @returns {PageContent}
  * */
-export function allocationSpecialismsPage(appealDetails, specialisms, session) {
+export function allocationSpecialismsPage(appealDetails, specialisms, sessionData) {
 	const shortReference = appealShortReference(appealDetails.appealReference);
 
 	const sessionSelections = (() => {
-		const allocationSpecialisms = session.acceptLPAStatement?.allocationSpecialisms;
+		const allocationSpecialisms = sessionData?.allocationSpecialisms;
 		if (!allocationSpecialisms) {
 			return [];
 		}

--- a/appeals/web/src/server/appeals/appeal-details/representations/lpa-statement/redact/redact.controller.js
+++ b/appeals/web/src/server/appeals/appeal-details/representations/lpa-statement/redact/redact.controller.js
@@ -52,7 +52,7 @@ export function postRedact(request, response) {
 export function renderAllocationCheck(request, response) {
 	const { errors, currentAppeal, session } = request;
 
-	const pageContent = allocationCheckPage(currentAppeal, session);
+	const pageContent = allocationCheckPage(currentAppeal, session.redactLPAStatement);
 
 	return response.status(200).render('patterns/change-page.pattern.njk', {
 		errors,
@@ -100,7 +100,7 @@ export async function renderAllocationLevel(request, response) {
 		currentAppeal,
 		currentRepresentation,
 		allocationLevels,
-		session
+		session.redactLPAStatement
 	);
 
 	return response.status(200).render('patterns/change-page.pattern.njk', {
@@ -138,7 +138,11 @@ export async function renderAllocationSpecialisms(request, response) {
 	const { errors, currentAppeal, session } = request;
 
 	const specialisms = await api.getAllocationDetailsSpecialisms(request.apiClient);
-	const pageContent = allocationSpecialismsPage(currentAppeal, specialisms, session);
+	const pageContent = allocationSpecialismsPage(
+		currentAppeal,
+		specialisms,
+		session.redactLPAStatement
+	);
 
 	return response.status(200).render('patterns/change-page.pattern.njk', {
 		errors,

--- a/appeals/web/src/server/appeals/appeal-details/representations/lpa-statement/valid/valid.controller.js
+++ b/appeals/web/src/server/appeals/appeal-details/representations/lpa-statement/valid/valid.controller.js
@@ -17,7 +17,7 @@ import { acceptRepresentation } from '../../representations.service.js';
 export function renderAllocationCheck(request, response) {
 	const { errors, currentAppeal, session } = request;
 
-	const pageContent = allocationCheckPage(currentAppeal, session);
+	const pageContent = allocationCheckPage(currentAppeal, session.acceptLPAStatement);
 
 	return response.status(200).render('patterns/change-page.pattern.njk', {
 		errors,
@@ -65,7 +65,7 @@ export async function renderAllocationLevel(request, response) {
 		currentAppeal,
 		currentRepresentation,
 		allocationLevels,
-		session
+		session.acceptLPAStatement
 	);
 
 	return response.status(200).render('patterns/change-page.pattern.njk', {
@@ -103,7 +103,11 @@ export async function renderAllocationSpecialisms(request, response) {
 	const { errors, currentAppeal, session } = request;
 
 	const specialisms = await api.getAllocationDetailsSpecialisms(request.apiClient);
-	const pageContent = allocationSpecialismsPage(currentAppeal, specialisms, session);
+	const pageContent = allocationSpecialismsPage(
+		currentAppeal,
+		specialisms,
+		session.acceptLPAStatement
+	);
 
 	return response.status(200).render('patterns/change-page.pattern.njk', {
 		errors,


### PR DESCRIPTION
## Describe your changes

fix(web): enable allocation mappers to use session regardless of context

Something I missed in my PR earlier.
