### PR TITLE
fix(appeals): unable to filter on personal list (a2-2384)

### DIFF
--- a/appeals/api/src/server/repositories/appeal-lists.repository.js
+++ b/appeals/api/src/server/repositories/appeal-lists.repository.js
@@ -113,26 +113,34 @@ const getAllAppeals = (
  */
 const getUserAppeals = (userId, pageNumber, pageSize, status) => {
 	const where = {
-		...(status && {
-			appealStatus: {
-				some: { valid: true, status }
-			}
-		}),
 		appealType: { key: { in: getEnabledAppealTypes() } },
-		appealStatus: {
-			some: {
-				valid: true,
-				status: {
-					notIn: [
-						APPEAL_CASE_STATUS.COMPLETE,
-						APPEAL_CASE_STATUS.CLOSED,
-						APPEAL_CASE_STATUS.TRANSFERRED,
-						APPEAL_CASE_STATUS.INVALID,
-						APPEAL_CASE_STATUS.WITHDRAWN
-					]
+		AND: [
+			...(status
+				? [
+						{
+							appealStatus: {
+								some: { valid: true, status }
+							}
+						}
+				  ]
+				: []),
+			{
+				appealStatus: {
+					some: {
+						valid: true,
+						status: {
+							notIn: [
+								APPEAL_CASE_STATUS.COMPLETE,
+								APPEAL_CASE_STATUS.CLOSED,
+								APPEAL_CASE_STATUS.TRANSFERRED,
+								APPEAL_CASE_STATUS.INVALID,
+								APPEAL_CASE_STATUS.WITHDRAWN
+							]
+						}
+					}
 				}
 			}
-		},
+		],
 		OR: [
 			{ inspector: { azureAdUserId: { equals: userId } } },
 			{ caseOfficer: { azureAdUserId: { equals: userId } } }


### PR DESCRIPTION
### Unable to filter on personal list (a2-2248)

#### API:
 - Fix bug in the where clause within the appeal-lists.repository getUserAppeals function
    
#### TESTING:
- All API unit tests pass
- Manually tested within browser
## Issue ticket number and link

[A2-2384 Unable to filter on personal list](https://pins-ds.atlassian.net/browse/A2-2384)

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [x] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [x] I have included unit tests to cover any testable code changes