### PR TITLE
fix(appeals): restored share ip-comments banner functionality (a2-2389)

### DIFF
--- a/appeals/web/src/server/appeals/appeal-details/accordions/utils/map-status-dependent-notifications.js
+++ b/appeals/web/src/server/appeals/appeal-details/accordions/utils/map-status-dependent-notifications.js
@@ -171,6 +171,15 @@ function mapStatusDependentNotificationsForStatements(
 			APPEAL_REPRESENTATION_STATUS.VALID ||
 		(appealDetails.documentationSummary?.ipComments?.counts?.valid ?? 0) > 0;
 
+	if (isLpaStatementDueDatePassed && hasItemsToShare) {
+		return [
+			createNotificationBanner({
+				bannerDefinitionKey: 'shareCommentsAndLpaStatement',
+				html: `<a href="/appeals-service/appeal-details/${appealDetails.appealId}/share" class="govuk-heading-s govuk-notification-banner__link">Share IP comments and LPA statement</a>`
+			})
+		];
+	}
+
 	const lpaStatementIncomplete =
 		appealDetails.documentationSummary?.lpaStatement?.representationStatus ===
 		APPEAL_REPRESENTATION_STATUS.INCOMPLETE;
@@ -178,7 +187,7 @@ function mapStatusDependentNotificationsForStatements(
 	if (lpaStatementIncomplete) {
 		return [
 			createNotificationBanner({
-				bannerDefinitionKey: 'shareCommentsAndLpaStatement',
+				bannerDefinitionKey: 'updateLpaStatement',
 				html: `<p class="govuk-notification-banner__heading">LPA statement incomplete</p> <a href="/appeals-service/appeal-details/${appealDetails.appealId}/lpa-statement" class="govuk-heading-s govuk-notification-banner__link">Update LPA statement</a>`
 			})
 		];

--- a/appeals/web/src/server/lib/mappers/components/page-components/notification-banners.mapper.js
+++ b/appeals/web/src/server/lib/mappers/components/page-components/notification-banners.mapper.js
@@ -2,7 +2,7 @@
  * @typedef {import('#appeals/appeal.constants.js').ServicePageName} ServicePageName
  */
 
-/** @typedef {'allocationDetailsUpdated'|'appealAwaitingTransfer'|'appealLinked'|'appealUnlinked'|'appealValidAndReadyToStart'|'appellantCaseNotValid'|'appellantFinalCommentsAwaitingReview'|'assignCaseOfficer'|'caseOfficerAdded'|'caseOfficerRemoved'|'caseProgressed'|'changePage'|'commentsAndLpaStatementShared'|'costsDocumentAdded'|'documentAdded'|'documentDeleted'|'documentDetailsUpdated'|'documentFilenameUpdated'|'documentVersionAdded'|'finalCommentsAcceptSuccess'|'finalCommentsAppellantRejectionSuccess'|'finalCommentsDocumentAddedSuccess'|'finalCommentsLPARejectionSuccess'|'finalCommentsRedactionSuccess'|'finalCommentsShared'|'horizonReferenceAdded'|'inspectorAdded'|'inspectorRemoved'|'interestedPartyCommentAdded'|'interestedPartyCommentsAddressAddedSuccess'|'interestedPartyCommentsAddressUpdatedSuccess'|'interestedPartyCommentsAwaitingReview'|'interestedPartyCommentsDocumentAddedSuccess'|'interestedPartyCommentsRedactionSuccess'|'interestedPartyCommentsRejectedSuccess'|'interestedPartyCommentsValidSuccess'|'internalCorrespondenceDocumentAdded'|'lpaFinalCommentsAwaitingReview'|'lpaQuestionnaireNotValid'|'lpaStatementAccepted'|'lpaStatementAwaitingReview'|'lpaStatementIncomplete'|'lpaStatementRedactedAndAccepted'|'neighbouringSiteAdded'|'neighbouringSiteAffected'|'neighbouringSiteRemoved'|'neighbouringSiteUpdated'|'notCheckedDocument'|'progressedToFinalComments'|'progressToFinalComments'|'readyForDecision'|'readyForLpaQuestionnaireReview'|'readyForSetUpSiteVisit'|'readyForValidation'|'relatedAppeal'|'shareCommentsAndLpaStatement'|'shareFinalComments'|'siteAddressUpdated'|'siteVisitArranged'|'timetableDueDateUpdated'} NotificationBannerDefinitionKey  */
+/** @typedef {'allocationDetailsUpdated'|'appealAwaitingTransfer'|'appealLinked'|'appealUnlinked'|'appealValidAndReadyToStart'|'appellantCaseNotValid'|'appellantFinalCommentsAwaitingReview'|'assignCaseOfficer'|'caseOfficerAdded'|'caseOfficerRemoved'|'caseProgressed'|'changePage'|'commentsAndLpaStatementShared'|'costsDocumentAdded'|'documentAdded'|'documentDeleted'|'documentDetailsUpdated'|'documentFilenameUpdated'|'documentVersionAdded'|'finalCommentsAcceptSuccess'|'finalCommentsAppellantRejectionSuccess'|'finalCommentsDocumentAddedSuccess'|'finalCommentsLPARejectionSuccess'|'finalCommentsRedactionSuccess'|'finalCommentsShared'|'horizonReferenceAdded'|'inspectorAdded'|'inspectorRemoved'|'interestedPartyCommentAdded'|'interestedPartyCommentsAddressAddedSuccess'|'interestedPartyCommentsAddressUpdatedSuccess'|'interestedPartyCommentsAwaitingReview'|'interestedPartyCommentsDocumentAddedSuccess'|'interestedPartyCommentsRedactionSuccess'|'interestedPartyCommentsRejectedSuccess'|'interestedPartyCommentsValidSuccess'|'internalCorrespondenceDocumentAdded'|'lpaFinalCommentsAwaitingReview'|'lpaQuestionnaireNotValid'|'lpaStatementAccepted'|'lpaStatementAwaitingReview'|'updateLpaStatement'|'lpaStatementIncomplete'|'lpaStatementRedactedAndAccepted'|'neighbouringSiteAdded'|'neighbouringSiteAffected'|'neighbouringSiteRemoved'|'neighbouringSiteUpdated'|'notCheckedDocument'|'progressedToFinalComments'|'progressToFinalComments'|'readyForDecision'|'readyForLpaQuestionnaireReview'|'readyForSetUpSiteVisit'|'readyForValidation'|'relatedAppeal'|'shareCommentsAndLpaStatement'|'shareFinalComments'|'siteAddressUpdated'|'siteVisitArranged'|'timetableDueDateUpdated'} NotificationBannerDefinitionKey  */
 
 /**
  * @typedef {Object} NotificationBannerDefinition
@@ -256,6 +256,10 @@ export const notificationBannerDefinitions = {
 		type: 'success',
 		pages: ['appealDetails'],
 		text: 'LPA statement redacted and accepted'
+	},
+	updateLpaStatement: {
+		type: 'important',
+		pages: ['appealDetails']
 	},
 	lpaStatementIncomplete: {
 		type: 'success',


### PR DESCRIPTION
## Describe your changes
### Restored share IP-Comments and LPA Statements banner functionality (a2-2389)

The original code that did this was missing.  Going back through git history it looks like it accidently got removed in a subsequent merge of another ticket sometime later.  I’ve now inserted the code back in refactored to match the recently refactored code in this area.

WEB:
 - Added code back to display the banner as required
 - Added missing definition for the LpaUpdated banner
    
TESTING:
- All WEB unit tests pass
- Manually tested within browser

## Issue ticket number and link

[A2-2389 Share IP comments and LPA Statement - Share banner not displaying on case details](https://pins-ds.atlassian.net/browse/A2-2389)

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [x] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [x] I have included unit tests to cover any testable code changes
