### PR TITLE
fix(appeals): add listed building check answers page has unstyled link (a2-1768)

### DIFF
--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/affected-listed-buildings/__tests__/__snapshots__/affected-listed-buildings.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/affected-listed-buildings/__tests__/__snapshots__/affected-listed-buildings.test.js.snap
@@ -39,7 +39,7 @@ exports[`affected-listed-buildings GET /add/check-and-confirm should render the 
             <dl class="govuk-summary-list govuk-!-margin-bottom-9">
                 <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Listed building number</dt>
                     <dd class="govuk-summary-list__value"><a href="https://historicengland.org.uk/listing/the-list/list-entry/12345"
-                        target="_blank">12345</a>
+                        class="govuk-link" target="_blank">12345</a>
                     </dd>
                     <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/1/affected-listed-buildings/add"> Change<span class="govuk-visually-hidden"> listed building number</span></a>
                     </dd>
@@ -70,7 +70,7 @@ exports[`affected-listed-buildings GET /change/:listedBuildingId/check-and-confi
             <dl class="govuk-summary-list govuk-!-margin-bottom-9">
                 <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Listed building</dt>
                     <dd class="govuk-summary-list__value"><a href="https://historicengland.org.uk/listing/the-list/list-entry/12345"
-                        target="_blank">12345</a>
+                        class="govuk-link" target="_blank">12345</a>
                     </dd>
                     <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/1/affected-listed-buildings/change/1"> Change<span class="govuk-visually-hidden"> affected listed building</span></a>
                     </dd>

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/affected-listed-buildings/__tests__/affected-listed-buildings.test.js
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/affected-listed-buildings/__tests__/affected-listed-buildings.test.js
@@ -102,7 +102,7 @@ describe('affected-listed-buildings', () => {
 			}).innerHTML;
 			expect(summaryListHtml).toContain('Listed building number</dt>');
 			expect(summaryListHtml).toContain(
-				'<a href="https://historicengland.org.uk/listing/the-list/list-entry/12345" target="_blank">12345</a>'
+				'<a href="https://historicengland.org.uk/listing/the-list/list-entry/12345" class="govuk-link" target="_blank">12345</a>'
 			);
 		});
 	});
@@ -223,7 +223,7 @@ describe('affected-listed-buildings', () => {
 			const unprettifiedElement = parseHtml(response.text, { skipPrettyPrint: true }).innerHTML;
 			expect(unprettifiedElement).toContain('Listed building</dt>');
 			expect(unprettifiedElement).toContain(
-				'<a href="https://historicengland.org.uk/listing/the-list/list-entry/12345" target="_blank">12345</a>'
+				'<a href="https://historicengland.org.uk/listing/the-list/list-entry/12345" class="govuk-link" target="_blank">12345</a>'
 			);
 		});
 	});

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/affected-listed-buildings/affected-listed-buildings.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/affected-listed-buildings/affected-listed-buildings.mapper.js
@@ -63,7 +63,7 @@ export function addAffectedListedBuildingCheckAndConfirmPage(appealData, current
 								text: 'Listed building number'
 							},
 							value: {
-								html: `<a href="https://historicengland.org.uk/listing/the-list/list-entry/${currentListedBuilding}" target="_blank">${currentListedBuilding}</a>`
+								html: `<a href="https://historicengland.org.uk/listing/the-list/list-entry/${currentListedBuilding}" class="govuk-link" target="_blank">${currentListedBuilding}</a>`
 							},
 							actions: {
 								items: [
@@ -198,7 +198,7 @@ export function removeAffectedListedBuildingPage(
 								text: 'Listed building'
 							},
 							value: {
-								html: `<a href="https://historicengland.org.uk/listing/the-list/list-entry/${listedBuilding}" target="_blank">${listedBuilding}</a>`
+								html: `<a href="https://historicengland.org.uk/listing/the-list/list-entry/${listedBuilding}" class="govuk-link" target="_blank">${listedBuilding}</a>`
 							}
 						}
 					]
@@ -290,7 +290,7 @@ export function changeAffectedListedBuildingCheckAndConfirmPage(
 								text: 'Listed building'
 							},
 							value: {
-								html: `<a href="https://historicengland.org.uk/listing/the-list/list-entry/${listedBuildingData}" target="_blank">${listedBuildingData}</a>`
+								html: `<a href="https://historicengland.org.uk/listing/the-list/list-entry/${listedBuildingData}" class="govuk-link" target="_blank">${listedBuildingData}</a>`
 							},
 							actions: {
 								items: [


### PR DESCRIPTION
#### WEB - add listed building check answers page has unstyled link

Added govuk-link class where missing in affected-listed-buildings mapper

## Issue ticket number and link
[Ticket: A2-1768](https://pins-ds.atlassian.net/browse/A2-1768)
