### PR TITLE
fix(appeals): issue determination due date should be 10 days after the site visit (a2-2248)

### DIFF
--- a/appeals/api/src/server/endpoints/appeals/__tests__/appeals.test.js
+++ b/appeals/api/src/server/endpoints/appeals/__tests__/appeals.test.js
@@ -1143,10 +1143,10 @@ describe('mapAppealToDueDate Tests', () => {
 		mockAppeal.appealStatus[0].status = APPEAL_CASE_STATUS.ISSUE_DETERMINATION;
 		mockAppeal.siteVisit = { visitDate: new Date('2023-02-01T00:00:00.000Z') };
 
-		const createdAtPlusThirtyBusinessDays = new Date('2023-03-15T00:00:00.000Z');
+		const createdAtPlusTenBusinessDays = new Date('2023-02-15T00:00:00.000Z');
 		// @ts-ignore
 		const dueDate = mapAppealToDueDate(mockAppeal, '', null);
-		expect(dueDate).toEqual(createdAtPlusThirtyBusinessDays);
+		expect(dueDate).toEqual(createdAtPlusTenBusinessDays);
 	});
 
 	test('maps STATE_TARGET_ISSUE_DETERMINATION when site visit not available', () => {

--- a/appeals/api/src/server/endpoints/appeals/appeals.formatter.js
+++ b/appeals/api/src/server/endpoints/appeals/appeals.formatter.js
@@ -19,6 +19,7 @@ const approxStageCompletion = {
 	STATE_TARGET_LPA_QUESTIONNAIRE_DUE: 10,
 	STATE_TARGET_ASSIGN_CASE_OFFICER: 15,
 	STATE_TARGET_ISSUE_DETERMINATION: 30,
+	STATE_TARGET_ISSUE_DETERMINATION_AFTER_SITE_VISIT: 10,
 	STATE_TARGET_STATEMENT_REVIEW: 55,
 	STATE_TARGET_FINAL_COMMENT_REVIEW: 60
 };
@@ -230,7 +231,7 @@ export const mapAppealToDueDate = (appeal, appellantCaseStatus, appellantCaseDue
 			if (appeal.siteVisit) {
 				return addBusinessDays(
 					new Date(appeal.siteVisit.visitEndTime || appeal.siteVisit.visitDate),
-					approxStageCompletion.STATE_TARGET_ISSUE_DETERMINATION
+					approxStageCompletion.STATE_TARGET_ISSUE_DETERMINATION_AFTER_SITE_VISIT
 				);
 			}
 			return addBusinessDays(


### PR DESCRIPTION
## Describe your changes

#### The issue determination due date should be 10 days after the site visit (a2-2248)

API:
- Added constant
- Updated due date calculation for issue determination after a site visit

TESTS:
- Updated API unit test
- All other API tests pass

## Issue ticket number and link
[Ticket: Review personal list deadlines (a2-2248)](https://pins-ds.atlassian.net.mcas.ms/browse/A2-2248)
