### PR TITLE
fix(appeals): clicking IP comments should take user to IP Comments Accepted Tab (a2-2356)

### DIFF
--- a/appeals/web/src/server/appeals/appeal-details/representations/__tests__/__snapshots__/representations.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/representations/__tests__/__snapshots__/representations.test.js.snap
@@ -1,0 +1,29 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`representations GET /share should contain link to interested-party-comments#valid 1`] = `
+"<main class="govuk-main-wrapper " id="main-content" role="main">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Appeal 351062</span>
+            <h1 class="govuk-heading-l">Share IP comments and statements</h1>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <div class="govuk-inset-text">We’ll share the <a href="/appeals-service/appeal-details/1/interested-party-comments#valid"
+                class="govuk-link">1 interested party comments</a> with the relevant parties.</div>
+            <div             class="govuk-warning-text"><span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+                <strong                 class="govuk-warning-text__text"><span class="govuk-warning-text__assistive">Warning</span> Do not confirm
+                    until you have reviewed all of the supporting documents and redacted any
+                    sensitive information.</strong>
+        </div>
+        <div class="govuk-grid-row">
+            <div class="govuk-grid-column-full">
+                <form method="post" novalidate="novalidate">
+                    <button class="govuk-button" data-module="govuk-button">Confirm</button>
+                </form>
+            </div>
+        </div>
+    </div>
+    </div>
+</main>"
+`;

--- a/appeals/web/src/server/appeals/appeal-details/representations/__tests__/representations.test.js
+++ b/appeals/web/src/server/appeals/appeal-details/representations/__tests__/representations.test.js
@@ -1,0 +1,42 @@
+import { parseHtml } from '@pins/platform';
+import { createTestEnvironment } from '#testing/index.js';
+import supertest from 'supertest';
+import nock from 'nock';
+import { appealData } from '#testing/app/fixtures/referencedata.js';
+
+const { app, teardown } = createTestEnvironment();
+const request = supertest(app);
+const baseUrl = '/appeals-service/appeal-details';
+
+describe('representations', () => {
+	afterEach(teardown);
+	describe('GET /share', () => {
+		let appealWithStatments;
+		const numIpComments = 1;
+		beforeEach(() => {
+			appealWithStatments = {
+				...appealData,
+				appealStatus: 'statements',
+				documentationSummary: {
+					ipComments: {
+						counts: {
+							valid: numIpComments
+						}
+					}
+				}
+			};
+			nock('http://test/').get('/appeals/1').reply(200, appealWithStatments);
+		});
+
+		it('should contain link to interested-party-comments#valid', async () => {
+			const response = await request.get(`${baseUrl}/1/share`);
+			const element = parseHtml(response.text);
+
+			expect(element.innerHTML).toMatchSnapshot();
+			expect(element.innerHTML).toContain('Share IP comments and statements</h1>');
+			expect(element.innerHTML).toContain(
+				`<a href="/appeals-service/appeal-details/1/interested-party-comments#valid"`
+			);
+		});
+	});
+});

--- a/appeals/web/src/server/appeals/appeal-details/representations/representations.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/representations/representations.mapper.js
@@ -123,7 +123,7 @@ export function statementAndCommentsSharePage(appeal) {
 		const numIpComments = appeal.documentationSummary?.ipComments?.counts?.valid ?? 0;
 
 		return numIpComments > 0
-			? `<a href="/appeals-service/appeal-details/${appeal.appealId}/interested-party-comments" class="govuk-link">${numIpComments} interested party comments</a>`
+			? `<a href="/appeals-service/appeal-details/${appeal.appealId}/interested-party-comments#valid" class="govuk-link">${numIpComments} interested party comments</a>`
 			: null;
 	})();
 


### PR DESCRIPTION
## Describe your changes

#### Clicking IP comments should take user to IP Comments Accepted Tab (a2-2356)

WEB:
- Added hash to link to open accepted tab as requested

TESTS:
- Added WEB unit test
- Added snapshot
- All WEB tests pass

## Issue ticket number and link
[Ticket: Review personal list deadlines (a2-2356)](https://pins-ds.atlassian.net.mcas.ms/browse/A2-2356)
