### PR TITLE
fix(web): wrap redacted final comment in show-more component on view and review screen

### DIFF
--- a/appeals/web/src/server/appeals/appeal-details/final-comments/view-and-review/__tests__/__snapshots__/view-and-review.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/final-comments/view-and-review/__tests__/__snapshots__/view-and-review.test.js.snap
@@ -186,76 +186,6 @@ exports[`final-comments GET /manage-documents/:folderId/:documentId should rende
 </main>"
 `;
 
-exports[`final-comments GET /review-comments with data should render review LPA final comments page with error if no option is selected 1`] = `
-"<main class="govuk-main-wrapper " id="main-content" role="main">
-    <div class="govuk-grid-row">
-        <div class="govuk-grid-column-two-thirds">
-            <div class="govuk-error-summary" data-module="govuk-error-summary">
-                <div role="alert">
-                    <h2 class="govuk-error-summary__title"> There is a problem</h2>
-                    <div class="govuk-error-summary__body">
-                        <ul class="govuk-list govuk-error-summary__list">
-                            <li><a href="#status">Select the outcome of your review</a>
-                            </li>
-                        </ul>
-                    </div>
-                </div>
-            </div>
-        </div>
-    </div>
-    <div class="govuk-grid-row">
-        <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Appeal 351062</span>
-            <h1 class="govuk-heading-l">Review LPA final comments</h1>
-        </div>
-    </div>
-    <div class="govuk-grid-row">
-        <div class="govuk-grid-column-full">
-            <dl class="govuk-summary-list">
-                <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Final comments</dt>
-                    <dd class="govuk-summary-list__value">
-                        <div class="pins-show-more" data-label="Read more" data-mode="text">Awaiting final comments review</div>
-                    </dd>
-                </div>
-                <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Supporting documents</dt>
-                    <dd class="govuk-summary-list__value">Not provided</dd>
-                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/final-comments/lpa/add-document"> Add<span class="govuk-visually-hidden"> supporting documents</span></a>
-                    </dd>
-                </div>
-            </dl>
-        </div>
-    </div>
-    <div class="govuk-grid-row">
-        <div class="govuk-grid-column-full">
-            <form action="" method="POST" novalidate>
-                <div class="govuk-form-group">
-                    <fieldset class="govuk-fieldset">
-                        <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">Review decision</legend>
-                        <div class="govuk-radios" data-module="govuk-radios">
-                            <div class="govuk-radios__item">
-                                <input class="govuk-radios__input" id="status" name="status" type="radio"
-                                value="valid">
-                                <label class="govuk-label govuk-radios__label" for="status">Accept final comments</label>
-                            </div>
-                            <div class="govuk-radios__item">
-                                <input class="govuk-radios__input" id="status-2" name="status" type="radio"
-                                value="valid_requires_redaction">
-                                <label class="govuk-label govuk-radios__label" for="status-2">Redact and accept final comments</label>
-                            </div>
-                            <div class="govuk-radios__item">
-                                <input class="govuk-radios__input" id="status-3" name="status" type="radio"
-                                value="invalid">
-                                <label class="govuk-label govuk-radios__label" for="status-3">Reject final comments</label>
-                            </div>
-                        </div>
-                    </fieldset>
-                </div>
-                <button class="govuk-button" data-module="govuk-button">Continue</button>
-            </form>
-        </div>
-    </div>
-</main>"
-`;
-
 exports[`final-comments GET /review-comments with data should render review LPA final comments page with the provided comments details 1`] = `
 "<main class="govuk-main-wrapper " id="main-content" role="main">
     <div class="govuk-grid-row">
@@ -324,6 +254,66 @@ exports[`final-comments GET /review-comments with data should render review appe
                 <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Final comments</dt>
                     <dd class="govuk-summary-list__value">
                         <div class="pins-show-more" data-label="Read more" data-mode="text">Awaiting final comments review</div>
+                    </dd>
+                </div>
+                <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Supporting documents</dt>
+                    <dd class="govuk-summary-list__value">Not provided</dd>
+                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/final-comments/lpa/add-document"> Add<span class="govuk-visually-hidden"> supporting documents</span></a>
+                    </dd>
+                </div>
+            </dl>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
+            <form action="" method="POST" novalidate>
+                <div class="govuk-form-group">
+                    <fieldset class="govuk-fieldset">
+                        <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">Review decision</legend>
+                        <div class="govuk-radios" data-module="govuk-radios">
+                            <div class="govuk-radios__item">
+                                <input class="govuk-radios__input" id="status" name="status" type="radio"
+                                value="valid">
+                                <label class="govuk-label govuk-radios__label" for="status">Accept final comments</label>
+                            </div>
+                            <div class="govuk-radios__item">
+                                <input class="govuk-radios__input" id="status-2" name="status" type="radio"
+                                value="valid_requires_redaction">
+                                <label class="govuk-label govuk-radios__label" for="status-2">Redact and accept final comments</label>
+                            </div>
+                            <div class="govuk-radios__item">
+                                <input class="govuk-radios__input" id="status-3" name="status" type="radio"
+                                value="invalid">
+                                <label class="govuk-label govuk-radios__label" for="status-3">Reject final comments</label>
+                            </div>
+                        </div>
+                    </fieldset>
+                </div>
+                <button class="govuk-button" data-module="govuk-button">Continue</button>
+            </form>
+        </div>
+    </div>
+</main>"
+`;
+
+exports[`final-comments GET /review-comments with redacted comment should render the redacted comment summary list row value inside a show-more component, if there is a redacted version of the comment 1`] = `
+"<main class="govuk-main-wrapper " id="main-content" role="main">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Appeal 351062</span>
+            <h1 class="govuk-heading-l">Review appellant final comments</h1>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
+            <dl class="govuk-summary-list">
+                <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Original final comments</dt>
+                    <dd class="govuk-summary-list__value">
+                        <div class="pins-show-more" data-label="Read more" data-mode="text">Awaiting final comments review</div>
+                    </dd>
+                </div>
+                <div class="govuk-summary-list__row govuk-summary-list__row--no-actions"><dt class="govuk-summary-list__key"> Redacted comment</dt>
+                    <dd class="govuk-summary-list__value">
+                        <div class="pins-show-more" data-label="Read more" data-mode="text">aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa</div>
                     </dd>
                 </div>
                 <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Supporting documents</dt>
@@ -466,6 +456,76 @@ exports[`final-comments GET change-document-name/:folderId/:documentId should re
                     </div>
                 </div>
                 <button type="submit" class="govuk-button" data-module="govuk-button">Confirm</button>
+            </form>
+        </div>
+    </div>
+</main>"
+`;
+
+exports[`final-comments POST /review-comments with data should render review LPA final comments page with error if no option is selected 1`] = `
+"<main class="govuk-main-wrapper " id="main-content" role="main">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <div class="govuk-error-summary" data-module="govuk-error-summary">
+                <div role="alert">
+                    <h2 class="govuk-error-summary__title"> There is a problem</h2>
+                    <div class="govuk-error-summary__body">
+                        <ul class="govuk-list govuk-error-summary__list">
+                            <li><a href="#status">Select the outcome of your review</a>
+                            </li>
+                        </ul>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Appeal 351062</span>
+            <h1 class="govuk-heading-l">Review LPA final comments</h1>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
+            <dl class="govuk-summary-list">
+                <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Final comments</dt>
+                    <dd class="govuk-summary-list__value">
+                        <div class="pins-show-more" data-label="Read more" data-mode="text">Awaiting final comments review</div>
+                    </dd>
+                </div>
+                <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Supporting documents</dt>
+                    <dd class="govuk-summary-list__value">Not provided</dd>
+                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/final-comments/lpa/add-document"> Add<span class="govuk-visually-hidden"> supporting documents</span></a>
+                    </dd>
+                </div>
+            </dl>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
+            <form action="" method="POST" novalidate>
+                <div class="govuk-form-group">
+                    <fieldset class="govuk-fieldset">
+                        <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">Review decision</legend>
+                        <div class="govuk-radios" data-module="govuk-radios">
+                            <div class="govuk-radios__item">
+                                <input class="govuk-radios__input" id="status" name="status" type="radio"
+                                value="valid">
+                                <label class="govuk-label govuk-radios__label" for="status">Accept final comments</label>
+                            </div>
+                            <div class="govuk-radios__item">
+                                <input class="govuk-radios__input" id="status-2" name="status" type="radio"
+                                value="valid_requires_redaction">
+                                <label class="govuk-label govuk-radios__label" for="status-2">Redact and accept final comments</label>
+                            </div>
+                            <div class="govuk-radios__item">
+                                <input class="govuk-radios__input" id="status-3" name="status" type="radio"
+                                value="invalid">
+                                <label class="govuk-label govuk-radios__label" for="status-3">Reject final comments</label>
+                            </div>
+                        </div>
+                    </fieldset>
+                </div>
+                <button class="govuk-button" data-module="govuk-button">Continue</button>
             </form>
         </div>
     </div>

--- a/appeals/web/src/server/appeals/appeal-details/final-comments/view-and-review/page-components/common.js
+++ b/appeals/web/src/server/appeals/appeal-details/final-comments/view-and-review/page-components/common.js
@@ -62,7 +62,23 @@ export function generateCommentsSummaryList(appealId, comment) {
 			}
 		},
 		...(comment.redactedRepresentation
-			? [{ key: { text: 'Redacted comment' }, value: { text: comment.redactedRepresentation } }]
+			? [
+					{
+						key: { text: 'Redacted comment' },
+						value: {
+							html: '',
+							pageComponents: [
+								{
+									type: 'show-more',
+									parameters: {
+										text: comment.redactedRepresentation,
+										labelText: 'Read more'
+									}
+								}
+							]
+						}
+					}
+			  ]
 			: []),
 		{
 			key: { text: 'Supporting documents' },


### PR DESCRIPTION
## Describe your changes

Adds a wrapping "show more" component to the redacted comment text summary list row on the view/review final comments screen. Also includes a small fix to the existing view-and-review unit tests (POST test was inside describe for GET tests, moved this out into its own describe)

## Issue ticket number and link
https://pins-ds.atlassian.net/browse/A2-2393
