### PR TITLE
fix(web): fix final comments shared banner displaying when progressing case

### DIFF
--- a/appeals/web/src/server/appeals/appeal-details/representations/__tests__/representations.test.js
+++ b/appeals/web/src/server/appeals/appeal-details/representations/__tests__/representations.test.js
@@ -1,8 +1,17 @@
 import { parseHtml } from '@pins/platform';
 import { createTestEnvironment } from '#testing/index.js';
+import { jest } from '@jest/globals';
 import supertest from 'supertest';
 import nock from 'nock';
-import { appealData } from '#testing/app/fixtures/referencedata.js';
+import {
+	appealData,
+	shareRepsResponseFinalComment,
+	appellantFinalCommentsAwaitingReview,
+	lpaFinalCommentsAwaitingReview,
+	caseNotes,
+	activeDirectoryUsersData
+} from '#testing/app/fixtures/referencedata.js';
+import usersService from '#appeals/appeal-users/users-service.js';
 
 const { app, teardown } = createTestEnvironment();
 const request = supertest(app);
@@ -37,6 +46,143 @@ describe('representations', () => {
 			expect(element.innerHTML).toContain(
 				`<a href="/appeals-service/appeal-details/1/interested-party-comments#valid"`
 			);
+		});
+	});
+
+	describe('POST /share', () => {
+		const appealId = 1;
+
+		// TODO: add test suites for ip comments and statements
+
+		describe('final comments', () => {
+			beforeEach(() => {
+				nock.cleanAll();
+				// @ts-ignore
+				usersService.getUsersByRole = jest.fn().mockResolvedValue(activeDirectoryUsersData);
+				// @ts-ignore
+				usersService.getUserById = jest.fn().mockResolvedValue(activeDirectoryUsersData[0]);
+				// @ts-ignore
+				usersService.getUserByRoleAndId = jest.fn().mockResolvedValue(activeDirectoryUsersData[0]);
+				nock('http://test/')
+					.get('/appeals/1/reps?type=appellant_final_comment')
+					.reply(200, appellantFinalCommentsAwaitingReview)
+					.persist();
+				nock('http://test/')
+					.get('/appeals/1/reps?type=lpa_final_comment')
+					.reply(200, lpaFinalCommentsAwaitingReview)
+					.persist();
+				nock('http://test/').get(`/appeals/${appealId}/case-notes`).reply(200, caseNotes);
+			});
+
+			const testCases = [
+				{
+					name: 'appellant',
+					representationType: 'appellant_final_comment'
+				},
+				{
+					name: 'lpa',
+					representationType: 'lpa_final_comment'
+				}
+			];
+
+			for (const testCase of testCases) {
+				it(`should call the publish representations API endpoint, redirect to the case details page, and render a "Final comments shared" success banner, if ${testCase.name} final comments were shared`, async () => {
+					nock('http://test/')
+						.get(`/appeals/${appealId}`)
+						.reply(200, {
+							...appealData,
+							appealId,
+							appealStatus: 'final_comments',
+							documentationSummary: {
+								appellantFinalComments: {
+									receivedAt: '2025-01-29T10:19:47.259Z',
+									representationStatus: 'valid',
+									status: 'received'
+								},
+								lpaFinalComments: {
+									receivedAt: '2025-01-29T10:19:47.259Z',
+									representationStatus: 'valid',
+									status: 'received'
+								}
+							}
+						})
+						.persist();
+					const mockShareRepsEndpoint = nock('http://test/')
+						.post(`/appeals/${appealId}/reps/publish`)
+						.reply(200, [
+							{
+								...shareRepsResponseFinalComment,
+								representationType: testCase.representationType
+							}
+						]);
+
+					const sharePostResponse = await request.post(`${baseUrl}/${appealId}/share`).send({});
+
+					expect(mockShareRepsEndpoint.isDone()).toBe(true);
+					expect(sharePostResponse.statusCode).toBe(302);
+					expect(sharePostResponse.text).toBe(
+						`Found. Redirecting to /appeals-service/appeal-details/${appealId}`
+					);
+
+					const response = await request.get(`${baseUrl}/${appealId}`);
+
+					expect(response.statusCode).toBe(200);
+
+					const notificationBannerHtml = parseHtml(response.text, {
+						rootElement: '.govuk-notification-banner--success',
+						skipPrettyPrint: true
+					}).innerHTML;
+
+					expect(notificationBannerHtml).toContain('Success</h3>');
+					expect(notificationBannerHtml).toContain('Final comments shared</p>');
+				});
+			}
+
+			it('should call the publish representations API endpoint, redirect to the case details page, and render a "Case progressed" success banner, if no final comments were shared', async () => {
+				nock('http://test/')
+					.get(`/appeals/${appealId}`)
+					.reply(200, {
+						...appealData,
+						appealId,
+						appealStatus: 'final_comments',
+						documentationSummary: {
+							appellantFinalComments: {
+								receivedAt: null,
+								representationStatus: null,
+								status: 'not_received'
+							},
+							lpaFinalComments: {
+								receivedAt: null,
+								representationStatus: null,
+								status: 'not_received'
+							}
+						}
+					})
+					.persist();
+				const mockShareRepsEndpoint = nock('http://test/')
+					.post(`/appeals/${appealId}/reps/publish`)
+					.reply(200, []);
+
+				const sharePostResponse = await request.post(`${baseUrl}/${appealId}/share`).send({});
+
+				expect(mockShareRepsEndpoint.isDone()).toBe(true);
+				expect(sharePostResponse.statusCode).toBe(302);
+				expect(sharePostResponse.text).toBe(
+					`Found. Redirecting to /appeals-service/appeal-details/${appealId}`
+				);
+
+				const response = await request.get(`${baseUrl}/${appealId}`);
+
+				expect(response.statusCode).toBe(200);
+
+				const notificationBannerHtml = parseHtml(response.text, {
+					rootElement: '.govuk-notification-banner--success',
+					skipPrettyPrint: true
+				}).innerHTML;
+
+				expect(notificationBannerHtml).toContain('Success</h3>');
+				expect(notificationBannerHtml).toContain('Case progressed</p>');
+			});
 		});
 	});
 });

--- a/appeals/web/src/server/appeals/appeal-details/representations/representations.controller.js
+++ b/appeals/web/src/server/appeals/appeal-details/representations/representations.controller.js
@@ -1,4 +1,5 @@
 import { APPEAL_CASE_STATUS } from 'pins-data-model';
+import { APPEAL_REPRESENTATION_TYPE } from '@pins/appeals/constants/common.js';
 import { dateIsInThePast, dateISOStringToDayMonthYearHourMinute } from '#lib/dates.js';
 import { addNotificationBannerToSession } from '#lib/session-utilities.js';
 import { statementAndCommentsSharePage, finalCommentsSharePage } from './representations.mapper.js';
@@ -49,7 +50,13 @@ export async function postShareRepresentations(request, response) {
 					? 'commentsAndLpaStatementShared'
 					: 'progressedToFinalComments';
 			case APPEAL_CASE_STATUS.FINAL_COMMENTS:
-				return publishedReps.length > 0 ? 'finalCommentsShared' : 'caseProgressed';
+				return publishedReps.filter(
+					(rep) =>
+						rep.representationType === APPEAL_REPRESENTATION_TYPE.APPELLANT_FINAL_COMMENT ||
+						rep.representationType === APPEAL_REPRESENTATION_TYPE.LPA_FINAL_COMMENT
+				).length > 0
+					? 'finalCommentsShared'
+					: 'caseProgressed';
 		}
 	})();
 

--- a/appeals/web/testing/app/fixtures/referencedata.js
+++ b/appeals/web/testing/app/fixtures/referencedata.js
@@ -2647,6 +2647,25 @@ export const representationRejectionReasons = [
 	}
 ];
 
+export const shareRepsResponseFinalComment = {
+	id: 1,
+	appealId: 1,
+	representationType: 'appellant_final_comment',
+	dateCreated: '2025-02-18T13:17:24.741Z',
+	dateLastUpdated: '2025-02-18T13:19:05.714Z',
+	originalRepresentation:
+		'Final comment from appellant. Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore.',
+	redactedRepresentation: null,
+	representedId: 1,
+	representativeId: null,
+	lpaCode: null,
+	status: 'published',
+	reviewer: null,
+	notes: null,
+	siteVisitRequested: false,
+	source: 'citizen'
+};
+
 export const baseSession = {
 	id: '',
 	cookie: { originalMaxAge: 1 },


### PR DESCRIPTION
## Describe your changes

Fixes issue where "Final comments shared" success banner was displaying instead of "Case progressed" when case is progressed (i.e. share reps endpoint is hit but no final comments were received). Also adds unit tests to cover both scenarios.

## Issue ticket number and link

https://pins-ds.atlassian.net/browse/A2-2409