### PR TITLE
fix(appeals): correct banner display conditions when appeal status is STATEMENTS (a2-2389)

### DIFF
--- a/appeals/web/src/server/appeals/appeal-details/accordions/utils/__tests__/__snapshots__/map-status-dependent-notifications.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/accordions/utils/__tests__/__snapshots__/map-status-dependent-notifications.test.js.snap
@@ -1,0 +1,86 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`mapStatusDependentNotifications when status is "statements" should return the "Interested party comments awaiting review" notification 1`] = `
+[
+  {
+    "parameters": {
+      "html": "<p class="govuk-notification-banner__heading">Interested party comments awaiting review</p><p><a class="govuk-notification-banner__link" href="/appeals-service/appeal-details/undefined/interested-party-comments" data-cy="banner-review-ip-comments">Review <span class="govuk-visually-hidden">interested party comments</span></a></p>",
+      "text": undefined,
+      "titleHeadingLevel": 3,
+      "titleText": "Important",
+      "type": "important",
+    },
+    "type": "notification-banner",
+  },
+]
+`;
+
+exports[`mapStatusDependentNotifications when status is "statements" should return the "LPA statement awaiting review" notification 1`] = `
+[
+  {
+    "parameters": {
+      "html": "<p class="govuk-notification-banner__heading">LPA statement awaiting review</p><p><a class="govuk-notification-banner__link" href="/appeals-service/appeal-details/undefined/lpa-statement" data-cy="banner-review-lpa-statement">Review <span class="govuk-visually-hidden">LPA statement</span></a></p>",
+      "text": undefined,
+      "titleHeadingLevel": 3,
+      "titleText": "Important",
+      "type": "important",
+    },
+    "type": "notification-banner",
+  },
+]
+`;
+
+exports[`mapStatusDependentNotifications when status is "statements" when the ip comments and LPA statement due dates are in the past and neither LPA Statement or IP Comments are awaiting a review should return the "Progress to final comments" notification 1`] = `
+[
+  {
+    "parameters": {
+      "html": "<a href="/appeals-service/appeal-details/undefined/share" class="govuk-heading-s govuk-notification-banner__link">Progress to final comments</a>",
+      "text": undefined,
+      "titleHeadingLevel": 3,
+      "titleText": "Important",
+      "type": "important",
+    },
+    "type": "notification-banner",
+  },
+]
+`;
+
+exports[`mapStatusDependentNotifications when status is "statements" when the ip comments and LPA statement due dates are in the past and neither LPA Statement or IP Comments are awaiting a review should return the "Share IP comments and LPA statement" notification 1`] = `
+[
+  {
+    "parameters": {
+      "html": "<a href="/appeals-service/appeal-details/undefined/share" class="govuk-heading-s govuk-notification-banner__link">Share IP comments and LPA statement</a>",
+      "text": undefined,
+      "titleHeadingLevel": 3,
+      "titleText": "Important",
+      "type": "important",
+    },
+    "type": "notification-banner",
+  },
+]
+`;
+
+exports[`mapStatusDependentNotifications when status is "statements" when the ip comments and LPA statement due dates are in the past should return the "Update LPA statement" notification 1`] = `
+[
+  {
+    "parameters": {
+      "html": "<p class="govuk-notification-banner__heading">LPA statement incomplete</p> <a href="/appeals-service/appeal-details/undefined/lpa-statement" class="govuk-heading-s govuk-notification-banner__link">Update LPA statement</a>",
+      "text": undefined,
+      "titleHeadingLevel": 3,
+      "titleText": "Important",
+      "type": "important",
+    },
+    "type": "notification-banner",
+  },
+  {
+    "parameters": {
+      "html": "<p class="govuk-notification-banner__heading">Interested party comments awaiting review</p><p><a class="govuk-notification-banner__link" href="/appeals-service/appeal-details/undefined/interested-party-comments" data-cy="banner-review-ip-comments">Review <span class="govuk-visually-hidden">interested party comments</span></a></p>",
+      "text": undefined,
+      "titleHeadingLevel": 3,
+      "titleText": "Important",
+      "type": "important",
+    },
+    "type": "notification-banner",
+  },
+]
+`;

--- a/appeals/web/src/server/appeals/appeal-details/accordions/utils/__tests__/map-status-dependent-notifications.test.js
+++ b/appeals/web/src/server/appeals/appeal-details/accordions/utils/__tests__/map-status-dependent-notifications.test.js
@@ -1,0 +1,149 @@
+// @ts-nocheck
+import { mapStatusDependentNotifications } from '#appeals/appeal-details/accordions/utils/index.js';
+
+function getDateDaysInFutureISO(days) {
+	const date = new Date(new Date().setDate(new Date().getDate() + days));
+	return date.toISOString();
+}
+
+describe('mapStatusDependentNotifications', () => {
+	let appealDetails;
+	let representationTypesAwaitingReview;
+	beforeEach(() => {
+		appealDetails = {};
+		representationTypesAwaitingReview = {};
+	});
+	describe('when status is "statements"', () => {
+		beforeEach(() => {
+			appealDetails.appealStatus = 'statements';
+			appealDetails.appealTimetable = {
+				lpaStatementDueDate: getDateDaysInFutureISO(1),
+				ipCommentsDueDate: getDateDaysInFutureISO(1)
+			};
+			appealDetails.documentationSummary = {
+				lpaStatement: {
+					representationStatus: 'complete'
+				}
+			};
+			representationTypesAwaitingReview.lpaStatement = true;
+			representationTypesAwaitingReview.ipComments = true;
+			appealDetails.documentationSummary.ipComments = {
+				counts: {
+					valid: 1
+				}
+			};
+		});
+
+		describe('when the ip comments and LPA statement due dates are in the past', () => {
+			beforeEach(() => {
+				appealDetails.appealTimetable.ipCommentsDueDate = getDateDaysInFutureISO(-1);
+				appealDetails.appealTimetable.lpaStatementDueDate = getDateDaysInFutureISO(-1);
+			});
+
+			it('should return the "Update LPA statement" notification', () => {
+				appealDetails.documentationSummary.lpaStatement.representationStatus = 'incomplete';
+				const banners = mapStatusDependentNotifications(
+					appealDetails,
+					representationTypesAwaitingReview
+				);
+				expect(banners).toMatchSnapshot();
+
+				expect(banners.length).toEqual(2);
+
+				banners.forEach((banner) => {
+					expect(banner.type).toEqual('notification-banner');
+				});
+
+				expect(banners[0].parameters.html).toEqual(
+					expect.stringContaining('>Update LPA statement</a>')
+				);
+				expect(banners[1].parameters.html).toEqual(
+					expect.stringContaining('>interested party comments</span></a>')
+				);
+			});
+
+			describe('and neither LPA Statement or IP Comments are awaiting a review', () => {
+				beforeEach(() => {
+					representationTypesAwaitingReview.lpaStatement = false;
+					representationTypesAwaitingReview.ipComments = false;
+				});
+
+				it('should return the "Share IP comments and LPA statement" notification', () => {
+					const banners = mapStatusDependentNotifications(
+						appealDetails,
+						representationTypesAwaitingReview
+					);
+
+					expect(banners).toMatchSnapshot();
+
+					expect(banners.length).toEqual(1);
+
+					const [banner] = banners;
+					expect(banner.type).toEqual('notification-banner');
+					expect(banner.parameters.html).toEqual(
+						expect.stringContaining('>Share IP comments and LPA statement</a>')
+					);
+				});
+
+				it('should return the "Progress to final comments" notification', () => {
+					appealDetails.documentationSummary.ipComments.status = 'not_received';
+					appealDetails.documentationSummary.lpaStatement.status = 'not_received';
+					appealDetails.documentationSummary.ipComments.counts.valid = 0;
+
+					const banners = mapStatusDependentNotifications(
+						appealDetails,
+						representationTypesAwaitingReview
+					);
+
+					expect(banners).toMatchSnapshot();
+
+					expect(banners.length).toEqual(1);
+
+					const [banner] = banners;
+
+					expect(banner.type).toEqual('notification-banner');
+					expect(banner.parameters.html).toEqual(
+						expect.stringContaining('>Progress to final comments</a>')
+					);
+				});
+			});
+		});
+
+		it('should return the "Interested party comments awaiting review" notification', () => {
+			representationTypesAwaitingReview.lpaStatement = false;
+			representationTypesAwaitingReview.ipComments = true;
+			const banners = mapStatusDependentNotifications(
+				appealDetails,
+				representationTypesAwaitingReview
+			);
+
+			expect(banners).toMatchSnapshot();
+
+			expect(banners.length).toEqual(1);
+
+			const [banner] = banners;
+			expect(banner.type).toEqual('notification-banner');
+			expect(banner.parameters.html).toEqual(
+				expect.stringContaining('>interested party comments</span></a>')
+			);
+		});
+
+		it('should return the "LPA statement awaiting review" notification', () => {
+			representationTypesAwaitingReview.lpaStatement = true;
+			representationTypesAwaitingReview.ipComments = false;
+			appealDetails.appealTimetable.lpaStatementDueDate = new Date().toISOString();
+			const banners = mapStatusDependentNotifications(
+				appealDetails,
+				representationTypesAwaitingReview
+			);
+
+			expect(banners).toMatchSnapshot();
+
+			expect(banners.length).toEqual(1);
+
+			const [banner] = banners;
+			expect(banner.type).toEqual('notification-banner');
+			expect(banner.parameters.html).toEqual(expect.stringContaining('>LPA statement</span></a>'));
+		});
+	});
+});


### PR DESCRIPTION
## Describe your changes
### Correct banner and personal-list actions display conditions when appeal status is STATEMENTS (a2-2389)

Although this ticket concentrates on appeal status of STATEMENTS, it is hopefully a template especially for the unit tests that we should use to bring all the other banners being displayed within the other appeal statuses.

WEB:
 - Refactored banners for STATEMENTS status to match acceptance criteria 
 - Add unit tests for banners with STATEMENTS status to test above criteria
 - Refactored CTAs for STATEMENTS status in personal list to match acceptance criteria 
 - Add unit tests for CTAs with STATEMENTS status in personal list to test above criteria
    
TESTING:
- All WEB unit tests pass
- Manually tested within browser

## Issue ticket number and link

[A2-2389 Share IP comments and LPA Statement - Share banner not displaying on case details](https://pins-ds.atlassian.net/browse/A2-2389)

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [x] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [x] I have included unit tests to cover any testable code changes
