### PR TITLE
Feature/a2 1737 redact final comment

### DIFF
--- a/appeals/web/src/server/appeals/appeal-details/final-comments/redact/redact.controller.js
+++ b/appeals/web/src/server/appeals/appeal-details/final-comments/redact/redact.controller.js
@@ -2,6 +2,7 @@ import logger from '#lib/logger.js';
 import { redactFinalCommentPage, confirmRedactFinalCommentPage } from './redact.mapper.js';
 import { redactAndAccept } from '#appeals/appeal-details/representations/representations.service.js';
 import { addNotificationBannerToSession } from '#lib/session-utilities.js';
+import { APPEAL_REPRESENTATION_STATUS } from '@pins/appeals/constants/common.js';
 import { formatFinalCommentsTypeText } from '../view-and-review/view-and-review.mapper.js';
 
 /** @type {import('@pins/express').RequestHandler<Response>}  */
@@ -13,6 +14,11 @@ export const getRedactFinalComment = async (request, response) => {
 		session,
 		params: { finalCommentsType }
 	} = request;
+
+	if (currentRepresentation.status === APPEAL_REPRESENTATION_STATUS.PUBLISHED) {
+		logger.info('returning 404 as final comments cannot be redacted after sharing');
+		return response.status(404).render('app/404.njk');
+	}
 
 	const pageContent = redactFinalCommentPage(
 		currentAppeal,
@@ -35,8 +41,13 @@ export const postRedactFinalComment = async (request, response) => {
 	const {
 		params: { appealId, finalCommentsType },
 		body: { redactedRepresentation },
-		session
+		session,
+		currentRepresentation
 	} = request;
+
+	if (currentRepresentation.status === APPEAL_REPRESENTATION_STATUS.PUBLISHED) {
+		throw new Error('cannot redact a final comment that has already been shared');
+	}
 
 	session.redactedRepresentation = redactedRepresentation;
 

--- a/appeals/web/src/server/appeals/appeal-details/final-comments/view-and-review/__tests__/__snapshots__/view-and-review.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/final-comments/view-and-review/__tests__/__snapshots__/view-and-review.test.js.snap
@@ -200,6 +200,8 @@ exports[`final-comments GET /review-comments with data should render review LPA 
                     <dd class="govuk-summary-list__value">
                         <div class="pins-show-more" data-label="Read more" data-mode="text">Awaiting final comments review</div>
                     </dd>
+                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/final-comments/lpa/redact"> Redact<span class="govuk-visually-hidden"> final comments</span></a>
+                    </dd>
                 </div>
                 <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Supporting documents</dt>
                     <dd class="govuk-summary-list__value">Not provided</dd>
@@ -255,6 +257,8 @@ exports[`final-comments GET /review-comments with data should render review appe
                     <dd class="govuk-summary-list__value">
                         <div class="pins-show-more" data-label="Read more" data-mode="text">Awaiting final comments review</div>
                     </dd>
+                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/final-comments/lpa/redact"> Redact<span class="govuk-visually-hidden"> final comments</span></a>
+                    </dd>
                 </div>
                 <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Supporting documents</dt>
                     <dd class="govuk-summary-list__value">Not provided</dd>
@@ -309,6 +313,8 @@ exports[`final-comments GET /review-comments with redacted comment should render
                 <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Original final comments</dt>
                     <dd class="govuk-summary-list__value">
                         <div class="pins-show-more" data-label="Read more" data-mode="text">Awaiting final comments review</div>
+                    </dd>
+                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/final-comments/lpa/redact"> Redact<span class="govuk-visually-hidden"> final comments</span></a>
                     </dd>
                 </div>
                 <div class="govuk-summary-list__row govuk-summary-list__row--no-actions"><dt class="govuk-summary-list__key"> Redacted comment</dt>
@@ -490,6 +496,8 @@ exports[`final-comments POST /review-comments with data should render review LPA
                 <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Final comments</dt>
                     <dd class="govuk-summary-list__value">
                         <div class="pins-show-more" data-label="Read more" data-mode="text">Awaiting final comments review</div>
+                    </dd>
+                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/final-comments/lpa/redact"> Redact<span class="govuk-visually-hidden"> final comments</span></a>
                     </dd>
                 </div>
                 <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Supporting documents</dt>

--- a/appeals/web/src/server/appeals/appeal-details/final-comments/view-and-review/page-components/common.js
+++ b/appeals/web/src/server/appeals/appeal-details/final-comments/view-and-review/page-components/common.js
@@ -1,5 +1,6 @@
 import { buildHtmUnorderedList } from '#lib/nunjucks-template-builders/tag-builders.js';
 import { preRenderPageComponents } from '#lib/nunjucks-template-builders/page-component-rendering.js';
+import { APPEAL_REPRESENTATION_STATUS } from '@pins/appeals/constants/common.js';
 
 /** @typedef {import('#appeals/appeal-details/representations/types.js').Representation} Representation */
 
@@ -58,7 +59,16 @@ export function generateCommentsSummaryList(appealId, comment) {
 						]
 				  },
 			actions: {
-				items: []
+				items:
+					comment.status === APPEAL_REPRESENTATION_STATUS.PUBLISHED
+						? []
+						: [
+								{
+									text: 'Redact',
+									href: `/appeals-service/appeal-details/${appealId}/final-comments/${commentTypePath}/redact`,
+									visuallyHiddenText: 'final comments'
+								}
+						  ]
 			}
 		},
 		...(comment.redactedRepresentation

--- a/appeals/web/src/server/appeals/appeal-details/final-comments/view-and-review/view-and-review.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/final-comments/view-and-review/view-and-review.mapper.js
@@ -3,6 +3,7 @@ import { COMMENT_STATUS } from '@pins/appeals/constants/common.js';
 import { generateCommentsSummaryList } from './page-components/common.js';
 import { mapNotificationBannersFromSession } from '#lib/mappers/index.js';
 import { isRepresentationReviewRequired } from '#lib/representation-utilities.js';
+import { capitalizeFirstLetter } from '#lib/string-utilities.js';
 
 /** @typedef {import("#appeals/appeal-details/appeal-details.types.js").WebAppeal} Appeal */
 /** @typedef {import('#appeals/appeal-details/representations/types.js').Representation} Representation */
@@ -24,16 +25,22 @@ export function reviewFinalCommentsPage(appealDetails, finalCommentsType, commen
 		appealDetails.appealId
 	);
 
+	const reviewRequired = isRepresentationReviewRequired(comment.status);
+
+	const title = reviewRequired
+		? `Review ${finalCommentsType} final comments`
+		: `${capitalizeFirstLetter(finalCommentsType)} final comments`;
+
 	const pageContent = {
-		title: `Review ${finalCommentsType} final comments`,
+		title,
 		backLinkUrl: `/appeals-service/appeal-details/${appealDetails.appealId}`,
 		preHeading: `Appeal ${shortReference}`,
-		heading: `Review ${finalCommentsType} final comments`,
+		heading: title,
 		submitButtonText: 'Continue',
 		pageComponents: [...notificationBanners, commentSummaryList]
 	};
 
-	if (isRepresentationReviewRequired(comment.status)) {
+	if (reviewRequired) {
 		pageContent.pageComponents.push({
 			type: 'radios',
 			parameters: {


### PR DESCRIPTION
## Describe your changes

* fix(web): display correct heading for view final comment page
* feat(web): disallow redacting final comments after they're shared
* fix(api): default to Written if procedureType is not set in transition
* feat(web): hide Redact button if final comment has already been shared
* test(web): update test snapshots

## Issue ticket number and link
[A2-1737](https://pins-ds.atlassian.net/browse/A2-1737)


[A2-1737]: https://pins-ds.atlassian.net/browse/A2-1737?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ