### PR TITLE
feat(appeals): using data model 1.9.16

### DIFF
--- a/appeals/api/package.json
+++ b/appeals/api/package.json
@@ -70,7 +70,7 @@
     "rhea": "3.0.1",
     "swagger-ui-express": "^5.0.1",
     "xstate": "4.32.1",
-    "pins-data-model": "github:Planning-Inspectorate/data-model#1.9.14"
+    "pins-data-model": "github:Planning-Inspectorate/data-model#1.9.16"
   },
   "devDependencies": {
     "@types/express": "^4.17.13",

--- a/appeals/api/src/database/migrations/20250217144504_rename_consulted_body_details/migration.sql
+++ b/appeals/api/src/database/migrations/20250217144504_rename_consulted_body_details/migration.sql
@@ -1,0 +1,26 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `eiaConsultedBodiesDetails` on the `LPAQuestionnaire` table. All the data in the column will be lost.
+
+*/
+BEGIN TRY
+
+BEGIN TRAN;
+
+-- AlterTable
+ALTER TABLE [dbo].[LPAQuestionnaire] DROP COLUMN [eiaConsultedBodiesDetails];
+ALTER TABLE [dbo].[LPAQuestionnaire] ADD [consultedBodiesDetails] NVARCHAR(1000);
+
+COMMIT TRAN;
+
+END TRY
+BEGIN CATCH
+
+IF @@TRANCOUNT > 0
+BEGIN
+    ROLLBACK TRAN;
+END;
+THROW
+
+END CATCH

--- a/appeals/api/src/database/migrations/20250219151821_add_type_of_planning_application/migration.sql
+++ b/appeals/api/src/database/migrations/20250219151821_add_type_of_planning_application/migration.sql
@@ -1,0 +1,19 @@
+BEGIN TRY
+
+BEGIN TRAN;
+
+-- AlterTable
+ALTER TABLE [dbo].[AppellantCase] ADD [typeOfPlanningApplication] NVARCHAR(1000);
+
+COMMIT TRAN;
+
+END TRY
+BEGIN CATCH
+
+IF @@TRANCOUNT > 0
+BEGIN
+    ROLLBACK TRAN;
+END;
+THROW
+
+END CATCH

--- a/appeals/api/src/database/schema.prisma
+++ b/appeals/api/src/database/schema.prisma
@@ -283,6 +283,7 @@ model AppellantCase {
   numberOfResidencesNetChange              Int?
   siteGridReferenceEasting                 String?
   siteGridReferenceNorthing                String?
+  typeOfPlanningApplication                String?
 }
 
 /// AppellantCaseValidationOutcome model
@@ -402,7 +403,7 @@ model LPAQuestionnaire {
   eiaScreeningOpinion                 Boolean?
   eiaRequiresEnvironmentalStatement   Boolean?
   eiaCompletedEnvironmentalStatement  Boolean?
-  eiaConsultedBodiesDetails           String?
+  consultedBodiesDetails              String?
   hasStatutoryConsultees              Boolean?
   hasInfrastructureLevy               Boolean?
   isInfrastructureLevyFormallyAdopted Boolean?

--- a/appeals/api/src/database/seed/data-samples.js
+++ b/appeals/api/src/database/seed/data-samples.js
@@ -236,7 +236,7 @@ export function createLPAQuestionnaireForAppealType(appealTypeShorthand) {
 				lpaProcedurePreferenceDetails: randomArrayValue(['Need for a detailed examination', null]),
 				lpaProcedurePreferenceDuration: randomArrayValue(procedureDurationPossibleValues),
 				eiaSensitiveAreaDetails: randomArrayValue(['test sensitive area details text', null]),
-				eiaConsultedBodiesDetails: randomArrayValue(['test consulted bodies details text', null]),
+				consultedBodiesDetails: randomArrayValue(['test consulted bodies details text', null]),
 				reasonForNeighbourVisits: randomArrayValue(['test reason for neighbour visits text', null]),
 				designatedSiteNameCustom: 'A custom value'
 			};

--- a/appeals/api/src/server/endpoints/appeals.d.ts
+++ b/appeals/api/src/server/endpoints/appeals.d.ts
@@ -358,7 +358,7 @@ interface SingleLPAQuestionnaireResponse {
 	lpaProcedurePreferenceDetails: string | null;
 	lpaProcedurePreferenceDuration: number | null;
 	eiaSensitiveAreaDetails: string | null;
-	eiaConsultedBodiesDetails: string | null;
+	consultedBodiesDetails: string | null;
 	reasonForNeighbourVisits: string | null;
 }
 
@@ -392,7 +392,7 @@ interface UpdateLPAQuestionnaireRequest {
 	lpaProcedurePreferenceDetails: string;
 	lpaProcedurePreferenceDuration: number;
 	eiaSensitiveAreaDetails: string | null;
-	eiaConsultedBodiesDetails: string | null;
+	consultedBodiesDetails: string | null;
 	reasonForNeighbourVisits: string | null;
 }
 

--- a/appeals/api/src/server/endpoints/lpa-questionnaires/lpa-questionnaires.controller.js
+++ b/appeals/api/src/server/endpoints/lpa-questionnaires/lpa-questionnaires.controller.js
@@ -63,7 +63,7 @@ const updateLPAQuestionnaireById = async (req, res) => {
 			lpaProcedurePreferenceDetails,
 			lpaProcedurePreferenceDuration,
 			eiaSensitiveAreaDetails,
-			eiaConsultedBodiesDetails,
+			consultedBodiesDetails,
 			reasonForNeighbourVisits,
 			designatedSiteNames
 		},
@@ -117,7 +117,7 @@ const updateLPAQuestionnaireById = async (req, res) => {
 					lpaProcedurePreferenceDetails,
 					lpaProcedurePreferenceDuration,
 					eiaSensitiveAreaDetails,
-					eiaConsultedBodiesDetails,
+					consultedBodiesDetails,
 					reasonForNeighbourVisits,
 					designatedSiteNames
 			  });

--- a/appeals/api/src/server/mappers/api/definitions/lpa-questionnaire.js
+++ b/appeals/api/src/server/mappers/api/definitions/lpa-questionnaire.js
@@ -101,7 +101,7 @@ const updateableFields = {
 		type: 'string',
 		nullable: true
 	},
-	eiaConsultedBodiesDetails: {
+	consultedBodiesDetails: {
 		type: 'string',
 		nullable: true
 	},

--- a/appeals/api/src/server/mappers/api/s78/map-lpa-questionnaire.js
+++ b/appeals/api/src/server/mappers/api/s78/map-lpa-questionnaire.js
@@ -52,8 +52,7 @@ export const mapLpaQuestionnaire = (data) => {
 			lpaProcedurePreferenceDetails: lpaQuestionnaire.lpaProcedurePreferenceDetails,
 			lpaProcedurePreferenceDuration: lpaQuestionnaire.lpaProcedurePreferenceDuration,
 			eiaSensitiveAreaDetails: lpaQuestionnaire.eiaSensitiveAreaDetails,
-			eiaConsultedBodiesDetails: lpaQuestionnaire.eiaConsultedBodiesDetails,
-			reasonForNeighbourVisits: lpaQuestionnaire.reasonForNeighbourVisits
+			consultedBodiesDetails: lpaQuestionnaire.consultedBodiesDetails
 		};
 	}
 };

--- a/appeals/api/src/server/mappers/integration/commands/appellant-case.mapper.js
+++ b/appeals/api/src/server/mappers/integration/commands/appellant-case.mapper.js
@@ -54,6 +54,7 @@ export const mapAppellantCaseIn = (command) => {
 		...(knowsAllOwners && { knowsAllOwners }),
 		...(knowsOtherOwners && { knowsOtherOwners }),
 		isGreenBelt: casedata.isGreenBelt,
+		typeOfPlanningApplication: casedata.typeOfPlanningApplication,
 		...(isS78 && {
 			appellantProcedurePreference: casedata.appellantProcedurePreference,
 			appellantProcedurePreferenceDetails: casedata.appellantProcedurePreferenceDetails,

--- a/appeals/api/src/server/mappers/integration/commands/questionnaire.mapper.js
+++ b/appeals/api/src/server/mappers/integration/commands/questionnaire.mapper.js
@@ -53,6 +53,7 @@ export const mapQuestionnaireIn = (command, isS78, designatedSites) => {
 				create: listedBuildingsData
 			}
 		}),
+		reasonForNeighbourVisits: casedata.reasonForNeighbourVisits,
 		...(isS78 && {
 			lpaStatement: casedata.lpaStatement,
 			affectsScheduledMonument: casedata.affectsScheduledMonument,
@@ -68,7 +69,7 @@ export const mapQuestionnaireIn = (command, isS78, designatedSites) => {
 			eiaScreeningOpinion: casedata.eiaScreeningOpinion,
 			eiaRequiresEnvironmentalStatement: casedata.eiaRequiresEnvironmentalStatement,
 			eiaCompletedEnvironmentalStatement: casedata.eiaCompletedEnvironmentalStatement,
-			eiaConsultedBodiesDetails: casedata.eiaConsultedBodiesDetails,
+			consultedBodiesDetails: casedata.consultedBodiesDetails,
 			hasStatutoryConsultees: casedata.hasStatutoryConsultees,
 			hasConsultationResponses: casedata.hasConsultationResponses,
 			hasEmergingPlan: casedata.hasEmergingPlan,
@@ -76,6 +77,7 @@ export const mapQuestionnaireIn = (command, isS78, designatedSites) => {
 			hasInfrastructureLevy: casedata.hasInfrastructureLevy,
 			isInfrastructureLevyFormallyAdopted: casedata.isInfrastructureLevyFormallyAdopted,
 			infrastructureLevyAdoptedDate: casedata.infrastructureLevyAdoptedDate,
+			infrastructureLevyExpectedDate: casedata.infrastructureLevyExpectedDate,
 			lpaProcedurePreference: casedata.lpaProcedurePreference,
 			lpaProcedurePreferenceDetails: casedata.lpaProcedurePreferenceDetails,
 			lpaProcedurePreferenceDuration: casedata.lpaProcedurePreferenceDuration

--- a/appeals/api/src/server/mappers/integration/s78/map-appellant-case.js
+++ b/appeals/api/src/server/mappers/integration/s78/map-appellant-case.js
@@ -23,6 +23,7 @@ export const mapAppellantCase = (data) => {
 		tenantAgriculturalHolding: casedata?.tenantAgriculturalHolding ?? null,
 		otherTenantsAgriculturalHolding: casedata?.otherTenantsAgriculturalHolding ?? null,
 		caseworkReason: casedata?.caseworkReason ?? null,
+		// @ts-ignore
 		developmentType: casedata?.developmentType ?? null,
 		jurisdiction: casedata?.jurisdiction ?? null,
 		numberOfResidencesNetChange: casedata?.numberOfResidencesNetChange ?? null,
@@ -31,11 +32,12 @@ export const mapAppellantCase = (data) => {
 		siteViewableFromRoad: casedata?.siteViewableFromRoad ?? null,
 		planningObligation: casedata?.planningObligation ?? null,
 		statusPlanningObligation: casedata?.statusPlanningObligation ?? null,
+		// @ts-ignore
+		typeOfPlanningApplication: casedata?.typeOfPlanningApplication,
 
 		//TODO:
 
-		designAccessStatementProvided: null,
+		designAccessStatementProvided: null
 		//inquiryHowManyWitnesses: null,
-		typeOfPlanningApplication: null
 	};
 };

--- a/appeals/api/src/server/mappers/integration/s78/map-lpa-questionnaire.js
+++ b/appeals/api/src/server/mappers/integration/s78/map-lpa-questionnaire.js
@@ -42,7 +42,7 @@ export const mapLpaQuestionnaire = (data) => {
 				.map((lb) => lb.listEntry) || null,
 		designatedSitesNames,
 		eiaSensitiveAreaDetails: casedata?.eiaSensitiveAreaDetails ?? null,
-		eiaConsultedBodiesDetails: casedata?.eiaConsultedBodiesDetails ?? null,
+		consultedBodiesDetails: casedata?.consultedBodiesDetails ?? null,
 		eiaScreeningOpinion: casedata?.eiaScreeningOpinion ?? null,
 
 		eiaColumnTwoThreshold: casedata?.eiaColumnTwoThreshold ?? null,

--- a/appeals/api/src/server/mappers/integration/shared/map-case-dates.js
+++ b/appeals/api/src/server/mappers/integration/shared/map-case-dates.js
@@ -40,6 +40,7 @@ export const mapCaseDates = (data) => {
 		transferredCaseClosedDate: findStatusDate(appeal.appealStatus, APPEAL_CASE_STATUS.CLOSED),
 		caseDecisionOutcomeDate: mapDate(appeal.inspectorDecision?.caseDecisionOutcomeDate),
 		caseDecisionPublishedDate: null,
-		caseCompletedDate: findStatusDate(appeal.appealStatus, APPEAL_CASE_STATUS.COMPLETE)
+		caseCompletedDate: findStatusDate(appeal.appealStatus, APPEAL_CASE_STATUS.COMPLETE),
+		appellantProofsSubmittedDate: null
 	};
 };

--- a/appeals/api/src/server/mappers/integration/shared/map-lpa-questionnaire.js
+++ b/appeals/api/src/server/mappers/integration/shared/map-lpa-questionnaire.js
@@ -25,6 +25,7 @@ export const mapLpaQuestionnaire = (data) => {
 		affectedListedBuildingNumbers:
 			casedata?.listedBuildingDetails
 				?.filter((lp) => lp.affectsListedBuilding)
-				.map((lb) => lb.listEntry) || null
+				.map((lb) => lb.listEntry) || null,
+		reasonForNeighbourVisits: casedata?.reasonForNeighbourVisits
 	};
 };

--- a/appeals/api/src/server/openapi-types.ts
+++ b/appeals/api/src/server/openapi-types.ts
@@ -5943,7 +5943,7 @@ export type LpaQuestionnaire = {
 	eiaEnvironmentalImpactSchedule?: string | null;
 	eiaDevelopmentDescription?: string | null;
 	eiaSensitiveAreaDetails?: string | null;
-	eiaConsultedBodiesDetails?: string | null;
+	consultedBodiesDetails?: string | null;
 	reasonForNeighbourVisits?: string | null;
 	designatedSiteNames?:
 		| {
@@ -10760,7 +10760,7 @@ export interface LpaQuestionnaireUpdateRequest {
 	eiaEnvironmentalImpactSchedule?: string | null;
 	eiaDevelopmentDescription?: string | null;
 	eiaSensitiveAreaDetails?: string | null;
-	eiaConsultedBodiesDetails?: string | null;
+	consultedBodiesDetails?: string | null;
 	reasonForNeighbourVisits?: string | null;
 	designatedSiteNames?:
 		| {

--- a/appeals/api/src/server/openapi.json
+++ b/appeals/api/src/server/openapi.json
@@ -16451,7 +16451,7 @@
 						"type": "string",
 						"nullable": true
 					},
-					"eiaConsultedBodiesDetails": {
+					"consultedBodiesDetails": {
 						"type": "string",
 						"nullable": true
 					},
@@ -28544,7 +28544,7 @@
 						"type": "string",
 						"nullable": true
 					},
-					"eiaConsultedBodiesDetails": {
+					"consultedBodiesDetails": {
 						"type": "string",
 						"nullable": true
 					},

--- a/appeals/api/src/server/repositories/lpa-questionnaire.repository.js
+++ b/appeals/api/src/server/repositories/lpa-questionnaire.repository.js
@@ -50,7 +50,7 @@ const updateLPAQuestionnaireById = (id, data) => {
 				lpaProcedurePreferenceDetails: data.lpaProcedurePreferenceDetails,
 				lpaProcedurePreferenceDuration: data.lpaProcedurePreferenceDuration,
 				eiaSensitiveAreaDetails: data.eiaSensitiveAreaDetails,
-				eiaConsultedBodiesDetails: data.eiaConsultedBodiesDetails,
+				consultedBodiesDetails: data.consultedBodiesDetails,
 				reasonForNeighbourVisits: data.reasonForNeighbourVisits,
 				...processDesignatedSites(id, data, transaction)
 			}

--- a/appeals/api/src/server/tests/appeals/has.js
+++ b/appeals/api/src/server/tests/appeals/has.js
@@ -240,7 +240,7 @@ export default {
 		eiaScreeningOpinion: null,
 		eiaRequiresEnvironmentalStatement: null,
 		eiaCompletedEnvironmentalStatement: null,
-		eiaConsultedBodiesDetails: null,
+		consultedBodiesDetails: null,
 		hasStatutoryConsultees: null,
 		hasInfrastructureLevy: null,
 		isInfrastructureLevyFormallyAdopted: null,

--- a/appeals/api/src/server/tests/appeals/s78.js
+++ b/appeals/api/src/server/tests/appeals/s78.js
@@ -240,7 +240,7 @@ export default {
 		eiaScreeningOpinion: null,
 		eiaRequiresEnvironmentalStatement: true,
 		eiaCompletedEnvironmentalStatement: null,
-		eiaConsultedBodiesDetails: null,
+		consultedBodiesDetails: null,
 		hasStatutoryConsultees: null,
 		hasInfrastructureLevy: true,
 		isInfrastructureLevyFormallyAdopted: false,

--- a/appeals/e2e/cypress/fixtures/appealsApiRequests.js
+++ b/appeals/e2e/cypress/fixtures/appealsApiRequests.js
@@ -33,7 +33,9 @@ const appealsApiRequests = {
 			siteAreaSquareMetres: 22,
 			siteSafetyDetails: ["It's dangerous"],
 			isGreenBelt: false,
+			typeOfPlanningApplication: null,
 			// S78 fields
+			developmentType: null,
 			agriculturalHolding: true,
 			tenantAgriculturalHolding: true,
 			otherTenantsAgriculturalHolding: null,
@@ -111,7 +113,7 @@ const appealsApiRequests = {
 			changedListedBuildingNumbers: ['14214', '62354'],
 			designatedSitesNames: ['cSAC', 'SAC', 'customVal1', 'customVal2'],
 			eiaSensitiveAreaDetails: null,
-			eiaConsultedBodiesDetails: null,
+			consultedBodiesDetails: null,
 			eiaScreeningOpinion: null,
 			eiaColumnTwoThreshold: null,
 			eiaRequiresEnvironmentalStatement: null,

--- a/appeals/functions/casedata-import/appellant-case/index.js
+++ b/appeals/functions/casedata-import/appellant-case/index.js
@@ -8,7 +8,7 @@ import { HTTPError } from 'got';
  * @param {*} msg
  */
 export default async function (context, msg) {
-	context.log('Appellant case import command', msg);
+	context.log('Appellant case import command');
 
 	const applicationProperties = context?.bindingData?.applicationProperties;
 
@@ -16,14 +16,14 @@ export default async function (context, msg) {
 		Boolean(applicationProperties) &&
 		Object.prototype.hasOwnProperty.call(applicationProperties, 'type');
 	if (!hasType) {
-		context.log.warn('Ignoring invalid message, no type', msg);
+		context.log.warn('Ignoring invalid message, no type');
 		return;
 	}
 
 	const type = applicationProperties?.type;
 
 	if (type !== EventType.Create) {
-		context.log.warn(`Ignoring invalid message, unsupported type '${type}'`, msg);
+		context.log.warn(`Ignoring invalid message, unsupported type '${type}'`);
 		return;
 	}
 

--- a/appeals/functions/casedata-import/questionnaire/index.js
+++ b/appeals/functions/casedata-import/questionnaire/index.js
@@ -8,7 +8,7 @@ import { HTTPError } from 'got';
  * @param {*} msg
  */
 export default async function (context, msg) {
-	context.log('LPA questionnaire import command', msg);
+	context.log('LPA questionnaire import command');
 
 	const applicationProperties = context?.bindingData?.applicationProperties;
 
@@ -16,14 +16,14 @@ export default async function (context, msg) {
 		Boolean(applicationProperties) &&
 		Object.prototype.hasOwnProperty.call(applicationProperties, 'type');
 	if (!hasType) {
-		context.log.warn('Ignoring invalid message, no type', msg);
+		context.log.warn('Ignoring invalid message, no type');
 		return;
 	}
 
 	const type = applicationProperties?.type;
 
 	if (type !== EventType.Create && type !== EventType.Update) {
-		context.log.warn(`Ignoring invalid message, unsupported type '${type}'`, msg);
+		context.log.warn(`Ignoring invalid message, unsupported type '${type}'`);
 		return;
 	}
 

--- a/appeals/functions/casedata-import/representation/index.js
+++ b/appeals/functions/casedata-import/representation/index.js
@@ -8,7 +8,7 @@ import { HTTPError } from 'got';
  * @param {*} msg
  */
 export default async function (context, msg) {
-	context.log('LPA questionnaire import command', msg);
+	context.log('Representation import command');
 
 	const applicationProperties = context?.bindingData?.applicationProperties;
 
@@ -16,14 +16,14 @@ export default async function (context, msg) {
 		Boolean(applicationProperties) &&
 		Object.prototype.hasOwnProperty.call(applicationProperties, 'type');
 	if (!hasType) {
-		context.log.warn('Ignoring invalid message, no type', msg);
+		context.log.warn('Ignoring invalid message, no type');
 		return;
 	}
 
 	const type = applicationProperties?.type;
 
-	if (type !== EventType.Create && type !== EventType.Update) {
-		context.log.warn(`Ignoring invalid message, unsupported type '${type}'`, msg);
+	if (type !== EventType.Create) {
+		context.log.warn(`Ignoring invalid message, unsupported type '${type}'`);
 		return;
 	}
 

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/environmental-impact-assessment/__tests__/environmental-impact-assessment.test.js
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/environmental-impact-assessment/__tests__/environmental-impact-assessment.test.js
@@ -161,7 +161,7 @@ describe('environmental-impact-assessment', () => {
 						.get('/appeals/1/lpa-questionnaires/2')
 						.reply(200, {
 							...lpaQuestionnaireDataNotValidated,
-							eiaConsultedBodiesDetails: testCase.value
+							consultedBodiesDetails: testCase.value
 						});
 
 					const response = await request.get(`${baseUrl}/1/lpa-questionnaire/2`);
@@ -189,7 +189,7 @@ describe('environmental-impact-assessment', () => {
 					.get('/appeals/1/lpa-questionnaires/2')
 					.reply(200, {
 						...lpaQuestionnaireDataNotValidated,
-						eiaConsultedBodiesDetails: 'a'.repeat(301)
+						consultedBodiesDetails: 'a'.repeat(301)
 					});
 
 				const response = await request.get(`${baseUrl}/1/lpa-questionnaire/2`);
@@ -611,7 +611,7 @@ describe('environmental-impact-assessment', () => {
 					.get(`/appeals/1/lpa-questionnaires/${appealDataFullPlanning.lpaQuestionnaireId}`)
 					.reply(200, {
 						...lpaQuestionnaireDataNotValidated,
-						eiaConsultedBodiesDetails: null
+						consultedBodiesDetails: null
 					});
 
 				const response = await request.get(
@@ -644,7 +644,7 @@ describe('environmental-impact-assessment', () => {
 					.get(`/appeals/1/lpa-questionnaires/${appealDataFullPlanning.lpaQuestionnaireId}`)
 					.reply(200, {
 						...lpaQuestionnaireDataNotValidated,
-						eiaConsultedBodiesDetails: 'test consulted bodies details'
+						consultedBodiesDetails: 'test consulted bodies details'
 					});
 
 				const response = await request.get(

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/environmental-impact-assessment/environmental-impact-assessment.controller.js
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/environmental-impact-assessment/environmental-impact-assessment.controller.js
@@ -265,7 +265,7 @@ const renderChangeEiaConsultedBodiesDetails = async (request, response) => {
 
 	const mappedPageContents = changeEiaConsultedBodiesDetailsPage(
 		request.currentAppeal,
-		lpaQuestionnaire.eiaConsultedBodiesDetails,
+		lpaQuestionnaire.consultedBodiesDetails,
 		request.session.eiaConsultedBodiesDetails?.radio,
 		request.session.eiaConsultedBodiesDetails?.details
 	);

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/environmental-impact-assessment/environmental-impact-assessment.service.js
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/environmental-impact-assessment/environmental-impact-assessment.service.js
@@ -78,15 +78,15 @@ export function changeEiaConsultedBodiesDetails(
 	updatedConsultedBodiesDetails
 ) {
 	/** @type {string|null} */
-	let eiaConsultedBodiesDetails = updatedConsultedBodiesDetails.details;
+	let consultedBodiesDetails = updatedConsultedBodiesDetails.details;
 
 	if (!convertFromYesNoToBoolean(updatedConsultedBodiesDetails.radio)) {
-		eiaConsultedBodiesDetails = null;
+		consultedBodiesDetails = null;
 	}
 
 	return apiClient.patch(`appeals/${appealId}/lpa-questionnaires/${lpaQuestionnaireId}`, {
 		json: {
-			eiaConsultedBodiesDetails
+			consultedBodiesDetails
 		}
 	});
 }

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/lpa-questionnaire.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/lpa-questionnaire.mapper.js
@@ -1031,7 +1031,7 @@ const generateS78LpaQuestionnaireComponents = (mappedLPAQData, mappedAppealDetai
 			rows: [
 				mappedLPAQData.lpaq?.representations?.display.summaryListItem,
 				mappedLPAQData.lpaq?.consultationResponses?.display.summaryListItem,
-				mappedLPAQData.lpaq?.eiaConsultedBodiesDetails?.display.summaryListItem
+				mappedLPAQData.lpaq?.consultedBodiesDetails?.display.summaryListItem
 			].filter(isDefined)
 		}
 	});

--- a/appeals/web/src/server/lib/mappers/data/lpa-questionnaire/s78.js
+++ b/appeals/web/src/server/lib/mappers/data/lpa-questionnaire/s78.js
@@ -53,7 +53,7 @@ export const submaps = {
 	procedurePreferenceDuration: mapProcedurePreferenceDuration,
 	otherRelevantPolicies: mapOtherRelevantPolicies,
 	eiaSensitiveAreaDetails: mapEiaSensitiveAreaDetails,
-	eiaConsultedBodiesDetails: mapEiaConsultedBodiesDetails,
+	consultedBodiesDetails: mapEiaConsultedBodiesDetails,
 	reasonForNeighbourVisits: mapReasonForNeighbourVisits,
 	inNearOrLikelyToAffectDesignatedSites: mapInNearOrLikelyToAffectDesignatedSites
 };

--- a/appeals/web/src/server/lib/mappers/data/lpa-questionnaire/submappers/map-eia-consulted-bodies-details.js
+++ b/appeals/web/src/server/lib/mappers/data/lpa-questionnaire/submappers/map-eia-consulted-bodies-details.js
@@ -10,10 +10,10 @@ export const mapEiaConsultedBodiesDetails = ({
 		id: 'eia-consulted-bodies-details',
 		text: 'Consulted relevant statutory consultees',
 		value:
-			(lpaQuestionnaireData.eiaConsultedBodiesDetails &&
-				lpaQuestionnaireData.eiaConsultedBodiesDetails?.length > 0) ||
+			(lpaQuestionnaireData.consultedBodiesDetails &&
+				lpaQuestionnaireData.consultedBodiesDetails?.length > 0) ||
 			false,
-		valueDetails: lpaQuestionnaireData.eiaConsultedBodiesDetails,
+		valueDetails: lpaQuestionnaireData.consultedBodiesDetails,
 		defaultText: 'No answer provided',
 		link: `${currentRoute}/environmental-impact-assessment/consulted-bodies-details/change`,
 		editable: userHasUpdateCase,

--- a/appeals/web/testing/app/fixtures/referencedata.js
+++ b/appeals/web/testing/app/fixtures/referencedata.js
@@ -1236,7 +1236,7 @@ export const lpaQuestionnaireDataNotValidated = {
 	scheduleType: 'Schedule 2',
 	sensitiveAreaDetails: 'The area is prone to flooding',
 	siteWithinGreenBelt: true,
-	statutoryConsulteesDetails: 'Some other people need to be consulted',
+	consultedBodiesDetails: 'Some other people need to be consulted',
 	validation: null
 };
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
 				"joi": "^17.7.0",
 				"node-cache": "^5.1.2",
 				"nodemon": "3.0.3",
-				"pins-data-model": "github:Planning-Inspectorate/data-model#1.9.14"
+				"pins-data-model": "github:Planning-Inspectorate/data-model#1.9.16"
 			},
 			"devDependencies": {
 				"@commitlint/cli": "17.0.1",
@@ -77,7 +77,7 @@
 				"pino": "^8.1.0",
 				"pino-http": "^8.1.0",
 				"pino-pretty": "^8.1.0",
-				"pins-data-model": "github:Planning-Inspectorate/data-model#1.9.14",
+				"pins-data-model": "github:Planning-Inspectorate/data-model#1.9.16",
 				"rhea": "3.0.1",
 				"swagger-ui-express": "^5.0.1",
 				"xstate": "4.32.1"
@@ -19940,8 +19940,8 @@
 			"license": "MIT"
 		},
 		"node_modules/pins-data-model": {
-			"version": "1.9.14",
-			"resolved": "git+ssh://git@github.com/Planning-Inspectorate/data-model.git#39818aab8c5f4a9d710e3b4ed3bd9f387eb3aae1",
+			"version": "1.9.16",
+			"resolved": "git+ssh://git@github.com/Planning-Inspectorate/data-model.git#74f30d23ccd43fe1d72ed903dc21360b7e812d88",
 			"integrity": "sha512-xk2gyAS0kAzFkiOWmo2pKvKAkQno2nER/buABJbmyVgIBsBGNSb7gQ91TmZOyn4aNEI90Q4Gxcq5w9q4+RyMpw==",
 			"license": "MIT",
 			"dependencies": {
@@ -29386,7 +29386,7 @@
 				"pino": "^8.1.0",
 				"pino-http": "^8.1.0",
 				"pino-pretty": "^8.1.0",
-				"pins-data-model": "github:Planning-Inspectorate/data-model#1.9.14",
+				"pins-data-model": "github:Planning-Inspectorate/data-model#1.9.16",
 				"prisma": "4.16.1",
 				"rhea": "3.0.1",
 				"rimraf": "^3.0.2",
@@ -40051,9 +40051,9 @@
 			"version": "4.0.0"
 		},
 		"pins-data-model": {
-			"version": "git+ssh://git@github.com/Planning-Inspectorate/data-model.git#39818aab8c5f4a9d710e3b4ed3bd9f387eb3aae1",
+			"version": "git+ssh://git@github.com/Planning-Inspectorate/data-model.git#74f30d23ccd43fe1d72ed903dc21360b7e812d88",
 			"integrity": "sha512-xk2gyAS0kAzFkiOWmo2pKvKAkQno2nER/buABJbmyVgIBsBGNSb7gQ91TmZOyn4aNEI90Q4Gxcq5w9q4+RyMpw==",
-			"from": "pins-data-model@github:Planning-Inspectorate/data-model#1.9.14",
+			"from": "pins-data-model@github:Planning-Inspectorate/data-model#1.9.16",
 			"requires": {
 				"jsonc-parser": "^3.3.1"
 			}

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
 		"joi": "^17.7.0",
 		"node-cache": "^5.1.2",
 		"nodemon": "3.0.3",
-		"pins-data-model": "github:Planning-Inspectorate/data-model#1.9.14"
+		"pins-data-model": "github:Planning-Inspectorate/data-model#1.9.16"
 	},
 	"devDependencies": {
 		"@commitlint/cli": "17.0.1",


### PR DESCRIPTION
Using a new version of the pins data model (1.9.16), which:

- rename consultedBodiesDetails to remove misleading eia prefix for S78
- infrastructureLevyExpectedDate added to S78 command (already on schema)
- typeOfPlanningApplication added to HAS and commands, used enum
- reasonForNeighbourVisits added to HAS and S78
- developmentType added to S78
- appellantProofsSubmittedDate added to S78


