### PR TITLE
fix(web): hide IP comments timetable change link after sharing comments

### DIFF
--- a/appeals/web/src/server/lib/mappers/data/appeal/submappers/ip-comments-due-date.mapper.js
+++ b/appeals/web/src/server/lib/mappers/data/appeal/submappers/ip-comments-due-date.mapper.js
@@ -12,6 +12,9 @@ export const mapIpCommentsDueDate = ({
 		text: 'Interested party comments due',
 		value: dateISOStringToDisplayDate(appealDetails.appealTimetable?.ipCommentsDueDate),
 		link: `${currentRoute}/appeal-timetables/ip-comments`,
-		editable: Boolean(userHasUpdateCasePermission && appealDetails.startedAt),
+		editable:
+			appealDetails.documentationSummary?.ipComments?.counts?.published === 0 &&
+			userHasUpdateCasePermission &&
+			Boolean(appealDetails.startedAt),
 		classes: 'appeal-ip-comments-due-date'
 	});


### PR DESCRIPTION
## Describe your changes

Hide IP comments timetable change link after sharing comments

## Issue ticket number and link
[A2-2408](https://pins-ds.atlassian.net/browse/A2-2408)


[A2-2408]: https://pins-ds.atlassian.net/browse/A2-2408?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ