### PR TITLE
fix(web): a2-2109 render persisted data on add IP comment views

### DIFF
--- a/appeals/web/src/server/appeals/appeal-details/representations/interested-party-comments/add-ip-comment/__tests__/add-ip-comment.test.js
+++ b/appeals/web/src/server/appeals/appeal-details/representations/interested-party-comments/add-ip-comment/__tests__/add-ip-comment.test.js
@@ -63,6 +63,32 @@ describe('add-ip-comment', () => {
 		it('should render an Email address field', () => {
 			expect(pageHtml.querySelector('input#email-address')).not.toBeNull();
 		});
+
+		it('should render any previous response', async () => {
+			nock('http://test/')
+				.get(`/appeals/${appealId}`)
+				.reply(200, { ...appealData, appealId });
+			nock('http://test/')
+				.get(`/appeals/${appealId}`)
+				.reply(200, { ...appealData, appealId });
+
+			//set session data with post request
+			await request
+				.post(`${baseUrl}/${appealId}/interested-party-comments/add/ip-details`)
+				.send({ firstName: 'First123', lastName: 'Last456', emailAddress: 'example@email.com' });
+
+			const response = await request.get(
+				`${baseUrl}/${appealId}/interested-party-comments/add/ip-details`
+			);
+
+			pageHtml = parseHtml(response.text);
+
+			expect(pageHtml.querySelector('input#first-name').getAttribute('value')).toEqual('First123');
+			expect(pageHtml.querySelector('input#last-name').getAttribute('value')).toEqual('Last456');
+			expect(pageHtml.querySelector('input#email-address').getAttribute('value')).toEqual(
+				'example@email.com'
+			);
+		});
 	});
 
 	describe('GET /add/check-address', () => {
@@ -95,6 +121,33 @@ describe('add-ip-comment', () => {
 		it('should render Yes and No radio buttons', () => {
 			expect(pageHtml.querySelector('input[type="radio"][value="yes"]')).not.toBeNull();
 			expect(pageHtml.querySelector('input[type="radio"][value="no"]')).not.toBeNull();
+		});
+
+		it('should render any previous response', async () => {
+			nock('http://test/')
+				.get(`/appeals/${appealId}`)
+				.reply(200, { ...appealData, appealId });
+			nock('http://test/')
+				.get(`/appeals/${appealId}`)
+				.reply(200, { ...appealData, appealId });
+
+			//set session data with post request
+			await request
+				.post(`${baseUrl}/${appealId}/interested-party-comments/add/check-address`)
+				.send({ addressProvided: 'no' });
+
+			const response = await request.get(
+				`${baseUrl}/${appealId}/interested-party-comments/add/check-address`
+			);
+
+			pageHtml = parseHtml(response.text);
+
+			expect(
+				pageHtml.querySelector('input[type="radio"][value="no"]').getAttribute('checked')
+			).toEqual('');
+			expect(
+				pageHtml.querySelector('input[type="radio"][value="yes"]').getAttribute('checked')
+			).toBeUndefined();
 		});
 	});
 
@@ -141,6 +194,40 @@ describe('add-ip-comment', () => {
 
 		it('should render a Postcode field', () => {
 			expect(pageHtml.querySelector('input#post-code')).not.toBeNull();
+		});
+
+		it('should render any previous response', async () => {
+			nock('http://test/')
+				.get(`/appeals/${appealId}`)
+				.reply(200, { ...appealData, appealId });
+			nock('http://test/')
+				.get(`/appeals/${appealId}`)
+				.reply(200, { ...appealData, appealId });
+
+			//set session data with post request
+			await request.post(`${baseUrl}/${appealId}/interested-party-comments/add/ip-address`).send({
+				addressLine1: 'Line 1',
+				addressLine2: 'Line 2',
+				town: 'Town',
+				county: 'County',
+				postCode: 'AB1 2CD'
+			});
+
+			const response = await request.get(
+				`${baseUrl}/${appealId}/interested-party-comments/add/ip-address`
+			);
+
+			pageHtml = parseHtml(response.text);
+
+			expect(pageHtml.querySelector('input#address-line-1').getAttribute('value')).toEqual(
+				'Line 1'
+			);
+			expect(pageHtml.querySelector('input#address-line-2').getAttribute('value')).toEqual(
+				'Line 2'
+			);
+			expect(pageHtml.querySelector('input#town').getAttribute('value')).toEqual('Town');
+			expect(pageHtml.querySelector('input#county').getAttribute('value')).toEqual('County');
+			expect(pageHtml.querySelector('input#post-code').getAttribute('value')).toEqual('AB1 2CD');
 		});
 	});
 

--- a/appeals/web/src/server/appeals/appeal-details/representations/interested-party-comments/add-ip-comment/add-ip-comment.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/representations/interested-party-comments/add-ip-comment/add-ip-comment.mapper.js
@@ -72,10 +72,11 @@ export const ipDetailsPage = (appealDetails, values, errors) => ({
 
 /**
  * @param {Appeal} appealDetails
+ * @param {string} value
  * @param {import('@pins/express').ValidationErrors | undefined} errors
  * @returns {PageContent}
  * */
-export const checkAddressPage = (appealDetails, errors) => ({
+export const checkAddressPage = (appealDetails, value, errors) => ({
 	title: 'Did the interested party provide an address?',
 	backLinkUrl: `/appeals-service/appeal-details/${appealDetails.appealId}/interested-party-comments/add/ip-details`,
 	preHeading: `Appeal ${appealShortReference(appealDetails.appealReference)}`,
@@ -98,11 +99,13 @@ export const checkAddressPage = (appealDetails, errors) => ({
 				items: [
 					{
 						value: 'yes',
-						text: 'Yes'
+						text: 'Yes',
+						checked: value === 'yes'
 					},
 					{
 						value: 'no',
-						text: 'No'
+						text: 'No',
+						checked: value === 'no'
 					}
 				],
 				errorMessage: errorAddressProvidedRadio(errors)
@@ -116,9 +119,10 @@ export const checkAddressPage = (appealDetails, errors) => ({
  * @param {import('@pins/express').ValidationErrors | undefined} errors
  * @param {boolean} providedAddress
  * @param {number} folderId
+ * @param {{ appealId: string, folderId: string, files: { GUID: string, name: string, documentType: string, size: number, stage: string, mimeType: string, receivedDate: string, redactionStatus: number, blobStoreUrl: string }[] }} fileUploadInfo - The file upload information object.
  * @returns {import('#appeals/appeal-documents/appeal-documents.types.js').DocumentUploadPageParameters}
  * */
-export const uploadPage = (appealDetails, errors, providedAddress, folderId) => ({
+export const uploadPage = (appealDetails, errors, providedAddress, folderId, fileUploadInfo) => ({
 	backButtonUrl: providedAddress
 		? `/appeals-service/appeal-details/${appealDetails.appealId}/interested-party-comments/add/ip-address`
 		: `/appeals-service/appeal-details/${appealDetails.appealId}/interested-party-comments/add/check-address`,
@@ -129,6 +133,13 @@ export const uploadPage = (appealDetails, errors, providedAddress, folderId) => 
 	// TODO: replace with real values
 	folderId: String(folderId),
 	useBlobEmulator: config.useBlobEmulator,
+	...(fileUploadInfo &&
+		Number(fileUploadInfo.appealId) === appealDetails.appealId &&
+		Number(fileUploadInfo.folderId) === folderId && {
+			uncommittedFiles: JSON.stringify({
+				files: fileUploadInfo.files
+			})
+		}),
 	blobStorageHost: config.useBlobEmulator ? config.blobEmulatorSasUrl : config.blobStorageUrl,
 	blobStorageContainer: config.blobStorageDefaultContainer,
 	documentStage: DOCUMENT_STAGE,


### PR DESCRIPTION
## Describe your changes

Include persisted data in rendered page views on add IP comment journey.

<!--
    Please include a summary of the change along with any relevant context.
    List any dependencies that are required for this change.
-->

## Issue ticket number and link
[Ticket](https://pins-ds.atlassian.net.mcas.ms/browse/A2-2109)
