### PR TITLE
fix(appeals): align final comments personal-list and info-banners (a2-2410)

### DIFF
--- a/appeals/web/src/server/appeals/appeal-details/accordions/utils/__tests__/__snapshots__/map-status-dependent-notifications.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/accordions/utils/__tests__/__snapshots__/map-status-dependent-notifications.test.js.snap
@@ -1,5 +1,65 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`mapStatusDependentNotifications when status is "final_comments" should return the "Appellant final comments awaiting review" notification 1`] = `
+[
+  {
+    "parameters": {
+      "html": "<p class="govuk-notification-banner__heading">Appellant final comments awaiting review</p><p><a class="govuk-notification-banner__link" href="/appeals-service/appeal-details/1234/final-comments/appellant" data-cy="banner-review-appellant-final-comments">Review <span class="govuk-visually-hidden">appellant final comments</span></a></p>",
+      "text": undefined,
+      "titleHeadingLevel": 3,
+      "titleText": "Important",
+      "type": "important",
+    },
+    "type": "notification-banner",
+  },
+]
+`;
+
+exports[`mapStatusDependentNotifications when status is "final_comments" should return the "LPA final comments awaiting review" notification 1`] = `
+[
+  {
+    "parameters": {
+      "html": "<p class="govuk-notification-banner__heading">LPA final comments awaiting review</p><p><a class="govuk-notification-banner__link" href="/appeals-service/appeal-details/1234/final-comments/lpa" data-cy="banner-review-lpa-final-comments">Review <span class="govuk-visually-hidden">L P A final comments</span></a></p>",
+      "text": undefined,
+      "titleHeadingLevel": 3,
+      "titleText": "Important",
+      "type": "important",
+    },
+    "type": "notification-banner",
+  },
+]
+`;
+
+exports[`mapStatusDependentNotifications when status is "final_comments" when the final comments due date is in the past should return the "Progress case" notification 1`] = `
+[
+  {
+    "parameters": {
+      "html": "<a href="/appeals-service/appeal-details/1234/share" class="govuk-heading-s govuk-notification-banner__link">Progress case</a>",
+      "text": undefined,
+      "titleHeadingLevel": 3,
+      "titleText": "Important",
+      "type": "important",
+    },
+    "type": "notification-banner",
+  },
+]
+`;
+
+exports[`mapStatusDependentNotifications when status is "final_comments" when the final comments due date is in the past should return the "Share final comments" notification 1`] = `
+[
+  {
+    "parameters": {
+      "html": "<a href="/appeals-service/appeal-details/1234/share" class="govuk-heading-s govuk-notification-banner__link">Share final comments</a>",
+      "text": undefined,
+      "titleHeadingLevel": 3,
+      "titleText": "Important",
+      "type": "important",
+    },
+    "type": "notification-banner",
+  },
+]
+`;
+
 exports[`mapStatusDependentNotifications when status is "statements" should return the "Interested party comments awaiting review" notification 1`] = `
 [
   {

--- a/appeals/web/src/server/appeals/appeal-details/accordions/utils/__tests__/map-status-dependent-notifications.test.js
+++ b/appeals/web/src/server/appeals/appeal-details/accordions/utils/__tests__/map-status-dependent-notifications.test.js
@@ -9,10 +9,12 @@ function getDateDaysInFutureISO(days) {
 describe('mapStatusDependentNotifications', () => {
 	let appealDetails;
 	let representationTypesAwaitingReview;
+
 	beforeEach(() => {
 		appealDetails = {};
 		representationTypesAwaitingReview = {};
 	});
+
 	describe('when status is "statements"', () => {
 		beforeEach(() => {
 			appealDetails.appealStatus = 'statements';
@@ -144,6 +146,127 @@ describe('mapStatusDependentNotifications', () => {
 			const [banner] = banners;
 			expect(banner.type).toEqual('notification-banner');
 			expect(banner.parameters.html).toEqual(expect.stringContaining('>LPA statement</span></a>'));
+		});
+	});
+
+	describe('when status is "final_comments"', () => {
+		beforeEach(() => {
+			appealDetails.appealId = '1234';
+			appealDetails.appealStatus = 'final_comments';
+			appealDetails.appealTimetable = {
+				finalCommentsDueDate: getDateDaysInFutureISO(1)
+			};
+			appealDetails.documentationSummary = {
+				appellantFinalComments: {
+					representationStatus: 'valid'
+				},
+				lpaFinalComments: {
+					representationStatus: 'valid'
+				}
+			};
+			representationTypesAwaitingReview.appellantFinalComments = false;
+			representationTypesAwaitingReview.lpaFinalComments = false;
+		});
+
+		it('should return the "Appellant final comments awaiting review" notification', () => {
+			representationTypesAwaitingReview.appellantFinalComments = true;
+			const banners = mapStatusDependentNotifications(
+				appealDetails,
+				representationTypesAwaitingReview
+			);
+			expect(banners).toMatchSnapshot();
+
+			expect(banners.length).toEqual(1);
+
+			const [banner] = banners;
+
+			expect(banner.type).toEqual('notification-banner');
+
+			expect(banner.parameters.html).toEqual(
+				expect.stringContaining('>Appellant final comments awaiting review</p>')
+			);
+			expect(banner.parameters.html).toEqual(
+				expect.stringContaining(
+					'href="/appeals-service/appeal-details/1234/final-comments/appellant"'
+				)
+			);
+			expect(banner.parameters.html).toEqual(
+				expect.stringContaining('>appellant final comments</span></a>')
+			);
+		});
+
+		it('should return the "LPA final comments awaiting review" notification', () => {
+			representationTypesAwaitingReview.lpaFinalComments = true;
+			const banners = mapStatusDependentNotifications(
+				appealDetails,
+				representationTypesAwaitingReview
+			);
+			expect(banners).toMatchSnapshot();
+
+			expect(banners.length).toEqual(1);
+
+			const [banner] = banners;
+
+			expect(banner.type).toEqual('notification-banner');
+
+			expect(banner.parameters.html).toEqual(
+				expect.stringContaining('>LPA final comments awaiting review</p>')
+			);
+			expect(banner.parameters.html).toEqual(
+				expect.stringContaining('href="/appeals-service/appeal-details/1234/final-comments/lpa"')
+			);
+			expect(banner.parameters.html).toEqual(
+				expect.stringContaining('>L P A final comments</span></a>')
+			);
+		});
+
+		describe('when the final comments due date is in the past', () => {
+			beforeEach(() => {
+				appealDetails.appealTimetable.finalCommentsDueDate = getDateDaysInFutureISO(-1);
+			});
+
+			it('should return the "Share final comments" notification', () => {
+				const banners = mapStatusDependentNotifications(
+					appealDetails,
+					representationTypesAwaitingReview
+				);
+				expect(banners).toMatchSnapshot();
+
+				expect(banners.length).toEqual(1);
+
+				const [banner] = banners;
+
+				expect(banner.type).toEqual('notification-banner');
+
+				expect(banner.parameters.html).toEqual(
+					expect.stringContaining('>Share final comments</a>')
+				);
+				expect(banner.parameters.html).toEqual(
+					expect.stringContaining('href="/appeals-service/appeal-details/1234/share"')
+				);
+			});
+
+			it('should return the "Progress case" notification', () => {
+				appealDetails.documentationSummary.appellantFinalComments.representationStatus = 'invalid';
+				appealDetails.documentationSummary.lpaFinalComments.representationStatus = 'invalid';
+
+				const banners = mapStatusDependentNotifications(
+					appealDetails,
+					representationTypesAwaitingReview
+				);
+				expect(banners).toMatchSnapshot();
+
+				expect(banners.length).toEqual(1);
+
+				const [banner] = banners;
+
+				expect(banner.type).toEqual('notification-banner');
+
+				expect(banner.parameters.html).toEqual(expect.stringContaining('>Progress case</a>'));
+				expect(banner.parameters.html).toEqual(
+					expect.stringContaining('href="/appeals-service/appeal-details/1234/share"')
+				);
+			});
 		});
 	});
 });

--- a/appeals/web/src/server/appeals/personal-list/__tests__/personal-list.test.js
+++ b/appeals/web/src/server/appeals/personal-list/__tests__/personal-list.test.js
@@ -339,7 +339,7 @@ describe('personal-list', () => {
 				const unprettifiedHtml = parseHtml(response.text, { skipPrettyPrint: true }).innerHTML;
 
 				expect(unprettifiedHtml).toContain(
-					'action-required"><a class="govuk-link" href="/appeals-service/appeal-details/24281/final-comments/lpa">Review LPA final comments<span class="govuk-visually-hidden"> for appeal 24281</span></a><br><a class="govuk-link" href="/appeals-service/appeal-details/24281/final-comments/appellant">Review appellant final comments<span class="govuk-visually-hidden"> for appeal 24281</span></a></td>'
+					'action-required"><a class="govuk-link" href="/appeals-service/appeal-details/24281/final-comments/appellant">Review appellant final comments<span class="govuk-visually-hidden"> for appeal 24281</span></a><br><a class="govuk-link" href="/appeals-service/appeal-details/24281/final-comments/lpa">Review LPA final comments<span class="govuk-visually-hidden"> for appeal 24281</span></a></td>'
 				);
 			});
 		});
@@ -686,7 +686,7 @@ describe('mapAppealStatusToActionRequiredHtml', () => {
 		);
 	});
 
-	it('should return "View case" link for any other status', () => {
+	it('should be blank for any other status', () => {
 		const result = mapAppealStatusToActionRequiredHtml(
 			{
 				...appeal,
@@ -695,9 +695,7 @@ describe('mapAppealStatusToActionRequiredHtml', () => {
 			},
 			true
 		);
-		expect(result).toEqual(
-			`<a class="govuk-link" href="/appeals-service/appeal-details/${appealId}">View case<span class="govuk-visually-hidden"> for appeal 123</span></a>`
-		);
+		expect(result).toEqual('');
 	});
 
 	describe('appeal status is statements', () => {

--- a/appeals/web/src/server/appeals/personal-list/personal-list.mapper.js
+++ b/appeals/web/src/server/appeals/personal-list/personal-list.mapper.js
@@ -394,43 +394,56 @@ export function mapAppealStatusToActionRequiredHtml(appeal, isCaseOfficer = fals
 				? dateIsInThePast(dateISOStringToDayMonthYearHourMinute(finalCommentsDueDate))
 				: false;
 
-			if (isFinalCommentsDueDatePassed) {
-				const hasValidFinalCommentsAppellant =
-					documentationSummary.appellantFinalComments?.representationStatus ===
-					APPEAL_REPRESENTATION_STATUS.VALID;
-				const hasValidFinalCommentsLPA =
-					documentationSummary.lpaFinalComments?.representationStatus ===
-					APPEAL_REPRESENTATION_STATUS.VALID;
+			const hasValidFinalCommentsAppellant =
+				documentationSummary.appellantFinalComments?.representationStatus ===
+				APPEAL_REPRESENTATION_STATUS.VALID;
 
-				let linkText = 'Progress case';
+			const hasValidFinalCommentsLPA =
+				documentationSummary.lpaFinalComments?.representationStatus ===
+				APPEAL_REPRESENTATION_STATUS.VALID;
 
-				if (hasValidFinalCommentsAppellant || hasValidFinalCommentsLPA) {
-					linkText = 'Share final comments';
+			const lpaReceived = lpaFinalCommentsStatus === 'received';
+			const appellantReceived = appellantFinalCommentsStatus === 'received';
+
+			const appellantFinalCommentsAwaitingReview =
+				appellantReceived &&
+				isRepresentationReviewRequired(appellantFinalCommentsRepresentationStatus);
+			const lpaFinalCommentsAwaitingReview =
+				lpaReceived && isRepresentationReviewRequired(lpaFinalCommentsRepresentationStatus);
+
+			// Build list of required actions
+			const actions = [];
+			if (appellantFinalCommentsAwaitingReview || lpaFinalCommentsAwaitingReview) {
+				if (appellantFinalCommentsAwaitingReview) {
+					actions.push(
+						`<a class="govuk-link" href="/appeals-service/appeal-details/${appealId}/final-comments/appellant">Review appellant final comments<span class="govuk-visually-hidden"> for appeal ${appealId}</span></a>`
+					);
 				}
-				return `<a class="govuk-link" href="/appeals-service/appeal-details/${appealId}/share">${linkText}</a>`;
+				if (lpaFinalCommentsAwaitingReview) {
+					actions.push(
+						`<a class="govuk-link" href="/appeals-service/appeal-details/${appealId}/final-comments/lpa">Review LPA final comments<span class="govuk-visually-hidden"> for appeal ${appealId}</span></a>`
+					);
+				}
 			} else {
-				const lpaReceived = lpaFinalCommentsStatus === 'received';
-				const appellantReceived = appellantFinalCommentsStatus === 'received';
-
 				if (!lpaReceived && !appellantReceived) {
-					return 'Awaiting final comments';
+					actions.push('Awaiting final comments');
 				}
-
-				const lpaAction =
-					lpaReceived && isRepresentationReviewRequired(lpaFinalCommentsRepresentationStatus)
-						? `<a class="govuk-link" href="/appeals-service/appeal-details/${appealId}/final-comments/lpa">Review LPA final comments<span class="govuk-visually-hidden"> for appeal ${appealId}</span></a>`
-						: null;
-				const appellantAction =
-					appellantReceived &&
-					isRepresentationReviewRequired(appellantFinalCommentsRepresentationStatus)
-						? `<a class="govuk-link" href="/appeals-service/appeal-details/${appealId}/final-comments/appellant">Review appellant final comments<span class="govuk-visually-hidden"> for appeal ${appealId}</span></a>`
-						: null;
-
-				return [lpaAction, appellantAction].filter(Boolean).join('<br>');
+				if (isFinalCommentsDueDatePassed) {
+					if (hasValidFinalCommentsAppellant || hasValidFinalCommentsLPA) {
+						actions.push(
+							`<a class="govuk-link" href="/appeals-service/appeal-details/${appealId}/share">Share final comments</a>`
+						);
+					} else {
+						actions.push(
+							`<a class="govuk-link" href="/appeals-service/appeal-details/${appealId}/share">Progress case</a>`
+						);
+					}
+				}
 			}
+			return actions.join('<br>');
 		}
 		default:
-			return `<a class="govuk-link" href="/appeals-service/appeal-details/${appealId}">View case<span class="govuk-visually-hidden"> for appeal ${appealId}</span></a>`;
+			return '';
 	}
 }
 


### PR DESCRIPTION
## Describe your changes
### Correct banner and personal-list actions display conditions when appeal status is FINAL COMMENTS (a2-2410)

WEB:
 - Refactored banners for FINAL COMMENTS status to match acceptance criteria 
 - Add unit tests for banners with FINAL COMMENTS status to test above criteria
 - Refactored CTAs for FINAL COMMENTS status in personal list to match acceptance criteria 
 - Add unit tests for CTAs with FINAL COMMENTS status in personal list to test above criteria
    
TESTING:
- All WEB unit tests pass
- Manually tested within browser

## Issue ticket number and link

[A2-2410 "Progress case" entry points vs "review final comments" when deadline has passed](https://pins-ds.atlassian.net/browse/A2-2410)

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [x] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [x] I have included unit tests to cover any testable code changes
