### PR TITLE
fix(web): fixes for the accept final comments flow

### DIFF
--- a/appeals/web/src/server/appeals/appeal-details/final-comments/accept/__tests__/__snapshots__/accept-final-comments.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/final-comments/accept/__tests__/__snapshots__/accept-final-comments.test.js.snap
@@ -15,12 +15,14 @@ exports[`final-comments GET / should render the accept appellant final comments 
                         <div class="pins-show-more" data-label="Read more" data-mode="text">Awaiting final comments review</div>
                     </dd>
                 </div>
-                <div class="govuk-summary-list__row govuk-summary-list__row--no-actions"><dt class="govuk-summary-list__key"> Supporting documents</dt>
+                <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Supporting documents</dt>
                     <dd class="govuk-summary-list__value"></dd>
+                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/final-comments/appellant/"> Change</a>
+                    </dd>
                 </div>
                 <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Review decisions</dt>
                     <dd class="govuk-summary-list__value">Accept final comments</dd>
-                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/final-comments/appellant"> Change</a>
+                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/final-comments/appellant/manage-documents/undefined"> Change</a>
                     </dd>
                 </div>
             </dl>
@@ -51,12 +53,14 @@ exports[`final-comments GET / should render the accept lpa final comments page w
                         <div class="pins-show-more" data-label="Read more" data-mode="text">Awaiting final comments review</div>
                     </dd>
                 </div>
-                <div class="govuk-summary-list__row govuk-summary-list__row--no-actions"><dt class="govuk-summary-list__key"> Supporting documents</dt>
+                <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Supporting documents</dt>
                     <dd class="govuk-summary-list__value"></dd>
+                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/final-comments/lpa/"> Change</a>
+                    </dd>
                 </div>
                 <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Review decisions</dt>
                     <dd class="govuk-summary-list__value">Accept final comments</dd>
-                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/final-comments/lpa"> Change</a>
+                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/final-comments/lpa/manage-documents/undefined"> Change</a>
                     </dd>
                 </div>
             </dl>

--- a/appeals/web/src/server/appeals/appeal-details/final-comments/accept/__tests__/accept-final-comments.test.js
+++ b/appeals/web/src/server/appeals/appeal-details/final-comments/accept/__tests__/accept-final-comments.test.js
@@ -73,7 +73,7 @@ describe('final-comments', () => {
 				expect(unprettifiedHTML).toContain('Review decisions</dt>');
 				expect(unprettifiedHTML).toContain('Accept final comments</dd>');
 				expect(unprettifiedHTML).toContain(
-					`href="/appeals-service/appeal-details/2/final-comments/${finalCommentsType.type}"> Change</a>`
+					`href="/appeals-service/appeal-details/2/final-comments/${finalCommentsType.type}/manage-documents`
 				);
 				expect(unprettifiedHTML).toContain(
 					`Accept ${finalCommentsType.label} final comments</button>`

--- a/appeals/web/src/server/appeals/appeal-details/final-comments/accept/accept.controller.js
+++ b/appeals/web/src/server/appeals/appeal-details/final-comments/accept/accept.controller.js
@@ -44,9 +44,14 @@ export const postConfirmAcceptFinalComment = async (request, response) => {
 			'valid'
 		);
 
+		const acceptFinalCommentsBannerType =
+			currentRepresentation.representationType === 'appellant_final_comment'
+				? 'appellantFinalCommentsAcceptSuccess'
+				: 'lpaFinalCommentsAcceptSuccess';
+
 		addNotificationBannerToSession({
-			session,
-			bannerDefinitionKey: 'finalCommentsAcceptSuccess',
+			session: session,
+			bannerDefinitionKey: acceptFinalCommentsBannerType,
 			appealId
 		});
 

--- a/appeals/web/src/server/appeals/appeal-details/final-comments/accept/accept.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/final-comments/accept/accept.mapper.js
@@ -33,23 +33,6 @@ export const acceptFinalCommentPage = (
 					},
 					'Original final comments:'
 				),
-				{
-					type: 'inset-text',
-					parameters: {
-						id: 'original-comment',
-						classes: 'govuk-!-margin-top-2',
-						html: '',
-						pageComponents: [
-							{
-								type: 'show-more',
-								parameters: {
-									text: representation.originalRepresentation,
-									labelText: 'Read more'
-								}
-							}
-						]
-					}
-				},
 				...redactInput({ representation, labelText: 'Redacted final comments:', session }),
 				buttonComponent(
 					'Continue',

--- a/appeals/web/src/server/appeals/appeal-details/final-comments/accept/components/summary-list.js
+++ b/appeals/web/src/server/appeals/appeal-details/final-comments/accept/components/summary-list.js
@@ -32,7 +32,15 @@ export const summaryList = (appealDetails, comment, finalCommentsType) => ({
 			},
 			{
 				key: { text: 'Supporting documents' },
-				value: { text: '' }
+				value: { text: '' },
+				actions: {
+					items: [
+						{
+							text: 'Change',
+							href: `/appeals-service/appeal-details/${appealDetails.appealId}/final-comments/${finalCommentsType}/`
+						}
+					]
+				}
 			},
 			{
 				key: { text: 'Review decisions' },
@@ -41,7 +49,7 @@ export const summaryList = (appealDetails, comment, finalCommentsType) => ({
 					items: [
 						{
 							text: 'Change',
-							href: `/appeals-service/appeal-details/${appealDetails.appealId}/final-comments/${finalCommentsType}`
+							href: `/appeals-service/appeal-details/${appealDetails.appealId}/final-comments/${finalCommentsType}/manage-documents/${comment.attachments?.[0]?.documentVersion?.document?.folderId}`
 						}
 					]
 				}

--- a/appeals/web/src/server/lib/mappers/components/page-components/notification-banners.mapper.js
+++ b/appeals/web/src/server/lib/mappers/components/page-components/notification-banners.mapper.js
@@ -2,7 +2,7 @@
  * @typedef {import('#appeals/appeal.constants.js').ServicePageName} ServicePageName
  */
 
-/** @typedef {'allocationDetailsUpdated'|'appealAwaitingTransfer'|'appealLinked'|'appealTypeChanged'|'appealUnlinked'|'appealValidAndReadyToStart'|'appealWithdrawalRequested'|'appellantCaseInvalidOrIncomplete'|'appellantCaseNotValid'|'appellantFinalCommentsAwaitingReview'|'assignCaseOfficer'|'caseOfficerAdded'|'caseOfficerRemoved'|'caseProgressed'|'changePage'|'caseStarted'|'commentsAndLpaStatementShared'|'costsDocumentAdded'|'documentAdded'|'documentDeleted'|'documentDetailsUpdated'|'documentFilenameUpdated'|'documentVersionAdded'|'finalCommentsAcceptSuccess'|'finalCommentsAppellantRejectionSuccess'|'finalCommentsDocumentAddedSuccess'|'finalCommentsLPARejectionSuccess'|'finalCommentsRedactionSuccess'|'finalCommentsShared'|'horizonReferenceAdded'|'inspectorAdded'|'inspectorRemoved'|'interestedPartyCommentAdded'|'interestedPartyCommentsAddressAddedSuccess'|'interestedPartyCommentsAddressUpdatedSuccess'|'interestedPartyCommentsAwaitingReview'|'interestedPartyCommentsDocumentAddedSuccess'|'interestedPartyCommentsRedactionSuccess'|'interestedPartyCommentsRejectedSuccess'|'interestedPartyCommentsValidSuccess'|'internalCorrespondenceDocumentAdded'|'issuedDecisionInvalid'|'issuedDecisionValid'|'lpaFinalCommentsAwaitingReview'|'lpaQuestionnaireNotValid'|'lpaqReviewComplete'|'lpaqReviewIncomplete'|'lpaStatementAccepted'|'lpaStatementAwaitingReview'|'updateLpaStatement'|'lpaStatementIncomplete'|'lpaStatementRedactedAndAccepted'|'neighbouringSiteAdded'|'neighbouringSiteAffected'|'neighbouringSiteRemoved'|'neighbouringSiteUpdated'|'notCheckedDocument'|'progressedToFinalComments'|'progressToFinalComments'|'readyForDecision'|'readyForLpaQuestionnaireReview'|'readyForSetUpSiteVisit'|'readyForValidation'|'relatedAppeal'|'shareCommentsAndLpaStatement'|'shareFinalComments'|'siteAddressUpdated'|'siteVisitScheduled'|'siteVisitRescheduled'|'siteVisitTypeChanged'|'siteVisitNoChanges'|'siteVisitChangedDefault'|'startDateChanged'|'timetableDueDateUpdated'} NotificationBannerDefinitionKey  */
+/** @typedef {'allocationDetailsUpdated'|'appealAwaitingTransfer'|'appealLinked'|'appealTypeChanged'|'appealUnlinked'|'appealValidAndReadyToStart'|'appealWithdrawalRequested'|'appellantCaseInvalidOrIncomplete'|'appellantCaseNotValid'|'appellantFinalCommentsAwaitingReview'|'assignCaseOfficer'|'caseOfficerAdded'|'caseOfficerRemoved'|'caseProgressed'|'changePage'|'caseStarted'|'commentsAndLpaStatementShared'|'costsDocumentAdded'|'documentAdded'|'documentDeleted'|'documentDetailsUpdated'|'documentFilenameUpdated'|'documentVersionAdded'|'appellantFinalCommentsAcceptSuccess'|'lpaFinalCommentsAcceptSuccess'|'finalCommentsAppellantRejectionSuccess'|'finalCommentsDocumentAddedSuccess'|'finalCommentsLPARejectionSuccess'|'finalCommentsRedactionSuccess'|'finalCommentsShared'|'horizonReferenceAdded'|'inspectorAdded'|'inspectorRemoved'|'interestedPartyCommentAdded'|'interestedPartyCommentsAddressAddedSuccess'|'interestedPartyCommentsAddressUpdatedSuccess'|'interestedPartyCommentsAwaitingReview'|'interestedPartyCommentsDocumentAddedSuccess'|'interestedPartyCommentsRedactionSuccess'|'interestedPartyCommentsRejectedSuccess'|'interestedPartyCommentsValidSuccess'|'internalCorrespondenceDocumentAdded'|'issuedDecisionInvalid'|'issuedDecisionValid'|'lpaFinalCommentsAwaitingReview'|'lpaQuestionnaireNotValid'|'lpaqReviewComplete'|'lpaqReviewIncomplete'|'lpaStatementAccepted'|'lpaStatementAwaitingReview'|'updateLpaStatement'|'lpaStatementIncomplete'|'lpaStatementRedactedAndAccepted'|'neighbouringSiteAdded'|'neighbouringSiteAffected'|'neighbouringSiteRemoved'|'neighbouringSiteUpdated'|'notCheckedDocument'|'progressedToFinalComments'|'progressToFinalComments'|'readyForDecision'|'readyForLpaQuestionnaireReview'|'readyForSetUpSiteVisit'|'readyForValidation'|'relatedAppeal'|'shareCommentsAndLpaStatement'|'shareFinalComments'|'siteAddressUpdated'|'siteVisitScheduled'|'siteVisitRescheduled'|'siteVisitTypeChanged'|'siteVisitNoChanges'|'siteVisitChangedDefault'|'startDateChanged'|'timetableDueDateUpdated'} NotificationBannerDefinitionKey  */
 
 /**
  * @typedef {Object} NotificationBannerDefinition
@@ -319,10 +319,15 @@ export const notificationBannerDefinitions = {
 		pages: ['viewFinalComments'],
 		text: 'Supporting document added'
 	},
-	finalCommentsAcceptSuccess: {
+	appellantFinalCommentsAcceptSuccess: {
 		type: 'success',
 		pages: ['appealDetails'],
-		text: 'Final comments accepted'
+		text: 'Appellant final comments accepted'
+	},
+	lpaFinalCommentsAcceptSuccess: {
+		type: 'success',
+		pages: ['appealDetails'],
+		text: 'LPA final comments accepted'
 	},
 	lpaqReviewComplete: {
 		type: 'success',


### PR DESCRIPTION
- created route for supporting docs "change" button in accept final comments view
- corrected call to success banner
- added condition to determine success banner type
- updated snapshot & test


https://pins-ds.atlassian.net/browse/A2-2232?atlOrigin=eyJpIjoiY2I0N2EzOWYzNDRkNDJiNDg5NjY1NWRhZDk3ZTdjYzMiLCJwIjoiaiJ9
