### PR TITLE
fix(web): a2-2139 filter deleted docs from IP supporting docs row

### DIFF
--- a/appeals/web/src/server/appeals/appeal-details/representations/interested-party-comments/view-and-review/page-components/common.js
+++ b/appeals/web/src/server/appeals/appeal-details/representations/interested-party-comments/view-and-review/page-components/common.js
@@ -60,8 +60,12 @@ export function generateCommentSummaryList(
 	const commentIsDocument = !comment.originalRepresentation && comment.attachments?.length > 0;
 	const folderId = comment.attachments?.[0]?.documentVersion?.document?.folderId ?? null;
 
+	const filteredAttachments = comment.attachments.filter(
+		(attachment) => !attachment.documentVersion.document.isDeleted
+	);
+
 	const attachmentsList =
-		comment.attachments.length > 0
+		filteredAttachments.length > 0
 			? buildHtmUnorderedList(
 					comment.attachments.map(
 						(a) => `<a class="govuk-link" href="#">${a.documentVersion.document.name}</a>`
@@ -142,7 +146,7 @@ export function generateCommentSummaryList(
 			value: attachmentsList ? { html: attachmentsList } : { text: 'Not provided' },
 			actions: {
 				items: [
-					...(comment.attachments?.length > 0
+					...(filteredAttachments.length > 0
 						? [
 								{
 									text: 'Manage',


### PR DESCRIPTION
## Describe your changes

Filter deleted items so they are not displayed in the IP supporting documents row.

## Issue ticket number and link
[Ticket](https://pins-ds.atlassian.net.mcas.ms/browse/A2-2139)
