### PR TITLE
fix(appeals): make sure correct ip comment is reviewed (a2-2517)

### DIFF
--- a/appeals/web/src/server/appeals/appeal-details/representations/interested-party-comments/view-and-review/__tests__/__snapshots__/view-and-review.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/representations/interested-party-comments/view-and-review/__tests__/__snapshots__/view-and-review.test.js.snap
@@ -48,7 +48,7 @@ exports[`interested-party-comments GET /manage-documents/:folderId/ should rende
                         </td>
                         <td class="govuk-table__cell">1 February 2023</td>
                         <td class="govuk-table__cell">No redaction required</td>
-                        <td class="govuk-table__cell"><a href="/appeals-service/appeal-details/2/interested-party-comments/5/manage-documents/1/15d19184-155b-4b6c-bba6-2bd2a61ca9a3"
+                        <td class="govuk-table__cell"><a href="/appeals-service/appeal-details/2/interested-party-comments/3670/manage-documents/1/15d19184-155b-4b6c-bba6-2bd2a61ca9a3"
                             class="govuk-link">View and edit <span class="govuk-visually-hidden">test-pdf-documentFolderInfo.pdf</span></a>
                         </td>
                     </tr>
@@ -63,7 +63,7 @@ exports[`interested-party-comments GET /manage-documents/:folderId/ should rende
                         </td>
                         <td class="govuk-table__cell">2 March 2024</td>
                         <td class="govuk-table__cell">No redaction required</td>
-                        <td class="govuk-table__cell"><a href="/appeals-service/appeal-details/2/interested-party-comments/5/manage-documents/1/47d8f073-c837-4f07-9161-c1a5626eba56"
+                        <td class="govuk-table__cell"><a href="/appeals-service/appeal-details/2/interested-party-comments/3670/manage-documents/1/47d8f073-c837-4f07-9161-c1a5626eba56"
                             class="govuk-link">View and edit <span class="govuk-visually-hidden">sample-20s-documentFolderInfo.mp4</span></a>
                         </td>
                     </tr>
@@ -123,7 +123,7 @@ exports[`interested-party-comments GET /manage-documents/:folderId/:documentId s
                         <div class="govuk-!-margin-bottom-1"><strong class="govuk-tag govuk-tag--yellow single-line">Virus scanning</strong>
                         </div>
                     </dd>
-                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/interested-party-comments/5/change-document-name/1/1"> Change<span class="govuk-visually-hidden"> test-pdf-documentFileVersionsInfo.pdf name</span></a>
+                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/interested-party-comments/3670/change-document-name/1/1"> Change<span class="govuk-visually-hidden"> test-pdf-documentFileVersionsInfo.pdf name</span></a>
                     </dd>
                 </div>
                 <div class="govuk-summary-list__row govuk-summary-list__row--no-actions"><dt class="govuk-summary-list__key"> Version</dt>
@@ -131,12 +131,12 @@ exports[`interested-party-comments GET /manage-documents/:folderId/:documentId s
                 </div>
                 <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Date submitted</dt>
                     <dd class="govuk-summary-list__value">1 February 2023</dd>
-                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/interested-party-comments/5/change-document-details/1/1"> Change<span class="govuk-visually-hidden"> test-pdf-documentFileVersionsInfo.pdf date received</span></a>
+                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/interested-party-comments/3670/change-document-details/1/1"> Change<span class="govuk-visually-hidden"> test-pdf-documentFileVersionsInfo.pdf date received</span></a>
                     </dd>
                 </div>
                 <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Redaction status</dt>
                     <dd class="govuk-summary-list__value">Redacted</dd>
-                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/interested-party-comments/5/change-document-details/1/1"> Change<span class="govuk-visually-hidden"> test-pdf-documentFileVersionsInfo.pdf redaction status</span></a>
+                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/interested-party-comments/3670/change-document-details/1/1"> Change<span class="govuk-visually-hidden"> test-pdf-documentFileVersionsInfo.pdf redaction status</span></a>
                     </dd>
                 </div>
             </dl>

--- a/appeals/web/src/server/appeals/appeal-details/representations/interested-party-comments/view-and-review/__tests__/view-and-review.test.js
+++ b/appeals/web/src/server/appeals/appeal-details/representations/interested-party-comments/view-and-review/__tests__/view-and-review.test.js
@@ -23,6 +23,8 @@ const { app, installMockApi, teardown } = createTestEnvironment();
 const request = supertest(app);
 const baseUrl = '/appeals-service/appeal-details';
 
+const commentId = interestedPartyCommentForReview.id;
+
 describe('interested-party-comments', () => {
 	beforeEach(() => {
 		installMockApi();
@@ -50,14 +52,18 @@ describe('interested-party-comments', () => {
 
 	describe('GET /review-comment with data', () => {
 		beforeEach(() => {
-			nock('http://test/').get('/appeals/2/reps/5').reply(200, interestedPartyCommentForReview);
+			nock('http://test/')
+				.get(`/appeals/2/reps/${commentId}`)
+				.reply(200, interestedPartyCommentForReview);
 			nock('http://test/')
 				.get('/appeals/2/reps?type=comment')
 				.reply(200, interestedPartyCommentsForReview);
 		});
 
 		it('should render review comment page with the provided comment details', async () => {
-			const response = await request.get(`${baseUrl}/2/interested-party-comments/5/review`);
+			const response = await request.get(
+				`${baseUrl}/2/interested-party-comments/${commentId}/review`
+			);
 
 			expect(response.statusCode).toBe(200);
 
@@ -81,8 +87,10 @@ describe('interested-party-comments', () => {
 			const testComment = structuredClone(interestedPartyCommentForReview);
 			testComment.represented.email = '';
 
-			nock('http://test/').get('/appeals/2/reps/55').reply(200, testComment);
-			const response = await request.get(`${baseUrl}/2/interested-party-comments/55/review`);
+			nock('http://test/').get(`/appeals/2/reps/${commentId}`).reply(200, testComment);
+			const response = await request.get(
+				`${baseUrl}/2/interested-party-comments/${commentId}/review`
+			);
 
 			expect(response.statusCode).toBe(200);
 
@@ -120,7 +128,9 @@ describe('interested-party-comments', () => {
 
 	describe('GET /view-comment with data', () => {
 		beforeEach(() => {
-			nock('http://test/').get('/appeals/2/reps/5').reply(200, interestedPartyCommentForView);
+			nock('http://test/')
+				.get(`/appeals/2/reps/${commentId}`)
+				.reply(200, interestedPartyCommentForView);
 
 			nock('http://test/')
 				.get('/appeals/2/reps?type=comment')
@@ -128,7 +138,9 @@ describe('interested-party-comments', () => {
 		});
 
 		it('should render view comment page with the provided comment details', async () => {
-			const response = await request.get(`${baseUrl}/2/interested-party-comments/5/view`);
+			const response = await request.get(
+				`${baseUrl}/2/interested-party-comments/${commentId}/view`
+			);
 
 			expect(response.statusCode).toBe(200);
 
@@ -166,8 +178,10 @@ describe('interested-party-comments', () => {
 
 	describe('POST /review', () => {
 		beforeEach(() => {
-			nock('http://test/').get('/appeals/2/reps/5').reply(200, interestedPartyCommentForReview);
-			nock('http://test/').patch('/appeals/2/reps/5').reply(200, {});
+			nock('http://test/')
+				.get(`/appeals/2/reps/${commentId}`)
+				.reply(200, interestedPartyCommentForReview);
+			nock('http://test/').patch(`/appeals/2/reps/${commentId}`).reply(200, {});
 			nock('http://test/')
 				.get('/appeals/2/reps?type=comment')
 				.reply(200, interestedPartyCommentsForReview);
@@ -175,7 +189,7 @@ describe('interested-party-comments', () => {
 
 		it('should set representation status to valid', async () => {
 			const response = await request
-				.post(`${baseUrl}/2/interested-party-comments/5/review`)
+				.post(`${baseUrl}/2/interested-party-comments/${commentId}/review`)
 				.send({ status: 'valid' });
 
 			expect(response.statusCode).toBe(302);
@@ -187,7 +201,9 @@ describe('interested-party-comments', () => {
 
 	describe('GET /reject/select-reason', () => {
 		beforeEach(() => {
-			nock('http://test/').get('/appeals/2/reps/5').reply(200, interestedPartyCommentForReview);
+			nock('http://test/')
+				.get(`/appeals/2/reps/${commentId}`)
+				.reply(200, interestedPartyCommentForReview);
 			nock('http://test')
 				.get('/appeals/representation-rejection-reasons?type=comment')
 				.reply(200, representationRejectionReasons);
@@ -198,7 +214,7 @@ describe('interested-party-comments', () => {
 		afterEach(teardown);
 		it('should render reject comment page', async () => {
 			const response = await request.get(
-				`${baseUrl}/2/interested-party-comments/5/reject/select-reason`
+				`${baseUrl}/2/interested-party-comments/${commentId}/reject/select-reason`
 			);
 
 			expect(response.statusCode).toBe(200);
@@ -212,7 +228,9 @@ describe('interested-party-comments', () => {
 
 	describe('GET /reject/allow-resubmit', () => {
 		beforeEach(() => {
-			nock('http://test/').get('/appeals/2/reps/5').reply(200, interestedPartyCommentForReview);
+			nock('http://test/')
+				.get(`/appeals/2/reps/${commentId}`)
+				.reply(200, interestedPartyCommentForReview);
 			nock('http://test/')
 				.post('/appeals/add-business-days')
 				.reply(200, JSON.stringify('2024-11-13T00:00:00.000Z'));
@@ -225,7 +243,7 @@ describe('interested-party-comments', () => {
 
 		it('should render allow resubmit page', async () => {
 			const response = await request.get(
-				`${baseUrl}/2/interested-party-comments/5/reject/allow-resubmit`
+				`${baseUrl}/2/interested-party-comments/${commentId}/reject/allow-resubmit`
 			);
 
 			expect(response.statusCode).toBe(200);
@@ -240,7 +258,9 @@ describe('interested-party-comments', () => {
 
 	describe('GET /reject/check-your-answers', () => {
 		beforeEach(() => {
-			nock('http://test/').get('/appeals/2/reps/5').reply(200, interestedPartyCommentForReview);
+			nock('http://test/')
+				.get(`/appeals/2/reps/${commentId}`)
+				.reply(200, interestedPartyCommentForReview);
 			nock('http://test')
 				.get('/appeals/representation-rejection-reasons?type=comment')
 				.reply(200, representationRejectionReasons);
@@ -253,7 +273,7 @@ describe('interested-party-comments', () => {
 
 		it('should render check your answers page', async () => {
 			const response = await request.get(
-				`${baseUrl}/2/interested-party-comments/5/reject/check-your-answers`
+				`${baseUrl}/2/interested-party-comments/${commentId}/reject/check-your-answers`
 			);
 
 			expect(response.statusCode).toBe(200);
@@ -268,7 +288,9 @@ describe('interested-party-comments', () => {
 
 	describe('GET /manage-documents/:folderId/', () => {
 		beforeEach(() => {
-			nock('http://test/').get('/appeals/2/reps/5').reply(200, interestedPartyCommentForReview);
+			nock('http://test/')
+				.get(`/appeals/2/reps/${commentId}`)
+				.reply(200, interestedPartyCommentForReview);
 
 			nock('http://test/')
 				.get('/appeals/2/document-folders/1')
@@ -286,7 +308,7 @@ describe('interested-party-comments', () => {
 			nock('http://test/').get('/appeals/2/document-folders/99').reply(404);
 
 			const response = await request.get(
-				`${baseUrl}/2/interested-party-comments/5/manage-documents/99`
+				`${baseUrl}/2/interested-party-comments/${commentId}/manage-documents/99`
 			);
 
 			expect(response.statusCode).toBe(404);
@@ -301,7 +323,7 @@ describe('interested-party-comments', () => {
 
 		it('should render manage folder page with the provided comment details', async () => {
 			const response = await request.get(
-				`${baseUrl}/2/interested-party-comments/5/manage-documents/1`
+				`${baseUrl}/2/interested-party-comments/${commentId}/manage-documents/1`
 			);
 
 			expect(response.statusCode).toBe(200);
@@ -335,7 +357,9 @@ describe('interested-party-comments', () => {
 				.get('/appeals/2/documents/1/versions')
 				.reply(200, documentFileVersionsInfo);
 
-			nock('http://test/').get('/appeals/2/reps/5').reply(200, interestedPartyCommentForReview);
+			nock('http://test/')
+				.get(`/appeals/2/reps/${commentId}`)
+				.reply(200, interestedPartyCommentForReview);
 
 			nock('http://test/')
 				.get('/appeals/2/document-folders/1')
@@ -362,7 +386,7 @@ describe('interested-party-comments', () => {
 			nock('http://test/').get('/appeals/2/document-folders/99').reply(404);
 
 			const response = await request.get(
-				`${baseUrl}/2/interested-party-comments/5/manage-documents/1/99`
+				`${baseUrl}/2/interested-party-comments/${commentId}/manage-documents/1/99`
 			);
 
 			expect(response.statusCode).toBe(404);
@@ -377,7 +401,7 @@ describe('interested-party-comments', () => {
 
 		it('should render manage document page with the provided comment details', async () => {
 			const response = await request.get(
-				`${baseUrl}/2/interested-party-comments/5/manage-documents/1/1`
+				`${baseUrl}/2/interested-party-comments/${commentId}/manage-documents/1/1`
 			);
 
 			expect(response.statusCode).toBe(200);
@@ -409,7 +433,9 @@ describe('interested-party-comments', () => {
 					appealStatus: 'statements'
 				});
 
-			nock('http://test/').get('/appeals/2/reps/5').reply(200, interestedPartyCommentForReview);
+			nock('http://test/')
+				.get(`/appeals/2/reps/${commentId}`)
+				.reply(200, interestedPartyCommentForReview);
 
 			nock('http://test/')
 				.get('/appeals/2/document-folders/1')
@@ -425,7 +451,7 @@ describe('interested-party-comments', () => {
 
 		it('should render change document page with the provided comment details', async () => {
 			const response = await request.get(
-				`${baseUrl}/2/interested-party-comments/5/change-document-name/1/1`
+				`${baseUrl}/2/interested-party-comments/${commentId}/change-document-name/1/1`
 			);
 
 			expect(response.statusCode).toBe(200);
@@ -455,7 +481,9 @@ describe('interested-party-comments', () => {
 				.get('/appeals/2/documents/1/versions')
 				.reply(200, documentFileVersionsInfo);
 
-			nock('http://test/').get('/appeals/2/reps/5').reply(200, interestedPartyCommentForReview);
+			nock('http://test/')
+				.get(`/appeals/2/reps/${commentId}`)
+				.reply(200, interestedPartyCommentForReview);
 
 			nock('http://test/')
 				.get('/appeals/2/document-folders/1')
@@ -480,7 +508,7 @@ describe('interested-party-comments', () => {
 
 		it('should render change document details page with the provided comment details', async () => {
 			const response = await request.get(
-				`${baseUrl}/2/interested-party-comments/5/change-document-details/1/1`
+				`${baseUrl}/2/interested-party-comments/${commentId}/change-document-details/1/1`
 			);
 
 			expect(response.statusCode).toBe(200);

--- a/appeals/web/src/server/appeals/appeal-details/representations/interested-party-comments/view-and-review/view-and-review.middleware.js
+++ b/appeals/web/src/server/appeals/appeal-details/representations/interested-party-comments/view-and-review/view-and-review.middleware.js
@@ -1,3 +1,14 @@
+import { getInterestedPartyComment } from '#appeals/appeal-details/representations/interested-party-comments/interested-party-comments.service.js';
+
+/** @type {import("express").Handler} */
+export const assureCurrentRepresentation = async (req, res, next) => {
+	const { appealId, commentId } = req.params;
+	if (req.currentRepresentation?.id !== parseInt(commentId)) {
+		req.currentRepresentation = await getInterestedPartyComment(req.apiClient, appealId, commentId);
+	}
+	next();
+};
+
 /** @type {import("express").Handler} */
 export const redirectIfCommentIsReviewed = (
 	{ currentAppeal, currentRepresentation },

--- a/appeals/web/src/server/appeals/appeal-details/representations/interested-party-comments/view-and-review/view-and-review.router.js
+++ b/appeals/web/src/server/appeals/appeal-details/representations/interested-party-comments/view-and-review/view-and-review.router.js
@@ -4,6 +4,7 @@ import * as controller from './view-and-review.controller.js';
 import rejectRouter from './reject/reject.router.js';
 import * as documentsValidators from '../../../../appeal-documents/appeal-documents.validators.js';
 import {
+	assureCurrentRepresentation,
 	redirectIfCommentIsReviewed,
 	redirectIfCommentIsUnreviewed
 } from './view-and-review.middleware.js';
@@ -17,6 +18,8 @@ import { validateAppeal } from '#appeals/appeal-details/appeal-details.middlewar
 import { validateStatus } from '#appeals/appeal-details/representations/common/validators.js';
 
 const router = createRouter({ mergeParams: true });
+
+router.use(assureCurrentRepresentation);
 
 router.use('/reject', rejectRouter);
 


### PR DESCRIPTION
## Describe your changes

WEB:
 - Add middleware to get correct ip comment if cached has a different comment id than in the link
 - Fixed unit tests.
 - Ran all unit tests successfully

## Issue ticket number and link
[Ticket: WEB -Reviewing an IP comment then reviewing the second shows you the content of the first comment (A2-2517)](https://pins-ds.atlassian.net/browse/A2-2517)
