### PR TITLE
fix(appeals): make sure the correct ip comment is reviewed (a2-2517)

### DIFF
--- a/appeals/web/src/server/appeals/appeal-details/representations/interested-party-comments/interested-party-comments.router.js
+++ b/appeals/web/src/server/appeals/appeal-details/representations/interested-party-comments/interested-party-comments.router.js
@@ -8,8 +8,6 @@ import viewAndReviewIpCommentRouter from './view-and-review/view-and-review.rout
 import redactIpCommentRouter from './redact/redact.router.js';
 import * as controller from './interested-party-comments.controller.js';
 import { validateComment } from './interested-party-comments.middleware.js';
-import { APPEAL_REPRESENTATION_TYPE } from '@pins/appeals/constants/common.js';
-import { withSingularRepresentation } from '../representations.middleware.js';
 
 const router = createRouter({ mergeParams: true });
 
@@ -21,13 +19,7 @@ router.use('/:commentId/edit', validateAppeal, validateComment, editIpCommentRou
 
 router.use('/:commentId/add-document', validateAppeal, validateComment, addDocumentRouter);
 
-router.use(
-	'/:commentId',
-	validateAppeal,
-	validateComment,
-	withSingularRepresentation(APPEAL_REPRESENTATION_TYPE.COMMENT),
-	viewAndReviewIpCommentRouter
-);
+router.use('/:commentId', validateAppeal, validateComment, viewAndReviewIpCommentRouter);
 
 router.route('/').get(validateAppeal, asyncHandler(controller.handleInterestedPartyComments));
 

--- a/appeals/web/src/server/appeals/appeal-details/representations/interested-party-comments/view-and-review/__tests__/__snapshots__/view-and-review.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/representations/interested-party-comments/view-and-review/__tests__/__snapshots__/view-and-review.test.js.snap
@@ -201,7 +201,7 @@ exports[`interested-party-comments GET /reject/check-your-answers should render 
                 </div>
                 <div class="govuk-summary-list__row govuk-summary-list__row--no-actions"><dt class="govuk-summary-list__key"> Comment</dt>
                     <dd class="govuk-summary-list__value">
-                        <div class="pins-show-more">Awaiting final comment</div>
+                        <div class="pins-show-more">Awaiting review comment 47</div>
                     </dd>
                 </div>
                 <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Review decision</dt>
@@ -338,7 +338,7 @@ exports[`interested-party-comments GET /review-comment with data should render r
                                         <dd class="govuk-summary-list__value">Lee Thornton</dd>
                                     </div>
                                     <div class="govuk-summary-list__row govuk-summary-list__row--no-actions"><dt class="govuk-summary-list__key"> Email</dt>
-                                        <dd class="govuk-summary-list__value">test1@example.com</dd>
+                                        <dd class="govuk-summary-list__value">Not provided</dd>
                                     </div>
                                     <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Address</dt>
                                         <dd class="govuk-summary-list__value">Not provided</dd>
@@ -349,7 +349,7 @@ exports[`interested-party-comments GET /review-comment with data should render r
                                         <dd                                         class="govuk-summary-list__value">9 October 2024</dd>
                                     </div>
                                     <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Comment</dt>
-                                        <dd class="govuk-summary-list__value">Awaiting final comment</dd>
+                                        <dd class="govuk-summary-list__value">Awaiting review comment 47</dd>
                                         <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/interested-party-comments/3670/redact"> Redact</a>
                                         </dd>
                                     </div>
@@ -428,7 +428,7 @@ exports[`interested-party-comments GET /review-comment with data should render r
                                         <dd                                         class="govuk-summary-list__value">9 October 2024</dd>
                                     </div>
                                     <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Comment</dt>
-                                        <dd class="govuk-summary-list__value">Awaiting final comment</dd>
+                                        <dd class="govuk-summary-list__value">Awaiting review comment 47</dd>
                                         <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/interested-party-comments/3670/redact"> Redact</a>
                                         </dd>
                                     </div>
@@ -505,7 +505,7 @@ exports[`interested-party-comments GET /view-comment with data should render vie
                     <dd                     class="govuk-summary-list__value">9 October 2024</dd>
                 </div>
                 <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Comment</dt>
-                    <dd class="govuk-summary-list__value">Awaiting review final comment</dd>
+                    <dd class="govuk-summary-list__value">Awaiting review comment 47</dd>
                     <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/interested-party-comments/3670/redact"> Redact</a>
                     </dd>
                 </div>


### PR DESCRIPTION
## Describe your changes

WEB:
 - Reverted a change made in [A2-1921](https://github.com/Planning-Inspectorate/appeals-back-office/pull/1022)
 - Fixed unit test snapshots.
 - Ran all unit tests successfully

## Issue ticket number and link
[Ticket: WEB -Reviewing an IP comment then reviewing the second shows you the content of the first comment (A2-2517)](https://pins-ds.atlassian.net/browse/A2-2517)


[A2-1921]: https://pins-ds.atlassian.net/browse/A2-1921?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ