### PR TITLE
feat(appeals): add a set up site visit due date in the personal list (a2-2525)

### DIFF
--- a/appeals/api/src/server/endpoints/appeals/__tests__/appeals.test.js
+++ b/appeals/api/src/server/endpoints/appeals/__tests__/appeals.test.js
@@ -1222,6 +1222,37 @@ describe('mapAppealToDueDate Tests', () => {
 		expect(dueDate).toEqual(mockAppeal.siteVisit.visitDate);
 	});
 
+	describe('handles STATE_TARGET_SITE_VISIT', () => {
+		let mockAppealWithTimetable = {};
+
+		beforeEach(() => {
+			mockAppealWithTimetable = {
+				...mockAppeal,
+				appealTimetable: {
+					id: 1262,
+					appealId: 523,
+					lpaQuestionnaireDueDate: new Date('2023-03-01T00:00:00.000Z')
+				}
+			};
+			mockAppealWithTimetable.appealStatus[0].status = APPEAL_CASE_STATUS.EVENT;
+		});
+
+		test('when final comments due date does not exist', () => {
+			// @ts-ignore
+			const dueDate = mapAppealToDueDate(mockAppealWithTimetable, '', null);
+			expect(dueDate).toEqual(mockAppealWithTimetable.appealTimetable.lpaQuestionnaireDueDate);
+		});
+
+		test('when final comments due date does exist', () => {
+			// @ts-ignore
+			mockAppealWithTimetable.appealTimetable.finalCommentsDueDate = new Date(
+				'2023-03-22T00:00:00.000Z'
+			);
+			const dueDate = mapAppealToDueDate(mockAppealWithTimetable, '', null);
+			expect(dueDate).toEqual(mockAppealWithTimetable.appealTimetable.finalCommentsDueDate);
+		});
+	});
+
 	test('handles STATE_TARGET_COMPLETE', () => {
 		mockAppeal.appealStatus[0].status = APPEAL_CASE_STATUS.COMPLETE;
 

--- a/appeals/api/src/server/endpoints/appeals/appeals.formatter.js
+++ b/appeals/api/src/server/endpoints/appeals/appeals.formatter.js
@@ -267,6 +267,12 @@ export const mapAppealToDueDate = (appeal, appellantCaseStatus, appellantCaseDue
 		case APPEAL_CASE_STATUS.AWAITING_EVENT: {
 			return new Date(appeal.siteVisit.visitDate);
 		}
+		case APPEAL_CASE_STATUS.EVENT: {
+			return new Date(
+				appeal.appealTimetable?.finalCommentsDueDate ||
+					appeal.appealTimetable?.lpaQuestionnaireDueDate
+			);
+		}
 		default: {
 			return undefined;
 		}


### PR DESCRIPTION
## Describe your changes
#### Add a Set up site visit due date in the personal list

#### API:
- Add case for appeal status EVENT within the appeals formatter
- Set the correct due date as required in the ACs

#### TESTS:
- Added unit tests for above
- All API unit tests pass
- Tested manually within the browser

## Issue ticket number and link
[Ticket: A2-2525](https://pins-ds.atlassian.net/browse/A2-2525)
