### PR TITLE
fix(web): a2-2535 use filtered list to display IP comment supporting …

### DIFF
--- a/appeals/web/src/server/appeals/appeal-details/representations/interested-party-comments/view-and-review/page-components/common.js
+++ b/appeals/web/src/server/appeals/appeal-details/representations/interested-party-comments/view-and-review/page-components/common.js
@@ -67,7 +67,7 @@ export function generateCommentSummaryList(
 	const attachmentsList =
 		filteredAttachments.length > 0
 			? buildHtmUnorderedList(
-					comment.attachments.map(
+					filteredAttachments.map(
 						(a) => `<a class="govuk-link" href="#">${a.documentVersion.document.name}</a>`
 					)
 			  )


### PR DESCRIPTION
…docs

## Describe your changes

Fixes bug so deleted items are *not* displayed on IP comment supporting docs list.

<!--
    Please include a summary of the change along with any relevant context.
    List any dependencies that are required for this change.
-->

## Issue ticket number and link
[Ticket](https://pins-ds.atlassian.net/browse/A2-2535)
