### PR TITLE
fix(web): A2-2451 Documentation Row - LPA Statement View CTA

### DIFF
--- a/appeals/web/src/server/lib/mappers/__tests__/mappers.test.js
+++ b/appeals/web/src/server/lib/mappers/__tests__/mappers.test.js
@@ -7,6 +7,8 @@ import { initialiseAndMapAppealData } from '../data/appeal/mapper.js';
 import { initialiseAndMapLPAQData } from '../data/lpa-questionnaire/mapper.js';
 import { areIdsDefinedAndUnique } from '#testing/lib/testMappers.js';
 import { mapPagination } from '../index.js';
+import { mapRepresentationDocumentSummaryActionLink } from '#lib/representation-utilities.js';
+import { APPEAL_REPRESENTATION_STATUS } from '@pins/appeals/constants/common.js';
 
 /** @typedef {import('../../../app/auth/auth-session.service').SessionWithAuth} SessionWithAuth */
 
@@ -134,6 +136,70 @@ describe('pagination mapper', () => {
 			expect(result.items?.[4]?.href).toEqual(
 				`${testBaseUrl}?pageSize=10&pageNumber=5${testAdditionalQueryString}`
 			);
+		});
+	});
+});
+
+describe('mapRepresentationDocumentSummaryActionLink', () => {
+	const baseRoute = '/appeals-service/appeal-details/4419';
+
+	describe('LPA Statement links', () => {
+		it('should return "Review" link for LPA statement when awaiting review', () => {
+			const link = mapRepresentationDocumentSummaryActionLink(
+				baseRoute,
+				'received',
+				APPEAL_REPRESENTATION_STATUS.AWAITING_REVIEW,
+				'lpa-statement'
+			);
+			expect(link).toBe(
+				`<a href="${baseRoute}/lpa-statement" data-cy="review-lpa-statement" class="govuk-link">Review<span class="govuk-visually-hidden"> LPA statement</span></a>`
+			);
+		});
+
+		it('should return "Review" link for LPA statement when incomplete', () => {
+			const link = mapRepresentationDocumentSummaryActionLink(
+				baseRoute,
+				'received',
+				APPEAL_REPRESENTATION_STATUS.INCOMPLETE,
+				'lpa-statement'
+			);
+			expect(link).toBe(
+				`<a href="${baseRoute}/lpa-statement" data-cy="review-lpa-statement" class="govuk-link">Review<span class="govuk-visually-hidden"> LPA statement</span></a>`
+			);
+		});
+
+		it('should return "View" link for LPA statement when valid', () => {
+			const link = mapRepresentationDocumentSummaryActionLink(
+				baseRoute,
+				'received',
+				APPEAL_REPRESENTATION_STATUS.VALID,
+				'lpa-statement'
+			);
+			expect(link).toBe(
+				`<a href="${baseRoute}/lpa-statement" data-cy="view-lpa-statement" class="govuk-link">View<span class="govuk-visually-hidden"> LPA statement</span></a>`
+			);
+		});
+
+		it('should return "View" link for LPA statement when published', () => {
+			const link = mapRepresentationDocumentSummaryActionLink(
+				baseRoute,
+				'received',
+				APPEAL_REPRESENTATION_STATUS.PUBLISHED,
+				'lpa-statement'
+			);
+			expect(link).toBe(
+				`<a href="${baseRoute}/lpa-statement" data-cy="view-lpa-statement" class="govuk-link">View<span class="govuk-visually-hidden"> LPA statement</span></a>`
+			);
+		});
+
+		it('should return an empty string when LPA statement is not received', () => {
+			const link = mapRepresentationDocumentSummaryActionLink(
+				baseRoute,
+				'not_received',
+				null,
+				'lpa-statement'
+			);
+			expect(link).toBe('');
 		});
 	});
 });

--- a/appeals/web/src/server/lib/mappers/data/appeal/submappers/lpa-statement.mapper.js
+++ b/appeals/web/src/server/lib/mappers/data/appeal/submappers/lpa-statement.mapper.js
@@ -1,7 +1,9 @@
-import { dateISOStringToDisplayDate } from '#lib/dates.js';
-import { mapRepresentationDocumentSummaryStatus } from '#lib/representation-utilities.js';
 import { documentationFolderTableItem } from '#lib/mappers/index.js';
-import { APPEAL_REPRESENTATION_STATUS } from '@pins/appeals/constants/common.js';
+import { dateISOStringToDisplayDate } from '#lib/dates.js';
+import {
+	mapRepresentationDocumentSummaryStatus,
+	mapRepresentationDocumentSummaryActionLink
+} from '#lib/representation-utilities.js';
 
 /** @type {import('../mapper.js').SubMapper} */
 export const mapLpaStatement = ({ appealDetails, currentRoute }) =>
@@ -17,10 +19,10 @@ export const mapLpaStatement = ({ appealDetails, currentRoute }) =>
 				? appealDetails?.documentationSummary?.lpaStatement?.receivedAt.toDateString()
 				: appealDetails?.documentationSummary?.lpaStatement?.receivedAt
 		),
-		actionHtml: [
-			APPEAL_REPRESENTATION_STATUS.AWAITING_REVIEW,
-			APPEAL_REPRESENTATION_STATUS.INCOMPLETE
-		].includes(appealDetails?.documentationSummary?.lpaStatement?.representationStatus ?? '')
-			? `<a href="${currentRoute}/lpa-statement" data-cy="review-lpa-statement" class="govuk-link">Review<span class="govuk-visually-hidden">LPA statement</span></a>`
-			: `<a href="${currentRoute}/lpa-statement" data-cy="view-lpa-statement" class="govuk-link">View<span class="govuk-visually-hidden">LPA statement</span></a>`
+		actionHtml: mapRepresentationDocumentSummaryActionLink(
+			currentRoute,
+			appealDetails?.documentationSummary?.lpaStatement?.status,
+			appealDetails?.documentationSummary?.lpaStatement?.representationStatus,
+			'lpa-statement'
+		)
 	});

--- a/appeals/web/src/server/lib/representation-utilities.js
+++ b/appeals/web/src/server/lib/representation-utilities.js
@@ -11,7 +11,7 @@ export function isRepresentationReviewRequired(representationStatus) {
  * @param {string} currentRoute
  * @param {string|undefined} documentationStatus
  * @param {string|null|undefined} representationStatus
- * @param {'appellant'|'lpa'} finalCommentsType
+ * @param {'appellant'|'lpa'|'lpa-statement'} finalCommentsType
  * @returns {string} action link html
  */
 export function mapRepresentationDocumentSummaryActionLink(
@@ -21,7 +21,17 @@ export function mapRepresentationDocumentSummaryActionLink(
 	finalCommentsType
 ) {
 	if (documentationStatus === 'received' && representationStatus) {
-		const reviewRequired = isRepresentationReviewRequired(representationStatus);
+		const reviewRequired =
+			representationStatus === APPEAL_REPRESENTATION_STATUS.AWAITING_REVIEW ||
+			representationStatus === APPEAL_REPRESENTATION_STATUS.INCOMPLETE;
+
+		if (finalCommentsType === 'lpa-statement') {
+			return `<a href="${currentRoute}/lpa-statement" data-cy="${
+				reviewRequired ? 'review' : 'view'
+			}-lpa-statement" class="govuk-link">${
+				reviewRequired ? 'Review' : 'View'
+			}<span class="govuk-visually-hidden"> LPA statement</span></a>`;
+		}
 
 		return `<a href="${currentRoute}/final-comments/${finalCommentsType}" data-cy="${
 			reviewRequired ? 'review' : 'view'


### PR DESCRIPTION
## Describe your changes

Refactored mapLpaStatement to use the generic method for consistency. Updated mapRepresentationDocumentSummaryActionLink to correctly handle lpa-statement links.

## Issue ticket number and link
[A2-2451](https://pins-ds.atlassian.net/browse/A2-2451)



[A2-2451]: https://pins-ds.atlassian.net/browse/A2-2451?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ