### PR TITLE
fix(appeals): broken ip comments review when address is missing (a2-2534)

### DIFF
--- a/appeals/web/src/server/appeals/appeal-details/representations/interested-party-comments/view-and-review/page-components/__tests__/__snapshots__/common.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/representations/interested-party-comments/view-and-review/page-components/__tests__/__snapshots__/common.test.js.snap
@@ -1,0 +1,205 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`generateCommentSummaryList should return the comment summary list including data 1`] = `
+{
+  "parameters": {
+    "rows": [
+      {
+        "key": {
+          "text": "Interested party",
+        },
+        "value": {
+          "text": "John Doe",
+        },
+      },
+      {
+        "key": {
+          "text": "Email",
+        },
+        "value": {
+          "text": "john.dow@example.com",
+        },
+      },
+      {
+        "actions": {
+          "items": [
+            {
+              "href": "/appeals-service/appeal-details/5/interested-party-comments/undefined/edit/address?review=undefined&editAddress=true",
+              "text": "Change",
+              "visuallyHiddenText": "address",
+            },
+          ],
+        },
+        "key": {
+          "text": "Address",
+        },
+        "value": {
+          "html": "123 Random street, </br>SW1A 1AA",
+        },
+      },
+      {
+        "actions": {
+          "items": [
+            {
+              "href": "/appeals-service/appeal-details/5/interested-party-comments/undefined/edit/site-visit-requested",
+              "text": "Change",
+              "visuallyHiddenText": "site visited requested",
+            },
+          ],
+        },
+        "key": {
+          "text": "Site visit requested",
+        },
+        "value": {
+          "text": "Yes",
+        },
+      },
+      {
+        "key": {
+          "text": "When did the interested party submit the comment?",
+        },
+        "value": {
+          "html": "",
+        },
+      },
+      {
+        "actions": {
+          "items": [
+            {
+              "href": "/appeals-service/appeal-details/5/interested-party-comments/undefined/redact",
+              "text": "Redact",
+            },
+          ],
+        },
+        "key": {
+          "text": "Comment",
+        },
+        "value": {
+          "text": "Test comment",
+        },
+      },
+      {
+        "actions": {
+          "items": [
+            {
+              "href": "/appeals-service/appeal-details/5/interested-party-comments/undefined/add-document",
+              "text": "Add",
+              "visuallyHiddenText": "supporting documents",
+            },
+          ],
+        },
+        "key": {
+          "text": "Supporting documents",
+        },
+        "value": {
+          "text": "Not provided",
+        },
+      },
+    ],
+  },
+  "type": "summary-list",
+  "wrapperHtml": {
+    "closing": "</div></div>",
+    "opening": "<div class="govuk-grid-row"><div class="govuk-grid-column-full">",
+  },
+}
+`;
+
+exports[`generateCommentSummaryList should return the default comment summary list 1`] = `
+{
+  "parameters": {
+    "rows": [
+      {
+        "key": {
+          "text": "Interested party",
+        },
+        "value": {
+          "text": "Not provided",
+        },
+      },
+      {
+        "key": {
+          "text": "Email",
+        },
+        "value": {
+          "text": "Not provided",
+        },
+      },
+      {
+        "actions": {
+          "items": [
+            {
+              "href": "/appeals-service/appeal-details/5/interested-party-comments/undefined/edit/address?review=undefined&editAddress=false",
+              "text": "Add",
+              "visuallyHiddenText": "address",
+            },
+          ],
+        },
+        "key": {
+          "text": "Address",
+        },
+        "value": {
+          "text": "Not provided",
+        },
+      },
+      {
+        "actions": {
+          "items": [],
+        },
+        "key": {
+          "text": "Site visit requested",
+        },
+        "value": {
+          "text": "No",
+        },
+      },
+      {
+        "key": {
+          "text": "When did the interested party submit the comment?",
+        },
+        "value": {
+          "html": "",
+        },
+      },
+      {
+        "actions": {
+          "items": [
+            {
+              "href": "/appeals-service/appeal-details/5/interested-party-comments/undefined/redact",
+              "text": "Redact",
+            },
+          ],
+        },
+        "key": {
+          "text": "Comment",
+        },
+        "value": {
+          "text": undefined,
+        },
+      },
+      {
+        "actions": {
+          "items": [
+            {
+              "href": "/appeals-service/appeal-details/5/interested-party-comments/undefined/add-document",
+              "text": "Add",
+              "visuallyHiddenText": "supporting documents",
+            },
+          ],
+        },
+        "key": {
+          "text": "Supporting documents",
+        },
+        "value": {
+          "text": "Not provided",
+        },
+      },
+    ],
+  },
+  "type": "summary-list",
+  "wrapperHtml": {
+    "closing": "</div></div>",
+    "opening": "<div class="govuk-grid-row"><div class="govuk-grid-column-full">",
+  },
+}
+`;

--- a/appeals/web/src/server/appeals/appeal-details/representations/interested-party-comments/view-and-review/page-components/__tests__/common.test.js
+++ b/appeals/web/src/server/appeals/appeal-details/representations/interested-party-comments/view-and-review/page-components/__tests__/common.test.js
@@ -1,0 +1,37 @@
+import { generateCommentSummaryList } from '#appeals/appeal-details/representations/interested-party-comments/view-and-review/page-components/common.js';
+
+describe('generateCommentSummaryList', () => {
+	it('should return the default comment summary list', () => {
+		const appealId = 5;
+		const comment = {};
+		const filter = {};
+		// @ts-ignore
+		const result = generateCommentSummaryList(appealId, comment, filter);
+		expect(result.parameters.rows[0].value.text).toContain('Not provided');
+		expect(result.parameters.rows[1].value.text).toContain('Not provided');
+		expect(result).toMatchSnapshot();
+	});
+
+	it('should return the comment summary list including data', () => {
+		const appealId = 5;
+		const comment = {
+			represented: {
+				address: {
+					addressLine1: '123 Random street',
+					postCode: 'SW1A 1AA'
+				},
+				name: 'John Doe',
+				email: 'john.dow@example.com'
+			},
+			siteVisitRequested: true,
+			whenSubmitted: '2021-01-01T00:00:00.000Z',
+			originalRepresentation: 'Test comment'
+		};
+		const filter = {};
+		// @ts-ignore
+		const result = generateCommentSummaryList(appealId, comment, filter);
+		expect(result.parameters.rows[0].value.text).toContain('John Doe');
+		expect(result.parameters.rows[1].value.text).toContain('john.dow@example.com');
+		expect(result).toMatchSnapshot();
+	});
+});

--- a/appeals/web/src/server/appeals/appeal-details/representations/interested-party-comments/view-and-review/page-components/common.js
+++ b/appeals/web/src/server/appeals/appeal-details/representations/interested-party-comments/view-and-review/page-components/common.js
@@ -52,40 +52,39 @@ export function generateCommentSummaryList(
 	comment,
 	{ isReviewPage } = { isReviewPage: false }
 ) {
-	const hasAddress =
-		comment.represented.address &&
-		comment.represented.address.addressLine1 &&
-		comment.represented.address.postCode;
+	const { addressLine1, postCode } = comment.represented?.address ?? {};
+	const hasAddress = addressLine1 && postCode;
 
-	const commentIsDocument = !comment.originalRepresentation && comment.attachments?.length > 0;
+	const commentIsDocument = !comment.originalRepresentation && comment.attachments?.length;
 	const folderId = comment.attachments?.[0]?.documentVersion?.document?.folderId ?? null;
 
-	const filteredAttachments = comment.attachments.filter(
+	const filteredAttachments = comment.attachments?.filter(
 		(attachment) => !attachment.documentVersion.document.isDeleted
 	);
 
-	const attachmentsList =
-		filteredAttachments.length > 0
-			? buildHtmUnorderedList(
-					filteredAttachments.map(
-						(a) => `<a class="govuk-link" href="#">${a.documentVersion.document.name}</a>`
-					)
-			  )
-			: null;
+	const attachmentsList = filteredAttachments?.length
+		? buildHtmUnorderedList(
+				filteredAttachments.map(
+					(a) => `<a class="govuk-link" href="#">${a.documentVersion.document.name}</a>`
+				)
+		  )
+		: null;
+
+	const { address, name, email } = comment.represented || {};
 
 	const rows = [
 		{
 			key: { text: 'Interested party' },
-			value: { text: comment.represented.name }
+			value: { text: name || 'Not provided' }
 		},
 		{
 			key: { text: 'Email' },
-			value: { text: comment.represented.email || 'Not provided' }
+			value: { text: email || 'Not provided' }
 		},
 		{
 			key: { text: 'Address' },
 			value: hasAddress
-				? { html: addressToMultilineStringHtml(comment.represented.address) }
+				? { html: addressToMultilineStringHtml(address) }
 				: { text: 'Not provided' },
 			actions: {
 				items: [
@@ -146,7 +145,7 @@ export function generateCommentSummaryList(
 			value: attachmentsList ? { html: attachmentsList } : { text: 'Not provided' },
 			actions: {
 				items: [
-					...(filteredAttachments.length > 0
+					...(filteredAttachments?.length
 						? [
 								{
 									text: 'Manage',


### PR DESCRIPTION
## Describe your changes
#### Fix IP-comments review when address is missing (a2-2534)

#### WEB:
- Updated generateCommentSummaryList function so that it is less likely to crash
- Added unit tests for above

#### TEST:
- All unit tests pass
- Snapshots added/updated
- Tested within browser

## Issue ticket number and link
[Ticket: Broken IP-comments review when address is missing (A2-2534)](https://pins-ds.atlassian.net.mcas.ms/browse/A2-2534)
