### PR TITLE
fix(api): A2-2546 Prevent RepAttachment from Being Removed During Spec Generation

### DIFF
--- a/appeals/api/src/server/endpoints/representations/representations.formatter.js
+++ b/appeals/api/src/server/endpoints/representations/representations.formatter.js
@@ -5,7 +5,7 @@ import { formatName } from '#utils/format-name.js';
 /** @typedef {import('@pins/appeals.api').Schema.Representation} Representation */
 /** @typedef {import('@pins/appeals.api').Schema.RepresentationAttachment} RepresentationAttachment */
 /** @typedef {import('@pins/appeals.api').Api.RepResponse} FormattedRep */
-/** @typedef {import('@pins/appeals.api').Api.RepAttachment} FormattedRepAttachment */
+/** @typedef {import('pins-data-model').Schemas.AppealRepresentationSubmission['documents'][number]} RepAttachment */
 
 /**
  *
@@ -70,7 +70,7 @@ const formatRepresentationSource = (rep) => {
 /**
  *
  * @param {RepresentationAttachment} attachment
- * @returns {FormattedRepAttachment}
+ * @returns {RepAttachment}
  */
 const formatAttachment = (attachment) => {
 	const { documentGuid, version, representationId, documentVersion } = attachment;

--- a/appeals/api/src/server/openapi-types.ts
+++ b/appeals/api/src/server/openapi-types.ts
@@ -81,7 +81,7 @@ export interface RepResponse {
 	/** @example "" */
 	notes?: string;
 	/** @example [] */
-	attachments?: RepAttachment[];
+	attachments?: any[];
 	/** @example "comment" */
 	representationType?: string;
 	/** @example false */
@@ -122,22 +122,6 @@ export interface RepResponse {
 		/** @example ["Illegible or Incomplete Documentation","Previously Decided or Duplicate Appeal"] */
 		text?: string[];
 	}[];
-}
-export interface RepAttachment {
-	documentGuid: string;
-	version: number;
-	representationId: number;
-	documentVersion?: {
-		documentGuid: string;
-		version: number;
-		documentType?: string;
-		originalFilename?: string;
-		fileName?: string;
-		mime?: string;
-		size?: number;
-		blobStoragePath?: string;
-		documentURI?: string;
-	};
 }
 
 export interface ValidateDate {


### PR DESCRIPTION
## Describe your changes

Refactored to use existing RepAttachment typedef from pins-data-model.

## Issue ticket number and link
[A2-2546](https://pins-ds.atlassian.net/browse/A2-2546)