### PR TITLE
fix(appeals): upload success banner showing in the wrong page of the service (a2-2537)

### DIFF
--- a/appeals/web/src/server/appeals/appeal-details/environmental-assessment/__tests__/__snapshots__/environmental-assessment.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/environmental-assessment/__tests__/__snapshots__/environmental-assessment.test.js.snap
@@ -1,0 +1,13 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`environmental-assessment POST /environmental-assessment/upload-documents/:folderId should eventually redirect to case details page displaying the success banner 1`] = `
+"<div class="govuk-notification-banner govuk-notification-banner--success govuk-!-margin-bottom-5"
+role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
+    <div class="govuk-notification-banner__header">
+        <h3 class="govuk-notification-banner__title" id="govuk-notification-banner-title"> Success</h3>
+    </div>
+    <div class="govuk-notification-banner__content">
+        <p class="govuk-notification-banner__heading">Environmental assessment documents uploaded</p>
+    </div>
+</div>"
+`;

--- a/appeals/web/src/server/appeals/appeal-details/environmental-assessment/__tests__/environmental-assessment.test.js
+++ b/appeals/web/src/server/appeals/appeal-details/environmental-assessment/__tests__/environmental-assessment.test.js
@@ -1,0 +1,79 @@
+// @ts-nocheck
+import supertest from 'supertest';
+import { createTestEnvironment } from '#testing/index.js';
+import {
+	activeDirectoryUsersData,
+	appealData,
+	fileUploadInfo
+} from '#testing/app/fixtures/referencedata.js';
+import { parseHtml } from '@pins/platform';
+import nock from 'nock';
+import { folderInfoResponse } from '@pins/appeals.api/src/server/tests/documents/mocks.js';
+import usersService from '#appeals/appeal-users/users-service.js';
+import { jest } from '@jest/globals';
+
+const { app, installMockApi, teardown } = createTestEnvironment();
+const request = supertest(app);
+const baseUrl = '/appeals-service/appeal-details';
+const appealId = appealData.appealId.toString();
+const folderId = folderInfoResponse.folderId;
+
+describe('environmental-assessment', () => {
+	beforeEach(() => {
+		installMockApi();
+		// @ts-ignore
+		usersService.getUsersByRole = jest.fn().mockResolvedValue(activeDirectoryUsersData);
+		// @ts-ignore
+		usersService.getUserById = jest.fn().mockResolvedValue(activeDirectoryUsersData[0]);
+		// @ts-ignore
+		usersService.getUserByRoleAndId = jest.fn().mockResolvedValue(activeDirectoryUsersData[0]);
+		nock('http://test/').get(`/appeals/${appealId}`).reply(200, appealData).persist();
+		nock('http://test/').post(`/appeals/${appealId}/documents`).reply(200, {}).persist();
+		nock('http://test/')
+			.get(`/appeals/${appealId}/document-folders/${folderId}`)
+			.reply(200, folderInfoResponse)
+			.persist();
+		nock('http://test/')
+			.get('/appeals/document-redaction-statuses')
+			.reply(200, [{ key: 'no_redaction_required', id: 10 }])
+			.persist();
+	});
+
+	afterEach(() => {
+		teardown();
+	});
+
+	describe('POST /environmental-assessment/upload-documents/:folderId', () => {
+		it(`should eventually redirect to case details page displaying the success banner`, async () => {
+			const addDocumentsResponse = await request
+				.post(`${baseUrl}/${appealId}/environmental-assessment/upload-documents/${folderId}`)
+				.send({
+					'upload-info': fileUploadInfo
+				});
+
+			expect(addDocumentsResponse.statusCode).toBe(302);
+
+			expect(addDocumentsResponse.text).toBe(
+				`Found. Redirecting to ${baseUrl}/${appealId}/environmental-assessment/check-your-answers/${folderId}`
+			);
+
+			const checkYourAnswersResponse = await request
+				.post(`${baseUrl}/${appealId}/environmental-assessment/check-your-answers/${folderId}`)
+				.send({});
+
+			expect(checkYourAnswersResponse.statusCode).toBe(302);
+			expect(checkYourAnswersResponse.text).toBe(`Found. Redirecting to ${baseUrl}/${appealId}`);
+
+			const caseDetailsResponse = await request.get(`${baseUrl}/${appealId}`);
+
+			expect(caseDetailsResponse.statusCode).toBe(200);
+
+			const element = parseHtml(caseDetailsResponse.text, {
+				rootElement: '.govuk-notification-banner'
+			});
+			expect(element.innerHTML).toMatchSnapshot();
+			expect(element.innerHTML).toContain('Success</h3>');
+			expect(element.innerHTML).toContain('Environmental assessment documents uploaded</p>');
+		});
+	});
+});

--- a/appeals/web/src/server/lib/mappers/components/page-components/__tests__/notification-banners.mapper.test.js
+++ b/appeals/web/src/server/lib/mappers/components/page-components/__tests__/notification-banners.mapper.test.js
@@ -69,7 +69,7 @@ describe('buildNotificationBanners', () => {
 			]
 		};
 
-		const result = mapNotificationBannersFromSession(session, 'appealDetails', appealId);
+		const result = mapNotificationBannersFromSession(session, 'manageNeighbouringSites', appealId);
 		expect(result).toEqual([]);
 	});
 

--- a/appeals/web/src/server/lib/mappers/components/page-components/notification-banners.mapper.js
+++ b/appeals/web/src/server/lib/mappers/components/page-components/notification-banners.mapper.js
@@ -68,7 +68,13 @@ export const notificationBannerDefinitions = {
 	},
 	documentAdded: {
 		type: 'success',
-		pages: ['appellantCase', 'lpaQuestionnaire', 'manageDocuments', 'viewFinalComments'],
+		pages: [
+			'appealDetails',
+			'appellantCase',
+			'lpaQuestionnaire',
+			'manageDocuments',
+			'viewFinalComments'
+		],
 		text: 'Document added'
 	},
 	documentVersionAdded: {


### PR DESCRIPTION
## Describe your changes
#### Upload environmental assessment success banner should appear in the case details page (a2-2537)

#### WEB:
- Add the 'appealDetails' page to the list of pages the 'documentAdded' banner can display on
- Amended unit tests for above
- Added a unit test to test the success banner appears when it should

#### TEST:
- All unit tests pass
- Snapshots added/updated
- Tested within browser

## Issue ticket number and link
[Ticket: Doc upload success banner showing in the wrong page of the service (A2-2537)](https://pins-ds.atlassian.net.mcas.ms/browse/A2-2537)
