### PR TITLE
Dynamic Back Button and Redirect URL Functionality

### DIFF
--- a/appeals/web/src/server/appeals/appeal-details/representations/__tests__/__snapshots__/representations.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/representations/__tests__/__snapshots__/representations.test.js.snap
@@ -9,7 +9,7 @@ exports[`representations GET /share should contain link to interested-party-comm
     </div>
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">
-            <div class="govuk-inset-text">We’ll share the <a href="/appeals-service/appeal-details/1/interested-party-comments#valid"
+            <div class="govuk-inset-text">We’ll share the <a href="/appeals-service/appeal-details/1/interested-party-comments?backUrl=/share#valid"
                 class="govuk-link">1 interested party comments</a> with the relevant parties.</div>
             <div             class="govuk-warning-text"><span class="govuk-warning-text__icon" aria-hidden="true">!</span>
                 <strong                 class="govuk-warning-text__text"><span class="govuk-warning-text__assistive">Warning</span> Do not confirm

--- a/appeals/web/src/server/appeals/appeal-details/representations/__tests__/representations.test.js
+++ b/appeals/web/src/server/appeals/appeal-details/representations/__tests__/representations.test.js
@@ -44,7 +44,7 @@ describe('representations', () => {
 			expect(element.innerHTML).toMatchSnapshot();
 			expect(element.innerHTML).toContain('Share IP comments and statements</h1>');
 			expect(element.innerHTML).toContain(
-				`<a href="/appeals-service/appeal-details/1/interested-party-comments#valid"`
+				`<a href="/appeals-service/appeal-details/1/interested-party-comments?backUrl=/share#valid"`
 			);
 		});
 	});

--- a/appeals/web/src/server/appeals/appeal-details/representations/final-comments/view-and-review/view-and-review.controller.js
+++ b/appeals/web/src/server/appeals/appeal-details/representations/final-comments/view-and-review/view-and-review.controller.js
@@ -7,12 +7,13 @@ import { reviewFinalCommentsPage } from './view-and-review.mapper.js';
 
 /**
  *
- * @param {(appealDetails: Appeal, finalCommentsType: string, comments: Representation, session: import('express-session').Session & Record<string, string>) => PageContent} contentMapper
+ * @param {(appealDetails: Appeal, finalCommentsType: string, comments: Representation, session: import('express-session').Session & Record<string, string>, backUrl: string) => PageContent} contentMapper
  * @param {string} templatePath
  * @returns {import('@pins/express').RenderHandler<any, any, any>}
  */
 export const render = (contentMapper, templatePath) => (request, response) => {
-	const { errors, currentRepresentation, currentAppeal, session } = request;
+	const { errors, currentRepresentation, currentAppeal, session, query } = request;
+	const backUrl = query.backUrl ? String(query.backUrl) : '/';
 
 	let { finalCommentsType } = request.params;
 
@@ -28,7 +29,8 @@ export const render = (contentMapper, templatePath) => (request, response) => {
 		currentAppeal,
 		finalCommentsType,
 		currentRepresentation,
-		session
+		session,
+		backUrl
 	);
 
 	return response.status(200).render(templatePath, {

--- a/appeals/web/src/server/appeals/appeal-details/representations/final-comments/view-and-review/view-and-review.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/representations/final-comments/view-and-review/view-and-review.mapper.js
@@ -4,6 +4,7 @@ import { generateCommentsSummaryList } from './page-components/common.js';
 import { mapNotificationBannersFromSession } from '#lib/mappers/index.js';
 import { isRepresentationReviewRequired } from '#lib/representation-utilities.js';
 import { capitalizeFirstLetter } from '#lib/string-utilities.js';
+import { constructUrl } from '#lib/mappers/utils/url.mapper.js';
 
 /** @typedef {import("#appeals/appeal-details/appeal-details.types.js").WebAppeal} Appeal */
 /** @typedef {import('#appeals/appeal-details/representations/types.js').Representation} Representation */
@@ -13,9 +14,16 @@ import { capitalizeFirstLetter } from '#lib/string-utilities.js';
  * @param {string} finalCommentsType
  * @param {Representation} comment
  * @param {import('@pins/express').Session} session
+ * @param {string | undefined} backUrl
  * @returns {PageContent}
  */
-export function reviewFinalCommentsPage(appealDetails, finalCommentsType, comment, session) {
+export function reviewFinalCommentsPage(
+	appealDetails,
+	finalCommentsType,
+	comment,
+	session,
+	backUrl
+) {
 	const shortReference = appealShortReference(appealDetails.appealReference);
 	const commentSummaryList = generateCommentsSummaryList(appealDetails.appealId, comment);
 
@@ -25,6 +33,8 @@ export function reviewFinalCommentsPage(appealDetails, finalCommentsType, commen
 		appealDetails.appealId
 	);
 
+	const backLinkUrl = constructUrl(backUrl, appealDetails.appealId);
+
 	const reviewRequired = isRepresentationReviewRequired(comment.status);
 
 	const title = reviewRequired
@@ -33,7 +43,7 @@ export function reviewFinalCommentsPage(appealDetails, finalCommentsType, commen
 
 	const pageContent = {
 		title,
-		backLinkUrl: `/appeals-service/appeal-details/${appealDetails.appealId}`,
+		backLinkUrl,
 		preHeading: `Appeal ${shortReference}`,
 		heading: title,
 		submitButtonText: 'Continue',

--- a/appeals/web/src/server/appeals/appeal-details/representations/interested-party-comments/interested-party-comments.controller.js
+++ b/appeals/web/src/server/appeals/appeal-details/representations/interested-party-comments/interested-party-comments.controller.js
@@ -20,7 +20,7 @@ export const handleInterestedPartyComments = (request, response) =>
  * @param {import('@pins/express/types/express.js').RenderedResponse<any, any, Number>} response
  */
 export async function renderInterestedPartyComments(request, response) {
-	const { errors, currentAppeal, session } = request;
+	const { errors, currentAppeal, session, query } = request;
 	const paginationParameters = {
 		pageNumber: 1,
 		pageSize: 1000
@@ -54,12 +54,15 @@ export async function renderInterestedPartyComments(request, response) {
 		)
 	]);
 
+	const backUrl = query.backUrl ? String(query.backUrl) : '/';
+
 	const mappedPageContent = await interestedPartyCommentsPage(
 		currentAppeal,
 		awaitingReviewComments,
 		validComments,
 		invalidComments,
-		session
+		session,
+		backUrl
 	);
 
 	return response.status(200).render('appeals/appeal/interested-party-comments.njk', {

--- a/appeals/web/src/server/appeals/appeal-details/representations/interested-party-comments/interested-party-comments.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/representations/interested-party-comments/interested-party-comments.mapper.js
@@ -4,6 +4,7 @@ import { dateISOStringToDisplayDate } from '#lib/dates.js';
 import { mapNotificationBannersFromSession } from '#lib/mappers/index.js';
 import { addressInputs } from '#lib/mappers/index.js';
 import { simpleHtmlComponent } from '#lib/mappers/index.js';
+import { constructUrl } from '#lib/mappers/utils/url.mapper.js';
 import { preRenderPageComponents } from '#lib/nunjucks-template-builders/page-component-rendering.js';
 import { buildHtmUnorderedList } from '#lib/nunjucks-template-builders/tag-builders.js';
 
@@ -20,6 +21,7 @@ import { buildHtmUnorderedList } from '#lib/nunjucks-template-builders/tag-build
  * @param {RepresentationList} valid
  * @param {RepresentationList} invalid
  * @param {import('@pins/express').Session} session
+ * @param {string | undefined} backUrl
  * @returns {Promise<PageContent>}
  */
 export async function interestedPartyCommentsPage(
@@ -27,9 +29,12 @@ export async function interestedPartyCommentsPage(
 	awaitingReview,
 	valid,
 	invalid,
-	session
+	session,
+	backUrl
 ) {
 	const shortReference = appealShortReference(appealDetails.appealReference);
+
+	const backLinkUrl = constructUrl(backUrl, appealDetails.appealId);
 
 	const notificationBanners = mapNotificationBannersFromSession(
 		session,
@@ -39,7 +44,7 @@ export async function interestedPartyCommentsPage(
 
 	const pageContent = {
 		title: 'Interested party comments',
-		backLinkUrl: `/appeals-service/appeal-details/${appealDetails.appealId}`,
+		backLinkUrl,
 		addCommentUrl: `/appeals-service/appeal-details/${appealDetails.appealId}/interested-party-comments/add`,
 		preHeading: `Appeal ${shortReference}`,
 		heading: 'Interested party comments',

--- a/appeals/web/src/server/appeals/appeal-details/representations/lpa-statement/lpa-statement.controller.js
+++ b/appeals/web/src/server/appeals/appeal-details/representations/lpa-statement/lpa-statement.controller.js
@@ -6,7 +6,9 @@ import { reviewLpaStatementPage, viewLpaStatementPage } from './lpa-statement.ma
  * @param {import('@pins/express/types/express.js').RenderedResponse<any, any, Number>} response
  */
 export const renderReviewLpaStatement = async (request, response) => {
-	const { errors, currentAppeal, currentRepresentation, session } = request;
+	const { errors, currentAppeal, currentRepresentation, session, query } = request;
+
+	const backUrl = query.backUrl ? String(query.backUrl) : '/';
 
 	const isReview = [
 		APPEAL_REPRESENTATION_STATUS.AWAITING_REVIEW,
@@ -16,7 +18,8 @@ export const renderReviewLpaStatement = async (request, response) => {
 	const pageContent = (isReview ? reviewLpaStatementPage : viewLpaStatementPage)(
 		currentAppeal,
 		currentRepresentation,
-		session
+		session,
+		backUrl
 	);
 
 	return response

--- a/appeals/web/src/server/appeals/appeal-details/representations/lpa-statement/lpa-statement.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/representations/lpa-statement/lpa-statement.mapper.js
@@ -3,6 +3,7 @@ import { preRenderPageComponents } from '#lib/nunjucks-template-builders/page-co
 import { buildHtmUnorderedList } from '#lib/nunjucks-template-builders/tag-builders.js';
 import { mapNotificationBannersFromSession } from '#lib/mappers/index.js';
 import { COMMENT_STATUS } from '@pins/appeals/constants/common.js';
+import { constructUrl } from '#lib/mappers/utils/url.mapper.js';
 
 /** @typedef {import("#appeals/appeal-details/appeal-details.types.js").WebAppeal} Appeal */
 /** @typedef {import('#appeals/appeal-details/representations/types.js').Representation} Representation */
@@ -96,10 +97,13 @@ export function baseSummaryList(appealId, lpaStatement, { isReview }) {
  * @param {Appeal} appealDetails
  * @param {Representation} lpaStatement
  * @param {import('express-session').Session & Partial<import('express-session').SessionData>} session
+ * @param {string | undefined} backUrl
  * @returns {PageContent}
  * */
-export function viewLpaStatementPage(appealDetails, lpaStatement, session) {
+export function viewLpaStatementPage(appealDetails, lpaStatement, session, backUrl) {
 	const shortReference = appealShortReference(appealDetails.appealReference);
+
+	const backLinkUrl = constructUrl(backUrl, appealDetails.appealId);
 
 	const lpaStatementSummaryList = baseSummaryList(appealDetails.appealId, lpaStatement, {
 		isReview: false
@@ -113,7 +117,7 @@ export function viewLpaStatementPage(appealDetails, lpaStatement, session) {
 
 	const pageContent = {
 		title: 'LPA statement',
-		backLinkUrl: `/appeals-service/appeal-details/${appealDetails.appealId}`,
+		backLinkUrl,
 		preHeading: `Appeal ${shortReference}`,
 		heading: 'LPA statement',
 		pageComponents
@@ -126,10 +130,13 @@ export function viewLpaStatementPage(appealDetails, lpaStatement, session) {
  * @param {Appeal} appealDetails
  * @param {Representation} lpaStatement
  * @param {import('express-session').Session & Partial<import('express-session').SessionData>} session
+ * @param {string | undefined} backUrl
  * @returns {PageContent}
  */
-export function reviewLpaStatementPage(appealDetails, lpaStatement, session) {
+export function reviewLpaStatementPage(appealDetails, lpaStatement, session, backUrl) {
 	const shortReference = appealShortReference(appealDetails.appealReference);
+
+	const backLinkUrl = constructUrl(backUrl, appealDetails.appealId);
 
 	const lpaStatementSummaryList = baseSummaryList(appealDetails.appealId, lpaStatement, {
 		isReview: true
@@ -177,7 +184,7 @@ export function reviewLpaStatementPage(appealDetails, lpaStatement, session) {
 
 	const pageContent = {
 		title: 'Review LPA statement',
-		backLinkUrl: `/appeals-service/appeal-details/${appealDetails.appealId}`,
+		backLinkUrl,
 		preHeading: `Appeal ${shortReference}`,
 		heading: 'Review LPA statement',
 		submitButtonText: 'Continue',

--- a/appeals/web/src/server/appeals/appeal-details/representations/representations.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/representations/representations.mapper.js
@@ -123,14 +123,14 @@ export function statementAndCommentsSharePage(appeal) {
 		const numIpComments = appeal.documentationSummary?.ipComments?.counts?.valid ?? 0;
 
 		return numIpComments > 0
-			? `<a href="/appeals-service/appeal-details/${appeal.appealId}/interested-party-comments#valid" class="govuk-link">${numIpComments} interested party comments</a>`
+			? `<a href="/appeals-service/appeal-details/${appeal.appealId}/interested-party-comments?backUrl=/share#valid" class="govuk-link">${numIpComments} interested party comments</a>`
 			: null;
 	})();
 
 	const statementsText =
 		appeal.documentationSummary?.lpaStatement?.representationStatus ===
 		APPEAL_REPRESENTATION_STATUS.VALID
-			? `<a href="/appeals-service/appeal-details/${appeal.appealId}/lpa-statement" class="govuk-link">1 statement</a>`
+			? `<a href="/appeals-service/appeal-details/${appeal.appealId}/lpa-statement?backUrl=/share" class="govuk-link">1 statement</a>`
 			: null;
 
 	const valueTexts = [ipCommentsText, statementsText].filter(Boolean);
@@ -189,15 +189,15 @@ export function finalCommentsSharePage(appeal) {
 
 	const infoText = (() => {
 		if (hasValidFinalCommentsAppellant && hasValidFinalCommentsLPA) {
-			return `We’ll share <a class="govuk-link" href="/appeals-service/appeal-details/${appeal.appealId}/final-comments/appellant">appellant final comments</a> and <a class="govuk-link" href="/appeals-service/appeal-details/${appeal.appealId}/final-comments/lpa">LPA final comments</a> with the relevant parties.`;
+			return `We’ll share <a class="govuk-link" href="/appeals-service/appeal-details/${appeal.appealId}/final-comments/appellant?backUrl=/share">appellant final comments</a> and <a class="govuk-link" href="/appeals-service/appeal-details/${appeal.appealId}/final-comments/lpa?backUrl=/share">LPA final comments</a> with the relevant parties.`;
 		}
 
 		if (hasValidFinalCommentsAppellant && !hasValidFinalCommentsLPA) {
-			return `We’ll share <a class="govuk-link" href="/appeals-service/appeal-details/${appeal.appealId}/final-comments/appellant">appellant final comments</a> with the relevant parties.`;
+			return `We’ll share <a class="govuk-link" href="/appeals-service/appeal-details/${appeal.appealId}/final-comments/appellant?backUrl=/share">appellant final comments</a> with the relevant parties.`;
 		}
 
 		if (!hasValidFinalCommentsAppellant && hasValidFinalCommentsLPA) {
-			return `We’ll share <a class="govuk-link" href="/appeals-service/appeal-details/${appeal.appealId}/final-comments/lpa">LPA final comments</a> with the relevant parties.`;
+			return `We’ll share <a class="govuk-link" href="/appeals-service/appeal-details/${appeal.appealId}/final-comments/lpa?backUrl=/share">LPA final comments</a> with the relevant parties.`;
 		}
 
 		return `There are no final comments to share.`;

--- a/appeals/web/src/server/lib/mappers/__tests__/mappers.test.js
+++ b/appeals/web/src/server/lib/mappers/__tests__/mappers.test.js
@@ -9,6 +9,7 @@ import { areIdsDefinedAndUnique } from '#testing/lib/testMappers.js';
 import { mapPagination } from '../index.js';
 import { mapRepresentationDocumentSummaryActionLink } from '#lib/representation-utilities.js';
 import { APPEAL_REPRESENTATION_STATUS } from '@pins/appeals/constants/common.js';
+import { constructUrl } from '#lib/mappers/utils/url.mapper.js';
 
 /** @typedef {import('../../../app/auth/auth-session.service').SessionWithAuth} SessionWithAuth */
 
@@ -200,6 +201,37 @@ describe('mapRepresentationDocumentSummaryActionLink', () => {
 				'lpa-statement'
 			);
 			expect(link).toBe('');
+		});
+	});
+});
+
+describe('URL mappers', () => {
+	const appealId = '1';
+
+	describe('constructUrl', () => {
+		it('should return the sign-in page URL when given "/signin" as input', () => {
+			const url = constructUrl('/signin');
+			expect(url).toBe('/auth/signin');
+		});
+
+		it('should return the "assigned to me" page URL when given "/personal-list" as input', () => {
+			const url = constructUrl('/personal-list');
+			expect(url).toBe('/appeals-service/personal-list');
+		});
+
+		it('should return the "case details" page URL when given "/" along with appeal ID as input', () => {
+			const url = constructUrl('/', appealId);
+			expect(url).toBe('/appeals-service/appeal-details/1/');
+		});
+
+		it('should return the "share" page URL when given "/share" along with appeal ID as input', () => {
+			const url = constructUrl('/share', appealId);
+			expect(url).toBe('/appeals-service/appeal-details/1/share');
+		});
+
+		it('should return the all cases page URL when given value that does not exist in URL map and as input and appeal ID not provided', () => {
+			const url = constructUrl('/foo');
+			expect(url).toBe('/appeals-service/all-cases');
 		});
 	});
 });

--- a/appeals/web/src/server/lib/mappers/utils/url.mapper.js
+++ b/appeals/web/src/server/lib/mappers/utils/url.mapper.js
@@ -1,0 +1,28 @@
+/**
+ * @param {string | undefined} url
+ * @param {string | number | undefined} appealId
+ * @returns {string}
+ * */
+
+export const constructUrl = (url = '/', appealId = undefined) => {
+	/** @type {Record<string, string>} */
+	const urlMap = {
+		'/personal-list': '/appeals-service/personal-list',
+		'/signin': '/auth/signin'
+	};
+
+	let constructedUrl = '';
+
+	if (urlMap[url]) {
+		// if found in map - return the map value
+		constructedUrl = urlMap[url];
+	} else if (appealId) {
+		// if not found in map and appealId exists return to appeal details subroute (or just appeal details page in case of "/")
+		constructedUrl = `/appeals-service/appeal-details/${appealId}${url}`;
+	} else {
+		// if not found in map and appealId doesn't exist fall back to all cases page
+		constructedUrl = '/appeals-service/all-cases';
+	}
+
+	return constructedUrl;
+};


### PR DESCRIPTION
https://pins-ds.atlassian.net/browse/A2-2401

This update introduces dynamic back button behavior and flexible redirect URL handling:
- Reads the `backUrl` query parameter and processes it using the `constructURL` utility
- Since most of the routes are sub-routes of appeal details page - instead of passing the full URL every time, only the path **after** `/<appealId>/` needs to be provided.  
  - **Example:** `?backUrl=/share` generates `/appeals-service/appeal-details/${appealId}/share`.  
- Routes that don’t follow this pattern, such as **Personal List**, are handled via a predefined mapping
  - **Example:** `?backUrl=/personal-list` resolves to `/appeals-service/personal-list`.  
- The same logic can be applied to **redirect URLs** after an action.  
  - **Example:** Passing `?redirectTo=/personal-list` redirects to **Personal List** instead of the default **Appeal Details** page.  

Thoughts or suggestions are welcome!

