### PR TITLE
fix(web): fixing read more text link to not show when there are less than 300 chars

### DIFF
--- a/appeals/web/src/client/components/show-more/show-more.js
+++ b/appeals/web/src/client/components/show-more/show-more.js
@@ -141,14 +141,14 @@ const initialiseTextMode = async (/** @type {ShowMoreComponentInstance} */ compo
 		componentInstance.elements.root.innerText
 	);
 
-	componentInstance.elements.root.innerHTML = '';
-	componentInstance.elements.root.appendChild(contentSpan);
-
 	const ellipsisSpan = document.createElement('span');
 
 	ellipsisSpan.className = CLASSES.ellipsis;
 	ellipsisSpan.setAttribute('aria-hidden', 'true');
 	ellipsisSpan.textContent = '…';
+
+	componentInstance.elements.root.innerHTML = '';
+	componentInstance.elements.root.appendChild(contentSpan);
 	componentInstance.elements.root.appendChild(ellipsisSpan);
 };
 

--- a/appeals/web/src/client/components/show-more/show-more.js
+++ b/appeals/web/src/client/components/show-more/show-more.js
@@ -141,15 +141,21 @@ const initialiseTextMode = async (/** @type {ShowMoreComponentInstance} */ compo
 		componentInstance.elements.root.innerText
 	);
 
-	const ellipsisSpan = document.createElement('span');
-
-	ellipsisSpan.className = CLASSES.ellipsis;
-	ellipsisSpan.setAttribute('aria-hidden', 'true');
-	ellipsisSpan.textContent = '…';
-
 	componentInstance.elements.root.innerHTML = '';
+
 	componentInstance.elements.root.appendChild(contentSpan);
-	componentInstance.elements.root.appendChild(ellipsisSpan);
+
+	if (
+		componentInstance.elements.root.getAttribute(ATTRIBUTES.fullText).length >
+		componentInstance.options.maximumCharactersBeforeHiding
+	) {
+		const ellipsisSpan = document.createElement('span');
+
+		ellipsisSpan.className = CLASSES.ellipsis;
+		ellipsisSpan.setAttribute('aria-hidden', 'true');
+		ellipsisSpan.textContent = '…';
+		componentInstance.elements.root.appendChild(ellipsisSpan);
+	}
 };
 
 const initialiseOptions = (/** @type {ShowMoreComponentInstance} */ componentInstance) => {
@@ -190,26 +196,31 @@ const initialiseComponentInstance = async (
 		await initialiseTextMode(componentInstance);
 	}
 
-	const button = document.createElement('button');
-	button.className = CLASSES.toggleButton;
-	button.setAttribute('aria-expanded', 'false');
-	button.setAttribute('type', 'button');
+	if (
+		componentInstance.elements.root.getAttribute(ATTRIBUTES.fullText).length >
+		componentInstance.options.maximumCharactersBeforeHiding
+	) {
+		const button = document.createElement('button');
+		button.className = CLASSES.toggleButton;
+		button.setAttribute('aria-expanded', 'false');
+		button.setAttribute('type', 'button');
 
-	const buttonLabel = document.createElement('span');
-	buttonLabel.className = CLASSES.toggleButtonLabel;
-	buttonLabel.textContent = componentInstance.options.toggleButtonTextCollapsed;
+		const buttonLabel = document.createElement('span');
+		buttonLabel.className = CLASSES.toggleButtonLabel;
+		buttonLabel.textContent = componentInstance.options.toggleButtonTextCollapsed;
 
-	const visuallyHiddenText = document.createElement('span');
-	visuallyHiddenText.className = 'govuk-visually-hidden';
-	const labelText = componentInstance.elements.root.getAttribute(ATTRIBUTES.label);
-	visuallyHiddenText.textContent = `, ${labelText}`;
+		const visuallyHiddenText = document.createElement('span');
+		visuallyHiddenText.className = 'govuk-visually-hidden';
+		const labelText = componentInstance.elements.root.getAttribute(ATTRIBUTES.label);
+		visuallyHiddenText.textContent = `, ${labelText}`;
 
-	button.appendChild(buttonLabel);
-	button.appendChild(visuallyHiddenText);
+		button.appendChild(buttonLabel);
+		button.appendChild(visuallyHiddenText);
 
-	componentInstance.elements.root.appendChild(button);
+		componentInstance.elements.root.appendChild(button);
 
-	bindEvents(componentInstance);
+		bindEvents(componentInstance);
+	}
 };
 
 const initialiseShowMore = () => {

--- a/appeals/web/src/client/components/show-more/show-more.js
+++ b/appeals/web/src/client/components/show-more/show-more.js
@@ -142,7 +142,6 @@ const initialiseTextMode = async (/** @type {ShowMoreComponentInstance} */ compo
 	);
 
 	componentInstance.elements.root.innerHTML = '';
-
 	componentInstance.elements.root.appendChild(contentSpan);
 
 	const ellipsisSpan = document.createElement('span');

--- a/appeals/web/src/client/components/show-more/show-more.js
+++ b/appeals/web/src/client/components/show-more/show-more.js
@@ -145,17 +145,12 @@ const initialiseTextMode = async (/** @type {ShowMoreComponentInstance} */ compo
 
 	componentInstance.elements.root.appendChild(contentSpan);
 
-	if (
-		componentInstance.elements.root.getAttribute(ATTRIBUTES.fullText).length >
-		componentInstance.options.maximumCharactersBeforeHiding
-	) {
-		const ellipsisSpan = document.createElement('span');
+	const ellipsisSpan = document.createElement('span');
 
-		ellipsisSpan.className = CLASSES.ellipsis;
-		ellipsisSpan.setAttribute('aria-hidden', 'true');
-		ellipsisSpan.textContent = '…';
-		componentInstance.elements.root.appendChild(ellipsisSpan);
-	}
+	ellipsisSpan.className = CLASSES.ellipsis;
+	ellipsisSpan.setAttribute('aria-hidden', 'true');
+	ellipsisSpan.textContent = '…';
+	componentInstance.elements.root.appendChild(ellipsisSpan);
 };
 
 const initialiseOptions = (/** @type {ShowMoreComponentInstance} */ componentInstance) => {
@@ -190,37 +185,39 @@ const initialiseComponentInstance = async (
 ) => {
 	initialiseOptions(componentInstance);
 
+	if (
+		componentInstance.elements.root.getAttribute(ATTRIBUTES.fullText).length <=
+		componentInstance.options.maximumCharactersBeforeHiding
+	) {
+		return;
+	}
+
 	if (isHtmlMode(componentInstance)) {
 		htmlModeToggleExpanded(componentInstance);
 	} else {
 		await initialiseTextMode(componentInstance);
 	}
 
-	if (
-		componentInstance.elements.root.getAttribute(ATTRIBUTES.fullText).length >
-		componentInstance.options.maximumCharactersBeforeHiding
-	) {
-		const button = document.createElement('button');
-		button.className = CLASSES.toggleButton;
-		button.setAttribute('aria-expanded', 'false');
-		button.setAttribute('type', 'button');
+	const button = document.createElement('button');
+	button.className = CLASSES.toggleButton;
+	button.setAttribute('aria-expanded', 'false');
+	button.setAttribute('type', 'button');
 
-		const buttonLabel = document.createElement('span');
-		buttonLabel.className = CLASSES.toggleButtonLabel;
-		buttonLabel.textContent = componentInstance.options.toggleButtonTextCollapsed;
+	const buttonLabel = document.createElement('span');
+	buttonLabel.className = CLASSES.toggleButtonLabel;
+	buttonLabel.textContent = componentInstance.options.toggleButtonTextCollapsed;
 
-		const visuallyHiddenText = document.createElement('span');
-		visuallyHiddenText.className = 'govuk-visually-hidden';
-		const labelText = componentInstance.elements.root.getAttribute(ATTRIBUTES.label);
-		visuallyHiddenText.textContent = `, ${labelText}`;
+	const visuallyHiddenText = document.createElement('span');
+	visuallyHiddenText.className = 'govuk-visually-hidden';
+	const labelText = componentInstance.elements.root.getAttribute(ATTRIBUTES.label);
+	visuallyHiddenText.textContent = `, ${labelText}`;
 
-		button.appendChild(buttonLabel);
-		button.appendChild(visuallyHiddenText);
+	button.appendChild(buttonLabel);
+	button.appendChild(visuallyHiddenText);
 
-		componentInstance.elements.root.appendChild(button);
+	componentInstance.elements.root.appendChild(button);
 
-		bindEvents(componentInstance);
-	}
+	bindEvents(componentInstance);
 };
 
 const initialiseShowMore = () => {


### PR DESCRIPTION
## Describe your changes
- Returning early from initialising instance statement so that read more link text doesn't show when less than 300 chars.  

<!--
    Please include a summary of the change along with any relevant context.
    List any dependencies that are required for this change.
-->

## Issue ticket number and link
[Ticket](https://pins-ds.atlassian.net.mcas.ms/browse/A2-2454)
