### PR TITLE
fix(A2-2543:web): showing supporting docs value for cya final comments page

### DIFF
--- a/appeals/web/src/server/appeals/appeal-details/representations/final-comments/accept/__tests__/__snapshots__/accept-final-comments.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/representations/final-comments/accept/__tests__/__snapshots__/accept-final-comments.test.js.snap
@@ -17,7 +17,6 @@ exports[`final-comments GET / should render the accept appellant final comments 
                 </div>
                 <div class="govuk-summary-list__row govuk-summary-list__row--no-actions"><dt class="govuk-summary-list__key"> Supporting documents</dt>
                     <dd class="govuk-summary-list__value">Not provided</dd>
-                    </dd>
                 </div>
                 <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Review decisions</dt>
                     <dd class="govuk-summary-list__value">Accept final comments</dd>

--- a/appeals/web/src/server/appeals/appeal-details/representations/final-comments/accept/__tests__/__snapshots__/accept-final-comments.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/representations/final-comments/accept/__tests__/__snapshots__/accept-final-comments.test.js.snap
@@ -17,7 +17,6 @@ exports[`final-comments GET / should render the accept appellant final comments 
                 </div>
                 <div class="govuk-summary-list__row govuk-summary-list__row--no-actions"><dt class="govuk-summary-list__key"> Supporting documents</dt>
                     <dd class="govuk-summary-list__value">Not provided</dd>
-                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/final-comments/appellant/"> Change</a>
                     </dd>
                 </div>
                 <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Review decisions</dt>

--- a/appeals/web/src/server/appeals/appeal-details/representations/final-comments/accept/__tests__/__snapshots__/accept-final-comments.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/representations/final-comments/accept/__tests__/__snapshots__/accept-final-comments.test.js.snap
@@ -16,7 +16,9 @@ exports[`final-comments GET / should render the accept appellant final comments 
                     </dd>
                 </div>
                 <div class="govuk-summary-list__row govuk-summary-list__row--no-actions"><dt class="govuk-summary-list__key"> Supporting documents</dt>
-                    <dd class="govuk-summary-list__value"></dd>
+                    <dd class="govuk-summary-list__value">Not provided</dd>
+                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/final-comments/appellant/"> Change</a>
+                    </dd>
                 </div>
                 <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Review decisions</dt>
                     <dd class="govuk-summary-list__value">Accept final comments</dd>
@@ -52,7 +54,7 @@ exports[`final-comments GET / should render the accept lpa final comments page w
                     </dd>
                 </div>
                 <div class="govuk-summary-list__row govuk-summary-list__row--no-actions"><dt class="govuk-summary-list__key"> Supporting documents</dt>
-                    <dd class="govuk-summary-list__value"></dd>
+                    <dd class="govuk-summary-list__value">Not provided</dd>
                 </div>
                 <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Review decisions</dt>
                     <dd class="govuk-summary-list__value">Accept final comments</dd>

--- a/appeals/web/src/server/appeals/appeal-details/representations/final-comments/accept/components/summary-list.js
+++ b/appeals/web/src/server/appeals/appeal-details/representations/final-comments/accept/components/summary-list.js
@@ -17,14 +17,8 @@ export const summaryList = (appealDetails, comment, finalCommentsType) => {
 	const attachmentsList = filteredAttachments?.length
 		? buildHtmUnorderedList(
 				filteredAttachments.map(
-					(a) => `<a class="govuk-link" target="_blank" href="${mapDocumentDownloadUrl(
-						appealDetails.appealId,
-						a.documentVersion,
-						a.documentId,
-						a.documentVersion.document.name
-					)}">
-						${a.documentVersion.document.name}
-					</a>`
+					(a) => `<a class="govuk-link" target="_blank" href="#">
+						${a.documentVersion.document.name}</a>`
 				)
 		  )
 		: null;
@@ -84,15 +78,4 @@ export const summaryList = (appealDetails, comment, finalCommentsType) => {
 			]
 		}
 	};
-};
-
-/**
- * @param {Number} appealId
- * @param {string} documentVersion
- * @param {string} documentId
- * @param {string} documentName
- * @returns {string}
- */
-const mapDocumentDownloadUrl = (appealId, documentVersion, documentId, documentName) => {
-	return `/documents/${appealId}/download/${documentId}/${documentVersion}/${documentName}`;
 };

--- a/appeals/web/src/server/appeals/appeal-details/representations/final-comments/accept/components/summary-list.js
+++ b/appeals/web/src/server/appeals/appeal-details/representations/final-comments/accept/components/summary-list.js
@@ -19,7 +19,6 @@ export const summaryList = (appealDetails, comment, finalCommentsType) => {
 				filteredAttachments.map(
 					(a) => `<a class="govuk-link" target="_blank" href="${mapDocumentDownloadUrl(
 						appealDetails.appealId,
-						a.documentVersion,
 						a.documentId,
 						a.documentVersion.document.name
 					)}">
@@ -88,11 +87,10 @@ export const summaryList = (appealDetails, comment, finalCommentsType) => {
 
 /**
  * @param {Number} appealId
- * @param {string} documentVersion
  * @param {string} documentId
  * @param {string} documentName
  * @returns {string}
  */
-const mapDocumentDownloadUrl = (appealId, documentVersion, documentId, documentName) => {
-	return `/documents/${appealId}/download/${documentId}/${documentVersion}/${documentName}`;
+const mapDocumentDownloadUrl = (appealId, documentId, documentName) => {
+	return `/documents/${appealId}/download/${documentId}/${documentName}`;
 };

--- a/appeals/web/src/server/appeals/appeal-details/representations/final-comments/accept/components/summary-list.js
+++ b/appeals/web/src/server/appeals/appeal-details/representations/final-comments/accept/components/summary-list.js
@@ -19,6 +19,7 @@ export const summaryList = (appealDetails, comment, finalCommentsType) => {
 				filteredAttachments.map(
 					(a) => `<a class="govuk-link" target="_blank" href="${mapDocumentDownloadUrl(
 						appealDetails.appealId,
+						a.documentVersion,
 						a.documentId,
 						a.documentVersion.document.name
 					)}">
@@ -87,10 +88,11 @@ export const summaryList = (appealDetails, comment, finalCommentsType) => {
 
 /**
  * @param {Number} appealId
+ * @param {string} documentVersion
  * @param {string} documentId
  * @param {string} documentName
  * @returns {string}
  */
-const mapDocumentDownloadUrl = (appealId, documentId, documentName) => {
-	return `/documents/${appealId}/download/${documentId}/${documentName}`;
+const mapDocumentDownloadUrl = (appealId, documentVersion, documentId, documentName) => {
+	return `/documents/${appealId}/download/${documentId}/${documentVersion}/${documentName}`;
 };

--- a/appeals/web/src/server/appeals/appeal-details/representations/final-comments/accept/components/summary-list.js
+++ b/appeals/web/src/server/appeals/appeal-details/representations/final-comments/accept/components/summary-list.js
@@ -17,7 +17,14 @@ export const summaryList = (appealDetails, comment, finalCommentsType) => {
 	const attachmentsList = filteredAttachments?.length
 		? buildHtmUnorderedList(
 				filteredAttachments.map(
-					(a) => `<a class="govuk-link" href="#">${a.documentVersion.document.name}</a>`
+					(a) => `<a class="govuk-link" target="_blank" href="${mapDocumentDownloadUrl(
+						appealDetails.appealId,
+						a.documentVersion,
+						a.documentId,
+						a.documentVersion.document.name
+					)}">
+						${a.documentVersion.document.name}
+					</a>`
 				)
 		  )
 		: null;
@@ -77,4 +84,15 @@ export const summaryList = (appealDetails, comment, finalCommentsType) => {
 			]
 		}
 	};
+};
+
+/**
+ * @param {Number} appealId
+ * @param {string} documentVersion
+ * @param {string} documentId
+ * @param {string} documentName
+ * @returns {string}
+ */
+const mapDocumentDownloadUrl = (appealId, documentVersion, documentId, documentName) => {
+	return `/documents/${appealId}/download/${documentId}/${documentVersion}/${documentName}`;
 };

--- a/appeals/web/src/server/appeals/appeal-details/representations/final-comments/accept/components/summary-list.js
+++ b/appeals/web/src/server/appeals/appeal-details/representations/final-comments/accept/components/summary-list.js
@@ -1,3 +1,5 @@
+import { buildHtmUnorderedList } from '#lib/nunjucks-template-builders/tag-builders.js';
+
 /** @typedef {import("#appeals/appeal-details/appeal-details.types.js").WebAppeal} Appeal */
 /** @typedef {import("#appeals/appeal-details/representations/types.js").Representation} Representation */
 
@@ -7,57 +9,72 @@
  * @param {string} finalCommentsType
  * @returns {PageComponent}
  */
-export const summaryList = (appealDetails, comment, finalCommentsType) => ({
-	type: 'summary-list',
-	wrapperHtml: {
-		opening: '<div class="govuk-grid-row"><div class="govuk-grid-column-full">',
-		closing: '</div></div>'
-	},
-	parameters: {
-		rows: [
-			{
-				key: { text: 'Original final comments' },
-				value: {
-					html: '',
-					pageComponents: [
-						{
-							type: 'show-more',
-							parameters: {
-								text: comment.originalRepresentation,
-								labelText: 'Read more'
+export const summaryList = (appealDetails, comment, finalCommentsType) => {
+	const filteredAttachments = comment.attachments?.filter(
+		(attachment) => !attachment.documentVersion.document.isDeleted
+	);
+
+	const attachmentsList = filteredAttachments?.length
+		? buildHtmUnorderedList(
+				filteredAttachments.map(
+					(a) => `<a class="govuk-link" href="#">${a.documentVersion.document.name}</a>`
+				)
+		  )
+		: null;
+
+	/** @type {PageComponent} */
+	return {
+		type: 'summary-list',
+		wrapperHtml: {
+			opening: '<div class="govuk-grid-row"><div class="govuk-grid-column-full">',
+			closing: '</div></div>'
+		},
+		parameters: {
+			rows: [
+				{
+					key: { text: 'Original final comments' },
+					value: {
+						html: '',
+						pageComponents: [
+							{
+								type: 'show-more',
+								parameters: {
+									text: comment.originalRepresentation,
+									labelText: 'Read more'
+								}
 							}
-						}
-					]
-				}
-			},
-			{
-				key: { text: 'Supporting documents' },
-				value: { text: '' },
-				...(comment.attachments?.length > 0
-					? {
-							actions: {
-								items: [
-									{
-										text: 'Change',
-										href: `/appeals-service/appeal-details/${appealDetails.appealId}/final-comments/${finalCommentsType}/manage-documents/${comment.attachments?.[0]?.documentVersion?.document?.folderId}`
-									}
-								]
+						]
+					}
+				},
+				{
+					key: { text: 'Supporting documents' },
+					value: attachmentsList ? { html: attachmentsList } : { text: 'Not provided' },
+					...(comment.attachments?.length > 0
+						? {
+								actions: {
+									items: [
+										{
+											text: 'Change',
+											href: `/appeals-service/appeal-details/${appealDetails.appealId}/final-comments/${finalCommentsType}/manage-documents/${comment.attachments?.[0]?.documentVersion?.document?.folderId}`
+										}
+									]
+								}
+						  }
+						: {})
+				},
+				{
+					key: { text: 'Review decisions' },
+					value: { text: 'Accept final comments' },
+					actions: {
+						items: [
+							{
+								text: 'Change',
+								href: `/appeals-service/appeal-details/${appealDetails.appealId}/final-comments/${finalCommentsType}/`
 							}
-					  }
-					: {})
-			},
-			{
-				key: { text: 'Review decisions' },
-				value: { text: 'Accept final comments' },
-				actions: {
-					items: [
-						{
-							text: 'Change',
-							href: `/appeals-service/appeal-details/${appealDetails.appealId}/final-comments/${finalCommentsType}/`
-						}
-					]
+						]
+					}
 				}
-			}
-		]
-	}
-});
+			]
+		}
+	};
+};


### PR DESCRIPTION
## Describe your changes
- Adding the standard code which pulls through supporting docs displays them on cya page
<!--
    Please include a summary of the change along with any relevant context.
    List any dependencies that are required for this change.
-->

## Issue ticket number and link
[Ticket](https://pins-ds.atlassian.net.mcas.ms/browse/A2-2543)
