### PR TITLE
fix(web): A2-2582 Add IP Comment - incorrect redaction status shows on document upload

### DIFF
--- a/appeals/web/src/server/appeals/appeal-details/representations/interested-party-comments/add-ip-comment/__tests__/add-ip-comment.test.js
+++ b/appeals/web/src/server/appeals/appeal-details/representations/interested-party-comments/add-ip-comment/__tests__/add-ip-comment.test.js
@@ -587,6 +587,37 @@ describe('add-ip-comment', () => {
 			expect(addDocumentsResponse.statusCode).toBe(302);
 		});
 
+		it('should send an API request to create a new document with correct redactionStatusId', async () => {
+			const documentFolderInfo = [
+				{
+					caseId: '2',
+					documents: [],
+					folderId: 55539,
+					path: 'representation/representationAttachments'
+				}
+			];
+
+			nock('http://test/')
+				.get(`/appeals/document-redaction-statuses`)
+				.reply(200, [
+					{ id: 1, key: 'unredacted' },
+					{ id: 2, key: 'no_redaction_required' },
+					{ id: 3, key: 'redacted' }
+				]);
+
+			nock('http://test/')
+				.get(`/appeals/${appealId}/document-folders?path=representation/representationAttachments`)
+				.reply(200, documentFolderInfo);
+			nock('http://test/').get(`/appeals/document-redaction-statuses`).reply(200, 1);
+			const addDocumentsResponse = await request
+				.post(`${baseUrl}/2/interested-party-comments/add/upload`)
+				.send({
+					'upload-info': fileUploadInfo
+				});
+
+			expect(addDocumentsResponse.statusCode).toBe(302);
+		});
+
 		it('should createIPComment on successful submission', async () => {
 			const appealId = 2;
 			const comment = {


### PR DESCRIPTION
## Describe your changes

redactionStatusId correctly set when adding IP comment, approach is  consistent with the additional documents flow.  

## Issue ticket number and link
[A2-2582](https://pins-ds.atlassian.net/browse/A2-2582)

[A2-2582]: https://pins-ds.atlassian.net/browse/A2-2582?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ