### PR TITLE
fix(appeals): add inspector name to site visit notify (a2-2578)

### DIFF
--- a/appeals/api/src/server/endpoints/appeals.d.ts
+++ b/appeals/api/src/server/endpoints/appeals.d.ts
@@ -796,6 +796,7 @@ export interface UpdateSiteVisitData {
 	appealReferenceNumber: string;
 	lpaReference: string;
 	siteAddress: string;
+	inspectorName?: string;
 	siteVisitChangeType: string;
 }
 

--- a/appeals/api/src/server/endpoints/appeals.d.ts
+++ b/appeals/api/src/server/endpoints/appeals.d.ts
@@ -781,6 +781,7 @@ export interface CreateSiteVisitData {
 	appealReferenceNumber: string;
 	lpaReference: string;
 	siteAddress: string;
+	inspectorName?: string;
 }
 
 export interface UpdateSiteVisitData {

--- a/appeals/api/src/server/endpoints/site-visits/__tests__/site-visits.test.js
+++ b/appeals/api/src/server/endpoints/site-visits/__tests__/site-visits.test.js
@@ -29,9 +29,12 @@ import config from '#config/config.js';
 describe('site visit routes', () => {
 	/** @type {typeof householdAppealData} */
 	let householdAppeal;
+	let inspectorName;
 
 	beforeEach(() => {
 		householdAppeal = JSON.parse(JSON.stringify(householdAppealData));
+
+		inspectorName = 'Jane Smith';
 
 		// @ts-ignore
 		databaseConnector.appealRelationship.findMany.mockResolvedValue([]);
@@ -1256,6 +1259,7 @@ describe('site visit routes', () => {
 							site_address: '96 The Avenue, Leftfield, Maidstone, Kent, MD21 5XY, United Kingdom',
 							start_time: '02:00',
 							end_time: '04:00',
+							inspector_name: '',
 							lpa_reference: '48269/APP/2021/1482',
 							visit_date: '31 March 2022'
 						},
@@ -1343,6 +1347,7 @@ describe('site visit routes', () => {
 						visitStartTime: siteVisit.visitStartTime,
 						visitType: siteVisit.siteVisitType.name,
 						previousVisitType: 'Access required',
+						inspectorName,
 						siteVisitChangeType: 'date-time'
 					})
 					.set('azureAdUserId', azureAdUserId);
@@ -1388,6 +1393,7 @@ describe('site visit routes', () => {
 							site_address: '96 The Avenue, Leftfield, Maidstone, Kent, MD21 5XY, United Kingdom',
 							start_time: '02:00',
 							end_time: '04:00',
+							inspector_name: inspectorName,
 							lpa_reference: '48269/APP/2021/1482',
 							visit_date: '31 March 2022'
 						},
@@ -1463,6 +1469,7 @@ describe('site visit routes', () => {
 							site_address: '96 The Avenue, Leftfield, Maidstone, Kent, MD21 5XY, United Kingdom',
 							start_time: '02:00',
 							end_time: '04:00',
+							inspector_name: '',
 							lpa_reference: '48269/APP/2021/1482',
 							visit_date: '31 March 2022'
 						},
@@ -1481,6 +1488,7 @@ describe('site visit routes', () => {
 							site_address: '96 The Avenue, Leftfield, Maidstone, Kent, MD21 5XY, United Kingdom',
 							start_time: '02:00',
 							end_time: '04:00',
+							inspector_name: '',
 							lpa_reference: '48269/APP/2021/1482',
 							visit_date: '31 March 2022'
 						},
@@ -1556,6 +1564,7 @@ describe('site visit routes', () => {
 							site_address: '96 The Avenue, Leftfield, Maidstone, Kent, MD21 5XY, United Kingdom',
 							start_time: '02:00',
 							end_time: '04:00',
+							inspector_name: '',
 							lpa_reference: '48269/APP/2021/1482',
 							visit_date: '31 March 2022'
 						},
@@ -1574,6 +1583,7 @@ describe('site visit routes', () => {
 							site_address: '96 The Avenue, Leftfield, Maidstone, Kent, MD21 5XY, United Kingdom',
 							start_time: '02:00',
 							end_time: '04:00',
+							inspector_name: '',
 							lpa_reference: '48269/APP/2021/1482',
 							visit_date: '31 March 2022'
 						},
@@ -1649,6 +1659,7 @@ describe('site visit routes', () => {
 							site_address: '96 The Avenue, Leftfield, Maidstone, Kent, MD21 5XY, United Kingdom',
 							start_time: '02:00',
 							end_time: '04:00',
+							inspector_name: '',
 							lpa_reference: '48269/APP/2021/1482',
 							visit_date: '31 March 2022'
 						},
@@ -1667,6 +1678,7 @@ describe('site visit routes', () => {
 							site_address: '96 The Avenue, Leftfield, Maidstone, Kent, MD21 5XY, United Kingdom',
 							start_time: '02:00',
 							end_time: '04:00',
+							inspector_name: '',
 							lpa_reference: '48269/APP/2021/1482',
 							visit_date: '31 March 2022'
 						},
@@ -1697,6 +1709,7 @@ describe('site visit routes', () => {
 						visitStartTime: siteVisit.visitStartTime,
 						visitType: siteVisit.siteVisitType.name,
 						previousVisitType: SITE_VISIT_TYPE_ACCESS_REQUIRED,
+						inspectorName,
 						siteVisitChangeType: 'visit-type'
 					})
 					.set('azureAdUserId', azureAdUserId);
@@ -1742,6 +1755,7 @@ describe('site visit routes', () => {
 							site_address: '96 The Avenue, Leftfield, Maidstone, Kent, MD21 5XY, United Kingdom',
 							start_time: '02:00',
 							end_time: '04:00',
+							inspector_name: inspectorName,
 							lpa_reference: '48269/APP/2021/1482',
 							visit_date: '31 March 2022'
 						},
@@ -1760,6 +1774,7 @@ describe('site visit routes', () => {
 							site_address: '96 The Avenue, Leftfield, Maidstone, Kent, MD21 5XY, United Kingdom',
 							start_time: '02:00',
 							end_time: '04:00',
+							inspector_name: inspectorName,
 							lpa_reference: '48269/APP/2021/1482',
 							visit_date: '31 March 2022'
 						},
@@ -1835,6 +1850,7 @@ describe('site visit routes', () => {
 							site_address: '96 The Avenue, Leftfield, Maidstone, Kent, MD21 5XY, United Kingdom',
 							start_time: '02:00',
 							end_time: '04:00',
+							inspector_name: '',
 							lpa_reference: '48269/APP/2021/1482',
 							visit_date: '31 March 2022'
 						},
@@ -1853,6 +1869,7 @@ describe('site visit routes', () => {
 							site_address: '96 The Avenue, Leftfield, Maidstone, Kent, MD21 5XY, United Kingdom',
 							start_time: '02:00',
 							end_time: '04:00',
+							inspector_name: '',
 							lpa_reference: '48269/APP/2021/1482',
 							visit_date: '31 March 2022'
 						},
@@ -1928,6 +1945,7 @@ describe('site visit routes', () => {
 							site_address: '96 The Avenue, Leftfield, Maidstone, Kent, MD21 5XY, United Kingdom',
 							start_time: '02:00',
 							end_time: '04:00',
+							inspector_name: '',
 							lpa_reference: '48269/APP/2021/1482',
 							visit_date: '31 March 2022'
 						},
@@ -2004,6 +2022,7 @@ describe('site visit routes', () => {
 							site_address: '96 The Avenue, Leftfield, Maidstone, Kent, MD21 5XY, United Kingdom',
 							start_time: '02:00',
 							end_time: '04:00',
+							inspector_name: '',
 							lpa_reference: '48269/APP/2021/1482',
 							visit_date: '31 March 2022'
 						},

--- a/appeals/api/src/server/endpoints/site-visits/__tests__/site-visits.test.js
+++ b/appeals/api/src/server/endpoints/site-visits/__tests__/site-visits.test.js
@@ -328,6 +328,7 @@ describe('site visit routes', () => {
 						personalisation: {
 							appeal_reference_number: '1345264',
 							lpa_reference: '48269/APP/2021/1482',
+							inspector_name: '',
 							site_address: '96 The Avenue, Leftfield, Maidstone, Kent, MD21 5XY, United Kingdom',
 							start_time: '02:00',
 							end_time: '04:00',
@@ -379,6 +380,7 @@ describe('site visit routes', () => {
 							appeal_reference_number: '1345264',
 							end_time: '12:00',
 							lpa_reference: '48269/APP/2021/1482',
+							inspector_name: '',
 							site_address: '96 The Avenue, Leftfield, Maidstone, Kent, MD21 5XY, United Kingdom',
 							start_time: '11:00',
 							visit_date: '1 March 2022'
@@ -396,6 +398,7 @@ describe('site visit routes', () => {
 							appeal_reference_number: '1345264',
 							end_time: '12:00',
 							lpa_reference: '48269/APP/2021/1482',
+							inspector_name: '',
 							site_address: '96 The Avenue, Leftfield, Maidstone, Kent, MD21 5XY, United Kingdom',
 							start_time: '11:00',
 							visit_date: '1 March 2022'
@@ -427,6 +430,7 @@ describe('site visit routes', () => {
 					.post(`/appeals/${householdAppeal.id}/site-visits`)
 					.send({
 						visitDate: siteVisit.visitDate,
+						inspectorName,
 						...visitData
 					})
 					.set('azureAdUserId', azureAdUserId);
@@ -448,6 +452,7 @@ describe('site visit routes', () => {
 							appeal_reference_number: '1345264',
 							end_time: '13:00',
 							lpa_reference: '48269/APP/2021/1482',
+							inspector_name: inspectorName,
 							site_address: '96 The Avenue, Leftfield, Maidstone, Kent, MD21 5XY, United Kingdom',
 							start_time: '12:00',
 							visit_date: '31 March 2022'

--- a/appeals/api/src/server/endpoints/site-visits/site-visits.controller.js
+++ b/appeals/api/src/server/endpoints/site-visits/site-visits.controller.js
@@ -32,7 +32,7 @@ const getSiteVisitById = async (req, res) => {
  */
 const postSiteVisit = async (req, res) => {
 	const {
-		body: { visitDate, visitEndTime, visitStartTime },
+		body: { visitDate, visitEndTime, visitStartTime, inspectorName = '' },
 		params,
 		visitType,
 		appeal
@@ -62,6 +62,7 @@ const postSiteVisit = async (req, res) => {
 		lpaEmail,
 		appealReferenceNumber: appeal.reference,
 		lpaReference: appeal.applicationReference || '',
+		inspectorName,
 		siteAddress
 	};
 

--- a/appeals/api/src/server/endpoints/site-visits/site-visits.controller.js
+++ b/appeals/api/src/server/endpoints/site-visits/site-visits.controller.js
@@ -91,7 +91,14 @@ const postSiteVisit = async (req, res) => {
  */
 const rearrangeSiteVisit = async (req, res) => {
 	const {
-		body: { visitDate, visitEndTime, visitStartTime, previousVisitType, siteVisitChangeType },
+		body: {
+			visitDate,
+			visitEndTime,
+			visitStartTime,
+			inspectorName = '',
+			previousVisitType,
+			siteVisitChangeType
+		},
 		params,
 		params: { siteVisitId },
 		visitType,
@@ -124,6 +131,7 @@ const rearrangeSiteVisit = async (req, res) => {
 		lpaEmail,
 		appealReferenceNumber: appeal.reference,
 		lpaReference: appeal.applicationReference || '',
+		inspectorName,
 		siteAddress
 	};
 

--- a/appeals/api/src/server/endpoints/site-visits/site-visits.service.js
+++ b/appeals/api/src/server/endpoints/site-visits/site-visits.service.js
@@ -15,7 +15,6 @@ import { EVENT_TYPE } from '@pins/appeals/constants/common.js';
 import { ERROR_NOT_FOUND } from '#endpoints/constants.js';
 import { toCamelCase } from '#utils/string-utils.js';
 // eslint-disable-next-line no-unused-vars
-import NotifyClient from '#utils/notify-client.js';
 import { broadcasters } from '#endpoints/integrations/integrations.broadcasters.js';
 import { EventType } from '@pins/event-client';
 
@@ -169,7 +168,8 @@ const updateSiteVisit = async (azureAdUserId, updateSiteVisitData, notifyClient)
 			site_address: updateSiteVisitData.siteAddress,
 			start_time: formatTime(updateSiteVisitData.visitStartTime),
 			end_time: formatTime(updateSiteVisitData.visitEndTime),
-			visit_date: formatDate(new Date(updateSiteVisitData.visitDate || ''), false)
+			visit_date: formatDate(new Date(updateSiteVisitData.visitDate || ''), false),
+			inspector_name: updateSiteVisitData.inspectorName
 		};
 
 		if (notifyTemplateIds.appellant && updateSiteVisitData.appellantEmail) {

--- a/appeals/api/src/server/endpoints/site-visits/site-visits.service.js
+++ b/appeals/api/src/server/endpoints/site-visits/site-visits.service.js
@@ -67,7 +67,8 @@ export const createSiteVisit = async (azureAdUserId, siteVisitData, notifyClient
 			site_address: siteVisitData.siteAddress,
 			start_time: formatTime(siteVisitData.visitStartTime),
 			end_time: formatTime(siteVisitData.visitEndTime),
-			visit_date: formatDate(new Date(siteVisitData.visitDate || ''), false)
+			visit_date: formatDate(new Date(siteVisitData.visitDate || ''), false),
+			inspector_name: siteVisitData.inspectorName
 		};
 
 		if (notifyTemplateIds.appellant && siteVisitData.appellantEmail) {

--- a/appeals/web/src/server/appeals/appeal-details/site-visit/site-visit.controller.js
+++ b/appeals/web/src/server/appeals/appeal-details/site-visit/site-visit.controller.js
@@ -9,6 +9,7 @@ import {
 	getSiteVisitSuccessBannerTypeAndChangeType
 } from './site-visit.mapper.js';
 import { addNotificationBannerToSession } from '#lib/session-utilities.js';
+import usersService from '#appeals/appeal-users/users-service.js';
 
 /**
  *
@@ -197,6 +198,10 @@ export const postScheduleOrManageSiteVisit = async (request, response, pageType)
 					mappedUpdateOrCreateSiteVisitParameters
 				);
 
+				const inspector =
+					appealDetails.inspector &&
+					(await usersService.getUserById(appealDetails.inspector, request.session));
+
 				await siteVisitService.updateSiteVisit(
 					request.apiClient,
 					mappedUpdateOrCreateSiteVisitParameters.appealIdNumber,
@@ -206,6 +211,7 @@ export const postScheduleOrManageSiteVisit = async (request, response, pageType)
 					mappedUpdateOrCreateSiteVisitParameters.visitStartTime,
 					mappedUpdateOrCreateSiteVisitParameters.visitEndTime,
 					mappedUpdateOrCreateSiteVisitParameters.previousVisitType,
+					inspector?.name || '',
 					successBannerAndChangeType.changeType
 				);
 

--- a/appeals/web/src/server/appeals/appeal-details/site-visit/site-visit.controller.js
+++ b/appeals/web/src/server/appeals/appeal-details/site-visit/site-visit.controller.js
@@ -179,6 +179,10 @@ export const postScheduleOrManageSiteVisit = async (request, response, pageType)
 				}
 			} = request;
 
+			const inspector =
+				appealDetails.inspector &&
+				(await usersService.getUserById(appealDetails.inspector, request.session));
+
 			const mappedUpdateOrCreateSiteVisitParameters =
 				mapPostScheduleOrManageSiteVisitToUpdateOrCreateSiteVisitParameters(
 					appealId,
@@ -189,7 +193,8 @@ export const postScheduleOrManageSiteVisit = async (request, response, pageType)
 					visitStartTimeMinute,
 					visitEndTimeHour,
 					visitEndTimeMinute,
-					visitType
+					visitType,
+					inspector?.name || ''
 				);
 
 			if (appealDetails.siteVisit?.siteVisitId) {
@@ -197,10 +202,6 @@ export const postScheduleOrManageSiteVisit = async (request, response, pageType)
 					appealDetails,
 					mappedUpdateOrCreateSiteVisitParameters
 				);
-
-				const inspector =
-					appealDetails.inspector &&
-					(await usersService.getUserById(appealDetails.inspector, request.session));
 
 				await siteVisitService.updateSiteVisit(
 					request.apiClient,
@@ -211,7 +212,7 @@ export const postScheduleOrManageSiteVisit = async (request, response, pageType)
 					mappedUpdateOrCreateSiteVisitParameters.visitStartTime,
 					mappedUpdateOrCreateSiteVisitParameters.visitEndTime,
 					mappedUpdateOrCreateSiteVisitParameters.previousVisitType,
-					inspector?.name || '',
+					mappedUpdateOrCreateSiteVisitParameters.inspectorName,
 					successBannerAndChangeType.changeType
 				);
 
@@ -229,7 +230,8 @@ export const postScheduleOrManageSiteVisit = async (request, response, pageType)
 					mappedUpdateOrCreateSiteVisitParameters.apiVisitType,
 					mappedUpdateOrCreateSiteVisitParameters.visitDate,
 					mappedUpdateOrCreateSiteVisitParameters.visitStartTime,
-					mappedUpdateOrCreateSiteVisitParameters.visitEndTime
+					mappedUpdateOrCreateSiteVisitParameters.visitEndTime,
+					mappedUpdateOrCreateSiteVisitParameters.inspectorName
 				);
 
 				addNotificationBannerToSession({

--- a/appeals/web/src/server/appeals/appeal-details/site-visit/site-visit.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/site-visit/site-visit.mapper.js
@@ -460,6 +460,7 @@ export function siteVisitBookedPage(appealId, appealReference) {
  * @param {string} visitEndTimeHour
  * @param {string} visitEndTimeMinute
  * @param {WebSiteVisitType} visitType
+ * @param {string} inspectorName
  * @returns {import('./site-visit.service.js').UpdateOrCreateSiteVisitParameters}
  */
 export function mapPostScheduleOrManageSiteVisitCommonParameters(
@@ -471,7 +472,8 @@ export function mapPostScheduleOrManageSiteVisitCommonParameters(
 	visitStartTimeMinute,
 	visitEndTimeHour,
 	visitEndTimeMinute,
-	visitType
+	visitType,
+	inspectorName
 ) {
 	return {
 		appealIdNumber: parseInt(appealId, 10),
@@ -501,7 +503,8 @@ export function mapPostScheduleOrManageSiteVisitCommonParameters(
 				  })
 				: undefined,
 		apiVisitType: mapWebVisitTypeToApiVisitType(visitType),
-		previousVisitType: ''
+		previousVisitType: '',
+		inspectorName
 	};
 }
 

--- a/appeals/web/src/server/appeals/appeal-details/site-visit/site-visit.service.js
+++ b/appeals/web/src/server/appeals/appeal-details/site-visit/site-visit.service.js
@@ -45,6 +45,7 @@ export async function createSiteVisit(
  * @param {string} [visitDate]
  * @param {string} [visitStartTime]
  * @param {string} [visitEndTime]
+ * @param {string} [inspectorName]
  * @param {string} [siteVisitChangeType]
  */
 export async function updateSiteVisit(
@@ -56,6 +57,7 @@ export async function updateSiteVisit(
 	visitStartTime,
 	visitEndTime,
 	previousVisitType,
+	inspectorName,
 	siteVisitChangeType
 ) {
 	return apiClient
@@ -66,6 +68,7 @@ export async function updateSiteVisit(
 				visitStartTime,
 				visitEndTime,
 				...(previousVisitType && { previousVisitType }),
+				inspectorName,
 				siteVisitChangeType
 			}
 		})

--- a/appeals/web/src/server/appeals/appeal-details/site-visit/site-visit.service.js
+++ b/appeals/web/src/server/appeals/appeal-details/site-visit/site-visit.service.js
@@ -4,6 +4,7 @@
  * @property {string} visitDate
  * @property {string|undefined} visitStartTime
  * @property {string|undefined} visitEndTime
+ * @property {string} inspectorName
  * @property {import('@pins/appeals/types/inspector.js').SiteVisitType} apiVisitType
  * @property {string} previousVisitType
  */
@@ -15,6 +16,7 @@
  * @param {string} visitDate
  * @param {string|undefined} visitStartTime
  * @param {string|undefined} visitEndTime
+ * @param {string} inspectorName
  */
 export async function createSiteVisit(
 	apiClient,
@@ -22,13 +24,15 @@ export async function createSiteVisit(
 	visitType,
 	visitDate,
 	visitStartTime,
-	visitEndTime
+	visitEndTime,
+	inspectorName
 ) {
 	return apiClient
 		.post(`appeals/${appealId}/site-visits`, {
 			json: {
 				visitDate,
 				visitType,
+				inspectorName,
 				...(visitStartTime !== '' && { visitStartTime }),
 				...(visitEndTime !== '' && { visitEndTime })
 			}
@@ -41,10 +45,10 @@ export async function createSiteVisit(
  * @param {number} appealId
  * @param {number} siteVisitId
  * @param {import('@pins/appeals/types/inspector.js').SiteVisitType} visitType
- * @param {string} [previousVisitType]
  * @param {string} [visitDate]
  * @param {string} [visitStartTime]
  * @param {string} [visitEndTime]
+ * @param {string} [previousVisitType]
  * @param {string} [inspectorName]
  * @param {string} [siteVisitChangeType]
  */

--- a/appeals/web/src/server/appeals/appeal-users/users-service.js
+++ b/appeals/web/src/server/appeals/appeal-users/users-service.js
@@ -55,11 +55,7 @@ const getUserById = async (id, session) => {
 	// TODO: add users from other groups as required
 	const users = [...caseOfficerUsers, ...inspectorUsers];
 
-	for (const user of users) {
-		if (user.id === id) {
-			return user;
-		}
-	}
+	return users.find((user) => user.id === id);
 };
 
 /**


### PR DESCRIPTION
## Describe your changes
#### Add inspector name to site visit notify (a2-2578)

Please note that any variables added to notify are ignored if they are not used.  It is safe to add this prior to the template/s being updated  to include it.

#### WEB:
- Add inspectorName to the UpdateSiteVisitData interface
- Add inspectorName to the CreateSiteVisitData interface
- Added unit tests for above

#### API:
- Add inspector_name to the notify variables for arranging a site visit
- Amended unit tests for above

#### TEST:
- All unit tests pass
- Tested within browser

## Issue ticket number and link
[Ticket: WEB/API - 500 seen when first scheduling site visit (A2-2578)](https://pins-ds.atlassian.net.mcas.ms/browse/A2-2578)
