### PR TITLE
fix(web): a2-2563 wrap long redacted strings in shared ip comments ta…

### DIFF
--- a/appeals/web/src/server/appeals/appeal-details/representations/interested-party-comments/interested-party-comments.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/representations/interested-party-comments/interested-party-comments.mapper.js
@@ -7,6 +7,7 @@ import { simpleHtmlComponent } from '#lib/mappers/index.js';
 import { constructUrl } from '#lib/mappers/utils/url.mapper.js';
 import { preRenderPageComponents } from '#lib/nunjucks-template-builders/page-component-rendering.js';
 import { buildHtmUnorderedList } from '#lib/nunjucks-template-builders/tag-builders.js';
+import { addInvisibleSpacesAfterRedactionCharacters } from '#lib/redaction-string-formatter.js';
 
 /**
  * @typedef {import('@pins/appeals.api').Appeals.SingleAppellantCaseResponse} SingleAppellantCaseResponse */
@@ -147,7 +148,9 @@ export function sharedIpCommentsPage(appealDetails, comments) {
 						{
 							type: 'show-more',
 							parameters: {
-								text: comment.redactedRepresentation || comment.originalRepresentation,
+								text: comment.redactedRepresentation
+									? addInvisibleSpacesAfterRedactionCharacters(comment.redactedRepresentation)
+									: comment.originalRepresentation,
 								labelText: 'Read more'
 							}
 						}

--- a/appeals/web/src/server/lib/__tests__/libraries.test.js
+++ b/appeals/web/src/server/lib/__tests__/libraries.test.js
@@ -34,6 +34,7 @@ import { linkedAppealStatus } from '#lib/appeals-formatter.js';
 import httpMocks from 'node-mocks-http';
 import { getOriginPathname, isInternalUrl, safeRedirect } from '#lib/url-utilities.js';
 import { stringIsValidPostcodeFormat } from '#lib/postcode.js';
+import { addInvisibleSpacesAfterRedactionCharacters } from '#lib/redaction-string-formatter.js';
 
 describe('Libraries', () => {
 	describe('addressFormatter', () => {
@@ -1214,6 +1215,16 @@ describe('Libraries', () => {
 				expect(result.pageNumber).toEqual(3);
 				expect(result.pageSize).toEqual(16);
 			});
+		});
+	});
+
+	describe('addInvisibleSpacesAfterRedactionCharacters', () => {
+		it('should add a unicode invisible space after each █ character', () => {
+			const originalString = 'some text ██████████████████████ more text';
+			const formattedString =
+				'some text █\u200B█\u200B█\u200B█\u200B█\u200B█\u200B█\u200B█\u200B█\u200B█\u200B█\u200B█\u200B█\u200B█\u200B█\u200B█\u200B█\u200B█\u200B█\u200B█\u200B█\u200B█\u200B more text';
+
+			expect(addInvisibleSpacesAfterRedactionCharacters(originalString)).toEqual(formattedString);
 		});
 	});
 });

--- a/appeals/web/src/server/lib/redaction-string-formatter.js
+++ b/appeals/web/src/server/lib/redaction-string-formatter.js
@@ -1,0 +1,10 @@
+/**
+ * @param {string} redactedString
+ * @returns {string}
+ */
+export function addInvisibleSpacesAfterRedactionCharacters(redactedString) {
+	return redactedString
+		.split('')
+		.map((char) => (char === '█' ? `${char}\u200B` : char))
+		.join('');
+}


### PR DESCRIPTION
…ble cell

* for display purposes only, add invisible spaces after each redaction character to prevent long redaction strings from overspilling gov uk table cells

<!--
    Please include a summary of the change along with any relevant context.
    List any dependencies that are required for this change.
-->

## Issue ticket number and link
[Ticket](https://pins-ds.atlassian.net.mcas.ms/browse/A2-2563)
