### PR TITLE
fix(A2-2454/web): Fixing Read more for redacted representations

### DIFF
--- a/appeals/web/src/client/components/show-more/show-more.js
+++ b/appeals/web/src/client/components/show-more/show-more.js
@@ -185,7 +185,7 @@ const initialiseComponentInstance = async (
 	initialiseOptions(componentInstance);
 
 	if (
-		componentInstance.elements.root.getAttribute(ATTRIBUTES.fullText).length <=
+		componentInstance.elements.root.innerText.length <=
 		componentInstance.options.maximumCharactersBeforeHiding
 	) {
 		return;


### PR DESCRIPTION
- Using inner html text rather than attribute since attribute is only set in initialiseTextMode method that runs after.
## Describe your changes

<!--
    Please include a summary of the change along with any relevant context.
    List any dependencies that are required for this change.
-->

## Issue ticket number and link
[Ticket](<!--Paste your ticket link here-->)
