### PR TITLE
fix(appeals): use document attachments to manage document versions (a2-2595)

### DIFF
--- a/appeals/web/src/server/appeals/appeal-details/representations/interested-party-comments/interested-party-comments.router.js
+++ b/appeals/web/src/server/appeals/appeal-details/representations/interested-party-comments/interested-party-comments.router.js
@@ -3,7 +3,6 @@ import { Router as createRouter } from 'express';
 import { validateAppeal } from '../../appeal-details.middleware.js';
 import addIpCommentRouter from './add-ip-comment/add-ip-comment.router.js';
 import editIpCommentRouter from './edit-ip-comment/edit-ip-comment.router.js';
-import addDocumentRouter from '../document-attachments/add-document.router.js';
 import viewAndReviewIpCommentRouter from './view-and-review/view-and-review.router.js';
 import redactIpCommentRouter from './redact/redact.router.js';
 import * as controller from './interested-party-comments.controller.js';
@@ -16,8 +15,6 @@ router.use('/add', validateAppeal, addIpCommentRouter);
 router.use('/:commentId/redact', redactIpCommentRouter);
 
 router.use('/:commentId/edit', validateAppeal, validateComment, editIpCommentRouter);
-
-router.use('/:commentId/add-document', validateAppeal, validateComment, addDocumentRouter);
 
 router.use('/:commentId', validateAppeal, validateComment, viewAndReviewIpCommentRouter);
 

--- a/appeals/web/src/server/appeals/appeal-details/representations/interested-party-comments/view-and-review/__tests__/__snapshots__/view-and-review.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/representations/interested-party-comments/view-and-review/__tests__/__snapshots__/view-and-review.test.js.snap
@@ -123,7 +123,7 @@ exports[`interested-party-comments GET /manage-documents/:folderId/:documentId s
                         <div class="govuk-!-margin-bottom-1"><strong class="govuk-tag govuk-tag--yellow single-line">Virus scanning</strong>
                         </div>
                     </dd>
-                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/interested-party-comments/5/change-document-name/1/1"> Change<span class="govuk-visually-hidden"> test-pdf-documentFileVersionsInfo.pdf name</span></a>
+                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/interested-party-comments/5/manage-documents/change-document-name/1/1"> Change<span class="govuk-visually-hidden"> test-pdf-documentFileVersionsInfo.pdf name</span></a>
                     </dd>
                 </div>
                 <div class="govuk-summary-list__row govuk-summary-list__row--no-actions"><dt class="govuk-summary-list__key"> Version</dt>
@@ -131,12 +131,12 @@ exports[`interested-party-comments GET /manage-documents/:folderId/:documentId s
                 </div>
                 <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Date submitted</dt>
                     <dd class="govuk-summary-list__value">1 February 2023</dd>
-                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/interested-party-comments/5/change-document-details/1/1"> Change<span class="govuk-visually-hidden"> test-pdf-documentFileVersionsInfo.pdf date received</span></a>
+                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/interested-party-comments/5/manage-documents/change-document-details/1/1"> Change<span class="govuk-visually-hidden"> test-pdf-documentFileVersionsInfo.pdf date received</span></a>
                     </dd>
                 </div>
                 <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Redaction status</dt>
                     <dd class="govuk-summary-list__value">Redacted</dd>
-                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/interested-party-comments/5/change-document-details/1/1"> Change<span class="govuk-visually-hidden"> test-pdf-documentFileVersionsInfo.pdf redaction status</span></a>
+                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/interested-party-comments/5/manage-documents/change-document-details/1/1"> Change<span class="govuk-visually-hidden"> test-pdf-documentFileVersionsInfo.pdf redaction status</span></a>
                     </dd>
                 </div>
             </dl>

--- a/appeals/web/src/server/appeals/appeal-details/representations/interested-party-comments/view-and-review/__tests__/view-and-review.test.js
+++ b/appeals/web/src/server/appeals/appeal-details/representations/interested-party-comments/view-and-review/__tests__/view-and-review.test.js
@@ -425,7 +425,7 @@ describe('interested-party-comments', () => {
 
 		it('should render change document page with the provided comment details', async () => {
 			const response = await request.get(
-				`${baseUrl}/2/interested-party-comments/5/change-document-name/1/1`
+				`${baseUrl}/2/interested-party-comments/5/manage-documents/change-document-name/1/1`
 			);
 
 			expect(response.statusCode).toBe(200);
@@ -480,7 +480,7 @@ describe('interested-party-comments', () => {
 
 		it('should render change document details page with the provided comment details', async () => {
 			const response = await request.get(
-				`${baseUrl}/2/interested-party-comments/5/change-document-details/1/1`
+				`${baseUrl}/2/interested-party-comments/5/manage-documents/change-document-details/1/1`
 			);
 
 			expect(response.statusCode).toBe(200);

--- a/appeals/web/src/server/appeals/appeal-details/representations/interested-party-comments/view-and-review/view-and-review.controller.js
+++ b/appeals/web/src/server/appeals/appeal-details/representations/interested-party-comments/view-and-review/view-and-review.controller.js
@@ -6,14 +6,8 @@ import {
 } from './view-and-review.mapper.js';
 import { patchInterestedPartyCommentStatus } from './view-and-review.service.js';
 import {
-	postChangeDocumentDetails,
-	postChangeDocumentFileName,
 	postDeleteDocument,
-	renderChangeDocumentDetails,
-	renderChangeDocumentFileName,
-	renderDeleteDocument,
-	renderManageDocument,
-	renderManageFolder
+	renderDeleteDocument
 } from '#appeals/appeal-documents/appeal-documents.controller.js';
 import { render } from '#appeals/appeal-details/representations/common/render.js';
 
@@ -76,97 +70,6 @@ export const postReviewInterestedPartyComment = async (request, response, next) 
 	});
 
 	return response.redirect(`/appeals-service/appeal-details/${appealId}/interested-party-comments`);
-};
-
-/** @type {import('@pins/express').RequestHandler<Response>} */
-export const getManageFolder = async (request, response) => {
-	const {
-		currentFolder,
-		params: { appealId, commentId }
-	} = request;
-
-	if (!currentFolder) {
-		return response.status(404).render('app/404');
-	}
-
-	await renderManageFolder({
-		request,
-		response,
-		backLinkUrl: `/appeals-service/appeal-details/${appealId}/interested-party-comments/${commentId}/review`,
-		viewAndEditUrl: `/appeals-service/appeal-details/${appealId}/interested-party-comments/${commentId}/manage-documents/{{folderId}}/{{documentId}}`,
-		pageHeadingTextOverride: 'Supporting documents',
-		dateColumnLabelTextOverride: 'Date submitted'
-	});
-};
-
-/** @type {import('@pins/express').RequestHandler<Response>} */
-export const getManageDocument = async (request, response) => {
-	const {
-		params: { commentId }
-	} = request;
-	await renderManageDocument({
-		request,
-		response,
-		backLinkUrl: `/appeals-service/appeal-details/${request.params.appealId}/interested-party-comments/${commentId}/manage-documents/{{folderId}}`,
-		uploadUpdatedDocumentUrl: `/appeals-service/appeal-details/${request.params.appealId}/interested-party-comments/${commentId}/add-documents/{{folderId}}/{{documentId}}`,
-		removeDocumentUrl: `/appeals-service/appeal-details/${request.params.appealId}/interested-party-comments/${commentId}/manage-documents/{{folderId}}/{{documentId}}/{{versionId}}/delete`,
-		pageTitleTextOverride: 'Manage versions',
-		dateRowLabelTextOverride: 'Date submitted'
-	});
-};
-
-/** @type {import('@pins/express').RequestHandler<Response>} */
-export const getChangeDocumentVersionDetails = async (request, response) => {
-	const {
-		params: { commentId }
-	} = request;
-
-	await renderChangeDocumentDetails({
-		request,
-		response,
-		backButtonUrl: `/appeals-service/appeal-details/${request.params.appealId}/interested-party-comments/${commentId}/manage-documents/${request.params.folderId}/${request.params.documentId}`
-	});
-};
-
-/** @type {import('@pins/express').RequestHandler<Response>} */
-export const postChangeDocumentVersionDetails = async (request, response) => {
-	const {
-		params: { commentId }
-	} = request;
-
-	await postChangeDocumentDetails({
-		request,
-		response,
-		backButtonUrl: `/appeals-service/appeal-details/${request.params.appealId}/interested-party-comments/${commentId}/manage-documents/${request.params.folderId}/${request.params.documentId}`,
-		nextPageUrl: `/appeals-service/appeal-details/${request.params.appealId}/interested-party-comments/${commentId}/manage-documents/${request.params.folderId}/${request.params.documentId}`
-	});
-};
-
-/** @type {import('@pins/express').RequestHandler<Response>} */
-export const getChangeDocumentFileNameDetails = async (request, response) => {
-	const {
-		params: { commentId }
-	} = request;
-
-	await renderChangeDocumentFileName({
-		request,
-		response,
-		backButtonUrl: `/appeals-service/appeal-details/${request.params.appealId}/interested-party-comments/${commentId}/manage-documents/${request.params.folderId}/${request.params.documentId}`
-	});
-};
-
-/** @type {import('@pins/express').RequestHandler<Response>} */
-export const postChangeDocumentFileNameDetails = async (request, response) => {
-	const {
-		params: { commentId }
-	} = request;
-
-	await postChangeDocumentFileName({
-		request,
-		response,
-		backButtonUrl: `/appeals-service/appeal-details/${request.params.appealId}/interested-party-comments/${commentId}/manage-documents/${request.params.folderId}/${request.params.documentId}`,
-		nextPageUrl: `/appeals-service/appeal-details/${request.params.appealId}/interested-party-comments/${commentId}/manage-documents/${request.params.folderId}/${request.params.documentId}`
-	});
 };
 
 /** @type {import('@pins/express').RequestHandler<Response>} */


### PR DESCRIPTION
## Describe your changes
#### Use document attachments to manage document versions (a2-2595)

#### WEB:
- Use manage-document routes 
- Remove replaced redundant routes and controller functions

#### TEST:
- Updated unit tests
- Updated snapshots
- All unit tests pass
- Tested within browser

## Issue ticket number and link
[Ticket: API/WEB - 'Page not found' error when clicking upload updated version for ip comments (A2-2595)](https://pins-ds.atlassian.net.mcas.ms/browse/A2-2595)
