### PR TITLE
fix(appeals): fix double slash in url issue

### DIFF
--- a/appeals/web/src/server/appeals/appeal-details/appeal-details.controller.js
+++ b/appeals/web/src/server/appeals/appeal-details/appeal-details.controller.js
@@ -40,10 +40,15 @@ export const viewAppealDetails = async (request, response) => {
 		]);
 	}
 
+	// Remove redundant slash at the end of the url if it exists to prevent a double slash when creating links
+	const currentUrl = request.originalUrl.endsWith('/')
+		? request.originalUrl.slice(0, -1)
+		: request.originalUrl;
+
 	const mappedPageContent = await appealDetailsPage(
 		currentAppeal,
 		appealCaseNotes,
-		request.originalUrl,
+		currentUrl,
 		session,
 		request,
 		appellantFinalComments,


### PR DESCRIPTION
## Describe your changes

When running the application, there is an issue where the links in the rows within the document section of the Case details page are corrupted with a double slash when the page itself has been loaded with a url containing and ending slash.  This certainly affects Linux when running the back office locally.  The links are broken.

This PR prevents the double slashes.