### PR TITLE
fix(appeals): cannot upload updated version of supporting document (a2-2594)

### DIFF
--- a/appeals/web/src/server/appeals/appeal-details/representations/final-comments/view-and-review/page-components/common.js
+++ b/appeals/web/src/server/appeals/appeal-details/representations/final-comments/view-and-review/page-components/common.js
@@ -30,9 +30,10 @@ export function generateCommentsSummaryList(appealId, comment) {
 	const commentIsDocument = !comment.originalRepresentation && comment.attachments?.length > 0;
 	const folderId = comment.attachments?.[0]?.documentVersion?.document?.folderId ?? null;
 
-	const filteredAttachments = comment.attachments?.filter(
-		(attachment) => !attachment.documentVersion.document.isDeleted
-	);
+	const filteredAttachments = comment.attachments?.filter((attachment) => {
+		const { isDeleted, latestVersionId } = attachment?.documentVersion?.document ?? {};
+		return latestVersionId === attachment.version && !isDeleted;
+	});
 
 	const attachmentsList = filteredAttachments?.length
 		? buildHtmUnorderedList(

--- a/appeals/web/src/server/appeals/appeal-details/representations/interested-party-comments/view-and-review/page-components/common.js
+++ b/appeals/web/src/server/appeals/appeal-details/representations/interested-party-comments/view-and-review/page-components/common.js
@@ -58,9 +58,10 @@ export function generateCommentSummaryList(
 	const commentIsDocument = !comment.originalRepresentation && comment.attachments?.length;
 	const folderId = comment.attachments?.[0]?.documentVersion?.document?.folderId ?? null;
 
-	const filteredAttachments = comment.attachments?.filter(
-		(attachment) => !attachment.documentVersion.document.isDeleted
-	);
+	const filteredAttachments = comment.attachments?.filter((attachment) => {
+		const { isDeleted, latestVersionId } = attachment?.documentVersion?.document ?? {};
+		return latestVersionId === attachment.version && !isDeleted;
+	});
 
 	const attachmentsList = filteredAttachments?.length
 		? buildHtmUnorderedList(

--- a/appeals/web/src/server/appeals/appeal-details/representations/lpa-statement/lpa-statement.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/representations/lpa-statement/lpa-statement.mapper.js
@@ -15,9 +15,10 @@ import { constructUrl } from '#lib/mappers/utils/url.mapper.js';
  * @returns {PageComponent}
  * */
 export function baseSummaryList(appealId, lpaStatement, { isReview }) {
-	const filteredAttachments = lpaStatement.attachments?.filter(
-		(attachment) => !attachment.documentVersion.document.isDeleted
-	);
+	const filteredAttachments = lpaStatement.attachments?.filter((attachment) => {
+		const { isDeleted, latestVersionId } = attachment?.documentVersion?.document ?? {};
+		return latestVersionId === attachment.version && !isDeleted;
+	});
 
 	const attachmentsList = filteredAttachments?.length
 		? buildHtmUnorderedList(


### PR DESCRIPTION
## Describe your changes
#### Fix uploading updated versions of supporting documents (a2-2594)

Please note, that there does seem to be some repetition when creating the attachments list for each of the different types of representation, but as other tickets are currently being worked on in this area, I thought it best not to create a common function in this PR.

#### WEB:
- Call postUploadDocumentVersionCheckAndConfirm instead of postUploadDocumentsCheckAndConfirm to upload versions
- Patch the representation attachment to include the new document version
- Remove duplicate filenames in each attachment list by filtering on latest document version

#### TEST:
- All unit tests pass
- Tested within browser

## Issue ticket number and link
[Ticket: API/WEB - Cannot upload updated version of supporting document (A2-2594)](https://pins-ds.atlassian.net.mcas.ms/browse/A2-2594)
