### PR TITLE
fix(api): using data model 1.9.19

### DIFF
--- a/appeals/api/package.json
+++ b/appeals/api/package.json
@@ -67,7 +67,7 @@
     "pino": "^8.1.0",
     "pino-http": "^8.1.0",
     "pino-pretty": "^8.1.0",
-    "pins-data-model": "github:Planning-Inspectorate/data-model#1.9.17",
+    "pins-data-model": "github:Planning-Inspectorate/data-model#1.9.19",
     "rhea": "3.0.1",
     "swagger-ui-express": "^5.0.1",
     "xstate": "4.32.1"

--- a/appeals/api/src/database/migrations/20250314101043_remove_inquiry_how_many_witnesses_from_command/migration.sql
+++ b/appeals/api/src/database/migrations/20250314101043_remove_inquiry_how_many_witnesses_from_command/migration.sql
@@ -1,0 +1,25 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `inquiryHowManyWitnesses` on the `AppellantCase` table. All the data in the column will be lost.
+
+*/
+BEGIN TRY
+
+BEGIN TRAN;
+
+-- AlterTable
+ALTER TABLE [dbo].[AppellantCase] DROP COLUMN [inquiryHowManyWitnesses];
+
+COMMIT TRAN;
+
+END TRY
+BEGIN CATCH
+
+IF @@TRANCOUNT > 0
+BEGIN
+    ROLLBACK TRAN;
+END;
+THROW
+
+END CATCH

--- a/appeals/api/src/database/schema.prisma
+++ b/appeals/api/src/database/schema.prisma
@@ -284,7 +284,6 @@ model AppellantCase {
   siteGridReferenceEasting                 String?
   siteGridReferenceNorthing                String?
   typeOfPlanningApplication                String?
-  inquiryHowManyWitnesses                  Int?
 }
 
 /// AppellantCaseValidationOutcome model

--- a/appeals/api/src/server/mappers/integration/commands/appellant-case.mapper.js
+++ b/appeals/api/src/server/mappers/integration/commands/appellant-case.mapper.js
@@ -72,8 +72,7 @@ export const mapAppellantCaseIn = (command) => {
 			jurisdiction: casedata.jurisdiction,
 			numberOfResidencesNetChange: casedata.numberOfResidencesNetChange,
 			siteGridReferenceEasting: casedata.siteGridReferenceEasting,
-			siteGridReferenceNorthing: casedata.siteGridReferenceNorthing,
-			inquiryHowManyWitnesses: casedata.inquiryHowManyWitnesses
+			siteGridReferenceNorthing: casedata.siteGridReferenceNorthing
 		})
 	};
 

--- a/appeals/api/src/server/mappers/integration/s78/map-appellant-case.js
+++ b/appeals/api/src/server/mappers/integration/s78/map-appellant-case.js
@@ -34,10 +34,8 @@ export const mapAppellantCase = (data) => {
 		statusPlanningObligation: casedata?.statusPlanningObligation ?? null,
 		// @ts-ignore
 		typeOfPlanningApplication: casedata?.typeOfPlanningApplication,
-		inquiryHowManyWitnesses: casedata?.inquiryHowManyWitnesses,
 
 		//TODO:
-
 		designAccessStatementProvided: null
 	};
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
 				"joi": "^17.7.0",
 				"node-cache": "^5.1.2",
 				"nodemon": "3.0.3",
-				"pins-data-model": "github:Planning-Inspectorate/data-model#1.9.17"
+				"pins-data-model": "github:Planning-Inspectorate/data-model#1.9.19"
 			},
 			"devDependencies": {
 				"@commitlint/cli": "17.0.1",
@@ -78,7 +78,7 @@
 				"pino": "^8.1.0",
 				"pino-http": "^8.1.0",
 				"pino-pretty": "^8.1.0",
-				"pins-data-model": "github:Planning-Inspectorate/data-model#1.9.17",
+				"pins-data-model": "github:Planning-Inspectorate/data-model#1.9.19",
 				"rhea": "3.0.1",
 				"swagger-ui-express": "^5.0.1",
 				"xstate": "4.32.1"
@@ -20065,8 +20065,8 @@
 			"license": "MIT"
 		},
 		"node_modules/pins-data-model": {
-			"version": "1.9.17",
-			"resolved": "git+ssh://git@github.com/Planning-Inspectorate/data-model.git#bb55b277d71569526d95279d8cf4ebc3d84f8b1e",
+			"version": "1.9.19",
+			"resolved": "git+ssh://git@github.com/Planning-Inspectorate/data-model.git#fc8d42fbf9a6a6e0b45fd829a440f97eb22b6a83",
 			"integrity": "sha512-xk2gyAS0kAzFkiOWmo2pKvKAkQno2nER/buABJbmyVgIBsBGNSb7gQ91TmZOyn4aNEI90Q4Gxcq5w9q4+RyMpw==",
 			"license": "MIT",
 			"dependencies": {
@@ -29591,7 +29591,7 @@
 				"pino": "^8.1.0",
 				"pino-http": "^8.1.0",
 				"pino-pretty": "^8.1.0",
-				"pins-data-model": "github:Planning-Inspectorate/data-model#1.9.17",
+				"pins-data-model": "github:Planning-Inspectorate/data-model#1.9.19",
 				"prisma": "4.16.1",
 				"rhea": "3.0.1",
 				"rimraf": "^3.0.2",
@@ -40240,9 +40240,9 @@
 			"version": "4.0.0"
 		},
 		"pins-data-model": {
-			"version": "git+ssh://git@github.com/Planning-Inspectorate/data-model.git#bb55b277d71569526d95279d8cf4ebc3d84f8b1e",
+			"version": "git+ssh://git@github.com/Planning-Inspectorate/data-model.git#fc8d42fbf9a6a6e0b45fd829a440f97eb22b6a83",
 			"integrity": "sha512-xk2gyAS0kAzFkiOWmo2pKvKAkQno2nER/buABJbmyVgIBsBGNSb7gQ91TmZOyn4aNEI90Q4Gxcq5w9q4+RyMpw==",
-			"from": "pins-data-model@github:Planning-Inspectorate/data-model#1.9.17",
+			"from": "pins-data-model@github:Planning-Inspectorate/data-model#1.9.19",
 			"requires": {
 				"jsonc-parser": "^3.3.1"
 			}

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
 		"joi": "^17.7.0",
 		"node-cache": "^5.1.2",
 		"nodemon": "3.0.3",
-		"pins-data-model": "github:Planning-Inspectorate/data-model#1.9.17"
+		"pins-data-model": "github:Planning-Inspectorate/data-model#1.9.19"
 	},
 	"devDependencies": {
 		"@commitlint/cli": "17.0.1",


### PR DESCRIPTION
There was a bit of confusion on the fields `appellantProcedurePreferenceWitnessCount` and `inquiryHowManyWitnesses`.
Now the latter is removed and we are using `appellantProcedurePreferenceWitnessCount` to capture the data.
