### PR TITLE
fix(api): update complete events correct query

### DIFF
--- a/appeals/api/src/server/repositories/appeal.repository.js
+++ b/appeals/api/src/server/repositories/appeal.repository.js
@@ -386,7 +386,8 @@ const getAppealsWithCompletedEvents = () =>
 		where: {
 			appealStatus: {
 				some: {
-					status: APPEAL_CASE_STATUS.AWAITING_EVENT
+					status: APPEAL_CASE_STATUS.AWAITING_EVENT,
+					valid: true
 				}
 			},
 			siteVisit: {


### PR DESCRIPTION
Adds the correct filter when loading appeals that have an AWAITING_EVENT elapsed.