### PR TITLE
fix(appeals): accept final comments change button and case history log fix

### DIFF
--- a/appeals/api/src/server/endpoints/representations/representations.controller.js
+++ b/appeals/api/src/server/endpoints/representations/representations.controller.js
@@ -183,7 +183,7 @@ export async function updateRepresentation(request, response) {
 					`AUDIT_TRAIL_REP_${camelToScreamingSnake(updatedRep.representationType)}_INVALID`
 				];
 			} else {
-				stringTokenReplacement(
+				return stringTokenReplacement(
 					// @ts-ignore
 					CONSTANTS[
 						`AUDIT_TRAIL_REP_${camelToScreamingSnake(updatedRep.representationType)}_STATUS_UPDATED`

--- a/appeals/web/src/server/appeals/appeal-details/representations/final-comments/accept/__tests__/__snapshots__/accept-final-comments.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/representations/final-comments/accept/__tests__/__snapshots__/accept-final-comments.test.js.snap
@@ -16,7 +16,7 @@ exports[`final-comments GET / should render the accept appellant final comments 
                     </dd>
                 </div>
                 <div class="govuk-summary-list__row govuk-summary-list__row--no-actions"><dt class="govuk-summary-list__key"> Supporting documents</dt>
-                    <dd class="govuk-summary-list__value"></dd>
+                    <dd class="govuk-summary-list__value">Not provided</dd>
                 </div>
                 <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Review decisions</dt>
                     <dd class="govuk-summary-list__value">Accept final comments</dd>
@@ -52,7 +52,7 @@ exports[`final-comments GET / should render the accept lpa final comments page w
                     </dd>
                 </div>
                 <div class="govuk-summary-list__row govuk-summary-list__row--no-actions"><dt class="govuk-summary-list__key"> Supporting documents</dt>
-                    <dd class="govuk-summary-list__value"></dd>
+                    <dd class="govuk-summary-list__value">Not provided</dd>
                 </div>
                 <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Review decisions</dt>
                     <dd class="govuk-summary-list__value">Accept final comments</dd>

--- a/appeals/web/src/server/appeals/appeal-details/representations/final-comments/accept/accept.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/representations/final-comments/accept/accept.mapper.js
@@ -3,6 +3,7 @@ import { preRenderPageComponents } from '#lib/nunjucks-template-builders/page-co
 import { wrapComponents, simpleHtmlComponent, buttonComponent } from '#lib/mappers/index.js';
 import { redactInput } from '#appeals/appeal-details/representations/common/components/redact-input.js';
 import { summaryList } from './components/summary-list.js';
+import { buildHtmUnorderedList } from '#lib/nunjucks-template-builders/tag-builders.js';
 
 /** @typedef {import("#appeals/appeal-details/appeal-details.types.js").WebAppeal} Appeal */
 /** @typedef {import("#appeals/appeal-details/representations/types.js").Representation} Representation */
@@ -76,8 +77,21 @@ export const acceptFinalCommentPage = (
 export const confirmAcceptFinalCommentPage = (appealDetails, representation, finalCommentsType) => {
 	const shortReference = appealShortReference(appealDetails.appealReference);
 
+	const attachmentsList =
+		representation.attachments.length > 0
+			? buildHtmUnorderedList(
+					representation.attachments.map(
+						(a) => `<a class="govuk-link" href="#">${a.documentVersion.document.name}</a>`
+					)
+			  )
+			: null;
+
+	console.log(`[accept.mapper.js] attachmentsList: ${attachmentsList}`);
+
 	/** @type {PageComponent[]} */
-	const pageComponents = [summaryList(appealDetails, representation, finalCommentsType)];
+	const pageComponents = [
+		summaryList(appealDetails, representation, finalCommentsType, attachmentsList)
+	];
 
 	preRenderPageComponents(pageComponents);
 

--- a/appeals/web/src/server/appeals/appeal-details/representations/final-comments/accept/components/summary-list.js
+++ b/appeals/web/src/server/appeals/appeal-details/representations/final-comments/accept/components/summary-list.js
@@ -5,9 +5,10 @@
  * @param {Appeal} appealDetails
  * @param {Representation} comment
  * @param {string} finalCommentsType
+ * @param {string|null} attachmentsList
  * @returns {PageComponent}
  */
-export const summaryList = (appealDetails, comment, finalCommentsType) => ({
+export const summaryList = (appealDetails, comment, finalCommentsType, attachmentsList) => ({
 	type: 'summary-list',
 	wrapperHtml: {
 		opening: '<div class="govuk-grid-row"><div class="govuk-grid-column-full">',
@@ -32,7 +33,7 @@ export const summaryList = (appealDetails, comment, finalCommentsType) => ({
 			},
 			{
 				key: { text: 'Supporting documents' },
-				value: { text: '' },
+				value: attachmentsList ? { html: attachmentsList } : { text: 'Not provided' },
 				...(comment.attachments?.length > 0
 					? {
 							actions: {


### PR DESCRIPTION
Fixed:
- Added missing return to stringTokenReplacement, allowing "details" data to equate correctly, fixing CreateAuditTrail call
- Added attachmentList into view mapper. providing necessary data to display supporting doc/s in final comments view
- Added supporting docs route for "change" button 

Ticket:
https://pins-ds.atlassian.net/browse/A2-86
