### PR TITLE
fix(web): fix ordering of success and important notification banners

### DIFF
--- a/appeals/web/src/server/appeals/appeal-details/__tests__/__snapshots__/appeal-details.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/__tests__/__snapshots__/appeal-details.test.js.snap
@@ -2,7 +2,8 @@
 
 exports[`appeal-details GET /:appealId "Progress case" important banners should render a "Progress case" important banner with the link to progress case from final comments with the expected content when Final Comments Due Date has passed and both Appellant and LPA Final Comments are absent or invalid. 1`] = `
 "<div class="govuk-notification-banner govuk-!-margin-bottom-5" role="region"
-aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
+aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner"
+data-index="0">
     <div class="govuk-notification-banner__header">
         <h3 class="govuk-notification-banner__title" id="govuk-notification-banner-title"> Important</h3>
     </div>
@@ -13,7 +14,8 @@ aria-labelledby="govuk-notification-banner-title" data-module="govuk-notificatio
 
 exports[`appeal-details GET /:appealId "Progress case" important banners should render a "Share final comments" important banner with the link to progress case from final comments with the expected content when Final Comments Due Date has passed and Appellant Final Comments are valid (but not LPA). 1`] = `
 "<div class="govuk-notification-banner govuk-!-margin-bottom-5" role="region"
-aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
+aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner"
+data-index="0">
     <div class="govuk-notification-banner__header">
         <h3 class="govuk-notification-banner__title" id="govuk-notification-banner-title"> Important</h3>
     </div>
@@ -24,7 +26,8 @@ aria-labelledby="govuk-notification-banner-title" data-module="govuk-notificatio
 
 exports[`appeal-details GET /:appealId "Progress case" important banners should render a "Share final comments" important banner with the link to progress case from final comments with the expected content when Final Comments Due Date has passed and LPA Final Comments are valid (but not Appellant). 1`] = `
 "<div class="govuk-notification-banner govuk-!-margin-bottom-5" role="region"
-aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
+aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner"
+data-index="0">
     <div class="govuk-notification-banner__header">
         <h3 class="govuk-notification-banner__title" id="govuk-notification-banner-title"> Important</h3>
     </div>
@@ -35,7 +38,8 @@ aria-labelledby="govuk-notification-banner-title" data-module="govuk-notificatio
 
 exports[`appeal-details GET /:appealId "Progress case" important banners should render a "Share final comments" important banner with the link to progress case from final comments with the expected content when Final Comments Due Date has passed and both Appellant and LPA Final Comments are valid. 1`] = `
 "<div class="govuk-notification-banner govuk-!-margin-bottom-5" role="region"
-aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
+aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner"
+data-index="0">
     <div class="govuk-notification-banner__header">
         <h3 class="govuk-notification-banner__title" id="govuk-notification-banner-title"> Important</h3>
     </div>
@@ -116,7 +120,8 @@ exports[`appeal-details GET /:appealId Case notes should render the case note de
 
 exports[`appeal-details GET /:appealId Notification banners should render a "Appeal ready for validation" important notification banner with a link to validate the appeal when the appeal status is "validation" 1`] = `
 "<div class="govuk-notification-banner govuk-!-margin-bottom-5" role="region"
-aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
+aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner"
+data-index="0">
     <div class="govuk-notification-banner__header">
         <h3 class="govuk-notification-banner__title" id="govuk-notification-banner-title"> Important</h3>
     </div>
@@ -130,7 +135,8 @@ aria-labelledby="govuk-notification-banner-title" data-module="govuk-notificatio
 
 exports[`appeal-details GET /:appealId Notification banners should render a "Appeal ready to be assigned to case officer" important notification banner with a link to assign case officer when status is "Assign case officer" 1`] = `
 "<div class="govuk-notification-banner govuk-!-margin-bottom-5" role="region"
-aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
+aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner"
+data-index="0">
     <div class="govuk-notification-banner__header">
         <h3 class="govuk-notification-banner__title" id="govuk-notification-banner-title"> Important</h3>
     </div>
@@ -145,7 +151,8 @@ aria-labelledby="govuk-notification-banner-title" data-module="govuk-notificatio
 
 exports[`appeal-details GET /:appealId Notification banners should render a "Horizon reference added" success notification banner, a "Transferred" status tag, and an inset text component with the appeal type and horizon link for the transferred appeal, when the appeal was successfully transferred to horizon 1`] = `
 "<div class="govuk-notification-banner govuk-notification-banner--success govuk-!-margin-bottom-5"
-role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
+role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner"
+data-index="0">
     <div class="govuk-notification-banner__header">
         <h3 class="govuk-notification-banner__title" id="govuk-notification-banner-title"> Success</h3>
     </div>
@@ -166,7 +173,8 @@ exports[`appeal-details GET /:appealId Notification banners should render a "Hor
 
 exports[`appeal-details GET /:appealId Notification banners should render a "LPA questionnaire ready for review" important notification banner with a link to review the questionnaire when the appeal status is "lpa_questionnaire" and the appeal has an LPA questionnaire ID 1`] = `
 "<div class="govuk-notification-banner govuk-!-margin-bottom-5" role="region"
-aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
+aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner"
+data-index="0">
     <div class="govuk-notification-banner__header">
         <h3 class="govuk-notification-banner__title" id="govuk-notification-banner-title"> Important</h3>
     </div>
@@ -181,7 +189,8 @@ aria-labelledby="govuk-notification-banner-title" data-module="govuk-notificatio
 
 exports[`appeal-details GET /:appealId Notification banners should render a "Neighbouring site added" success notification banner when an inspector/3rd party neighbouring site was added 1`] = `
 "<div class="govuk-notification-banner govuk-notification-banner--success govuk-!-margin-bottom-5"
-role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
+role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner"
+data-index="0">
     <div class="govuk-notification-banner__header">
         <h3 class="govuk-notification-banner__title" id="govuk-notification-banner-title"> Success</h3>
     </div>
@@ -193,7 +202,8 @@ role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govu
 
 exports[`appeal-details GET /:appealId Notification banners should render a "Neighbouring site removed" success notification banner when an inspector/3rd party neighbouring site was removed 1`] = `
 "<div class="govuk-notification-banner govuk-notification-banner--success govuk-!-margin-bottom-5"
-role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
+role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner"
+data-index="0">
     <div class="govuk-notification-banner__header">
         <h3 class="govuk-notification-banner__title" id="govuk-notification-banner-title"> Success</h3>
     </div>
@@ -205,7 +215,8 @@ role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govu
 
 exports[`appeal-details GET /:appealId Notification banners should render a "Neighbouring site updated" success notification banner when an inspector/3rd party neighbouring site was updated 1`] = `
 "<div class="govuk-notification-banner govuk-notification-banner--success govuk-!-margin-bottom-5"
-role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
+role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner"
+data-index="0">
     <div class="govuk-notification-banner__header">
         <h3 class="govuk-notification-banner__title" id="govuk-notification-banner-title"> Success</h3>
     </div>
@@ -217,7 +228,8 @@ role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govu
 
 exports[`appeal-details GET /:appealId Notification banners should render a "Site visit ready to set up" important notification banner with a link to schedule the site visit when the appeal status is "event" 1`] = `
 "<div class="govuk-notification-banner govuk-!-margin-bottom-5" role="region"
-aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
+aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner"
+data-index="0">
     <div class="govuk-notification-banner__header">
         <h3 class="govuk-notification-banner__title" id="govuk-notification-banner-title"> Important</h3>
     </div>
@@ -232,7 +244,8 @@ aria-labelledby="govuk-notification-banner-title" data-module="govuk-notificatio
 
 exports[`appeal-details GET /:appealId Notification banners should render a "This appeal is awaiting transfer" important notification banner with a link to add the Horizon reference of the transferred appeal when the appeal is awaiting transfer 1`] = `
 "<div class="govuk-notification-banner govuk-!-margin-bottom-5" role="region"
-aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
+aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner"
+data-index="0">
     <div class="govuk-notification-banner__header">
         <h3 class="govuk-notification-banner__title" id="govuk-notification-banner-title"> Important</h3>
     </div>
@@ -246,7 +259,8 @@ aria-labelledby="govuk-notification-banner-title" data-module="govuk-notificatio
 
 exports[`appeal-details GET /:appealId Notification banners should render a "This appeal is now the lead for appeal" success notification banner when the appeal was successfully linked as the lead of a back-office appeal 1`] = `
 "<div class="govuk-notification-banner govuk-notification-banner--success govuk-!-margin-bottom-5"
-role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
+role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner"
+data-index="0">
     <div class="govuk-notification-banner__header">
         <h3 class="govuk-notification-banner__title" id="govuk-notification-banner-title"> Success</h3>
     </div>
@@ -258,7 +272,8 @@ role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govu
 
 exports[`appeal-details GET /:appealId Notification banners should render a success notification banner when a costs decision document was uploaded 1`] = `
 "<div class="govuk-notification-banner govuk-notification-banner--success govuk-!-margin-bottom-5"
-role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
+role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner"
+data-index="0">
     <div class="govuk-notification-banner__header">
         <h3 class="govuk-notification-banner__title" id="govuk-notification-banner-title"> Success</h3>
     </div>
@@ -270,7 +285,8 @@ role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govu
 
 exports[`appeal-details GET /:appealId Notification banners should render a success notification banner when a cross-team correspondence document was uploaded 1`] = `
 "<div class="govuk-notification-banner govuk-notification-banner--success govuk-!-margin-bottom-5"
-role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
+role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner"
+data-index="0">
     <div class="govuk-notification-banner__header">
         <h3 class="govuk-notification-banner__title" id="govuk-notification-banner-title"> Success</h3>
     </div>
@@ -282,7 +298,8 @@ role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govu
 
 exports[`appeal-details GET /:appealId Notification banners should render a success notification banner when a new version of a costs decision document was uploaded 1`] = `
 "<div class="govuk-notification-banner govuk-notification-banner--success govuk-!-margin-bottom-5"
-role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
+role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner"
+data-index="0">
     <div class="govuk-notification-banner__header">
         <h3 class="govuk-notification-banner__title" id="govuk-notification-banner-title"> Success</h3>
     </div>
@@ -294,7 +311,8 @@ role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govu
 
 exports[`appeal-details GET /:appealId Notification banners should render a success notification banner when a new version of an LPA costs document was uploaded 1`] = `
 "<div class="govuk-notification-banner govuk-notification-banner--success govuk-!-margin-bottom-5"
-role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
+role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner"
+data-index="0">
     <div class="govuk-notification-banner__header">
         <h3 class="govuk-notification-banner__title" id="govuk-notification-banner-title"> Success</h3>
     </div>
@@ -306,7 +324,8 @@ role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govu
 
 exports[`appeal-details GET /:appealId Notification banners should render a success notification banner when a new version of an appellant costs document was uploaded 1`] = `
 "<div class="govuk-notification-banner govuk-notification-banner--success govuk-!-margin-bottom-5"
-role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
+role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner"
+data-index="0">
     <div class="govuk-notification-banner__header">
         <h3 class="govuk-notification-banner__title" id="govuk-notification-banner-title"> Success</h3>
     </div>
@@ -318,7 +337,8 @@ role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govu
 
 exports[`appeal-details GET /:appealId Notification banners should render a success notification banner when a service user was updated 1`] = `
 "<div class="govuk-notification-banner govuk-notification-banner--success govuk-!-margin-bottom-5"
-role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
+role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner"
+data-index="0">
     <div class="govuk-notification-banner__header">
         <h3 class="govuk-notification-banner__title" id="govuk-notification-banner-title"> Success</h3>
     </div>
@@ -330,7 +350,8 @@ role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govu
 
 exports[`appeal-details GET /:appealId Notification banners should render a success notification banner when a user was successfully assigned as case officer 1`] = `
 "<div class="govuk-notification-banner govuk-notification-banner--success govuk-!-margin-bottom-5"
-role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
+role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner"
+data-index="0">
     <div class="govuk-notification-banner__header">
         <h3 class="govuk-notification-banner__title" id="govuk-notification-banner-title"> Success</h3>
     </div>
@@ -342,7 +363,8 @@ role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govu
 
 exports[`appeal-details GET /:appealId Notification banners should render a success notification banner when a user was successfully assigned as inspector 1`] = `
 "<div class="govuk-notification-banner govuk-notification-banner--success govuk-!-margin-bottom-5"
-role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
+role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner"
+data-index="0">
     <div class="govuk-notification-banner__header">
         <h3 class="govuk-notification-banner__title" id="govuk-notification-banner-title"> Success</h3>
     </div>
@@ -354,7 +376,8 @@ role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govu
 
 exports[`appeal-details GET /:appealId Notification banners should render a success notification banner when a user was successfully unassigned as inspector 1`] = `
 "<div class="govuk-notification-banner govuk-notification-banner--success govuk-!-margin-bottom-5"
-role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
+role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner"
+data-index="0">
     <div class="govuk-notification-banner__header">
         <h3 class="govuk-notification-banner__title" id="govuk-notification-banner-title"> Success</h3>
     </div>
@@ -366,7 +389,8 @@ role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govu
 
 exports[`appeal-details GET /:appealId Notification banners should render a success notification banner when an LPA costs document was uploaded 1`] = `
 "<div class="govuk-notification-banner govuk-notification-banner--success govuk-!-margin-bottom-5"
-role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
+role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner"
+data-index="0">
     <div class="govuk-notification-banner__header">
         <h3 class="govuk-notification-banner__title" id="govuk-notification-banner-title"> Success</h3>
     </div>
@@ -378,7 +402,8 @@ role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govu
 
 exports[`appeal-details GET /:appealId Notification banners should render a success notification banner when an appellant costs document was uploaded 1`] = `
 "<div class="govuk-notification-banner govuk-notification-banner--success govuk-!-margin-bottom-5"
-role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
+role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner"
+data-index="0">
     <div class="govuk-notification-banner__header">
         <h3 class="govuk-notification-banner__title" id="govuk-notification-banner-title"> Success</h3>
     </div>
@@ -390,7 +415,8 @@ role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govu
 
 exports[`appeal-details GET /:appealId Notification banners should render a success notification banner when an inspector correspondence document was uploaded 1`] = `
 "<div class="govuk-notification-banner govuk-notification-banner--success govuk-!-margin-bottom-5"
-role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
+role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner"
+data-index="0">
     <div class="govuk-notification-banner__header">
         <h3 class="govuk-notification-banner__title" id="govuk-notification-banner-title"> Success</h3>
     </div>
@@ -402,7 +428,8 @@ role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govu
 
 exports[`appeal-details GET /:appealId Notification banners should render a success notification banner when the inspector access was updated 1`] = `
 "<div class="govuk-notification-banner govuk-notification-banner--success govuk-!-margin-bottom-5"
-role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
+role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner"
+data-index="0">
     <div class="govuk-notification-banner__header">
         <h3 class="govuk-notification-banner__title" id="govuk-notification-banner-title"> Success</h3>
     </div>
@@ -414,7 +441,8 @@ role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govu
 
 exports[`appeal-details GET /:appealId Notification banners should render a success notification banner when the lpa application reference was updated 1`] = `
 "<div class="govuk-notification-banner govuk-notification-banner--success govuk-!-margin-bottom-5"
-role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
+role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner"
+data-index="0">
     <div class="govuk-notification-banner__header">
         <h3 class="govuk-notification-banner__title" id="govuk-notification-banner-title"> Success</h3>
     </div>
@@ -426,7 +454,8 @@ role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govu
 
 exports[`appeal-details GET /:appealId Notification banners should render a success notification banner when the safety risks was updated 1`] = `
 "<div class="govuk-notification-banner govuk-notification-banner--success govuk-!-margin-bottom-5"
-role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
+role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner"
+data-index="0">
     <div class="govuk-notification-banner__header">
         <h3 class="govuk-notification-banner__title" id="govuk-notification-banner-title"> Success</h3>
     </div>
@@ -438,7 +467,8 @@ role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govu
 
 exports[`appeal-details GET /:appealId Notification banners should render a success notification banner with appropriate content if the appeal was just linked as the child of a back-office appeal 1`] = `
 "<div class="govuk-notification-banner govuk-notification-banner--success govuk-!-margin-bottom-5"
-role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
+role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner"
+data-index="0">
     <div class="govuk-notification-banner__header">
         <h3 class="govuk-notification-banner__title" id="govuk-notification-banner-title"> Success</h3>
     </div>
@@ -450,7 +480,8 @@ role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govu
 
 exports[`appeal-details GET /:appealId Notification banners should render a success notification banner with appropriate content if the appeal was just linked as the child of a legacy (Horizon) appeal 1`] = `
 "<div class="govuk-notification-banner govuk-notification-banner--success govuk-!-margin-bottom-5"
-role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
+role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner"
+data-index="0">
     <div class="govuk-notification-banner__header">
         <h3 class="govuk-notification-banner__title" id="govuk-notification-banner-title"> Success</h3>
     </div>
@@ -462,7 +493,8 @@ role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govu
 
 exports[`appeal-details GET /:appealId Notification banners should render a success notification banner with appropriate content if the appeal was just linked as the lead of a legacy (Horizon) appeal 1`] = `
 "<div class="govuk-notification-banner govuk-notification-banner--success govuk-!-margin-bottom-5"
-role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
+role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner"
+data-index="0">
     <div class="govuk-notification-banner__header">
         <h3 class="govuk-notification-banner__title" id="govuk-notification-banner-title"> Success</h3>
     </div>
@@ -474,7 +506,8 @@ role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govu
 
 exports[`appeal-details GET /:appealId Notification banners should render an important notification banner when the appeal has unreviewed IP comments 1`] = `
 "<div class="govuk-notification-banner govuk-!-margin-bottom-5" role="region"
-aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
+aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner"
+data-index="0">
     <div class="govuk-notification-banner__header">
         <h3 class="govuk-notification-banner__title" id="govuk-notification-banner-title"> Important</h3>
     </div>
@@ -952,7 +985,8 @@ exports[`appeal-details GET /:appealId should not render action links to the man
 
 exports[`appeal-details GET /:appealId should render a "Appeal valid" notification banner with a link to start case when status is "READY_TO_START" 1`] = `
 "<div class="govuk-notification-banner govuk-!-margin-bottom-5" role="region"
-aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
+aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner"
+data-index="0">
     <div class="govuk-notification-banner__header">
         <h3 class="govuk-notification-banner__title" id="govuk-notification-banner-title"> Important</h3>
     </div>
@@ -2861,7 +2895,8 @@ exports[`appeal-details GET /:appealId should render an Issue a decision notific
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds govuk-!-margin-bottom-5">
             <div class="govuk-notification-banner govuk-!-margin-bottom-5" role="region"
-            aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
+            aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner"
+            data-index="0">
                 <div class="govuk-notification-banner__header">
                     <h3 class="govuk-notification-banner__title" id="govuk-notification-banner-title"> Important</h3>
                 </div>

--- a/appeals/web/src/server/appeals/appeal-details/appeal-details.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/appeal-details.mapper.js
@@ -1,6 +1,6 @@
 import { appealShortReference } from '#lib/appeals-formatter.js';
 import { initialiseAndMapAppealData } from '#lib/mappers/data/appeal/mapper.js';
-import { mapNotificationBannersFromSession } from '#lib/mappers/index.js';
+import { mapNotificationBannersFromSession, sortNotificationBanners } from '#lib/mappers/index.js';
 import { preRenderPageComponents } from '#lib/nunjucks-template-builders/page-component-rendering.js';
 import { generateAccordionItems } from './accordions/index.js';
 import { generateCaseNotes } from './case-notes/case-notes.mapper.js';
@@ -49,10 +49,13 @@ export async function appealDetailsPage(
 	const accordion = generateAccordionItems(appealDetails, mappedData, session);
 
 	const statusDependentNotifications = mapStatusDependentNotifications(appealDetails);
+	const notificationBanners = sortNotificationBanners([
+		...statusDependentNotifications,
+		...mapNotificationBannersFromSession(session, 'appealDetails', appealDetails.appealId)
+	]);
 
 	const pageComponents = [
-		...statusDependentNotifications,
-		...mapNotificationBannersFromSession(session, 'appealDetails', appealDetails.appealId),
+		...notificationBanners,
 		...(await generateStatusTags(mappedData, appealDetails, request)),
 		generateCaseSummary(mappedData),
 		...caseDownload,

--- a/appeals/web/src/server/appeals/appeal-details/appellant-case/__tests__/__snapshots__/appellant-case.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/appellant-case/__tests__/__snapshots__/appellant-case.test.js.snap
@@ -1,8 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`appellant-case GET /appellant-case should render a "Application decision date updated" notification banner when the application decision date is updated 1`] = `
+exports[`appellant-case GET /appellant-case notification banners should render a "Application decision date updated" notification banner when the application decision date is updated 1`] = `
 "<div class="govuk-notification-banner govuk-notification-banner--success govuk-!-margin-bottom-5"
-role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
+role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner"
+data-index="0">
     <div class="govuk-notification-banner__header">
         <h3 class="govuk-notification-banner__title" id="govuk-notification-banner-title"> Success</h3>
     </div>
@@ -12,9 +13,10 @@ role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govu
 </div>"
 `;
 
-exports[`appellant-case GET /appellant-case should render a "Green belt status updated" notification banner when the green belt response is changed 1`] = `
+exports[`appellant-case GET /appellant-case notification banners should render a "Green belt status updated" notification banner when the green belt response is changed 1`] = `
 "<div class="govuk-notification-banner govuk-notification-banner--success govuk-!-margin-bottom-5"
-role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
+role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner"
+data-index="0">
     <div class="govuk-notification-banner__header">
         <h3 class="govuk-notification-banner__title" id="govuk-notification-banner-title"> Success</h3>
     </div>
@@ -24,12 +26,13 @@ role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govu
 </div>"
 `;
 
-exports[`appellant-case GET /appellant-case should render a "Inspector access (appellant) updated" success notification banner when the inspector access (appellant) is updated 1`] = `
+exports[`appellant-case GET /appellant-case notification banners should render a "Inspector access (appellant) updated" success notification banner when the inspector access (appellant) is updated 1`] = `
 "<main class="govuk-main-wrapper " id="main-content" role="main">
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds govuk-!-margin-bottom-5">
             <div class="govuk-notification-banner govuk-notification-banner--success govuk-!-margin-bottom-5"
-            role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
+            role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner"
+            data-index="0">
                 <div class="govuk-notification-banner__header">
                     <h3 class="govuk-notification-banner__title" id="govuk-notification-banner-title"> Success</h3>
                 </div>
@@ -275,9 +278,10 @@ exports[`appellant-case GET /appellant-case should render a "Inspector access (a
 </main>"
 `;
 
-exports[`appellant-case GET /appellant-case should render a "Inspector access (appellant) updated" success notification banner when the inspector access (appellant) is updated 2`] = `
+exports[`appellant-case GET /appellant-case notification banners should render a "Inspector access (appellant) updated" success notification banner when the inspector access (appellant) is updated 2`] = `
 "<div class="govuk-notification-banner govuk-notification-banner--success govuk-!-margin-bottom-5"
-role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
+role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner"
+data-index="0">
     <div class="govuk-notification-banner__header">
         <h3 class="govuk-notification-banner__title" id="govuk-notification-banner-title"> Success</h3>
     </div>
@@ -287,12 +291,13 @@ role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govu
 </div>"
 `;
 
-exports[`appellant-case GET /appellant-case should render a "LPA application reference" success notification banner when the planning application reference is updated 1`] = `
+exports[`appellant-case GET /appellant-case notification banners should render a "LPA application reference" success notification banner when the planning application reference is updated 1`] = `
 "<main class="govuk-main-wrapper " id="main-content" role="main">
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds govuk-!-margin-bottom-5">
             <div class="govuk-notification-banner govuk-notification-banner--success govuk-!-margin-bottom-5"
-            role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
+            role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner"
+            data-index="0">
                 <div class="govuk-notification-banner__header">
                     <h3 class="govuk-notification-banner__title" id="govuk-notification-banner-title"> Success</h3>
                 </div>
@@ -538,9 +543,10 @@ exports[`appellant-case GET /appellant-case should render a "LPA application ref
 </main>"
 `;
 
-exports[`appellant-case GET /appellant-case should render a "Part of agricultural holding updated" notification banner when the part of agricultural holding response is changed 1`] = `
+exports[`appellant-case GET /appellant-case notification banners should render a "Part of agricultural holding updated" notification banner when the part of agricultural holding response is changed 1`] = `
 "<div class="govuk-notification-banner govuk-notification-banner--success govuk-!-margin-bottom-5"
-role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
+role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner"
+data-index="0">
     <div class="govuk-notification-banner__header">
         <h3 class="govuk-notification-banner__title" id="govuk-notification-banner-title"> Success</h3>
     </div>
@@ -550,9 +556,10 @@ role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govu
 </div>"
 `;
 
-exports[`appellant-case GET /appellant-case should render a "Planning obligation status updated" notification banner when the planning obligation status is changed 1`] = `
+exports[`appellant-case GET /appellant-case notification banners should render a "Planning obligation status updated" notification banner when the planning obligation status is changed 1`] = `
 "<div class="govuk-notification-banner govuk-notification-banner--success govuk-!-margin-bottom-5"
-role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
+role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner"
+data-index="0">
     <div class="govuk-notification-banner__header">
         <h3 class="govuk-notification-banner__title" id="govuk-notification-banner-title"> Success</h3>
     </div>
@@ -562,9 +569,10 @@ role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govu
 </div>"
 `;
 
-exports[`appellant-case GET /appellant-case should render a "Site area updated" success notification banner when the site area is updated 1`] = `
+exports[`appellant-case GET /appellant-case notification banners should render a "Site area updated" success notification banner when the site area is updated 1`] = `
 "<div class="govuk-notification-banner govuk-notification-banner--success govuk-!-margin-bottom-5"
-role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
+role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner"
+data-index="0">
     <div class="govuk-notification-banner__header">
         <h3 class="govuk-notification-banner__title" id="govuk-notification-banner-title"> Success</h3>
     </div>
@@ -574,9 +582,10 @@ role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govu
 </div>"
 `;
 
-exports[`appellant-case GET /appellant-case should render a "Site health and safety risks updated" success notification banner when the planning application reference is updated 1`] = `
+exports[`appellant-case GET /appellant-case notification banners should render a "Site health and safety risks updated" success notification banner when the planning application reference is updated 1`] = `
 "<div class="govuk-notification-banner govuk-notification-banner--success govuk-!-margin-bottom-5"
-role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
+role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner"
+data-index="0">
     <div class="govuk-notification-banner__header">
         <h3 class="govuk-notification-banner__title" id="govuk-notification-banner-title"> Success</h3>
     </div>
@@ -586,12 +595,13 @@ role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govu
 </div>"
 `;
 
-exports[`appellant-case GET /appellant-case should render a "Site updated" notification when the site address has been updated 1`] = `
+exports[`appellant-case GET /appellant-case notification banners should render a "Site updated" notification when the site address has been updated 1`] = `
 "<main class="govuk-main-wrapper " id="main-content" role="main">
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds govuk-!-margin-bottom-5">
             <div class="govuk-notification-banner govuk-notification-banner--success govuk-!-margin-bottom-5"
-            role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
+            role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner"
+            data-index="0">
                 <div class="govuk-notification-banner__header">
                     <h3 class="govuk-notification-banner__title" id="govuk-notification-banner-title"> Success</h3>
                 </div>
@@ -837,9 +847,10 @@ exports[`appellant-case GET /appellant-case should render a "Site updated" notif
 </main>"
 `;
 
-exports[`appellant-case GET /appellant-case should render a "Site updated" notification when the site address has been updated 2`] = `
+exports[`appellant-case GET /appellant-case notification banners should render a "Site updated" notification when the site address has been updated 2`] = `
 "<div class="govuk-notification-banner govuk-notification-banner--success govuk-!-margin-bottom-5"
-role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
+role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner"
+data-index="0">
     <div class="govuk-notification-banner__header">
         <h3 class="govuk-notification-banner__title" id="govuk-notification-banner-title"> Success</h3>
     </div>
@@ -849,9 +860,10 @@ role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govu
 </div>"
 `;
 
-exports[`appellant-case GET /appellant-case should render a "Tenant of agricultural holding updated" notification banner when the tenant of agricultural holding response is changed 1`] = `
+exports[`appellant-case GET /appellant-case notification banners should render a "Tenant of agricultural holding updated" notification banner when the tenant of agricultural holding response is changed 1`] = `
 "<div class="govuk-notification-banner govuk-notification-banner--success govuk-!-margin-bottom-5"
-role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
+role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner"
+data-index="0">
     <div class="govuk-notification-banner__header">
         <h3 class="govuk-notification-banner__title" id="govuk-notification-banner-title"> Success</h3>
     </div>
@@ -861,12 +873,13 @@ role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govu
 </div>"
 `;
 
-exports[`appellant-case GET /appellant-case should render a success notification banner when a service user was updated 1`] = `
+exports[`appellant-case GET /appellant-case notification banners should render a success notification banner when a service user was updated 1`] = `
 "<main class="govuk-main-wrapper " id="main-content" role="main">
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds govuk-!-margin-bottom-5">
             <div class="govuk-notification-banner govuk-notification-banner--success govuk-!-margin-bottom-5"
-            role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
+            role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner"
+            data-index="0">
                 <div class="govuk-notification-banner__header">
                     <h3 class="govuk-notification-banner__title" id="govuk-notification-banner-title"> Success</h3>
                 </div>
@@ -1112,9 +1125,10 @@ exports[`appellant-case GET /appellant-case should render a success notification
 </main>"
 `;
 
-exports[`appellant-case GET /appellant-case should render a success notification banner when a service user was updated 2`] = `
+exports[`appellant-case GET /appellant-case notification banners should render a success notification banner when a service user was updated 2`] = `
 "<div class="govuk-notification-banner govuk-notification-banner--success govuk-!-margin-bottom-5"
-role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
+role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner"
+data-index="0">
     <div class="govuk-notification-banner__header">
         <h3 class="govuk-notification-banner__title" id="govuk-notification-banner-title"> Success</h3>
     </div>
@@ -1124,9 +1138,10 @@ role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govu
 </div>"
 `;
 
-exports[`appellant-case GET /appellant-case should render an "Appeal is incomplete" notification banner with the expected content when the appellant case has been reviewed with an outcome of "incomplete" 1`] = `
+exports[`appellant-case GET /appellant-case notification banners should render an "Appeal is incomplete" notification banner with the expected content when the appellant case has been reviewed with an outcome of "incomplete" 1`] = `
 "<div class="govuk-notification-banner govuk-!-margin-bottom-5" role="region"
-aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
+aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner"
+data-index="0">
     <div class="govuk-notification-banner__header">
         <h3 class="govuk-notification-banner__title" id="govuk-notification-banner-title"> Appeal is incomplete</h3>
     </div>
@@ -1168,9 +1183,10 @@ aria-labelledby="govuk-notification-banner-title" data-module="govuk-notificatio
 </div>"
 `;
 
-exports[`appellant-case GET /appellant-case should render an "Appeal is invalid" notification banner with the expected content when the appellant case has been reviewed with an outcome of "invalid" 1`] = `
+exports[`appellant-case GET /appellant-case notification banners should render an "Appeal is invalid" notification banner with the expected content when the appellant case has been reviewed with an outcome of "invalid" 1`] = `
 "<div class="govuk-notification-banner govuk-!-margin-bottom-5" role="region"
-aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
+aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner"
+data-index="0">
     <div class="govuk-notification-banner__header">
         <h3 class="govuk-notification-banner__title" id="govuk-notification-banner-title"> Appeal is invalid</h3>
     </div>
@@ -1207,9 +1223,10 @@ aria-labelledby="govuk-notification-banner-title" data-module="govuk-notificatio
 </div>"
 `;
 
-exports[`appellant-case GET /appellant-case should render an "Other tenants of agricultural holding updated" notification banner when the other tenants of agricultural holding response is changed 1`] = `
+exports[`appellant-case GET /appellant-case notification banners should render an "Other tenants of agricultural holding updated" notification banner when the other tenants of agricultural holding response is changed 1`] = `
 "<div class="govuk-notification-banner govuk-notification-banner--success govuk-!-margin-bottom-5"
-role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
+role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner"
+data-index="0">
     <div class="govuk-notification-banner__header">
         <h3 class="govuk-notification-banner__title" id="govuk-notification-banner-title"> Success</h3>
     </div>
@@ -2049,7 +2066,8 @@ exports[`appellant-case GET /appellant-case should render the appellant case pag
 
 exports[`appellant-case GET /appellant-case with unchecked documents should render a notification banner when a file is unscanned 1`] = `
 "<div class="govuk-notification-banner govuk-!-margin-bottom-5" role="region"
-aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
+aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner"
+data-index="0">
     <div class="govuk-notification-banner__header">
         <h3 class="govuk-notification-banner__title" id="govuk-notification-banner-title"> Important</h3>
     </div>

--- a/appeals/web/src/server/appeals/appeal-details/appellant-case/__tests__/appellant-case.test.js
+++ b/appeals/web/src/server/appeals/appeal-details/appellant-case/__tests__/appellant-case.test.js
@@ -211,436 +211,485 @@ describe('appellant-case', () => {
 			});
 		}
 
-		it('should render a "LPA application reference" success notification banner when the planning application reference is updated', async () => {
-			const appealId = appealData.appealId.toString();
-			nock('http://test/').patch(`/appeals/${appealId}`).reply(200, {
-				planningApplicationReference: '12345/A/67890'
-			});
-
-			const validData = {
-				planningApplicationReference: '12345/A/67890'
-			};
-
-			await request
-				.post(`${baseUrl}/${appealId}/appellant-case/lpa-reference/change`)
-				.send(validData);
-
-			const response = await request.get(`${baseUrl}/1${appellantCasePagePath}`);
-
-			const element = parseHtml(response.text);
-			expect(element.innerHTML).toMatchSnapshot();
-
-			const notificationBannerElementHTML = parseHtml(response.text, {
-				rootElement: '.govuk-notification-banner'
-			}).innerHTML;
-			expect(notificationBannerElementHTML).toContain('Success</h3>');
-			expect(notificationBannerElementHTML).toContain('LPA application reference updated</p>');
-		});
-
-		it('should render a "Application decision date updated" notification banner when the application decision date is updated', async () => {
-			const appealId = appealData.appealId.toString();
-			const appellantCaseId = appealData.appellantCaseId;
-			const validData = {
-				'application-decision-date-day': '11',
-				'application-decision-date-month': '06',
-				'application-decision-date-year': '2021'
-			};
-
-			nock('http://test/')
-				.patch(`/appeals/${appealId}/appellant-cases/${appellantCaseId}`)
-				.reply(200, { ...validData });
-
-			await request
-				.post(`${baseUrl}/${appealId}/appellant-case/application-decision-date/change`)
-				.send(validData);
-
-			const response = await request.get(`${baseUrl}/1${appellantCasePagePath}`);
-
-			const notificationBannerElementHTML = parseHtml(response.text, {
-				rootElement: notificationBannerElement
-			}).innerHTML;
-
-			expect(notificationBannerElementHTML).toMatchSnapshot();
-			expect(notificationBannerElementHTML).toContain('Success</h3>');
-			expect(notificationBannerElementHTML).toContain('Application decision date changed');
-		});
-
-		it('should render a "Green belt status updated" notification banner when the green belt response is changed', async () => {
-			const appealId = appealData.appealId.toString();
-			const appellantCaseId = appealData.appellantCaseId;
-			const appellantCaseUrl = `/appeals-service/appeal-details/${appealId}/appellant-case`;
-
-			const validData = {
-				greenBeltRadio: 'yes'
-			};
-
-			nock('http://test/')
-				.patch(`/appeals/${appealId}/appellant-cases/${appellantCaseId}`)
-				.reply(200, {});
-
-			await request.post(`${appellantCaseUrl}/green-belt/change/appellant`).send(validData);
-
-			const response = await request.get(`${baseUrl}/1${appellantCasePagePath}`);
-			const notificationBannerElementHTML = parseHtml(response.text, {
-				rootElement: notificationBannerElement
-			}).innerHTML;
-
-			expect(notificationBannerElementHTML).toMatchSnapshot();
-			expect(notificationBannerElementHTML).toContain('Success</h3>');
-			expect(notificationBannerElementHTML).toContain('Green belt status updated');
-		});
-
-		it('should render a "Site health and safety risks updated" success notification banner when the planning application reference is updated', async () => {
-			const appealId = appealData.appealId;
-			const appellantCaseId = appealData.appellantCaseId;
-			const validData = {
-				safetyRisksRadio: 'yes',
-				safetyRisksDetails: 'Details'
-			};
-
-			nock('http://test/')
-				.patch(`/appeals/${appealId}/appellant-cases/${appellantCaseId}`)
-				.reply(200, {
-					...validData
+		describe('notification banners', () => {
+			it('should render a "LPA application reference" success notification banner when the planning application reference is updated', async () => {
+				const appealId = appealData.appealId.toString();
+				nock('http://test/').patch(`/appeals/${appealId}`).reply(200, {
+					planningApplicationReference: '12345/A/67890'
 				});
 
-			await request
-				.post(`${baseUrl}/${appealId}/appellant-case/safety-risks/change/appellant`)
-				.send(validData);
+				const validData = {
+					planningApplicationReference: '12345/A/67890'
+				};
 
-			const response = await request.get(`${baseUrl}/1${appellantCasePagePath}`);
+				await request
+					.post(`${baseUrl}/${appealId}/appellant-case/lpa-reference/change`)
+					.send(validData);
 
-			const element = parseHtml(response.text, { rootElement: notificationBannerElement });
-			expect(element.innerHTML).toMatchSnapshot();
+				const response = await request.get(`${baseUrl}/1${appellantCasePagePath}`);
 
-			const notificationBannerElementHTML = parseHtml(response.text, {
-				rootElement: notificationBannerElement
-			}).innerHTML;
+				const element = parseHtml(response.text);
+				expect(element.innerHTML).toMatchSnapshot();
 
-			expect(notificationBannerElementHTML).toContain('Success</h3>');
-			expect(notificationBannerElementHTML).toContain(
-				'Site health and safety risks (appellant answer) updated</p>'
-			);
-		});
+				const notificationBannerElementHTML = parseHtml(response.text, {
+					rootElement: '.govuk-notification-banner'
+				}).innerHTML;
+				expect(notificationBannerElementHTML).toContain('Success</h3>');
+				expect(notificationBannerElementHTML).toContain('LPA application reference updated</p>');
+			});
 
-		it('should render a "Site area updated" success notification banner when the site area is updated', async () => {
-			const appealId = appealData.appealId.toString();
-			const appellantCaseId = appealData.appellantCaseId.toString();
-			nock('http://test/')
-				.patch(`/appeals/${appealId}/appellant-cases/${appellantCaseId}`)
-				.reply(200, {
-					siteAreaSquareMetres: '31.5'
+			it('should render a "Application decision date updated" notification banner when the application decision date is updated', async () => {
+				const appealId = appealData.appealId.toString();
+				const appellantCaseId = appealData.appellantCaseId;
+				const validData = {
+					'application-decision-date-day': '11',
+					'application-decision-date-month': '06',
+					'application-decision-date-year': '2021'
+				};
+
+				nock('http://test/')
+					.patch(`/appeals/${appealId}/appellant-cases/${appellantCaseId}`)
+					.reply(200, { ...validData });
+
+				await request
+					.post(`${baseUrl}/${appealId}/appellant-case/application-decision-date/change`)
+					.send(validData);
+
+				const response = await request.get(`${baseUrl}/1${appellantCasePagePath}`);
+
+				const notificationBannerElementHTML = parseHtml(response.text, {
+					rootElement: notificationBannerElement
+				}).innerHTML;
+
+				expect(notificationBannerElementHTML).toMatchSnapshot();
+				expect(notificationBannerElementHTML).toContain('Success</h3>');
+				expect(notificationBannerElementHTML).toContain('Application decision date changed');
+			});
+
+			it('should render a "Green belt status updated" notification banner when the green belt response is changed', async () => {
+				const appealId = appealData.appealId.toString();
+				const appellantCaseId = appealData.appellantCaseId;
+				const appellantCaseUrl = `/appeals-service/appeal-details/${appealId}/appellant-case`;
+
+				const validData = {
+					greenBeltRadio: 'yes'
+				};
+
+				nock('http://test/')
+					.patch(`/appeals/${appealId}/appellant-cases/${appellantCaseId}`)
+					.reply(200, {});
+
+				await request.post(`${appellantCaseUrl}/green-belt/change/appellant`).send(validData);
+
+				const response = await request.get(`${baseUrl}/1${appellantCasePagePath}`);
+				const notificationBannerElementHTML = parseHtml(response.text, {
+					rootElement: notificationBannerElement
+				}).innerHTML;
+
+				expect(notificationBannerElementHTML).toMatchSnapshot();
+				expect(notificationBannerElementHTML).toContain('Success</h3>');
+				expect(notificationBannerElementHTML).toContain('Green belt status updated');
+			});
+
+			it('should render a "Site health and safety risks updated" success notification banner when the planning application reference is updated', async () => {
+				const appealId = appealData.appealId;
+				const appellantCaseId = appealData.appellantCaseId;
+				const validData = {
+					safetyRisksRadio: 'yes',
+					safetyRisksDetails: 'Details'
+				};
+
+				nock('http://test/')
+					.patch(`/appeals/${appealId}/appellant-cases/${appellantCaseId}`)
+					.reply(200, {
+						...validData
+					});
+
+				await request
+					.post(`${baseUrl}/${appealId}/appellant-case/safety-risks/change/appellant`)
+					.send(validData);
+
+				const response = await request.get(`${baseUrl}/1${appellantCasePagePath}`);
+
+				const element = parseHtml(response.text, { rootElement: notificationBannerElement });
+				expect(element.innerHTML).toMatchSnapshot();
+
+				const notificationBannerElementHTML = parseHtml(response.text, {
+					rootElement: notificationBannerElement
+				}).innerHTML;
+
+				expect(notificationBannerElementHTML).toContain('Success</h3>');
+				expect(notificationBannerElementHTML).toContain(
+					'Site health and safety risks (appellant answer) updated</p>'
+				);
+			});
+
+			it('should render a "Site area updated" success notification banner when the site area is updated', async () => {
+				const appealId = appealData.appealId.toString();
+				const appellantCaseId = appealData.appellantCaseId.toString();
+				nock('http://test/')
+					.patch(`/appeals/${appealId}/appellant-cases/${appellantCaseId}`)
+					.reply(200, {
+						siteAreaSquareMetres: '31.5'
+					});
+
+				const validData = {
+					siteArea: '31.5'
+				};
+
+				await request
+					.post(`${baseUrl}/${appealId}/appellant-case/site-area/change`)
+					.send(validData);
+
+				const response = await request.get(`${baseUrl}/1${appellantCasePagePath}`);
+
+				const element = parseHtml(response.text, { rootElement: notificationBannerElement });
+				expect(element.innerHTML).toMatchSnapshot();
+
+				const notificationBannerElementHTML = parseHtml(response.text, {
+					rootElement: notificationBannerElement
+				}).innerHTML;
+
+				expect(notificationBannerElementHTML).toContain('Success</h3>');
+				expect(notificationBannerElementHTML).toContain('Site area updated</p>');
+			});
+
+			it('should render a "Inspector access (appellant) updated" success notification banner when the inspector access (appellant) is updated', async () => {
+				const appealId = appealData.appealId;
+				const appellantCaseId = appealData.appellantCaseId;
+				const validData = {
+					inspectorAccessRadio: 'yes',
+					inspectorAccessDetails: 'Details'
+				};
+
+				nock('http://test/')
+					.patch(`/appeals/${appealId}/appellant-cases/${appellantCaseId}`)
+					.reply(200, {
+						...validData
+					});
+
+				await request
+					.post(`${baseUrl}/${appealId}/appellant-case/inspector-access/change/appellant`)
+					.send(validData);
+
+				const response = await request.get(`${baseUrl}/1${appellantCasePagePath}`);
+
+				const element = parseHtml(response.text);
+				expect(element.innerHTML).toMatchSnapshot();
+
+				const notificationBannerElementHTML = parseHtml(response.text, {
+					rootElement: notificationBannerElement
+				}).innerHTML;
+
+				expect(notificationBannerElementHTML).toMatchSnapshot();
+				expect(notificationBannerElementHTML).toContain('Success</h3>');
+				expect(notificationBannerElementHTML).toContain('Inspector access (appellant) updated</p>');
+			});
+
+			it('should render a success notification banner when a service user was updated', async () => {
+				nock('http://test/').patch(`/appeals/1/service-user`).reply(200, {
+					serviceUserId: 1
+				});
+				const validData = {
+					firstName: 'Jessica',
+					lastName: 'Jones',
+					organisationName: 'Jones Inc',
+					phoneNumber: '01234 567 890',
+					emailAddress: 'jones@mail.com'
+				};
+				await request.post(`${baseUrl}/1/appellant-case/service-user/change/agent`).send(validData);
+
+				const caseDetailsResponse = await request.get(`${baseUrl}/1/appellant-case`);
+
+				const element = parseHtml(caseDetailsResponse.text);
+				expect(element.innerHTML).toMatchSnapshot();
+
+				const notificationBannerElementHTML = parseHtml(caseDetailsResponse.text, {
+					rootElement: notificationBannerElement
+				}).innerHTML;
+				expect(notificationBannerElementHTML).toMatchSnapshot();
+				expect(notificationBannerElementHTML).toContain('Success</h3>');
+				expect(notificationBannerElementHTML).toContain('Agent details updated</p>');
+			});
+
+			it('should render a "Site updated" notification when the site address has been updated', async () => {
+				const appealId = appealData.appealId.toString();
+				nock('http://test/').patch(`/appeals/${appealId}/addresses/1`).reply(200, {
+					addressLine1: '1 Grove Cottage',
+					county: 'Devon',
+					postcode: 'NR35 2ND',
+					town: 'Woodton'
+				});
+				nock('http://test/')
+					.get(`/appeals/${appealData.appealId}/appellant-case`)
+					.reply(200, appealData);
+
+				await request.post(`${baseUrl}/${appealId}/appellant-case/site-address/change/1`).send({
+					addressLine1: '1 Grove Cottage',
+					county: 'Devon',
+					postCode: 'NR35 2ND',
+					town: 'Woodton'
 				});
 
-			const validData = {
-				siteArea: '31.5'
-			};
+				const response = await request.get(`${baseUrl}/1${appellantCasePagePath}`);
 
-			await request.post(`${baseUrl}/${appealId}/appellant-case/site-area/change`).send(validData);
+				const element = parseHtml(response.text);
+				expect(element.innerHTML).toMatchSnapshot();
 
-			const response = await request.get(`${baseUrl}/1${appellantCasePagePath}`);
+				const notificationBannerElementHTML = parseHtml(response.text, {
+					rootElement: notificationBannerElement
+				}).innerHTML;
 
-			const element = parseHtml(response.text, { rootElement: notificationBannerElement });
-			expect(element.innerHTML).toMatchSnapshot();
+				expect(notificationBannerElementHTML).toMatchSnapshot();
+				expect(notificationBannerElementHTML).toContain('Success</h3>');
+				expect(notificationBannerElementHTML).toContain('Site address updated</p>');
+			});
 
-			const notificationBannerElementHTML = parseHtml(response.text, {
-				rootElement: notificationBannerElement
-			}).innerHTML;
+			it('should render an "Appeal is invalid" notification banner with the expected content when the appellant case has been reviewed with an outcome of "invalid"', async () => {
+				nock.cleanAll();
+				nock('http://test/').get('/appeals/1').reply(200, appealData);
+				nock('http://test/')
+					.get('/appeals/1/appellant-cases/0')
+					.reply(200, appellantCaseDataInvalidOutcome);
 
-			expect(notificationBannerElementHTML).toContain('Success</h3>');
-			expect(notificationBannerElementHTML).toContain('Site area updated</p>');
-		});
+				const response = await request.get(`${baseUrl}/1${appellantCasePagePath}`);
 
-		it('should render a "Inspector access (appellant) updated" success notification banner when the inspector access (appellant) is updated', async () => {
-			const appealId = appealData.appealId;
-			const appellantCaseId = appealData.appellantCaseId;
-			const validData = {
-				inspectorAccessRadio: 'yes',
-				inspectorAccessDetails: 'Details'
-			};
+				const notificationBannerHTML = parseHtml(response.text, {
+					rootElement: '.govuk-notification-banner'
+				}).innerHTML;
 
-			nock('http://test/')
-				.patch(`/appeals/${appealId}/appellant-cases/${appellantCaseId}`)
-				.reply(200, {
-					...validData
+				expect(notificationBannerHTML).toMatchSnapshot();
+
+				const unprettifiedNotificationBannerHTML = parseHtml(response.text, {
+					rootElement: '.govuk-notification-banner',
+					skipPrettyPrint: true
+				}).innerHTML;
+
+				expect(unprettifiedNotificationBannerHTML).toContain('Appeal is invalid</h3>');
+				expect(unprettifiedNotificationBannerHTML).toContain(
+					'<details class="govuk-details" data-module="govuk-details">'
+				);
+				expect(unprettifiedNotificationBannerHTML).toContain(
+					'Incorrect name and/or missing documents</span>'
+				);
+				expect(unprettifiedNotificationBannerHTML).toContain(
+					'Appellant name is not the same on the application form and appeal form</li>'
+				);
+				expect(unprettifiedNotificationBannerHTML).toContain(
+					'Attachments and/or appendices have not been included to the full statement of case</span>'
+				);
+				expect(unprettifiedNotificationBannerHTML).toContain('test reason 1</li>');
+				expect(unprettifiedNotificationBannerHTML).toContain('Other</span>');
+				expect(unprettifiedNotificationBannerHTML).toContain('test reason 2</li>');
+				expect(unprettifiedNotificationBannerHTML).toContain('test reason 3</li>');
+			});
+
+			it('should render an "Appeal is incomplete" notification banner with the expected content when the appellant case has been reviewed with an outcome of "incomplete"', async () => {
+				nock.cleanAll();
+				nock('http://test/').get('/appeals/1').reply(200, appealData);
+				nock('http://test/')
+					.get('/appeals/1/appellant-cases/0')
+					.reply(200, appellantCaseDataIncompleteOutcome);
+
+				const response = await request.get(`${baseUrl}/1${appellantCasePagePath}`);
+
+				const notificationBannerHTML = parseHtml(response.text, {
+					rootElement: '.govuk-notification-banner'
+				}).innerHTML;
+
+				expect(notificationBannerHTML).toMatchSnapshot();
+
+				const unprettifiedNotificationBannerHTML = parseHtml(response.text, {
+					rootElement: '.govuk-notification-banner',
+					skipPrettyPrint: true
+				}).innerHTML;
+
+				expect(unprettifiedNotificationBannerHTML).toContain('Appeal is incomplete</h3>');
+				expect(unprettifiedNotificationBannerHTML).toContain(
+					'<details class="govuk-details" data-module="govuk-details">'
+				);
+				expect(unprettifiedNotificationBannerHTML).toContain('Due date</dt>');
+				expect(unprettifiedNotificationBannerHTML).toContain('2 October 2024</dd>');
+				expect(unprettifiedNotificationBannerHTML).toContain(
+					'Incorrect name and/or missing documents</span>'
+				);
+				expect(unprettifiedNotificationBannerHTML).toContain(
+					'Appellant name is not the same on the application form and appeal form</li>'
+				);
+				expect(unprettifiedNotificationBannerHTML).toContain(
+					'Attachments and/or appendices have not been included to the full statement of case</span>'
+				);
+				expect(unprettifiedNotificationBannerHTML).toContain('test reason 1</li>');
+				expect(unprettifiedNotificationBannerHTML).toContain('Other</span>');
+				expect(unprettifiedNotificationBannerHTML).toContain('test reason 2</li>');
+				expect(unprettifiedNotificationBannerHTML).toContain('test reason 3</li>');
+			});
+
+			it('should not render an "Appeal is incomplete" notification banner when the appellant case has been reviewed with an outcome of "incomplete" and then re-reviewed with an outcome of "valid"', async () => {
+				nock.cleanAll();
+				nock('http://test/').get('/appeals/1').reply(200, appealData);
+				nock('http://test/')
+					.get('/appeals/1/appellant-cases/0')
+					.reply(200, appellantCaseDataIncompleteOutcome);
+
+				const incompleteOutcomeResponse = await request.get(`${baseUrl}/1${appellantCasePagePath}`);
+
+				const unprettifiedNotificationBannerHTML = parseHtml(incompleteOutcomeResponse.text, {
+					rootElement: '.govuk-notification-banner',
+					skipPrettyPrint: true
+				}).innerHTML;
+
+				expect(unprettifiedNotificationBannerHTML).toContain('Appeal is incomplete</h3>');
+
+				nock.cleanAll();
+				nock('http://test/').get('/appeals/1').reply(200, appealData);
+				nock('http://test/')
+					.get('/appeals/1/appellant-cases/0')
+					.reply(200, appellantCaseDataValidOutcome);
+
+				const validOutcomeResponse = await request.get(`${baseUrl}/1${appellantCasePagePath}`);
+
+				const unprettifiedHTML = parseHtml(validOutcomeResponse.text, {
+					skipPrettyPrint: true
+				}).innerHTML;
+
+				expect(unprettifiedHTML).not.toContain('Appeal is incomplete</h3>');
+			});
+
+			it('should render a "Planning obligation status updated" notification banner when the planning obligation status is changed', async () => {
+				const appealId = appealData.appealId.toString();
+				const appellantCaseUrl = `/appeals-service/appeal-details/${appealId}/appellant-case`;
+
+				nock('http://test/')
+					.patch(`/appeals/${appealId}/appellant-cases/${appealData.appellantCaseId}`)
+					.reply(200, {});
+
+				await request.post(`${appellantCaseUrl}/planning-obligation/status/change`).send({
+					planningObligationStatusRadio: 'finalised'
 				});
 
-			await request
-				.post(`${baseUrl}/${appealId}/appellant-case/inspector-access/change/appellant`)
-				.send(validData);
+				const response = await request.get(`${baseUrl}/1${appellantCasePagePath}`);
+				const notificationBannerElementHTML = parseHtml(response.text, {
+					rootElement: notificationBannerElement
+				}).innerHTML;
 
-			const response = await request.get(`${baseUrl}/1${appellantCasePagePath}`);
-
-			const element = parseHtml(response.text);
-			expect(element.innerHTML).toMatchSnapshot();
-
-			const notificationBannerElementHTML = parseHtml(response.text, {
-				rootElement: notificationBannerElement
-			}).innerHTML;
-
-			expect(notificationBannerElementHTML).toMatchSnapshot();
-			expect(notificationBannerElementHTML).toContain('Success</h3>');
-			expect(notificationBannerElementHTML).toContain('Inspector access (appellant) updated</p>');
-		});
-
-		it('should render a success notification banner when a service user was updated', async () => {
-			nock('http://test/').patch(`/appeals/1/service-user`).reply(200, {
-				serviceUserId: 1
-			});
-			const validData = {
-				firstName: 'Jessica',
-				lastName: 'Jones',
-				organisationName: 'Jones Inc',
-				phoneNumber: '01234 567 890',
-				emailAddress: 'jones@mail.com'
-			};
-			await request.post(`${baseUrl}/1/appellant-case/service-user/change/agent`).send(validData);
-
-			const caseDetailsResponse = await request.get(`${baseUrl}/1/appellant-case`);
-
-			const element = parseHtml(caseDetailsResponse.text);
-			expect(element.innerHTML).toMatchSnapshot();
-
-			const notificationBannerElementHTML = parseHtml(caseDetailsResponse.text, {
-				rootElement: notificationBannerElement
-			}).innerHTML;
-			expect(notificationBannerElementHTML).toMatchSnapshot();
-			expect(notificationBannerElementHTML).toContain('Success</h3>');
-			expect(notificationBannerElementHTML).toContain('Agent details updated</p>');
-		});
-
-		it('should render a "Site updated" notification when the site address has been updated', async () => {
-			const appealId = appealData.appealId.toString();
-			nock('http://test/').patch(`/appeals/${appealId}/addresses/1`).reply(200, {
-				addressLine1: '1 Grove Cottage',
-				county: 'Devon',
-				postcode: 'NR35 2ND',
-				town: 'Woodton'
-			});
-			nock('http://test/')
-				.get(`/appeals/${appealData.appealId}/appellant-case`)
-				.reply(200, appealData);
-
-			await request.post(`${baseUrl}/${appealId}/appellant-case/site-address/change/1`).send({
-				addressLine1: '1 Grove Cottage',
-				county: 'Devon',
-				postCode: 'NR35 2ND',
-				town: 'Woodton'
+				expect(notificationBannerElementHTML).toMatchSnapshot();
+				expect(notificationBannerElementHTML).toContain('Success</h3>');
+				expect(notificationBannerElementHTML).toContain('Planning obligation status updated');
 			});
 
-			const response = await request.get(`${baseUrl}/1${appellantCasePagePath}`);
+			it('should render a "Part of agricultural holding updated" notification banner when the part of agricultural holding response is changed', async () => {
+				const appealId = appealData.appealId.toString();
+				const appellantCaseUrl = `/appeals-service/appeal-details/${appealId}/appellant-case`;
 
-			const element = parseHtml(response.text);
-			expect(element.innerHTML).toMatchSnapshot();
+				nock('http://test/')
+					.patch(`/appeals/${appealId}/appellant-cases/${appealData.appellantCaseId}`)
+					.reply(200, {});
 
-			const notificationBannerElementHTML = parseHtml(response.text, {
-				rootElement: notificationBannerElement
-			}).innerHTML;
+				await request.post(`${appellantCaseUrl}/agricultural-holding/change`).send({
+					partOfAgriculturalHoldingRadio: 'yes'
+				});
 
-			expect(notificationBannerElementHTML).toMatchSnapshot();
-			expect(notificationBannerElementHTML).toContain('Success</h3>');
-			expect(notificationBannerElementHTML).toContain('Site address updated</p>');
-		});
+				const response = await request.get(`${baseUrl}/1${appellantCasePagePath}`);
+				const notificationBannerElementHTML = parseHtml(response.text, {
+					rootElement: notificationBannerElement
+				}).innerHTML;
 
-		it('should render an "Appeal is invalid" notification banner with the expected content when the appellant case has been reviewed with an outcome of "invalid"', async () => {
-			nock.cleanAll();
-			nock('http://test/').get('/appeals/1').reply(200, appealData);
-			nock('http://test/')
-				.get('/appeals/1/appellant-cases/0')
-				.reply(200, appellantCaseDataInvalidOutcome);
-
-			const response = await request.get(`${baseUrl}/1${appellantCasePagePath}`);
-
-			const notificationBannerHTML = parseHtml(response.text, {
-				rootElement: '.govuk-notification-banner'
-			}).innerHTML;
-
-			expect(notificationBannerHTML).toMatchSnapshot();
-
-			const unprettifiedNotificationBannerHTML = parseHtml(response.text, {
-				rootElement: '.govuk-notification-banner',
-				skipPrettyPrint: true
-			}).innerHTML;
-
-			expect(unprettifiedNotificationBannerHTML).toContain('Appeal is invalid</h3>');
-			expect(unprettifiedNotificationBannerHTML).toContain(
-				'<details class="govuk-details" data-module="govuk-details">'
-			);
-			expect(unprettifiedNotificationBannerHTML).toContain(
-				'Incorrect name and/or missing documents</span>'
-			);
-			expect(unprettifiedNotificationBannerHTML).toContain(
-				'Appellant name is not the same on the application form and appeal form</li>'
-			);
-			expect(unprettifiedNotificationBannerHTML).toContain(
-				'Attachments and/or appendices have not been included to the full statement of case</span>'
-			);
-			expect(unprettifiedNotificationBannerHTML).toContain('test reason 1</li>');
-			expect(unprettifiedNotificationBannerHTML).toContain('Other</span>');
-			expect(unprettifiedNotificationBannerHTML).toContain('test reason 2</li>');
-			expect(unprettifiedNotificationBannerHTML).toContain('test reason 3</li>');
-		});
-
-		it('should render an "Appeal is incomplete" notification banner with the expected content when the appellant case has been reviewed with an outcome of "incomplete"', async () => {
-			nock.cleanAll();
-			nock('http://test/').get('/appeals/1').reply(200, appealData);
-			nock('http://test/')
-				.get('/appeals/1/appellant-cases/0')
-				.reply(200, appellantCaseDataIncompleteOutcome);
-
-			const response = await request.get(`${baseUrl}/1${appellantCasePagePath}`);
-
-			const notificationBannerHTML = parseHtml(response.text, {
-				rootElement: '.govuk-notification-banner'
-			}).innerHTML;
-
-			expect(notificationBannerHTML).toMatchSnapshot();
-
-			const unprettifiedNotificationBannerHTML = parseHtml(response.text, {
-				rootElement: '.govuk-notification-banner',
-				skipPrettyPrint: true
-			}).innerHTML;
-
-			expect(unprettifiedNotificationBannerHTML).toContain('Appeal is incomplete</h3>');
-			expect(unprettifiedNotificationBannerHTML).toContain(
-				'<details class="govuk-details" data-module="govuk-details">'
-			);
-			expect(unprettifiedNotificationBannerHTML).toContain('Due date</dt>');
-			expect(unprettifiedNotificationBannerHTML).toContain('2 October 2024</dd>');
-			expect(unprettifiedNotificationBannerHTML).toContain(
-				'Incorrect name and/or missing documents</span>'
-			);
-			expect(unprettifiedNotificationBannerHTML).toContain(
-				'Appellant name is not the same on the application form and appeal form</li>'
-			);
-			expect(unprettifiedNotificationBannerHTML).toContain(
-				'Attachments and/or appendices have not been included to the full statement of case</span>'
-			);
-			expect(unprettifiedNotificationBannerHTML).toContain('test reason 1</li>');
-			expect(unprettifiedNotificationBannerHTML).toContain('Other</span>');
-			expect(unprettifiedNotificationBannerHTML).toContain('test reason 2</li>');
-			expect(unprettifiedNotificationBannerHTML).toContain('test reason 3</li>');
-		});
-
-		it('should not render an "Appeal is incomplete" notification banner when the appellant case has been reviewed with an outcome of "incomplete" and then re-reviewed with an outcome of "valid"', async () => {
-			nock.cleanAll();
-			nock('http://test/').get('/appeals/1').reply(200, appealData);
-			nock('http://test/')
-				.get('/appeals/1/appellant-cases/0')
-				.reply(200, appellantCaseDataIncompleteOutcome);
-
-			const incompleteOutcomeResponse = await request.get(`${baseUrl}/1${appellantCasePagePath}`);
-
-			const unprettifiedNotificationBannerHTML = parseHtml(incompleteOutcomeResponse.text, {
-				rootElement: '.govuk-notification-banner',
-				skipPrettyPrint: true
-			}).innerHTML;
-
-			expect(unprettifiedNotificationBannerHTML).toContain('Appeal is incomplete</h3>');
-
-			nock.cleanAll();
-			nock('http://test/').get('/appeals/1').reply(200, appealData);
-			nock('http://test/')
-				.get('/appeals/1/appellant-cases/0')
-				.reply(200, appellantCaseDataValidOutcome);
-
-			const validOutcomeResponse = await request.get(`${baseUrl}/1${appellantCasePagePath}`);
-
-			const unprettifiedHTML = parseHtml(validOutcomeResponse.text, {
-				skipPrettyPrint: true
-			}).innerHTML;
-
-			expect(unprettifiedHTML).not.toContain('Appeal is incomplete</h3>');
-		});
-
-		it('should render a "Planning obligation status updated" notification banner when the planning obligation status is changed', async () => {
-			const appealId = appealData.appealId.toString();
-			const appellantCaseUrl = `/appeals-service/appeal-details/${appealId}/appellant-case`;
-
-			nock('http://test/')
-				.patch(`/appeals/${appealId}/appellant-cases/${appealData.appellantCaseId}`)
-				.reply(200, {});
-
-			await request.post(`${appellantCaseUrl}/planning-obligation/status/change`).send({
-				planningObligationStatusRadio: 'finalised'
+				expect(notificationBannerElementHTML).toMatchSnapshot();
+				expect(notificationBannerElementHTML).toContain('Success</h3>');
+				expect(notificationBannerElementHTML).toContain('Part of agricultural holding updated');
 			});
 
-			const response = await request.get(`${baseUrl}/1${appellantCasePagePath}`);
-			const notificationBannerElementHTML = parseHtml(response.text, {
-				rootElement: notificationBannerElement
-			}).innerHTML;
+			it('should render a "Tenant of agricultural holding updated" notification banner when the tenant of agricultural holding response is changed', async () => {
+				const appealId = appealData.appealId.toString();
+				const appellantCaseUrl = `/appeals-service/appeal-details/${appealId}/appellant-case`;
 
-			expect(notificationBannerElementHTML).toMatchSnapshot();
-			expect(notificationBannerElementHTML).toContain('Success</h3>');
-			expect(notificationBannerElementHTML).toContain('Planning obligation status updated');
-		});
+				nock('http://test/')
+					.patch(`/appeals/${appealId}/appellant-cases/${appealData.appellantCaseId}`)
+					.reply(200, {});
 
-		it('should render a "Part of agricultural holding updated" notification banner when the part of agricultural holding response is changed', async () => {
-			const appealId = appealData.appealId.toString();
-			const appellantCaseUrl = `/appeals-service/appeal-details/${appealId}/appellant-case`;
+				await request.post(`${appellantCaseUrl}/agricultural-holding/tenant/change`).send({
+					tenantOfAgriculturalHoldingRadio: 'yes'
+				});
 
-			nock('http://test/')
-				.patch(`/appeals/${appealId}/appellant-cases/${appealData.appellantCaseId}`)
-				.reply(200, {});
+				const response = await request.get(`${baseUrl}/1${appellantCasePagePath}`);
+				const notificationBannerElementHTML = parseHtml(response.text, {
+					rootElement: notificationBannerElement
+				}).innerHTML;
 
-			await request.post(`${appellantCaseUrl}/agricultural-holding/change`).send({
-				partOfAgriculturalHoldingRadio: 'yes'
+				expect(notificationBannerElementHTML).toMatchSnapshot();
+				expect(notificationBannerElementHTML).toContain('Success</h3>');
+				expect(notificationBannerElementHTML).toContain('Tenant of agricultural holding updated');
 			});
 
-			const response = await request.get(`${baseUrl}/1${appellantCasePagePath}`);
-			const notificationBannerElementHTML = parseHtml(response.text, {
-				rootElement: notificationBannerElement
-			}).innerHTML;
+			it('should render an "Other tenants of agricultural holding updated" notification banner when the other tenants of agricultural holding response is changed', async () => {
+				const appealId = appealData.appealId.toString();
+				const appellantCaseUrl = `/appeals-service/appeal-details/${appealId}/appellant-case`;
 
-			expect(notificationBannerElementHTML).toMatchSnapshot();
-			expect(notificationBannerElementHTML).toContain('Success</h3>');
-			expect(notificationBannerElementHTML).toContain('Part of agricultural holding updated');
-		});
+				nock('http://test/')
+					.patch(`/appeals/${appealId}/appellant-cases/${appealData.appellantCaseId}`)
+					.reply(200, {});
 
-		it('should render a "Tenant of agricultural holding updated" notification banner when the tenant of agricultural holding response is changed', async () => {
-			const appealId = appealData.appealId.toString();
-			const appellantCaseUrl = `/appeals-service/appeal-details/${appealId}/appellant-case`;
+				await request.post(`${appellantCaseUrl}/agricultural-holding/other-tenants/change`).send({
+					otherTenantsOfAgriculturalHoldingRadio: 'yes'
+				});
 
-			nock('http://test/')
-				.patch(`/appeals/${appealId}/appellant-cases/${appealData.appellantCaseId}`)
-				.reply(200, {});
+				const response = await request.get(`${baseUrl}/1${appellantCasePagePath}`);
+				const notificationBannerElementHTML = parseHtml(response.text, {
+					rootElement: notificationBannerElement
+				}).innerHTML;
 
-			await request.post(`${appellantCaseUrl}/agricultural-holding/tenant/change`).send({
-				tenantOfAgriculturalHoldingRadio: 'yes'
+				expect(notificationBannerElementHTML).toMatchSnapshot();
+				expect(notificationBannerElementHTML).toContain('Success</h3>');
+				expect(notificationBannerElementHTML).toContain(
+					'Other tenants of agricultural holding updated'
+				);
 			});
 
-			const response = await request.get(`${baseUrl}/1${appellantCasePagePath}`);
-			const notificationBannerElementHTML = parseHtml(response.text, {
-				rootElement: notificationBannerElement
-			}).innerHTML;
+			it('should render success banners before (above) important banners', async () => {
+				const appealId = appealData.appealId.toString();
+				const appellantCaseId = appealData.appellantCaseId;
+				const appellantCaseUrl = `/appeals-service/appeal-details/${appealId}/appellant-case`;
 
-			expect(notificationBannerElementHTML).toMatchSnapshot();
-			expect(notificationBannerElementHTML).toContain('Success</h3>');
-			expect(notificationBannerElementHTML).toContain('Tenant of agricultural holding updated');
-		});
+				nock.cleanAll();
+				nock('http://test/').get(`/appeals/${appealId}`).reply(200, appealData);
+				nock('http://test/')
+					.get(`/appeals/${appealId}/appellant-cases/0`)
+					.reply(200, appellantCaseDataIncompleteOutcome);
 
-		it('should render an "Other tenants of agricultural holding updated" notification banner when the other tenants of agricultural holding response is changed', async () => {
-			const appealId = appealData.appealId.toString();
-			const appellantCaseUrl = `/appeals-service/appeal-details/${appealId}/appellant-case`;
+				nock('http://test/')
+					.patch(`/appeals/${appealId}/appellant-cases/${appellantCaseId}`)
+					.reply(200, {});
 
-			nock('http://test/')
-				.patch(`/appeals/${appealId}/appellant-cases/${appealData.appellantCaseId}`)
-				.reply(200, {});
+				await request.post(`${appellantCaseUrl}/green-belt/change/appellant`).send({
+					greenBeltRadio: 'yes'
+				});
 
-			await request.post(`${appellantCaseUrl}/agricultural-holding/other-tenants/change`).send({
-				otherTenantsOfAgriculturalHoldingRadio: 'yes'
+				nock('http://test/').get(`/appeals/${appealId}`).reply(200, appealData);
+				nock('http://test/')
+					.get(`/appeals/${appealId}/appellant-cases/0`)
+					.reply(200, appellantCaseDataIncompleteOutcome);
+
+				const response = await request.get(`${baseUrl}/${appealId}${appellantCasePagePath}`);
+
+				expect(response.statusCode).toBe(200);
+
+				const firstBannerHtml = parseHtml(response.text, {
+					rootElement: `.govuk-notification-banner[data-index='0']`,
+					skipPrettyPrint: true
+				}).innerHTML;
+				expect(firstBannerHtml).toContain(
+					'<h3 class="govuk-notification-banner__title" id="govuk-notification-banner-title" > Success</h3>'
+				);
+
+				const secondBannerHtml = parseHtml(response.text, {
+					rootElement: `.govuk-notification-banner[data-index='1']`,
+					skipPrettyPrint: true
+				}).innerHTML;
+				expect(secondBannerHtml).toContain(
+					'<h3 class="govuk-notification-banner__title" id="govuk-notification-banner-title" > Appeal is incomplete</h3>'
+				);
 			});
-
-			const response = await request.get(`${baseUrl}/1${appellantCasePagePath}`);
-			const notificationBannerElementHTML = parseHtml(response.text, {
-				rootElement: notificationBannerElement
-			}).innerHTML;
-
-			expect(notificationBannerElementHTML).toMatchSnapshot();
-			expect(notificationBannerElementHTML).toContain('Success</h3>');
-			expect(notificationBannerElementHTML).toContain(
-				'Other tenants of agricultural holding updated'
-			);
 		});
 
 		describe('show more', () => {

--- a/appeals/web/src/server/appeals/appeal-details/appellant-case/appellant-case.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/appellant-case/appellant-case.mapper.js
@@ -15,7 +15,8 @@ import {
 	userHasPermission,
 	removeSummaryListActions,
 	mapNotificationBannersFromSession,
-	createNotificationBanner
+	createNotificationBanner,
+	sortNotificationBanners
 } from '#lib/mappers/index.js';
 import { appealShortReference } from '#lib/appeals-formatter.js';
 import { preRenderPageComponents } from '#lib/nunjucks-template-builders/page-component-rendering.js';
@@ -454,7 +455,7 @@ export function mapAppellantCaseNotificationBanners(
 	if (
 		getDocumentsForVirusStatus(appellantCaseData, APPEAL_VIRUS_CHECK_STATUS.NOT_SCANNED).length > 0
 	) {
-		banners.unshift(createNotificationBanner({ bannerDefinitionKey: 'notCheckedDocument' }));
+		banners.push(createNotificationBanner({ bannerDefinitionKey: 'notCheckedDocument' }));
 	}
 
 	if (validationOutcome === 'invalid' || validationOutcome === 'incomplete') {
@@ -508,7 +509,7 @@ export function mapAppellantCaseNotificationBanners(
 			});
 		}
 
-		banners.unshift(
+		banners.push(
 			createNotificationBanner({
 				bannerDefinitionKey: 'appellantCaseNotValid',
 				titleText: `Appeal is ${String(validationOutcome)}`,
@@ -517,7 +518,7 @@ export function mapAppellantCaseNotificationBanners(
 		);
 	}
 
-	return banners;
+	return sortNotificationBanners(banners);
 }
 
 /**

--- a/appeals/web/src/server/appeals/appeal-details/environmental-assessment/__tests__/__snapshots__/environmental-assessment.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/environmental-assessment/__tests__/__snapshots__/environmental-assessment.test.js.snap
@@ -378,7 +378,8 @@ exports[`environmental-assessment POST /environmental-assessment/upload-document
 
 exports[`environmental-assessment POST /environmental-assessment/upload-documents/:folderId should eventually redirect to case details page displaying the success banner 2`] = `
 "<div class="govuk-notification-banner govuk-notification-banner--success govuk-!-margin-bottom-5"
-role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
+role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner"
+data-index="0">
     <div class="govuk-notification-banner__header">
         <h3 class="govuk-notification-banner__title" id="govuk-notification-banner-title"> Success</h3>
     </div>
@@ -422,7 +423,8 @@ exports[`environmental-assessment POST /environmental-assessment/upload-document
 
 exports[`environmental-assessment POST /environmental-assessment/upload-documents/:folderId/:documentId should eventually redirect to case details page displaying the success banner 2`] = `
 "<div class="govuk-notification-banner govuk-notification-banner--success govuk-!-margin-bottom-5"
-role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
+role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner"
+data-index="0">
     <div class="govuk-notification-banner__header">
         <h3 class="govuk-notification-banner__title" id="govuk-notification-banner-title"> Success</h3>
     </div>

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/__tests__/__snapshots__/lpa-questionnaire.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/__tests__/__snapshots__/lpa-questionnaire.test.js.snap
@@ -704,7 +704,19 @@ exports[`LPA Questionnaire review GET / with unchecked documents should render a
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds govuk-!-margin-bottom-5">
             <div class="govuk-notification-banner govuk-!-margin-bottom-5" role="region"
-            aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
+            aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner"
+            data-index="0">
+                <div class="govuk-notification-banner__header">
+                    <h3 class="govuk-notification-banner__title" id="govuk-notification-banner-title"> Important</h3>
+                </div>
+                <div class="govuk-notification-banner__content">
+                    <p class="govuk-notification-banner__heading">Virus scan in progress</p><a class="govuk-notification-banner__link" href=""
+                    data-cy="refresh-page">Refresh page to see if scan has finished</a>
+                </div>
+            </div>
+            <div class="govuk-notification-banner govuk-!-margin-bottom-5" role="region"
+            aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner"
+            data-index="1">
                 <div class="govuk-notification-banner__header">
                     <h3 class="govuk-notification-banner__title" id="govuk-notification-banner-title"> LPA Questionnaire is incomplete</h3>
                 </div>
@@ -744,16 +756,6 @@ exports[`LPA Questionnaire review GET / with unchecked documents should render a
                             </ul>
                         </div>
                     </details>
-                </div>
-            </div>
-            <div class="govuk-notification-banner govuk-!-margin-bottom-5" role="region"
-            aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
-                <div class="govuk-notification-banner__header">
-                    <h3 class="govuk-notification-banner__title" id="govuk-notification-banner-title"> Important</h3>
-                </div>
-                <div class="govuk-notification-banner__content">
-                    <p class="govuk-notification-banner__heading">Virus scan in progress</p><a class="govuk-notification-banner__link" href=""
-                    data-cy="refresh-page">Refresh page to see if scan has finished</a>
                 </div>
             </div>
         </div>
@@ -3263,7 +3265,8 @@ exports[`LPA Questionnaire review GET /lpa-questionnaire/2/change-document-name/
 
 exports[`LPA Questionnaire review Notification banners should render a "Column 2 threshold criteria status changed" success notification banner when meets eia column two threshold is changed 1`] = `
 "<div class="govuk-notification-banner govuk-notification-banner--success govuk-!-margin-bottom-5"
-role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
+role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner"
+data-index="0">
     <div class="govuk-notification-banner__header">
         <h3 class="govuk-notification-banner__title" id="govuk-notification-banner-title"> Success</h3>
     </div>
@@ -3275,7 +3278,8 @@ role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govu
 
 exports[`LPA Questionnaire review Notification banners should render a "Description of development updated" success notification banner when eia development description is changed 1`] = `
 "<div class="govuk-notification-banner govuk-notification-banner--success govuk-!-margin-bottom-5"
-role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
+role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner"
+data-index="0">
     <div class="govuk-notification-banner__header">
         <h3 class="govuk-notification-banner__title" id="govuk-notification-banner-title"> Success</h3>
     </div>
@@ -3287,7 +3291,8 @@ role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govu
 
 exports[`LPA Questionnaire review Notification banners should render a "Development category updated" success notification banner when eia environmental impact schedule is changed 1`] = `
 "<div class="govuk-notification-banner govuk-notification-banner--success govuk-!-margin-bottom-5"
-role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
+role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner"
+data-index="0">
     <div class="govuk-notification-banner__header">
         <h3 class="govuk-notification-banner__title" id="govuk-notification-banner-title"> Success</h3>
     </div>
@@ -3299,7 +3304,8 @@ role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govu
 
 exports[`LPA Questionnaire review Notification banners should render a "Inspector access (lpa) updated" success notification banner when the inspector access (lpa) is updated 1`] = `
 "<div class="govuk-notification-banner govuk-notification-banner--success govuk-!-margin-bottom-5"
-role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
+role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner"
+data-index="0">
     <div class="govuk-notification-banner__header">
         <h3 class="govuk-notification-banner__title" id="govuk-notification-banner-title"> Success</h3>
     </div>
@@ -3311,7 +3317,8 @@ role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govu
 
 exports[`LPA Questionnaire review Notification banners should render a "Neighbouring site added" success notification banner when a neighbouring site was added 1`] = `
 "<div class="govuk-notification-banner govuk-notification-banner--success govuk-!-margin-bottom-5"
-role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
+role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner"
+data-index="0">
     <div class="govuk-notification-banner__header">
         <h3 class="govuk-notification-banner__title" id="govuk-notification-banner-title"> Success</h3>
     </div>
@@ -3323,7 +3330,8 @@ role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govu
 
 exports[`LPA Questionnaire review Notification banners should render a "Neighbouring site removed" success notification banner when an inspector/3rd party neighbouring site was removed 1`] = `
 "<div class="govuk-notification-banner govuk-notification-banner--success govuk-!-margin-bottom-5"
-role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
+role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner"
+data-index="0">
     <div class="govuk-notification-banner__header">
         <h3 class="govuk-notification-banner__title" id="govuk-notification-banner-title"> Success</h3>
     </div>
@@ -3335,7 +3343,8 @@ role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govu
 
 exports[`LPA Questionnaire review Notification banners should render a "Neighbouring site updated" success notification banner when an inspector/3rd party neighbouring site was updated 1`] = `
 "<div class="govuk-notification-banner govuk-notification-banner--success govuk-!-margin-bottom-5"
-role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
+role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner"
+data-index="0">
     <div class="govuk-notification-banner__header">
         <h3 class="govuk-notification-banner__title" id="govuk-notification-banner-title"> Success</h3>
     </div>
@@ -3347,7 +3356,8 @@ role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govu
 
 exports[`LPA Questionnaire review Notification banners should render a "Notification methods updated" success notification banner when notification methods are changed 1`] = `
 "<div class="govuk-notification-banner govuk-notification-banner--success govuk-!-margin-bottom-5"
-role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
+role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner"
+data-index="0">
     <div class="govuk-notification-banner__header">
         <h3 class="govuk-notification-banner__title" id="govuk-notification-banner-title"> Success</h3>
     </div>
@@ -3359,7 +3369,8 @@ role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govu
 
 exports[`LPA Questionnaire review Notification banners should render a "Safety risks updated" success notification banner when the safety risks (lpa) is updated 1`] = `
 "<div class="govuk-notification-banner govuk-notification-banner--success govuk-!-margin-bottom-5"
-role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
+role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner"
+data-index="0">
     <div class="govuk-notification-banner__header">
         <h3 class="govuk-notification-banner__title" id="govuk-notification-banner-title"> Success</h3>
     </div>
@@ -3371,7 +3382,8 @@ role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govu
 
 exports[`LPA Questionnaire review Notification banners should render a success notification banner when "green belt" is updated 1`] = `
 "<div class="govuk-notification-banner govuk-notification-banner--success govuk-!-margin-bottom-5"
-role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
+role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner"
+data-index="0">
     <div class="govuk-notification-banner__header">
         <h3 class="govuk-notification-banner__title" id="govuk-notification-banner-title"> Success</h3>
     </div>
@@ -3383,7 +3395,8 @@ role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govu
 
 exports[`LPA Questionnaire review Notification banners should render a success notification banner when "is correct appeal type" is updated 1`] = `
 "<div class="govuk-notification-banner govuk-notification-banner--success govuk-!-margin-bottom-5"
-role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
+role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner"
+data-index="0">
     <div class="govuk-notification-banner__header">
         <h3 class="govuk-notification-banner__title" id="govuk-notification-banner-title"> Success</h3>
     </div>
@@ -3395,7 +3408,8 @@ role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govu
 
 exports[`LPA Questionnaire review Notification banners should render an "Environmental statement status changed" success notification banner when eia requires environmental statement is changed 1`] = `
 "<div class="govuk-notification-banner govuk-notification-banner--success govuk-!-margin-bottom-5"
-role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
+role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner"
+data-index="0">
     <div class="govuk-notification-banner__header">
         <h3 class="govuk-notification-banner__title" id="govuk-notification-banner-title"> Success</h3>
     </div>
@@ -3407,7 +3421,8 @@ role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govu
 
 exports[`LPA Questionnaire review Notification banners should render an "LPA questionnaire incomplete" notification banner, including the LPA questionnaire due date, when the LPA questionnaire is marked as incomplete 1`] = `
 "<div class="govuk-notification-banner govuk-!-margin-bottom-5" role="region"
-aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
+aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner"
+data-index="0">
     <div class="govuk-notification-banner__header">
         <h3 class="govuk-notification-banner__title" id="govuk-notification-banner-title"> LPA Questionnaire is incomplete</h3>
     </div>
@@ -3471,7 +3486,8 @@ exports[`LPA Questionnaire review POST / should render LPA Questionnaire review 
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds govuk-!-margin-bottom-5">
             <div class="govuk-notification-banner govuk-!-margin-bottom-5" role="region"
-            aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
+            aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner"
+            data-index="0">
                 <div class="govuk-notification-banner__header">
                     <h3 class="govuk-notification-banner__title" id="govuk-notification-banner-title"> LPA Questionnaire is incomplete</h3>
                 </div>

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/lpa-questionnaire.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/lpa-questionnaire.mapper.js
@@ -5,7 +5,8 @@ import {
 	inputInstructionIsRadiosInputInstruction,
 	yesNoInput,
 	createNotificationBanner,
-	mapNotificationBannersFromSession
+	mapNotificationBannersFromSession,
+	sortNotificationBanners
 } from '#lib/mappers/index.js';
 import { initialiseAndMapAppealData } from '#lib/mappers/data/appeal/mapper.js';
 import { initialiseAndMapLPAQData } from '#lib/mappers/data/lpa-questionnaire/mapper.js';
@@ -502,7 +503,7 @@ function mapLPAQuestionnaireNotificationBanners(
 	const banners = mapNotificationBannersFromSession(session, 'lpaQuestionnaire', appealId);
 
 	if (getDocumentsForVirusStatus(lpaqData, 'not_scanned').length > 0) {
-		banners.unshift(createNotificationBanner({ bannerDefinitionKey: 'notCheckedDocument' }));
+		banners.push(createNotificationBanner({ bannerDefinitionKey: 'notCheckedDocument' }));
 	}
 
 	if (validationOutcome === 'incomplete') {
@@ -556,7 +557,7 @@ function mapLPAQuestionnaireNotificationBanners(
 			});
 		}
 
-		banners.unshift(
+		banners.push(
 			createNotificationBanner({
 				bannerDefinitionKey: 'lpaQuestionnaireNotValid',
 				titleText: `LPA Questionnaire is ${String(validationOutcome)}`,
@@ -565,7 +566,7 @@ function mapLPAQuestionnaireNotificationBanners(
 		);
 	}
 
-	return banners;
+	return sortNotificationBanners(banners);
 }
 
 /**

--- a/appeals/web/src/server/appeals/appeal-details/withdrawal/withdrawal.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/withdrawal/withdrawal.mapper.js
@@ -1,7 +1,11 @@
 import { capitalize } from 'lodash-es';
 import { appealShortReference } from '#lib/appeals-formatter.js';
 import { dateISOStringToDisplayDate } from '#lib/dates.js';
-import { mapNotificationBannersFromSession, createNotificationBanner } from '#lib/mappers/index.js';
+import {
+	mapNotificationBannersFromSession,
+	createNotificationBanner,
+	sortNotificationBanners
+} from '#lib/mappers/index.js';
 import { preRenderPageComponents } from '#lib/nunjucks-template-builders/page-component-rendering.js';
 import { APPEAL_VIRUS_CHECK_STATUS } from 'pins-data-model';
 import {
@@ -82,7 +86,7 @@ export function manageWithdrawalRequestFolderPage(
 		preHeading: 'Manage folder',
 		heading: pageHeadingTextOverride || `${folderPathToFolderNameText(folder.path)} documents`,
 		pageComponents: [
-			...notificationBanners,
+			...sortNotificationBanners(notificationBanners),
 			...errorSummaryPageComponents,
 			{
 				type: 'table',

--- a/appeals/web/src/server/lib/mappers/components/page-components/__tests__/notification-banners.mapper.test.js
+++ b/appeals/web/src/server/lib/mappers/components/page-components/__tests__/notification-banners.mapper.test.js
@@ -1,5 +1,8 @@
 // @ts-nocheck
-import { mapNotificationBannersFromSession } from '../notification-banners.mapper.js';
+import {
+	mapNotificationBannersFromSession,
+	sortNotificationBanners
+} from '../notification-banners.mapper.js';
 import { jest } from '@jest/globals';
 
 describe('buildNotificationBanners', () => {
@@ -104,7 +107,10 @@ describe('buildNotificationBanners', () => {
 					titleText: 'Success',
 					titleHeadingLevel: 3,
 					type: 'success',
-					text: 'Document added'
+					text: 'Document added',
+					attributes: {
+						'data-index': 0
+					}
 				}
 			}
 		]);
@@ -129,7 +135,10 @@ describe('buildNotificationBanners', () => {
 					titleText: 'Success',
 					titleHeadingLevel: 3,
 					type: 'success',
-					text: 'custom text content'
+					text: 'custom text content',
+					attributes: {
+						'data-index': 0
+					}
 				}
 			}
 		]);
@@ -155,9 +164,68 @@ describe('buildNotificationBanners', () => {
 					titleHeadingLevel: 3,
 					type: 'success',
 					text: 'Document added',
-					html: '<p>custom text content</p>'
+					html: '<p>custom text content</p>',
+					attributes: {
+						'data-index': 0
+					}
 				}
 			}
+		]);
+	});
+});
+
+describe('sortNotificationBanners', () => {
+	const successBannerOne = {
+		type: 'notification-banner',
+		parameters: {
+			titleText: 'First success banner',
+			type: 'success'
+		}
+	};
+	const successBannerTwo = {
+		type: 'notification-banner',
+		parameters: {
+			titleText: 'Second success banner',
+			type: 'success'
+		}
+	};
+	const importantBannerOne = {
+		type: 'notification-banner',
+		parameters: {
+			titleText: 'First important banner',
+			type: 'important'
+		}
+	};
+	const importantBannerTwo = {
+		type: 'notification-banner',
+		parameters: {
+			titleText: 'Second important banner',
+			type: 'important'
+		}
+	};
+
+	it('should sort success banners before (above) important banners', () => {
+		expect(
+			sortNotificationBanners([
+				successBannerOne,
+				importantBannerOne,
+				successBannerTwo,
+				importantBannerTwo
+			])
+		).toEqual([successBannerOne, successBannerTwo, importantBannerOne, importantBannerTwo]);
+	});
+
+	it('should not change the relative ordering of success banners', () => {
+		expect(sortNotificationBanners([successBannerTwo, successBannerOne])).toEqual([
+			successBannerTwo,
+			successBannerOne
+		]);
+	});
+
+	it('should not change the relative ordering of important banners', () => {
+		expect(sortNotificationBanners([importantBannerTwo, importantBannerOne])).toEqual([
+			importantBannerTwo,
+			importantBannerOne
 		]);
 	});
 });

--- a/appeals/web/src/server/lib/mappers/components/page-components/notification-banners.mapper.js
+++ b/appeals/web/src/server/lib/mappers/components/page-components/notification-banners.mapper.js
@@ -478,7 +478,7 @@ export function mapNotificationBannersFromSession(session, servicePage, appealId
 			!displayedBannerKeys.includes(bannerData.key)
 	);
 
-	return notificationBanners;
+	return sortNotificationBanners(notificationBanners);
 }
 
 /**
@@ -531,4 +531,25 @@ export function mapRequiredActionToNotificationBannerKey(requiredAction) {
 	}
 
 	return appealActionRequiredToNotificationBannerMapping[requiredAction];
+}
+
+/**
+ * @param {PageComponent[]} bannerComponents
+ * @returns {PageComponent[]}
+ */
+export function sortNotificationBanners(bannerComponents) {
+	const sortedBanners = bannerComponents.sort((a, b) => {
+		if (a.parameters.type === 'success' && b.parameters.type === 'important') {
+			return -1;
+		} else if (a.parameters.type === 'important' && b.parameters.type === 'success') {
+			return 1;
+		}
+		return 0;
+	});
+
+	sortedBanners.forEach(
+		(bannerComponent, index) => (bannerComponent.parameters.attributes = { 'data-index': index })
+	);
+
+	return sortedBanners;
 }

--- a/appeals/web/src/server/lib/nunjucks-template-builders/gds-components-properties-jsdoc.js
+++ b/appeals/web/src/server/lib/nunjucks-template-builders/gds-components-properties-jsdoc.js
@@ -412,6 +412,7 @@
  * @property {string} [titleId] The id for the banner title, and the aria-labelledby attribute in the banner. Defaults to govuk-notification-banner-title.
  * @property {boolean} [disabledAutoFocus] If you set type to success, or role to alert, JavaScript moves the keyboard focus to the notification banner when the page loads. To disable this behaviour, set disableAutoFocus to true.
  * @property {string} [classes] The classes that you want to add to the notification banner.
+ * @property {string} [attributes] Attributes to add to the notification banner.
  */
 
 /**


### PR DESCRIPTION
## Describe your changes

Adds a new function `sortNotificationBanners` to ensure success and important notification banners are always sorted in the correct order relative to one-another.

## Issue ticket number and link
https://pins-ds.atlassian.net/browse/A2-2419