### PR TITLE
fix(web): A2-2614 Review IP and Final Comments - Supporting document links do not open when clicked

### DIFF
--- a/appeals/web/src/server/appeals/appeal-details/representations/final-comments/accept/__tests__/__snapshots__/accept-final-comments.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/representations/final-comments/accept/__tests__/__snapshots__/accept-final-comments.test.js.snap
@@ -15,8 +15,16 @@ exports[`final-comments GET / should render the accept appellant final comments 
                         <div class="pins-show-more" data-label="Read more" data-mode="text">Awaiting final comments review</div>
                     </dd>
                 </div>
-                <div class="govuk-summary-list__row govuk-summary-list__row--no-actions"><dt class="govuk-summary-list__key"> Supporting documents</dt>
-                    <dd class="govuk-summary-list__value">Not provided</dd>
+                <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Supporting documents</dt>
+                    <dd class="govuk-summary-list__value">
+                        <ul class="govuk-list govuk-!-margin-top-0 govuk-!-padding-left-0">
+                            <li><a class="govuk-link" href="/documents/4881/download/ed52cdc1-3cc2-462a-8623-c1ae256969d6/blank copy 5.pdf"
+                                target="_blank">blank copy 5.pdf</a>
+                            </li>
+                        </ul>
+                    </dd>
+                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/final-comments/appellant/manage-documents/135568"> Change</a>
+                    </dd>
                 </div>
                 <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Review decisions</dt>
                     <dd class="govuk-summary-list__value">Accept final comments</dd>
@@ -51,8 +59,16 @@ exports[`final-comments GET / should render the accept lpa final comments page w
                         <div class="pins-show-more" data-label="Read more" data-mode="text">Awaiting final comments review</div>
                     </dd>
                 </div>
-                <div class="govuk-summary-list__row govuk-summary-list__row--no-actions"><dt class="govuk-summary-list__key"> Supporting documents</dt>
-                    <dd class="govuk-summary-list__value">Not provided</dd>
+                <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Supporting documents</dt>
+                    <dd class="govuk-summary-list__value">
+                        <ul class="govuk-list govuk-!-margin-top-0 govuk-!-padding-left-0">
+                            <li><a class="govuk-link" href="/documents/4881/download/ed52cdc1-3cc2-462a-8623-c1ae256969d6/blank copy 5.pdf"
+                                target="_blank">blank copy 5.pdf</a>
+                            </li>
+                        </ul>
+                    </dd>
+                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/final-comments/lpa/manage-documents/135568"> Change</a>
+                    </dd>
                 </div>
                 <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Review decisions</dt>
                     <dd class="govuk-summary-list__value">Accept final comments</dd>

--- a/appeals/web/src/server/appeals/appeal-details/representations/final-comments/accept/__tests__/accept-final-comments.test.js
+++ b/appeals/web/src/server/appeals/appeal-details/representations/final-comments/accept/__tests__/accept-final-comments.test.js
@@ -1,7 +1,7 @@
 /* eslint-disable jest/expect-expect */
 import {
 	appealDataFullPlanning,
-	finalCommentsForReview
+	finalCommentsForReviewWithAttachments
 } from '#testing/app/fixtures/referencedata.js';
 import { createTestEnvironment } from '#testing/index.js';
 import { parseHtml } from '@pins/platform';
@@ -44,7 +44,7 @@ describe('final-comments', () => {
 			it(`should render the accept ${finalCommentsType.type} final comments page with the expected content`, async () => {
 				nock('http://test/')
 					.get(`/appeals/2/reps?type=${finalCommentsType.type}_final_comment`)
-					.reply(200, finalCommentsForReview)
+					.reply(200, finalCommentsForReviewWithAttachments)
 					.persist();
 
 				const response = await request.get(
@@ -87,12 +87,12 @@ describe('final-comments', () => {
 			it(`should call the patch rep status endpoint and redirect to the case details page`, async () => {
 				nock('http://test/')
 					.get(`/appeals/2/reps?type=${finalCommentsType.type}_final_comment`)
-					.reply(200, finalCommentsForReview)
+					.reply(200, finalCommentsForReviewWithAttachments)
 					.persist();
 
 				const mockedPatchFinalCommentStatusEndpoint = nock('http://test/')
 					.patch(`/appeals/2/reps/3670`)
-					.reply(200, finalCommentsForReview.items[0])
+					.reply(200, finalCommentsForReviewWithAttachments.items[0])
 					.persist();
 
 				const response = await request

--- a/appeals/web/src/server/appeals/appeal-details/representations/final-comments/accept/accept.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/representations/final-comments/accept/accept.mapper.js
@@ -4,6 +4,7 @@ import { wrapComponents, simpleHtmlComponent, buttonComponent } from '#lib/mappe
 import { redactInput } from '#appeals/appeal-details/representations/common/components/redact-input.js';
 import { summaryList } from './components/summary-list.js';
 import { buildHtmUnorderedList } from '#lib/nunjucks-template-builders/tag-builders.js';
+import { mapDocumentDownloadUrl } from '#appeals/appeal-documents/appeal-documents.mapper.js';
 
 /** @typedef {import("#appeals/appeal-details/appeal-details.types.js").WebAppeal} Appeal */
 /** @typedef {import("#appeals/appeal-details/representations/types.js").Representation} Representation */
@@ -81,7 +82,12 @@ export const confirmAcceptFinalCommentPage = (appealDetails, representation, fin
 		representation.attachments.length > 0
 			? buildHtmUnorderedList(
 					representation.attachments.map(
-						(a) => `<a class="govuk-link" href="#">${a.documentVersion.document.name}</a>`
+						(a) =>
+							`<a class="govuk-link" href="${mapDocumentDownloadUrl(
+								a.documentVersion.document.caseId,
+								a.documentVersion.document.guid,
+								a.documentVersion.document.name
+							)}" target="_blank">${a.documentVersion.document.name}</a>`
 					)
 			  )
 			: null;

--- a/appeals/web/src/server/appeals/appeal-details/representations/final-comments/view-and-review/__tests__/__snapshots__/view-and-review.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/representations/final-comments/view-and-review/__tests__/__snapshots__/view-and-review.test.js.snap
@@ -297,8 +297,20 @@ exports[`final-comments GET /review-comments with data should render review LPA 
                     </dd>
                 </div>
                 <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Supporting documents</dt>
-                    <dd class="govuk-summary-list__value">Not provided</dd>
-                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/final-comments/lpa/add-document"> Add<span class="govuk-visually-hidden"> supporting documents</span></a>
+                    <dd class="govuk-summary-list__value">
+                        <ul class="govuk-list govuk-!-margin-top-0 govuk-!-padding-left-0">
+                            <li><a class="govuk-link" href="/documents/4881/download/ed52cdc1-3cc2-462a-8623-c1ae256969d6/blank copy 5.pdf"
+                                target="_blank">blank copy 5.pdf</a>
+                            </li>
+                        </ul>
+                    </dd>
+                    <dd class="govuk-summary-list__actions">
+                        <ul class="govuk-summary-list__actions-list">
+                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/2/final-comments/lpa/manage-documents/135568"> Manage<span class="govuk-visually-hidden"> supporting documents</span></a>
+                            </li>
+                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/2/final-comments/lpa/add-document"> Add<span class="govuk-visually-hidden"> supporting documents</span></a>
+                            </li>
+                        </ul>
                     </dd>
                 </div>
             </dl>
@@ -594,8 +606,20 @@ exports[`final-comments POST /review-comments with data should render review LPA
                     </dd>
                 </div>
                 <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Supporting documents</dt>
-                    <dd class="govuk-summary-list__value">Not provided</dd>
-                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/final-comments/lpa/add-document"> Add<span class="govuk-visually-hidden"> supporting documents</span></a>
+                    <dd class="govuk-summary-list__value">
+                        <ul class="govuk-list govuk-!-margin-top-0 govuk-!-padding-left-0">
+                            <li><a class="govuk-link" href="/documents/4881/download/ed52cdc1-3cc2-462a-8623-c1ae256969d6/blank copy 5.pdf"
+                                target="_blank">blank copy 5.pdf</a>
+                            </li>
+                        </ul>
+                    </dd>
+                    <dd class="govuk-summary-list__actions">
+                        <ul class="govuk-summary-list__actions-list">
+                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/2/final-comments/lpa/manage-documents/135568"> Manage<span class="govuk-visually-hidden"> supporting documents</span></a>
+                            </li>
+                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/2/final-comments/lpa/add-document"> Add<span class="govuk-visually-hidden"> supporting documents</span></a>
+                            </li>
+                        </ul>
                     </dd>
                 </div>
             </dl>

--- a/appeals/web/src/server/appeals/appeal-details/representations/final-comments/view-and-review/__tests__/view-and-review.test.js
+++ b/appeals/web/src/server/appeals/appeal-details/representations/final-comments/view-and-review/__tests__/view-and-review.test.js
@@ -9,7 +9,8 @@ import {
 	finalCommentsForReview,
 	interestedPartyCommentForReview,
 	activeDirectoryUsersData,
-	documentFileVersionsInfoChecked
+	documentFileVersionsInfoChecked,
+	finalCommentsForReviewWithAttachments
 } from '#testing/app/fixtures/referencedata.js';
 import { createTestEnvironment } from '#testing/index.js';
 import { parseHtml } from '@pins/platform';
@@ -34,13 +35,8 @@ describe('final-comments', () => {
 			});
 
 		nock('http://test/')
-			.get('/appeals/2/document-folders')
-			.query({ path: 'representation/representationAttachments' })
-			.reply(200, [{ folderId: 1234, path: 'representation/attachments' }]);
-
-		nock('http://test/')
 			.get('/appeals/2/reps?type=lpa_final_comment')
-			.reply(200, finalCommentsForReview)
+			.reply(200, finalCommentsForReviewWithAttachments)
 			.persist();
 
 		nock('http://test/')

--- a/appeals/web/src/server/appeals/appeal-details/representations/final-comments/view-and-review/page-components/common.js
+++ b/appeals/web/src/server/appeals/appeal-details/representations/final-comments/view-and-review/page-components/common.js
@@ -1,6 +1,7 @@
 import { buildHtmUnorderedList } from '#lib/nunjucks-template-builders/tag-builders.js';
 import { preRenderPageComponents } from '#lib/nunjucks-template-builders/page-component-rendering.js';
 import { APPEAL_REPRESENTATION_STATUS } from '@pins/appeals/constants/common.js';
+import { mapDocumentDownloadUrl } from '#appeals/appeal-documents/appeal-documents.mapper.js';
 
 /** @typedef {import('#appeals/appeal-details/representations/types.js').Representation} Representation */
 
@@ -38,7 +39,12 @@ export function generateCommentsSummaryList(appealId, comment) {
 	const attachmentsList = filteredAttachments?.length
 		? buildHtmUnorderedList(
 				filteredAttachments.map(
-					(a) => `<a class="govuk-link" href="#">${a.documentVersion.document.name}</a>`
+					(a) =>
+						`<a class="govuk-link" href="${mapDocumentDownloadUrl(
+							a.documentVersion.document.caseId,
+							a.documentVersion.document.guid,
+							a.documentVersion.document.name
+						)}" target="_blank">${a.documentVersion.document.name}</a>`
 				)
 		  )
 		: null;

--- a/appeals/web/src/server/appeals/appeal-details/representations/interested-party-comments/interested-party-comments.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/representations/interested-party-comments/interested-party-comments.mapper.js
@@ -8,6 +8,7 @@ import { constructUrl } from '#lib/mappers/utils/url.mapper.js';
 import { preRenderPageComponents } from '#lib/nunjucks-template-builders/page-component-rendering.js';
 import { buildHtmUnorderedList } from '#lib/nunjucks-template-builders/tag-builders.js';
 import { addInvisibleSpacesAfterRedactionCharacters } from '#lib/redaction-string-formatter.js';
+import { mapDocumentDownloadUrl } from '#appeals/appeal-documents/appeal-documents.mapper.js';
 
 /**
  * @typedef {import('@pins/appeals.api').Appeals.SingleAppellantCaseResponse} SingleAppellantCaseResponse */
@@ -159,7 +160,12 @@ export function sharedIpCommentsPage(appealDetails, comments) {
 				{
 					html: buildHtmUnorderedList(
 						comment.attachments.map(
-							(a) => `<a class="govuk-link" href="#">${a.documentVersion.document.name}</a>`
+							(a) =>
+								`<a class="govuk-link" href="${mapDocumentDownloadUrl(
+									a.documentVersion.document.caseId,
+									a.documentVersion.document.guid,
+									a.documentVersion.document.name
+								)}" target="_blank">${a.documentVersion.document.name}</a>`
 						)
 					)
 				}

--- a/appeals/web/src/server/appeals/appeal-details/representations/interested-party-comments/view-and-review/page-components/common.js
+++ b/appeals/web/src/server/appeals/appeal-details/representations/interested-party-comments/view-and-review/page-components/common.js
@@ -1,3 +1,4 @@
+import { mapDocumentDownloadUrl } from '#appeals/appeal-documents/appeal-documents.mapper.js';
 import { addressToMultilineStringHtml } from '#lib/address-formatter.js';
 import { dateISOStringToDisplayDate } from '#lib/dates.js';
 import { simpleHtmlComponent, wrapComponents } from '#lib/mappers/index.js';
@@ -66,7 +67,12 @@ export function generateCommentSummaryList(
 	const attachmentsList = filteredAttachments?.length
 		? buildHtmUnorderedList(
 				filteredAttachments.map(
-					(a) => `<a class="govuk-link" href="#">${a.documentVersion.document.name}</a>`
+					(a) =>
+						`<a class="govuk-link" href="${mapDocumentDownloadUrl(
+							a.documentVersion.document.caseId,
+							a.documentVersion.document.guid,
+							a.documentVersion.document.name
+						)}" target="_blank">${a.documentVersion.document.name}</a>`
 				)
 		  )
 		: null;

--- a/appeals/web/src/server/appeals/appeal-details/representations/lpa-statement/incomplete/incomplete.controller.js
+++ b/appeals/web/src/server/appeals/appeal-details/representations/lpa-statement/incomplete/incomplete.controller.js
@@ -18,6 +18,7 @@ import {
 import { addNotificationBannerToSession } from '#lib/session-utilities.js';
 import { representationIncomplete } from '../../representations.service.js';
 import { mapRejectionReasonPayload } from '../../representations.mapper.js';
+import { mapDocumentDownloadUrl } from '#appeals/appeal-documents/appeal-documents.mapper.js';
 
 const statusFormatMap = {
 	[COMMENT_STATUS.INCOMPLETE]: 'Statement incomplete'
@@ -110,7 +111,12 @@ export const renderCheckYourAnswers = async (
 		currentRepresentation.attachments.length > 0
 			? buildHtmUnorderedList(
 					currentRepresentation.attachments.map(
-						(a) => `<a class="govuk-link" href="#">${a.documentVersion.document.name}</a>`
+						(a) =>
+							`<a class="govuk-link" href="${mapDocumentDownloadUrl(
+								a.documentVersion.document.caseId,
+								a.documentVersion.document.guid,
+								a.documentVersion.document.name
+							)}" target="_blank">${a.documentVersion.document.name}</a>`
 					)
 			  )
 			: null;

--- a/appeals/web/src/server/appeals/appeal-details/representations/lpa-statement/lpa-statement.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/representations/lpa-statement/lpa-statement.mapper.js
@@ -4,6 +4,7 @@ import { buildHtmUnorderedList } from '#lib/nunjucks-template-builders/tag-build
 import { mapNotificationBannersFromSession } from '#lib/mappers/index.js';
 import { COMMENT_STATUS } from '@pins/appeals/constants/common.js';
 import { constructUrl } from '#lib/mappers/utils/url.mapper.js';
+import { mapDocumentDownloadUrl } from '#appeals/appeal-documents/appeal-documents.mapper.js';
 
 /** @typedef {import("#appeals/appeal-details/appeal-details.types.js").WebAppeal} Appeal */
 /** @typedef {import('#appeals/appeal-details/representations/types.js').Representation} Representation */
@@ -23,7 +24,12 @@ export function baseSummaryList(appealId, lpaStatement, { isReview }) {
 	const attachmentsList = filteredAttachments?.length
 		? buildHtmUnorderedList(
 				filteredAttachments.map(
-					(a) => `<a class="govuk-link" href="#">${a.documentVersion.document.name}</a>`
+					(a) =>
+						`<a class="govuk-link" href="${mapDocumentDownloadUrl(
+							a.documentVersion.document.caseId,
+							a.documentVersion.document.guid,
+							a.documentVersion.document.name
+						)}" target="_blank">${a.documentVersion.document.name}</a>`
 				)
 		  )
 		: null;

--- a/appeals/web/src/server/appeals/appeal-documents/__tests__/appeal-documents.test.js
+++ b/appeals/web/src/server/appeals/appeal-documents/__tests__/appeal-documents.test.js
@@ -6,7 +6,7 @@ import {
 	appellantCaseDataNotValidated,
 	documentFileVersionsInfo
 } from '#testing/app/fixtures/referencedata.js';
-import { mapRedactionStatusKeyToName } from '../appeal-documents.mapper.js';
+import { mapDocumentDownloadUrl, mapRedactionStatusKeyToName } from '../appeal-documents.mapper.js';
 import { APPEAL_REDACTED_STATUS } from 'pins-data-model';
 
 const { app, installMockApi, teardown } = createTestEnvironment();
@@ -331,7 +331,6 @@ describe('appeal-documents', () => {
 			const result = mapRedactionStatusKeyToName('123');
 			expect(result).toBe('');
 		});
-
 	});
 });
 
@@ -348,3 +347,30 @@ const processAttrs = (/** @type {NamedNodeMap | undefined} */ attrs) => {
 
 	return items;
 };
+
+describe('mapDocumentDownloadUrl', () => {
+	it('should return the correct URL when documentVersion is provided', () => {
+		const result = mapDocumentDownloadUrl(1, '2', 'document.pdf', 3);
+		expect(result).toBe('/documents/1/download/2/3/document.pdf');
+	});
+
+	it('should return the correct URL when documentVersion is not provided', () => {
+		const result = mapDocumentDownloadUrl(1, '2', 'document.pdf');
+		expect(result).toBe('/documents/1/download/2/document.pdf');
+	});
+
+	it('should handle appealId as a string', () => {
+		const result = mapDocumentDownloadUrl('1', '2', 'document.pdf', 4);
+		expect(result).toBe('/documents/1/download/2/4/document.pdf');
+	});
+
+	it('should handle special characters in the filename safely', () => {
+		const result = mapDocumentDownloadUrl(1, '2', 'docu ment.pdf');
+		expect(result).toBe('/documents/1/download/2/docu ment.pdf');
+	});
+
+	it('should handle missing filename gracefully', () => {
+		const result = mapDocumentDownloadUrl(1, '2', '');
+		expect(result).toBe('/documents/1/download/2/');
+	});
+});

--- a/appeals/web/testing/app/fixtures/referencedata.js
+++ b/appeals/web/testing/app/fixtures/referencedata.js
@@ -3172,6 +3172,49 @@ export const finalCommentsForReview = {
 	pageSize: 30
 };
 
+export const finalCommentsForReviewWithAttachments = {
+	itemCount: 1,
+	items: [
+		{
+			id: 3670,
+			origin: 'citizen',
+			author: 'Lee Thornton',
+			status: 'awaiting_review',
+			originalRepresentation: 'Awaiting final comments review',
+			redactedRepresentation: '',
+			created: '2024-10-09T17:23:24.406Z',
+			notes: '',
+			representationType: 'lpa_final_comment',
+			siteVisitRequested: false,
+			attachments: [
+				{
+					documentVersion: {
+						document: {
+							caseId: '4881',
+							folderId: 135568,
+							guid: 'ed52cdc1-3cc2-462a-8623-c1ae256969d6',
+							name: 'blank copy 5.pdf',
+							isDeleted: false
+						}
+					}
+				}
+			],
+			represented: {
+				id: 3838,
+				name: 'Lee Thornton',
+				email: 'test1@example.com',
+				address: {
+					addressLine1: '',
+					postCode: ''
+				}
+			}
+		}
+	],
+	page: 1,
+	pageCount: 1,
+	pageSize: 30
+};
+
 export const appellantFinalCommentsAwaitingReview = {
 	itemCount: 1,
 	items: [


### PR DESCRIPTION
## Describe your changes

Resolved issue where supporting document links did not open when clicked while reviewing IP, Final Comments, and Statements. Identified and fixed the issue in six affected areas for consistency.

## Issue ticket number and link
[A2-2614](https://pins-ds.atlassian.net/browse/A2-2614)