### PR TITLE
fix(web): remove withdraw link from ip comment flows (a2-2597)

### DIFF
--- a/appeals/web/src/server/appeals/appeal-details/representations/interested-party-comments/__tests__/__snapshots__/interested-party-comments.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/representations/interested-party-comments/__tests__/__snapshots__/interested-party-comments.test.js.snap
@@ -117,8 +117,6 @@ exports[`interested-party-comments GET /interested-party-comments with data shou
                     </table>
                 </div>
             </div>
-            <p class="govuk-body"><a href="#" class="govuk-link">Withdrawn interested party comments</a>
-            </p>
         </div>
     </div>
 </main>"
@@ -241,8 +239,6 @@ exports[`interested-party-comments GET /interested-party-comments with data shou
                     </table>
                 </div>
             </div>
-            <p class="govuk-body"><a href="#" class="govuk-link">Withdrawn interested party comments</a>
-            </p>
         </div>
     </div>
 </main>"
@@ -365,8 +361,6 @@ exports[`interested-party-comments GET /interested-party-comments with data shou
                     </table>
                 </div>
             </div>
-            <p class="govuk-body"><a href="#" class="govuk-link">Withdrawn interested party comments</a>
-            </p>
         </div>
     </div>
 </main>"

--- a/appeals/web/src/server/appeals/appeal-details/representations/interested-party-comments/view-and-review/__tests__/__snapshots__/view-and-review.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/representations/interested-party-comments/view-and-review/__tests__/__snapshots__/view-and-review.test.js.snap
@@ -507,8 +507,6 @@ exports[`interested-party-comments GET /view-comment with data should render vie
             </dl>
         </div>
     </div>
-    <div class="govuk-!-margin-bottom-3"><a class="govuk-link" href="#">Withdraw comment</a>
-    </div>
 </main>"
 `;
 

--- a/appeals/web/src/server/appeals/appeal-details/representations/interested-party-comments/view-and-review/__tests__/__snapshots__/view-and-review.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/representations/interested-party-comments/view-and-review/__tests__/__snapshots__/view-and-review.test.js.snap
@@ -356,7 +356,6 @@ exports[`interested-party-comments GET /review-comment with data should render r
             </dl>
         </div>
     </div>
-    <div class="govuk-!-margin-bottom-3"></div>
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-full">
             <form action="" method="POST" novalidate>
@@ -430,7 +429,6 @@ exports[`interested-party-comments GET /review-comment with data should render r
             </dl>
         </div>
     </div>
-    <div class="govuk-!-margin-bottom-3"></div>
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-full">
             <form action="" method="POST" novalidate>

--- a/appeals/web/src/server/appeals/appeal-details/representations/interested-party-comments/view-and-review/page-components/common.js
+++ b/appeals/web/src/server/appeals/appeal-details/representations/interested-party-comments/view-and-review/page-components/common.js
@@ -1,25 +1,10 @@
 import { mapDocumentDownloadUrl } from '#appeals/appeal-documents/appeal-documents.mapper.js';
 import { addressToMultilineStringHtml } from '#lib/address-formatter.js';
 import { dateISOStringToDisplayDate } from '#lib/dates.js';
-import { simpleHtmlComponent, wrapComponents } from '#lib/mappers/index.js';
 import { buildHtmUnorderedList } from '#lib/nunjucks-template-builders/tag-builders.js';
 import { COMMENT_STATUS } from '@pins/appeals/constants/common.js';
 
 /** @typedef {import('#appeals/appeal-details/representations/types.js').Representation} Representation */
-
-/**
- * Generates the withdraw link component.
- * @returns {PageComponent} The withdraw link component.
- */
-export function generateWithdrawLink() {
-	return wrapComponents(
-		[simpleHtmlComponent('a', { class: 'govuk-link', href: '#' }, 'Withdraw comment')],
-		{
-			opening: '<div class="govuk-!-margin-bottom-3">',
-			closing: '</div>'
-		}
-	);
-}
 
 /**
  * @param {Representation} comment - The comment object.

--- a/appeals/web/src/server/appeals/appeal-details/representations/interested-party-comments/view-and-review/page-components/review.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/representations/interested-party-comments/view-and-review/page-components/review.mapper.js
@@ -1,6 +1,6 @@
 import { appealShortReference } from '#lib/appeals-formatter.js';
 import { COMMENT_STATUS } from '@pins/appeals/constants/common.js';
-import { generateCommentSummaryList, generateWithdrawLink } from './common.js';
+import { generateCommentSummaryList } from './common.js';
 import { mapNotificationBannersFromSession } from '#lib/mappers/index.js';
 
 /** @typedef {import("#appeals/appeal-details/appeal-details.types.js").WebAppeal} Appeal */
@@ -17,7 +17,6 @@ export function reviewInterestedPartyCommentPage(appealDetails, comment, session
 	const commentSummaryList = generateCommentSummaryList(appealDetails.appealId, comment, {
 		isReviewPage: true
 	});
-	const withdrawLink = generateWithdrawLink();
 
 	/** @type {PageComponent} */
 	const siteVisitRequestCheckbox = {
@@ -85,8 +84,7 @@ export function reviewInterestedPartyCommentPage(appealDetails, comment, session
 			...mapNotificationBannersFromSession(session, 'reviewIpComment', appealDetails.appealId),
 			commentSummaryList,
 			siteVisitRequestCheckbox,
-			commentValidityRadioButtons,
-			withdrawLink
+			commentValidityRadioButtons
 		]
 	};
 

--- a/appeals/web/src/server/appeals/appeal-details/representations/interested-party-comments/view-and-review/page-components/view.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/representations/interested-party-comments/view-and-review/page-components/view.mapper.js
@@ -1,6 +1,6 @@
 import { appealShortReference } from '#lib/appeals-formatter.js';
 import { mapNotificationBannersFromSession } from '#lib/mappers/index.js';
-import { generateCommentSummaryList, generateWithdrawLink } from './common.js';
+import { generateCommentSummaryList } from './common.js';
 import { preRenderPageComponents } from '#lib/nunjucks-template-builders/page-component-rendering.js';
 import { APPEAL_REPRESENTATION_STATUS } from '@pins/appeals/constants/common.js';
 
@@ -16,7 +16,6 @@ import { APPEAL_REPRESENTATION_STATUS } from '@pins/appeals/constants/common.js'
 export function viewInterestedPartyCommentPage(appealDetails, comment, session) {
 	const shortReference = appealShortReference(appealDetails.appealReference);
 	const commentSummaryList = generateCommentSummaryList(appealDetails.appealId, comment);
-	const withdrawLink = generateWithdrawLink();
 	const notificationBanners = mapNotificationBannersFromSession(
 		session,
 		'viewIpComment',
@@ -40,7 +39,7 @@ export function viewInterestedPartyCommentPage(appealDetails, comment, session) 
 		backLinkUrl: `/appeals-service/appeal-details/${appealDetails.appealId}/interested-party-comments${backLinkHash}`,
 		preHeading: `Appeal ${shortReference}`,
 		heading: 'View comment',
-		pageComponents: [...notificationBanners, commentSummaryList, withdrawLink]
+		pageComponents: [...notificationBanners, commentSummaryList]
 	};
 
 	preRenderPageComponents(pageContent.pageComponents);

--- a/appeals/web/src/server/views/appeals/appeal/interested-party-comments.njk
+++ b/appeals/web/src/server/views/appeals/appeal/interested-party-comments.njk
@@ -76,9 +76,6 @@
           }
         ]
       }) }}
-      <p class="govuk-body">
-        <a href="#" class="govuk-link">Withdrawn interested party comments</a>
-      </p>
     </div>
   </div>
 {%- endblock -%}


### PR DESCRIPTION
- Removed withdraw link from view page
- Removed withdraw link from review page
- Removed withdraw link from .njk file rendering IP comments overview page
- Updated snapshots

https://pins-ds.atlassian.net/browse/A2-2597