### PR TITLE
chore(appeals): add node to  e2e pipeline

### DIFF
--- a/azure-pipelines-e2e-appeals.yml
+++ b/azure-pipelines-e2e-appeals.yml
@@ -29,6 +29,11 @@ jobs:
     pool: pins-odt-agent-pool-tests
 
     steps:
+      - task: NodeTool@0
+        inputs:
+          versionSpec: "22.x"
+        displayName: "Install Node.js"
+
       - task: ShellScript@2
         inputs:
           scriptPath: 'appeals/e2e/install-chromium.sh'


### PR DESCRIPTION
`e2e` pipeline failing after node 22 update

`Unable to locate executable file: 'npm'`

Added NodeTool task with v22 hint
[Ticket](https://dev.azure.com/planninginspectorate/appeals-back-office/_build/results?buildId=108229&view=logs&j=f52bf699-3ddc-5068-598c-8f87b671093d&t=c33f332c-202a-58bd-65a0-17bfc6e3b077&l=9)
