### PR TITLE
fix(web): force allocation selection

### DIFF
--- a/appeals/web/src/server/appeals/appeal-details/representations/lpa-statement/allocation/allocation.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/representations/lpa-statement/allocation/allocation.mapper.js
@@ -56,9 +56,16 @@ export function allocationCheckPage(appealDetails, sessionData) {
  * @param {Representation} lpaStatement
  * @param {string[]} allocationLevels
  * @param {Record<string, string>} sessionData
+ * @param {'valid' | 'redact'} flowRoute
  * @returns {PageContent}
  * */
-export function allocationLevelPage(appealDetails, lpaStatement, allocationLevels, sessionData) {
+export function allocationLevelPage(
+	appealDetails,
+	lpaStatement,
+	allocationLevels,
+	sessionData,
+	flowRoute
+) {
 	const shortReference = appealShortReference(appealDetails.appealReference);
 
 	/** @type {PageComponent[]} */
@@ -72,7 +79,9 @@ export function allocationLevelPage(appealDetails, lpaStatement, allocationLevel
 
 	return {
 		title: 'Allocation level',
-		backLinkUrl: `/appeals-service/appeal-details/${appealDetails.appealId}/lpa-statement/valid/allocation-check`,
+		backLinkUrl: `/appeals-service/appeal-details/${appealDetails.appealId}/lpa-statement/${
+			sessionData.forcedAllocation ? '' : `${flowRoute}/allocation-check`
+		}`,
 		preHeading: `Appeal ${shortReference}`,
 		heading: 'Allocation level',
 		submitButtonText: 'Continue',

--- a/appeals/web/src/server/appeals/appeal-details/representations/lpa-statement/lpa-statement.controller.js
+++ b/appeals/web/src/server/appeals/appeal-details/representations/lpa-statement/lpa-statement.controller.js
@@ -43,7 +43,9 @@ export const postReviewLpaStatement = async (request, response) => {
 	const {
 		errors,
 		params: { appealId },
-		body: { status }
+		body: { status },
+		currentAppeal,
+		session
 	} = request;
 
 	if (errors) {
@@ -52,6 +54,15 @@ export const postReviewLpaStatement = async (request, response) => {
 
 	switch (status) {
 		case COMMENT_STATUS.VALID:
+			if (
+				!currentAppeal.allocationDetails?.level ||
+				!currentAppeal.allocationDetails?.specialisms?.length
+			) {
+				session.acceptLPAStatement.forcedAllocation = true;
+				return response.redirect(
+					`/appeals-service/appeal-details/${appealId}/lpa-statement/valid/allocation-level`
+				);
+			}
 			return response.redirect(
 				`/appeals-service/appeal-details/${appealId}/lpa-statement/valid/allocation-check`
 			);

--- a/appeals/web/src/server/appeals/appeal-details/representations/lpa-statement/redact/redact.controller.js
+++ b/appeals/web/src/server/appeals/appeal-details/representations/lpa-statement/redact/redact.controller.js
@@ -36,8 +36,20 @@ export async function renderConfirm(request, response) {
  * */
 export function postRedact(request, response) {
 	const {
-		params: { appealId }
+		params: { appealId },
+		currentAppeal,
+		session
 	} = request;
+
+	if (
+		!currentAppeal.allocationDetails?.level ||
+		!currentAppeal.allocationDetails?.specialisms?.length
+	) {
+		session.acceptLPAStatement.forcedAllocation = true;
+		return response.redirect(
+			`/appeals-service/appeal-details/${appealId}/lpa-statement/redact/allocation-level`
+		);
+	}
 
 	return response.redirect(
 		`/appeals-service/appeal-details/${appealId}/lpa-statement/redact/allocation-check`
@@ -100,7 +112,8 @@ export async function renderAllocationLevel(request, response) {
 		currentAppeal,
 		currentRepresentation,
 		allocationLevels,
-		session.redactLPAStatement
+		session.redactLPAStatement,
+		'redact'
 	);
 
 	return response.status(200).render('patterns/change-page.pattern.njk', {

--- a/appeals/web/src/server/appeals/appeal-details/representations/lpa-statement/redact/redact.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/representations/lpa-statement/redact/redact.mapper.js
@@ -71,7 +71,7 @@ export function redactLpaStatementPage(appealDetails, lpaStatement, session) {
  * @param {Appeal} appealDetails
  * @param {Representation} lpaStatement
  * @param {import('#lib/api/allocation-details.api.js').AllocationDetailsSpecialism[]} specialismData
- * @param {SessionWithAuth & { redactLPAStatement?: { redactedRepresentation: string, allocationLevelAndSpecialisms: string, allocationLevel: string, allocationSpecialisms: string[] } }} session
+ * @param {SessionWithAuth & { redactLPAStatement?: { redactedRepresentation: string, allocationLevelAndSpecialisms: string, allocationLevel: string, allocationSpecialisms: string[], forcedAllocation: boolean } }} session
  * @returns {PageContent}
  */
 export function redactConfirmPage(appealDetails, lpaStatement, specialismData, session) {
@@ -162,6 +162,23 @@ export function redactConfirmPage(appealDetails, lpaStatement, specialismData, s
 							]
 						}
 					},
+					...(sessionData?.forcedAllocation
+						? [
+								{
+									key: { text: 'Do you need to update the allocation level and specialisms?' },
+									value: { text: updatingAllocation ? 'Yes' : 'No' },
+									actions: {
+										items: [
+											{
+												text: 'Change',
+												href: `/appeals-service/appeal-details/${appealDetails.appealId}/lpa-statement/valid/allocation-check`,
+												visuallyHiddenText: 'allocation level and specialisms'
+											}
+										]
+									}
+								}
+						  ]
+						: []),
 					...(updatingAllocation
 						? [
 								{

--- a/appeals/web/src/server/appeals/appeal-details/representations/lpa-statement/valid/valid.controller.js
+++ b/appeals/web/src/server/appeals/appeal-details/representations/lpa-statement/valid/valid.controller.js
@@ -65,7 +65,8 @@ export async function renderAllocationLevel(request, response) {
 		currentAppeal,
 		currentRepresentation,
 		allocationLevels,
-		session.acceptLPAStatement
+		session.acceptLPAStatement,
+		'valid'
 	);
 
 	return response.status(200).render('patterns/change-page.pattern.njk', {

--- a/appeals/web/src/server/appeals/appeal-details/representations/lpa-statement/valid/valid.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/representations/lpa-statement/valid/valid.mapper.js
@@ -11,7 +11,7 @@ import { ensureArray } from '#lib/array-utilities.js';
  * @param {Appeal} appealDetails
  * @param {Representation} lpaStatement
  * @param {import('#lib/api/allocation-details.api.js').AllocationDetailsSpecialism[]} specialismData
- * @param {SessionWithAuth & { acceptLPAStatement?: { allocationLevelAndSpecialisms: string, allocationLevel: string, allocationSpecialisms: string[] } }} session
+ * @param {SessionWithAuth & { acceptLPAStatement?: { allocationLevelAndSpecialisms: string, allocationLevel: string, allocationSpecialisms: string[], forcedAllocation: boolean } }} session
  * @returns {PageContent}
  * */
 export const confirmPage = (appealDetails, lpaStatement, specialismData, session) => {
@@ -98,19 +98,23 @@ export const confirmPage = (appealDetails, lpaStatement, specialismData, session
 							]
 						}
 					},
-					{
-						key: { text: 'Do you need to update the allocation level and specialisms?' },
-						value: { text: updatingAllocation ? 'Yes' : 'No' },
-						actions: {
-							items: [
+					...(sessionData?.forcedAllocation
+						? [
 								{
-									text: 'Change',
-									href: `/appeals-service/appeal-details/${appealDetails.appealId}/lpa-statement/valid/allocation-check`,
-									visuallyHiddenText: 'allocation level and specialisms'
+									key: { text: 'Do you need to update the allocation level and specialisms?' },
+									value: { text: updatingAllocation ? 'Yes' : 'No' },
+									actions: {
+										items: [
+											{
+												text: 'Change',
+												href: `/appeals-service/appeal-details/${appealDetails.appealId}/lpa-statement/valid/allocation-check`,
+												visuallyHiddenText: 'allocation level and specialisms'
+											}
+										]
+									}
 								}
-							]
-						}
-					},
+						  ]
+						: []),
 					...(updatingAllocation
 						? [
 								{


### PR DESCRIPTION
## Describe your changes

Forces the user into the allocation flow when accepting or redacting an LPA statement if no allocation level or specialisms have been set

## Issue ticket number and link
[Ticket](https://pins-ds.atlassian.net/browse/A2-2467)
