### PR TITLE
Fix/a2 2468 radio buttons

### DIFF
--- a/appeals/web/src/server/appeals/appeal-details/representations/lpa-statement/incomplete/incomplete.router.js
+++ b/appeals/web/src/server/appeals/appeal-details/representations/lpa-statement/incomplete/incomplete.router.js
@@ -15,12 +15,13 @@ import { validateSetNewDate } from './incomplete.validator.js';
 
 const router = Router({ mergeParams: true });
 
-router.get('/reasons', renderReasons);
-router.post('/reasons', validateRejectReason, validateRejectionReasonTextItems, postReasons);
+router
+	.route('/reasons')
+	.get(renderReasons)
+	.post(validateRejectReason, validateRejectionReasonTextItems, postReasons);
 
-router.get('/date', renderSetNewDate);
-router.post('/date', validateSetNewDate, postSetNewDate);
+router.route('/date').get(renderSetNewDate).post(validateSetNewDate, postSetNewDate);
 
-router.get('/confirm', renderCheckYourAnswers);
-router.post('/confirm', postCheckYourAnswers);
+router.route('/confirm').get(renderCheckYourAnswers).post(postCheckYourAnswers);
+
 export default router;

--- a/appeals/web/src/server/appeals/appeal-details/representations/lpa-statement/lpa-statement.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/representations/lpa-statement/lpa-statement.mapper.js
@@ -152,6 +152,8 @@ export function reviewLpaStatementPage(appealDetails, lpaStatement, session, bac
 		isReview: true
 	});
 
+	const { status } = session.lpaStatement?.[appealDetails.appealId] ?? {};
+
 	/** @type {PageComponent} */
 	const lpaStatementValidityRadioButtons = {
 		type: 'radios',
@@ -169,7 +171,7 @@ export function reviewLpaStatementPage(appealDetails, lpaStatement, session, bac
 				{
 					value: COMMENT_STATUS.VALID,
 					text: 'Accept statement',
-					checked: session.lpaStatement?.status === COMMENT_STATUS.VALID
+					checked: status === COMMENT_STATUS.VALID
 				},
 				{
 					value: COMMENT_STATUS.VALID_REQUIRES_REDACTION,
@@ -179,7 +181,7 @@ export function reviewLpaStatementPage(appealDetails, lpaStatement, session, bac
 				{
 					value: COMMENT_STATUS.INCOMPLETE,
 					text: 'Statement incomplete',
-					checked: session.lpaStatement?.status === COMMENT_STATUS.INCOMPLETE
+					checked: status === COMMENT_STATUS.INCOMPLETE
 				}
 			]
 		}

--- a/appeals/web/src/server/appeals/appeal-details/representations/lpa-statement/lpa-statement.router.js
+++ b/appeals/web/src/server/appeals/appeal-details/representations/lpa-statement/lpa-statement.router.js
@@ -14,9 +14,17 @@ const router = Router({ mergeParams: true });
 router
 	.route('/')
 	.get(renderReviewLpaStatement)
-	.post(validateStatus, saveBodyToSession('lpaStatement'), postReviewLpaStatement);
+	.post(
+		validateStatus,
+		saveBodyToSession('lpaStatement', { scopeToAppeal: true }),
+		postReviewLpaStatement
+	);
 
-router.use('/incomplete', saveBodyToSession('lpaStatement'), incompleteRouter);
+router.use(
+	'/incomplete',
+	saveBodyToSession('lpaStatement', { scopeToAppeal: true }),
+	incompleteRouter
+);
 
 router.use('/valid', validRouter);
 

--- a/appeals/web/src/server/lib/middleware/save-body-to-session.js
+++ b/appeals/web/src/server/lib/middleware/save-body-to-session.js
@@ -1,9 +1,26 @@
 /**
  * @param {string} key
+ * @param {{ scopeToAppeal?: boolean }} [options]
  * @returns {import('@pins/express').RequestHandler<{}>}
  */
-export const saveBodyToSession = (key) => (request, _, next) => {
-	request.session[key] = { ...(request.session[key] || {}), ...request.body };
+export const saveBodyToSession = (key, options) => (request, _, next) => {
+	const { appealId } = request.params;
+
+	if (!request.session[key]) {
+		request.session[key] = {};
+	}
+
+	if (options?.scopeToAppeal) {
+		request.session[key][appealId] = {
+			...request.session[key][appealId],
+			...request.body
+		};
+	} else {
+		request.session[key] = {
+			...request.session[key],
+			...request.body
+		};
+	}
 
 	next();
 };


### PR DESCRIPTION
## Describe your changes

* refactor(web): use express .route chain syntax in incomplete router
* refactor(web): allow saveBodyToSession to optionally scope to appeal
* fix(web): scope session values to appeal in incomplete flow
* refactor(web): use concretised controllers for rendering reject reasons
This allows me to scope to appeal ID in the incomplete flow without
introducing the `scopeToAppeal` option excessively. Still using the
common mapper for the actual checkbox items.

## Issue ticket number and link
[A2-2468](https://pins-ds.atlassian.net/browse/A2-2468)


[A2-2468]: https://pins-ds.atlassian.net/browse/A2-2468?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ