### PR TITLE
fix(web): global content updates to document upload success banners

### DIFF
--- a/appeals/web/src/server/appeals/appeal-details/__tests__/__snapshots__/appeal-details.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/__tests__/__snapshots__/appeal-details.test.js.snap
@@ -291,7 +291,7 @@ data-index="0">
         <h3 class="govuk-notification-banner__title" id="govuk-notification-banner-title"> Success</h3>
     </div>
     <div class="govuk-notification-banner__content">
-        <p class="govuk-notification-banner__heading">Cross-team correspondence documents uploaded</p>
+        <p class="govuk-notification-banner__heading">Cross-team correspondence added</p>
     </div>
 </div>"
 `;
@@ -395,7 +395,7 @@ data-index="0">
         <h3 class="govuk-notification-banner__title" id="govuk-notification-banner-title"> Success</h3>
     </div>
     <div class="govuk-notification-banner__content">
-        <p class="govuk-notification-banner__heading">LPA costs application documents uploaded</p>
+        <p class="govuk-notification-banner__heading">LPA costs application added</p>
     </div>
 </div>"
 `;
@@ -408,7 +408,7 @@ data-index="0">
         <h3 class="govuk-notification-banner__title" id="govuk-notification-banner-title"> Success</h3>
     </div>
     <div class="govuk-notification-banner__content">
-        <p class="govuk-notification-banner__heading">Appellant costs application documents uploaded</p>
+        <p class="govuk-notification-banner__heading">Appellant costs application added</p>
     </div>
 </div>"
 `;
@@ -421,7 +421,7 @@ data-index="0">
         <h3 class="govuk-notification-banner__title" id="govuk-notification-banner-title"> Success</h3>
     </div>
     <div class="govuk-notification-banner__content">
-        <p class="govuk-notification-banner__heading">Inspector correspondence documents uploaded</p>
+        <p class="govuk-notification-banner__heading">Inspector correspondence added</p>
     </div>
 </div>"
 `;

--- a/appeals/web/src/server/appeals/appeal-details/__tests__/appeal-details.test.js
+++ b/appeals/web/src/server/appeals/appeal-details/__tests__/appeal-details.test.js
@@ -594,9 +594,7 @@ describe('appeal-details', () => {
 
 				expect(notificationBannerElementHTML).toMatchSnapshot();
 				expect(notificationBannerElementHTML).toContain('Success</h3>');
-				expect(notificationBannerElementHTML).toContain(
-					'Appellant costs application documents uploaded</p>'
-				);
+				expect(notificationBannerElementHTML).toContain('Appellant costs application added</p>');
 			});
 
 			it('should render a success notification banner when a new version of an appellant costs document was uploaded', async () => {
@@ -693,9 +691,7 @@ describe('appeal-details', () => {
 
 				expect(notificationBannerElementHTML).toMatchSnapshot();
 				expect(notificationBannerElementHTML).toContain('Success</h3>');
-				expect(notificationBannerElementHTML).toContain(
-					'LPA costs application documents uploaded</p>'
-				);
+				expect(notificationBannerElementHTML).toContain('LPA costs application added</p>');
 			});
 
 			it('should render a success notification banner when a new version of an LPA costs document was uploaded', async () => {
@@ -995,9 +991,7 @@ describe('appeal-details', () => {
 
 				expect(notificationBannerElementHTML).toMatchSnapshot();
 				expect(notificationBannerElementHTML).toContain('Success</h3>');
-				expect(notificationBannerElementHTML).toContain(
-					'Cross-team correspondence documents uploaded</p>'
-				);
+				expect(notificationBannerElementHTML).toContain('Cross-team correspondence added</p>');
 			});
 
 			it('should render a success notification banner when an inspector correspondence document was uploaded', async () => {
@@ -1036,9 +1030,7 @@ describe('appeal-details', () => {
 
 				expect(notificationBannerElementHTML).toMatchSnapshot();
 				expect(notificationBannerElementHTML).toContain('Success</h3>');
-				expect(notificationBannerElementHTML).toContain(
-					'Inspector correspondence documents uploaded</p>'
-				);
+				expect(notificationBannerElementHTML).toContain('Inspector correspondence added</p>');
 			});
 
 			it('should render an important notification banner when the appeal has unreviewed IP comments', async () => {

--- a/appeals/web/src/server/appeals/appeal-details/appellant-case/appellant-case.controller.js
+++ b/appeals/web/src/server/appeals/appeal-details/appellant-case/appellant-case.controller.js
@@ -28,6 +28,7 @@ import {
 import { capitalize } from 'lodash-es';
 import { addNotificationBannerToSession } from '#lib/session-utilities.js';
 import { APPEAL_DOCUMENT_TYPE } from 'pins-data-model';
+import { mapFolderNameToDisplayLabel } from '#lib/mappers/utils/documents-and-folders.js';
 
 /**
  *
@@ -343,7 +344,7 @@ export const getAddDocumentsCheckAndConfirm = async (request, response) => {
 
 /** @type {import('@pins/express').RequestHandler<Response>} */
 export const postAddDocumentsCheckAndConfirm = async (request, response) => {
-	const { currentAppeal } = request;
+	const { currentAppeal, currentFolder } = request;
 
 	if (!currentAppeal) {
 		return response.status(404).render('app/404');
@@ -358,7 +359,8 @@ export const postAddDocumentsCheckAndConfirm = async (request, response) => {
 				addNotificationBannerToSession({
 					session: request.session,
 					bannerDefinitionKey: 'documentAdded',
-					appealId: currentAppeal.appealId
+					appealId: currentAppeal.appealId,
+					text: `${mapFolderNameToDisplayLabel(currentFolder?.path) || 'Documents'} added`
 				});
 			}
 		});

--- a/appeals/web/src/server/appeals/appeal-details/costs/costs.controller.js
+++ b/appeals/web/src/server/appeals/appeal-details/costs/costs.controller.js
@@ -23,6 +23,7 @@ import {
 import { capitalize } from 'lodash-es';
 import { addNotificationBannerToSession } from '#lib/session-utilities.js';
 import logger from '#lib/logger.js';
+import { mapFolderNameToDisplayLabel } from '#lib/mappers/utils/documents-and-folders.js';
 
 /** @type {import('@pins/express').RequestHandler<Response>}  */
 export const getDocumentUpload = async (request, response) => {
@@ -252,11 +253,7 @@ export const getAddDocumentsCheckAndConfirm = async (request, response) => {
  * @param {import('@pins/express/types/express.js').RenderedResponse<any, any, Number>} response
  */
 export const postAddDocumentsCheckAndConfirm = async (request, response) => {
-	const {
-		currentAppeal,
-		session,
-		params: { costsCategory, costsDocumentType }
-	} = request;
+	const { currentAppeal, currentFolder, session } = request;
 
 	if (!currentAppeal) {
 		return response.status(404).render('app/404');
@@ -276,11 +273,9 @@ export const postAddDocumentsCheckAndConfirm = async (request, response) => {
 
 				addNotificationBannerToSession({
 					session,
-					bannerDefinitionKey: 'costsDocumentAdded',
+					bannerDefinitionKey: 'documentAdded',
 					appealId: currentAppeal.appealId,
-					text: `${
-						costsCategory === 'lpa' ? 'LPA' : capitalize(costsCategory)
-					} costs ${costsDocumentType} documents uploaded`
+					text: `${mapFolderNameToDisplayLabel(currentFolder.path)} added`
 				});
 			}
 		});

--- a/appeals/web/src/server/appeals/appeal-details/internal-correspondence/internal-correspondence.controller.js
+++ b/appeals/web/src/server/appeals/appeal-details/internal-correspondence/internal-correspondence.controller.js
@@ -18,6 +18,7 @@ import {
 import { addNotificationBannerToSession } from '#lib/session-utilities.js';
 import { capitalize } from 'lodash-es';
 import logger from '#lib/logger.js';
+import { mapFolderNameToDisplayLabel } from '#lib/mappers/utils/documents-and-folders.js';
 
 /** @type {import('@pins/express').RequestHandler<Response>}  */
 export const getDocumentUpload = async (request, response) => {
@@ -195,6 +196,7 @@ export const getAddDocumentsCheckAndConfirm = async (request, response) => {
 export const postAddDocumentsCheckAndConfirm = async (request, response) => {
 	const {
 		currentAppeal,
+		currentFolder,
 		session,
 		params: { correspondenceCategory }
 	} = request;
@@ -213,7 +215,7 @@ export const postAddDocumentsCheckAndConfirm = async (request, response) => {
 					session,
 					bannerDefinitionKey: 'internalCorrespondenceDocumentAdded',
 					appealId: currentAppeal.appealId,
-					text: `${capitalize(correspondenceCategory)} correspondence documents uploaded`
+					text: `${mapFolderNameToDisplayLabel(currentFolder.path)} added`
 				});
 			}
 		});

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/lpa-questionnaire.controller.js
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/lpa-questionnaire.controller.js
@@ -29,6 +29,7 @@ import {
 import { addNotificationBannerToSession } from '#lib/session-utilities.js';
 import { APPEAL_TYPE } from '@pins/appeals/constants/common.js';
 import * as appealDetailsService from '#appeals/appeal-details/appeal-details.service.js';
+import { mapFolderNameToDisplayLabel } from '#lib/mappers/utils/documents-and-folders.js';
 
 /**
  * @param {import('@pins/express/types/express.js').Request} request
@@ -465,7 +466,8 @@ export const postAddDocumentsCheckAndConfirm = async (request, response) => {
 				addNotificationBannerToSession({
 					session: request.session,
 					bannerDefinitionKey: 'documentAdded',
-					appealId: currentAppeal.appealId
+					appealId: currentAppeal.appealId,
+					text: `${mapFolderNameToDisplayLabel(currentFolder?.path) || 'Documents'} added`
 				});
 			}
 		});

--- a/appeals/web/src/server/lib/constants.js
+++ b/appeals/web/src/server/lib/constants.js
@@ -1,2 +1,54 @@
+import { APPEAL_DOCUMENT_TYPE } from 'pins-data-model';
+
 export const SHOW_MORE_MAXIMUM_CHARACTERS_BEFORE_HIDING = 300;
 export const SHOW_MORE_MAXIMUM_ROWS_BEFORE_HIDING = 3;
+
+export const DOCUMENT_FOLDER_DISPLAY_LABELS = {
+	[APPEAL_DOCUMENT_TYPE.APPELLANT_STATEMENT]: 'Appeal statement',
+	[APPEAL_DOCUMENT_TYPE.ORIGINAL_APPLICATION_FORM]: 'Application form',
+	[APPEAL_DOCUMENT_TYPE.APPLICATION_DECISION_LETTER]: 'Application decision letter',
+	[APPEAL_DOCUMENT_TYPE.CHANGED_DESCRIPTION]: 'Agreement to change description evidence',
+	[APPEAL_DOCUMENT_TYPE.APPELLANT_CASE_WITHDRAWAL_LETTER]: 'Appellant withdrawal request',
+	[APPEAL_DOCUMENT_TYPE.APPELLANT_CASE_CORRESPONDENCE]: 'Additional documents',
+	[APPEAL_DOCUMENT_TYPE.DESIGN_ACCESS_STATEMENT]: 'Design and access statement',
+	[APPEAL_DOCUMENT_TYPE.PLANS_DRAWINGS]: 'Plans, drawings and list of plans',
+	[APPEAL_DOCUMENT_TYPE.NEW_PLANS_DRAWINGS]: 'New plans or drawings',
+	[APPEAL_DOCUMENT_TYPE.PLANNING_OBLIGATION]: 'Planning obligation',
+	[APPEAL_DOCUMENT_TYPE.OWNERSHIP_CERTIFICATE]: 'Ownership certificate and/or land declaration',
+	[APPEAL_DOCUMENT_TYPE.OTHER_NEW_DOCUMENTS]: 'Other new supporting documents',
+	[APPEAL_DOCUMENT_TYPE.ENVIRONMENTAL_ASSESSMENT]: 'Environmental assessment',
+	[APPEAL_DOCUMENT_TYPE.WHO_NOTIFIED]: 'Who was notified about the application',
+	[APPEAL_DOCUMENT_TYPE.WHO_NOTIFIED_SITE_NOTICE]: 'Site notice',
+	[APPEAL_DOCUMENT_TYPE.WHO_NOTIFIED_LETTER_TO_NEIGHBOURS]: 'Letter or email notification',
+	[APPEAL_DOCUMENT_TYPE.WHO_NOTIFIED_PRESS_ADVERT]: 'Press advert notification',
+	[APPEAL_DOCUMENT_TYPE.CONSERVATION_MAP]: 'Conservation area map and guidance',
+	[APPEAL_DOCUMENT_TYPE.OTHER_PARTY_REPRESENTATIONS]:
+		'Representations from other parties documents',
+	[APPEAL_DOCUMENT_TYPE.PLANNING_OFFICER_REPORT]: `Planning officer's report`,
+	[APPEAL_DOCUMENT_TYPE.DEVELOPMENT_PLAN_POLICIES]:
+		'Relevant policies from statutory development plan',
+	[APPEAL_DOCUMENT_TYPE.TREE_PRESERVATION_PLAN]: 'Plan showing extent of TPO',
+	[APPEAL_DOCUMENT_TYPE.DEFINITIVE_MAP_STATEMENT]: 'Definitive map and statement extract',
+	[APPEAL_DOCUMENT_TYPE.COMMUNITY_INFRASTRUCTURE_LEVY]: 'Community infrastructure levy',
+	[APPEAL_DOCUMENT_TYPE.SUPPLEMENTARY_PLANNING]: 'Supplementary planning documents',
+	[APPEAL_DOCUMENT_TYPE.EMERGING_PLAN]: 'Emerging plan relevant to appeal',
+	[APPEAL_DOCUMENT_TYPE.CONSULTATION_RESPONSES]: 'Consultation responses or standing advice',
+	[APPEAL_DOCUMENT_TYPE.EIA_ENVIRONMENTAL_STATEMENT]: 'Environmental statement',
+	[APPEAL_DOCUMENT_TYPE.EIA_SCREENING_OPINION]: 'Screening opinion documents',
+	[APPEAL_DOCUMENT_TYPE.EIA_SCREENING_DIRECTION]: 'Screening direction documents',
+	[APPEAL_DOCUMENT_TYPE.LPA_CASE_CORRESPONDENCE]: 'Additional documents',
+	[APPEAL_DOCUMENT_TYPE.OTHER_RELEVANT_POLICIES]: 'Other relevant policies',
+	[APPEAL_DOCUMENT_TYPE.APPEAL_NOTIFICATION]: 'Appeal notification letter',
+	[APPEAL_DOCUMENT_TYPE.APPELLANT_COSTS_APPLICATION]: 'Appellant costs application',
+	[APPEAL_DOCUMENT_TYPE.APPELLANT_COSTS_WITHDRAWAL]: 'Appellant costs withdrawal',
+	[APPEAL_DOCUMENT_TYPE.APPELLANT_COSTS_CORRESPONDENCE]: 'Appellant costs correspondence',
+	[APPEAL_DOCUMENT_TYPE.LPA_COSTS_APPLICATION]: 'LPA costs application',
+	[APPEAL_DOCUMENT_TYPE.LPA_COSTS_WITHDRAWAL]: 'LPA costs withdrawal',
+	[APPEAL_DOCUMENT_TYPE.LPA_COSTS_CORRESPONDENCE]: 'LPA costs correspondence',
+	[APPEAL_DOCUMENT_TYPE.COSTS_DECISION_LETTER]: 'Costs decision',
+	[APPEAL_DOCUMENT_TYPE.CROSS_TEAM_CORRESPONDENCE]: 'Cross-team correspondence',
+	[APPEAL_DOCUMENT_TYPE.INSPECTOR_CORRESPONDENCE]: 'Inspector correspondence',
+	[APPEAL_DOCUMENT_TYPE.UNCATEGORISED]: 'Documents',
+	[APPEAL_DOCUMENT_TYPE.CASE_DECISION_LETTER]: 'Decision letter',
+	representationAttachments: ''
+};

--- a/appeals/web/src/server/lib/mappers/utils/__tests__/documents-and-folders.test.js
+++ b/appeals/web/src/server/lib/mappers/utils/__tests__/documents-and-folders.test.js
@@ -1,0 +1,207 @@
+// @ts-nocheck
+import { APPEAL_DOCUMENT_TYPE } from 'pins-data-model';
+import { mapFolderNameToDisplayLabel } from '#lib/mappers/utils/documents-and-folders.js';
+
+describe('documents and folders', () => {
+	describe('mapFolderNameToDisplayLabel', () => {
+		const testCases = [
+			{
+				documentType: APPEAL_DOCUMENT_TYPE.APPELLANT_STATEMENT,
+				label: 'Appeal statement'
+			},
+			{
+				documentType: APPEAL_DOCUMENT_TYPE.ORIGINAL_APPLICATION_FORM,
+				label: 'Application form'
+			},
+			{
+				documentType: APPEAL_DOCUMENT_TYPE.APPLICATION_DECISION_LETTER,
+				label: 'Application decision letter'
+			},
+			{
+				documentType: APPEAL_DOCUMENT_TYPE.CHANGED_DESCRIPTION,
+				label: 'Agreement to change description evidence'
+			},
+			{
+				documentType: APPEAL_DOCUMENT_TYPE.APPELLANT_CASE_WITHDRAWAL_LETTER,
+				label: 'Appellant withdrawal request'
+			},
+			{
+				documentType: APPEAL_DOCUMENT_TYPE.APPELLANT_CASE_CORRESPONDENCE,
+				label: 'Additional documents'
+			},
+			{
+				documentType: APPEAL_DOCUMENT_TYPE.DESIGN_ACCESS_STATEMENT,
+				label: 'Design and access statement'
+			},
+			{
+				documentType: APPEAL_DOCUMENT_TYPE.PLANS_DRAWINGS,
+				label: 'Plans, drawings and list of plans'
+			},
+			{
+				documentType: APPEAL_DOCUMENT_TYPE.NEW_PLANS_DRAWINGS,
+				label: 'New plans or drawings'
+			},
+			{
+				documentType: APPEAL_DOCUMENT_TYPE.PLANNING_OBLIGATION,
+				label: 'Planning obligation'
+			},
+			{
+				documentType: APPEAL_DOCUMENT_TYPE.OWNERSHIP_CERTIFICATE,
+				label: 'Ownership certificate and/or land declaration'
+			},
+			{
+				documentType: APPEAL_DOCUMENT_TYPE.OTHER_NEW_DOCUMENTS,
+				label: 'Other new supporting documents'
+			},
+			{
+				documentType: APPEAL_DOCUMENT_TYPE.ENVIRONMENTAL_ASSESSMENT,
+				label: 'Environmental assessment'
+			},
+			{
+				documentType: APPEAL_DOCUMENT_TYPE.WHO_NOTIFIED,
+				label: 'Who was notified about the application'
+			},
+			{
+				documentType: APPEAL_DOCUMENT_TYPE.WHO_NOTIFIED_SITE_NOTICE,
+				label: 'Site notice'
+			},
+			{
+				documentType: APPEAL_DOCUMENT_TYPE.WHO_NOTIFIED_LETTER_TO_NEIGHBOURS,
+				label: 'Letter or email notification'
+			},
+			{
+				documentType: APPEAL_DOCUMENT_TYPE.WHO_NOTIFIED_PRESS_ADVERT,
+				label: 'Press advert notification'
+			},
+			{
+				documentType: APPEAL_DOCUMENT_TYPE.CONSERVATION_MAP,
+				label: 'Conservation area map and guidance'
+			},
+			{
+				documentType: APPEAL_DOCUMENT_TYPE.OTHER_PARTY_REPRESENTATIONS,
+				label: 'Representations from other parties documents'
+			},
+			{
+				documentType: APPEAL_DOCUMENT_TYPE.PLANNING_OFFICER_REPORT,
+				label: `Planning officer's report`
+			},
+			{
+				documentType: APPEAL_DOCUMENT_TYPE.DEVELOPMENT_PLAN_POLICIES,
+				label: 'Relevant policies from statutory development plan'
+			},
+			{
+				documentType: APPEAL_DOCUMENT_TYPE.TREE_PRESERVATION_PLAN,
+				label: 'Plan showing extent of TPO'
+			},
+			{
+				documentType: APPEAL_DOCUMENT_TYPE.DEFINITIVE_MAP_STATEMENT,
+				label: 'Definitive map and statement extract'
+			},
+			{
+				documentType: APPEAL_DOCUMENT_TYPE.COMMUNITY_INFRASTRUCTURE_LEVY,
+				label: 'Community infrastructure levy'
+			},
+			{
+				documentType: APPEAL_DOCUMENT_TYPE.SUPPLEMENTARY_PLANNING,
+				label: 'Supplementary planning documents'
+			},
+			{
+				documentType: APPEAL_DOCUMENT_TYPE.EMERGING_PLAN,
+				label: 'Emerging plan relevant to appeal'
+			},
+			{
+				documentType: APPEAL_DOCUMENT_TYPE.CONSULTATION_RESPONSES,
+				label: 'Consultation responses or standing advice'
+			},
+			{
+				documentType: APPEAL_DOCUMENT_TYPE.EIA_ENVIRONMENTAL_STATEMENT,
+				label: 'Environmental statement'
+			},
+			{
+				documentType: APPEAL_DOCUMENT_TYPE.EIA_SCREENING_OPINION,
+				label: 'Screening opinion documents'
+			},
+			{
+				documentType: APPEAL_DOCUMENT_TYPE.EIA_SCREENING_DIRECTION,
+				label: 'Screening direction documents'
+			},
+			{
+				documentType: APPEAL_DOCUMENT_TYPE.LPA_CASE_CORRESPONDENCE,
+				label: 'Additional documents'
+			},
+			{
+				documentType: APPEAL_DOCUMENT_TYPE.OTHER_RELEVANT_POLICIES,
+				label: 'Other relevant policies'
+			},
+			{
+				documentType: APPEAL_DOCUMENT_TYPE.APPEAL_NOTIFICATION,
+				label: 'Appeal notification letter'
+			},
+			{
+				documentType: APPEAL_DOCUMENT_TYPE.APPELLANT_COSTS_APPLICATION,
+				label: 'Appellant costs application'
+			},
+			{
+				documentType: APPEAL_DOCUMENT_TYPE.APPELLANT_COSTS_WITHDRAWAL,
+				label: 'Appellant costs withdrawal'
+			},
+			{
+				documentType: APPEAL_DOCUMENT_TYPE.APPELLANT_COSTS_CORRESPONDENCE,
+				label: 'Appellant costs correspondence'
+			},
+			{
+				documentType: APPEAL_DOCUMENT_TYPE.LPA_COSTS_APPLICATION,
+				label: 'LPA costs application'
+			},
+			{
+				documentType: APPEAL_DOCUMENT_TYPE.LPA_COSTS_WITHDRAWAL,
+				label: 'LPA costs withdrawal'
+			},
+			{
+				documentType: APPEAL_DOCUMENT_TYPE.LPA_COSTS_CORRESPONDENCE,
+				label: 'LPA costs correspondence'
+			},
+			{
+				documentType: APPEAL_DOCUMENT_TYPE.COSTS_DECISION_LETTER,
+				label: 'Costs decision'
+			},
+			{
+				documentType: APPEAL_DOCUMENT_TYPE.CROSS_TEAM_CORRESPONDENCE,
+				label: 'Cross-team correspondence'
+			},
+			{
+				documentType: APPEAL_DOCUMENT_TYPE.INSPECTOR_CORRESPONDENCE,
+				label: 'Inspector correspondence'
+			},
+			{
+				documentType: APPEAL_DOCUMENT_TYPE.UNCATEGORISED,
+				label: 'Documents'
+			},
+			{
+				documentType: APPEAL_DOCUMENT_TYPE.CASE_DECISION_LETTER,
+				label: 'Decision letter'
+			}
+		];
+
+		for (const testCase of testCases) {
+			it(`should return "${testCase.label}" if folderPath document type fragment is "${testCase.documentType}"`, () => {
+				expect(mapFolderNameToDisplayLabel(`caseStage/${testCase.documentType}`)).toBe(
+					testCase.label
+				);
+			});
+		}
+
+		it('should return undefined if folderPath is falsy', () => {
+			expect(mapFolderNameToDisplayLabel(``)).toBe(undefined);
+			expect(mapFolderNameToDisplayLabel()).toBe(undefined);
+		});
+
+		it('should return undefined if folderPath does not contain "/"', () => {
+			expect(mapFolderNameToDisplayLabel('invalidFolderPath')).toBe(undefined);
+		});
+
+		it('should return undefined if an entry matching the document type fragment of the folder path is not present in DOCUMENT_FOLDER_DISPLAY_LABELS', () => {
+			expect(mapFolderNameToDisplayLabel('caseStage/unhandledDocumentType')).toBe(undefined);
+		});
+	});
+});

--- a/appeals/web/src/server/lib/mappers/utils/documents-and-folders.js
+++ b/appeals/web/src/server/lib/mappers/utils/documents-and-folders.js
@@ -1,0 +1,17 @@
+import { DOCUMENT_FOLDER_DISPLAY_LABELS } from '#lib/constants.js';
+
+/**
+ * @param {string|undefined} folderPath
+ * @returns {string|undefined}
+ */
+export function mapFolderNameToDisplayLabel(folderPath) {
+	if (!folderPath || !folderPath.includes('/')) {
+		return;
+	}
+
+	const documentType = folderPath.split('/')[1];
+
+	if (documentType in DOCUMENT_FOLDER_DISPLAY_LABELS) {
+		return DOCUMENT_FOLDER_DISPLAY_LABELS[documentType];
+	}
+}


### PR DESCRIPTION
## Describe your changes

Global update to display appropriate folder name in "document added" success banners content. Includes addition of a new web-only constant `DOCUMENT_FOLDER_DISPLAY_LABELS` which may come in handy for future refactoring of document/folder related content (eg. in document upload flows, manage folder and document pages).

## Issue ticket number and link
https://pins-ds.atlassian.net/browse/A2-1754