### PR TITLE
fix(web): updating date logic to display earliest date on personal list

### DIFF
--- a/appeals/api/src/server/endpoints/appeals/appeals.formatter.js
+++ b/appeals/api/src/server/endpoints/appeals/appeals.formatter.js
@@ -249,14 +249,20 @@ export const mapAppealToDueDate = (appeal, appellantCaseStatus, appellantCaseDue
 			return null;
 		}
 		case APPEAL_CASE_STATUS.STATEMENTS: {
-			if (appeal.appealTimetable?.appellantStatementDueDate) {
-				return new Date(appeal.appealTimetable?.appellantStatementDueDate);
+			if (appeal.appealTimetable?.lpaStatementDueDate && appeal.appealTimetable?.ipCommentsDueDate) {
+				 const lpaDate = new Date(appeal.appealTimetable.lpaStatementDueDate);
+		     const ipDate = new Date(appeal.appealTimetable.ipCommentsDueDate);
+
+				 return lpaDate < ipDate ? lpaDate : ipDate;
 			}
 			if (appeal.appealTimetable?.lpaStatementDueDate) {
 				return new Date(appeal.appealTimetable?.lpaStatementDueDate);
 			}
 			if (appeal.appealTimetable?.ipCommentsDueDate) {
 				return new Date(appeal.appealTimetable?.ipCommentsDueDate);
+			}
+			if (appeal.appealTimetable?.appellantStatementDueDate) {
+				return new Date(appeal.appealTimetable?.appellantStatementDueDate);
 			}
 			return add(new Date(appeal.caseCreatedDate), {
 				days: approxStageCompletion.STATE_TARGET_STATEMENT_REVIEW


### PR DESCRIPTION
## Describe your changes
Upating the date logic for the personal page to display the earliest due date out of lpaStatementDueDate and IPCommentDueDate when both are available. 
<!--
    Please include a summary of the change along with any relevant context.
    List any dependencies that are required for this change.
-->

## Issue ticket number and link
https://pins-ds.atlassian.net/browse/A2-2608
