### PR TITLE
fix(api): A2-2689 Incorrect Swagger parameter name for type in GET /appeals/{appealId}/reps endpoint

### DIFF
--- a/appeals/api/src/server/endpoints/representations/representations.routes.js
+++ b/appeals/api/src/server/endpoints/representations/representations.routes.js
@@ -52,7 +52,7 @@ router.get(
 		required: true,
 		example: '434bff4e-8191-4ce0-9a0a-91e5d6cdd882'
 	}
-  #swagger.parameters['types'] = {
+  #swagger.parameters['type'] = {
     in: 'query',
     required: false,
     example: 'lpa_statement'

--- a/appeals/api/src/server/openapi.json
+++ b/appeals/api/src/server/openapi.json
@@ -3749,7 +3749,7 @@
 						}
 					},
 					{
-						"name": "types",
+						"name": "type",
 						"in": "query",
 						"required": false,
 						"example": "lpa_statement",


### PR DESCRIPTION
## Describe your changes

Edited the Swagger definition for the endpoint, correcting the parameter to type, also updated the openapi.json file.

## Issue ticket number and link
[A2-2689](https://pins-ds.atlassian.net/browse/A2-2689)

[A2-2689]: https://pins-ds.atlassian.net/browse/A2-2689?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ