### PR TITLE
fix(web): fix crash on submitting lpa statement review page

### DIFF
--- a/appeals/web/src/server/appeals/appeal-details/representations/lpa-statement/__tests__/__snapshots__/lpa-statement.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/representations/lpa-statement/__tests__/__snapshots__/lpa-statement.test.js.snap
@@ -1,5 +1,181 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`lpa-statements GET / should render the review LPA statement page with the expected content if the statement is awaiting review 1`] = `
+"<main class="govuk-main-wrapper " id="main-content" role="main">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Appeal 351062</span>
+            <h1 class="govuk-heading-l">Review LPA statement</h1>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
+            <form method="POST" novalidate="novalidate">
+                <div class="govuk-grid-row">
+                    <div class="govuk-grid-column-full">
+                        <dl class="govuk-summary-list">
+                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Statement</dt>
+                                <dd class="govuk-summary-list__value">
+                                    <div class="pins-show-more" data-label="Statement" data-mode="text">Every single thing in the world has its own personality - and it is up
+                                        to you to make friends with the little rascals. Steve wants reflections,
+                                        so let&#39;s give him eflections It&#39;s amazing what you can do with
+                                        a little love in your heart. Clouds are free they come and go as they please.
+                                        The secret to doing anything is believing that you can do it. Anything
+                                        hatyou believe you can do strong enough, you can do. Anything. As long
+                                        as you believe. It looks so good, I might as well not stop. This present
+                                        moment is perfect simply due to the fact you&#39;re xperiencingit. Making
+                                        all those little fluffies that live in the clouds. You don&#39;t want to
+                                        kill all your dark areas they are very important. I will take some magic
+                                        white, and a little bit of andykebrown and a little touch of yellow. Anyone
+                                        can paint. Each highlight must have it&#39;s own private shadow. Don&#39;t
+                                        fiddle with it all day.</div>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Supporting documents</dt>
+                                <dd class="govuk-summary-list__value">Not provided</dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/3/lpa-statement/add-document"> Add<span class="govuk-visually-hidden"> supporting documents</span></a>
+                                </dd>
+                            </div>
+                        </dl>
+                    </div>
+                </div>
+                <div class="govuk-form-group">
+                    <fieldset class="govuk-fieldset">
+                        <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">Review decision</legend>
+                        <div class="govuk-radios" data-module="govuk-radios">
+                            <div class="govuk-radios__item">
+                                <input class="govuk-radios__input" id="status" name="status" type="radio"
+                                value="valid">
+                                <label class="govuk-label govuk-radios__label" for="status">Accept statement</label>
+                            </div>
+                            <div class="govuk-radios__item">
+                                <input class="govuk-radios__input" id="status-2" name="status" type="radio"
+                                value="valid_requires_redaction">
+                                <label class="govuk-label govuk-radios__label" for="status-2">Redact and accept statement</label>
+                            </div>
+                            <div class="govuk-radios__item">
+                                <input class="govuk-radios__input" id="status-3" name="status" type="radio"
+                                value="incomplete">
+                                <label class="govuk-label govuk-radios__label" for="status-3">Statement incomplete</label>
+                            </div>
+                        </div>
+                    </fieldset>
+                </div>
+                <button type="submit" data-prevent-double-click="true" class="govuk-button"
+                data-module="govuk-button">Continue</button>
+            </form>
+        </div>
+    </div>
+</main>"
+`;
+
+exports[`lpa-statements GET / should render the review LPA statement page with the expected content if the statement is incomplete 1`] = `
+"<main class="govuk-main-wrapper " id="main-content" role="main">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Appeal 351062</span>
+            <h1 class="govuk-heading-l">Review LPA statement</h1>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
+            <form method="POST" novalidate="novalidate">
+                <div class="govuk-grid-row">
+                    <div class="govuk-grid-column-full">
+                        <dl class="govuk-summary-list">
+                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Statement</dt>
+                                <dd class="govuk-summary-list__value">
+                                    <div class="pins-show-more" data-label="Statement" data-mode="text">Every single thing in the world has its own personality - and it is up
+                                        to you to make friends with the little rascals. Steve wants reflections,
+                                        so let&#39;s give him eflections It&#39;s amazing what you can do with
+                                        a little love in your heart. Clouds are free they come and go as they please.
+                                        The secret to doing anything is believing that you can do it. Anything
+                                        hatyou believe you can do strong enough, you can do. Anything. As long
+                                        as you believe. It looks so good, I might as well not stop. This present
+                                        moment is perfect simply due to the fact you&#39;re xperiencingit. Making
+                                        all those little fluffies that live in the clouds. You don&#39;t want to
+                                        kill all your dark areas they are very important. I will take some magic
+                                        white, and a little bit of andykebrown and a little touch of yellow. Anyone
+                                        can paint. Each highlight must have it&#39;s own private shadow. Don&#39;t
+                                        fiddle with it all day.</div>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Supporting documents</dt>
+                                <dd class="govuk-summary-list__value">Not provided</dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/3/lpa-statement/add-document"> Add<span class="govuk-visually-hidden"> supporting documents</span></a>
+                                </dd>
+                            </div>
+                        </dl>
+                    </div>
+                </div>
+                <div class="govuk-form-group">
+                    <fieldset class="govuk-fieldset">
+                        <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">Review decision</legend>
+                        <div class="govuk-radios" data-module="govuk-radios">
+                            <div class="govuk-radios__item">
+                                <input class="govuk-radios__input" id="status" name="status" type="radio"
+                                value="valid">
+                                <label class="govuk-label govuk-radios__label" for="status">Accept statement</label>
+                            </div>
+                            <div class="govuk-radios__item">
+                                <input class="govuk-radios__input" id="status-2" name="status" type="radio"
+                                value="valid_requires_redaction">
+                                <label class="govuk-label govuk-radios__label" for="status-2">Redact and accept statement</label>
+                            </div>
+                            <div class="govuk-radios__item">
+                                <input class="govuk-radios__input" id="status-3" name="status" type="radio"
+                                value="incomplete">
+                                <label class="govuk-label govuk-radios__label" for="status-3">Statement incomplete</label>
+                            </div>
+                        </div>
+                    </fieldset>
+                </div>
+                <button type="submit" data-prevent-double-click="true" class="govuk-button"
+                data-module="govuk-button">Continue</button>
+            </form>
+        </div>
+    </div>
+</main>"
+`;
+
+exports[`lpa-statements GET / should render the view LPA statement page with the expected content if the statement is neither awaiting review nor incomplete 1`] = `
+"<main class="govuk-main-wrapper " id="main-content" role="main">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Appeal 351062</span>
+            <h1 class="govuk-heading-l">LPA statement</h1>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
+            <dl class="govuk-summary-list">
+                <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Statement</dt>
+                    <dd class="govuk-summary-list__value">
+                        <div class="pins-show-more" data-label="Statement" data-mode="text">Every single thing in the world has its own personality - and it is up
+                            to you to make friends with the little rascals. Steve wants reflections,
+                            so let&#39;s give him eflections It&#39;s amazing what you can do with
+                            a little love in your heart. Clouds are free they come and go as they please.
+                            The secret to doing anything is believing that you can do it. Anything
+                            hatyou believe you can do strong enough, you can do. Anything. As long
+                            as you believe. It looks so good, I might as well not stop. This present
+                            moment is perfect simply due to the fact you&#39;re xperiencingit. Making
+                            all those little fluffies that live in the clouds. You don&#39;t want to
+                            kill all your dark areas they are very important. I will take some magic
+                            white, and a little bit of andykebrown and a little touch of yellow. Anyone
+                            can paint. Each highlight must have it&#39;s own private shadow. Don&#39;t
+                            fiddle with it all day.</div>
+                    </dd>
+                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/3/lpa-statement/redact"> Redact<span class="govuk-visually-hidden"> statement</span></a>
+                    </dd>
+                </div>
+                <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Supporting documents</dt>
+                    <dd class="govuk-summary-list__value">Not provided</dd>
+                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/3/lpa-statement/add-document"> Add<span class="govuk-visually-hidden"> supporting documents</span></a>
+                    </dd>
+                </div>
+            </dl>
+        </div>
+    </div>
+</main>"
+`;
+
 exports[`lpa-statements GET /manage-documents/:folderId/ should render a 404 error page if the folderId is invalid 1`] = `
 "<main class="govuk-main-wrapper " id="main-content" role="main">
     <div class="govuk-grid-row">
@@ -290,4 +466,18 @@ exports[`lpa-statements GET change-document-name/:folderId/:documentId should re
         </div>
     </div>
 </main>"
+`;
+
+exports[`lpa-statements POST / should re-render the review page with the expected error message if a review status was not selected 1`] = `
+"<div class="govuk-error-summary" data-module="govuk-error-summary">
+    <div role="alert">
+        <h2 class="govuk-error-summary__title"> There is a problem</h2>
+        <div class="govuk-error-summary__body">
+            <ul class="govuk-list govuk-error-summary__list">
+                <li><a href="#status">Select your review decision</a>
+                </li>
+            </ul>
+        </div>
+    </div>
+</div>"
 `;

--- a/appeals/web/src/server/appeals/appeal-details/representations/lpa-statement/lpa-statement.controller.js
+++ b/appeals/web/src/server/appeals/appeal-details/representations/lpa-statement/lpa-statement.controller.js
@@ -54,6 +54,9 @@ export const postReviewLpaStatement = async (request, response) => {
 
 	switch (status) {
 		case COMMENT_STATUS.VALID:
+			if (!('acceptLPAStatement' in session)) {
+				session.acceptLPAStatement = {};
+			}
 			if (
 				!currentAppeal.allocationDetails?.level ||
 				!currentAppeal.allocationDetails?.specialisms?.length

--- a/appeals/web/testing/app/fixtures/referencedata.js
+++ b/appeals/web/testing/app/fixtures/referencedata.js
@@ -3274,6 +3274,30 @@ export const lpaFinalCommentsAwaitingReview = {
 	pageSize: 30
 };
 
+export const lpaStatementAwaitingReview = {
+	id: 66816,
+	origin: 'lpa',
+	author: 'Wiltshire Council',
+	status: 'awaiting_review',
+	originalRepresentation: `Every single thing in the world has its own personality - and it is up to you to make friends with the little rascals. Steve wants reflections, so let's give him eflections It's amazing what you can do with a little love in your heart. Clouds are free they come and go as they please.\n\nThe secret to doing anything is believing that you can do it. Anything hatyou believe you can do strong enough, you can do. Anything. As long as you believe. It looks so good, I might as well not stop. This present moment is perfect simply due to the fact you're xperiencingit. Making all those little fluffies that live in the clouds.\n\nYou don't want to kill all your dark areas they are very important. I will take some magic white, and a little bit of andykebrown and a little touch of yellow. Anyone can paint. Each highlight must have it's own private shadow. Don't fiddle with it all day.`,
+	redactedRepresentation: '',
+	created: '2025-03-20T12:00:20.709Z',
+	notes: '',
+	attachments: [],
+	representationType: 'lpa_statement',
+	siteVisitRequested: false,
+	source: 'lpa',
+	rejectionReasons: []
+};
+
+export const getAppealRepsResponse = {
+	itemCount: 0,
+	items: [],
+	page: 1,
+	pageCount: 1,
+	pageSize: 30
+};
+
 export const interestedPartyCommentForView = {
 	id: 3670,
 	origin: 'citizen',


### PR DESCRIPTION
## Describe your changes

Small code fix to address a crash when submitting the lpa statement review page with "Accept" outcome. Also adds some unit tests to cover this scenario (but more are needed for the lpa statement flow as a whole, tech debt ticket to be created)

## Issue ticket number and link
https://pins-ds.atlassian.net/browse/A2-2681
