### PR TITLE
fix(api): caseValidationDate set on invalid appeals

### DIFF
--- a/appeals/api/src/server/mappers/integration/__tests__/mappers.test.js
+++ b/appeals/api/src/server/mappers/integration/__tests__/mappers.test.js
@@ -1,0 +1,130 @@
+import { APPEAL_CASE_STATUS } from 'pins-data-model';
+import { findStatusDate } from '#utils/mapping/map-dates.js';
+import { isCaseInvalid } from '#utils/case-invalid.js';
+
+describe('appeals generic mappers', () => {
+	test('map case validation date on invalid appeal', async () => {
+		const input = {
+			appeal: {
+				appealStatus: [
+					{
+						status: APPEAL_CASE_STATUS.ASSIGN_CASE_OFFICER,
+						valid: false,
+						createdAt: new Date('2025-03-16T09:12:33.334Z'),
+						subStateMachineName: null,
+						compoundStateName: null,
+						id: 1,
+						appealId: 1
+					},
+					{
+						status: APPEAL_CASE_STATUS.VALIDATION,
+						valid: false,
+						createdAt: new Date('2025-03-17T09:12:33.334Z'),
+						subStateMachineName: null,
+						compoundStateName: null,
+						id: 1,
+						appealId: 1
+					},
+					{
+						status: APPEAL_CASE_STATUS.READY_TO_START,
+						valid: false,
+						createdAt: new Date('2025-03-18T09:12:33.334Z'),
+						subStateMachineName: null,
+						compoundStateName: null,
+						id: 1,
+						appealId: 1
+					},
+					{
+						status: APPEAL_CASE_STATUS.LPA_QUESTIONNAIRE,
+						valid: false,
+						createdAt: new Date('2025-03-19T09:12:33.334Z'),
+						subStateMachineName: null,
+						compoundStateName: null,
+						id: 1,
+						appealId: 1
+					},
+					{
+						status: APPEAL_CASE_STATUS.ISSUE_DETERMINATION,
+						valid: false,
+						createdAt: new Date('2025-03-20T09:12:33.334Z'),
+						subStateMachineName: null,
+						compoundStateName: null,
+						id: 1,
+						appealId: 1
+					},
+					{
+						status: APPEAL_CASE_STATUS.INVALID,
+						valid: true,
+						createdAt: new Date('2025-03-21T09:12:33.334Z'),
+						subStateMachineName: null,
+						compoundStateName: null,
+						id: 1,
+						appealId: 1
+					}
+				]
+			}
+		};
+
+		const { appeal } = input;
+		const output = isCaseInvalid(appeal.appealStatus)
+			? findStatusDate(appeal.appealStatus, APPEAL_CASE_STATUS.READY_TO_START)
+			: findStatusDate(appeal.appealStatus, APPEAL_CASE_STATUS.INVALID) ??
+			  findStatusDate(appeal.appealStatus, APPEAL_CASE_STATUS.READY_TO_START);
+
+		console.log(output);
+		expect(output).toBe('2025-03-18T09:12:33.334Z');
+	});
+
+	test('map case validation date on invalid appellant case', async () => {
+		const input = {
+			appeal: {
+				appealStatus: [
+					{
+						status: APPEAL_CASE_STATUS.ASSIGN_CASE_OFFICER,
+						valid: false,
+						createdAt: new Date('2025-03-16T09:12:33.334Z'),
+						subStateMachineName: null,
+						compoundStateName: null,
+						id: 1,
+						appealId: 1
+					},
+					{
+						status: APPEAL_CASE_STATUS.VALIDATION,
+						valid: false,
+						createdAt: new Date('2025-03-17T09:12:33.334Z'),
+						subStateMachineName: null,
+						compoundStateName: null,
+						id: 1,
+						appealId: 1
+					},
+					{
+						status: APPEAL_CASE_STATUS.READY_TO_START,
+						valid: false,
+						createdAt: new Date('2025-03-18T09:12:33.334Z'),
+						subStateMachineName: null,
+						compoundStateName: null,
+						id: 1,
+						appealId: 1
+					},
+					{
+						status: APPEAL_CASE_STATUS.INVALID,
+						valid: true,
+						createdAt: new Date('2025-03-19T09:12:33.334Z'),
+						subStateMachineName: null,
+						compoundStateName: null,
+						id: 1,
+						appealId: 1
+					}
+				]
+			}
+		};
+
+		const { appeal } = input;
+		const output = isCaseInvalid(appeal.appealStatus)
+			? findStatusDate(appeal.appealStatus, APPEAL_CASE_STATUS.READY_TO_START)
+			: findStatusDate(appeal.appealStatus, APPEAL_CASE_STATUS.INVALID) ??
+			  findStatusDate(appeal.appealStatus, APPEAL_CASE_STATUS.READY_TO_START);
+
+		expect(output).toBe('2025-03-19T09:12:33.334Z');
+	});
+});

--- a/appeals/api/src/server/mappers/integration/shared/map-case-dates.js
+++ b/appeals/api/src/server/mappers/integration/shared/map-case-dates.js
@@ -1,5 +1,6 @@
 import { APPEAL_CASE_STATUS } from 'pins-data-model';
 import { mapDate, findStatusDate } from '#utils/mapping/map-dates.js';
+import { isCaseInvalid } from '#utils/case-invalid.js';
 
 /** @typedef {import('@pins/appeals.api').Schema.Appeal} Appeal */
 /** @typedef {import('@pins/appeals.api').Schema.AppealStatus} AppealStatus */
@@ -13,6 +14,11 @@ import { mapDate, findStatusDate } from '#utils/mapping/map-dates.js';
 export const mapCaseDates = (data) => {
 	const { appeal } = data;
 
+	const appellantCaseValidationDate = isCaseInvalid(appeal.appealStatus)
+		? findStatusDate(appeal.appealStatus, APPEAL_CASE_STATUS.READY_TO_START)
+		: findStatusDate(appeal.appealStatus, APPEAL_CASE_STATUS.INVALID) ??
+		  findStatusDate(appeal.appealStatus, APPEAL_CASE_STATUS.READY_TO_START);
+
 	const lpaqValidationDate =
 		findStatusDate(appeal.appealStatus, APPEAL_CASE_STATUS.EVENT) ??
 		findStatusDate(appeal.appealStatus, APPEAL_CASE_STATUS.AWAITING_EVENT);
@@ -25,7 +31,7 @@ export const mapCaseDates = (data) => {
 		caseCreatedDate: mapDate(appeal.caseCreatedDate),
 		caseUpdatedDate: mapDate(appeal.caseUpdatedDate),
 		caseValidDate: mapDate(appeal.caseValidDate),
-		caseValidationDate: findStatusDate(appeal.appealStatus, APPEAL_CASE_STATUS.READY_TO_START),
+		caseValidationDate: appellantCaseValidationDate,
 		caseExtensionDate: mapDate(appeal.caseExtensionDate),
 		caseStartedDate: mapDate(appeal.caseStartedDate),
 		casePublishedDate: findStatusDate(appeal.appealStatus, APPEAL_CASE_STATUS.READY_TO_START),

--- a/appeals/api/src/server/utils/case-invalid.js
+++ b/appeals/api/src/server/utils/case-invalid.js
@@ -1,0 +1,16 @@
+import { APPEAL_CASE_STATUS } from 'pins-data-model';
+
+/** @typedef {import('@pins/appeals.api').Schema.AppealStatus} AppealStatus */
+
+/**
+ *
+ * @param {AppealStatus[]} appealStatuses
+ */
+export const isCaseInvalid = (appealStatuses) =>
+	appealStatuses.find(
+		(appealStatus) =>
+			appealStatus.status === APPEAL_CASE_STATUS.INVALID && appealStatus.valid === true
+	) &&
+	appealStatuses.find(
+		(appealStatus) => appealStatus.status === APPEAL_CASE_STATUS.ISSUE_DETERMINATION
+	);


### PR DESCRIPTION
When an appeal is INVALID, it returns the correct `caseValidationDate` and applies the correct logic based on the state transition history.
