### PR TITLE
fix(web): set supporting document date to today

### DIFF
--- a/appeals/web/src/server/appeals/appeal-details/representations/document-attachments/add-document.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/representations/document-attachments/add-document.mapper.js
@@ -1,5 +1,5 @@
 import { appealShortReference } from '#lib/appeals-formatter.js';
-import { dateISOStringToDayMonthYearHourMinute } from '#lib/dates.js';
+import { dateISOStringToDayMonthYearHourMinute, getTodaysISOString } from '#lib/dates.js';
 import { dateInput } from '#lib/mappers/index.js';
 
 /** @typedef {import("../../appeal-details.types.js").WebAppeal} Appeal */
@@ -24,7 +24,7 @@ export const dateSubmitted = (appealDetails, errors, date, backLinkUrl) => ({
 			value:
 				date.day && date.month && date.year
 					? date
-					: dateISOStringToDayMonthYearHourMinute(new Date().toISOString()),
+					: dateISOStringToDayMonthYearHourMinute(getTodaysISOString()),
 			legendText: 'When was the supporting document submitted?',
 			legendIsPageHeading: true,
 			hint: 'For example, 27 3 2024'

--- a/appeals/web/src/server/appeals/appeal-details/representations/document-attachments/add-document.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/representations/document-attachments/add-document.mapper.js
@@ -1,4 +1,5 @@
 import { appealShortReference } from '#lib/appeals-formatter.js';
+import { dateISOStringToDayMonthYearHourMinute } from '#lib/dates.js';
 import { dateInput } from '#lib/mappers/index.js';
 
 /** @typedef {import("../../appeal-details.types.js").WebAppeal} Appeal */
@@ -20,7 +21,10 @@ export const dateSubmitted = (appealDetails, errors, date, backLinkUrl) => ({
 		dateInput({
 			id: 'date',
 			name: 'date',
-			value: date,
+			value:
+				date.day && date.month && date.year
+					? date
+					: dateISOStringToDayMonthYearHourMinute(new Date().toISOString()),
 			legendText: 'When was the supporting document submitted?',
 			legendIsPageHeading: true,
 			hint: 'For example, 27 3 2024'

--- a/appeals/web/src/server/appeals/appeal-details/representations/interested-party-comments/add-ip-comment/__tests__/__snapshots__/add-ip-comment.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/representations/interested-party-comments/add-ip-comment/__tests__/__snapshots__/add-ip-comment.test.js.snap
@@ -205,21 +205,21 @@ exports[`add-ip-comment GET /date-submitted should match the snapshot 1`] = `
                                         <div class="govuk-form-group">
                                             <label class="govuk-label govuk-date-input__label" for="date-day">Day</label>
                                             <input class="govuk-input govuk-date-input__input govuk-input--width-2"
-                                            id="date-day" name="day" type="text" inputmode="numeric">
+                                            id="date-day" name="day" type="text" value="21" inputmode="numeric">
                                         </div>
                                     </div>
                                     <div class="govuk-date-input__item">
                                         <div class="govuk-form-group">
                                             <label class="govuk-label govuk-date-input__label" for="date-month">Month</label>
                                             <input class="govuk-input govuk-date-input__input govuk-input--width-2"
-                                            id="date-month" name="month" type="text" inputmode="numeric">
+                                            id="date-month" name="month" type="text" value="3" inputmode="numeric">
                                         </div>
                                     </div>
                                     <div class="govuk-date-input__item">
                                         <div class="govuk-form-group">
                                             <label class="govuk-label govuk-date-input__label" for="date-year">Year</label>
                                             <input class="govuk-input govuk-date-input__input govuk-input--width-4"
-                                            id="date-year" name="year" type="text" inputmode="numeric">
+                                            id="date-year" name="year" type="text" value="2025" inputmode="numeric">
                                         </div>
                                     </div>
                                 </div>

--- a/appeals/web/src/server/appeals/appeal-details/representations/interested-party-comments/add-ip-comment/__tests__/__snapshots__/add-ip-comment.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/representations/interested-party-comments/add-ip-comment/__tests__/__snapshots__/add-ip-comment.test.js.snap
@@ -205,21 +205,21 @@ exports[`add-ip-comment GET /date-submitted should match the snapshot 1`] = `
                                         <div class="govuk-form-group">
                                             <label class="govuk-label govuk-date-input__label" for="date-day">Day</label>
                                             <input class="govuk-input govuk-date-input__input govuk-input--width-2"
-                                            id="date-day" name="day" type="text" value="21" inputmode="numeric">
+                                            id="date-day" name="day" type="text" value="30" inputmode="numeric">
                                         </div>
                                     </div>
                                     <div class="govuk-date-input__item">
                                         <div class="govuk-form-group">
                                             <label class="govuk-label govuk-date-input__label" for="date-month">Month</label>
                                             <input class="govuk-input govuk-date-input__input govuk-input--width-2"
-                                            id="date-month" name="month" type="text" value="3" inputmode="numeric">
+                                            id="date-month" name="month" type="text" value="10" inputmode="numeric">
                                         </div>
                                     </div>
                                     <div class="govuk-date-input__item">
                                         <div class="govuk-form-group">
                                             <label class="govuk-label govuk-date-input__label" for="date-year">Year</label>
                                             <input class="govuk-input govuk-date-input__input govuk-input--width-4"
-                                            id="date-year" name="year" type="text" value="2025" inputmode="numeric">
+                                            id="date-year" name="year" type="text" value="2024" inputmode="numeric">
                                         </div>
                                     </div>
                                 </div>

--- a/appeals/web/src/server/appeals/appeal-details/representations/interested-party-comments/add-ip-comment/__tests__/add-ip-comment.test.js
+++ b/appeals/web/src/server/appeals/appeal-details/representations/interested-party-comments/add-ip-comment/__tests__/add-ip-comment.test.js
@@ -375,6 +375,10 @@ describe('add-ip-comment', () => {
 				.get(`/appeals/${appealId}`)
 				.reply(200, { ...appealData, appealId });
 
+			jest
+				.useFakeTimers({ doNotFake: ['nextTick', 'setImmediate'] })
+				.setSystemTime(new Date('2024-10-30'));
+
 			const response = await request.get(
 				`${baseUrl}/${appealId}/interested-party-comments/add/date-submitted`
 			);

--- a/appeals/web/src/server/appeals/appeal-details/representations/interested-party-comments/add-ip-comment/add-ip-comment.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/representations/interested-party-comments/add-ip-comment/add-ip-comment.mapper.js
@@ -9,7 +9,7 @@ import config from '@pins/appeals.web/environment/config.js';
 import { DOCUMENT_STAGE, DOCUMENT_TYPE } from '../interested-party-comments.service.js';
 import { ODW_SYSTEM_ID } from '@pins/appeals/constants/common.js';
 import { dateInput } from '#lib/mappers/index.js';
-import { dateISOStringToDayMonthYearHourMinute } from '#lib/dates.js';
+import { dateISOStringToDayMonthYearHourMinute, getTodaysISOString } from '#lib/dates.js';
 
 /** @typedef {import("../../../appeal-details.types.js").WebAppeal} Appeal */
 /** @typedef {import('#appeals/appeal-details/representations/types.js').interestedPartyComment} IpComment */
@@ -234,7 +234,7 @@ export const dateSubmitted = (appealDetails, errors, date, backLinkUrl) => ({
 			value:
 				date.day && date.month && date.year
 					? date
-					: dateISOStringToDayMonthYearHourMinute(new Date().toISOString()),
+					: dateISOStringToDayMonthYearHourMinute(getTodaysISOString()),
 			legendText: 'When did the interested party submit the comment?',
 			legendIsPageHeading: true,
 			hint: 'For example, 27 3 2024'

--- a/appeals/web/src/server/appeals/appeal-details/representations/interested-party-comments/add-ip-comment/add-ip-comment.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/representations/interested-party-comments/add-ip-comment/add-ip-comment.mapper.js
@@ -9,6 +9,7 @@ import config from '@pins/appeals.web/environment/config.js';
 import { DOCUMENT_STAGE, DOCUMENT_TYPE } from '../interested-party-comments.service.js';
 import { ODW_SYSTEM_ID } from '@pins/appeals/constants/common.js';
 import { dateInput } from '#lib/mappers/index.js';
+import { dateISOStringToDayMonthYearHourMinute } from '#lib/dates.js';
 
 /** @typedef {import("../../../appeal-details.types.js").WebAppeal} Appeal */
 /** @typedef {import('#appeals/appeal-details/representations/types.js').interestedPartyComment} IpComment */
@@ -230,7 +231,10 @@ export const dateSubmitted = (appealDetails, errors, date, backLinkUrl) => ({
 		dateInput({
 			id: 'date',
 			name: 'date',
-			value: date,
+			value:
+				date.day && date.month && date.year
+					? date
+					: dateISOStringToDayMonthYearHourMinute(new Date().toISOString()),
 			legendText: 'When did the interested party submit the comment?',
 			legendIsPageHeading: true,
 			hint: 'For example, 27 3 2024'


### PR DESCRIPTION
## Describe your changes

When adding a supporting document to a statement, ip comment or final comment. The submitted date input boxes are blank. This release sets them to todays date.

## Issue ticket number and link
[Ticket](https://pins-ds.atlassian.net/browse/A2-2635)
