### PR TITLE
fix(appeals): redacted comment pre-populated with another appeal comment for all reps (a2-2555)

### DIFF
--- a/appeals/web/src/server/appeals/appeal-details/representations/lpa-statement/redact/redact.controller.js
+++ b/appeals/web/src/server/appeals/appeal-details/representations/lpa-statement/redact/redact.controller.js
@@ -38,8 +38,11 @@ export function postRedact(request, response) {
 	const {
 		params: { appealId },
 		currentAppeal,
+		currentRepresentation,
 		session
 	} = request;
+
+	session.redactLPAStatement.lpaStatementId = currentRepresentation.id;
 
 	if (
 		!currentAppeal.allocationDetails?.level ||

--- a/appeals/web/src/server/appeals/appeal-details/representations/lpa-statement/redact/redact.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/representations/lpa-statement/redact/redact.mapper.js
@@ -11,11 +11,15 @@ import { redactInput } from '../../../representations/common/components/redact-i
 /**
  * @param {Appeal} appealDetails
  * @param {Representation} lpaStatement
- * @param {import('express-session').Session & Record<string, string> & { redactLPAStatement?: { redactedRepresentation: string, allocationLevelAndSpecialisms: string, allocationLevel: string, allocationSpecialisms: string[] } }} [session]
+ * @param {import('express-session').Session & Record<string, string> & { redactLPAStatement?: { redactedRepresentation: string, lpaStatementId: number, allocationLevelAndSpecialisms: string, allocationLevel: string, allocationSpecialisms: string[] } }} [session]
  * @returns {PageContent}
  */
 export function redactLpaStatementPage(appealDetails, lpaStatement, session) {
 	const shortReference = appealShortReference(appealDetails.appealReference);
+
+	if (session && session.redactLPAStatement?.lpaStatementId !== lpaStatement.id) {
+		delete session.redactLPAStatement;
+	}
 
 	/** @type {PageComponent[]} */
 	const pageComponents = [


### PR DESCRIPTION
## Describe your changes
#### Prevent redacted comment pre-populated with another appeal comment (a2-2555)

#### WEB:
- Clear the session.redactLPAStatement if redacting a different LPA Statement comment

#### TEST:
- All unit tests pass
- Tested within browser

## Issue ticket number and link
[Ticket: WEB/API E2E- Redacted comment pre-populated with another appeal comment for all reps  (A2-2555)](https://pins-ds.atlassian.net.mcas.ms/browse/A2-2594)
