### PR TITLE
fix(web): fix unhandled api 400 validation error in web app when linking unlinkable appeals

### DIFF
--- a/appeals/web/src/server/appeals/appeal-details/linked-appeals/linked-appeals.controller.js
+++ b/appeals/web/src/server/appeals/appeal-details/linked-appeals/linked-appeals.controller.js
@@ -1,4 +1,5 @@
 import logger from '#lib/logger.js';
+import { HTTPError } from 'got';
 import {
 	postUnlinkRequest,
 	linkAppealToBackOfficeAppeal,
@@ -220,6 +221,12 @@ export const postAddLinkedAppealCheckAndConfirm = async (request, response) => {
 
 		return response.redirect(`/appeals-service/appeal-details/${appealId}`);
 	} catch (error) {
+		if (error instanceof HTTPError && error.response.statusCode === 400) {
+			// @ts-ignore
+			request.errors = error.response.body.errors;
+			return renderAddLinkedAppealCheckAndConfirm(request, response);
+		}
+
 		logger.error(error);
 	}
 


### PR DESCRIPTION
## Describe your changes

Adds error handling for 400 (validation) errors returned to web app from link-appeal API endpoint, eg. when trying to link appeals that cannot be linked due to already being parent/child. Also adds a unit test for this scenario.

## Issue ticket number and link
https://pins-ds.atlassian.net/browse/A2-2576
