### PR TITLE
fix(web): fix ip comment manage folder page back link url

### DIFF
--- a/appeals/web/src/server/appeals/appeal-details/representations/document-attachments/manage-documents.controller.js
+++ b/appeals/web/src/server/appeals/appeal-details/representations/document-attachments/manage-documents.controller.js
@@ -24,13 +24,16 @@ import { constructUrl } from '#lib/mappers/utils/url.mapper.js';
 /** @type {import('@pins/express').RequestHandler<Response>} */
 export const getManageFolder = async (request, response) => {
 	const { currentAppeal, query } = request;
-
 	const manageFolderBaseUrl = request.baseUrl;
-	const representationBackLinkUrl = manageFolderBaseUrl.split('/').slice(0, -1).join('/');
+
+	const representationBackLinkUrlSegments = manageFolderBaseUrl.split('/').slice(0, -1)
+	
 	const backLinkUrl = query.backUrl
 		? constructUrl(String(query.backUrl), currentAppeal.appealId)
-		: representationBackLinkUrl;
-
+		: representationBackLinkUrlSegments[4] === 'interested-party-comments'
+			? representationBackLinkUrlSegments.toSpliced(representationBackLinkUrlSegments.length, 0, 'view').join('/')
+			: representationBackLinkUrlSegments.join('/')
+	
 	await renderManageFolder({
 		request,
 		response,


### PR DESCRIPTION
* add `/view` to backlink url when user is on interested-party-comments manage documents page

<!--
    Please include a summary of the change along with any relevant context.
    List any dependencies that are required for this change.
-->

## Issue ticket number and link
[Ticket](https://pins-ds.atlassian.net.mcas.ms/browse/A2-2691)
