### PR TITLE
feat(appeals): case timetable showing rows and action links pre case start (a2-2673)

### DIFF
--- a/appeals/web/src/server/appeals/appeal-details/__tests__/__snapshots__/appeal-details.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/__tests__/__snapshots__/appeal-details.test.js.snap
@@ -520,6 +520,155 @@ data-index="0">
 </div>"
 `;
 
+exports[`appeal-details GET /:appealId Timetable Valid date should render a "Timetable" with a Valid date row and a Start date row including no date and start action link 1`] = `
+"<dl class="govuk-summary-list appeal-case-timetable">
+    <div class="govuk-summary-list__row appeal-valid-date"><dt class="govuk-summary-list__key"> Valid date</dt>
+        <dd class="govuk-summary-list__value">23 May 2023</dd>
+        <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/3/appellant-case/valid/date"
+            data-cy="change-valid-date">Change<span class="govuk-visually-hidden"> Valid date</span></a>
+        </dd>
+    </div>
+    <div class="govuk-summary-list__row appeal-start-date"><dt class="govuk-summary-list__key"> Start date</dt>
+        <dd class="govuk-summary-list__value">Not started</dd>
+        <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/3/start-case/add"
+            data-cy="start-start-case-date">Start<span class="govuk-visually-hidden"> Start date</span></a>
+        </dd>
+    </div>
+</dl>"
+`;
+
+exports[`appeal-details GET /:appealId Timetable Valid date should render a "Timetable" with all rows with the Start date row including a date and change action link 1`] = `
+"<dl class="govuk-summary-list appeal-case-timetable">
+    <div class="govuk-summary-list__row appeal-valid-date"><dt class="govuk-summary-list__key"> Valid date</dt>
+        <dd class="govuk-summary-list__value">23 May 2023</dd>
+        <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/3/appellant-case/valid/date"
+            data-cy="-valid-date"><span class="govuk-visually-hidden"> Valid date</span></a>
+        </dd>
+    </div>
+    <div class="govuk-summary-list__row appeal-start-date"><dt class="govuk-summary-list__key"> Start date</dt>
+        <dd class="govuk-summary-list__value">23 May 2023</dd>
+        <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/3/start-case/change"
+            data-cy="change-start-case-date">Change<span class="govuk-visually-hidden"> Start date</span></a>
+        </dd>
+    </div>
+    <div class="govuk-summary-list__row appeal-lpa-questionnaire-due-date"><dt class="govuk-summary-list__key"> LPA questionnaire due</dt>
+        <dd class="govuk-summary-list__value">11 October 2023</dd>
+        <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/3/appeal-timetables/lpa-questionnaire"
+            data-cy="change-lpa-questionnaire-due-date">Change<span class="govuk-visually-hidden"> LPA questionnaire due</span></a>
+        </dd>
+    </div>
+    <div class="govuk-summary-list__row appeal-lpa-statement-due-date"><dt class="govuk-summary-list__key"> LPA statement due</dt>
+        <dd class="govuk-summary-list__value"></dd>
+        <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/3/appeal-timetables/lpa-statement"
+            data-cy="change-lpa-statement-due-date">Change<span class="govuk-visually-hidden"> LPA statement due</span></a>
+        </dd>
+    </div>
+    <div class="govuk-summary-list__row appeal-ip-comments-due-date"><dt class="govuk-summary-list__key"> Interested party comments due</dt>
+        <dd         class="govuk-summary-list__value"></dd>
+    </div>
+    <div class="govuk-summary-list__row appeal-final-comments-due-date"><dt class="govuk-summary-list__key"> Final comments due</dt>
+        <dd class="govuk-summary-list__value"></dd>
+        <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/3/appeal-timetables/final-comments"
+            data-cy="change-final-comments-due-date">Change<span class="govuk-visually-hidden"> Final comments due</span></a>
+        </dd>
+    </div>
+    <div class="govuk-summary-list__row s106-obligation-due-date"><dt class="govuk-summary-list__key"> S106 obligation due</dt>
+        <dd class="govuk-summary-list__value"></dd>
+        <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/3/appeal-timetables/s106-obligation"
+            data-cy="change-s106-obligation-due-date">Change<span class="govuk-visually-hidden"> S106 obligation due</span></a>
+        </dd>
+    </div>
+    <div class="govuk-summary-list__row appeal-site-visit"><dt class="govuk-summary-list__key"> Site visit</dt>
+        <dd class="govuk-summary-list__value">
+            <ul class="govuk-list govuk-!-margin-top-0 govuk-!-padding-left-0">
+                <li>9 October 2023</li>
+                <li>9:38am - 10:00am</li>
+            </ul>
+        </dd>
+        <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/3/site-visit/manage-visit"
+            data-cy="change-schedule-visit">Change<span class="govuk-visually-hidden"> Site visit</span></a>
+        </dd>
+    </div>
+</dl>"
+`;
+
+exports[`appeal-details GET /:appealId Timetable Valid date should render a "Timetable" with all rows with the Start date without an action link 1`] = `
+"<dl class="govuk-summary-list appeal-case-timetable">
+    <div class="govuk-summary-list__row appeal-valid-date"><dt class="govuk-summary-list__key"> Valid date</dt>
+        <dd class="govuk-summary-list__value">23 May 2023</dd>
+        <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/3/appellant-case/valid/date"
+            data-cy="-valid-date"><span class="govuk-visually-hidden"> Valid date</span></a>
+        </dd>
+    </div>
+    <div class="govuk-summary-list__row appeal-start-date"><dt class="govuk-summary-list__key"> Start date</dt>
+        <dd class="govuk-summary-list__value">23 May 2023</dd>
+        <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/3/start-case/change"
+            data-cy="-start-case-date"><span class="govuk-visually-hidden"> Start date</span></a>
+        </dd>
+    </div>
+    <div class="govuk-summary-list__row appeal-lpa-questionnaire-due-date"><dt class="govuk-summary-list__key"> LPA questionnaire due</dt>
+        <dd class="govuk-summary-list__value">11 October 2023</dd>
+        <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/3/appeal-timetables/lpa-questionnaire"
+            data-cy="change-lpa-questionnaire-due-date">Change<span class="govuk-visually-hidden"> LPA questionnaire due</span></a>
+        </dd>
+    </div>
+    <div class="govuk-summary-list__row appeal-lpa-statement-due-date"><dt class="govuk-summary-list__key"> LPA statement due</dt>
+        <dd class="govuk-summary-list__value"></dd>
+        <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/3/appeal-timetables/lpa-statement"
+            data-cy="change-lpa-statement-due-date">Change<span class="govuk-visually-hidden"> LPA statement due</span></a>
+        </dd>
+    </div>
+    <div class="govuk-summary-list__row appeal-ip-comments-due-date"><dt class="govuk-summary-list__key"> Interested party comments due</dt>
+        <dd         class="govuk-summary-list__value"></dd>
+    </div>
+    <div class="govuk-summary-list__row appeal-final-comments-due-date"><dt class="govuk-summary-list__key"> Final comments due</dt>
+        <dd class="govuk-summary-list__value"></dd>
+        <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/3/appeal-timetables/final-comments"
+            data-cy="change-final-comments-due-date">Change<span class="govuk-visually-hidden"> Final comments due</span></a>
+        </dd>
+    </div>
+    <div class="govuk-summary-list__row s106-obligation-due-date"><dt class="govuk-summary-list__key"> S106 obligation due</dt>
+        <dd class="govuk-summary-list__value"></dd>
+        <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/3/appeal-timetables/s106-obligation"
+            data-cy="change-s106-obligation-due-date">Change<span class="govuk-visually-hidden"> S106 obligation due</span></a>
+        </dd>
+    </div>
+    <div class="govuk-summary-list__row appeal-site-visit"><dt class="govuk-summary-list__key"> Site visit</dt>
+        <dd class="govuk-summary-list__value">
+            <ul class="govuk-list govuk-!-margin-top-0 govuk-!-padding-left-0">
+                <li>9 October 2023</li>
+                <li>9:38am - 10:00am</li>
+            </ul>
+        </dd>
+        <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/3/site-visit/manage-visit"
+            data-cy="change-schedule-visit">Change<span class="govuk-visually-hidden"> Site visit</span></a>
+        </dd>
+    </div>
+</dl>"
+`;
+
+exports[`appeal-details GET /:appealId Timetable Valid date should render a "Timetable" with only a Valid date row with no date and a validate action link 1`] = `
+"<dl class="govuk-summary-list appeal-case-timetable">
+    <div class="govuk-summary-list__row appeal-valid-date"><dt class="govuk-summary-list__key"> Valid date</dt>
+        <dd class="govuk-summary-list__value">Not validated</dd>
+        <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/3/appellant-case"
+            data-cy="validate-valid-date">Validate<span class="govuk-visually-hidden"> Valid date</span></a>
+        </dd>
+    </div>
+</dl>"
+`;
+
+exports[`appeal-details GET /:appealId Timetable Valid date should render a "Timetable" with only a Valid date row with no date and no action link 1`] = `
+"<dl class="govuk-summary-list appeal-case-timetable">
+    <div class="govuk-summary-list__row appeal-valid-date"><dt class="govuk-summary-list__key"> Valid date</dt>
+        <dd class="govuk-summary-list__value">Not validated</dd>
+        <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/3/appellant-case"
+            data-cy="-valid-date"><span class="govuk-visually-hidden"> Valid date</span></a>
+        </dd>
+    </div>
+</dl>"
+`;
+
 exports[`appeal-details GET /:appealId should not render action links to the manage linked appeals page or the add linked appeal page in the linked appeals row, if the appeal is linked as a child of an external lead appeal 1`] = `
 "<main class="govuk-main-wrapper" id="main-content">
     <div class="govuk-grid-row">
@@ -721,9 +870,12 @@ exports[`appeal-details GET /:appealId should not render action links to the man
                             <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-3"> Timetable</span></h2>
                         </div>
                         <div id="accordion-default1-content-3" class="govuk-accordion__section-content">
-                            <dl class="govuk-summary-list">
+                            <dl class="govuk-summary-list appeal-case-timetable">
                                 <div class="govuk-summary-list__row appeal-valid-date"><dt class="govuk-summary-list__key"> Valid date</dt>
                                     <dd class="govuk-summary-list__value">23 May 2023</dd>
+                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/valid/date"
+                                        data-cy="-valid-date"><span class="govuk-visually-hidden"> Valid date</span></a>
+                                    </dd>
                                 </div>
                                 <div class="govuk-summary-list__row appeal-start-date"><dt class="govuk-summary-list__key"> Start date</dt>
                                     <dd class="govuk-summary-list__value">23 May 2023</dd>
@@ -1188,9 +1340,12 @@ exports[`appeal-details GET /:appealId should render a Decision inset panel when
                         <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-3"> Timetable</span></h2>
                     </div>
                     <div id="accordion-default1-content-3" class="govuk-accordion__section-content">
-                        <dl class="govuk-summary-list">
+                        <dl class="govuk-summary-list appeal-case-timetable">
                             <div class="govuk-summary-list__row appeal-valid-date"><dt class="govuk-summary-list__key"> Valid date</dt>
                                 <dd class="govuk-summary-list__value">23 May 2023</dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/appellant-case/valid/date"
+                                    data-cy="-valid-date"><span class="govuk-visually-hidden"> Valid date</span></a>
+                                </dd>
                             </div>
                             <div class="govuk-summary-list__row appeal-start-date"><dt class="govuk-summary-list__key"> Start date</dt>
                                 <dd class="govuk-summary-list__value">23 May 2023</dd>
@@ -1648,9 +1803,12 @@ exports[`appeal-details GET /:appealId should render a child tag next to the app
                             <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-3"> Timetable</span></h2>
                         </div>
                         <div id="accordion-default1-content-3" class="govuk-accordion__section-content">
-                            <dl class="govuk-summary-list">
+                            <dl class="govuk-summary-list appeal-case-timetable">
                                 <div class="govuk-summary-list__row appeal-valid-date"><dt class="govuk-summary-list__key"> Valid date</dt>
                                     <dd class="govuk-summary-list__value">23 May 2023</dd>
+                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/valid/date"
+                                        data-cy="-valid-date"><span class="govuk-visually-hidden"> Valid date</span></a>
+                                    </dd>
                                 </div>
                                 <div class="govuk-summary-list__row appeal-start-date"><dt class="govuk-summary-list__key"> Start date</dt>
                                     <dd class="govuk-summary-list__value">23 May 2023</dd>
@@ -2108,9 +2266,12 @@ exports[`appeal-details GET /:appealId should render a lead tag next to the appe
                             <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-3"> Timetable</span></h2>
                         </div>
                         <div id="accordion-default1-content-3" class="govuk-accordion__section-content">
-                            <dl class="govuk-summary-list">
+                            <dl class="govuk-summary-list appeal-case-timetable">
                                 <div class="govuk-summary-list__row appeal-valid-date"><dt class="govuk-summary-list__key"> Valid date</dt>
                                     <dd class="govuk-summary-list__value">23 May 2023</dd>
+                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/valid/date"
+                                        data-cy="-valid-date"><span class="govuk-visually-hidden"> Valid date</span></a>
+                                    </dd>
                                 </div>
                                 <div class="govuk-summary-list__row appeal-start-date"><dt class="govuk-summary-list__key"> Start date</dt>
                                     <dd class="govuk-summary-list__value">23 May 2023</dd>
@@ -2588,9 +2749,12 @@ exports[`appeal-details GET /:appealId should render action links to the manage 
                             <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-3"> Timetable</span></h2>
                         </div>
                         <div id="accordion-default1-content-3" class="govuk-accordion__section-content">
-                            <dl class="govuk-summary-list">
+                            <dl class="govuk-summary-list appeal-case-timetable">
                                 <div class="govuk-summary-list__row appeal-valid-date"><dt class="govuk-summary-list__key"> Valid date</dt>
                                     <dd class="govuk-summary-list__value">23 May 2023</dd>
+                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/valid/date"
+                                        data-cy="-valid-date"><span class="govuk-visually-hidden"> Valid date</span></a>
+                                    </dd>
                                 </div>
                                 <div class="govuk-summary-list__row appeal-start-date"><dt class="govuk-summary-list__key"> Start date</dt>
                                     <dd class="govuk-summary-list__value">23 May 2023</dd>
@@ -3051,9 +3215,12 @@ exports[`appeal-details GET /:appealId should render an Issue a decision notific
                         <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-3"> Timetable</span></h2>
                     </div>
                     <div id="accordion-default1-content-3" class="govuk-accordion__section-content">
-                        <dl class="govuk-summary-list">
+                        <dl class="govuk-summary-list appeal-case-timetable">
                             <div class="govuk-summary-list__row appeal-valid-date"><dt class="govuk-summary-list__key"> Valid date</dt>
                                 <dd class="govuk-summary-list__value">23 May 2023</dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/appellant-case/valid/date"
+                                    data-cy="-valid-date"><span class="govuk-visually-hidden"> Valid date</span></a>
+                                </dd>
                             </div>
                             <div class="govuk-summary-list__row appeal-start-date"><dt class="govuk-summary-list__key"> Start date</dt>
                                 <dd class="govuk-summary-list__value">23 May 2023</dd>
@@ -3501,9 +3668,12 @@ exports[`appeal-details GET /:appealId should render an action link to the add l
                         <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-3"> Timetable</span></h2>
                     </div>
                     <div id="accordion-default1-content-3" class="govuk-accordion__section-content">
-                        <dl class="govuk-summary-list">
+                        <dl class="govuk-summary-list appeal-case-timetable">
                             <div class="govuk-summary-list__row appeal-valid-date"><dt class="govuk-summary-list__key"> Valid date</dt>
                                 <dd class="govuk-summary-list__value">23 May 2023</dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/valid/date"
+                                    data-cy="-valid-date"><span class="govuk-visually-hidden"> Valid date</span></a>
+                                </dd>
                             </div>
                             <div class="govuk-summary-list__row appeal-start-date"><dt class="govuk-summary-list__key"> Start date</dt>
                                 <dd class="govuk-summary-list__value">23 May 2023</dd>
@@ -3951,12 +4121,18 @@ exports[`appeal-details GET /:appealId should render the appellant case status a
                         <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-3"> Timetable</span></h2>
                     </div>
                     <div id="accordion-default1-content-3" class="govuk-accordion__section-content">
-                        <dl class="govuk-summary-list">
+                        <dl class="govuk-summary-list appeal-case-timetable">
                             <div class="govuk-summary-list__row appeal-valid-date"><dt class="govuk-summary-list__key"> Valid date</dt>
                                 <dd class="govuk-summary-list__value">23 May 2023</dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/appellant-case/valid/date"
+                                    data-cy="-valid-date"><span class="govuk-visually-hidden"> Valid date</span></a>
+                                </dd>
                             </div>
                             <div class="govuk-summary-list__row appeal-start-date"><dt class="govuk-summary-list__key"> Start date</dt>
                                 <dd class="govuk-summary-list__value">23 May 2023</dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/start-case/change"
+                                    data-cy="-start-case-date"><span class="govuk-visually-hidden"> Start date</span></a>
+                                </dd>
                             </div>
                             <div class="govuk-summary-list__row appeal-lpa-questionnaire-due-date"><dt class="govuk-summary-list__key"> LPA questionnaire due</dt>
                                 <dd class="govuk-summary-list__value">11 October 2023</dd>
@@ -4400,12 +4576,18 @@ exports[`appeal-details GET /:appealId should render the appellant case status a
                         <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-3"> Timetable</span></h2>
                     </div>
                     <div id="accordion-default1-content-3" class="govuk-accordion__section-content">
-                        <dl class="govuk-summary-list">
+                        <dl class="govuk-summary-list appeal-case-timetable">
                             <div class="govuk-summary-list__row appeal-valid-date"><dt class="govuk-summary-list__key"> Valid date</dt>
                                 <dd class="govuk-summary-list__value">23 May 2023</dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/appellant-case/valid/date"
+                                    data-cy="-valid-date"><span class="govuk-visually-hidden"> Valid date</span></a>
+                                </dd>
                             </div>
                             <div class="govuk-summary-list__row appeal-start-date"><dt class="govuk-summary-list__key"> Start date</dt>
                                 <dd class="govuk-summary-list__value">23 May 2023</dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/start-case/change"
+                                    data-cy="-start-case-date"><span class="govuk-visually-hidden"> Start date</span></a>
+                                </dd>
                             </div>
                             <div class="govuk-summary-list__row appeal-lpa-questionnaire-due-date"><dt class="govuk-summary-list__key"> LPA questionnaire due</dt>
                                 <dd class="govuk-summary-list__value">11 October 2023</dd>
@@ -4849,12 +5031,18 @@ exports[`appeal-details GET /:appealId should render the appellant case status a
                         <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-3"> Timetable</span></h2>
                     </div>
                     <div id="accordion-default1-content-3" class="govuk-accordion__section-content">
-                        <dl class="govuk-summary-list">
+                        <dl class="govuk-summary-list appeal-case-timetable">
                             <div class="govuk-summary-list__row appeal-valid-date"><dt class="govuk-summary-list__key"> Valid date</dt>
                                 <dd class="govuk-summary-list__value">23 May 2023</dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/appellant-case/valid/date"
+                                    data-cy="-valid-date"><span class="govuk-visually-hidden"> Valid date</span></a>
+                                </dd>
                             </div>
                             <div class="govuk-summary-list__row appeal-start-date"><dt class="govuk-summary-list__key"> Start date</dt>
                                 <dd class="govuk-summary-list__value">23 May 2023</dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/start-case/change"
+                                    data-cy="-start-case-date"><span class="govuk-visually-hidden"> Start date</span></a>
+                                </dd>
                             </div>
                             <div class="govuk-summary-list__row appeal-lpa-questionnaire-due-date"><dt class="govuk-summary-list__key"> LPA questionnaire due</dt>
                                 <dd class="govuk-summary-list__value">11 October 2023</dd>
@@ -5310,9 +5498,12 @@ exports[`appeal-details GET /:appealId should render the case reference for each
                             <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-3"> Timetable</span></h2>
                         </div>
                         <div id="accordion-default1-content-3" class="govuk-accordion__section-content">
-                            <dl class="govuk-summary-list">
+                            <dl class="govuk-summary-list appeal-case-timetable">
                                 <div class="govuk-summary-list__row appeal-valid-date"><dt class="govuk-summary-list__key"> Valid date</dt>
                                     <dd class="govuk-summary-list__value">23 May 2023</dd>
+                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/valid/date"
+                                        data-cy="-valid-date"><span class="govuk-visually-hidden"> Valid date</span></a>
+                                    </dd>
                                 </div>
                                 <div class="govuk-summary-list__row appeal-start-date"><dt class="govuk-summary-list__key"> Start date</dt>
                                     <dd class="govuk-summary-list__value">23 May 2023</dd>
@@ -5800,9 +5991,12 @@ exports[`appeal-details GET /:appealId should render the lead or child status af
                             <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-3"> Timetable</span></h2>
                         </div>
                         <div id="accordion-default1-content-3" class="govuk-accordion__section-content">
-                            <dl class="govuk-summary-list">
+                            <dl class="govuk-summary-list appeal-case-timetable">
                                 <div class="govuk-summary-list__row appeal-valid-date"><dt class="govuk-summary-list__key"> Valid date</dt>
                                     <dd class="govuk-summary-list__value">23 May 2023</dd>
+                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/valid/date"
+                                        data-cy="-valid-date"><span class="govuk-visually-hidden"> Valid date</span></a>
+                                    </dd>
                                 </div>
                                 <div class="govuk-summary-list__row appeal-start-date"><dt class="govuk-summary-list__key"> Start date</dt>
                                     <dd class="govuk-summary-list__value">23 May 2023</dd>
@@ -6274,9 +6468,12 @@ exports[`appeal-details GET /:appealId should render the received appeal details
                             <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default3-heading-3"> Timetable</span></h2>
                         </div>
                         <div id="accordion-default3-content-3" class="govuk-accordion__section-content">
-                            <dl class="govuk-summary-list">
+                            <dl class="govuk-summary-list appeal-case-timetable">
                                 <div class="govuk-summary-list__row appeal-valid-date"><dt class="govuk-summary-list__key"> Valid date</dt>
                                     <dd class="govuk-summary-list__value">23 May 2023</dd>
+                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/3/appellant-case/valid/date"
+                                        data-cy="-valid-date"><span class="govuk-visually-hidden"> Valid date</span></a>
+                                    </dd>
                                 </div>
                                 <div class="govuk-summary-list__row appeal-start-date"><dt class="govuk-summary-list__key"> Start date</dt>
                                     <dd class="govuk-summary-list__value">23 May 2023</dd>
@@ -6720,9 +6917,12 @@ exports[`appeal-details GET /:appealId should render the received appeal details
                         <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-3"> Timetable</span></h2>
                     </div>
                     <div id="accordion-default1-content-3" class="govuk-accordion__section-content">
-                        <dl class="govuk-summary-list">
+                        <dl class="govuk-summary-list appeal-case-timetable">
                             <div class="govuk-summary-list__row appeal-valid-date"><dt class="govuk-summary-list__key"> Valid date</dt>
                                 <dd class="govuk-summary-list__value">23 May 2023</dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/valid/date"
+                                    data-cy="-valid-date"><span class="govuk-visually-hidden"> Valid date</span></a>
+                                </dd>
                             </div>
                             <div class="govuk-summary-list__row appeal-start-date"><dt class="govuk-summary-list__key"> Start date</dt>
                                 <dd class="govuk-summary-list__value">23 May 2023</dd>
@@ -7189,9 +7389,12 @@ exports[`appeal-details GET /:appealId should render the received appeal details
                             <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default2-heading-3"> Timetable</span></h2>
                         </div>
                         <div id="accordion-default2-content-3" class="govuk-accordion__section-content">
-                            <dl class="govuk-summary-list">
+                            <dl class="govuk-summary-list appeal-case-timetable">
                                 <div class="govuk-summary-list__row appeal-valid-date"><dt class="govuk-summary-list__key"> Valid date</dt>
                                     <dd class="govuk-summary-list__value">23 May 2023</dd>
+                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/appellant-case/valid/date"
+                                        data-cy="-valid-date"><span class="govuk-visually-hidden"> Valid date</span></a>
+                                    </dd>
                                 </div>
                                 <div class="govuk-summary-list__row appeal-start-date"><dt class="govuk-summary-list__key"> Start date</dt>
                                     <dd class="govuk-summary-list__value">23 May 2023</dd>
@@ -7639,13 +7842,13 @@ exports[`appeal-details GET /:appealId should render the received appeal details
                             <div class="govuk-summary-list__row appeal-valid-date"><dt class="govuk-summary-list__key"> Valid date</dt>
                                 <dd class="govuk-summary-list__value">23 May 2023</dd>
                                 <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/appellant-case/valid/date"
-                                    data-cy="change-valid-date">Change<span class="govuk-visually-hidden"> Valid date</span></a>
+                                    data-cy="-valid-date"><span class="govuk-visually-hidden"> Valid date</span></a>
                                 </dd>
                             </div>
                             <div class="govuk-summary-list__row appeal-start-date"><dt class="govuk-summary-list__key"> Start date</dt>
-                                <dd class="govuk-summary-list__value">Not added</dd>
+                                <dd class="govuk-summary-list__value">Not started</dd>
                                 <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/start-case/add"
-                                    data-cy="add-start-case-date">Add<span class="govuk-visually-hidden"> Start date</span></a>
+                                    data-cy="start-start-case-date">Start<span class="govuk-visually-hidden"> Start date</span></a>
                                 </dd>
                             </div>
                         </dl>
@@ -8103,9 +8306,12 @@ exports[`appeal-details should not render a back button 1`] = `
                                     <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default2-heading-3"> Timetable</span></h2>
                                 </div>
                                 <div id="accordion-default2-content-3" class="govuk-accordion__section-content">
-                                    <dl class="govuk-summary-list">
+                                    <dl class="govuk-summary-list appeal-case-timetable">
                                         <div class="govuk-summary-list__row appeal-valid-date"><dt class="govuk-summary-list__key"> Valid date</dt>
                                             <dd class="govuk-summary-list__value">23 May 2023</dd>
+                                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/appellant-case/valid/date"
+                                                data-cy="-valid-date"><span class="govuk-visually-hidden"> Valid date</span></a>
+                                            </dd>
                                         </div>
                                         <div class="govuk-summary-list__row appeal-start-date"><dt class="govuk-summary-list__key"> Start date</dt>
                                             <dd class="govuk-summary-list__value">23 May 2023</dd>

--- a/appeals/web/src/server/appeals/appeal-details/accordions/has.js
+++ b/appeals/web/src/server/appeals/appeal-details/accordions/has.js
@@ -27,6 +27,7 @@ export function generateAccordion(appealDetails, mappedData, session) {
 				{
 					type: 'summary-list',
 					parameters: {
+						classes: 'appeal-case-timetable',
 						rows: [
 							mappedData.appeal.validAt.display.summaryListItem,
 							mappedData.appeal.startedAt.display.summaryListItem,

--- a/appeals/web/src/server/appeals/appeal-details/accordions/s78.js
+++ b/appeals/web/src/server/appeals/appeal-details/accordions/s78.js
@@ -27,6 +27,7 @@ export function generateAccordion(appealDetails, mappedData, session) {
 		{
 			type: 'summary-list',
 			parameters: {
+				classes: 'appeal-case-timetable',
 				rows: [
 					mappedData.appeal.validAt.display.summaryListItem,
 					mappedData.appeal.startedAt.display.summaryListItem,

--- a/appeals/web/src/server/lib/mappers/data/appeal/submappers/__tests__/final-comments-due-date.mapper.test.js
+++ b/appeals/web/src/server/lib/mappers/data/appeal/submappers/__tests__/final-comments-due-date.mapper.test.js
@@ -1,0 +1,56 @@
+// @ts-nocheck
+import { mapFinalCommentDueDate } from '#lib/mappers/data/appeal/submappers/final-comment-due-date.mapper.js';
+
+describe('final-comments-due-date.mapper', () => {
+	let data;
+	beforeEach(() => {
+		data = {
+			currentRoute: '/test',
+			appealDetails: {
+				validAt: '2025-01-01',
+				appealTimetable: { finalCommentsDueDate: '2025-01-10' },
+				documentationSummary: { finalComments: { counts: { published: 0 } } }
+			},
+			userHasUpdateCasePermission: true
+		};
+	});
+
+	it('should not display Final Comments due date', () => {
+		const mappedData = mapFinalCommentDueDate(data);
+		expect(mappedData).toEqual({
+			display: {},
+			id: 'final-comments-due-date'
+		});
+	});
+
+	it('should display Final Comments due date with Change action link', () => {
+		data.appealDetails.startedAt = '2025-01-01';
+		const mappedData = mapFinalCommentDueDate(data);
+		expect(mappedData).toEqual({
+			display: {
+				summaryListItem: {
+					actions: {
+						items: [
+							{
+								attributes: {
+									'data-cy': 'change-final-comments-due-date'
+								},
+								href: '/test/appeal-timetables/final-comments',
+								text: 'Change',
+								visuallyHiddenText: 'Final comments due'
+							}
+						]
+					},
+					classes: 'appeal-final-comments-due-date',
+					key: {
+						text: 'Final comments due'
+					},
+					value: {
+						text: '10 January 2025'
+					}
+				}
+			},
+			id: 'final-comments-due-date'
+		});
+	});
+});

--- a/appeals/web/src/server/lib/mappers/data/appeal/submappers/__tests__/ip-comments-due-date.mapper.test.js
+++ b/appeals/web/src/server/lib/mappers/data/appeal/submappers/__tests__/ip-comments-due-date.mapper.test.js
@@ -1,0 +1,56 @@
+// @ts-nocheck
+import { mapIpCommentsDueDate } from '#lib/mappers/data/appeal/submappers/ip-comments-due-date.mapper.js';
+
+describe('ip-comments-due-date.mapper', () => {
+	let data;
+	beforeEach(() => {
+		data = {
+			currentRoute: '/test',
+			appealDetails: {
+				validAt: '2025-01-01',
+				appealTimetable: { ipCommentsDueDate: '2025-01-10' },
+				documentationSummary: { ipComments: { counts: { published: 0 } } }
+			},
+			userHasUpdateCasePermission: true
+		};
+	});
+
+	it('should not display IP Comments due date', () => {
+		const mappedData = mapIpCommentsDueDate(data);
+		expect(mappedData).toEqual({
+			display: {},
+			id: 'ip-comments-due-date'
+		});
+	});
+
+	it('should display IP Comments due date with Change action link', () => {
+		data.appealDetails.startedAt = '2025-01-01';
+		const mappedData = mapIpCommentsDueDate(data);
+		expect(mappedData).toEqual({
+			display: {
+				summaryListItem: {
+					actions: {
+						items: [
+							{
+								attributes: {
+									'data-cy': 'change-ip-comments-due-date'
+								},
+								href: '/test/appeal-timetables/ip-comments',
+								text: 'Change',
+								visuallyHiddenText: 'Interested party comments due'
+							}
+						]
+					},
+					classes: 'appeal-ip-comments-due-date',
+					key: {
+						text: 'Interested party comments due'
+					},
+					value: {
+						text: '10 January 2025'
+					}
+				}
+			},
+			id: 'ip-comments-due-date'
+		});
+	});
+});

--- a/appeals/web/src/server/lib/mappers/data/appeal/submappers/__tests__/lpa-questionnaire-due-date.mapper.test.js
+++ b/appeals/web/src/server/lib/mappers/data/appeal/submappers/__tests__/lpa-questionnaire-due-date.mapper.test.js
@@ -1,0 +1,55 @@
+// @ts-nocheck
+import { mapLpaQuestionnaireDueDate } from '#lib/mappers/data/appeal/submappers/lpa-questionnaire-due-date.mapper.js';
+
+describe('lpa-questionnaire-due-date.mapper', () => {
+	let data;
+	beforeEach(() => {
+		data = {
+			currentRoute: '/test',
+			appealDetails: {
+				validAt: '2025-01-01',
+				appealTimetable: { lpaQuestionnaireDueDate: '2025-01-10' }
+			},
+			userHasUpdateCasePermission: true
+		};
+	});
+
+	it('should not display LPA Questionnaire due date', () => {
+		const mappedData = mapLpaQuestionnaireDueDate(data);
+		expect(mappedData).toEqual({
+			display: {},
+			id: 'lpa-questionnaire-due-date'
+		});
+	});
+
+	it('should display LPA Questionnaire due date with Change action link', () => {
+		data.appealDetails.startedAt = '2025-01-01';
+		const mappedData = mapLpaQuestionnaireDueDate(data);
+		expect(mappedData).toEqual({
+			display: {
+				summaryListItem: {
+					actions: {
+						items: [
+							{
+								attributes: {
+									'data-cy': 'change-lpa-questionnaire-due-date'
+								},
+								href: '/test/appeal-timetables/lpa-questionnaire',
+								text: 'Change',
+								visuallyHiddenText: 'LPA questionnaire due'
+							}
+						]
+					},
+					classes: 'appeal-lpa-questionnaire-due-date',
+					key: {
+						text: 'LPA questionnaire due'
+					},
+					value: {
+						text: '10 January 2025'
+					}
+				}
+			},
+			id: 'lpa-questionnaire-due-date'
+		});
+	});
+});

--- a/appeals/web/src/server/lib/mappers/data/appeal/submappers/__tests__/lpa-statement-due-date.mapper.test.js
+++ b/appeals/web/src/server/lib/mappers/data/appeal/submappers/__tests__/lpa-statement-due-date.mapper.test.js
@@ -1,0 +1,55 @@
+// @ts-nocheck
+import { mapLpaStatementDueDate } from '#lib/mappers/data/appeal/submappers/lpa-statement-due-date.mapper.js';
+
+describe('lpa-statement-due-date.mapper', () => {
+	let data;
+	beforeEach(() => {
+		data = {
+			currentRoute: '/test',
+			appealDetails: {
+				validAt: '2025-01-01',
+				appealTimetable: { lpaStatementDueDate: '2025-01-10' }
+			},
+			userHasUpdateCasePermission: true
+		};
+	});
+
+	it('should not display LPA Statement due date', () => {
+		const mappedData = mapLpaStatementDueDate(data);
+		expect(mappedData).toEqual({
+			display: {},
+			id: 'lpa-statement-due-date'
+		});
+	});
+
+	it('should display LPA Statement due date with Change action link', () => {
+		data.appealDetails.startedAt = '2025-01-01';
+		const mappedData = mapLpaStatementDueDate(data);
+		expect(mappedData).toEqual({
+			display: {
+				summaryListItem: {
+					actions: {
+						items: [
+							{
+								attributes: {
+									'data-cy': 'change-lpa-statement-due-date'
+								},
+								href: '/test/appeal-timetables/lpa-statement',
+								text: 'Change',
+								visuallyHiddenText: 'LPA statement due'
+							}
+						]
+					},
+					classes: 'appeal-lpa-statement-due-date',
+					key: {
+						text: 'LPA statement due'
+					},
+					value: {
+						text: '10 January 2025'
+					}
+				}
+			},
+			id: 'lpa-statement-due-date'
+		});
+	});
+});

--- a/appeals/web/src/server/lib/mappers/data/appeal/submappers/__tests__/s106-obligation-due-date.mapper.test.js
+++ b/appeals/web/src/server/lib/mappers/data/appeal/submappers/__tests__/s106-obligation-due-date.mapper.test.js
@@ -1,0 +1,55 @@
+// @ts-nocheck
+import { mapS106ObligationDue } from '#lib/mappers/data/appeal/submappers/s106-obligation-due-date.mapper.js';
+
+describe('s106-obligation-due-date.mapper', () => {
+	let data;
+	beforeEach(() => {
+		data = {
+			currentRoute: '/test',
+			appealDetails: {
+				validAt: '2025-01-01',
+				appealTimetable: { s106ObligationDueDate: '2025-01-10' }
+			},
+			userHasUpdateCasePermission: true
+		};
+	});
+
+	it('should not display S106 Obligation due date', () => {
+		const mappedData = mapS106ObligationDue(data);
+		expect(mappedData).toEqual({
+			display: {},
+			id: 's106-obligation-due-date'
+		});
+	});
+
+	it('should display S106 Obligation due date with Change action link', () => {
+		data.appealDetails.startedAt = '2025-01-01';
+		const mappedData = mapS106ObligationDue(data);
+		expect(mappedData).toEqual({
+			display: {
+				summaryListItem: {
+					actions: {
+						items: [
+							{
+								attributes: {
+									'data-cy': 'change-s106-obligation-due-date'
+								},
+								href: '/test/appeal-timetables/s106-obligation',
+								text: 'Change',
+								visuallyHiddenText: 'S106 obligation due'
+							}
+						]
+					},
+					classes: 's106-obligation-due-date',
+					key: {
+						text: 'S106 obligation due'
+					},
+					value: {
+						text: '10 January 2025'
+					}
+				}
+			},
+			id: 's106-obligation-due-date'
+		});
+	});
+});

--- a/appeals/web/src/server/lib/mappers/data/appeal/submappers/__tests__/site-visit-date.mapper.test.js
+++ b/appeals/web/src/server/lib/mappers/data/appeal/submappers/__tests__/site-visit-date.mapper.test.js
@@ -1,0 +1,58 @@
+// @ts-nocheck
+import { mapSiteVisitDate } from '#lib/mappers/data/appeal/submappers/site-visit-date.mapper.js';
+
+describe('site-visit-date.mapper', () => {
+	let data;
+	let session;
+	beforeEach(() => {
+		data = {
+			currentRoute: '/test',
+			appealDetails: {
+				validAt: '2025-01-01',
+				appealTimetable: { finalCommentsDueDate: '2025-01-10' },
+				siteVisit: { visitDate: '2025-01-10' }
+			},
+			userHasUpdateCasePermission: true,
+			session: { permissions: { setEvents: true } }
+		};
+	});
+
+	it('should not display Site Visit date', () => {
+		const mappedData = mapSiteVisitDate(data);
+		expect(mappedData).toEqual({
+			display: {},
+			id: 'schedule-visit'
+		});
+	});
+
+	it('should display Site Visit date with Change action link', () => {
+		data.appealDetails.startedAt = '2025-01-01';
+		const mappedData = mapSiteVisitDate(data, null, session);
+		expect(mappedData).toEqual({
+			display: {
+				summaryListItem: {
+					actions: {
+						items: [
+							{
+								attributes: {
+									'data-cy': 'change-schedule-visit'
+								},
+								href: '/test/site-visit/manage-visit',
+								text: 'Change',
+								visuallyHiddenText: 'Site visit'
+							}
+						]
+					},
+					classes: 'appeal-site-visit',
+					key: {
+						text: 'Site visit'
+					},
+					value: {
+						html: '<ul class="govuk-list govuk-!-margin-top-0 govuk-!-padding-left-0"><li>10 January 2025</li></ul>'
+					}
+				}
+			},
+			id: 'schedule-visit'
+		});
+	});
+});

--- a/appeals/web/src/server/lib/mappers/data/appeal/submappers/__tests__/started-at.mapper.test.js
+++ b/appeals/web/src/server/lib/mappers/data/appeal/submappers/__tests__/started-at.mapper.test.js
@@ -1,0 +1,118 @@
+// @ts-nocheck
+import { mapStartedAt } from '#lib/mappers/data/appeal/submappers/started-at.mapper.js';
+
+describe('started-at.mapper', () => {
+	let data;
+	beforeEach(() => {
+		data = {
+			currentRoute: '/test',
+			appealDetails: {
+				validAt: '2025-01-01',
+				documentationSummary: { lpaQuestionnaire: { status: 'not_received' } }
+			},
+			userHasUpdateCasePermission: true
+		};
+	});
+
+	it('should not display', () => {
+		delete data.appealDetails.validAt;
+		const mappedData = mapStartedAt(data);
+		expect(mappedData).toEqual({
+			display: {},
+			id: 'start-case-date'
+		});
+	});
+
+	it('should contain Not started and a Start action link', () => {
+		const mappedData = mapStartedAt(data);
+		expect(mappedData).toEqual({
+			display: {
+				summaryListItem: {
+					actions: {
+						items: [
+							{
+								attributes: {
+									'data-cy': 'start-start-case-date'
+								},
+								href: '/test/start-case/add',
+								text: 'Start',
+								visuallyHiddenText: 'Start date'
+							}
+						]
+					},
+					classes: 'appeal-start-date',
+					key: {
+						text: 'Start date'
+					},
+					value: {
+						text: 'Not started'
+					}
+				}
+			},
+			id: 'start-case-date'
+		});
+	});
+
+	it('should contain a start date and a Change action link', () => {
+		data.appealDetails.startedAt = '2025-01-01';
+		const mappedData = mapStartedAt(data);
+		expect(mappedData).toEqual({
+			display: {
+				summaryListItem: {
+					actions: {
+						items: [
+							{
+								attributes: {
+									'data-cy': 'change-start-case-date'
+								},
+								href: '/test/start-case/change',
+								text: 'Change',
+								visuallyHiddenText: 'Start date'
+							}
+						]
+					},
+					classes: 'appeal-start-date',
+					key: {
+						text: 'Start date'
+					},
+					value: {
+						text: '1 January 2025'
+					}
+				}
+			},
+			id: 'start-case-date'
+		});
+	});
+
+	it('should contain a start date and no action link text', () => {
+		data.appealDetails.startedAt = '2025-01-01';
+		data.appealDetails.documentationSummary.lpaQuestionnaire.status = 'received';
+		const mappedData = mapStartedAt(data);
+		expect(mappedData).toEqual({
+			display: {
+				summaryListItem: {
+					actions: {
+						items: [
+							{
+								attributes: {
+									'data-cy': '-start-case-date'
+								},
+								href: '/test/start-case/change',
+								text: '',
+								visuallyHiddenText: 'Start date'
+							}
+						]
+					},
+					classes: 'appeal-start-date',
+					key: {
+						text: 'Start date'
+					},
+					value: {
+						text: '1 January 2025'
+					}
+				}
+			},
+			id: 'start-case-date'
+		});
+	});
+});

--- a/appeals/web/src/server/lib/mappers/data/appeal/submappers/__tests__/valid-at.mapper.test.js
+++ b/appeals/web/src/server/lib/mappers/data/appeal/submappers/__tests__/valid-at.mapper.test.js
@@ -1,0 +1,139 @@
+// @ts-nocheck
+import { mapValidAt } from '#lib/mappers/data/appeal/submappers/valid-at.mapper.js';
+
+describe('valid-at.mapper', () => {
+	let data;
+	beforeEach(() => {
+		data = {
+			currentRoute: '/test',
+			appealDetails: {
+				caseOfficer: 'case-officer'
+			},
+			userHasUpdateCasePermission: true
+		};
+	});
+
+	it('should contain not validated and no action link', () => {
+		delete data.appealDetails.caseOfficer;
+		const mappedData = mapValidAt(data);
+		expect(mappedData).toEqual({
+			display: {
+				summaryListItem: {
+					actions: {
+						items: [
+							{
+								attributes: {
+									'data-cy': '-valid-date'
+								},
+								href: '/test/appellant-case',
+								text: '',
+								visuallyHiddenText: 'Valid date'
+							}
+						]
+					},
+					classes: 'appeal-valid-date',
+					key: {
+						text: 'Valid date'
+					},
+					value: {
+						text: 'Not validated'
+					}
+				}
+			},
+			id: 'valid-date'
+		});
+	});
+
+	it('should contain not validated and a Validate action link', () => {
+		const mappedData = mapValidAt(data);
+		expect(mappedData).toEqual({
+			display: {
+				summaryListItem: {
+					actions: {
+						items: [
+							{
+								attributes: {
+									'data-cy': 'validate-valid-date'
+								},
+								href: '/test/appellant-case',
+								text: 'Validate',
+								visuallyHiddenText: 'Valid date'
+							}
+						]
+					},
+					classes: 'appeal-valid-date',
+					key: {
+						text: 'Valid date'
+					},
+					value: {
+						text: 'Not validated'
+					}
+				}
+			},
+			id: 'valid-date'
+		});
+	});
+
+	it('should contain a valid date and a Change action link', () => {
+		data.appealDetails.validAt = '2025-01-01';
+		const mappedData = mapValidAt(data);
+		expect(mappedData).toEqual({
+			display: {
+				summaryListItem: {
+					actions: {
+						items: [
+							{
+								attributes: {
+									'data-cy': 'change-valid-date'
+								},
+								href: '/test/appellant-case/valid/date',
+								text: 'Change',
+								visuallyHiddenText: 'Valid date'
+							}
+						]
+					},
+					classes: 'appeal-valid-date',
+					key: {
+						text: 'Valid date'
+					},
+					value: {
+						text: '1 January 2025'
+					}
+				}
+			},
+			id: 'valid-date'
+		});
+	});
+
+	it('should contain a valid date and no action link', () => {
+		data.appealDetails.validAt = '2025-01-01';
+		data.appealDetails.startedAt = '2025-01-01';
+		const mappedData = mapValidAt(data);
+		expect(mappedData).toEqual({
+			display: {
+				summaryListItem: {
+					actions: {
+						items: [
+							{
+								attributes: {
+									'data-cy': '-valid-date'
+								},
+								href: '/test/appellant-case/valid/date',
+								text: '',
+								visuallyHiddenText: 'Valid date'
+							}
+						]
+					},
+					classes: 'appeal-valid-date',
+					key: {
+						text: 'Valid date'
+					},
+					value: {
+						text: '1 January 2025'
+					}
+				}
+			},
+			id: 'valid-date'
+		});
+	});
+});

--- a/appeals/web/src/server/lib/mappers/data/appeal/submappers/final-comment-due-date.mapper.js
+++ b/appeals/web/src/server/lib/mappers/data/appeal/submappers/final-comment-due-date.mapper.js
@@ -8,9 +8,13 @@ export const mapFinalCommentDueDate = ({
 	appealDetails,
 	currentRoute,
 	userHasUpdateCasePermission
-}) =>
-	textSummaryListItem({
-		id: 'final-comments-due-date',
+}) => {
+	const id = 'final-comments-due-date';
+	if (!appealDetails.startedAt) {
+		return { id, display: {} };
+	}
+	return textSummaryListItem({
+		id,
 		text: 'Final comments due',
 		value: dateISOStringToDisplayDate(appealDetails.appealTimetable?.finalCommentsDueDate),
 		link: `${currentRoute}/appeal-timetables/final-comments`,
@@ -19,3 +23,4 @@ export const mapFinalCommentDueDate = ({
 			!isStatePassed(appealDetails, APPEAL_CASE_STATUS.FINAL_COMMENTS),
 		classes: 'appeal-final-comments-due-date'
 	});
+};

--- a/appeals/web/src/server/lib/mappers/data/appeal/submappers/ip-comments-due-date.mapper.js
+++ b/appeals/web/src/server/lib/mappers/data/appeal/submappers/ip-comments-due-date.mapper.js
@@ -6,9 +6,13 @@ export const mapIpCommentsDueDate = ({
 	appealDetails,
 	currentRoute,
 	userHasUpdateCasePermission
-}) =>
-	textSummaryListItem({
-		id: 'ip-comments-due-date',
+}) => {
+	const id = 'ip-comments-due-date';
+	if (!appealDetails.startedAt) {
+		return { id, display: {} };
+	}
+	return textSummaryListItem({
+		id,
 		text: 'Interested party comments due',
 		value: dateISOStringToDisplayDate(appealDetails.appealTimetable?.ipCommentsDueDate),
 		link: `${currentRoute}/appeal-timetables/ip-comments`,
@@ -18,3 +22,4 @@ export const mapIpCommentsDueDate = ({
 			Boolean(appealDetails.startedAt),
 		classes: 'appeal-ip-comments-due-date'
 	});
+};

--- a/appeals/web/src/server/lib/mappers/data/appeal/submappers/lpa-questionnaire-due-date.mapper.js
+++ b/appeals/web/src/server/lib/mappers/data/appeal/submappers/lpa-questionnaire-due-date.mapper.js
@@ -6,12 +6,17 @@ export const mapLpaQuestionnaireDueDate = ({
 	appealDetails,
 	currentRoute,
 	userHasUpdateCasePermission
-}) =>
-	textSummaryListItem({
-		id: 'lpa-questionnaire-due-date',
+}) => {
+	const id = 'lpa-questionnaire-due-date';
+	if (!appealDetails.startedAt) {
+		return { id, display: {} };
+	}
+	return textSummaryListItem({
+		id,
 		text: 'LPA questionnaire due',
 		value: dateISOStringToDisplayDate(appealDetails.appealTimetable?.lpaQuestionnaireDueDate),
 		link: `${currentRoute}/appeal-timetables/lpa-questionnaire`,
 		editable: Boolean(userHasUpdateCasePermission && appealDetails.validAt),
 		classes: 'appeal-lpa-questionnaire-due-date'
 	});
+};

--- a/appeals/web/src/server/lib/mappers/data/appeal/submappers/lpa-statement-due-date.mapper.js
+++ b/appeals/web/src/server/lib/mappers/data/appeal/submappers/lpa-statement-due-date.mapper.js
@@ -8,9 +8,13 @@ export const mapLpaStatementDueDate = ({
 	appealDetails,
 	currentRoute,
 	userHasUpdateCasePermission
-}) =>
-	textSummaryListItem({
-		id: 'lpa-statement-due-date',
+}) => {
+	const id = 'lpa-statement-due-date';
+	if (!appealDetails.startedAt) {
+		return { id, display: {} };
+	}
+	return textSummaryListItem({
+		id,
 		text: 'LPA statement due',
 		value: dateISOStringToDisplayDate(appealDetails.appealTimetable?.lpaStatementDueDate),
 		link: `${currentRoute}/appeal-timetables/lpa-statement`,
@@ -18,3 +22,4 @@ export const mapLpaStatementDueDate = ({
 			userHasUpdateCasePermission && !isStatePassed(appealDetails, APPEAL_CASE_STATUS.STATEMENTS),
 		classes: 'appeal-lpa-statement-due-date'
 	});
+};

--- a/appeals/web/src/server/lib/mappers/data/appeal/submappers/s106-obligation-due-date.mapper.js
+++ b/appeals/web/src/server/lib/mappers/data/appeal/submappers/s106-obligation-due-date.mapper.js
@@ -6,12 +6,17 @@ export const mapS106ObligationDue = ({
 	appealDetails,
 	currentRoute,
 	userHasUpdateCasePermission
-}) =>
-	textSummaryListItem({
-		id: 's106-obligation-due-date',
+}) => {
+	const id = 's106-obligation-due-date';
+	if (!appealDetails.startedAt) {
+		return { id, display: {} };
+	}
+	return textSummaryListItem({
+		id,
 		text: 'S106 obligation due',
 		value: dateISOStringToDisplayDate(appealDetails.appealTimetable?.s106ObligationDueDate),
 		link: `${currentRoute}/appeal-timetables/s106-obligation`,
 		editable: Boolean(userHasUpdateCasePermission && appealDetails.validAt),
 		classes: 's106-obligation-due-date'
 	});
+};

--- a/appeals/web/src/server/lib/mappers/data/appeal/submappers/site-visit-date.mapper.js
+++ b/appeals/web/src/server/lib/mappers/data/appeal/submappers/site-visit-date.mapper.js
@@ -16,6 +16,10 @@ export function dateAndTimeFormatter(date, startTime, endTime) {
 
 /** @type {import('../mapper.js').SubMapper} */
 export const mapSiteVisitDate = ({ appealDetails, currentRoute, session }) => {
+	const id = 'schedule-visit';
+	if (!appealDetails.startedAt) {
+		return { id, display: {} };
+	}
 	const hasVisit = Boolean(appealDetails.siteVisit?.visitDate);
 	const value =
 		(hasVisit &&
@@ -27,7 +31,7 @@ export const mapSiteVisitDate = ({ appealDetails, currentRoute, session }) => {
 		'Visit date not yet set';
 
 	return textSummaryListItem({
-		id: 'schedule-visit',
+		id,
 		text: 'Site visit',
 		value: { html: value },
 		link: `${currentRoute}/site-visit/${hasVisit ? 'manage' : 'schedule'}-visit`,

--- a/appeals/web/src/server/lib/mappers/data/appeal/submappers/started-at.mapper.js
+++ b/appeals/web/src/server/lib/mappers/data/appeal/submappers/started-at.mapper.js
@@ -3,30 +3,25 @@ import { textSummaryListItem } from '#lib/mappers/index.js';
 
 /** @type {import('../mapper.js').SubMapper} */
 export const mapStartedAt = ({ appealDetails, currentRoute, userHasUpdateCasePermission }) => {
-	if (
-		appealDetails.startedAt &&
-		appealDetails.documentationSummary?.lpaQuestionnaire?.status === 'not_received'
-	) {
-		return textSummaryListItem({
-			id: 'start-case-date',
-			text: 'Start date',
-			value: dateISOStringToDisplayDate(appealDetails.startedAt, 'Not added'),
-			link: `${currentRoute}/start-case/change`,
-			editable: Boolean(appealDetails.validAt && userHasUpdateCasePermission),
-			classes: 'appeal-start-date',
-			actionText: 'Change'
-		});
+	const id = 'start-case-date';
+	if (!appealDetails.validAt) {
+		return { id, display: {} };
 	}
 
 	return textSummaryListItem({
-		id: 'start-case-date',
+		id,
 		text: 'Start date',
-		value: dateISOStringToDisplayDate(appealDetails.startedAt, 'Not added'),
-		link: `${currentRoute}/start-case/add`,
-		editable: Boolean(
-			appealDetails.validAt && !appealDetails.startedAt && userHasUpdateCasePermission
-		),
+		value: dateISOStringToDisplayDate(appealDetails.startedAt, 'Not started'),
+		link: appealDetails.startedAt
+			? `${currentRoute}/start-case/change`
+			: `${currentRoute}/start-case/add`,
+		editable: Boolean(userHasUpdateCasePermission),
 		classes: 'appeal-start-date',
-		actionText: 'Add'
+		actionText:
+			appealDetails.documentationSummary.lpaQuestionnaire?.status !== 'not_received'
+				? ''
+				: appealDetails.startedAt
+				? 'Change'
+				: 'Start'
 	});
 };

--- a/appeals/web/src/server/lib/mappers/data/appeal/submappers/valid-at.mapper.js
+++ b/appeals/web/src/server/lib/mappers/data/appeal/submappers/valid-at.mapper.js
@@ -6,10 +6,16 @@ export const mapValidAt = ({ appealDetails, currentRoute, userHasUpdateCasePermi
 	textSummaryListItem({
 		id: 'valid-date',
 		text: 'Valid date',
-		value: dateISOStringToDisplayDate(appealDetails.validAt, 'Not added'),
-		link: `${currentRoute}/appellant-case/valid/date`,
-		editable: Boolean(
-			appealDetails.validAt && !appealDetails.startedAt && userHasUpdateCasePermission
-		),
+		value: dateISOStringToDisplayDate(appealDetails.validAt, 'Not validated'),
+		link: appealDetails.validAt
+			? `${currentRoute}/appellant-case/valid/date`
+			: `${currentRoute}/appellant-case`,
+		actionText:
+			!appealDetails.caseOfficer || appealDetails.startedAt
+				? ''
+				: appealDetails.validAt
+				? 'Change'
+				: 'Validate',
+		editable: Boolean(userHasUpdateCasePermission),
 		classes: 'appeal-valid-date'
 	});


### PR DESCRIPTION
## Describe your changes
#### Prevent case timetable showing rows and action links pre case start (a2-2673)

#### WEB:
- Timetable rows are filtered out via the sub-mappers returning the display parameter as an empty object when they should not be shown.  Also satisfies typescript.
- Added a class to the timetable summary list to allow for snapshots of the whole timetable in unit tests
- Unit tests to test for each AC
- Unit tests and snapshots updated to match

#### TEST:
- All unit tests pass
- Tested within browser

## Issue ticket number and link
[Ticket:  Case timetable showing rows and action links pre case start (A2-2673)](https://pins-ds.atlassian.net.mcas.ms/browse/A2-2673)
