### PR TITLE
fix(api): A2-2710 appellant & LPA not receiving email on site visit type change

### DIFF
--- a/appeals/api/src/server/endpoints/site-visits/__tests__/site-visits.test.js
+++ b/appeals/api/src/server/endpoints/site-visits/__tests__/site-visits.test.js
@@ -1273,7 +1273,7 @@ describe('site visit routes', () => {
 				);
 			});
 
-			test('updates an Accompanied site visit to Unaccompanied and changing time and date, does not send notify emails', async () => {
+			test('updates an Accompanied site visit to Unaccompanied and changing time and date, sends notify emails', async () => {
 				const { siteVisit } = householdAppeal;
 				siteVisit.siteVisitType.name = SITE_VISIT_TYPE_UNACCOMPANIED;
 
@@ -1327,7 +1327,45 @@ describe('site visit routes', () => {
 				});
 
 				// eslint-disable-next-line no-undef
-				expect(mockSendEmail).not.toHaveBeenCalled();
+				expect(mockSendEmail).toHaveBeenCalledTimes(2);
+
+				// eslint-disable-next-line no-undef
+				expect(mockSendEmail).toHaveBeenCalledWith(
+					config.govNotify.template.siteVisitChange.accompaniedToUnaccompanied.appellant.id,
+					'test@136s7.com',
+					{
+						emailReplyToId: null,
+						personalisation: {
+							appeal_reference_number: '1345264',
+							site_address: '96 The Avenue, Leftfield, Maidstone, Kent, MD21 5XY, United Kingdom',
+							start_time: '02:00',
+							end_time: '04:00',
+							inspector_name: '',
+							lpa_reference: '48269/APP/2021/1482',
+							visit_date: '31 March 2022'
+						},
+						reference: null
+					}
+				);
+
+				// eslint-disable-next-line no-undef
+				expect(mockSendEmail).toHaveBeenCalledWith(
+					config.govNotify.template.siteVisitChange.accompaniedToUnaccompanied.lpa.id,
+					'maid@lpa-email.gov.uk',
+					{
+						emailReplyToId: null,
+						personalisation: {
+							appeal_reference_number: '1345264',
+							site_address: '96 The Avenue, Leftfield, Maidstone, Kent, MD21 5XY, United Kingdom',
+							start_time: '02:00',
+							end_time: '04:00',
+							inspector_name: '',
+							lpa_reference: '48269/APP/2021/1482',
+							visit_date: '31 March 2022'
+						},
+						reference: null
+					}
+				);
 			});
 
 			test('updates an Access required site visit to changing time and date, sends notify emails to Appellant', async () => {
@@ -2517,7 +2555,10 @@ describe('site visit routes', () => {
 
 		test('returns templates for all transition types with all', () => {
 			const result = fetchVisitNotificationTemplateIds('Accompanied', 'Unaccompanied', 'all');
-			expect(result).toEqual({});
+			expect(result).toEqual({
+				appellant: { id: 'mock-site-visit-change-unaccompanied-to-accompanied-appellant-id' },
+				lpa: { id: 'mock-site-visit-change-unaccompanied-to-accompanied-lpa-id' }
+			});
 		});
 
 		test('returns appellant template ID for Access Required visit date/time change', () => {

--- a/appeals/api/src/server/endpoints/site-visits/site-visits.service.js
+++ b/appeals/api/src/server/endpoints/site-visits/site-visits.service.js
@@ -210,7 +210,6 @@ const updateSiteVisit = async (azureAdUserId, updateSiteVisitData, notifyClient)
  */
 const fetchVisitNotificationTemplateIds = (visitType, previousVisitType, siteVisitChangeType) => {
 	switch (siteVisitChangeType) {
-		case 'all':
 		case 'unchanged':
 			return {};
 
@@ -231,6 +230,7 @@ const fetchVisitNotificationTemplateIds = (visitType, previousVisitType, siteVis
 			}
 			return {};
 
+		case 'all':
 		case 'visit-type': {
 			const transitionKey = toCamelCase(`${previousVisitType} To ${visitType}`);
 			return config.govNotify.template.siteVisitChange[transitionKey] || {};

--- a/appeals/web/src/server/appeals/appeal-details/site-visit/site-visit.controller.js
+++ b/appeals/web/src/server/appeals/appeal-details/site-visit/site-visit.controller.js
@@ -6,7 +6,8 @@ import {
 	stringIsSiteVisitConfirmationPageType,
 	siteVisitBookedPage,
 	mapPostScheduleOrManageSiteVisitCommonParameters as mapPostScheduleOrManageSiteVisitToUpdateOrCreateSiteVisitParameters,
-	getSiteVisitSuccessBannerTypeAndChangeType
+	getSiteVisitSuccessBannerTypeAndChangeType,
+	setPreviousVisitTypeIfChanged
 } from './site-visit.mapper.js';
 import { addNotificationBannerToSession } from '#lib/session-utilities.js';
 import usersService from '#appeals/appeal-users/users-service.js';
@@ -196,6 +197,11 @@ export const postScheduleOrManageSiteVisit = async (request, response, pageType)
 					visitType,
 					inspector?.name || ''
 				);
+
+			setPreviousVisitTypeIfChanged(
+				mappedUpdateOrCreateSiteVisitParameters,
+				appealDetails.siteVisit?.visitType
+			);
 
 			if (appealDetails.siteVisit?.siteVisitId) {
 				const successBannerAndChangeType = getSiteVisitSuccessBannerTypeAndChangeType(

--- a/appeals/web/src/server/appeals/appeal-details/site-visit/site-visit.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/site-visit/site-visit.mapper.js
@@ -563,5 +563,23 @@ export function getSiteVisitSuccessBannerTypeAndChangeType(
 		bannerTypeAndChangeType.changeType = 'unchanged';
 	}
 
+	if (visitTypeChanged) {
+		updateOrCreateSiteVisitParameters.previousVisitType = oldApiVisitType;
+	}
+
 	return bannerTypeAndChangeType;
+}
+
+/**
+ * @param {import('./site-visit.service.js').UpdateOrCreateSiteVisitParameters} updateOrCreateSiteVisitParameters
+ * @param {ApiVisitType | undefined} oldApiVisitType
+ */
+export function setPreviousVisitTypeIfChanged(updateOrCreateSiteVisitParameters, oldApiVisitType) {
+	if (
+		oldApiVisitType &&
+		updateOrCreateSiteVisitParameters.apiVisitType &&
+		oldApiVisitType.toLowerCase() !== updateOrCreateSiteVisitParameters.apiVisitType.toLowerCase()
+	) {
+		updateOrCreateSiteVisitParameters.previousVisitType = oldApiVisitType;
+	}
 }


### PR DESCRIPTION
## Describe your changes

Reinstated previousVisitType handling, also fixed missing emails when both time/date and visit type were changed.

## Issue ticket number and link
[A2-2710](https://pins-ds.atlassian.net/browse/A2-2710)
[A2-2709](https://pins-ds.atlassian.net/browse/A2-2709)


[A2-2710]: https://pins-ds.atlassian.net/browse/A2-2710?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[A2-2709]: https://pins-ds.atlassian.net/browse/A2-2709?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ