### PR TITLE
fix(web): updates to change page pattern to only render valid elements inside form tag

### DIFF
--- a/appeals/web/src/server/appeals/appeal-details/appellant-case/__tests__/__snapshots__/appellant-case.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/appellant-case/__tests__/__snapshots__/appellant-case.test.js.snap
@@ -4110,9 +4110,13 @@ exports[`appellant-case GET /appellant-case/valid/date should render the valid d
         <div class="govuk-grid-column-two-thirds">
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full">
+                    <p class="govuk-body">This is the date all case documentation was received and the appeal was
+                        valid.</p>
+                </div>
+            </div>
+            <div class="govuk-grid-row">
+                <div class="govuk-grid-column-full">
                     <form method="POST" novalidate="novalidate">
-                        <p class="govuk-body">This is the date all case documentation was received and the appeal was
-                            valid.</p>
                         <div class="govuk-form-group">
                             <fieldset class="govuk-fieldset" role="group" aria-describedby="valid-date-hint">
                                 <div id="valid-date-hint" class="govuk-hint">For example, 27 3 2023</div>
@@ -7131,9 +7135,13 @@ exports[`appellant-case POST /appellant-case/valid/date should re-render the upd
         <div class="govuk-grid-column-two-thirds">
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full">
+                    <p class="govuk-body">This is the date all case documentation was received and the appeal was
+                        valid.</p>
+                </div>
+            </div>
+            <div class="govuk-grid-row">
+                <div class="govuk-grid-column-full">
                     <form method="POST" novalidate="novalidate">
-                        <p class="govuk-body">This is the date all case documentation was received and the appeal was
-                            valid.</p>
                         <div class="govuk-form-group">
                             <fieldset class="govuk-fieldset" role="group" aria-describedby="valid-date-hint">
                                 <div id="valid-date-hint" class="govuk-hint">For example, 27 3 2023</div>
@@ -7200,9 +7208,13 @@ exports[`appellant-case POST /appellant-case/valid/date should re-render the upd
         <div class="govuk-grid-column-two-thirds">
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full">
+                    <p class="govuk-body">This is the date all case documentation was received and the appeal was
+                        valid.</p>
+                </div>
+            </div>
+            <div class="govuk-grid-row">
+                <div class="govuk-grid-column-full">
                     <form method="POST" novalidate="novalidate">
-                        <p class="govuk-body">This is the date all case documentation was received and the appeal was
-                            valid.</p>
                         <div class="govuk-form-group">
                             <fieldset class="govuk-fieldset" role="group" aria-describedby="valid-date-hint">
                                 <div id="valid-date-hint" class="govuk-hint">For example, 27 3 2023</div>
@@ -7269,9 +7281,13 @@ exports[`appellant-case POST /appellant-case/valid/date should re-render the upd
         <div class="govuk-grid-column-two-thirds">
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full">
+                    <p class="govuk-body">This is the date all case documentation was received and the appeal was
+                        valid.</p>
+                </div>
+            </div>
+            <div class="govuk-grid-row">
+                <div class="govuk-grid-column-full">
                     <form method="POST" novalidate="novalidate">
-                        <p class="govuk-body">This is the date all case documentation was received and the appeal was
-                            valid.</p>
                         <div class="govuk-form-group">
                             <fieldset class="govuk-fieldset" role="group" aria-describedby="valid-date-hint">
                                 <div id="valid-date-hint" class="govuk-hint">For example, 27 3 2023</div>
@@ -7336,9 +7352,13 @@ exports[`appellant-case POST /appellant-case/valid/date should re-render the val
         <div class="govuk-grid-column-two-thirds">
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full">
+                    <p class="govuk-body">This is the date all case documentation was received and the appeal was
+                        valid.</p>
+                </div>
+            </div>
+            <div class="govuk-grid-row">
+                <div class="govuk-grid-column-full">
                     <form method="POST" novalidate="novalidate">
-                        <p class="govuk-body">This is the date all case documentation was received and the appeal was
-                            valid.</p>
                         <div class="govuk-form-group">
                             <fieldset class="govuk-fieldset" role="group" aria-describedby="valid-date-hint">
                                 <div id="valid-date-hint" class="govuk-hint">For example, 27 3 2023</div>
@@ -7405,9 +7425,13 @@ exports[`appellant-case POST /appellant-case/valid/date should re-render the val
         <div class="govuk-grid-column-two-thirds">
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full">
+                    <p class="govuk-body">This is the date all case documentation was received and the appeal was
+                        valid.</p>
+                </div>
+            </div>
+            <div class="govuk-grid-row">
+                <div class="govuk-grid-column-full">
                     <form method="POST" novalidate="novalidate">
-                        <p class="govuk-body">This is the date all case documentation was received and the appeal was
-                            valid.</p>
                         <div class="govuk-form-group">
                             <fieldset class="govuk-fieldset" role="group" aria-describedby="valid-date-hint">
                                 <div id="valid-date-hint" class="govuk-hint">For example, 27 3 2023</div>
@@ -7474,9 +7498,13 @@ exports[`appellant-case POST /appellant-case/valid/date should re-render the val
         <div class="govuk-grid-column-two-thirds">
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full">
+                    <p class="govuk-body">This is the date all case documentation was received and the appeal was
+                        valid.</p>
+                </div>
+            </div>
+            <div class="govuk-grid-row">
+                <div class="govuk-grid-column-full">
                     <form method="POST" novalidate="novalidate">
-                        <p class="govuk-body">This is the date all case documentation was received and the appeal was
-                            valid.</p>
                         <div class="govuk-form-group">
                             <fieldset class="govuk-fieldset" role="group" aria-describedby="valid-date-hint">
                                 <div id="valid-date-hint" class="govuk-hint">For example, 27 3 2023</div>
@@ -7543,9 +7571,13 @@ exports[`appellant-case POST /appellant-case/valid/date should re-render the val
         <div class="govuk-grid-column-two-thirds">
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full">
+                    <p class="govuk-body">This is the date all case documentation was received and the appeal was
+                        valid.</p>
+                </div>
+            </div>
+            <div class="govuk-grid-row">
+                <div class="govuk-grid-column-full">
                     <form method="POST" novalidate="novalidate">
-                        <p class="govuk-body">This is the date all case documentation was received and the appeal was
-                            valid.</p>
                         <div class="govuk-form-group">
                             <fieldset class="govuk-fieldset" role="group" aria-describedby="valid-date-hint">
                                 <div id="valid-date-hint" class="govuk-hint">For example, 27 3 2023</div>
@@ -7612,9 +7644,13 @@ exports[`appellant-case POST /appellant-case/valid/date should re-render the val
         <div class="govuk-grid-column-two-thirds">
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full">
+                    <p class="govuk-body">This is the date all case documentation was received and the appeal was
+                        valid.</p>
+                </div>
+            </div>
+            <div class="govuk-grid-row">
+                <div class="govuk-grid-column-full">
                     <form method="POST" novalidate="novalidate">
-                        <p class="govuk-body">This is the date all case documentation was received and the appeal was
-                            valid.</p>
                         <div class="govuk-form-group">
                             <fieldset class="govuk-fieldset" role="group" aria-describedby="valid-date-hint">
                                 <div id="valid-date-hint" class="govuk-hint">For example, 27 3 2023</div>
@@ -7681,9 +7717,13 @@ exports[`appellant-case POST /appellant-case/valid/date should re-render the val
         <div class="govuk-grid-column-two-thirds">
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full">
+                    <p class="govuk-body">This is the date all case documentation was received and the appeal was
+                        valid.</p>
+                </div>
+            </div>
+            <div class="govuk-grid-row">
+                <div class="govuk-grid-column-full">
                     <form method="POST" novalidate="novalidate">
-                        <p class="govuk-body">This is the date all case documentation was received and the appeal was
-                            valid.</p>
                         <div class="govuk-form-group">
                             <fieldset class="govuk-fieldset" role="group" aria-describedby="valid-date-hint">
                                 <div id="valid-date-hint" class="govuk-hint">For example, 27 3 2023</div>
@@ -7748,9 +7788,13 @@ exports[`appellant-case POST /appellant-case/valid/date should re-render the val
         <div class="govuk-grid-column-two-thirds">
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full">
+                    <p class="govuk-body">This is the date all case documentation was received and the appeal was
+                        valid.</p>
+                </div>
+            </div>
+            <div class="govuk-grid-row">
+                <div class="govuk-grid-column-full">
                     <form method="POST" novalidate="novalidate">
-                        <p class="govuk-body">This is the date all case documentation was received and the appeal was
-                            valid.</p>
                         <div class="govuk-form-group">
                             <fieldset class="govuk-fieldset" role="group" aria-describedby="valid-date-hint">
                                 <div id="valid-date-hint" class="govuk-hint">For example, 27 3 2023</div>
@@ -7815,9 +7859,13 @@ exports[`appellant-case POST /appellant-case/valid/date should re-render the val
         <div class="govuk-grid-column-two-thirds">
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full">
+                    <p class="govuk-body">This is the date all case documentation was received and the appeal was
+                        valid.</p>
+                </div>
+            </div>
+            <div class="govuk-grid-row">
+                <div class="govuk-grid-column-full">
                     <form method="POST" novalidate="novalidate">
-                        <p class="govuk-body">This is the date all case documentation was received and the appeal was
-                            valid.</p>
                         <div class="govuk-form-group">
                             <fieldset class="govuk-fieldset" role="group" aria-describedby="valid-date-hint">
                                 <div id="valid-date-hint" class="govuk-hint">For example, 27 3 2023</div>
@@ -7882,9 +7930,13 @@ exports[`appellant-case POST /appellant-case/valid/date should re-render the val
         <div class="govuk-grid-column-two-thirds">
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full">
+                    <p class="govuk-body">This is the date all case documentation was received and the appeal was
+                        valid.</p>
+                </div>
+            </div>
+            <div class="govuk-grid-row">
+                <div class="govuk-grid-column-full">
                     <form method="POST" novalidate="novalidate">
-                        <p class="govuk-body">This is the date all case documentation was received and the appeal was
-                            valid.</p>
                         <div class="govuk-form-group">
                             <fieldset class="govuk-fieldset" role="group" aria-describedby="valid-date-hint">
                                 <div id="valid-date-hint" class="govuk-hint">For example, 27 3 2023</div>

--- a/appeals/web/src/server/appeals/appeal-details/appellant-case/outcome-valid/outcome-valid.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/appellant-case/outcome-valid/outcome-valid.mapper.js
@@ -75,7 +75,8 @@ export function updateValidDatePage(
 		backLinkText: 'Back',
 		heading: title,
 		submitButtonText: 'Confirm',
-		pageComponents: [validDateTextComponent, selectDateComponent, insetTextComponent]
+		prePageComponents: [validDateTextComponent],
+		pageComponents: [selectDateComponent, insetTextComponent]
 	};
 
 	return pageContent;

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/__tests__/__snapshots__/lpa-questionnaire.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/__tests__/__snapshots__/lpa-questionnaire.test.js.snap
@@ -2771,9 +2771,13 @@ exports[`LPA Questionnaire review GET /lpa-questionnaire/1/environment-service-t
                         </div>
                         <button type="submit" data-prevent-double-click="true" class="govuk-button"
                         data-module="govuk-button">Continue</button>
-                        <p class="govuk-body"><a class="govuk-link" href="/appeals-service/appeal-details/1">Return to your appeal</a>
-                        </p>
                     </form>
+                </div>
+            </div>
+            <div class="govuk-grid-row">
+                <div class="govuk-grid-column-full">
+                    <p class="govuk-body"><a class="govuk-link" href="/appeals-service/appeal-details/1">Return to your appeal</a>
+                    </p>
                 </div>
             </div>
         </div>
@@ -6379,9 +6383,13 @@ exports[`LPA Questionnaire review POST /lpa-questionnaire/1/environment-service-
                         </div>
                         <button type="submit" data-prevent-double-click="true" class="govuk-button"
                         data-module="govuk-button">Continue</button>
-                        <p class="govuk-body"><a class="govuk-link" href="/appeals-service/appeal-details/1">Return to your appeal</a>
-                        </p>
                     </form>
+                </div>
+            </div>
+            <div class="govuk-grid-row">
+                <div class="govuk-grid-column-full">
+                    <p class="govuk-body"><a class="govuk-link" href="/appeals-service/appeal-details/1">Return to your appeal</a>
+                    </p>
                 </div>
             </div>
         </div>

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/affected-listed-buildings/affected-listed-buildings.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/affected-listed-buildings/affected-listed-buildings.mapper.js
@@ -187,7 +187,7 @@ export function removeAffectedListedBuildingPage(
 		backLinkUrl: `/appeals-service/appeal-details/${appealData.appealId}/lpa-questionnaire/${appealData.lpaQuestionnaireId}/affected-listed-buildings/manage`,
 		preHeading: `Appeal ${shortAppealReference}`,
 		heading: 'Remove affected listed building',
-		pageComponents: [
+		prePageComponents: [
 			{
 				type: 'summary-list',
 				parameters: {
@@ -203,7 +203,9 @@ export function removeAffectedListedBuildingPage(
 						}
 					]
 				}
-			},
+			}
+		],
+		pageComponents: [
 			yesNoInput({
 				name: 'removeAffectedListedBuilding',
 				legendText: 'Do you want to remove this listed building?'

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/changed-listed-buildings/changed-listed-buildings.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/changed-listed-buildings/changed-listed-buildings.mapper.js
@@ -189,7 +189,7 @@ export function removeChangedListedBuildingPage(
 		preHeading: `Appeal ${shortAppealReference}`,
 		heading: 'Confirm that you want to remove the changed listed building',
 		submitButtonText: 'Remove changed listed building',
-		pageComponents: [
+		prePageComponents: [
 			{
 				type: 'summary-list',
 				parameters: {

--- a/appeals/web/src/server/appeals/appeal-details/neighbouring-sites/__tests__/__snapshots__/neighbouring-sites.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/neighbouring-sites/__tests__/__snapshots__/neighbouring-sites.test.js.snap
@@ -276,12 +276,16 @@ exports[`neighbouring-sites GET /remove/site/:siteId should render the remove ne
         <div class="govuk-grid-column-two-thirds">
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full">
+                    <dl class="govuk-summary-list govuk-summary-list--no-border">
+                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Address</dt>
+                            <dd class="govuk-summary-list__value">1 Grove Cottage, Shotesham Road, Woodton, Devon, NR35 2ND</dd>
+                        </div>
+                    </dl>
+                </div>
+            </div>
+            <div class="govuk-grid-row">
+                <div class="govuk-grid-column-full">
                     <form method="POST" novalidate="novalidate">
-                        <dl class="govuk-summary-list govuk-summary-list--no-border">
-                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Address</dt>
-                                <dd class="govuk-summary-list__value">1 Grove Cottage, Shotesham Road, Woodton, Devon, NR35 2ND</dd>
-                            </div>
-                        </dl>
                         <div class="govuk-form-group">
                             <fieldset class="govuk-fieldset">
                                 <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">Do you want to remove this site?</legend>
@@ -1277,12 +1281,16 @@ exports[`neighbouring-sites POST /remove/site/:siteId should re-render remove ne
         <div class="govuk-grid-column-two-thirds">
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full">
+                    <dl class="govuk-summary-list govuk-summary-list--no-border">
+                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Address</dt>
+                            <dd class="govuk-summary-list__value">1 Grove Cottage, Shotesham Road, Woodton, Devon, NR35 2ND</dd>
+                        </div>
+                    </dl>
+                </div>
+            </div>
+            <div class="govuk-grid-row">
+                <div class="govuk-grid-column-full">
                     <form method="POST" novalidate="novalidate">
-                        <dl class="govuk-summary-list govuk-summary-list--no-border">
-                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Address</dt>
-                                <dd class="govuk-summary-list__value">1 Grove Cottage, Shotesham Road, Woodton, Devon, NR35 2ND</dd>
-                            </div>
-                        </dl>
                         <div class="govuk-form-group">
                             <fieldset class="govuk-fieldset">
                                 <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">Do you want to remove this site?</legend>

--- a/appeals/web/src/server/appeals/appeal-details/neighbouring-sites/neighbouring-sites.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/neighbouring-sites/neighbouring-sites.mapper.js
@@ -220,7 +220,7 @@ export function removeNeighbouringSitePage(appealData, origin, siteId) {
 		backLinkUrl: `${origin}/neighbouring-sites/manage`,
 		preHeading: `Appeal ${shortAppealReference}`,
 		heading: 'Remove neighbouring site',
-		pageComponents: [
+		prePageComponents: [
 			{
 				type: 'summary-list',
 				parameters: {
@@ -236,7 +236,9 @@ export function removeNeighbouringSitePage(appealData, origin, siteId) {
 						}
 					]
 				}
-			},
+			}
+		],
+		pageComponents: [
 			yesNoInput({
 				name: 'remove-neighbouring-site',
 				legendText: 'Do you want to remove this site?'

--- a/appeals/web/src/server/appeals/appeal-details/representations/lpa-statement/__tests__/__snapshots__/lpa-statement.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/representations/lpa-statement/__tests__/__snapshots__/lpa-statement.test.js.snap
@@ -9,35 +9,39 @@ exports[`lpa-statements GET / should render the review LPA statement page with t
     </div>
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-full">
-            <form method="POST" novalidate="novalidate">
-                <div class="govuk-grid-row">
-                    <div class="govuk-grid-column-full">
-                        <dl class="govuk-summary-list">
-                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Statement</dt>
-                                <dd class="govuk-summary-list__value">
-                                    <div class="pins-show-more" data-label="Statement" data-mode="text">Every single thing in the world has its own personality - and it is up
-                                        to you to make friends with the little rascals. Steve wants reflections,
-                                        so let&#39;s give him eflections It&#39;s amazing what you can do with
-                                        a little love in your heart. Clouds are free they come and go as they please.
-                                        The secret to doing anything is believing that you can do it. Anything
-                                        hatyou believe you can do strong enough, you can do. Anything. As long
-                                        as you believe. It looks so good, I might as well not stop. This present
-                                        moment is perfect simply due to the fact you&#39;re xperiencingit. Making
-                                        all those little fluffies that live in the clouds. You don&#39;t want to
-                                        kill all your dark areas they are very important. I will take some magic
-                                        white, and a little bit of andykebrown and a little touch of yellow. Anyone
-                                        can paint. Each highlight must have it&#39;s own private shadow. Don&#39;t
-                                        fiddle with it all day.</div>
-                                </dd>
-                            </div>
-                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Supporting documents</dt>
-                                <dd class="govuk-summary-list__value">Not provided</dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/3/lpa-statement/add-document">Add<span class="govuk-visually-hidden"> supporting documents</span></a>
-                                </dd>
-                            </div>
-                        </dl>
-                    </div>
+            <div class="govuk-grid-row">
+                <div class="govuk-grid-column-full">
+                    <dl class="govuk-summary-list">
+                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Statement</dt>
+                            <dd class="govuk-summary-list__value">
+                                <div class="pins-show-more" data-label="Statement" data-mode="text">Every single thing in the world has its own personality - and it is up
+                                    to you to make friends with the little rascals. Steve wants reflections,
+                                    so let&#39;s give him eflections It&#39;s amazing what you can do with
+                                    a little love in your heart. Clouds are free they come and go as they please.
+                                    The secret to doing anything is believing that you can do it. Anything
+                                    hatyou believe you can do strong enough, you can do. Anything. As long
+                                    as you believe. It looks so good, I might as well not stop. This present
+                                    moment is perfect simply due to the fact you&#39;re xperiencingit. Making
+                                    all those little fluffies that live in the clouds. You don&#39;t want to
+                                    kill all your dark areas they are very important. I will take some magic
+                                    white, and a little bit of andykebrown and a little touch of yellow. Anyone
+                                    can paint. Each highlight must have it&#39;s own private shadow. Don&#39;t
+                                    fiddle with it all day.</div>
+                            </dd>
+                        </div>
+                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Supporting documents</dt>
+                            <dd class="govuk-summary-list__value">Not provided</dd>
+                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/3/lpa-statement/add-document">Add<span class="govuk-visually-hidden"> supporting documents</span></a>
+                            </dd>
+                        </div>
+                    </dl>
                 </div>
+            </div>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <form method="POST" novalidate="novalidate">
                 <div class="govuk-form-group">
                     <fieldset class="govuk-fieldset">
                         <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">Review decision</legend>
@@ -77,35 +81,39 @@ exports[`lpa-statements GET / should render the review LPA statement page with t
     </div>
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-full">
-            <form method="POST" novalidate="novalidate">
-                <div class="govuk-grid-row">
-                    <div class="govuk-grid-column-full">
-                        <dl class="govuk-summary-list">
-                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Statement</dt>
-                                <dd class="govuk-summary-list__value">
-                                    <div class="pins-show-more" data-label="Statement" data-mode="text">Every single thing in the world has its own personality - and it is up
-                                        to you to make friends with the little rascals. Steve wants reflections,
-                                        so let&#39;s give him eflections It&#39;s amazing what you can do with
-                                        a little love in your heart. Clouds are free they come and go as they please.
-                                        The secret to doing anything is believing that you can do it. Anything
-                                        hatyou believe you can do strong enough, you can do. Anything. As long
-                                        as you believe. It looks so good, I might as well not stop. This present
-                                        moment is perfect simply due to the fact you&#39;re xperiencingit. Making
-                                        all those little fluffies that live in the clouds. You don&#39;t want to
-                                        kill all your dark areas they are very important. I will take some magic
-                                        white, and a little bit of andykebrown and a little touch of yellow. Anyone
-                                        can paint. Each highlight must have it&#39;s own private shadow. Don&#39;t
-                                        fiddle with it all day.</div>
-                                </dd>
-                            </div>
-                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Supporting documents</dt>
-                                <dd class="govuk-summary-list__value">Not provided</dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/3/lpa-statement/add-document">Add<span class="govuk-visually-hidden"> supporting documents</span></a>
-                                </dd>
-                            </div>
-                        </dl>
-                    </div>
+            <div class="govuk-grid-row">
+                <div class="govuk-grid-column-full">
+                    <dl class="govuk-summary-list">
+                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Statement</dt>
+                            <dd class="govuk-summary-list__value">
+                                <div class="pins-show-more" data-label="Statement" data-mode="text">Every single thing in the world has its own personality - and it is up
+                                    to you to make friends with the little rascals. Steve wants reflections,
+                                    so let&#39;s give him eflections It&#39;s amazing what you can do with
+                                    a little love in your heart. Clouds are free they come and go as they please.
+                                    The secret to doing anything is believing that you can do it. Anything
+                                    hatyou believe you can do strong enough, you can do. Anything. As long
+                                    as you believe. It looks so good, I might as well not stop. This present
+                                    moment is perfect simply due to the fact you&#39;re xperiencingit. Making
+                                    all those little fluffies that live in the clouds. You don&#39;t want to
+                                    kill all your dark areas they are very important. I will take some magic
+                                    white, and a little bit of andykebrown and a little touch of yellow. Anyone
+                                    can paint. Each highlight must have it&#39;s own private shadow. Don&#39;t
+                                    fiddle with it all day.</div>
+                            </dd>
+                        </div>
+                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Supporting documents</dt>
+                            <dd class="govuk-summary-list__value">Not provided</dd>
+                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/3/lpa-statement/add-document">Add<span class="govuk-visually-hidden"> supporting documents</span></a>
+                            </dd>
+                        </div>
+                    </dl>
                 </div>
+            </div>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <form method="POST" novalidate="novalidate">
                 <div class="govuk-form-group">
                     <fieldset class="govuk-fieldset">
                         <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">Review decision</legend>

--- a/appeals/web/src/server/appeals/appeal-details/representations/lpa-statement/allocation/allocation.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/representations/lpa-statement/allocation/allocation.mapper.js
@@ -31,7 +31,6 @@ export function allocationCheckPage(appealDetails, sessionData) {
 
 	/** @type {PageComponent[]} */
 	const pageComponents = [
-		...(appealDetails.allocationDetails ? [currentStatus] : []),
 		yesNoInput({
 			name: 'allocationLevelAndSpecialisms',
 			id: 'allocationLevelAndSpecialisms',
@@ -47,6 +46,7 @@ export function allocationCheckPage(appealDetails, sessionData) {
 		preHeading: `Appeal ${shortReference}`,
 		heading: 'Allocation level and specialisms',
 		submitButtonText: 'Continue',
+		prePageComponents: appealDetails.allocationDetails ? [currentStatus] : [],
 		pageComponents
 	};
 }

--- a/appeals/web/src/server/appeals/appeal-details/representations/lpa-statement/lpa-statement.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/representations/lpa-statement/lpa-statement.mapper.js
@@ -236,12 +236,11 @@ export function reviewLpaStatementPage(appealDetails, lpaStatement, session, bac
 		}
 	};
 
-	const pageComponents = [
+	const prePageComponents = [
 		...mapNotificationBannersFromSession(session, 'lpaStatement', appealDetails.appealId),
-		lpaStatementSummaryList,
-		lpaStatementValidityRadioButtons
+		lpaStatementSummaryList
 	];
-	preRenderPageComponents(pageComponents);
+	preRenderPageComponents(prePageComponents);
 
 	const pageContent = {
 		title: 'Review LPA statement',
@@ -250,7 +249,8 @@ export function reviewLpaStatementPage(appealDetails, lpaStatement, session, bac
 		heading: 'Review LPA statement',
 		submitButtonText: 'Continue',
 		formWrapperColumnClass: 'govuk-grid-column-two-thirds',
-		pageComponents
+		prePageComponents,
+		pageComponents: [lpaStatementValidityRadioButtons]
 	};
 
 	return pageContent;

--- a/appeals/web/src/server/appeals/appeal-details/service-user/__tests__/__snapshots__/service-user.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/service-user/__tests__/__snapshots__/service-user.test.js.snap
@@ -120,9 +120,13 @@ exports[`service-user GET /change/:userType should render the change service use
                         </div>
                         <button type="submit" data-prevent-double-click="true" class="govuk-button"
                         data-module="govuk-button">Continue</button>
-                        <p class="govuk-body"><a class="govuk-link" href="/appeals-service/appeal-details/1/service-user/remove/agent">Remove agent</a>
-                        </p>
                     </form>
+                </div>
+            </div>
+            <div class="govuk-grid-row">
+                <div class="govuk-grid-column-full">
+                    <p class="govuk-body"><a class="govuk-link" href="/appeals-service/appeal-details/1/service-user/remove/agent">Remove agent</a>
+                    </p>
                 </div>
             </div>
         </div>
@@ -208,9 +212,13 @@ exports[`service-user GET /remove/:userType should render the remove service use
                     <form method="POST" novalidate="novalidate">
                         <button type="submit" data-prevent-double-click="true" class="govuk-button"
                         data-module="govuk-button">Remove agent</button>
-                        <p class="govuk-body"><a class="govuk-link" href="/appeals-service/appeal-details/1/service-user/change/agent">Cancel</a>
-                        </p>
                     </form>
+                </div>
+            </div>
+            <div class="govuk-grid-row">
+                <div class="govuk-grid-column-full">
+                    <p class="govuk-body"><a class="govuk-link" href="/appeals-service/appeal-details/1/service-user/change/agent">Cancel</a>
+                    </p>
                 </div>
             </div>
         </div>
@@ -780,9 +788,13 @@ exports[`service-user POST /change/:userType should re-render changeServiceUser 
                         </div>
                         <button type="submit" data-prevent-double-click="true" class="govuk-button"
                         data-module="govuk-button">Continue</button>
-                        <p class="govuk-body"><a class="govuk-link" href="/appeals-service/appeal-details/1/service-user/remove/agent">Remove agent</a>
-                        </p>
                     </form>
+                </div>
+            </div>
+            <div class="govuk-grid-row">
+                <div class="govuk-grid-column-full">
+                    <p class="govuk-body"><a class="govuk-link" href="/appeals-service/appeal-details/1/service-user/remove/agent">Remove agent</a>
+                    </p>
                 </div>
             </div>
         </div>
@@ -845,9 +857,13 @@ exports[`service-user POST /change/:userType should re-render changeServiceUser 
                         </div>
                         <button type="submit" data-prevent-double-click="true" class="govuk-button"
                         data-module="govuk-button">Continue</button>
-                        <p class="govuk-body"><a class="govuk-link" href="/appeals-service/appeal-details/1/service-user/remove/agent">Remove agent</a>
-                        </p>
                     </form>
+                </div>
+            </div>
+            <div class="govuk-grid-row">
+                <div class="govuk-grid-column-full">
+                    <p class="govuk-body"><a class="govuk-link" href="/appeals-service/appeal-details/1/service-user/remove/agent">Remove agent</a>
+                    </p>
                 </div>
             </div>
         </div>
@@ -910,9 +926,13 @@ exports[`service-user POST /change/:userType should re-render changeServiceUser 
                         </div>
                         <button type="submit" data-prevent-double-click="true" class="govuk-button"
                         data-module="govuk-button">Continue</button>
-                        <p class="govuk-body"><a class="govuk-link" href="/appeals-service/appeal-details/1/service-user/remove/agent">Remove agent</a>
-                        </p>
                     </form>
+                </div>
+            </div>
+            <div class="govuk-grid-row">
+                <div class="govuk-grid-column-full">
+                    <p class="govuk-body"><a class="govuk-link" href="/appeals-service/appeal-details/1/service-user/remove/agent">Remove agent</a>
+                    </p>
                 </div>
             </div>
         </div>
@@ -975,9 +995,13 @@ exports[`service-user POST /change/:userType should re-render changeServiceUser 
                         </div>
                         <button type="submit" data-prevent-double-click="true" class="govuk-button"
                         data-module="govuk-button">Continue</button>
-                        <p class="govuk-body"><a class="govuk-link" href="/appeals-service/appeal-details/1/service-user/remove/agent">Remove agent</a>
-                        </p>
                     </form>
+                </div>
+            </div>
+            <div class="govuk-grid-row">
+                <div class="govuk-grid-column-full">
+                    <p class="govuk-body"><a class="govuk-link" href="/appeals-service/appeal-details/1/service-user/remove/agent">Remove agent</a>
+                    </p>
                 </div>
             </div>
         </div>
@@ -1040,9 +1064,13 @@ exports[`service-user POST /change/:userType should re-render changeServiceUser 
                         </div>
                         <button type="submit" data-prevent-double-click="true" class="govuk-button"
                         data-module="govuk-button">Continue</button>
-                        <p class="govuk-body"><a class="govuk-link" href="/appeals-service/appeal-details/1/service-user/remove/agent">Remove agent</a>
-                        </p>
                     </form>
+                </div>
+            </div>
+            <div class="govuk-grid-row">
+                <div class="govuk-grid-column-full">
+                    <p class="govuk-body"><a class="govuk-link" href="/appeals-service/appeal-details/1/service-user/remove/agent">Remove agent</a>
+                    </p>
                 </div>
             </div>
         </div>
@@ -1106,9 +1134,13 @@ exports[`service-user POST /change/:userType should re-render changeServiceUser 
                         </div>
                         <button type="submit" data-prevent-double-click="true" class="govuk-button"
                         data-module="govuk-button">Continue</button>
-                        <p class="govuk-body"><a class="govuk-link" href="/appeals-service/appeal-details/1/service-user/remove/agent">Remove agent</a>
-                        </p>
                     </form>
+                </div>
+            </div>
+            <div class="govuk-grid-row">
+                <div class="govuk-grid-column-full">
+                    <p class="govuk-body"><a class="govuk-link" href="/appeals-service/appeal-details/1/service-user/remove/agent">Remove agent</a>
+                    </p>
                 </div>
             </div>
         </div>
@@ -1171,9 +1203,13 @@ exports[`service-user POST /change/:userType should re-render changeServiceUser 
                         </div>
                         <button type="submit" data-prevent-double-click="true" class="govuk-button"
                         data-module="govuk-button">Continue</button>
-                        <p class="govuk-body"><a class="govuk-link" href="/appeals-service/appeal-details/1/service-user/remove/agent">Remove agent</a>
-                        </p>
                     </form>
+                </div>
+            </div>
+            <div class="govuk-grid-row">
+                <div class="govuk-grid-column-full">
+                    <p class="govuk-body"><a class="govuk-link" href="/appeals-service/appeal-details/1/service-user/remove/agent">Remove agent</a>
+                    </p>
                 </div>
             </div>
         </div>
@@ -1236,9 +1272,13 @@ exports[`service-user POST /change/:userType should re-render changeServiceUser 
                         </div>
                         <button type="submit" data-prevent-double-click="true" class="govuk-button"
                         data-module="govuk-button">Continue</button>
-                        <p class="govuk-body"><a class="govuk-link" href="/appeals-service/appeal-details/1/service-user/remove/agent">Remove agent</a>
-                        </p>
                     </form>
+                </div>
+            </div>
+            <div class="govuk-grid-row">
+                <div class="govuk-grid-column-full">
+                    <p class="govuk-body"><a class="govuk-link" href="/appeals-service/appeal-details/1/service-user/remove/agent">Remove agent</a>
+                    </p>
                 </div>
             </div>
         </div>

--- a/appeals/web/src/server/appeals/appeal-details/site-visit/__tests__/__snapshots__/site-visit.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/site-visit/__tests__/__snapshots__/site-visit.test.js.snap
@@ -11,41 +11,45 @@ exports[`site-visit GET /site-visit/manage-visit should render the manage visit 
         <div class="govuk-grid-column-two-thirds">
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full">
+                    <details class="govuk-details">
+                        <summary class="govuk-details__summary"><span class="govuk-details__summary-text"> Site information</span>
+                        </summary>
+                        <div class="govuk-details__text">
+                            <dl class="govuk-summary-list govuk-summary-list--no-border">
+                                <div class="govuk-summary-list__row appeal-site-address"><dt class="govuk-summary-list__key"> Site address</dt>
+                                    <dd class="govuk-summary-list__value">21 The Pavement, Wandsworth, SW4 0HY</dd>
+                                </div>
+                                <div class="govuk-summary-list__row appeal-lpa-health-and-safety"><dt class="govuk-summary-list__key"> Potential safety risks (LPA answer)</dt>
+                                    <dd                                     class="govuk-summary-list__value"><span>No</span>
+                                        </dd>
+                                </div>
+                                <div class="govuk-summary-list__row appeal-appellant-health-and-safety"><dt class="govuk-summary-list__key"> Potential safety risks (appellant answer)</dt>
+                                    <dd                                     class="govuk-summary-list__value"><span>Yes</span>
+                                        <br><span>Dogs on site</span>
+                                        </dd>
+                                </div>
+                                <div class="govuk-summary-list__row appeal-neighbouring-sites-inspector"><dt class="govuk-summary-list__key"> Address of the neighbour’s land or property</dt>
+                                    <dd                                     class="govuk-summary-list__value">
+                                        <ul class="govuk-list govuk-list--bullet">
+                                            <li>1 Grove Cottage, Shotesham Road, Woodton, Devon, NR35 2ND</li>
+                                        </ul>
+                                        </dd>
+                                </div>
+                                <div class="govuk-summary-list__row appeal-neighbouring-sites-inspector"><dt class="govuk-summary-list__key"> Neighbouring sites (inspector and/or third party request)</dt>
+                                    <dd                                     class="govuk-summary-list__value">
+                                        <ul class="govuk-list govuk-list--bullet">
+                                            <li>2 Grove Cottage, Shotesham Road, Woodton, Devon, NR35 2ND</li>
+                                        </ul>
+                                        </dd>
+                                </div>
+                            </dl>
+                        </div>
+                    </details>
+                </div>
+            </div>
+            <div class="govuk-grid-row">
+                <div class="govuk-grid-column-full">
                     <form method="POST" novalidate="novalidate">
-                        <details class="govuk-details">
-                            <summary class="govuk-details__summary"><span class="govuk-details__summary-text"> Site information</span>
-                            </summary>
-                            <div class="govuk-details__text">
-                                <dl class="govuk-summary-list govuk-summary-list--no-border">
-                                    <div class="govuk-summary-list__row appeal-site-address"><dt class="govuk-summary-list__key"> Site address</dt>
-                                        <dd class="govuk-summary-list__value">21 The Pavement, Wandsworth, SW4 0HY</dd>
-                                    </div>
-                                    <div class="govuk-summary-list__row appeal-lpa-health-and-safety"><dt class="govuk-summary-list__key"> Potential safety risks (LPA answer)</dt>
-                                        <dd                                         class="govuk-summary-list__value"><span>No</span>
-                                            </dd>
-                                    </div>
-                                    <div class="govuk-summary-list__row appeal-appellant-health-and-safety"><dt class="govuk-summary-list__key"> Potential safety risks (appellant answer)</dt>
-                                        <dd                                         class="govuk-summary-list__value"><span>Yes</span>
-                                            <br><span>Dogs on site</span>
-                                            </dd>
-                                    </div>
-                                    <div class="govuk-summary-list__row appeal-neighbouring-sites-inspector"><dt class="govuk-summary-list__key"> Address of the neighbour’s land or property</dt>
-                                        <dd                                         class="govuk-summary-list__value">
-                                            <ul class="govuk-list govuk-list--bullet">
-                                                <li>1 Grove Cottage, Shotesham Road, Woodton, Devon, NR35 2ND</li>
-                                            </ul>
-                                            </dd>
-                                    </div>
-                                    <div class="govuk-summary-list__row appeal-neighbouring-sites-inspector"><dt class="govuk-summary-list__key"> Neighbouring sites (inspector and/or third party request)</dt>
-                                        <dd                                         class="govuk-summary-list__value">
-                                            <ul class="govuk-list govuk-list--bullet">
-                                                <li>2 Grove Cottage, Shotesham Road, Woodton, Devon, NR35 2ND</li>
-                                            </ul>
-                                            </dd>
-                                    </div>
-                                </dl>
-                            </div>
-                        </details>
                         <div class="govuk-form-group">
                             <fieldset class="govuk-fieldset">
                                 <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">Select visit type</legend>
@@ -139,41 +143,45 @@ exports[`site-visit GET /site-visit/schedule-visit should render the schedule vi
         <div class="govuk-grid-column-two-thirds">
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full">
+                    <details class="govuk-details">
+                        <summary class="govuk-details__summary"><span class="govuk-details__summary-text"> Site information</span>
+                        </summary>
+                        <div class="govuk-details__text">
+                            <dl class="govuk-summary-list govuk-summary-list--no-border">
+                                <div class="govuk-summary-list__row appeal-site-address"><dt class="govuk-summary-list__key"> Site address</dt>
+                                    <dd class="govuk-summary-list__value">21 The Pavement, Wandsworth, SW4 0HY</dd>
+                                </div>
+                                <div class="govuk-summary-list__row appeal-lpa-health-and-safety"><dt class="govuk-summary-list__key"> Potential safety risks (LPA answer)</dt>
+                                    <dd                                     class="govuk-summary-list__value"><span>No</span>
+                                        </dd>
+                                </div>
+                                <div class="govuk-summary-list__row appeal-appellant-health-and-safety"><dt class="govuk-summary-list__key"> Potential safety risks (appellant answer)</dt>
+                                    <dd                                     class="govuk-summary-list__value"><span>Yes</span>
+                                        <br><span>Dogs on site</span>
+                                        </dd>
+                                </div>
+                                <div class="govuk-summary-list__row appeal-neighbouring-sites-inspector"><dt class="govuk-summary-list__key"> Address of the neighbour’s land or property</dt>
+                                    <dd                                     class="govuk-summary-list__value">
+                                        <ul class="govuk-list govuk-list--bullet">
+                                            <li>1 Grove Cottage, Shotesham Road, Woodton, Devon, NR35 2ND</li>
+                                        </ul>
+                                        </dd>
+                                </div>
+                                <div class="govuk-summary-list__row appeal-neighbouring-sites-inspector"><dt class="govuk-summary-list__key"> Neighbouring sites (inspector and/or third party request)</dt>
+                                    <dd                                     class="govuk-summary-list__value">
+                                        <ul class="govuk-list govuk-list--bullet">
+                                            <li>2 Grove Cottage, Shotesham Road, Woodton, Devon, NR35 2ND</li>
+                                        </ul>
+                                        </dd>
+                                </div>
+                            </dl>
+                        </div>
+                    </details>
+                </div>
+            </div>
+            <div class="govuk-grid-row">
+                <div class="govuk-grid-column-full">
                     <form method="POST" novalidate="novalidate">
-                        <details class="govuk-details">
-                            <summary class="govuk-details__summary"><span class="govuk-details__summary-text"> Site information</span>
-                            </summary>
-                            <div class="govuk-details__text">
-                                <dl class="govuk-summary-list govuk-summary-list--no-border">
-                                    <div class="govuk-summary-list__row appeal-site-address"><dt class="govuk-summary-list__key"> Site address</dt>
-                                        <dd class="govuk-summary-list__value">21 The Pavement, Wandsworth, SW4 0HY</dd>
-                                    </div>
-                                    <div class="govuk-summary-list__row appeal-lpa-health-and-safety"><dt class="govuk-summary-list__key"> Potential safety risks (LPA answer)</dt>
-                                        <dd                                         class="govuk-summary-list__value"><span>No</span>
-                                            </dd>
-                                    </div>
-                                    <div class="govuk-summary-list__row appeal-appellant-health-and-safety"><dt class="govuk-summary-list__key"> Potential safety risks (appellant answer)</dt>
-                                        <dd                                         class="govuk-summary-list__value"><span>Yes</span>
-                                            <br><span>Dogs on site</span>
-                                            </dd>
-                                    </div>
-                                    <div class="govuk-summary-list__row appeal-neighbouring-sites-inspector"><dt class="govuk-summary-list__key"> Address of the neighbour’s land or property</dt>
-                                        <dd                                         class="govuk-summary-list__value">
-                                            <ul class="govuk-list govuk-list--bullet">
-                                                <li>1 Grove Cottage, Shotesham Road, Woodton, Devon, NR35 2ND</li>
-                                            </ul>
-                                            </dd>
-                                    </div>
-                                    <div class="govuk-summary-list__row appeal-neighbouring-sites-inspector"><dt class="govuk-summary-list__key"> Neighbouring sites (inspector and/or third party request)</dt>
-                                        <dd                                         class="govuk-summary-list__value">
-                                            <ul class="govuk-list govuk-list--bullet">
-                                                <li>2 Grove Cottage, Shotesham Road, Woodton, Devon, NR35 2ND</li>
-                                            </ul>
-                                            </dd>
-                                    </div>
-                                </dl>
-                            </div>
-                        </details>
                         <div class="govuk-form-group">
                             <fieldset class="govuk-fieldset">
                                 <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">Select visit type</legend>
@@ -362,41 +370,45 @@ exports[`site-visit POST /site-visit/manage-visit should re-render the manage vi
         <div class="govuk-grid-column-two-thirds">
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full">
+                    <details class="govuk-details">
+                        <summary class="govuk-details__summary"><span class="govuk-details__summary-text"> Site information</span>
+                        </summary>
+                        <div class="govuk-details__text">
+                            <dl class="govuk-summary-list govuk-summary-list--no-border">
+                                <div class="govuk-summary-list__row appeal-site-address"><dt class="govuk-summary-list__key"> Site address</dt>
+                                    <dd class="govuk-summary-list__value">21 The Pavement, Wandsworth, SW4 0HY</dd>
+                                </div>
+                                <div class="govuk-summary-list__row appeal-lpa-health-and-safety"><dt class="govuk-summary-list__key"> Potential safety risks (LPA answer)</dt>
+                                    <dd                                     class="govuk-summary-list__value"><span>No</span>
+                                        </dd>
+                                </div>
+                                <div class="govuk-summary-list__row appeal-appellant-health-and-safety"><dt class="govuk-summary-list__key"> Potential safety risks (appellant answer)</dt>
+                                    <dd                                     class="govuk-summary-list__value"><span>Yes</span>
+                                        <br><span>Dogs on site</span>
+                                        </dd>
+                                </div>
+                                <div class="govuk-summary-list__row appeal-neighbouring-sites-inspector"><dt class="govuk-summary-list__key"> Address of the neighbour’s land or property</dt>
+                                    <dd                                     class="govuk-summary-list__value">
+                                        <ul class="govuk-list govuk-list--bullet">
+                                            <li>1 Grove Cottage, Shotesham Road, Woodton, Devon, NR35 2ND</li>
+                                        </ul>
+                                        </dd>
+                                </div>
+                                <div class="govuk-summary-list__row appeal-neighbouring-sites-inspector"><dt class="govuk-summary-list__key"> Neighbouring sites (inspector and/or third party request)</dt>
+                                    <dd                                     class="govuk-summary-list__value">
+                                        <ul class="govuk-list govuk-list--bullet">
+                                            <li>2 Grove Cottage, Shotesham Road, Woodton, Devon, NR35 2ND</li>
+                                        </ul>
+                                        </dd>
+                                </div>
+                            </dl>
+                        </div>
+                    </details>
+                </div>
+            </div>
+            <div class="govuk-grid-row">
+                <div class="govuk-grid-column-full">
                     <form method="POST" novalidate="novalidate">
-                        <details class="govuk-details">
-                            <summary class="govuk-details__summary"><span class="govuk-details__summary-text"> Site information</span>
-                            </summary>
-                            <div class="govuk-details__text">
-                                <dl class="govuk-summary-list govuk-summary-list--no-border">
-                                    <div class="govuk-summary-list__row appeal-site-address"><dt class="govuk-summary-list__key"> Site address</dt>
-                                        <dd class="govuk-summary-list__value">21 The Pavement, Wandsworth, SW4 0HY</dd>
-                                    </div>
-                                    <div class="govuk-summary-list__row appeal-lpa-health-and-safety"><dt class="govuk-summary-list__key"> Potential safety risks (LPA answer)</dt>
-                                        <dd                                         class="govuk-summary-list__value"><span>No</span>
-                                            </dd>
-                                    </div>
-                                    <div class="govuk-summary-list__row appeal-appellant-health-and-safety"><dt class="govuk-summary-list__key"> Potential safety risks (appellant answer)</dt>
-                                        <dd                                         class="govuk-summary-list__value"><span>Yes</span>
-                                            <br><span>Dogs on site</span>
-                                            </dd>
-                                    </div>
-                                    <div class="govuk-summary-list__row appeal-neighbouring-sites-inspector"><dt class="govuk-summary-list__key"> Address of the neighbour’s land or property</dt>
-                                        <dd                                         class="govuk-summary-list__value">
-                                            <ul class="govuk-list govuk-list--bullet">
-                                                <li>1 Grove Cottage, Shotesham Road, Woodton, Devon, NR35 2ND</li>
-                                            </ul>
-                                            </dd>
-                                    </div>
-                                    <div class="govuk-summary-list__row appeal-neighbouring-sites-inspector"><dt class="govuk-summary-list__key"> Neighbouring sites (inspector and/or third party request)</dt>
-                                        <dd                                         class="govuk-summary-list__value">
-                                            <ul class="govuk-list govuk-list--bullet">
-                                                <li>2 Grove Cottage, Shotesham Road, Woodton, Devon, NR35 2ND</li>
-                                            </ul>
-                                            </dd>
-                                    </div>
-                                </dl>
-                            </div>
-                        </details>
                         <div class="govuk-form-group">
                             <fieldset class="govuk-fieldset">
                                 <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">Select visit type</legend>
@@ -505,41 +517,45 @@ exports[`site-visit POST /site-visit/manage-visit should re-render the manage vi
         <div class="govuk-grid-column-two-thirds">
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full">
+                    <details class="govuk-details">
+                        <summary class="govuk-details__summary"><span class="govuk-details__summary-text"> Site information</span>
+                        </summary>
+                        <div class="govuk-details__text">
+                            <dl class="govuk-summary-list govuk-summary-list--no-border">
+                                <div class="govuk-summary-list__row appeal-site-address"><dt class="govuk-summary-list__key"> Site address</dt>
+                                    <dd class="govuk-summary-list__value">21 The Pavement, Wandsworth, SW4 0HY</dd>
+                                </div>
+                                <div class="govuk-summary-list__row appeal-lpa-health-and-safety"><dt class="govuk-summary-list__key"> Potential safety risks (LPA answer)</dt>
+                                    <dd                                     class="govuk-summary-list__value"><span>No</span>
+                                        </dd>
+                                </div>
+                                <div class="govuk-summary-list__row appeal-appellant-health-and-safety"><dt class="govuk-summary-list__key"> Potential safety risks (appellant answer)</dt>
+                                    <dd                                     class="govuk-summary-list__value"><span>Yes</span>
+                                        <br><span>Dogs on site</span>
+                                        </dd>
+                                </div>
+                                <div class="govuk-summary-list__row appeal-neighbouring-sites-inspector"><dt class="govuk-summary-list__key"> Address of the neighbour’s land or property</dt>
+                                    <dd                                     class="govuk-summary-list__value">
+                                        <ul class="govuk-list govuk-list--bullet">
+                                            <li>1 Grove Cottage, Shotesham Road, Woodton, Devon, NR35 2ND</li>
+                                        </ul>
+                                        </dd>
+                                </div>
+                                <div class="govuk-summary-list__row appeal-neighbouring-sites-inspector"><dt class="govuk-summary-list__key"> Neighbouring sites (inspector and/or third party request)</dt>
+                                    <dd                                     class="govuk-summary-list__value">
+                                        <ul class="govuk-list govuk-list--bullet">
+                                            <li>2 Grove Cottage, Shotesham Road, Woodton, Devon, NR35 2ND</li>
+                                        </ul>
+                                        </dd>
+                                </div>
+                            </dl>
+                        </div>
+                    </details>
+                </div>
+            </div>
+            <div class="govuk-grid-row">
+                <div class="govuk-grid-column-full">
                     <form method="POST" novalidate="novalidate">
-                        <details class="govuk-details">
-                            <summary class="govuk-details__summary"><span class="govuk-details__summary-text"> Site information</span>
-                            </summary>
-                            <div class="govuk-details__text">
-                                <dl class="govuk-summary-list govuk-summary-list--no-border">
-                                    <div class="govuk-summary-list__row appeal-site-address"><dt class="govuk-summary-list__key"> Site address</dt>
-                                        <dd class="govuk-summary-list__value">21 The Pavement, Wandsworth, SW4 0HY</dd>
-                                    </div>
-                                    <div class="govuk-summary-list__row appeal-lpa-health-and-safety"><dt class="govuk-summary-list__key"> Potential safety risks (LPA answer)</dt>
-                                        <dd                                         class="govuk-summary-list__value"><span>No</span>
-                                            </dd>
-                                    </div>
-                                    <div class="govuk-summary-list__row appeal-appellant-health-and-safety"><dt class="govuk-summary-list__key"> Potential safety risks (appellant answer)</dt>
-                                        <dd                                         class="govuk-summary-list__value"><span>Yes</span>
-                                            <br><span>Dogs on site</span>
-                                            </dd>
-                                    </div>
-                                    <div class="govuk-summary-list__row appeal-neighbouring-sites-inspector"><dt class="govuk-summary-list__key"> Address of the neighbour’s land or property</dt>
-                                        <dd                                         class="govuk-summary-list__value">
-                                            <ul class="govuk-list govuk-list--bullet">
-                                                <li>1 Grove Cottage, Shotesham Road, Woodton, Devon, NR35 2ND</li>
-                                            </ul>
-                                            </dd>
-                                    </div>
-                                    <div class="govuk-summary-list__row appeal-neighbouring-sites-inspector"><dt class="govuk-summary-list__key"> Neighbouring sites (inspector and/or third party request)</dt>
-                                        <dd                                         class="govuk-summary-list__value">
-                                            <ul class="govuk-list govuk-list--bullet">
-                                                <li>2 Grove Cottage, Shotesham Road, Woodton, Devon, NR35 2ND</li>
-                                            </ul>
-                                            </dd>
-                                    </div>
-                                </dl>
-                            </div>
-                        </details>
                         <div class="govuk-form-group">
                             <fieldset class="govuk-fieldset">
                                 <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">Select visit type</legend>
@@ -650,41 +666,45 @@ exports[`site-visit POST /site-visit/manage-visit should re-render the manage vi
         <div class="govuk-grid-column-two-thirds">
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full">
+                    <details class="govuk-details">
+                        <summary class="govuk-details__summary"><span class="govuk-details__summary-text"> Site information</span>
+                        </summary>
+                        <div class="govuk-details__text">
+                            <dl class="govuk-summary-list govuk-summary-list--no-border">
+                                <div class="govuk-summary-list__row appeal-site-address"><dt class="govuk-summary-list__key"> Site address</dt>
+                                    <dd class="govuk-summary-list__value">21 The Pavement, Wandsworth, SW4 0HY</dd>
+                                </div>
+                                <div class="govuk-summary-list__row appeal-lpa-health-and-safety"><dt class="govuk-summary-list__key"> Potential safety risks (LPA answer)</dt>
+                                    <dd                                     class="govuk-summary-list__value"><span>No</span>
+                                        </dd>
+                                </div>
+                                <div class="govuk-summary-list__row appeal-appellant-health-and-safety"><dt class="govuk-summary-list__key"> Potential safety risks (appellant answer)</dt>
+                                    <dd                                     class="govuk-summary-list__value"><span>Yes</span>
+                                        <br><span>Dogs on site</span>
+                                        </dd>
+                                </div>
+                                <div class="govuk-summary-list__row appeal-neighbouring-sites-inspector"><dt class="govuk-summary-list__key"> Address of the neighbour’s land or property</dt>
+                                    <dd                                     class="govuk-summary-list__value">
+                                        <ul class="govuk-list govuk-list--bullet">
+                                            <li>1 Grove Cottage, Shotesham Road, Woodton, Devon, NR35 2ND</li>
+                                        </ul>
+                                        </dd>
+                                </div>
+                                <div class="govuk-summary-list__row appeal-neighbouring-sites-inspector"><dt class="govuk-summary-list__key"> Neighbouring sites (inspector and/or third party request)</dt>
+                                    <dd                                     class="govuk-summary-list__value">
+                                        <ul class="govuk-list govuk-list--bullet">
+                                            <li>2 Grove Cottage, Shotesham Road, Woodton, Devon, NR35 2ND</li>
+                                        </ul>
+                                        </dd>
+                                </div>
+                            </dl>
+                        </div>
+                    </details>
+                </div>
+            </div>
+            <div class="govuk-grid-row">
+                <div class="govuk-grid-column-full">
                     <form method="POST" novalidate="novalidate">
-                        <details class="govuk-details">
-                            <summary class="govuk-details__summary"><span class="govuk-details__summary-text"> Site information</span>
-                            </summary>
-                            <div class="govuk-details__text">
-                                <dl class="govuk-summary-list govuk-summary-list--no-border">
-                                    <div class="govuk-summary-list__row appeal-site-address"><dt class="govuk-summary-list__key"> Site address</dt>
-                                        <dd class="govuk-summary-list__value">21 The Pavement, Wandsworth, SW4 0HY</dd>
-                                    </div>
-                                    <div class="govuk-summary-list__row appeal-lpa-health-and-safety"><dt class="govuk-summary-list__key"> Potential safety risks (LPA answer)</dt>
-                                        <dd                                         class="govuk-summary-list__value"><span>No</span>
-                                            </dd>
-                                    </div>
-                                    <div class="govuk-summary-list__row appeal-appellant-health-and-safety"><dt class="govuk-summary-list__key"> Potential safety risks (appellant answer)</dt>
-                                        <dd                                         class="govuk-summary-list__value"><span>Yes</span>
-                                            <br><span>Dogs on site</span>
-                                            </dd>
-                                    </div>
-                                    <div class="govuk-summary-list__row appeal-neighbouring-sites-inspector"><dt class="govuk-summary-list__key"> Address of the neighbour’s land or property</dt>
-                                        <dd                                         class="govuk-summary-list__value">
-                                            <ul class="govuk-list govuk-list--bullet">
-                                                <li>1 Grove Cottage, Shotesham Road, Woodton, Devon, NR35 2ND</li>
-                                            </ul>
-                                            </dd>
-                                    </div>
-                                    <div class="govuk-summary-list__row appeal-neighbouring-sites-inspector"><dt class="govuk-summary-list__key"> Neighbouring sites (inspector and/or third party request)</dt>
-                                        <dd                                         class="govuk-summary-list__value">
-                                            <ul class="govuk-list govuk-list--bullet">
-                                                <li>2 Grove Cottage, Shotesham Road, Woodton, Devon, NR35 2ND</li>
-                                            </ul>
-                                            </dd>
-                                    </div>
-                                </dl>
-                            </div>
-                        </details>
                         <div class="govuk-form-group">
                             <fieldset class="govuk-fieldset">
                                 <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">Select visit type</legend>
@@ -795,41 +815,45 @@ exports[`site-visit POST /site-visit/manage-visit should re-render the manage vi
         <div class="govuk-grid-column-two-thirds">
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full">
+                    <details class="govuk-details">
+                        <summary class="govuk-details__summary"><span class="govuk-details__summary-text"> Site information</span>
+                        </summary>
+                        <div class="govuk-details__text">
+                            <dl class="govuk-summary-list govuk-summary-list--no-border">
+                                <div class="govuk-summary-list__row appeal-site-address"><dt class="govuk-summary-list__key"> Site address</dt>
+                                    <dd class="govuk-summary-list__value">21 The Pavement, Wandsworth, SW4 0HY</dd>
+                                </div>
+                                <div class="govuk-summary-list__row appeal-lpa-health-and-safety"><dt class="govuk-summary-list__key"> Potential safety risks (LPA answer)</dt>
+                                    <dd                                     class="govuk-summary-list__value"><span>No</span>
+                                        </dd>
+                                </div>
+                                <div class="govuk-summary-list__row appeal-appellant-health-and-safety"><dt class="govuk-summary-list__key"> Potential safety risks (appellant answer)</dt>
+                                    <dd                                     class="govuk-summary-list__value"><span>Yes</span>
+                                        <br><span>Dogs on site</span>
+                                        </dd>
+                                </div>
+                                <div class="govuk-summary-list__row appeal-neighbouring-sites-inspector"><dt class="govuk-summary-list__key"> Address of the neighbour’s land or property</dt>
+                                    <dd                                     class="govuk-summary-list__value">
+                                        <ul class="govuk-list govuk-list--bullet">
+                                            <li>1 Grove Cottage, Shotesham Road, Woodton, Devon, NR35 2ND</li>
+                                        </ul>
+                                        </dd>
+                                </div>
+                                <div class="govuk-summary-list__row appeal-neighbouring-sites-inspector"><dt class="govuk-summary-list__key"> Neighbouring sites (inspector and/or third party request)</dt>
+                                    <dd                                     class="govuk-summary-list__value">
+                                        <ul class="govuk-list govuk-list--bullet">
+                                            <li>2 Grove Cottage, Shotesham Road, Woodton, Devon, NR35 2ND</li>
+                                        </ul>
+                                        </dd>
+                                </div>
+                            </dl>
+                        </div>
+                    </details>
+                </div>
+            </div>
+            <div class="govuk-grid-row">
+                <div class="govuk-grid-column-full">
                     <form method="POST" novalidate="novalidate">
-                        <details class="govuk-details">
-                            <summary class="govuk-details__summary"><span class="govuk-details__summary-text"> Site information</span>
-                            </summary>
-                            <div class="govuk-details__text">
-                                <dl class="govuk-summary-list govuk-summary-list--no-border">
-                                    <div class="govuk-summary-list__row appeal-site-address"><dt class="govuk-summary-list__key"> Site address</dt>
-                                        <dd class="govuk-summary-list__value">21 The Pavement, Wandsworth, SW4 0HY</dd>
-                                    </div>
-                                    <div class="govuk-summary-list__row appeal-lpa-health-and-safety"><dt class="govuk-summary-list__key"> Potential safety risks (LPA answer)</dt>
-                                        <dd                                         class="govuk-summary-list__value"><span>No</span>
-                                            </dd>
-                                    </div>
-                                    <div class="govuk-summary-list__row appeal-appellant-health-and-safety"><dt class="govuk-summary-list__key"> Potential safety risks (appellant answer)</dt>
-                                        <dd                                         class="govuk-summary-list__value"><span>Yes</span>
-                                            <br><span>Dogs on site</span>
-                                            </dd>
-                                    </div>
-                                    <div class="govuk-summary-list__row appeal-neighbouring-sites-inspector"><dt class="govuk-summary-list__key"> Address of the neighbour’s land or property</dt>
-                                        <dd                                         class="govuk-summary-list__value">
-                                            <ul class="govuk-list govuk-list--bullet">
-                                                <li>1 Grove Cottage, Shotesham Road, Woodton, Devon, NR35 2ND</li>
-                                            </ul>
-                                            </dd>
-                                    </div>
-                                    <div class="govuk-summary-list__row appeal-neighbouring-sites-inspector"><dt class="govuk-summary-list__key"> Neighbouring sites (inspector and/or third party request)</dt>
-                                        <dd                                         class="govuk-summary-list__value">
-                                            <ul class="govuk-list govuk-list--bullet">
-                                                <li>2 Grove Cottage, Shotesham Road, Woodton, Devon, NR35 2ND</li>
-                                            </ul>
-                                            </dd>
-                                    </div>
-                                </dl>
-                            </div>
-                        </details>
                         <div class="govuk-form-group">
                             <fieldset class="govuk-fieldset">
                                 <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">Select visit type</legend>
@@ -940,41 +964,45 @@ exports[`site-visit POST /site-visit/manage-visit should re-render the manage vi
         <div class="govuk-grid-column-two-thirds">
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full">
+                    <details class="govuk-details">
+                        <summary class="govuk-details__summary"><span class="govuk-details__summary-text"> Site information</span>
+                        </summary>
+                        <div class="govuk-details__text">
+                            <dl class="govuk-summary-list govuk-summary-list--no-border">
+                                <div class="govuk-summary-list__row appeal-site-address"><dt class="govuk-summary-list__key"> Site address</dt>
+                                    <dd class="govuk-summary-list__value">21 The Pavement, Wandsworth, SW4 0HY</dd>
+                                </div>
+                                <div class="govuk-summary-list__row appeal-lpa-health-and-safety"><dt class="govuk-summary-list__key"> Potential safety risks (LPA answer)</dt>
+                                    <dd                                     class="govuk-summary-list__value"><span>No</span>
+                                        </dd>
+                                </div>
+                                <div class="govuk-summary-list__row appeal-appellant-health-and-safety"><dt class="govuk-summary-list__key"> Potential safety risks (appellant answer)</dt>
+                                    <dd                                     class="govuk-summary-list__value"><span>Yes</span>
+                                        <br><span>Dogs on site</span>
+                                        </dd>
+                                </div>
+                                <div class="govuk-summary-list__row appeal-neighbouring-sites-inspector"><dt class="govuk-summary-list__key"> Address of the neighbour’s land or property</dt>
+                                    <dd                                     class="govuk-summary-list__value">
+                                        <ul class="govuk-list govuk-list--bullet">
+                                            <li>1 Grove Cottage, Shotesham Road, Woodton, Devon, NR35 2ND</li>
+                                        </ul>
+                                        </dd>
+                                </div>
+                                <div class="govuk-summary-list__row appeal-neighbouring-sites-inspector"><dt class="govuk-summary-list__key"> Neighbouring sites (inspector and/or third party request)</dt>
+                                    <dd                                     class="govuk-summary-list__value">
+                                        <ul class="govuk-list govuk-list--bullet">
+                                            <li>2 Grove Cottage, Shotesham Road, Woodton, Devon, NR35 2ND</li>
+                                        </ul>
+                                        </dd>
+                                </div>
+                            </dl>
+                        </div>
+                    </details>
+                </div>
+            </div>
+            <div class="govuk-grid-row">
+                <div class="govuk-grid-column-full">
                     <form method="POST" novalidate="novalidate">
-                        <details class="govuk-details">
-                            <summary class="govuk-details__summary"><span class="govuk-details__summary-text"> Site information</span>
-                            </summary>
-                            <div class="govuk-details__text">
-                                <dl class="govuk-summary-list govuk-summary-list--no-border">
-                                    <div class="govuk-summary-list__row appeal-site-address"><dt class="govuk-summary-list__key"> Site address</dt>
-                                        <dd class="govuk-summary-list__value">21 The Pavement, Wandsworth, SW4 0HY</dd>
-                                    </div>
-                                    <div class="govuk-summary-list__row appeal-lpa-health-and-safety"><dt class="govuk-summary-list__key"> Potential safety risks (LPA answer)</dt>
-                                        <dd                                         class="govuk-summary-list__value"><span>No</span>
-                                            </dd>
-                                    </div>
-                                    <div class="govuk-summary-list__row appeal-appellant-health-and-safety"><dt class="govuk-summary-list__key"> Potential safety risks (appellant answer)</dt>
-                                        <dd                                         class="govuk-summary-list__value"><span>Yes</span>
-                                            <br><span>Dogs on site</span>
-                                            </dd>
-                                    </div>
-                                    <div class="govuk-summary-list__row appeal-neighbouring-sites-inspector"><dt class="govuk-summary-list__key"> Address of the neighbour’s land or property</dt>
-                                        <dd                                         class="govuk-summary-list__value">
-                                            <ul class="govuk-list govuk-list--bullet">
-                                                <li>1 Grove Cottage, Shotesham Road, Woodton, Devon, NR35 2ND</li>
-                                            </ul>
-                                            </dd>
-                                    </div>
-                                    <div class="govuk-summary-list__row appeal-neighbouring-sites-inspector"><dt class="govuk-summary-list__key"> Neighbouring sites (inspector and/or third party request)</dt>
-                                        <dd                                         class="govuk-summary-list__value">
-                                            <ul class="govuk-list govuk-list--bullet">
-                                                <li>2 Grove Cottage, Shotesham Road, Woodton, Devon, NR35 2ND</li>
-                                            </ul>
-                                            </dd>
-                                    </div>
-                                </dl>
-                            </div>
-                        </details>
                         <div class="govuk-form-group">
                             <fieldset class="govuk-fieldset">
                                 <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">Select visit type</legend>
@@ -1085,41 +1113,45 @@ exports[`site-visit POST /site-visit/manage-visit should re-render the manage vi
         <div class="govuk-grid-column-two-thirds">
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full">
+                    <details class="govuk-details">
+                        <summary class="govuk-details__summary"><span class="govuk-details__summary-text"> Site information</span>
+                        </summary>
+                        <div class="govuk-details__text">
+                            <dl class="govuk-summary-list govuk-summary-list--no-border">
+                                <div class="govuk-summary-list__row appeal-site-address"><dt class="govuk-summary-list__key"> Site address</dt>
+                                    <dd class="govuk-summary-list__value">21 The Pavement, Wandsworth, SW4 0HY</dd>
+                                </div>
+                                <div class="govuk-summary-list__row appeal-lpa-health-and-safety"><dt class="govuk-summary-list__key"> Potential safety risks (LPA answer)</dt>
+                                    <dd                                     class="govuk-summary-list__value"><span>No</span>
+                                        </dd>
+                                </div>
+                                <div class="govuk-summary-list__row appeal-appellant-health-and-safety"><dt class="govuk-summary-list__key"> Potential safety risks (appellant answer)</dt>
+                                    <dd                                     class="govuk-summary-list__value"><span>Yes</span>
+                                        <br><span>Dogs on site</span>
+                                        </dd>
+                                </div>
+                                <div class="govuk-summary-list__row appeal-neighbouring-sites-inspector"><dt class="govuk-summary-list__key"> Address of the neighbour’s land or property</dt>
+                                    <dd                                     class="govuk-summary-list__value">
+                                        <ul class="govuk-list govuk-list--bullet">
+                                            <li>1 Grove Cottage, Shotesham Road, Woodton, Devon, NR35 2ND</li>
+                                        </ul>
+                                        </dd>
+                                </div>
+                                <div class="govuk-summary-list__row appeal-neighbouring-sites-inspector"><dt class="govuk-summary-list__key"> Neighbouring sites (inspector and/or third party request)</dt>
+                                    <dd                                     class="govuk-summary-list__value">
+                                        <ul class="govuk-list govuk-list--bullet">
+                                            <li>2 Grove Cottage, Shotesham Road, Woodton, Devon, NR35 2ND</li>
+                                        </ul>
+                                        </dd>
+                                </div>
+                            </dl>
+                        </div>
+                    </details>
+                </div>
+            </div>
+            <div class="govuk-grid-row">
+                <div class="govuk-grid-column-full">
                     <form method="POST" novalidate="novalidate">
-                        <details class="govuk-details">
-                            <summary class="govuk-details__summary"><span class="govuk-details__summary-text"> Site information</span>
-                            </summary>
-                            <div class="govuk-details__text">
-                                <dl class="govuk-summary-list govuk-summary-list--no-border">
-                                    <div class="govuk-summary-list__row appeal-site-address"><dt class="govuk-summary-list__key"> Site address</dt>
-                                        <dd class="govuk-summary-list__value">21 The Pavement, Wandsworth, SW4 0HY</dd>
-                                    </div>
-                                    <div class="govuk-summary-list__row appeal-lpa-health-and-safety"><dt class="govuk-summary-list__key"> Potential safety risks (LPA answer)</dt>
-                                        <dd                                         class="govuk-summary-list__value"><span>No</span>
-                                            </dd>
-                                    </div>
-                                    <div class="govuk-summary-list__row appeal-appellant-health-and-safety"><dt class="govuk-summary-list__key"> Potential safety risks (appellant answer)</dt>
-                                        <dd                                         class="govuk-summary-list__value"><span>Yes</span>
-                                            <br><span>Dogs on site</span>
-                                            </dd>
-                                    </div>
-                                    <div class="govuk-summary-list__row appeal-neighbouring-sites-inspector"><dt class="govuk-summary-list__key"> Address of the neighbour’s land or property</dt>
-                                        <dd                                         class="govuk-summary-list__value">
-                                            <ul class="govuk-list govuk-list--bullet">
-                                                <li>1 Grove Cottage, Shotesham Road, Woodton, Devon, NR35 2ND</li>
-                                            </ul>
-                                            </dd>
-                                    </div>
-                                    <div class="govuk-summary-list__row appeal-neighbouring-sites-inspector"><dt class="govuk-summary-list__key"> Neighbouring sites (inspector and/or third party request)</dt>
-                                        <dd                                         class="govuk-summary-list__value">
-                                            <ul class="govuk-list govuk-list--bullet">
-                                                <li>2 Grove Cottage, Shotesham Road, Woodton, Devon, NR35 2ND</li>
-                                            </ul>
-                                            </dd>
-                                    </div>
-                                </dl>
-                            </div>
-                        </details>
                         <div class="govuk-form-group">
                             <fieldset class="govuk-fieldset">
                                 <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">Select visit type</legend>
@@ -1230,41 +1262,45 @@ exports[`site-visit POST /site-visit/manage-visit should re-render the manage vi
         <div class="govuk-grid-column-two-thirds">
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full">
+                    <details class="govuk-details">
+                        <summary class="govuk-details__summary"><span class="govuk-details__summary-text"> Site information</span>
+                        </summary>
+                        <div class="govuk-details__text">
+                            <dl class="govuk-summary-list govuk-summary-list--no-border">
+                                <div class="govuk-summary-list__row appeal-site-address"><dt class="govuk-summary-list__key"> Site address</dt>
+                                    <dd class="govuk-summary-list__value">21 The Pavement, Wandsworth, SW4 0HY</dd>
+                                </div>
+                                <div class="govuk-summary-list__row appeal-lpa-health-and-safety"><dt class="govuk-summary-list__key"> Potential safety risks (LPA answer)</dt>
+                                    <dd                                     class="govuk-summary-list__value"><span>No</span>
+                                        </dd>
+                                </div>
+                                <div class="govuk-summary-list__row appeal-appellant-health-and-safety"><dt class="govuk-summary-list__key"> Potential safety risks (appellant answer)</dt>
+                                    <dd                                     class="govuk-summary-list__value"><span>Yes</span>
+                                        <br><span>Dogs on site</span>
+                                        </dd>
+                                </div>
+                                <div class="govuk-summary-list__row appeal-neighbouring-sites-inspector"><dt class="govuk-summary-list__key"> Address of the neighbour’s land or property</dt>
+                                    <dd                                     class="govuk-summary-list__value">
+                                        <ul class="govuk-list govuk-list--bullet">
+                                            <li>1 Grove Cottage, Shotesham Road, Woodton, Devon, NR35 2ND</li>
+                                        </ul>
+                                        </dd>
+                                </div>
+                                <div class="govuk-summary-list__row appeal-neighbouring-sites-inspector"><dt class="govuk-summary-list__key"> Neighbouring sites (inspector and/or third party request)</dt>
+                                    <dd                                     class="govuk-summary-list__value">
+                                        <ul class="govuk-list govuk-list--bullet">
+                                            <li>2 Grove Cottage, Shotesham Road, Woodton, Devon, NR35 2ND</li>
+                                        </ul>
+                                        </dd>
+                                </div>
+                            </dl>
+                        </div>
+                    </details>
+                </div>
+            </div>
+            <div class="govuk-grid-row">
+                <div class="govuk-grid-column-full">
                     <form method="POST" novalidate="novalidate">
-                        <details class="govuk-details">
-                            <summary class="govuk-details__summary"><span class="govuk-details__summary-text"> Site information</span>
-                            </summary>
-                            <div class="govuk-details__text">
-                                <dl class="govuk-summary-list govuk-summary-list--no-border">
-                                    <div class="govuk-summary-list__row appeal-site-address"><dt class="govuk-summary-list__key"> Site address</dt>
-                                        <dd class="govuk-summary-list__value">21 The Pavement, Wandsworth, SW4 0HY</dd>
-                                    </div>
-                                    <div class="govuk-summary-list__row appeal-lpa-health-and-safety"><dt class="govuk-summary-list__key"> Potential safety risks (LPA answer)</dt>
-                                        <dd                                         class="govuk-summary-list__value"><span>No</span>
-                                            </dd>
-                                    </div>
-                                    <div class="govuk-summary-list__row appeal-appellant-health-and-safety"><dt class="govuk-summary-list__key"> Potential safety risks (appellant answer)</dt>
-                                        <dd                                         class="govuk-summary-list__value"><span>Yes</span>
-                                            <br><span>Dogs on site</span>
-                                            </dd>
-                                    </div>
-                                    <div class="govuk-summary-list__row appeal-neighbouring-sites-inspector"><dt class="govuk-summary-list__key"> Address of the neighbour’s land or property</dt>
-                                        <dd                                         class="govuk-summary-list__value">
-                                            <ul class="govuk-list govuk-list--bullet">
-                                                <li>1 Grove Cottage, Shotesham Road, Woodton, Devon, NR35 2ND</li>
-                                            </ul>
-                                            </dd>
-                                    </div>
-                                    <div class="govuk-summary-list__row appeal-neighbouring-sites-inspector"><dt class="govuk-summary-list__key"> Neighbouring sites (inspector and/or third party request)</dt>
-                                        <dd                                         class="govuk-summary-list__value">
-                                            <ul class="govuk-list govuk-list--bullet">
-                                                <li>2 Grove Cottage, Shotesham Road, Woodton, Devon, NR35 2ND</li>
-                                            </ul>
-                                            </dd>
-                                    </div>
-                                </dl>
-                            </div>
-                        </details>
                         <div class="govuk-form-group">
                             <fieldset class="govuk-fieldset">
                                 <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">Select visit type</legend>
@@ -1375,41 +1411,45 @@ exports[`site-visit POST /site-visit/manage-visit should re-render the manage vi
         <div class="govuk-grid-column-two-thirds">
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full">
+                    <details class="govuk-details">
+                        <summary class="govuk-details__summary"><span class="govuk-details__summary-text"> Site information</span>
+                        </summary>
+                        <div class="govuk-details__text">
+                            <dl class="govuk-summary-list govuk-summary-list--no-border">
+                                <div class="govuk-summary-list__row appeal-site-address"><dt class="govuk-summary-list__key"> Site address</dt>
+                                    <dd class="govuk-summary-list__value">21 The Pavement, Wandsworth, SW4 0HY</dd>
+                                </div>
+                                <div class="govuk-summary-list__row appeal-lpa-health-and-safety"><dt class="govuk-summary-list__key"> Potential safety risks (LPA answer)</dt>
+                                    <dd                                     class="govuk-summary-list__value"><span>No</span>
+                                        </dd>
+                                </div>
+                                <div class="govuk-summary-list__row appeal-appellant-health-and-safety"><dt class="govuk-summary-list__key"> Potential safety risks (appellant answer)</dt>
+                                    <dd                                     class="govuk-summary-list__value"><span>Yes</span>
+                                        <br><span>Dogs on site</span>
+                                        </dd>
+                                </div>
+                                <div class="govuk-summary-list__row appeal-neighbouring-sites-inspector"><dt class="govuk-summary-list__key"> Address of the neighbour’s land or property</dt>
+                                    <dd                                     class="govuk-summary-list__value">
+                                        <ul class="govuk-list govuk-list--bullet">
+                                            <li>1 Grove Cottage, Shotesham Road, Woodton, Devon, NR35 2ND</li>
+                                        </ul>
+                                        </dd>
+                                </div>
+                                <div class="govuk-summary-list__row appeal-neighbouring-sites-inspector"><dt class="govuk-summary-list__key"> Neighbouring sites (inspector and/or third party request)</dt>
+                                    <dd                                     class="govuk-summary-list__value">
+                                        <ul class="govuk-list govuk-list--bullet">
+                                            <li>2 Grove Cottage, Shotesham Road, Woodton, Devon, NR35 2ND</li>
+                                        </ul>
+                                        </dd>
+                                </div>
+                            </dl>
+                        </div>
+                    </details>
+                </div>
+            </div>
+            <div class="govuk-grid-row">
+                <div class="govuk-grid-column-full">
                     <form method="POST" novalidate="novalidate">
-                        <details class="govuk-details">
-                            <summary class="govuk-details__summary"><span class="govuk-details__summary-text"> Site information</span>
-                            </summary>
-                            <div class="govuk-details__text">
-                                <dl class="govuk-summary-list govuk-summary-list--no-border">
-                                    <div class="govuk-summary-list__row appeal-site-address"><dt class="govuk-summary-list__key"> Site address</dt>
-                                        <dd class="govuk-summary-list__value">21 The Pavement, Wandsworth, SW4 0HY</dd>
-                                    </div>
-                                    <div class="govuk-summary-list__row appeal-lpa-health-and-safety"><dt class="govuk-summary-list__key"> Potential safety risks (LPA answer)</dt>
-                                        <dd                                         class="govuk-summary-list__value"><span>No</span>
-                                            </dd>
-                                    </div>
-                                    <div class="govuk-summary-list__row appeal-appellant-health-and-safety"><dt class="govuk-summary-list__key"> Potential safety risks (appellant answer)</dt>
-                                        <dd                                         class="govuk-summary-list__value"><span>Yes</span>
-                                            <br><span>Dogs on site</span>
-                                            </dd>
-                                    </div>
-                                    <div class="govuk-summary-list__row appeal-neighbouring-sites-inspector"><dt class="govuk-summary-list__key"> Address of the neighbour’s land or property</dt>
-                                        <dd                                         class="govuk-summary-list__value">
-                                            <ul class="govuk-list govuk-list--bullet">
-                                                <li>1 Grove Cottage, Shotesham Road, Woodton, Devon, NR35 2ND</li>
-                                            </ul>
-                                            </dd>
-                                    </div>
-                                    <div class="govuk-summary-list__row appeal-neighbouring-sites-inspector"><dt class="govuk-summary-list__key"> Neighbouring sites (inspector and/or third party request)</dt>
-                                        <dd                                         class="govuk-summary-list__value">
-                                            <ul class="govuk-list govuk-list--bullet">
-                                                <li>2 Grove Cottage, Shotesham Road, Woodton, Devon, NR35 2ND</li>
-                                            </ul>
-                                            </dd>
-                                    </div>
-                                </dl>
-                            </div>
-                        </details>
                         <div class="govuk-form-group">
                             <fieldset class="govuk-fieldset">
                                 <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">Select visit type</legend>
@@ -1518,41 +1558,45 @@ exports[`site-visit POST /site-visit/manage-visit should re-render the manage vi
         <div class="govuk-grid-column-two-thirds">
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full">
+                    <details class="govuk-details">
+                        <summary class="govuk-details__summary"><span class="govuk-details__summary-text"> Site information</span>
+                        </summary>
+                        <div class="govuk-details__text">
+                            <dl class="govuk-summary-list govuk-summary-list--no-border">
+                                <div class="govuk-summary-list__row appeal-site-address"><dt class="govuk-summary-list__key"> Site address</dt>
+                                    <dd class="govuk-summary-list__value">21 The Pavement, Wandsworth, SW4 0HY</dd>
+                                </div>
+                                <div class="govuk-summary-list__row appeal-lpa-health-and-safety"><dt class="govuk-summary-list__key"> Potential safety risks (LPA answer)</dt>
+                                    <dd                                     class="govuk-summary-list__value"><span>No</span>
+                                        </dd>
+                                </div>
+                                <div class="govuk-summary-list__row appeal-appellant-health-and-safety"><dt class="govuk-summary-list__key"> Potential safety risks (appellant answer)</dt>
+                                    <dd                                     class="govuk-summary-list__value"><span>Yes</span>
+                                        <br><span>Dogs on site</span>
+                                        </dd>
+                                </div>
+                                <div class="govuk-summary-list__row appeal-neighbouring-sites-inspector"><dt class="govuk-summary-list__key"> Address of the neighbour’s land or property</dt>
+                                    <dd                                     class="govuk-summary-list__value">
+                                        <ul class="govuk-list govuk-list--bullet">
+                                            <li>1 Grove Cottage, Shotesham Road, Woodton, Devon, NR35 2ND</li>
+                                        </ul>
+                                        </dd>
+                                </div>
+                                <div class="govuk-summary-list__row appeal-neighbouring-sites-inspector"><dt class="govuk-summary-list__key"> Neighbouring sites (inspector and/or third party request)</dt>
+                                    <dd                                     class="govuk-summary-list__value">
+                                        <ul class="govuk-list govuk-list--bullet">
+                                            <li>2 Grove Cottage, Shotesham Road, Woodton, Devon, NR35 2ND</li>
+                                        </ul>
+                                        </dd>
+                                </div>
+                            </dl>
+                        </div>
+                    </details>
+                </div>
+            </div>
+            <div class="govuk-grid-row">
+                <div class="govuk-grid-column-full">
                     <form method="POST" novalidate="novalidate">
-                        <details class="govuk-details">
-                            <summary class="govuk-details__summary"><span class="govuk-details__summary-text"> Site information</span>
-                            </summary>
-                            <div class="govuk-details__text">
-                                <dl class="govuk-summary-list govuk-summary-list--no-border">
-                                    <div class="govuk-summary-list__row appeal-site-address"><dt class="govuk-summary-list__key"> Site address</dt>
-                                        <dd class="govuk-summary-list__value">21 The Pavement, Wandsworth, SW4 0HY</dd>
-                                    </div>
-                                    <div class="govuk-summary-list__row appeal-lpa-health-and-safety"><dt class="govuk-summary-list__key"> Potential safety risks (LPA answer)</dt>
-                                        <dd                                         class="govuk-summary-list__value"><span>No</span>
-                                            </dd>
-                                    </div>
-                                    <div class="govuk-summary-list__row appeal-appellant-health-and-safety"><dt class="govuk-summary-list__key"> Potential safety risks (appellant answer)</dt>
-                                        <dd                                         class="govuk-summary-list__value"><span>Yes</span>
-                                            <br><span>Dogs on site</span>
-                                            </dd>
-                                    </div>
-                                    <div class="govuk-summary-list__row appeal-neighbouring-sites-inspector"><dt class="govuk-summary-list__key"> Address of the neighbour’s land or property</dt>
-                                        <dd                                         class="govuk-summary-list__value">
-                                            <ul class="govuk-list govuk-list--bullet">
-                                                <li>1 Grove Cottage, Shotesham Road, Woodton, Devon, NR35 2ND</li>
-                                            </ul>
-                                            </dd>
-                                    </div>
-                                    <div class="govuk-summary-list__row appeal-neighbouring-sites-inspector"><dt class="govuk-summary-list__key"> Neighbouring sites (inspector and/or third party request)</dt>
-                                        <dd                                         class="govuk-summary-list__value">
-                                            <ul class="govuk-list govuk-list--bullet">
-                                                <li>2 Grove Cottage, Shotesham Road, Woodton, Devon, NR35 2ND</li>
-                                            </ul>
-                                            </dd>
-                                    </div>
-                                </dl>
-                            </div>
-                        </details>
                         <div class="govuk-form-group">
                             <fieldset class="govuk-fieldset">
                                 <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">Select visit type</legend>
@@ -1661,41 +1705,45 @@ exports[`site-visit POST /site-visit/manage-visit should re-render the manage vi
         <div class="govuk-grid-column-two-thirds">
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full">
+                    <details class="govuk-details">
+                        <summary class="govuk-details__summary"><span class="govuk-details__summary-text"> Site information</span>
+                        </summary>
+                        <div class="govuk-details__text">
+                            <dl class="govuk-summary-list govuk-summary-list--no-border">
+                                <div class="govuk-summary-list__row appeal-site-address"><dt class="govuk-summary-list__key"> Site address</dt>
+                                    <dd class="govuk-summary-list__value">21 The Pavement, Wandsworth, SW4 0HY</dd>
+                                </div>
+                                <div class="govuk-summary-list__row appeal-lpa-health-and-safety"><dt class="govuk-summary-list__key"> Potential safety risks (LPA answer)</dt>
+                                    <dd                                     class="govuk-summary-list__value"><span>No</span>
+                                        </dd>
+                                </div>
+                                <div class="govuk-summary-list__row appeal-appellant-health-and-safety"><dt class="govuk-summary-list__key"> Potential safety risks (appellant answer)</dt>
+                                    <dd                                     class="govuk-summary-list__value"><span>Yes</span>
+                                        <br><span>Dogs on site</span>
+                                        </dd>
+                                </div>
+                                <div class="govuk-summary-list__row appeal-neighbouring-sites-inspector"><dt class="govuk-summary-list__key"> Address of the neighbour’s land or property</dt>
+                                    <dd                                     class="govuk-summary-list__value">
+                                        <ul class="govuk-list govuk-list--bullet">
+                                            <li>1 Grove Cottage, Shotesham Road, Woodton, Devon, NR35 2ND</li>
+                                        </ul>
+                                        </dd>
+                                </div>
+                                <div class="govuk-summary-list__row appeal-neighbouring-sites-inspector"><dt class="govuk-summary-list__key"> Neighbouring sites (inspector and/or third party request)</dt>
+                                    <dd                                     class="govuk-summary-list__value">
+                                        <ul class="govuk-list govuk-list--bullet">
+                                            <li>2 Grove Cottage, Shotesham Road, Woodton, Devon, NR35 2ND</li>
+                                        </ul>
+                                        </dd>
+                                </div>
+                            </dl>
+                        </div>
+                    </details>
+                </div>
+            </div>
+            <div class="govuk-grid-row">
+                <div class="govuk-grid-column-full">
                     <form method="POST" novalidate="novalidate">
-                        <details class="govuk-details">
-                            <summary class="govuk-details__summary"><span class="govuk-details__summary-text"> Site information</span>
-                            </summary>
-                            <div class="govuk-details__text">
-                                <dl class="govuk-summary-list govuk-summary-list--no-border">
-                                    <div class="govuk-summary-list__row appeal-site-address"><dt class="govuk-summary-list__key"> Site address</dt>
-                                        <dd class="govuk-summary-list__value">21 The Pavement, Wandsworth, SW4 0HY</dd>
-                                    </div>
-                                    <div class="govuk-summary-list__row appeal-lpa-health-and-safety"><dt class="govuk-summary-list__key"> Potential safety risks (LPA answer)</dt>
-                                        <dd                                         class="govuk-summary-list__value"><span>No</span>
-                                            </dd>
-                                    </div>
-                                    <div class="govuk-summary-list__row appeal-appellant-health-and-safety"><dt class="govuk-summary-list__key"> Potential safety risks (appellant answer)</dt>
-                                        <dd                                         class="govuk-summary-list__value"><span>Yes</span>
-                                            <br><span>Dogs on site</span>
-                                            </dd>
-                                    </div>
-                                    <div class="govuk-summary-list__row appeal-neighbouring-sites-inspector"><dt class="govuk-summary-list__key"> Address of the neighbour’s land or property</dt>
-                                        <dd                                         class="govuk-summary-list__value">
-                                            <ul class="govuk-list govuk-list--bullet">
-                                                <li>1 Grove Cottage, Shotesham Road, Woodton, Devon, NR35 2ND</li>
-                                            </ul>
-                                            </dd>
-                                    </div>
-                                    <div class="govuk-summary-list__row appeal-neighbouring-sites-inspector"><dt class="govuk-summary-list__key"> Neighbouring sites (inspector and/or third party request)</dt>
-                                        <dd                                         class="govuk-summary-list__value">
-                                            <ul class="govuk-list govuk-list--bullet">
-                                                <li>2 Grove Cottage, Shotesham Road, Woodton, Devon, NR35 2ND</li>
-                                            </ul>
-                                            </dd>
-                                    </div>
-                                </dl>
-                            </div>
-                        </details>
                         <div class="govuk-form-group">
                             <fieldset class="govuk-fieldset">
                                 <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">Select visit type</legend>
@@ -1806,41 +1854,45 @@ exports[`site-visit POST /site-visit/manage-visit should re-render the manage vi
         <div class="govuk-grid-column-two-thirds">
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full">
+                    <details class="govuk-details">
+                        <summary class="govuk-details__summary"><span class="govuk-details__summary-text"> Site information</span>
+                        </summary>
+                        <div class="govuk-details__text">
+                            <dl class="govuk-summary-list govuk-summary-list--no-border">
+                                <div class="govuk-summary-list__row appeal-site-address"><dt class="govuk-summary-list__key"> Site address</dt>
+                                    <dd class="govuk-summary-list__value">21 The Pavement, Wandsworth, SW4 0HY</dd>
+                                </div>
+                                <div class="govuk-summary-list__row appeal-lpa-health-and-safety"><dt class="govuk-summary-list__key"> Potential safety risks (LPA answer)</dt>
+                                    <dd                                     class="govuk-summary-list__value"><span>No</span>
+                                        </dd>
+                                </div>
+                                <div class="govuk-summary-list__row appeal-appellant-health-and-safety"><dt class="govuk-summary-list__key"> Potential safety risks (appellant answer)</dt>
+                                    <dd                                     class="govuk-summary-list__value"><span>Yes</span>
+                                        <br><span>Dogs on site</span>
+                                        </dd>
+                                </div>
+                                <div class="govuk-summary-list__row appeal-neighbouring-sites-inspector"><dt class="govuk-summary-list__key"> Address of the neighbour’s land or property</dt>
+                                    <dd                                     class="govuk-summary-list__value">
+                                        <ul class="govuk-list govuk-list--bullet">
+                                            <li>1 Grove Cottage, Shotesham Road, Woodton, Devon, NR35 2ND</li>
+                                        </ul>
+                                        </dd>
+                                </div>
+                                <div class="govuk-summary-list__row appeal-neighbouring-sites-inspector"><dt class="govuk-summary-list__key"> Neighbouring sites (inspector and/or third party request)</dt>
+                                    <dd                                     class="govuk-summary-list__value">
+                                        <ul class="govuk-list govuk-list--bullet">
+                                            <li>2 Grove Cottage, Shotesham Road, Woodton, Devon, NR35 2ND</li>
+                                        </ul>
+                                        </dd>
+                                </div>
+                            </dl>
+                        </div>
+                    </details>
+                </div>
+            </div>
+            <div class="govuk-grid-row">
+                <div class="govuk-grid-column-full">
                     <form method="POST" novalidate="novalidate">
-                        <details class="govuk-details">
-                            <summary class="govuk-details__summary"><span class="govuk-details__summary-text"> Site information</span>
-                            </summary>
-                            <div class="govuk-details__text">
-                                <dl class="govuk-summary-list govuk-summary-list--no-border">
-                                    <div class="govuk-summary-list__row appeal-site-address"><dt class="govuk-summary-list__key"> Site address</dt>
-                                        <dd class="govuk-summary-list__value">21 The Pavement, Wandsworth, SW4 0HY</dd>
-                                    </div>
-                                    <div class="govuk-summary-list__row appeal-lpa-health-and-safety"><dt class="govuk-summary-list__key"> Potential safety risks (LPA answer)</dt>
-                                        <dd                                         class="govuk-summary-list__value"><span>No</span>
-                                            </dd>
-                                    </div>
-                                    <div class="govuk-summary-list__row appeal-appellant-health-and-safety"><dt class="govuk-summary-list__key"> Potential safety risks (appellant answer)</dt>
-                                        <dd                                         class="govuk-summary-list__value"><span>Yes</span>
-                                            <br><span>Dogs on site</span>
-                                            </dd>
-                                    </div>
-                                    <div class="govuk-summary-list__row appeal-neighbouring-sites-inspector"><dt class="govuk-summary-list__key"> Address of the neighbour’s land or property</dt>
-                                        <dd                                         class="govuk-summary-list__value">
-                                            <ul class="govuk-list govuk-list--bullet">
-                                                <li>1 Grove Cottage, Shotesham Road, Woodton, Devon, NR35 2ND</li>
-                                            </ul>
-                                            </dd>
-                                    </div>
-                                    <div class="govuk-summary-list__row appeal-neighbouring-sites-inspector"><dt class="govuk-summary-list__key"> Neighbouring sites (inspector and/or third party request)</dt>
-                                        <dd                                         class="govuk-summary-list__value">
-                                            <ul class="govuk-list govuk-list--bullet">
-                                                <li>2 Grove Cottage, Shotesham Road, Woodton, Devon, NR35 2ND</li>
-                                            </ul>
-                                            </dd>
-                                    </div>
-                                </dl>
-                            </div>
-                        </details>
                         <div class="govuk-form-group">
                             <fieldset class="govuk-fieldset">
                                 <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">Select visit type</legend>
@@ -1949,41 +2001,45 @@ exports[`site-visit POST /site-visit/manage-visit should re-render the manage vi
         <div class="govuk-grid-column-two-thirds">
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full">
+                    <details class="govuk-details">
+                        <summary class="govuk-details__summary"><span class="govuk-details__summary-text"> Site information</span>
+                        </summary>
+                        <div class="govuk-details__text">
+                            <dl class="govuk-summary-list govuk-summary-list--no-border">
+                                <div class="govuk-summary-list__row appeal-site-address"><dt class="govuk-summary-list__key"> Site address</dt>
+                                    <dd class="govuk-summary-list__value">21 The Pavement, Wandsworth, SW4 0HY</dd>
+                                </div>
+                                <div class="govuk-summary-list__row appeal-lpa-health-and-safety"><dt class="govuk-summary-list__key"> Potential safety risks (LPA answer)</dt>
+                                    <dd                                     class="govuk-summary-list__value"><span>No</span>
+                                        </dd>
+                                </div>
+                                <div class="govuk-summary-list__row appeal-appellant-health-and-safety"><dt class="govuk-summary-list__key"> Potential safety risks (appellant answer)</dt>
+                                    <dd                                     class="govuk-summary-list__value"><span>Yes</span>
+                                        <br><span>Dogs on site</span>
+                                        </dd>
+                                </div>
+                                <div class="govuk-summary-list__row appeal-neighbouring-sites-inspector"><dt class="govuk-summary-list__key"> Address of the neighbour’s land or property</dt>
+                                    <dd                                     class="govuk-summary-list__value">
+                                        <ul class="govuk-list govuk-list--bullet">
+                                            <li>1 Grove Cottage, Shotesham Road, Woodton, Devon, NR35 2ND</li>
+                                        </ul>
+                                        </dd>
+                                </div>
+                                <div class="govuk-summary-list__row appeal-neighbouring-sites-inspector"><dt class="govuk-summary-list__key"> Neighbouring sites (inspector and/or third party request)</dt>
+                                    <dd                                     class="govuk-summary-list__value">
+                                        <ul class="govuk-list govuk-list--bullet">
+                                            <li>2 Grove Cottage, Shotesham Road, Woodton, Devon, NR35 2ND</li>
+                                        </ul>
+                                        </dd>
+                                </div>
+                            </dl>
+                        </div>
+                    </details>
+                </div>
+            </div>
+            <div class="govuk-grid-row">
+                <div class="govuk-grid-column-full">
                     <form method="POST" novalidate="novalidate">
-                        <details class="govuk-details">
-                            <summary class="govuk-details__summary"><span class="govuk-details__summary-text"> Site information</span>
-                            </summary>
-                            <div class="govuk-details__text">
-                                <dl class="govuk-summary-list govuk-summary-list--no-border">
-                                    <div class="govuk-summary-list__row appeal-site-address"><dt class="govuk-summary-list__key"> Site address</dt>
-                                        <dd class="govuk-summary-list__value">21 The Pavement, Wandsworth, SW4 0HY</dd>
-                                    </div>
-                                    <div class="govuk-summary-list__row appeal-lpa-health-and-safety"><dt class="govuk-summary-list__key"> Potential safety risks (LPA answer)</dt>
-                                        <dd                                         class="govuk-summary-list__value"><span>No</span>
-                                            </dd>
-                                    </div>
-                                    <div class="govuk-summary-list__row appeal-appellant-health-and-safety"><dt class="govuk-summary-list__key"> Potential safety risks (appellant answer)</dt>
-                                        <dd                                         class="govuk-summary-list__value"><span>Yes</span>
-                                            <br><span>Dogs on site</span>
-                                            </dd>
-                                    </div>
-                                    <div class="govuk-summary-list__row appeal-neighbouring-sites-inspector"><dt class="govuk-summary-list__key"> Address of the neighbour’s land or property</dt>
-                                        <dd                                         class="govuk-summary-list__value">
-                                            <ul class="govuk-list govuk-list--bullet">
-                                                <li>1 Grove Cottage, Shotesham Road, Woodton, Devon, NR35 2ND</li>
-                                            </ul>
-                                            </dd>
-                                    </div>
-                                    <div class="govuk-summary-list__row appeal-neighbouring-sites-inspector"><dt class="govuk-summary-list__key"> Neighbouring sites (inspector and/or third party request)</dt>
-                                        <dd                                         class="govuk-summary-list__value">
-                                            <ul class="govuk-list govuk-list--bullet">
-                                                <li>2 Grove Cottage, Shotesham Road, Woodton, Devon, NR35 2ND</li>
-                                            </ul>
-                                            </dd>
-                                    </div>
-                                </dl>
-                            </div>
-                        </details>
                         <div class="govuk-form-group">
                             <fieldset class="govuk-fieldset">
                                 <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">Select visit type</legend>
@@ -2092,41 +2148,45 @@ exports[`site-visit POST /site-visit/manage-visit should re-render the manage vi
         <div class="govuk-grid-column-two-thirds">
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full">
+                    <details class="govuk-details">
+                        <summary class="govuk-details__summary"><span class="govuk-details__summary-text"> Site information</span>
+                        </summary>
+                        <div class="govuk-details__text">
+                            <dl class="govuk-summary-list govuk-summary-list--no-border">
+                                <div class="govuk-summary-list__row appeal-site-address"><dt class="govuk-summary-list__key"> Site address</dt>
+                                    <dd class="govuk-summary-list__value">21 The Pavement, Wandsworth, SW4 0HY</dd>
+                                </div>
+                                <div class="govuk-summary-list__row appeal-lpa-health-and-safety"><dt class="govuk-summary-list__key"> Potential safety risks (LPA answer)</dt>
+                                    <dd                                     class="govuk-summary-list__value"><span>No</span>
+                                        </dd>
+                                </div>
+                                <div class="govuk-summary-list__row appeal-appellant-health-and-safety"><dt class="govuk-summary-list__key"> Potential safety risks (appellant answer)</dt>
+                                    <dd                                     class="govuk-summary-list__value"><span>Yes</span>
+                                        <br><span>Dogs on site</span>
+                                        </dd>
+                                </div>
+                                <div class="govuk-summary-list__row appeal-neighbouring-sites-inspector"><dt class="govuk-summary-list__key"> Address of the neighbour’s land or property</dt>
+                                    <dd                                     class="govuk-summary-list__value">
+                                        <ul class="govuk-list govuk-list--bullet">
+                                            <li>1 Grove Cottage, Shotesham Road, Woodton, Devon, NR35 2ND</li>
+                                        </ul>
+                                        </dd>
+                                </div>
+                                <div class="govuk-summary-list__row appeal-neighbouring-sites-inspector"><dt class="govuk-summary-list__key"> Neighbouring sites (inspector and/or third party request)</dt>
+                                    <dd                                     class="govuk-summary-list__value">
+                                        <ul class="govuk-list govuk-list--bullet">
+                                            <li>2 Grove Cottage, Shotesham Road, Woodton, Devon, NR35 2ND</li>
+                                        </ul>
+                                        </dd>
+                                </div>
+                            </dl>
+                        </div>
+                    </details>
+                </div>
+            </div>
+            <div class="govuk-grid-row">
+                <div class="govuk-grid-column-full">
                     <form method="POST" novalidate="novalidate">
-                        <details class="govuk-details">
-                            <summary class="govuk-details__summary"><span class="govuk-details__summary-text"> Site information</span>
-                            </summary>
-                            <div class="govuk-details__text">
-                                <dl class="govuk-summary-list govuk-summary-list--no-border">
-                                    <div class="govuk-summary-list__row appeal-site-address"><dt class="govuk-summary-list__key"> Site address</dt>
-                                        <dd class="govuk-summary-list__value">21 The Pavement, Wandsworth, SW4 0HY</dd>
-                                    </div>
-                                    <div class="govuk-summary-list__row appeal-lpa-health-and-safety"><dt class="govuk-summary-list__key"> Potential safety risks (LPA answer)</dt>
-                                        <dd                                         class="govuk-summary-list__value"><span>No</span>
-                                            </dd>
-                                    </div>
-                                    <div class="govuk-summary-list__row appeal-appellant-health-and-safety"><dt class="govuk-summary-list__key"> Potential safety risks (appellant answer)</dt>
-                                        <dd                                         class="govuk-summary-list__value"><span>Yes</span>
-                                            <br><span>Dogs on site</span>
-                                            </dd>
-                                    </div>
-                                    <div class="govuk-summary-list__row appeal-neighbouring-sites-inspector"><dt class="govuk-summary-list__key"> Address of the neighbour’s land or property</dt>
-                                        <dd                                         class="govuk-summary-list__value">
-                                            <ul class="govuk-list govuk-list--bullet">
-                                                <li>1 Grove Cottage, Shotesham Road, Woodton, Devon, NR35 2ND</li>
-                                            </ul>
-                                            </dd>
-                                    </div>
-                                    <div class="govuk-summary-list__row appeal-neighbouring-sites-inspector"><dt class="govuk-summary-list__key"> Neighbouring sites (inspector and/or third party request)</dt>
-                                        <dd                                         class="govuk-summary-list__value">
-                                            <ul class="govuk-list govuk-list--bullet">
-                                                <li>2 Grove Cottage, Shotesham Road, Woodton, Devon, NR35 2ND</li>
-                                            </ul>
-                                            </dd>
-                                    </div>
-                                </dl>
-                            </div>
-                        </details>
                         <div class="govuk-form-group">
                             <fieldset class="govuk-fieldset">
                                 <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">Select visit type</legend>
@@ -2241,41 +2301,45 @@ exports[`site-visit POST /site-visit/manage-visit should re-render the manage vi
         <div class="govuk-grid-column-two-thirds">
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full">
+                    <details class="govuk-details">
+                        <summary class="govuk-details__summary"><span class="govuk-details__summary-text"> Site information</span>
+                        </summary>
+                        <div class="govuk-details__text">
+                            <dl class="govuk-summary-list govuk-summary-list--no-border">
+                                <div class="govuk-summary-list__row appeal-site-address"><dt class="govuk-summary-list__key"> Site address</dt>
+                                    <dd class="govuk-summary-list__value">21 The Pavement, Wandsworth, SW4 0HY</dd>
+                                </div>
+                                <div class="govuk-summary-list__row appeal-lpa-health-and-safety"><dt class="govuk-summary-list__key"> Potential safety risks (LPA answer)</dt>
+                                    <dd                                     class="govuk-summary-list__value"><span>No</span>
+                                        </dd>
+                                </div>
+                                <div class="govuk-summary-list__row appeal-appellant-health-and-safety"><dt class="govuk-summary-list__key"> Potential safety risks (appellant answer)</dt>
+                                    <dd                                     class="govuk-summary-list__value"><span>Yes</span>
+                                        <br><span>Dogs on site</span>
+                                        </dd>
+                                </div>
+                                <div class="govuk-summary-list__row appeal-neighbouring-sites-inspector"><dt class="govuk-summary-list__key"> Address of the neighbour’s land or property</dt>
+                                    <dd                                     class="govuk-summary-list__value">
+                                        <ul class="govuk-list govuk-list--bullet">
+                                            <li>1 Grove Cottage, Shotesham Road, Woodton, Devon, NR35 2ND</li>
+                                        </ul>
+                                        </dd>
+                                </div>
+                                <div class="govuk-summary-list__row appeal-neighbouring-sites-inspector"><dt class="govuk-summary-list__key"> Neighbouring sites (inspector and/or third party request)</dt>
+                                    <dd                                     class="govuk-summary-list__value">
+                                        <ul class="govuk-list govuk-list--bullet">
+                                            <li>2 Grove Cottage, Shotesham Road, Woodton, Devon, NR35 2ND</li>
+                                        </ul>
+                                        </dd>
+                                </div>
+                            </dl>
+                        </div>
+                    </details>
+                </div>
+            </div>
+            <div class="govuk-grid-row">
+                <div class="govuk-grid-column-full">
                     <form method="POST" novalidate="novalidate">
-                        <details class="govuk-details">
-                            <summary class="govuk-details__summary"><span class="govuk-details__summary-text"> Site information</span>
-                            </summary>
-                            <div class="govuk-details__text">
-                                <dl class="govuk-summary-list govuk-summary-list--no-border">
-                                    <div class="govuk-summary-list__row appeal-site-address"><dt class="govuk-summary-list__key"> Site address</dt>
-                                        <dd class="govuk-summary-list__value">21 The Pavement, Wandsworth, SW4 0HY</dd>
-                                    </div>
-                                    <div class="govuk-summary-list__row appeal-lpa-health-and-safety"><dt class="govuk-summary-list__key"> Potential safety risks (LPA answer)</dt>
-                                        <dd                                         class="govuk-summary-list__value"><span>No</span>
-                                            </dd>
-                                    </div>
-                                    <div class="govuk-summary-list__row appeal-appellant-health-and-safety"><dt class="govuk-summary-list__key"> Potential safety risks (appellant answer)</dt>
-                                        <dd                                         class="govuk-summary-list__value"><span>Yes</span>
-                                            <br><span>Dogs on site</span>
-                                            </dd>
-                                    </div>
-                                    <div class="govuk-summary-list__row appeal-neighbouring-sites-inspector"><dt class="govuk-summary-list__key"> Address of the neighbour’s land or property</dt>
-                                        <dd                                         class="govuk-summary-list__value">
-                                            <ul class="govuk-list govuk-list--bullet">
-                                                <li>1 Grove Cottage, Shotesham Road, Woodton, Devon, NR35 2ND</li>
-                                            </ul>
-                                            </dd>
-                                    </div>
-                                    <div class="govuk-summary-list__row appeal-neighbouring-sites-inspector"><dt class="govuk-summary-list__key"> Neighbouring sites (inspector and/or third party request)</dt>
-                                        <dd                                         class="govuk-summary-list__value">
-                                            <ul class="govuk-list govuk-list--bullet">
-                                                <li>2 Grove Cottage, Shotesham Road, Woodton, Devon, NR35 2ND</li>
-                                            </ul>
-                                            </dd>
-                                    </div>
-                                </dl>
-                            </div>
-                        </details>
                         <div class="govuk-form-group">
                             <fieldset class="govuk-fieldset">
                                 <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">Select visit type</legend>
@@ -2384,41 +2448,45 @@ exports[`site-visit POST /site-visit/schedule-visit should re-render the schedul
         <div class="govuk-grid-column-two-thirds">
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full">
+                    <details class="govuk-details">
+                        <summary class="govuk-details__summary"><span class="govuk-details__summary-text"> Site information</span>
+                        </summary>
+                        <div class="govuk-details__text">
+                            <dl class="govuk-summary-list govuk-summary-list--no-border">
+                                <div class="govuk-summary-list__row appeal-site-address"><dt class="govuk-summary-list__key"> Site address</dt>
+                                    <dd class="govuk-summary-list__value">21 The Pavement, Wandsworth, SW4 0HY</dd>
+                                </div>
+                                <div class="govuk-summary-list__row appeal-lpa-health-and-safety"><dt class="govuk-summary-list__key"> Potential safety risks (LPA answer)</dt>
+                                    <dd                                     class="govuk-summary-list__value"><span>No</span>
+                                        </dd>
+                                </div>
+                                <div class="govuk-summary-list__row appeal-appellant-health-and-safety"><dt class="govuk-summary-list__key"> Potential safety risks (appellant answer)</dt>
+                                    <dd                                     class="govuk-summary-list__value"><span>Yes</span>
+                                        <br><span>Dogs on site</span>
+                                        </dd>
+                                </div>
+                                <div class="govuk-summary-list__row appeal-neighbouring-sites-inspector"><dt class="govuk-summary-list__key"> Address of the neighbour’s land or property</dt>
+                                    <dd                                     class="govuk-summary-list__value">
+                                        <ul class="govuk-list govuk-list--bullet">
+                                            <li>1 Grove Cottage, Shotesham Road, Woodton, Devon, NR35 2ND</li>
+                                        </ul>
+                                        </dd>
+                                </div>
+                                <div class="govuk-summary-list__row appeal-neighbouring-sites-inspector"><dt class="govuk-summary-list__key"> Neighbouring sites (inspector and/or third party request)</dt>
+                                    <dd                                     class="govuk-summary-list__value">
+                                        <ul class="govuk-list govuk-list--bullet">
+                                            <li>2 Grove Cottage, Shotesham Road, Woodton, Devon, NR35 2ND</li>
+                                        </ul>
+                                        </dd>
+                                </div>
+                            </dl>
+                        </div>
+                    </details>
+                </div>
+            </div>
+            <div class="govuk-grid-row">
+                <div class="govuk-grid-column-full">
                     <form method="POST" novalidate="novalidate">
-                        <details class="govuk-details">
-                            <summary class="govuk-details__summary"><span class="govuk-details__summary-text"> Site information</span>
-                            </summary>
-                            <div class="govuk-details__text">
-                                <dl class="govuk-summary-list govuk-summary-list--no-border">
-                                    <div class="govuk-summary-list__row appeal-site-address"><dt class="govuk-summary-list__key"> Site address</dt>
-                                        <dd class="govuk-summary-list__value">21 The Pavement, Wandsworth, SW4 0HY</dd>
-                                    </div>
-                                    <div class="govuk-summary-list__row appeal-lpa-health-and-safety"><dt class="govuk-summary-list__key"> Potential safety risks (LPA answer)</dt>
-                                        <dd                                         class="govuk-summary-list__value"><span>No</span>
-                                            </dd>
-                                    </div>
-                                    <div class="govuk-summary-list__row appeal-appellant-health-and-safety"><dt class="govuk-summary-list__key"> Potential safety risks (appellant answer)</dt>
-                                        <dd                                         class="govuk-summary-list__value"><span>Yes</span>
-                                            <br><span>Dogs on site</span>
-                                            </dd>
-                                    </div>
-                                    <div class="govuk-summary-list__row appeal-neighbouring-sites-inspector"><dt class="govuk-summary-list__key"> Address of the neighbour’s land or property</dt>
-                                        <dd                                         class="govuk-summary-list__value">
-                                            <ul class="govuk-list govuk-list--bullet">
-                                                <li>1 Grove Cottage, Shotesham Road, Woodton, Devon, NR35 2ND</li>
-                                            </ul>
-                                            </dd>
-                                    </div>
-                                    <div class="govuk-summary-list__row appeal-neighbouring-sites-inspector"><dt class="govuk-summary-list__key"> Neighbouring sites (inspector and/or third party request)</dt>
-                                        <dd                                         class="govuk-summary-list__value">
-                                            <ul class="govuk-list govuk-list--bullet">
-                                                <li>2 Grove Cottage, Shotesham Road, Woodton, Devon, NR35 2ND</li>
-                                            </ul>
-                                            </dd>
-                                    </div>
-                                </dl>
-                            </div>
-                        </details>
                         <div class="govuk-form-group">
                             <fieldset class="govuk-fieldset">
                                 <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">Select visit type</legend>
@@ -2527,41 +2595,45 @@ exports[`site-visit POST /site-visit/schedule-visit should re-render the schedul
         <div class="govuk-grid-column-two-thirds">
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full">
+                    <details class="govuk-details">
+                        <summary class="govuk-details__summary"><span class="govuk-details__summary-text"> Site information</span>
+                        </summary>
+                        <div class="govuk-details__text">
+                            <dl class="govuk-summary-list govuk-summary-list--no-border">
+                                <div class="govuk-summary-list__row appeal-site-address"><dt class="govuk-summary-list__key"> Site address</dt>
+                                    <dd class="govuk-summary-list__value">21 The Pavement, Wandsworth, SW4 0HY</dd>
+                                </div>
+                                <div class="govuk-summary-list__row appeal-lpa-health-and-safety"><dt class="govuk-summary-list__key"> Potential safety risks (LPA answer)</dt>
+                                    <dd                                     class="govuk-summary-list__value"><span>No</span>
+                                        </dd>
+                                </div>
+                                <div class="govuk-summary-list__row appeal-appellant-health-and-safety"><dt class="govuk-summary-list__key"> Potential safety risks (appellant answer)</dt>
+                                    <dd                                     class="govuk-summary-list__value"><span>Yes</span>
+                                        <br><span>Dogs on site</span>
+                                        </dd>
+                                </div>
+                                <div class="govuk-summary-list__row appeal-neighbouring-sites-inspector"><dt class="govuk-summary-list__key"> Address of the neighbour’s land or property</dt>
+                                    <dd                                     class="govuk-summary-list__value">
+                                        <ul class="govuk-list govuk-list--bullet">
+                                            <li>1 Grove Cottage, Shotesham Road, Woodton, Devon, NR35 2ND</li>
+                                        </ul>
+                                        </dd>
+                                </div>
+                                <div class="govuk-summary-list__row appeal-neighbouring-sites-inspector"><dt class="govuk-summary-list__key"> Neighbouring sites (inspector and/or third party request)</dt>
+                                    <dd                                     class="govuk-summary-list__value">
+                                        <ul class="govuk-list govuk-list--bullet">
+                                            <li>2 Grove Cottage, Shotesham Road, Woodton, Devon, NR35 2ND</li>
+                                        </ul>
+                                        </dd>
+                                </div>
+                            </dl>
+                        </div>
+                    </details>
+                </div>
+            </div>
+            <div class="govuk-grid-row">
+                <div class="govuk-grid-column-full">
                     <form method="POST" novalidate="novalidate">
-                        <details class="govuk-details">
-                            <summary class="govuk-details__summary"><span class="govuk-details__summary-text"> Site information</span>
-                            </summary>
-                            <div class="govuk-details__text">
-                                <dl class="govuk-summary-list govuk-summary-list--no-border">
-                                    <div class="govuk-summary-list__row appeal-site-address"><dt class="govuk-summary-list__key"> Site address</dt>
-                                        <dd class="govuk-summary-list__value">21 The Pavement, Wandsworth, SW4 0HY</dd>
-                                    </div>
-                                    <div class="govuk-summary-list__row appeal-lpa-health-and-safety"><dt class="govuk-summary-list__key"> Potential safety risks (LPA answer)</dt>
-                                        <dd                                         class="govuk-summary-list__value"><span>No</span>
-                                            </dd>
-                                    </div>
-                                    <div class="govuk-summary-list__row appeal-appellant-health-and-safety"><dt class="govuk-summary-list__key"> Potential safety risks (appellant answer)</dt>
-                                        <dd                                         class="govuk-summary-list__value"><span>Yes</span>
-                                            <br><span>Dogs on site</span>
-                                            </dd>
-                                    </div>
-                                    <div class="govuk-summary-list__row appeal-neighbouring-sites-inspector"><dt class="govuk-summary-list__key"> Address of the neighbour’s land or property</dt>
-                                        <dd                                         class="govuk-summary-list__value">
-                                            <ul class="govuk-list govuk-list--bullet">
-                                                <li>1 Grove Cottage, Shotesham Road, Woodton, Devon, NR35 2ND</li>
-                                            </ul>
-                                            </dd>
-                                    </div>
-                                    <div class="govuk-summary-list__row appeal-neighbouring-sites-inspector"><dt class="govuk-summary-list__key"> Neighbouring sites (inspector and/or third party request)</dt>
-                                        <dd                                         class="govuk-summary-list__value">
-                                            <ul class="govuk-list govuk-list--bullet">
-                                                <li>2 Grove Cottage, Shotesham Road, Woodton, Devon, NR35 2ND</li>
-                                            </ul>
-                                            </dd>
-                                    </div>
-                                </dl>
-                            </div>
-                        </details>
                         <div class="govuk-form-group">
                             <fieldset class="govuk-fieldset">
                                 <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">Select visit type</legend>
@@ -2672,41 +2744,45 @@ exports[`site-visit POST /site-visit/schedule-visit should re-render the schedul
         <div class="govuk-grid-column-two-thirds">
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full">
+                    <details class="govuk-details">
+                        <summary class="govuk-details__summary"><span class="govuk-details__summary-text"> Site information</span>
+                        </summary>
+                        <div class="govuk-details__text">
+                            <dl class="govuk-summary-list govuk-summary-list--no-border">
+                                <div class="govuk-summary-list__row appeal-site-address"><dt class="govuk-summary-list__key"> Site address</dt>
+                                    <dd class="govuk-summary-list__value">21 The Pavement, Wandsworth, SW4 0HY</dd>
+                                </div>
+                                <div class="govuk-summary-list__row appeal-lpa-health-and-safety"><dt class="govuk-summary-list__key"> Potential safety risks (LPA answer)</dt>
+                                    <dd                                     class="govuk-summary-list__value"><span>No</span>
+                                        </dd>
+                                </div>
+                                <div class="govuk-summary-list__row appeal-appellant-health-and-safety"><dt class="govuk-summary-list__key"> Potential safety risks (appellant answer)</dt>
+                                    <dd                                     class="govuk-summary-list__value"><span>Yes</span>
+                                        <br><span>Dogs on site</span>
+                                        </dd>
+                                </div>
+                                <div class="govuk-summary-list__row appeal-neighbouring-sites-inspector"><dt class="govuk-summary-list__key"> Address of the neighbour’s land or property</dt>
+                                    <dd                                     class="govuk-summary-list__value">
+                                        <ul class="govuk-list govuk-list--bullet">
+                                            <li>1 Grove Cottage, Shotesham Road, Woodton, Devon, NR35 2ND</li>
+                                        </ul>
+                                        </dd>
+                                </div>
+                                <div class="govuk-summary-list__row appeal-neighbouring-sites-inspector"><dt class="govuk-summary-list__key"> Neighbouring sites (inspector and/or third party request)</dt>
+                                    <dd                                     class="govuk-summary-list__value">
+                                        <ul class="govuk-list govuk-list--bullet">
+                                            <li>2 Grove Cottage, Shotesham Road, Woodton, Devon, NR35 2ND</li>
+                                        </ul>
+                                        </dd>
+                                </div>
+                            </dl>
+                        </div>
+                    </details>
+                </div>
+            </div>
+            <div class="govuk-grid-row">
+                <div class="govuk-grid-column-full">
                     <form method="POST" novalidate="novalidate">
-                        <details class="govuk-details">
-                            <summary class="govuk-details__summary"><span class="govuk-details__summary-text"> Site information</span>
-                            </summary>
-                            <div class="govuk-details__text">
-                                <dl class="govuk-summary-list govuk-summary-list--no-border">
-                                    <div class="govuk-summary-list__row appeal-site-address"><dt class="govuk-summary-list__key"> Site address</dt>
-                                        <dd class="govuk-summary-list__value">21 The Pavement, Wandsworth, SW4 0HY</dd>
-                                    </div>
-                                    <div class="govuk-summary-list__row appeal-lpa-health-and-safety"><dt class="govuk-summary-list__key"> Potential safety risks (LPA answer)</dt>
-                                        <dd                                         class="govuk-summary-list__value"><span>No</span>
-                                            </dd>
-                                    </div>
-                                    <div class="govuk-summary-list__row appeal-appellant-health-and-safety"><dt class="govuk-summary-list__key"> Potential safety risks (appellant answer)</dt>
-                                        <dd                                         class="govuk-summary-list__value"><span>Yes</span>
-                                            <br><span>Dogs on site</span>
-                                            </dd>
-                                    </div>
-                                    <div class="govuk-summary-list__row appeal-neighbouring-sites-inspector"><dt class="govuk-summary-list__key"> Address of the neighbour’s land or property</dt>
-                                        <dd                                         class="govuk-summary-list__value">
-                                            <ul class="govuk-list govuk-list--bullet">
-                                                <li>1 Grove Cottage, Shotesham Road, Woodton, Devon, NR35 2ND</li>
-                                            </ul>
-                                            </dd>
-                                    </div>
-                                    <div class="govuk-summary-list__row appeal-neighbouring-sites-inspector"><dt class="govuk-summary-list__key"> Neighbouring sites (inspector and/or third party request)</dt>
-                                        <dd                                         class="govuk-summary-list__value">
-                                            <ul class="govuk-list govuk-list--bullet">
-                                                <li>2 Grove Cottage, Shotesham Road, Woodton, Devon, NR35 2ND</li>
-                                            </ul>
-                                            </dd>
-                                    </div>
-                                </dl>
-                            </div>
-                        </details>
                         <div class="govuk-form-group">
                             <fieldset class="govuk-fieldset">
                                 <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">Select visit type</legend>
@@ -2817,41 +2893,45 @@ exports[`site-visit POST /site-visit/schedule-visit should re-render the schedul
         <div class="govuk-grid-column-two-thirds">
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full">
+                    <details class="govuk-details">
+                        <summary class="govuk-details__summary"><span class="govuk-details__summary-text"> Site information</span>
+                        </summary>
+                        <div class="govuk-details__text">
+                            <dl class="govuk-summary-list govuk-summary-list--no-border">
+                                <div class="govuk-summary-list__row appeal-site-address"><dt class="govuk-summary-list__key"> Site address</dt>
+                                    <dd class="govuk-summary-list__value">21 The Pavement, Wandsworth, SW4 0HY</dd>
+                                </div>
+                                <div class="govuk-summary-list__row appeal-lpa-health-and-safety"><dt class="govuk-summary-list__key"> Potential safety risks (LPA answer)</dt>
+                                    <dd                                     class="govuk-summary-list__value"><span>No</span>
+                                        </dd>
+                                </div>
+                                <div class="govuk-summary-list__row appeal-appellant-health-and-safety"><dt class="govuk-summary-list__key"> Potential safety risks (appellant answer)</dt>
+                                    <dd                                     class="govuk-summary-list__value"><span>Yes</span>
+                                        <br><span>Dogs on site</span>
+                                        </dd>
+                                </div>
+                                <div class="govuk-summary-list__row appeal-neighbouring-sites-inspector"><dt class="govuk-summary-list__key"> Address of the neighbour’s land or property</dt>
+                                    <dd                                     class="govuk-summary-list__value">
+                                        <ul class="govuk-list govuk-list--bullet">
+                                            <li>1 Grove Cottage, Shotesham Road, Woodton, Devon, NR35 2ND</li>
+                                        </ul>
+                                        </dd>
+                                </div>
+                                <div class="govuk-summary-list__row appeal-neighbouring-sites-inspector"><dt class="govuk-summary-list__key"> Neighbouring sites (inspector and/or third party request)</dt>
+                                    <dd                                     class="govuk-summary-list__value">
+                                        <ul class="govuk-list govuk-list--bullet">
+                                            <li>2 Grove Cottage, Shotesham Road, Woodton, Devon, NR35 2ND</li>
+                                        </ul>
+                                        </dd>
+                                </div>
+                            </dl>
+                        </div>
+                    </details>
+                </div>
+            </div>
+            <div class="govuk-grid-row">
+                <div class="govuk-grid-column-full">
                     <form method="POST" novalidate="novalidate">
-                        <details class="govuk-details">
-                            <summary class="govuk-details__summary"><span class="govuk-details__summary-text"> Site information</span>
-                            </summary>
-                            <div class="govuk-details__text">
-                                <dl class="govuk-summary-list govuk-summary-list--no-border">
-                                    <div class="govuk-summary-list__row appeal-site-address"><dt class="govuk-summary-list__key"> Site address</dt>
-                                        <dd class="govuk-summary-list__value">21 The Pavement, Wandsworth, SW4 0HY</dd>
-                                    </div>
-                                    <div class="govuk-summary-list__row appeal-lpa-health-and-safety"><dt class="govuk-summary-list__key"> Potential safety risks (LPA answer)</dt>
-                                        <dd                                         class="govuk-summary-list__value"><span>No</span>
-                                            </dd>
-                                    </div>
-                                    <div class="govuk-summary-list__row appeal-appellant-health-and-safety"><dt class="govuk-summary-list__key"> Potential safety risks (appellant answer)</dt>
-                                        <dd                                         class="govuk-summary-list__value"><span>Yes</span>
-                                            <br><span>Dogs on site</span>
-                                            </dd>
-                                    </div>
-                                    <div class="govuk-summary-list__row appeal-neighbouring-sites-inspector"><dt class="govuk-summary-list__key"> Address of the neighbour’s land or property</dt>
-                                        <dd                                         class="govuk-summary-list__value">
-                                            <ul class="govuk-list govuk-list--bullet">
-                                                <li>1 Grove Cottage, Shotesham Road, Woodton, Devon, NR35 2ND</li>
-                                            </ul>
-                                            </dd>
-                                    </div>
-                                    <div class="govuk-summary-list__row appeal-neighbouring-sites-inspector"><dt class="govuk-summary-list__key"> Neighbouring sites (inspector and/or third party request)</dt>
-                                        <dd                                         class="govuk-summary-list__value">
-                                            <ul class="govuk-list govuk-list--bullet">
-                                                <li>2 Grove Cottage, Shotesham Road, Woodton, Devon, NR35 2ND</li>
-                                            </ul>
-                                            </dd>
-                                    </div>
-                                </dl>
-                            </div>
-                        </details>
                         <div class="govuk-form-group">
                             <fieldset class="govuk-fieldset">
                                 <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">Select visit type</legend>
@@ -2962,41 +3042,45 @@ exports[`site-visit POST /site-visit/schedule-visit should re-render the schedul
         <div class="govuk-grid-column-two-thirds">
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full">
+                    <details class="govuk-details">
+                        <summary class="govuk-details__summary"><span class="govuk-details__summary-text"> Site information</span>
+                        </summary>
+                        <div class="govuk-details__text">
+                            <dl class="govuk-summary-list govuk-summary-list--no-border">
+                                <div class="govuk-summary-list__row appeal-site-address"><dt class="govuk-summary-list__key"> Site address</dt>
+                                    <dd class="govuk-summary-list__value">21 The Pavement, Wandsworth, SW4 0HY</dd>
+                                </div>
+                                <div class="govuk-summary-list__row appeal-lpa-health-and-safety"><dt class="govuk-summary-list__key"> Potential safety risks (LPA answer)</dt>
+                                    <dd                                     class="govuk-summary-list__value"><span>No</span>
+                                        </dd>
+                                </div>
+                                <div class="govuk-summary-list__row appeal-appellant-health-and-safety"><dt class="govuk-summary-list__key"> Potential safety risks (appellant answer)</dt>
+                                    <dd                                     class="govuk-summary-list__value"><span>Yes</span>
+                                        <br><span>Dogs on site</span>
+                                        </dd>
+                                </div>
+                                <div class="govuk-summary-list__row appeal-neighbouring-sites-inspector"><dt class="govuk-summary-list__key"> Address of the neighbour’s land or property</dt>
+                                    <dd                                     class="govuk-summary-list__value">
+                                        <ul class="govuk-list govuk-list--bullet">
+                                            <li>1 Grove Cottage, Shotesham Road, Woodton, Devon, NR35 2ND</li>
+                                        </ul>
+                                        </dd>
+                                </div>
+                                <div class="govuk-summary-list__row appeal-neighbouring-sites-inspector"><dt class="govuk-summary-list__key"> Neighbouring sites (inspector and/or third party request)</dt>
+                                    <dd                                     class="govuk-summary-list__value">
+                                        <ul class="govuk-list govuk-list--bullet">
+                                            <li>2 Grove Cottage, Shotesham Road, Woodton, Devon, NR35 2ND</li>
+                                        </ul>
+                                        </dd>
+                                </div>
+                            </dl>
+                        </div>
+                    </details>
+                </div>
+            </div>
+            <div class="govuk-grid-row">
+                <div class="govuk-grid-column-full">
                     <form method="POST" novalidate="novalidate">
-                        <details class="govuk-details">
-                            <summary class="govuk-details__summary"><span class="govuk-details__summary-text"> Site information</span>
-                            </summary>
-                            <div class="govuk-details__text">
-                                <dl class="govuk-summary-list govuk-summary-list--no-border">
-                                    <div class="govuk-summary-list__row appeal-site-address"><dt class="govuk-summary-list__key"> Site address</dt>
-                                        <dd class="govuk-summary-list__value">21 The Pavement, Wandsworth, SW4 0HY</dd>
-                                    </div>
-                                    <div class="govuk-summary-list__row appeal-lpa-health-and-safety"><dt class="govuk-summary-list__key"> Potential safety risks (LPA answer)</dt>
-                                        <dd                                         class="govuk-summary-list__value"><span>No</span>
-                                            </dd>
-                                    </div>
-                                    <div class="govuk-summary-list__row appeal-appellant-health-and-safety"><dt class="govuk-summary-list__key"> Potential safety risks (appellant answer)</dt>
-                                        <dd                                         class="govuk-summary-list__value"><span>Yes</span>
-                                            <br><span>Dogs on site</span>
-                                            </dd>
-                                    </div>
-                                    <div class="govuk-summary-list__row appeal-neighbouring-sites-inspector"><dt class="govuk-summary-list__key"> Address of the neighbour’s land or property</dt>
-                                        <dd                                         class="govuk-summary-list__value">
-                                            <ul class="govuk-list govuk-list--bullet">
-                                                <li>1 Grove Cottage, Shotesham Road, Woodton, Devon, NR35 2ND</li>
-                                            </ul>
-                                            </dd>
-                                    </div>
-                                    <div class="govuk-summary-list__row appeal-neighbouring-sites-inspector"><dt class="govuk-summary-list__key"> Neighbouring sites (inspector and/or third party request)</dt>
-                                        <dd                                         class="govuk-summary-list__value">
-                                            <ul class="govuk-list govuk-list--bullet">
-                                                <li>2 Grove Cottage, Shotesham Road, Woodton, Devon, NR35 2ND</li>
-                                            </ul>
-                                            </dd>
-                                    </div>
-                                </dl>
-                            </div>
-                        </details>
                         <div class="govuk-form-group">
                             <fieldset class="govuk-fieldset">
                                 <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">Select visit type</legend>
@@ -3107,41 +3191,45 @@ exports[`site-visit POST /site-visit/schedule-visit should re-render the schedul
         <div class="govuk-grid-column-two-thirds">
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full">
+                    <details class="govuk-details">
+                        <summary class="govuk-details__summary"><span class="govuk-details__summary-text"> Site information</span>
+                        </summary>
+                        <div class="govuk-details__text">
+                            <dl class="govuk-summary-list govuk-summary-list--no-border">
+                                <div class="govuk-summary-list__row appeal-site-address"><dt class="govuk-summary-list__key"> Site address</dt>
+                                    <dd class="govuk-summary-list__value">21 The Pavement, Wandsworth, SW4 0HY</dd>
+                                </div>
+                                <div class="govuk-summary-list__row appeal-lpa-health-and-safety"><dt class="govuk-summary-list__key"> Potential safety risks (LPA answer)</dt>
+                                    <dd                                     class="govuk-summary-list__value"><span>No</span>
+                                        </dd>
+                                </div>
+                                <div class="govuk-summary-list__row appeal-appellant-health-and-safety"><dt class="govuk-summary-list__key"> Potential safety risks (appellant answer)</dt>
+                                    <dd                                     class="govuk-summary-list__value"><span>Yes</span>
+                                        <br><span>Dogs on site</span>
+                                        </dd>
+                                </div>
+                                <div class="govuk-summary-list__row appeal-neighbouring-sites-inspector"><dt class="govuk-summary-list__key"> Address of the neighbour’s land or property</dt>
+                                    <dd                                     class="govuk-summary-list__value">
+                                        <ul class="govuk-list govuk-list--bullet">
+                                            <li>1 Grove Cottage, Shotesham Road, Woodton, Devon, NR35 2ND</li>
+                                        </ul>
+                                        </dd>
+                                </div>
+                                <div class="govuk-summary-list__row appeal-neighbouring-sites-inspector"><dt class="govuk-summary-list__key"> Neighbouring sites (inspector and/or third party request)</dt>
+                                    <dd                                     class="govuk-summary-list__value">
+                                        <ul class="govuk-list govuk-list--bullet">
+                                            <li>2 Grove Cottage, Shotesham Road, Woodton, Devon, NR35 2ND</li>
+                                        </ul>
+                                        </dd>
+                                </div>
+                            </dl>
+                        </div>
+                    </details>
+                </div>
+            </div>
+            <div class="govuk-grid-row">
+                <div class="govuk-grid-column-full">
                     <form method="POST" novalidate="novalidate">
-                        <details class="govuk-details">
-                            <summary class="govuk-details__summary"><span class="govuk-details__summary-text"> Site information</span>
-                            </summary>
-                            <div class="govuk-details__text">
-                                <dl class="govuk-summary-list govuk-summary-list--no-border">
-                                    <div class="govuk-summary-list__row appeal-site-address"><dt class="govuk-summary-list__key"> Site address</dt>
-                                        <dd class="govuk-summary-list__value">21 The Pavement, Wandsworth, SW4 0HY</dd>
-                                    </div>
-                                    <div class="govuk-summary-list__row appeal-lpa-health-and-safety"><dt class="govuk-summary-list__key"> Potential safety risks (LPA answer)</dt>
-                                        <dd                                         class="govuk-summary-list__value"><span>No</span>
-                                            </dd>
-                                    </div>
-                                    <div class="govuk-summary-list__row appeal-appellant-health-and-safety"><dt class="govuk-summary-list__key"> Potential safety risks (appellant answer)</dt>
-                                        <dd                                         class="govuk-summary-list__value"><span>Yes</span>
-                                            <br><span>Dogs on site</span>
-                                            </dd>
-                                    </div>
-                                    <div class="govuk-summary-list__row appeal-neighbouring-sites-inspector"><dt class="govuk-summary-list__key"> Address of the neighbour’s land or property</dt>
-                                        <dd                                         class="govuk-summary-list__value">
-                                            <ul class="govuk-list govuk-list--bullet">
-                                                <li>1 Grove Cottage, Shotesham Road, Woodton, Devon, NR35 2ND</li>
-                                            </ul>
-                                            </dd>
-                                    </div>
-                                    <div class="govuk-summary-list__row appeal-neighbouring-sites-inspector"><dt class="govuk-summary-list__key"> Neighbouring sites (inspector and/or third party request)</dt>
-                                        <dd                                         class="govuk-summary-list__value">
-                                            <ul class="govuk-list govuk-list--bullet">
-                                                <li>2 Grove Cottage, Shotesham Road, Woodton, Devon, NR35 2ND</li>
-                                            </ul>
-                                            </dd>
-                                    </div>
-                                </dl>
-                            </div>
-                        </details>
                         <div class="govuk-form-group">
                             <fieldset class="govuk-fieldset">
                                 <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">Select visit type</legend>
@@ -3252,41 +3340,45 @@ exports[`site-visit POST /site-visit/schedule-visit should re-render the schedul
         <div class="govuk-grid-column-two-thirds">
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full">
+                    <details class="govuk-details">
+                        <summary class="govuk-details__summary"><span class="govuk-details__summary-text"> Site information</span>
+                        </summary>
+                        <div class="govuk-details__text">
+                            <dl class="govuk-summary-list govuk-summary-list--no-border">
+                                <div class="govuk-summary-list__row appeal-site-address"><dt class="govuk-summary-list__key"> Site address</dt>
+                                    <dd class="govuk-summary-list__value">21 The Pavement, Wandsworth, SW4 0HY</dd>
+                                </div>
+                                <div class="govuk-summary-list__row appeal-lpa-health-and-safety"><dt class="govuk-summary-list__key"> Potential safety risks (LPA answer)</dt>
+                                    <dd                                     class="govuk-summary-list__value"><span>No</span>
+                                        </dd>
+                                </div>
+                                <div class="govuk-summary-list__row appeal-appellant-health-and-safety"><dt class="govuk-summary-list__key"> Potential safety risks (appellant answer)</dt>
+                                    <dd                                     class="govuk-summary-list__value"><span>Yes</span>
+                                        <br><span>Dogs on site</span>
+                                        </dd>
+                                </div>
+                                <div class="govuk-summary-list__row appeal-neighbouring-sites-inspector"><dt class="govuk-summary-list__key"> Address of the neighbour’s land or property</dt>
+                                    <dd                                     class="govuk-summary-list__value">
+                                        <ul class="govuk-list govuk-list--bullet">
+                                            <li>1 Grove Cottage, Shotesham Road, Woodton, Devon, NR35 2ND</li>
+                                        </ul>
+                                        </dd>
+                                </div>
+                                <div class="govuk-summary-list__row appeal-neighbouring-sites-inspector"><dt class="govuk-summary-list__key"> Neighbouring sites (inspector and/or third party request)</dt>
+                                    <dd                                     class="govuk-summary-list__value">
+                                        <ul class="govuk-list govuk-list--bullet">
+                                            <li>2 Grove Cottage, Shotesham Road, Woodton, Devon, NR35 2ND</li>
+                                        </ul>
+                                        </dd>
+                                </div>
+                            </dl>
+                        </div>
+                    </details>
+                </div>
+            </div>
+            <div class="govuk-grid-row">
+                <div class="govuk-grid-column-full">
                     <form method="POST" novalidate="novalidate">
-                        <details class="govuk-details">
-                            <summary class="govuk-details__summary"><span class="govuk-details__summary-text"> Site information</span>
-                            </summary>
-                            <div class="govuk-details__text">
-                                <dl class="govuk-summary-list govuk-summary-list--no-border">
-                                    <div class="govuk-summary-list__row appeal-site-address"><dt class="govuk-summary-list__key"> Site address</dt>
-                                        <dd class="govuk-summary-list__value">21 The Pavement, Wandsworth, SW4 0HY</dd>
-                                    </div>
-                                    <div class="govuk-summary-list__row appeal-lpa-health-and-safety"><dt class="govuk-summary-list__key"> Potential safety risks (LPA answer)</dt>
-                                        <dd                                         class="govuk-summary-list__value"><span>No</span>
-                                            </dd>
-                                    </div>
-                                    <div class="govuk-summary-list__row appeal-appellant-health-and-safety"><dt class="govuk-summary-list__key"> Potential safety risks (appellant answer)</dt>
-                                        <dd                                         class="govuk-summary-list__value"><span>Yes</span>
-                                            <br><span>Dogs on site</span>
-                                            </dd>
-                                    </div>
-                                    <div class="govuk-summary-list__row appeal-neighbouring-sites-inspector"><dt class="govuk-summary-list__key"> Address of the neighbour’s land or property</dt>
-                                        <dd                                         class="govuk-summary-list__value">
-                                            <ul class="govuk-list govuk-list--bullet">
-                                                <li>1 Grove Cottage, Shotesham Road, Woodton, Devon, NR35 2ND</li>
-                                            </ul>
-                                            </dd>
-                                    </div>
-                                    <div class="govuk-summary-list__row appeal-neighbouring-sites-inspector"><dt class="govuk-summary-list__key"> Neighbouring sites (inspector and/or third party request)</dt>
-                                        <dd                                         class="govuk-summary-list__value">
-                                            <ul class="govuk-list govuk-list--bullet">
-                                                <li>2 Grove Cottage, Shotesham Road, Woodton, Devon, NR35 2ND</li>
-                                            </ul>
-                                            </dd>
-                                    </div>
-                                </dl>
-                            </div>
-                        </details>
                         <div class="govuk-form-group">
                             <fieldset class="govuk-fieldset">
                                 <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">Select visit type</legend>
@@ -3397,41 +3489,45 @@ exports[`site-visit POST /site-visit/schedule-visit should re-render the schedul
         <div class="govuk-grid-column-two-thirds">
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full">
+                    <details class="govuk-details">
+                        <summary class="govuk-details__summary"><span class="govuk-details__summary-text"> Site information</span>
+                        </summary>
+                        <div class="govuk-details__text">
+                            <dl class="govuk-summary-list govuk-summary-list--no-border">
+                                <div class="govuk-summary-list__row appeal-site-address"><dt class="govuk-summary-list__key"> Site address</dt>
+                                    <dd class="govuk-summary-list__value">21 The Pavement, Wandsworth, SW4 0HY</dd>
+                                </div>
+                                <div class="govuk-summary-list__row appeal-lpa-health-and-safety"><dt class="govuk-summary-list__key"> Potential safety risks (LPA answer)</dt>
+                                    <dd                                     class="govuk-summary-list__value"><span>No</span>
+                                        </dd>
+                                </div>
+                                <div class="govuk-summary-list__row appeal-appellant-health-and-safety"><dt class="govuk-summary-list__key"> Potential safety risks (appellant answer)</dt>
+                                    <dd                                     class="govuk-summary-list__value"><span>Yes</span>
+                                        <br><span>Dogs on site</span>
+                                        </dd>
+                                </div>
+                                <div class="govuk-summary-list__row appeal-neighbouring-sites-inspector"><dt class="govuk-summary-list__key"> Address of the neighbour’s land or property</dt>
+                                    <dd                                     class="govuk-summary-list__value">
+                                        <ul class="govuk-list govuk-list--bullet">
+                                            <li>1 Grove Cottage, Shotesham Road, Woodton, Devon, NR35 2ND</li>
+                                        </ul>
+                                        </dd>
+                                </div>
+                                <div class="govuk-summary-list__row appeal-neighbouring-sites-inspector"><dt class="govuk-summary-list__key"> Neighbouring sites (inspector and/or third party request)</dt>
+                                    <dd                                     class="govuk-summary-list__value">
+                                        <ul class="govuk-list govuk-list--bullet">
+                                            <li>2 Grove Cottage, Shotesham Road, Woodton, Devon, NR35 2ND</li>
+                                        </ul>
+                                        </dd>
+                                </div>
+                            </dl>
+                        </div>
+                    </details>
+                </div>
+            </div>
+            <div class="govuk-grid-row">
+                <div class="govuk-grid-column-full">
                     <form method="POST" novalidate="novalidate">
-                        <details class="govuk-details">
-                            <summary class="govuk-details__summary"><span class="govuk-details__summary-text"> Site information</span>
-                            </summary>
-                            <div class="govuk-details__text">
-                                <dl class="govuk-summary-list govuk-summary-list--no-border">
-                                    <div class="govuk-summary-list__row appeal-site-address"><dt class="govuk-summary-list__key"> Site address</dt>
-                                        <dd class="govuk-summary-list__value">21 The Pavement, Wandsworth, SW4 0HY</dd>
-                                    </div>
-                                    <div class="govuk-summary-list__row appeal-lpa-health-and-safety"><dt class="govuk-summary-list__key"> Potential safety risks (LPA answer)</dt>
-                                        <dd                                         class="govuk-summary-list__value"><span>No</span>
-                                            </dd>
-                                    </div>
-                                    <div class="govuk-summary-list__row appeal-appellant-health-and-safety"><dt class="govuk-summary-list__key"> Potential safety risks (appellant answer)</dt>
-                                        <dd                                         class="govuk-summary-list__value"><span>Yes</span>
-                                            <br><span>Dogs on site</span>
-                                            </dd>
-                                    </div>
-                                    <div class="govuk-summary-list__row appeal-neighbouring-sites-inspector"><dt class="govuk-summary-list__key"> Address of the neighbour’s land or property</dt>
-                                        <dd                                         class="govuk-summary-list__value">
-                                            <ul class="govuk-list govuk-list--bullet">
-                                                <li>1 Grove Cottage, Shotesham Road, Woodton, Devon, NR35 2ND</li>
-                                            </ul>
-                                            </dd>
-                                    </div>
-                                    <div class="govuk-summary-list__row appeal-neighbouring-sites-inspector"><dt class="govuk-summary-list__key"> Neighbouring sites (inspector and/or third party request)</dt>
-                                        <dd                                         class="govuk-summary-list__value">
-                                            <ul class="govuk-list govuk-list--bullet">
-                                                <li>2 Grove Cottage, Shotesham Road, Woodton, Devon, NR35 2ND</li>
-                                            </ul>
-                                            </dd>
-                                    </div>
-                                </dl>
-                            </div>
-                        </details>
                         <div class="govuk-form-group">
                             <fieldset class="govuk-fieldset">
                                 <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">Select visit type</legend>
@@ -3540,41 +3636,45 @@ exports[`site-visit POST /site-visit/schedule-visit should re-render the schedul
         <div class="govuk-grid-column-two-thirds">
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full">
+                    <details class="govuk-details">
+                        <summary class="govuk-details__summary"><span class="govuk-details__summary-text"> Site information</span>
+                        </summary>
+                        <div class="govuk-details__text">
+                            <dl class="govuk-summary-list govuk-summary-list--no-border">
+                                <div class="govuk-summary-list__row appeal-site-address"><dt class="govuk-summary-list__key"> Site address</dt>
+                                    <dd class="govuk-summary-list__value">21 The Pavement, Wandsworth, SW4 0HY</dd>
+                                </div>
+                                <div class="govuk-summary-list__row appeal-lpa-health-and-safety"><dt class="govuk-summary-list__key"> Potential safety risks (LPA answer)</dt>
+                                    <dd                                     class="govuk-summary-list__value"><span>No</span>
+                                        </dd>
+                                </div>
+                                <div class="govuk-summary-list__row appeal-appellant-health-and-safety"><dt class="govuk-summary-list__key"> Potential safety risks (appellant answer)</dt>
+                                    <dd                                     class="govuk-summary-list__value"><span>Yes</span>
+                                        <br><span>Dogs on site</span>
+                                        </dd>
+                                </div>
+                                <div class="govuk-summary-list__row appeal-neighbouring-sites-inspector"><dt class="govuk-summary-list__key"> Address of the neighbour’s land or property</dt>
+                                    <dd                                     class="govuk-summary-list__value">
+                                        <ul class="govuk-list govuk-list--bullet">
+                                            <li>1 Grove Cottage, Shotesham Road, Woodton, Devon, NR35 2ND</li>
+                                        </ul>
+                                        </dd>
+                                </div>
+                                <div class="govuk-summary-list__row appeal-neighbouring-sites-inspector"><dt class="govuk-summary-list__key"> Neighbouring sites (inspector and/or third party request)</dt>
+                                    <dd                                     class="govuk-summary-list__value">
+                                        <ul class="govuk-list govuk-list--bullet">
+                                            <li>2 Grove Cottage, Shotesham Road, Woodton, Devon, NR35 2ND</li>
+                                        </ul>
+                                        </dd>
+                                </div>
+                            </dl>
+                        </div>
+                    </details>
+                </div>
+            </div>
+            <div class="govuk-grid-row">
+                <div class="govuk-grid-column-full">
                     <form method="POST" novalidate="novalidate">
-                        <details class="govuk-details">
-                            <summary class="govuk-details__summary"><span class="govuk-details__summary-text"> Site information</span>
-                            </summary>
-                            <div class="govuk-details__text">
-                                <dl class="govuk-summary-list govuk-summary-list--no-border">
-                                    <div class="govuk-summary-list__row appeal-site-address"><dt class="govuk-summary-list__key"> Site address</dt>
-                                        <dd class="govuk-summary-list__value">21 The Pavement, Wandsworth, SW4 0HY</dd>
-                                    </div>
-                                    <div class="govuk-summary-list__row appeal-lpa-health-and-safety"><dt class="govuk-summary-list__key"> Potential safety risks (LPA answer)</dt>
-                                        <dd                                         class="govuk-summary-list__value"><span>No</span>
-                                            </dd>
-                                    </div>
-                                    <div class="govuk-summary-list__row appeal-appellant-health-and-safety"><dt class="govuk-summary-list__key"> Potential safety risks (appellant answer)</dt>
-                                        <dd                                         class="govuk-summary-list__value"><span>Yes</span>
-                                            <br><span>Dogs on site</span>
-                                            </dd>
-                                    </div>
-                                    <div class="govuk-summary-list__row appeal-neighbouring-sites-inspector"><dt class="govuk-summary-list__key"> Address of the neighbour’s land or property</dt>
-                                        <dd                                         class="govuk-summary-list__value">
-                                            <ul class="govuk-list govuk-list--bullet">
-                                                <li>1 Grove Cottage, Shotesham Road, Woodton, Devon, NR35 2ND</li>
-                                            </ul>
-                                            </dd>
-                                    </div>
-                                    <div class="govuk-summary-list__row appeal-neighbouring-sites-inspector"><dt class="govuk-summary-list__key"> Neighbouring sites (inspector and/or third party request)</dt>
-                                        <dd                                         class="govuk-summary-list__value">
-                                            <ul class="govuk-list govuk-list--bullet">
-                                                <li>2 Grove Cottage, Shotesham Road, Woodton, Devon, NR35 2ND</li>
-                                            </ul>
-                                            </dd>
-                                    </div>
-                                </dl>
-                            </div>
-                        </details>
                         <div class="govuk-form-group">
                             <fieldset class="govuk-fieldset">
                                 <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">Select visit type</legend>
@@ -3683,41 +3783,45 @@ exports[`site-visit POST /site-visit/schedule-visit should re-render the schedul
         <div class="govuk-grid-column-two-thirds">
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full">
+                    <details class="govuk-details">
+                        <summary class="govuk-details__summary"><span class="govuk-details__summary-text"> Site information</span>
+                        </summary>
+                        <div class="govuk-details__text">
+                            <dl class="govuk-summary-list govuk-summary-list--no-border">
+                                <div class="govuk-summary-list__row appeal-site-address"><dt class="govuk-summary-list__key"> Site address</dt>
+                                    <dd class="govuk-summary-list__value">21 The Pavement, Wandsworth, SW4 0HY</dd>
+                                </div>
+                                <div class="govuk-summary-list__row appeal-lpa-health-and-safety"><dt class="govuk-summary-list__key"> Potential safety risks (LPA answer)</dt>
+                                    <dd                                     class="govuk-summary-list__value"><span>No</span>
+                                        </dd>
+                                </div>
+                                <div class="govuk-summary-list__row appeal-appellant-health-and-safety"><dt class="govuk-summary-list__key"> Potential safety risks (appellant answer)</dt>
+                                    <dd                                     class="govuk-summary-list__value"><span>Yes</span>
+                                        <br><span>Dogs on site</span>
+                                        </dd>
+                                </div>
+                                <div class="govuk-summary-list__row appeal-neighbouring-sites-inspector"><dt class="govuk-summary-list__key"> Address of the neighbour’s land or property</dt>
+                                    <dd                                     class="govuk-summary-list__value">
+                                        <ul class="govuk-list govuk-list--bullet">
+                                            <li>1 Grove Cottage, Shotesham Road, Woodton, Devon, NR35 2ND</li>
+                                        </ul>
+                                        </dd>
+                                </div>
+                                <div class="govuk-summary-list__row appeal-neighbouring-sites-inspector"><dt class="govuk-summary-list__key"> Neighbouring sites (inspector and/or third party request)</dt>
+                                    <dd                                     class="govuk-summary-list__value">
+                                        <ul class="govuk-list govuk-list--bullet">
+                                            <li>2 Grove Cottage, Shotesham Road, Woodton, Devon, NR35 2ND</li>
+                                        </ul>
+                                        </dd>
+                                </div>
+                            </dl>
+                        </div>
+                    </details>
+                </div>
+            </div>
+            <div class="govuk-grid-row">
+                <div class="govuk-grid-column-full">
                     <form method="POST" novalidate="novalidate">
-                        <details class="govuk-details">
-                            <summary class="govuk-details__summary"><span class="govuk-details__summary-text"> Site information</span>
-                            </summary>
-                            <div class="govuk-details__text">
-                                <dl class="govuk-summary-list govuk-summary-list--no-border">
-                                    <div class="govuk-summary-list__row appeal-site-address"><dt class="govuk-summary-list__key"> Site address</dt>
-                                        <dd class="govuk-summary-list__value">21 The Pavement, Wandsworth, SW4 0HY</dd>
-                                    </div>
-                                    <div class="govuk-summary-list__row appeal-lpa-health-and-safety"><dt class="govuk-summary-list__key"> Potential safety risks (LPA answer)</dt>
-                                        <dd                                         class="govuk-summary-list__value"><span>No</span>
-                                            </dd>
-                                    </div>
-                                    <div class="govuk-summary-list__row appeal-appellant-health-and-safety"><dt class="govuk-summary-list__key"> Potential safety risks (appellant answer)</dt>
-                                        <dd                                         class="govuk-summary-list__value"><span>Yes</span>
-                                            <br><span>Dogs on site</span>
-                                            </dd>
-                                    </div>
-                                    <div class="govuk-summary-list__row appeal-neighbouring-sites-inspector"><dt class="govuk-summary-list__key"> Address of the neighbour’s land or property</dt>
-                                        <dd                                         class="govuk-summary-list__value">
-                                            <ul class="govuk-list govuk-list--bullet">
-                                                <li>1 Grove Cottage, Shotesham Road, Woodton, Devon, NR35 2ND</li>
-                                            </ul>
-                                            </dd>
-                                    </div>
-                                    <div class="govuk-summary-list__row appeal-neighbouring-sites-inspector"><dt class="govuk-summary-list__key"> Neighbouring sites (inspector and/or third party request)</dt>
-                                        <dd                                         class="govuk-summary-list__value">
-                                            <ul class="govuk-list govuk-list--bullet">
-                                                <li>2 Grove Cottage, Shotesham Road, Woodton, Devon, NR35 2ND</li>
-                                            </ul>
-                                            </dd>
-                                    </div>
-                                </dl>
-                            </div>
-                        </details>
                         <div class="govuk-form-group">
                             <fieldset class="govuk-fieldset">
                                 <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">Select visit type</legend>
@@ -3828,41 +3932,45 @@ exports[`site-visit POST /site-visit/schedule-visit should re-render the schedul
         <div class="govuk-grid-column-two-thirds">
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full">
+                    <details class="govuk-details">
+                        <summary class="govuk-details__summary"><span class="govuk-details__summary-text"> Site information</span>
+                        </summary>
+                        <div class="govuk-details__text">
+                            <dl class="govuk-summary-list govuk-summary-list--no-border">
+                                <div class="govuk-summary-list__row appeal-site-address"><dt class="govuk-summary-list__key"> Site address</dt>
+                                    <dd class="govuk-summary-list__value">21 The Pavement, Wandsworth, SW4 0HY</dd>
+                                </div>
+                                <div class="govuk-summary-list__row appeal-lpa-health-and-safety"><dt class="govuk-summary-list__key"> Potential safety risks (LPA answer)</dt>
+                                    <dd                                     class="govuk-summary-list__value"><span>No</span>
+                                        </dd>
+                                </div>
+                                <div class="govuk-summary-list__row appeal-appellant-health-and-safety"><dt class="govuk-summary-list__key"> Potential safety risks (appellant answer)</dt>
+                                    <dd                                     class="govuk-summary-list__value"><span>Yes</span>
+                                        <br><span>Dogs on site</span>
+                                        </dd>
+                                </div>
+                                <div class="govuk-summary-list__row appeal-neighbouring-sites-inspector"><dt class="govuk-summary-list__key"> Address of the neighbour’s land or property</dt>
+                                    <dd                                     class="govuk-summary-list__value">
+                                        <ul class="govuk-list govuk-list--bullet">
+                                            <li>1 Grove Cottage, Shotesham Road, Woodton, Devon, NR35 2ND</li>
+                                        </ul>
+                                        </dd>
+                                </div>
+                                <div class="govuk-summary-list__row appeal-neighbouring-sites-inspector"><dt class="govuk-summary-list__key"> Neighbouring sites (inspector and/or third party request)</dt>
+                                    <dd                                     class="govuk-summary-list__value">
+                                        <ul class="govuk-list govuk-list--bullet">
+                                            <li>2 Grove Cottage, Shotesham Road, Woodton, Devon, NR35 2ND</li>
+                                        </ul>
+                                        </dd>
+                                </div>
+                            </dl>
+                        </div>
+                    </details>
+                </div>
+            </div>
+            <div class="govuk-grid-row">
+                <div class="govuk-grid-column-full">
                     <form method="POST" novalidate="novalidate">
-                        <details class="govuk-details">
-                            <summary class="govuk-details__summary"><span class="govuk-details__summary-text"> Site information</span>
-                            </summary>
-                            <div class="govuk-details__text">
-                                <dl class="govuk-summary-list govuk-summary-list--no-border">
-                                    <div class="govuk-summary-list__row appeal-site-address"><dt class="govuk-summary-list__key"> Site address</dt>
-                                        <dd class="govuk-summary-list__value">21 The Pavement, Wandsworth, SW4 0HY</dd>
-                                    </div>
-                                    <div class="govuk-summary-list__row appeal-lpa-health-and-safety"><dt class="govuk-summary-list__key"> Potential safety risks (LPA answer)</dt>
-                                        <dd                                         class="govuk-summary-list__value"><span>No</span>
-                                            </dd>
-                                    </div>
-                                    <div class="govuk-summary-list__row appeal-appellant-health-and-safety"><dt class="govuk-summary-list__key"> Potential safety risks (appellant answer)</dt>
-                                        <dd                                         class="govuk-summary-list__value"><span>Yes</span>
-                                            <br><span>Dogs on site</span>
-                                            </dd>
-                                    </div>
-                                    <div class="govuk-summary-list__row appeal-neighbouring-sites-inspector"><dt class="govuk-summary-list__key"> Address of the neighbour’s land or property</dt>
-                                        <dd                                         class="govuk-summary-list__value">
-                                            <ul class="govuk-list govuk-list--bullet">
-                                                <li>1 Grove Cottage, Shotesham Road, Woodton, Devon, NR35 2ND</li>
-                                            </ul>
-                                            </dd>
-                                    </div>
-                                    <div class="govuk-summary-list__row appeal-neighbouring-sites-inspector"><dt class="govuk-summary-list__key"> Neighbouring sites (inspector and/or third party request)</dt>
-                                        <dd                                         class="govuk-summary-list__value">
-                                            <ul class="govuk-list govuk-list--bullet">
-                                                <li>2 Grove Cottage, Shotesham Road, Woodton, Devon, NR35 2ND</li>
-                                            </ul>
-                                            </dd>
-                                    </div>
-                                </dl>
-                            </div>
-                        </details>
                         <div class="govuk-form-group">
                             <fieldset class="govuk-fieldset">
                                 <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">Select visit type</legend>
@@ -3971,41 +4079,45 @@ exports[`site-visit POST /site-visit/schedule-visit should re-render the schedul
         <div class="govuk-grid-column-two-thirds">
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full">
+                    <details class="govuk-details">
+                        <summary class="govuk-details__summary"><span class="govuk-details__summary-text"> Site information</span>
+                        </summary>
+                        <div class="govuk-details__text">
+                            <dl class="govuk-summary-list govuk-summary-list--no-border">
+                                <div class="govuk-summary-list__row appeal-site-address"><dt class="govuk-summary-list__key"> Site address</dt>
+                                    <dd class="govuk-summary-list__value">21 The Pavement, Wandsworth, SW4 0HY</dd>
+                                </div>
+                                <div class="govuk-summary-list__row appeal-lpa-health-and-safety"><dt class="govuk-summary-list__key"> Potential safety risks (LPA answer)</dt>
+                                    <dd                                     class="govuk-summary-list__value"><span>No</span>
+                                        </dd>
+                                </div>
+                                <div class="govuk-summary-list__row appeal-appellant-health-and-safety"><dt class="govuk-summary-list__key"> Potential safety risks (appellant answer)</dt>
+                                    <dd                                     class="govuk-summary-list__value"><span>Yes</span>
+                                        <br><span>Dogs on site</span>
+                                        </dd>
+                                </div>
+                                <div class="govuk-summary-list__row appeal-neighbouring-sites-inspector"><dt class="govuk-summary-list__key"> Address of the neighbour’s land or property</dt>
+                                    <dd                                     class="govuk-summary-list__value">
+                                        <ul class="govuk-list govuk-list--bullet">
+                                            <li>1 Grove Cottage, Shotesham Road, Woodton, Devon, NR35 2ND</li>
+                                        </ul>
+                                        </dd>
+                                </div>
+                                <div class="govuk-summary-list__row appeal-neighbouring-sites-inspector"><dt class="govuk-summary-list__key"> Neighbouring sites (inspector and/or third party request)</dt>
+                                    <dd                                     class="govuk-summary-list__value">
+                                        <ul class="govuk-list govuk-list--bullet">
+                                            <li>2 Grove Cottage, Shotesham Road, Woodton, Devon, NR35 2ND</li>
+                                        </ul>
+                                        </dd>
+                                </div>
+                            </dl>
+                        </div>
+                    </details>
+                </div>
+            </div>
+            <div class="govuk-grid-row">
+                <div class="govuk-grid-column-full">
                     <form method="POST" novalidate="novalidate">
-                        <details class="govuk-details">
-                            <summary class="govuk-details__summary"><span class="govuk-details__summary-text"> Site information</span>
-                            </summary>
-                            <div class="govuk-details__text">
-                                <dl class="govuk-summary-list govuk-summary-list--no-border">
-                                    <div class="govuk-summary-list__row appeal-site-address"><dt class="govuk-summary-list__key"> Site address</dt>
-                                        <dd class="govuk-summary-list__value">21 The Pavement, Wandsworth, SW4 0HY</dd>
-                                    </div>
-                                    <div class="govuk-summary-list__row appeal-lpa-health-and-safety"><dt class="govuk-summary-list__key"> Potential safety risks (LPA answer)</dt>
-                                        <dd                                         class="govuk-summary-list__value"><span>No</span>
-                                            </dd>
-                                    </div>
-                                    <div class="govuk-summary-list__row appeal-appellant-health-and-safety"><dt class="govuk-summary-list__key"> Potential safety risks (appellant answer)</dt>
-                                        <dd                                         class="govuk-summary-list__value"><span>Yes</span>
-                                            <br><span>Dogs on site</span>
-                                            </dd>
-                                    </div>
-                                    <div class="govuk-summary-list__row appeal-neighbouring-sites-inspector"><dt class="govuk-summary-list__key"> Address of the neighbour’s land or property</dt>
-                                        <dd                                         class="govuk-summary-list__value">
-                                            <ul class="govuk-list govuk-list--bullet">
-                                                <li>1 Grove Cottage, Shotesham Road, Woodton, Devon, NR35 2ND</li>
-                                            </ul>
-                                            </dd>
-                                    </div>
-                                    <div class="govuk-summary-list__row appeal-neighbouring-sites-inspector"><dt class="govuk-summary-list__key"> Neighbouring sites (inspector and/or third party request)</dt>
-                                        <dd                                         class="govuk-summary-list__value">
-                                            <ul class="govuk-list govuk-list--bullet">
-                                                <li>2 Grove Cottage, Shotesham Road, Woodton, Devon, NR35 2ND</li>
-                                            </ul>
-                                            </dd>
-                                    </div>
-                                </dl>
-                            </div>
-                        </details>
                         <div class="govuk-form-group">
                             <fieldset class="govuk-fieldset">
                                 <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">Select visit type</legend>
@@ -4114,41 +4226,45 @@ exports[`site-visit POST /site-visit/schedule-visit should re-render the schedul
         <div class="govuk-grid-column-two-thirds">
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full">
+                    <details class="govuk-details">
+                        <summary class="govuk-details__summary"><span class="govuk-details__summary-text"> Site information</span>
+                        </summary>
+                        <div class="govuk-details__text">
+                            <dl class="govuk-summary-list govuk-summary-list--no-border">
+                                <div class="govuk-summary-list__row appeal-site-address"><dt class="govuk-summary-list__key"> Site address</dt>
+                                    <dd class="govuk-summary-list__value">21 The Pavement, Wandsworth, SW4 0HY</dd>
+                                </div>
+                                <div class="govuk-summary-list__row appeal-lpa-health-and-safety"><dt class="govuk-summary-list__key"> Potential safety risks (LPA answer)</dt>
+                                    <dd                                     class="govuk-summary-list__value"><span>No</span>
+                                        </dd>
+                                </div>
+                                <div class="govuk-summary-list__row appeal-appellant-health-and-safety"><dt class="govuk-summary-list__key"> Potential safety risks (appellant answer)</dt>
+                                    <dd                                     class="govuk-summary-list__value"><span>Yes</span>
+                                        <br><span>Dogs on site</span>
+                                        </dd>
+                                </div>
+                                <div class="govuk-summary-list__row appeal-neighbouring-sites-inspector"><dt class="govuk-summary-list__key"> Address of the neighbour’s land or property</dt>
+                                    <dd                                     class="govuk-summary-list__value">
+                                        <ul class="govuk-list govuk-list--bullet">
+                                            <li>1 Grove Cottage, Shotesham Road, Woodton, Devon, NR35 2ND</li>
+                                        </ul>
+                                        </dd>
+                                </div>
+                                <div class="govuk-summary-list__row appeal-neighbouring-sites-inspector"><dt class="govuk-summary-list__key"> Neighbouring sites (inspector and/or third party request)</dt>
+                                    <dd                                     class="govuk-summary-list__value">
+                                        <ul class="govuk-list govuk-list--bullet">
+                                            <li>2 Grove Cottage, Shotesham Road, Woodton, Devon, NR35 2ND</li>
+                                        </ul>
+                                        </dd>
+                                </div>
+                            </dl>
+                        </div>
+                    </details>
+                </div>
+            </div>
+            <div class="govuk-grid-row">
+                <div class="govuk-grid-column-full">
                     <form method="POST" novalidate="novalidate">
-                        <details class="govuk-details">
-                            <summary class="govuk-details__summary"><span class="govuk-details__summary-text"> Site information</span>
-                            </summary>
-                            <div class="govuk-details__text">
-                                <dl class="govuk-summary-list govuk-summary-list--no-border">
-                                    <div class="govuk-summary-list__row appeal-site-address"><dt class="govuk-summary-list__key"> Site address</dt>
-                                        <dd class="govuk-summary-list__value">21 The Pavement, Wandsworth, SW4 0HY</dd>
-                                    </div>
-                                    <div class="govuk-summary-list__row appeal-lpa-health-and-safety"><dt class="govuk-summary-list__key"> Potential safety risks (LPA answer)</dt>
-                                        <dd                                         class="govuk-summary-list__value"><span>No</span>
-                                            </dd>
-                                    </div>
-                                    <div class="govuk-summary-list__row appeal-appellant-health-and-safety"><dt class="govuk-summary-list__key"> Potential safety risks (appellant answer)</dt>
-                                        <dd                                         class="govuk-summary-list__value"><span>Yes</span>
-                                            <br><span>Dogs on site</span>
-                                            </dd>
-                                    </div>
-                                    <div class="govuk-summary-list__row appeal-neighbouring-sites-inspector"><dt class="govuk-summary-list__key"> Address of the neighbour’s land or property</dt>
-                                        <dd                                         class="govuk-summary-list__value">
-                                            <ul class="govuk-list govuk-list--bullet">
-                                                <li>1 Grove Cottage, Shotesham Road, Woodton, Devon, NR35 2ND</li>
-                                            </ul>
-                                            </dd>
-                                    </div>
-                                    <div class="govuk-summary-list__row appeal-neighbouring-sites-inspector"><dt class="govuk-summary-list__key"> Neighbouring sites (inspector and/or third party request)</dt>
-                                        <dd                                         class="govuk-summary-list__value">
-                                            <ul class="govuk-list govuk-list--bullet">
-                                                <li>2 Grove Cottage, Shotesham Road, Woodton, Devon, NR35 2ND</li>
-                                            </ul>
-                                            </dd>
-                                    </div>
-                                </dl>
-                            </div>
-                        </details>
                         <div class="govuk-form-group">
                             <fieldset class="govuk-fieldset">
                                 <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">Select visit type</legend>
@@ -4261,41 +4377,45 @@ exports[`site-visit POST /site-visit/schedule-visit should re-render the schedul
         <div class="govuk-grid-column-two-thirds">
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full">
+                    <details class="govuk-details">
+                        <summary class="govuk-details__summary"><span class="govuk-details__summary-text"> Site information</span>
+                        </summary>
+                        <div class="govuk-details__text">
+                            <dl class="govuk-summary-list govuk-summary-list--no-border">
+                                <div class="govuk-summary-list__row appeal-site-address"><dt class="govuk-summary-list__key"> Site address</dt>
+                                    <dd class="govuk-summary-list__value">21 The Pavement, Wandsworth, SW4 0HY</dd>
+                                </div>
+                                <div class="govuk-summary-list__row appeal-lpa-health-and-safety"><dt class="govuk-summary-list__key"> Potential safety risks (LPA answer)</dt>
+                                    <dd                                     class="govuk-summary-list__value"><span>No</span>
+                                        </dd>
+                                </div>
+                                <div class="govuk-summary-list__row appeal-appellant-health-and-safety"><dt class="govuk-summary-list__key"> Potential safety risks (appellant answer)</dt>
+                                    <dd                                     class="govuk-summary-list__value"><span>Yes</span>
+                                        <br><span>Dogs on site</span>
+                                        </dd>
+                                </div>
+                                <div class="govuk-summary-list__row appeal-neighbouring-sites-inspector"><dt class="govuk-summary-list__key"> Address of the neighbour’s land or property</dt>
+                                    <dd                                     class="govuk-summary-list__value">
+                                        <ul class="govuk-list govuk-list--bullet">
+                                            <li>1 Grove Cottage, Shotesham Road, Woodton, Devon, NR35 2ND</li>
+                                        </ul>
+                                        </dd>
+                                </div>
+                                <div class="govuk-summary-list__row appeal-neighbouring-sites-inspector"><dt class="govuk-summary-list__key"> Neighbouring sites (inspector and/or third party request)</dt>
+                                    <dd                                     class="govuk-summary-list__value">
+                                        <ul class="govuk-list govuk-list--bullet">
+                                            <li>2 Grove Cottage, Shotesham Road, Woodton, Devon, NR35 2ND</li>
+                                        </ul>
+                                        </dd>
+                                </div>
+                            </dl>
+                        </div>
+                    </details>
+                </div>
+            </div>
+            <div class="govuk-grid-row">
+                <div class="govuk-grid-column-full">
                     <form method="POST" novalidate="novalidate">
-                        <details class="govuk-details">
-                            <summary class="govuk-details__summary"><span class="govuk-details__summary-text"> Site information</span>
-                            </summary>
-                            <div class="govuk-details__text">
-                                <dl class="govuk-summary-list govuk-summary-list--no-border">
-                                    <div class="govuk-summary-list__row appeal-site-address"><dt class="govuk-summary-list__key"> Site address</dt>
-                                        <dd class="govuk-summary-list__value">21 The Pavement, Wandsworth, SW4 0HY</dd>
-                                    </div>
-                                    <div class="govuk-summary-list__row appeal-lpa-health-and-safety"><dt class="govuk-summary-list__key"> Potential safety risks (LPA answer)</dt>
-                                        <dd                                         class="govuk-summary-list__value"><span>No</span>
-                                            </dd>
-                                    </div>
-                                    <div class="govuk-summary-list__row appeal-appellant-health-and-safety"><dt class="govuk-summary-list__key"> Potential safety risks (appellant answer)</dt>
-                                        <dd                                         class="govuk-summary-list__value"><span>Yes</span>
-                                            <br><span>Dogs on site</span>
-                                            </dd>
-                                    </div>
-                                    <div class="govuk-summary-list__row appeal-neighbouring-sites-inspector"><dt class="govuk-summary-list__key"> Address of the neighbour’s land or property</dt>
-                                        <dd                                         class="govuk-summary-list__value">
-                                            <ul class="govuk-list govuk-list--bullet">
-                                                <li>1 Grove Cottage, Shotesham Road, Woodton, Devon, NR35 2ND</li>
-                                            </ul>
-                                            </dd>
-                                    </div>
-                                    <div class="govuk-summary-list__row appeal-neighbouring-sites-inspector"><dt class="govuk-summary-list__key"> Neighbouring sites (inspector and/or third party request)</dt>
-                                        <dd                                         class="govuk-summary-list__value">
-                                            <ul class="govuk-list govuk-list--bullet">
-                                                <li>2 Grove Cottage, Shotesham Road, Woodton, Devon, NR35 2ND</li>
-                                            </ul>
-                                            </dd>
-                                    </div>
-                                </dl>
-                            </div>
-                        </details>
                         <div class="govuk-form-group">
                             <fieldset class="govuk-fieldset">
                                 <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">Select visit type</legend>
@@ -4406,41 +4526,45 @@ exports[`site-visit POST /site-visit/schedule-visit should re-render the schedul
         <div class="govuk-grid-column-two-thirds">
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full">
+                    <details class="govuk-details">
+                        <summary class="govuk-details__summary"><span class="govuk-details__summary-text"> Site information</span>
+                        </summary>
+                        <div class="govuk-details__text">
+                            <dl class="govuk-summary-list govuk-summary-list--no-border">
+                                <div class="govuk-summary-list__row appeal-site-address"><dt class="govuk-summary-list__key"> Site address</dt>
+                                    <dd class="govuk-summary-list__value">21 The Pavement, Wandsworth, SW4 0HY</dd>
+                                </div>
+                                <div class="govuk-summary-list__row appeal-lpa-health-and-safety"><dt class="govuk-summary-list__key"> Potential safety risks (LPA answer)</dt>
+                                    <dd                                     class="govuk-summary-list__value"><span>No</span>
+                                        </dd>
+                                </div>
+                                <div class="govuk-summary-list__row appeal-appellant-health-and-safety"><dt class="govuk-summary-list__key"> Potential safety risks (appellant answer)</dt>
+                                    <dd                                     class="govuk-summary-list__value"><span>Yes</span>
+                                        <br><span>Dogs on site</span>
+                                        </dd>
+                                </div>
+                                <div class="govuk-summary-list__row appeal-neighbouring-sites-inspector"><dt class="govuk-summary-list__key"> Address of the neighbour’s land or property</dt>
+                                    <dd                                     class="govuk-summary-list__value">
+                                        <ul class="govuk-list govuk-list--bullet">
+                                            <li>1 Grove Cottage, Shotesham Road, Woodton, Devon, NR35 2ND</li>
+                                        </ul>
+                                        </dd>
+                                </div>
+                                <div class="govuk-summary-list__row appeal-neighbouring-sites-inspector"><dt class="govuk-summary-list__key"> Neighbouring sites (inspector and/or third party request)</dt>
+                                    <dd                                     class="govuk-summary-list__value">
+                                        <ul class="govuk-list govuk-list--bullet">
+                                            <li>2 Grove Cottage, Shotesham Road, Woodton, Devon, NR35 2ND</li>
+                                        </ul>
+                                        </dd>
+                                </div>
+                            </dl>
+                        </div>
+                    </details>
+                </div>
+            </div>
+            <div class="govuk-grid-row">
+                <div class="govuk-grid-column-full">
                     <form method="POST" novalidate="novalidate">
-                        <details class="govuk-details">
-                            <summary class="govuk-details__summary"><span class="govuk-details__summary-text"> Site information</span>
-                            </summary>
-                            <div class="govuk-details__text">
-                                <dl class="govuk-summary-list govuk-summary-list--no-border">
-                                    <div class="govuk-summary-list__row appeal-site-address"><dt class="govuk-summary-list__key"> Site address</dt>
-                                        <dd class="govuk-summary-list__value">21 The Pavement, Wandsworth, SW4 0HY</dd>
-                                    </div>
-                                    <div class="govuk-summary-list__row appeal-lpa-health-and-safety"><dt class="govuk-summary-list__key"> Potential safety risks (LPA answer)</dt>
-                                        <dd                                         class="govuk-summary-list__value"><span>No</span>
-                                            </dd>
-                                    </div>
-                                    <div class="govuk-summary-list__row appeal-appellant-health-and-safety"><dt class="govuk-summary-list__key"> Potential safety risks (appellant answer)</dt>
-                                        <dd                                         class="govuk-summary-list__value"><span>Yes</span>
-                                            <br><span>Dogs on site</span>
-                                            </dd>
-                                    </div>
-                                    <div class="govuk-summary-list__row appeal-neighbouring-sites-inspector"><dt class="govuk-summary-list__key"> Address of the neighbour’s land or property</dt>
-                                        <dd                                         class="govuk-summary-list__value">
-                                            <ul class="govuk-list govuk-list--bullet">
-                                                <li>1 Grove Cottage, Shotesham Road, Woodton, Devon, NR35 2ND</li>
-                                            </ul>
-                                            </dd>
-                                    </div>
-                                    <div class="govuk-summary-list__row appeal-neighbouring-sites-inspector"><dt class="govuk-summary-list__key"> Neighbouring sites (inspector and/or third party request)</dt>
-                                        <dd                                         class="govuk-summary-list__value">
-                                            <ul class="govuk-list govuk-list--bullet">
-                                                <li>2 Grove Cottage, Shotesham Road, Woodton, Devon, NR35 2ND</li>
-                                            </ul>
-                                            </dd>
-                                    </div>
-                                </dl>
-                            </div>
-                        </details>
                         <div class="govuk-form-group">
                             <fieldset class="govuk-fieldset">
                                 <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">Select visit type</legend>
@@ -4551,41 +4675,45 @@ exports[`site-visit POST /site-visit/schedule-visit should re-render the schedul
         <div class="govuk-grid-column-two-thirds">
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full">
+                    <details class="govuk-details">
+                        <summary class="govuk-details__summary"><span class="govuk-details__summary-text"> Site information</span>
+                        </summary>
+                        <div class="govuk-details__text">
+                            <dl class="govuk-summary-list govuk-summary-list--no-border">
+                                <div class="govuk-summary-list__row appeal-site-address"><dt class="govuk-summary-list__key"> Site address</dt>
+                                    <dd class="govuk-summary-list__value">21 The Pavement, Wandsworth, SW4 0HY</dd>
+                                </div>
+                                <div class="govuk-summary-list__row appeal-lpa-health-and-safety"><dt class="govuk-summary-list__key"> Potential safety risks (LPA answer)</dt>
+                                    <dd                                     class="govuk-summary-list__value"><span>No</span>
+                                        </dd>
+                                </div>
+                                <div class="govuk-summary-list__row appeal-appellant-health-and-safety"><dt class="govuk-summary-list__key"> Potential safety risks (appellant answer)</dt>
+                                    <dd                                     class="govuk-summary-list__value"><span>Yes</span>
+                                        <br><span>Dogs on site</span>
+                                        </dd>
+                                </div>
+                                <div class="govuk-summary-list__row appeal-neighbouring-sites-inspector"><dt class="govuk-summary-list__key"> Address of the neighbour’s land or property</dt>
+                                    <dd                                     class="govuk-summary-list__value">
+                                        <ul class="govuk-list govuk-list--bullet">
+                                            <li>1 Grove Cottage, Shotesham Road, Woodton, Devon, NR35 2ND</li>
+                                        </ul>
+                                        </dd>
+                                </div>
+                                <div class="govuk-summary-list__row appeal-neighbouring-sites-inspector"><dt class="govuk-summary-list__key"> Neighbouring sites (inspector and/or third party request)</dt>
+                                    <dd                                     class="govuk-summary-list__value">
+                                        <ul class="govuk-list govuk-list--bullet">
+                                            <li>2 Grove Cottage, Shotesham Road, Woodton, Devon, NR35 2ND</li>
+                                        </ul>
+                                        </dd>
+                                </div>
+                            </dl>
+                        </div>
+                    </details>
+                </div>
+            </div>
+            <div class="govuk-grid-row">
+                <div class="govuk-grid-column-full">
                     <form method="POST" novalidate="novalidate">
-                        <details class="govuk-details">
-                            <summary class="govuk-details__summary"><span class="govuk-details__summary-text"> Site information</span>
-                            </summary>
-                            <div class="govuk-details__text">
-                                <dl class="govuk-summary-list govuk-summary-list--no-border">
-                                    <div class="govuk-summary-list__row appeal-site-address"><dt class="govuk-summary-list__key"> Site address</dt>
-                                        <dd class="govuk-summary-list__value">21 The Pavement, Wandsworth, SW4 0HY</dd>
-                                    </div>
-                                    <div class="govuk-summary-list__row appeal-lpa-health-and-safety"><dt class="govuk-summary-list__key"> Potential safety risks (LPA answer)</dt>
-                                        <dd                                         class="govuk-summary-list__value"><span>No</span>
-                                            </dd>
-                                    </div>
-                                    <div class="govuk-summary-list__row appeal-appellant-health-and-safety"><dt class="govuk-summary-list__key"> Potential safety risks (appellant answer)</dt>
-                                        <dd                                         class="govuk-summary-list__value"><span>Yes</span>
-                                            <br><span>Dogs on site</span>
-                                            </dd>
-                                    </div>
-                                    <div class="govuk-summary-list__row appeal-neighbouring-sites-inspector"><dt class="govuk-summary-list__key"> Address of the neighbour’s land or property</dt>
-                                        <dd                                         class="govuk-summary-list__value">
-                                            <ul class="govuk-list govuk-list--bullet">
-                                                <li>1 Grove Cottage, Shotesham Road, Woodton, Devon, NR35 2ND</li>
-                                            </ul>
-                                            </dd>
-                                    </div>
-                                    <div class="govuk-summary-list__row appeal-neighbouring-sites-inspector"><dt class="govuk-summary-list__key"> Neighbouring sites (inspector and/or third party request)</dt>
-                                        <dd                                         class="govuk-summary-list__value">
-                                            <ul class="govuk-list govuk-list--bullet">
-                                                <li>2 Grove Cottage, Shotesham Road, Woodton, Devon, NR35 2ND</li>
-                                            </ul>
-                                            </dd>
-                                    </div>
-                                </dl>
-                            </div>
-                        </details>
                         <div class="govuk-form-group">
                             <fieldset class="govuk-fieldset">
                                 <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">Select visit type</legend>
@@ -4700,41 +4828,45 @@ exports[`site-visit POST /site-visit/schedule-visit should re-render the schedul
         <div class="govuk-grid-column-two-thirds">
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full">
+                    <details class="govuk-details">
+                        <summary class="govuk-details__summary"><span class="govuk-details__summary-text"> Site information</span>
+                        </summary>
+                        <div class="govuk-details__text">
+                            <dl class="govuk-summary-list govuk-summary-list--no-border">
+                                <div class="govuk-summary-list__row appeal-site-address"><dt class="govuk-summary-list__key"> Site address</dt>
+                                    <dd class="govuk-summary-list__value">21 The Pavement, Wandsworth, SW4 0HY</dd>
+                                </div>
+                                <div class="govuk-summary-list__row appeal-lpa-health-and-safety"><dt class="govuk-summary-list__key"> Potential safety risks (LPA answer)</dt>
+                                    <dd                                     class="govuk-summary-list__value"><span>No</span>
+                                        </dd>
+                                </div>
+                                <div class="govuk-summary-list__row appeal-appellant-health-and-safety"><dt class="govuk-summary-list__key"> Potential safety risks (appellant answer)</dt>
+                                    <dd                                     class="govuk-summary-list__value"><span>Yes</span>
+                                        <br><span>Dogs on site</span>
+                                        </dd>
+                                </div>
+                                <div class="govuk-summary-list__row appeal-neighbouring-sites-inspector"><dt class="govuk-summary-list__key"> Address of the neighbour’s land or property</dt>
+                                    <dd                                     class="govuk-summary-list__value">
+                                        <ul class="govuk-list govuk-list--bullet">
+                                            <li>1 Grove Cottage, Shotesham Road, Woodton, Devon, NR35 2ND</li>
+                                        </ul>
+                                        </dd>
+                                </div>
+                                <div class="govuk-summary-list__row appeal-neighbouring-sites-inspector"><dt class="govuk-summary-list__key"> Neighbouring sites (inspector and/or third party request)</dt>
+                                    <dd                                     class="govuk-summary-list__value">
+                                        <ul class="govuk-list govuk-list--bullet">
+                                            <li>2 Grove Cottage, Shotesham Road, Woodton, Devon, NR35 2ND</li>
+                                        </ul>
+                                        </dd>
+                                </div>
+                            </dl>
+                        </div>
+                    </details>
+                </div>
+            </div>
+            <div class="govuk-grid-row">
+                <div class="govuk-grid-column-full">
                     <form method="POST" novalidate="novalidate">
-                        <details class="govuk-details">
-                            <summary class="govuk-details__summary"><span class="govuk-details__summary-text"> Site information</span>
-                            </summary>
-                            <div class="govuk-details__text">
-                                <dl class="govuk-summary-list govuk-summary-list--no-border">
-                                    <div class="govuk-summary-list__row appeal-site-address"><dt class="govuk-summary-list__key"> Site address</dt>
-                                        <dd class="govuk-summary-list__value">21 The Pavement, Wandsworth, SW4 0HY</dd>
-                                    </div>
-                                    <div class="govuk-summary-list__row appeal-lpa-health-and-safety"><dt class="govuk-summary-list__key"> Potential safety risks (LPA answer)</dt>
-                                        <dd                                         class="govuk-summary-list__value"><span>No</span>
-                                            </dd>
-                                    </div>
-                                    <div class="govuk-summary-list__row appeal-appellant-health-and-safety"><dt class="govuk-summary-list__key"> Potential safety risks (appellant answer)</dt>
-                                        <dd                                         class="govuk-summary-list__value"><span>Yes</span>
-                                            <br><span>Dogs on site</span>
-                                            </dd>
-                                    </div>
-                                    <div class="govuk-summary-list__row appeal-neighbouring-sites-inspector"><dt class="govuk-summary-list__key"> Address of the neighbour’s land or property</dt>
-                                        <dd                                         class="govuk-summary-list__value">
-                                            <ul class="govuk-list govuk-list--bullet">
-                                                <li>1 Grove Cottage, Shotesham Road, Woodton, Devon, NR35 2ND</li>
-                                            </ul>
-                                            </dd>
-                                    </div>
-                                    <div class="govuk-summary-list__row appeal-neighbouring-sites-inspector"><dt class="govuk-summary-list__key"> Neighbouring sites (inspector and/or third party request)</dt>
-                                        <dd                                         class="govuk-summary-list__value">
-                                            <ul class="govuk-list govuk-list--bullet">
-                                                <li>2 Grove Cottage, Shotesham Road, Woodton, Devon, NR35 2ND</li>
-                                            </ul>
-                                            </dd>
-                                    </div>
-                                </dl>
-                            </div>
-                        </details>
                         <div class="govuk-form-group">
                             <fieldset class="govuk-fieldset">
                                 <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">Select visit type</legend>

--- a/appeals/web/src/server/appeals/appeal-details/site-visit/site-visit.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/site-visit/site-visit.mapper.js
@@ -259,8 +259,8 @@ export async function scheduleOrManageSiteVisitPage(
 		preHeading: `Appeal ${shortAppealReference}`,
 		heading: `${titlePrefix} site visit`,
 		submitButtonText: 'Confirm',
+		prePageComponents: [siteInformationComponent],
 		pageComponents: [
-			siteInformationComponent,
 			selectVisitTypeComponent,
 			selectDateComponent,
 			selectTimeHtmlComponent,
@@ -270,8 +270,8 @@ export async function scheduleOrManageSiteVisitPage(
 		]
 	};
 
-	if (pageContent.pageComponents) {
-		preRenderPageComponents(pageContent.pageComponents);
+	if (pageContent.prePageComponents) {
+		preRenderPageComponents(pageContent.prePageComponents);
 	}
 
 	return pageContent;

--- a/appeals/web/src/server/appeals/appeal-details/withdrawal/__tests__/__snapshots__/withdrawal.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/withdrawal/__tests__/__snapshots__/withdrawal.test.js.snap
@@ -163,32 +163,36 @@ exports[`withdrawal GET /withdrawal/check-your-answers should render the check y
         <div class="govuk-grid-column-two-thirds">
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full">
-                    <form method="POST" novalidate="novalidate">
-                        <dl class="govuk-summary-list">
-                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Withdrawal request</dt>
-                                <dd class="govuk-summary-list__value"><a class="govuk-link" href="/documents/APP/Q9999/D/21/351062/download-uncommitted/1/test-document.txt"
-                                    target="_blank">test-document.txt</a>
-                                </dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/withdrawal/start">Change<span class="govuk-visually-hidden"> withdrawal request</span></a>
-                                </dd>
-                            </div>
-                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Request date</dt>
-                                <dd class="govuk-summary-list__value">1 January 2024</dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/withdrawal/withdrawal-request-date">Change<span class="govuk-visually-hidden"> request date</span></a>
-                                </dd>
-                            </div>
-                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Redaction status</dt>
-                                <dd class="govuk-summary-list__value">Unredacted</dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/withdrawal/redaction-status">Change<span class="govuk-visually-hidden"> redaction status</span></a>
-                                </dd>
-                            </div>
-                        </dl>
-                        <div class="govuk-warning-text"><span class="govuk-warning-text__icon" aria-hidden="true">!</span>
-                            <strong                             class="govuk-warning-text__text"><span class="govuk-visually-hidden">Warning</span> You are about to tell
-                                the relevant parties the appeal has been withdrawn and it is being closed.
-                                Any appointments for this case should be cancelled. Only limited changes
-                                can be made to the case once it is closed.</strong>
+                    <dl class="govuk-summary-list">
+                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Withdrawal request</dt>
+                            <dd class="govuk-summary-list__value"><a class="govuk-link" href="/documents/APP/Q9999/D/21/351062/download-uncommitted/1/test-document.txt"
+                                target="_blank">test-document.txt</a>
+                            </dd>
+                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/withdrawal/start">Change<span class="govuk-visually-hidden"> withdrawal request</span></a>
+                            </dd>
                         </div>
+                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Request date</dt>
+                            <dd class="govuk-summary-list__value">1 January 2024</dd>
+                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/withdrawal/withdrawal-request-date">Change<span class="govuk-visually-hidden"> request date</span></a>
+                            </dd>
+                        </div>
+                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Redaction status</dt>
+                            <dd class="govuk-summary-list__value">Unredacted</dd>
+                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/withdrawal/redaction-status">Change<span class="govuk-visually-hidden"> redaction status</span></a>
+                            </dd>
+                        </div>
+                    </dl>
+                    <div class="govuk-warning-text"><span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+                        <strong                         class="govuk-warning-text__text"><span class="govuk-visually-hidden">Warning</span> You are about to tell
+                            the relevant parties the appeal has been withdrawn and it is being closed.
+                            Any appointments for this case should be cancelled. Only limited changes
+                            can be made to the case once it is closed.</strong>
+                    </div>
+                </div>
+            </div>
+            <div class="govuk-grid-row">
+                <div class="govuk-grid-column-full">
+                    <form method="POST" novalidate="novalidate">
                         <div class="govuk-form-group">
                             <div class="govuk-checkboxes" data-module="govuk-checkboxes">
                                 <div class="govuk-checkboxes__item">
@@ -219,9 +223,13 @@ exports[`withdrawal GET /withdrawal-request-date should render the withdrawal re
         <div class="govuk-grid-column-two-thirds">
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full">
+                    <div class="govuk-hint">This is the date on the withdrawal correspondence from the appellant</div>
+                </div>
+            </div>
+            <div class="govuk-grid-row">
+                <div class="govuk-grid-column-full">
                     <form method="POST" novalidate="novalidate">
-                        <div class="govuk-hint">This is the date on the withdrawal correspondence from the appellant</div>
-                        <div                         class="govuk-form-group">
+                        <div class="govuk-form-group">
                             <fieldset class="govuk-fieldset" role="group" aria-describedby="withdrawal-request-date-hint">
                                 <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">Enter date</legend>
                                 <div id="withdrawal-request-date-hint" class="govuk-hint">For example, 27 11 2023</div>
@@ -252,13 +260,13 @@ exports[`withdrawal GET /withdrawal-request-date should render the withdrawal re
                                     </div>
                                 </div>
                             </fieldset>
+                        </div>
+                        <button type="submit" data-prevent-double-click="true" class="govuk-button"
+                        data-module="govuk-button">Continue</button>
+                    </form>
                 </div>
-                <button type="submit" data-prevent-double-click="true" class="govuk-button"
-                data-module="govuk-button">Continue</button>
-                </form>
             </div>
         </div>
-    </div>
     </div>
 </main>"
 `;
@@ -366,32 +374,36 @@ exports[`withdrawal POST /withdrawal/check-your-answers should render the check 
         <div class="govuk-grid-column-two-thirds">
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full">
-                    <form method="POST" novalidate="novalidate">
-                        <dl class="govuk-summary-list">
-                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Withdrawal request</dt>
-                                <dd class="govuk-summary-list__value"><a class="govuk-link" href="/documents/APP/Q9999/D/21/351062/download-uncommitted/1/test-document.txt"
-                                    target="_blank">test-document.txt</a>
-                                </dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/withdrawal/start">Change<span class="govuk-visually-hidden"> withdrawal request</span></a>
-                                </dd>
-                            </div>
-                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Request date</dt>
-                                <dd class="govuk-summary-list__value">1 January 2024</dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/withdrawal/withdrawal-request-date">Change<span class="govuk-visually-hidden"> request date</span></a>
-                                </dd>
-                            </div>
-                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Redaction status</dt>
-                                <dd class="govuk-summary-list__value">Unredacted</dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/withdrawal/redaction-status">Change<span class="govuk-visually-hidden"> redaction status</span></a>
-                                </dd>
-                            </div>
-                        </dl>
-                        <div class="govuk-warning-text"><span class="govuk-warning-text__icon" aria-hidden="true">!</span>
-                            <strong                             class="govuk-warning-text__text"><span class="govuk-visually-hidden">Warning</span> You are about to tell
-                                the relevant parties the appeal has been withdrawn and it is being closed.
-                                Any appointments for this case should be cancelled. Only limited changes
-                                can be made to the case once it is closed.</strong>
+                    <dl class="govuk-summary-list">
+                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Withdrawal request</dt>
+                            <dd class="govuk-summary-list__value"><a class="govuk-link" href="/documents/APP/Q9999/D/21/351062/download-uncommitted/1/test-document.txt"
+                                target="_blank">test-document.txt</a>
+                            </dd>
+                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/withdrawal/start">Change<span class="govuk-visually-hidden"> withdrawal request</span></a>
+                            </dd>
                         </div>
+                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Request date</dt>
+                            <dd class="govuk-summary-list__value">1 January 2024</dd>
+                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/withdrawal/withdrawal-request-date">Change<span class="govuk-visually-hidden"> request date</span></a>
+                            </dd>
+                        </div>
+                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Redaction status</dt>
+                            <dd class="govuk-summary-list__value">Unredacted</dd>
+                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/withdrawal/redaction-status">Change<span class="govuk-visually-hidden"> redaction status</span></a>
+                            </dd>
+                        </div>
+                    </dl>
+                    <div class="govuk-warning-text"><span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+                        <strong                         class="govuk-warning-text__text"><span class="govuk-visually-hidden">Warning</span> You are about to tell
+                            the relevant parties the appeal has been withdrawn and it is being closed.
+                            Any appointments for this case should be cancelled. Only limited changes
+                            can be made to the case once it is closed.</strong>
+                    </div>
+                </div>
+            </div>
+            <div class="govuk-grid-row">
+                <div class="govuk-grid-column-full">
+                    <form method="POST" novalidate="novalidate">
                         <div class="govuk-form-group">
                             <div class="govuk-checkboxes" data-module="govuk-checkboxes">
                                 <div class="govuk-checkboxes__item">

--- a/appeals/web/src/server/appeals/appeal-details/withdrawal/withdrawal.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/withdrawal/withdrawal.mapper.js
@@ -204,15 +204,15 @@ export function dateWithdrawalRequestPage(
 		backLinkText: 'Back',
 		preHeading: `Appeal ${appealShortReference(appealData.appealReference)}`,
 		heading: title,
-		pageComponents: [
+		prePageComponents: [
 			{
 				type: 'hint',
 				parameters: {
 					text: 'This is the date on the withdrawal correspondence from the appellant'
 				}
-			},
-			selectDateComponent
-		]
+			}
+		],
+		pageComponents: [selectDateComponent]
 	};
 }
 
@@ -378,7 +378,8 @@ export function checkAndConfirmPage(appealData, session) {
 		preHeading: `Appeal ${appealShortReference(appealData.appealReference)}`,
 		heading: title,
 		submitButtonText: 'Confirm',
-		pageComponents: [summaryListComponent, warningTextComponent, insetConfirmComponent]
+		prePageComponents: [summaryListComponent, warningTextComponent],
+		pageComponents: [insetConfirmComponent]
 	};
 
 	if (pageContent.pageComponents) {

--- a/appeals/web/src/server/lib/mappers/types.js
+++ b/appeals/web/src/server/lib/mappers/types.js
@@ -334,9 +334,12 @@
  * @property {string} [skipButtonUrl]
  * @property {PageComponent[]} [pageComponents]
  * @property {boolean} [forceRenderSubmitButton]
+ * @property {PageComponent[]} [prePageComponents]
  * @property {PageComponent[]} [postPageComponents]
  * @property {string} [hint]
  * @property {string} [formWrapperColumnClass]
+ * @property {string} [prePageWrapperColumnClass]
+ * @property {string} [postPageWrapperColumnClass]
  */
 
 /**

--- a/appeals/web/src/server/views/app/includes/change-page-content.pattern.njk
+++ b/appeals/web/src/server/views/app/includes/change-page-content.pattern.njk
@@ -1,19 +1,34 @@
-	<div class="govuk-grid-row">
-		<div class="govuk-grid-column-full">
-			<form method="POST" novalidate="novalidate">
+{%- if pageContent.prePageComponents and pageContent.prePageComponents | length -%}
+<div class="govuk-grid-row">
+	<div class="{{ pageContent.prePageWrapperColumnClass if pageContent.prePageWrapperColumnClass else 'govuk-grid-column-full' }}">
+	{%- for component in pageContent.prePageComponents -%}
+		{%- include "../../appeals/components/page-component.njk" -%}
+	{%- endfor -%}
+	</div>
+</div>
+{%- endif -%}
+<div class="govuk-grid-row">
+	<div class="{{ pageContent.formWrapperColumnClass if pageContent.formWrapperColumnClass else 'govuk-grid-column-full' }}">
+		<form method="POST" novalidate="novalidate">
+			{%- if pageContent.pageComponents and pageContent.pageComponents | length -%}
 				{%- for component in pageContent.pageComponents -%}
 					{%- include "../../appeals/components/page-component.njk" -%}
 				{%- endfor -%}
-				{{ govukButton({
-					text: pageContent.submitButtonText if pageContent.submitButtonText else "Continue",
-					type: "submit",
-					preventDoubleClick: true
-				}) }}
-				{%- if pageContent.postPageComponents -%}
-					{%- for component in pageContent.postPageComponents -%}
-						{%- include "../../appeals/components/page-component.njk" -%}
-					{%- endfor -%}
-				{%- endif -%}
-			</form>
-		</div>
+			{%- endif -%}
+			{{ govukButton({
+				text: pageContent.submitButtonText if pageContent.submitButtonText else "Continue",
+				type: "submit",
+				preventDoubleClick: true
+			}) }}
+		</form>
 	</div>
+</div>
+{%- if pageContent.postPageComponents and pageContent.postPageComponents | length -%}
+<div class="govuk-grid-row">
+	<div class="{{ pageContent.postPageWrapperColumnClass if pageContent.postPageWrapperColumnClass else 'govuk-grid-column-full' }}">
+	{%- for component in pageContent.postPageComponents -%}
+		{%- include "../../appeals/components/page-component.njk" -%}
+	{%- endfor -%}
+	</div>
+</div>
+{%- endif -%}

--- a/appeals/web/src/server/views/patterns/display-page.pattern.njk
+++ b/appeals/web/src/server/views/patterns/display-page.pattern.njk
@@ -60,12 +60,16 @@
 					{{ govukButton({
 						text: pageContent.submitButtonText if pageContent.submitButtonText else "Continue"
 					}) }}
-					{%- if pageContent.postPageComponents -%}
-						{%- for component in pageContent.postPageComponents -%}
-							{%- include "../appeals/components/page-component.njk" -%}
-						{%- endfor -%}
-					{%- endif -%}
 				</form>
+			</div>
+		</div>
+	{%- endif -%}
+	{%- if pageContent.postPageComponents -%}
+		<div class="govuk-grid-row">
+			<div class="govuk-grid-column-full">
+				{%- for component in pageContent.postPageComponents -%}
+					{%- include "../appeals/components/page-component.njk" -%}
+				{%- endfor -%}
 			</div>
 		</div>
 	{%- endif -%}


### PR DESCRIPTION
## Describe your changes

Updated change page pattern template to add support for rendering page components outside the form tag where desired. Associated updates to existing clients of the change page pattern to render components that are not valid children of the form element outside the form tag where possible. The ideal fix would be to create a separate `PageContent` type for change pages, and refactor all existing code to use that, but given the increasing likelihood the page component system will be removed entirely in the foreseeable future, I didn't want to spend more time than seemed reasonably necessary on this.

## Issue ticket number and link
https://pins-ds.atlassian.net/browse/A2-2682
