### PR TITLE
fix(web): hide deleted docs on final comments check your answers page

### DIFF
--- a/appeals/web/src/server/appeals/appeal-details/representations/common/document-attachment-list.js
+++ b/appeals/web/src/server/appeals/appeal-details/representations/common/document-attachment-list.js
@@ -4,9 +4,14 @@ import { buildHtmUnorderedList } from '#lib/nunjucks-template-builders/tag-build
 import { mapDocumentDownloadUrl } from '#appeals/appeal-documents/appeal-documents.mapper.js';
 
 export const getAttachmentList = (/** @type {Representation} */ representation) => {
-	return representation.attachments.length > 0
+	const filteredAttachments = representation.attachments?.filter((attachment) => {
+		const { isDeleted, latestVersionId } = attachment?.documentVersion?.document ?? {};
+		return latestVersionId === attachment.version && !isDeleted;
+	});
+
+	return filteredAttachments.length > 0
 		? buildHtmUnorderedList(
-				representation.attachments.map(
+				filteredAttachments.map(
 					(a) =>
 						`<a class="govuk-link" href="${mapDocumentDownloadUrl(
 							a.documentVersion.document.caseId,

--- a/appeals/web/testing/app/fixtures/referencedata.js
+++ b/appeals/web/testing/app/fixtures/referencedata.js
@@ -3198,6 +3198,17 @@ export const finalCommentsForReviewWithAttachments = {
 							isDeleted: false
 						}
 					}
+				},
+				{
+					documentVersion: {
+						document: {
+							caseId: '4881',
+							folderId: 135568,
+							guid: 'ceb49369-01d4-479b-84f5-50136e7ceb6f',
+							name: 'deleted_file.pdf',
+							isDeleted: true
+						}
+					}
 				}
 			],
 			represented: {


### PR DESCRIPTION
## Describe your changes

Stop showing deleted documents on the check your answers page after accepting/rejecting final comments.

They were being filtered on the review final comments page but not the check details page.

## Issue ticket number and link
[A2-2685](https://pins-ds.atlassian.net.mcas.ms/browse/A2-2685?McasTsid=20596&McasCtx=4)


[A2-2685]: https://pins-ds.atlassian.net/browse/A2-2685?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ