### PR TITLE
fix/a2-2411-correcting-documentation-final-comments-fields

### DIFF
--- a/appeals/web/src/server/appeals/appeal-details/__tests__/appeal-details.test.js
+++ b/appeals/web/src/server/appeals/appeal-details/__tests__/appeal-details.test.js
@@ -2398,7 +2398,7 @@ describe('appeal-details', () => {
 
 						expect(unprettifiedHTML).toContain('Documentation</th>');
 						expect(unprettifiedHTML).toContain(
-							`${testCase.rowLabel}</th><td class="govuk-table__cell">Not received</td><td class="govuk-table__cell"></td><td class="govuk-table__cell govuk-!-text-align-right"></td>`
+							`${testCase.rowLabel}</th><td class="govuk-table__cell">No final comments</td><td class="govuk-table__cell">Not applicable</td><td class="govuk-table__cell govuk-!-text-align-right"></td>`
 						);
 					});
 

--- a/appeals/web/src/server/lib/__tests__/libraries.test.js
+++ b/appeals/web/src/server/lib/__tests__/libraries.test.js
@@ -35,6 +35,7 @@ import httpMocks from 'node-mocks-http';
 import { getOriginPathname, isInternalUrl, safeRedirect } from '#lib/url-utilities.js';
 import { stringIsValidPostcodeFormat } from '#lib/postcode.js';
 import { addInvisibleSpacesAfterRedactionCharacters } from '#lib/redaction-string-formatter.js';
+import { mapRepresentationDocumentSummaryStatus } from '#lib/representation-utilities.js';
 
 describe('Libraries', () => {
 	describe('addressFormatter', () => {
@@ -1573,5 +1574,26 @@ describe('safeRedirect', () => {
 		safeRedirect(request, response, url);
 
 		expect(response._getRedirectUrl()).toBe('/');
+	});
+});
+
+describe('mapRepresentationDocumentSummaryStatus', () => {
+	it('Should return "No final comments" if no final comments were received', () => {
+		expect(mapRepresentationDocumentSummaryStatus('not_received', null)).toBe('No final comments');
+	});
+	it('Should return "Accepted" if final comment was accepted', () => {
+		expect(mapRepresentationDocumentSummaryStatus('received', 'valid')).toBe('Accepted');
+	});
+	it('Should return "Rejected" if final comment was rejected', () => {
+		expect(mapRepresentationDocumentSummaryStatus('received', 'invalid')).toBe('Rejected');
+	});
+	it('Should return "Shared" if final comment was shared', () => {
+		expect(mapRepresentationDocumentSummaryStatus('received', 'published')).toBe('Shared');
+	});
+	it('Should return "Incomplete" if final comment is incomplete', () => {
+		expect(mapRepresentationDocumentSummaryStatus('received', 'incomplete')).toBe('Incomplete');
+	});
+	it('Should return "Received" if final comment is received', () => {
+		expect(mapRepresentationDocumentSummaryStatus('received', 'default')).toBe('Received');
 	});
 });

--- a/appeals/web/src/server/lib/mappers/data/appeal/submappers/appellant-final-comments.mapper.js
+++ b/appeals/web/src/server/lib/mappers/data/appeal/submappers/appellant-final-comments.mapper.js
@@ -14,9 +14,10 @@ export const mapAppellantFinalComments = ({ appealDetails, currentRoute }) =>
 			appealDetails?.documentationSummary?.appellantFinalComments?.status,
 			appealDetails?.documentationSummary?.appellantFinalComments?.representationStatus
 		),
-		receivedText: dateISOStringToDisplayDate(
-			appealDetails?.documentationSummary?.appellantFinalComments?.receivedAt
-		),
+		receivedText:
+			dateISOStringToDisplayDate(
+				appealDetails?.documentationSummary?.appellantFinalComments?.receivedAt
+			) || 'Not applicable',
 		actionHtml: mapRepresentationDocumentSummaryActionLink(
 			currentRoute,
 			appealDetails?.documentationSummary?.appellantFinalComments?.status,

--- a/appeals/web/src/server/lib/mappers/data/appeal/submappers/lpa-final-comments.mapper.js
+++ b/appeals/web/src/server/lib/mappers/data/appeal/submappers/lpa-final-comments.mapper.js
@@ -14,9 +14,10 @@ export const mapLPAFinalComments = ({ appealDetails, currentRoute }) =>
 			appealDetails?.documentationSummary?.lpaFinalComments?.status,
 			appealDetails?.documentationSummary?.lpaFinalComments?.representationStatus
 		),
-		receivedText: dateISOStringToDisplayDate(
-			appealDetails?.documentationSummary?.lpaFinalComments?.receivedAt
-		),
+		receivedText:
+			dateISOStringToDisplayDate(
+				appealDetails?.documentationSummary?.lpaFinalComments?.receivedAt
+			) || 'Not applicable',
 		actionHtml: mapRepresentationDocumentSummaryActionLink(
 			currentRoute,
 			appealDetails?.documentationSummary?.lpaFinalComments?.status,

--- a/appeals/web/src/server/lib/representation-utilities.js
+++ b/appeals/web/src/server/lib/representation-utilities.js
@@ -59,7 +59,7 @@ export function mapRepresentationDocumentSummaryActionLink(
  */
 export function mapRepresentationDocumentSummaryStatus(documentationStatus, representationStatus) {
 	if (documentationStatus !== 'received' || !representationStatus) {
-		return 'Not received';
+		return 'No final comments';
 	}
 
 	switch (representationStatus) {


### PR DESCRIPTION
- Updated null text to "No final comments"
- Set null date text to "Not applicable"

https://pins-ds.atlassian.net/browse/A2-2411