### PR TITLE
fix(web): render multiple rep attachments in numbered list

### DIFF
--- a/appeals/web/src/server/appeals/appeal-details/appellant-case/appellant-case.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/appellant-case/appellant-case.mapper.js
@@ -9,7 +9,7 @@ import {
 import { capitalize } from 'lodash-es';
 import { mapReasonOptionsToCheckboxItemParameters } from '#lib/validation-outcome-reasons-formatter.js';
 import { mapReasonsToReasonsListHtml } from '#lib/reasons-formatter.js';
-import { buildHtmUnorderedList } from '#lib/nunjucks-template-builders/tag-builders.js';
+import { buildHtmlList } from '#lib/nunjucks-template-builders/tag-builders.js';
 import { initialiseAndMapData } from '#lib/mappers/data/appellant-case/mapper.js';
 import {
 	userHasPermission,
@@ -470,7 +470,10 @@ export function mapAppellantCaseNotificationBanners(
 				type: 'details',
 				parameters: {
 					summaryText: reason.name?.name,
-					html: buildHtmUnorderedList(reason.text || [], 0, listClasses)
+					html: buildHtmlList({
+						...(reason.text ? { items: reason.text } : {}),
+						listClasses
+					})
 				}
 			}));
 
@@ -481,11 +484,10 @@ export function mapAppellantCaseNotificationBanners(
 				type: 'details',
 				parameters: {
 					summaryText: 'Incorrect name and/or missing documents',
-					html: buildHtmUnorderedList(
-						reasonsWithoutText.map((reason) => reason.name.name),
-						0,
+					html: buildHtmlList({
+						items: reasonsWithoutText.map((reason) => reason.name.name),
 						listClasses
-					)
+					})
 				}
 			});
 		}

--- a/appeals/web/src/server/appeals/appeal-details/environmental-assessment/__tests__/environmental-assessment.test.js
+++ b/appeals/web/src/server/appeals/appeal-details/environmental-assessment/__tests__/environmental-assessment.test.js
@@ -226,6 +226,10 @@ describe('environmental-assessment', () => {
 
 	describe('POST /environmental-assessment/manage-documents/:folderId/:documentId/:versionId/delete', () => {
 		it('should render the delete document version page', async () => {
+			nock('http://test/')
+				.delete(`/appeals/${appealId}/documents/${documentId}/${version}`)
+				.reply(200);
+
 			const response = await request
 				.post(
 					`${baseUrl}/${appealId}/environmental-assessment/manage-documents/${folderId}/${documentId}/${version}/delete`

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/lpa-questionnaire.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/lpa-questionnaire.mapper.js
@@ -18,7 +18,7 @@ import {
 } from '#lib/dates.js';
 import { mapReasonOptionsToCheckboxItemParameters } from '#lib/validation-outcome-reasons-formatter.js';
 import { mapReasonsToReasonsListHtml } from '#lib/reasons-formatter.js';
-import { buildHtmUnorderedList } from '#lib/nunjucks-template-builders/tag-builders.js';
+import { buildHtmlList } from '#lib/nunjucks-template-builders/tag-builders.js';
 import { isDefined, isFolderInfo } from '#lib/ts-utilities.js';
 import { appealShortReference } from '#lib/appeals-formatter.js';
 import { preRenderPageComponents } from '#lib/nunjucks-template-builders/page-component-rendering.js';
@@ -516,7 +516,10 @@ function mapLPAQuestionnaireNotificationBanners(
 				type: 'details',
 				parameters: {
 					summaryText: reason.name?.name,
-					html: buildHtmUnorderedList(reason.text || [], 0, listClasses)
+					html: buildHtmlList({
+						...(reason.text ? { items: reason.text } : {}),
+						listClasses
+					})
 				}
 			}));
 
@@ -529,11 +532,10 @@ function mapLPAQuestionnaireNotificationBanners(
 				type: 'details',
 				parameters: {
 					summaryText: 'Incorrect name and/or missing documents',
-					html: buildHtmUnorderedList(
-						reasonsWithoutText.map((reason) => reason.name.name),
-						0,
+					html: buildHtmlList({
+						items: reasonsWithoutText.map((reason) => reason.name.name),
 						listClasses
-					)
+					})
 				}
 			});
 		}

--- a/appeals/web/src/server/appeals/appeal-details/representations/common/components/reject-reasons.js
+++ b/appeals/web/src/server/appeals/appeal-details/representations/common/components/reject-reasons.js
@@ -1,5 +1,5 @@
 import { ensureArray } from '#lib/array-utilities.js';
-import { buildHtmUnorderedList } from '#lib/nunjucks-template-builders/tag-builders.js';
+import { buildHtmlList } from '#lib/nunjucks-template-builders/tag-builders.js';
 
 /**
  * @typedef {import('@pins/appeals.api').Appeals.ReasonOption} ReasonOption
@@ -62,5 +62,8 @@ export const buildRejectionReasons = (reasonOptions, reasons, reasonsText) => {
  * @returns {string}
  */
 export const rejectionReasonHtml = (reasons) => {
-	return buildHtmUnorderedList(reasons, 0, 'govuk-list govuk-!-margin-top-0 govuk-list--bullet');
+	return buildHtmlList({
+		...(reasons ? { items: reasons } : {}),
+		listClasses: 'govuk-list govuk-!-margin-top-0 govuk-list--bullet'
+	});
 };

--- a/appeals/web/src/server/appeals/appeal-details/representations/common/document-attachment-list.js
+++ b/appeals/web/src/server/appeals/appeal-details/representations/common/document-attachment-list.js
@@ -1,6 +1,6 @@
 /** @typedef {import("#appeals/appeal-details/representations/types.js").Representation} Representation */
 
-import { buildHtmUnorderedList } from '#lib/nunjucks-template-builders/tag-builders.js';
+import { buildHtmlList } from '#lib/nunjucks-template-builders/tag-builders.js';
 import { mapDocumentDownloadUrl } from '#appeals/appeal-documents/appeal-documents.mapper.js';
 
 export const getAttachmentList = (/** @type {Representation} */ representation) => {
@@ -10,15 +10,17 @@ export const getAttachmentList = (/** @type {Representation} */ representation) 
 	});
 
 	return filteredAttachments.length > 0
-		? buildHtmUnorderedList(
-				filteredAttachments.map(
+		? buildHtmlList({
+				items: filteredAttachments.map(
 					(a) =>
 						`<a class="govuk-link" href="${mapDocumentDownloadUrl(
 							a.documentVersion.document.caseId,
 							a.documentVersion.document.guid,
 							a.documentVersion.document.name
 						)}" target="_blank">${a.documentVersion.document.name}</a>`
-				)
-		  )
+				),
+				isOrderedList: true,
+				isNumberedList: filteredAttachments.length > 1
+		  })
 		: null;
 };

--- a/appeals/web/src/server/appeals/appeal-details/representations/final-comments/accept/__tests__/__snapshots__/accept-final-comments.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/representations/final-comments/accept/__tests__/__snapshots__/accept-final-comments.test.js.snap
@@ -17,11 +17,11 @@ exports[`final-comments GET / should render the accept appellant final comments 
                 </div>
                 <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Supporting documents</dt>
                     <dd class="govuk-summary-list__value">
-                        <ul class="govuk-list govuk-!-margin-top-0 govuk-!-padding-left-0">
+                        <ol class="govuk-list govuk-!-margin-top-0 govuk-!-padding-left-0">
                             <li><a class="govuk-link" href="/documents/4881/download/ed52cdc1-3cc2-462a-8623-c1ae256969d6/blank copy 5.pdf"
                                 target="_blank">blank copy 5.pdf</a>
                             </li>
-                        </ul>
+                        </ol>
                     </dd>
                     <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/final-comments/appellant/manage-documents/135568">Change</a>
                     </dd>
@@ -61,11 +61,11 @@ exports[`final-comments GET / should render the accept lpa final comments page w
                 </div>
                 <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Supporting documents</dt>
                     <dd class="govuk-summary-list__value">
-                        <ul class="govuk-list govuk-!-margin-top-0 govuk-!-padding-left-0">
+                        <ol class="govuk-list govuk-!-margin-top-0 govuk-!-padding-left-0">
                             <li><a class="govuk-link" href="/documents/4881/download/ed52cdc1-3cc2-462a-8623-c1ae256969d6/blank copy 5.pdf"
                                 target="_blank">blank copy 5.pdf</a>
                             </li>
-                        </ul>
+                        </ol>
                     </dd>
                     <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/final-comments/lpa/manage-documents/135568">Change</a>
                     </dd>

--- a/appeals/web/src/server/appeals/appeal-details/representations/final-comments/view-and-review/__tests__/__snapshots__/view-and-review.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/representations/final-comments/view-and-review/__tests__/__snapshots__/view-and-review.test.js.snap
@@ -297,11 +297,11 @@ exports[`final-comments GET /review-comments with data should render review LPA 
                 </div>
                 <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Supporting documents</dt>
                     <dd class="govuk-summary-list__value">
-                        <ul class="govuk-list govuk-!-margin-top-0 govuk-!-padding-left-0">
+                        <ol class="govuk-list govuk-!-margin-top-0 govuk-!-padding-left-0">
                             <li><a class="govuk-link" href="/documents/4881/download/ed52cdc1-3cc2-462a-8623-c1ae256969d6/blank copy 5.pdf"
                                 target="_blank">blank copy 5.pdf</a>
                             </li>
-                        </ul>
+                        </ol>
                     </dd>
                     <dd class="govuk-summary-list__actions">
                         <ul class="govuk-summary-list__actions-list">
@@ -607,11 +607,11 @@ exports[`final-comments POST /review-comments with data should render review LPA
                 </div>
                 <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Supporting documents</dt>
                     <dd class="govuk-summary-list__value">
-                        <ul class="govuk-list govuk-!-margin-top-0 govuk-!-padding-left-0">
+                        <ol class="govuk-list govuk-!-margin-top-0 govuk-!-padding-left-0">
                             <li><a class="govuk-link" href="/documents/4881/download/ed52cdc1-3cc2-462a-8623-c1ae256969d6/blank copy 5.pdf"
                                 target="_blank">blank copy 5.pdf</a>
                             </li>
-                        </ul>
+                        </ol>
                     </dd>
                     <dd class="govuk-summary-list__actions">
                         <ul class="govuk-summary-list__actions-list">

--- a/appeals/web/src/server/appeals/appeal-details/representations/final-comments/view-and-review/page-components/common.js
+++ b/appeals/web/src/server/appeals/appeal-details/representations/final-comments/view-and-review/page-components/common.js
@@ -1,4 +1,4 @@
-import { buildHtmUnorderedList } from '#lib/nunjucks-template-builders/tag-builders.js';
+import { buildHtmlList } from '#lib/nunjucks-template-builders/tag-builders.js';
 import { preRenderPageComponents } from '#lib/nunjucks-template-builders/page-component-rendering.js';
 import { APPEAL_REPRESENTATION_STATUS } from '@pins/appeals/constants/common.js';
 import { mapDocumentDownloadUrl } from '#appeals/appeal-documents/appeal-documents.mapper.js';
@@ -37,16 +37,18 @@ export function generateCommentsSummaryList(appealId, comment) {
 	});
 
 	const attachmentsList = filteredAttachments?.length
-		? buildHtmUnorderedList(
-				filteredAttachments.map(
+		? buildHtmlList({
+				items: filteredAttachments.map(
 					(a) =>
 						`<a class="govuk-link" href="${mapDocumentDownloadUrl(
 							a.documentVersion.document.caseId,
 							a.documentVersion.document.guid,
 							a.documentVersion.document.name
 						)}" target="_blank">${a.documentVersion.document.name}</a>`
-				)
-		  )
+				),
+				isOrderedList: true,
+				isNumberedList: filteredAttachments.length > 1
+		  })
 		: null;
 
 	const commentTypePath = mapRepresentationTypeToPath(comment.representationType);

--- a/appeals/web/src/server/appeals/appeal-details/representations/interested-party-comments/interested-party-comments.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/representations/interested-party-comments/interested-party-comments.mapper.js
@@ -6,7 +6,7 @@ import { addressInputs } from '#lib/mappers/index.js';
 import { simpleHtmlComponent } from '#lib/mappers/index.js';
 import { constructUrl } from '#lib/mappers/utils/url.mapper.js';
 import { preRenderPageComponents } from '#lib/nunjucks-template-builders/page-component-rendering.js';
-import { buildHtmUnorderedList } from '#lib/nunjucks-template-builders/tag-builders.js';
+import { buildHtmlList } from '#lib/nunjucks-template-builders/tag-builders.js';
 import { highlightRedactedSections } from '#lib/redaction-string-formatter.js';
 import { mapDocumentDownloadUrl } from '#appeals/appeal-documents/appeal-documents.mapper.js';
 
@@ -161,16 +161,18 @@ export function sharedIpCommentsPage(appealDetails, comments) {
 					]
 				},
 				{
-					html: buildHtmUnorderedList(
-						comment.attachments.map(
+					html: buildHtmlList({
+						items: comment.attachments.map(
 							(a) =>
 								`<a class="govuk-link" href="${mapDocumentDownloadUrl(
 									a.documentVersion.document.caseId,
 									a.documentVersion.document.guid,
 									a.documentVersion.document.name
 								)}" target="_blank">${a.documentVersion.document.name}</a>`
-						)
-					)
+						),
+						isOrderedList: true,
+						isNumberedList: comment.attachments.length > 1
+					})
 				}
 			])
 		}

--- a/appeals/web/src/server/appeals/appeal-details/representations/interested-party-comments/view-and-review/page-components/common.js
+++ b/appeals/web/src/server/appeals/appeal-details/representations/interested-party-comments/view-and-review/page-components/common.js
@@ -1,7 +1,7 @@
 import { mapDocumentDownloadUrl } from '#appeals/appeal-documents/appeal-documents.mapper.js';
 import { addressToMultilineStringHtml } from '#lib/address-formatter.js';
 import { dateISOStringToDisplayDate } from '#lib/dates.js';
-import { buildHtmUnorderedList } from '#lib/nunjucks-template-builders/tag-builders.js';
+import { buildHtmlList } from '#lib/nunjucks-template-builders/tag-builders.js';
 import { COMMENT_STATUS } from '@pins/appeals/constants/common.js';
 
 /** @typedef {import('#appeals/appeal-details/representations/types.js').Representation} Representation */
@@ -50,16 +50,18 @@ export function generateCommentSummaryList(
 	});
 
 	const attachmentsList = filteredAttachments?.length
-		? buildHtmUnorderedList(
-				filteredAttachments.map(
+		? buildHtmlList({
+				items: filteredAttachments.map(
 					(a) =>
 						`<a class="govuk-link" href="${mapDocumentDownloadUrl(
 							a.documentVersion.document.caseId,
 							a.documentVersion.document.guid,
 							a.documentVersion.document.name
 						)}" target="_blank">${a.documentVersion.document.name}</a>`
-				)
-		  )
+				),
+				isOrderedList: true,
+				isNumberedList: filteredAttachments.length > 1
+		  })
 		: null;
 
 	const { address, name, email } = comment.represented || {};

--- a/appeals/web/src/server/appeals/appeal-details/representations/interested-party-comments/view-and-review/page-components/reject.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/representations/interested-party-comments/view-and-review/page-components/reject.mapper.js
@@ -2,7 +2,7 @@ import { dateISOStringToDisplayDate, addBusinessDays } from '#lib/dates.js';
 import { appealShortReference } from '#lib/appeals-formatter.js';
 import { yesNoInput } from '#lib/mappers/components/page-components/radio.js';
 import { simpleHtmlComponent } from '#lib/mappers/components/page-components/html.js';
-import { buildHtmUnorderedList } from '#lib/nunjucks-template-builders/tag-builders.js';
+import { buildHtmlList } from '#lib/nunjucks-template-builders/tag-builders.js';
 import { rejectionReasonHtml } from '#appeals/appeal-details/representations/common/components/reject-reasons.js';
 
 /** @typedef {import("#appeals/appeal-details/appeal-details.types.js").WebAppeal} Appeal */
@@ -95,9 +95,13 @@ export function rejectCheckYourAnswersPage(appealDetails, comment, rejectionReas
 
 	const attachmentsList =
 		comment.attachments.length > 0
-			? buildHtmUnorderedList(
-					comment.attachments.map((a) => `<a href="#">${a.documentVersion.document.name}</a>`)
-			  )
+			? buildHtmlList({
+					items: comment.attachments.map(
+						(a) => `<a href="#">${a.documentVersion.document.name}</a>`
+					),
+					isOrderedList: true,
+					isNumberedList: comment.attachments.length > 1
+			  })
 			: null;
 
 	/** @type {PageComponent} */

--- a/appeals/web/src/server/appeals/appeal-details/representations/lpa-statement/incomplete/incomplete.controller.js
+++ b/appeals/web/src/server/appeals/appeal-details/representations/lpa-statement/incomplete/incomplete.controller.js
@@ -7,7 +7,7 @@ import {
 	getRepresentationRejectionReasonOptions,
 	updateRejectionReasons
 } from '../../representations.service.js';
-import { buildHtmUnorderedList } from '#lib/nunjucks-template-builders/tag-builders.js';
+import { buildHtmlList } from '#lib/nunjucks-template-builders/tag-builders.js';
 import { simpleHtmlComponent } from '#lib/mappers/index.js';
 import { dateISOStringToDisplayDate, addBusinessDays } from '#lib/dates.js';
 import { capitalize } from 'lodash-es';
@@ -137,16 +137,18 @@ export const renderCheckYourAnswers = async (
 
 	const attachmentsList =
 		currentRepresentation.attachments.length > 0
-			? buildHtmUnorderedList(
-					currentRepresentation.attachments.map(
+			? buildHtmlList({
+					items: currentRepresentation.attachments.map(
 						(a) =>
 							`<a class="govuk-link" href="${mapDocumentDownloadUrl(
 								a.documentVersion.document.caseId,
 								a.documentVersion.document.guid,
 								a.documentVersion.document.name
 							)}" target="_blank">${a.documentVersion.document.name}</a>`
-					)
-			  )
+					),
+					isOrderedList: true,
+					isNumberedList: currentRepresentation.attachments.length > 1
+			  })
 			: null;
 
 	return renderCheckYourAnswersComponent(

--- a/appeals/web/src/server/appeals/appeal-details/representations/lpa-statement/lpa-statement.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/representations/lpa-statement/lpa-statement.mapper.js
@@ -1,6 +1,6 @@
 import { appealShortReference } from '#lib/appeals-formatter.js';
 import { preRenderPageComponents } from '#lib/nunjucks-template-builders/page-component-rendering.js';
-import { buildHtmUnorderedList } from '#lib/nunjucks-template-builders/tag-builders.js';
+import { buildHtmlList } from '#lib/nunjucks-template-builders/tag-builders.js';
 import { mapNotificationBannersFromSession } from '#lib/mappers/index.js';
 import { COMMENT_STATUS } from '@pins/appeals/constants/common.js';
 import { constructUrl } from '#lib/mappers/utils/url.mapper.js';
@@ -22,16 +22,18 @@ export function baseSummaryList(appealId, lpaStatement, { isReview }) {
 	});
 
 	const attachmentsList = filteredAttachments?.length
-		? buildHtmUnorderedList(
-				filteredAttachments.map(
+		? buildHtmlList({
+				items: filteredAttachments.map(
 					(a) =>
 						`<a class="govuk-link" href="${mapDocumentDownloadUrl(
 							a.documentVersion.document.caseId,
 							a.documentVersion.document.guid,
 							a.documentVersion.document.name
 						)}" target="_blank">${a.documentVersion.document.name}</a>`
-				)
-		  )
+				),
+				isOrderedList: true,
+				isNumberedList: filteredAttachments.length > 1
+		  })
 		: null;
 
 	const folderId = lpaStatement.attachments?.[0]?.documentVersion?.document?.folderId ?? null;

--- a/appeals/web/src/server/appeals/appeal-details/representations/lpa-statement/valid/valid.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/representations/lpa-statement/valid/valid.mapper.js
@@ -1,6 +1,6 @@
 import { appealShortReference } from '#lib/appeals-formatter.js';
 import { preRenderPageComponents } from '#lib/nunjucks-template-builders/page-component-rendering.js';
-import { buildHtmUnorderedList } from '#lib/nunjucks-template-builders/tag-builders.js';
+import { buildHtmlList } from '#lib/nunjucks-template-builders/tag-builders.js';
 import { ensureArray } from '#lib/array-utilities.js';
 import { mapDocumentDownloadUrl } from '#appeals/appeal-documents/appeal-documents.mapper.js';
 
@@ -32,16 +32,18 @@ export const confirmPage = (appealDetails, lpaStatement, specialismData, session
 
 	const attachmentsList =
 		lpaStatement.attachments.length > 0
-			? buildHtmUnorderedList(
-					lpaStatement.attachments.map(
+			? buildHtmlList({
+					items: lpaStatement.attachments.map(
 						(a) =>
 							`<a class="govuk-link" href="${mapDocumentDownloadUrl(
 								a.documentVersion.document.caseId,
 								a.documentVersion.document.guid,
 								a.documentVersion.document.name
 							)}" target="_blank">${a.documentVersion.document.name}</a>`
-					)
-			  )
+					),
+					isOrderedList: true,
+					isNumberedList: lpaStatement.attachments.length > 1
+			  })
 			: null;
 
 	const folderId = lpaStatement.attachments?.[0]?.documentVersion?.document?.folderId ?? null;

--- a/appeals/web/src/server/lib/nunjucks-template-builders/__tests__/nunjucks-template-builders.test.js
+++ b/appeals/web/src/server/lib/nunjucks-template-builders/__tests__/nunjucks-template-builders.test.js
@@ -1,0 +1,76 @@
+import { buildHtmlList } from '../tag-builders.js';
+
+describe('tag-builders', () => {
+	describe('buildHtmlList', () => {
+		it('should render an empty string if no item parameter is passed', () => {
+			expect(buildHtmlList({})).toEqual('');
+		});
+
+		it('should render an empty string if an empty array of items is passed', () => {
+			expect(buildHtmlList({ items: [] })).toEqual('');
+		});
+
+		it('should render an unordered list with the default classes, with a list item containing each supplied item, if only the items parameter is passed', () => {
+			expect(
+				buildHtmlList({
+					items: ['first item', 'second item']
+				})
+			).toEqual(
+				'<ul class="govuk-list govuk-!-margin-top-0 govuk-!-padding-left-0"><li>first item</li><li>second item</li></ul>'
+			);
+		});
+
+		it('should render the supplied classes on the list tag if the listClasses parameter is passed', () => {
+			expect(
+				buildHtmlList({
+					items: ['first item', 'second item'],
+					listClasses: 'test-class'
+				})
+			).toEqual('<ul class="test-class"><li>first item</li><li>second item</li></ul>');
+		});
+
+		it('should render an ordered list if the isOrderedList parameter is passed with a value of "true"', () => {
+			expect(
+				buildHtmlList({
+					items: ['first item', 'second item'],
+					isOrderedList: true
+				})
+			).toEqual(
+				'<ol class="govuk-list govuk-!-margin-top-0 govuk-!-padding-left-0"><li>first item</li><li>second item</li></ol>'
+			);
+		});
+
+		it('should render the "govuk-list--number" modifier class on the list tag if the isNumberedList parameter is passed with a value of "true"', () => {
+			expect(
+				buildHtmlList({
+					items: ['first item', 'second item'],
+					isNumberedList: true
+				})
+			).toEqual(
+				'<ul class="govuk-list govuk-!-margin-top-0 govuk-!-padding-left-0 govuk-list--number"><li>first item</li><li>second item</li></ul>'
+			);
+		});
+
+		it('should render an ordered list with the "govuk-list--number" modifier class on the list tag if the isOrderedList and isNumberedList parameters are both passed with values of "true"', () => {
+			expect(
+				buildHtmlList({
+					items: ['first item', 'second item'],
+					isOrderedList: true,
+					isNumberedList: true
+				})
+			).toEqual(
+				'<ol class="govuk-list govuk-!-margin-top-0 govuk-!-padding-left-0 govuk-list--number"><li>first item</li><li>second item</li></ol>'
+			);
+		});
+
+		it('should render a nested list with the supplied items if an array of string arrays is passed as the items parameter', () => {
+			expect(
+				buildHtmlList({
+					items: ['first item', ['first nested item', 'second nested item']]
+				})
+			).toEqual(
+				'<ul class="govuk-list govuk-!-margin-top-0 govuk-!-padding-left-0"><li>first item</li><li><ul class=""><li>first nested item</li><li>second nested item</li></ul></li></ul>'
+			);
+		});
+	});
+});

--- a/appeals/web/src/server/lib/nunjucks-template-builders/tag-builders.js
+++ b/appeals/web/src/server/lib/nunjucks-template-builders/tag-builders.js
@@ -11,26 +11,38 @@
  */
 
 /**
- * @param {Array<string|string[]>|undefined} items
- * @param {number} [recursionDepth]
- * @param {string} listClasses
+ * @param {Object} params
+ * @param {(string|string[])[]} [params.items]
+ * @param {number} [params.recursionDepth]
+ * @param {string} [params.listClasses]
+ * @param {boolean} [params.isOrderedList]
+ * @param {boolean} [params.isNumberedList]
  * @returns {string}
  */
-export const buildHtmUnorderedList = (
-	items,
+export const buildHtmlList = ({
+	items = [],
 	recursionDepth = 0,
-	listClasses = 'govuk-list govuk-!-margin-top-0 govuk-!-padding-left-0'
-) => {
+	listClasses = 'govuk-list govuk-!-margin-top-0 govuk-!-padding-left-0',
+	isOrderedList = false,
+	isNumberedList = false
+}) => {
 	if (!items?.length) {
 		return '';
 	}
+	const listTag = isOrderedList ? 'ol' : 'ul';
 	const listItems = items
 		.map(
 			(item) =>
-				`<li>${Array.isArray(item) ? buildHtmUnorderedList(item, recursionDepth + 1) : item}</li>`
+				`<li>${
+					Array.isArray(item)
+						? buildHtmlList({ items: item, recursionDepth: recursionDepth + 1 })
+						: item
+				}</li>`
 		)
 		.join('');
-	return `<ul class="${recursionDepth === 0 ? listClasses : ''}">${listItems}</ul>`;
+	return `<${listTag} class="${
+		recursionDepth === 0 ? `${listClasses}${isNumberedList ? ' govuk-list--number' : ''}` : ''
+	}">${listItems}</${listTag}>`;
 };
 
 /**


### PR DESCRIPTION
## Describe your changes

Updated html list tag builder to support ordered list option (also renamed the function to reflect this) and to accept params as a single object to avoid callers needing to pass default values for optional params just to preserve parameter ordering (updated all callers to reflect this). Updated calls to the list tag builder from reps code to ensure attachments are always rendered as numbered lists if more than one attachment is present. Also added some unit tests for the tag builder function.

## Issue ticket number and link
https://pins-ds.atlassian.net/browse/A2-2636
