### PR TITLE
feat(web): add s78 start case select procedure type page and entry points

### DIFF
--- a/appeals/web/src/common/feature-flags.js
+++ b/appeals/web/src/common/feature-flags.js
@@ -22,3 +22,5 @@ export const isFeatureActive = (featureFlagName = null) => {
 
 	return config.featureFlags[featureFlagName];
 };
+
+export default { isFeatureActive };

--- a/appeals/web/src/server/appeals/appeal-details/__tests__/__snapshots__/appeal-details.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/__tests__/__snapshots__/appeal-details.test.js.snap
@@ -530,7 +530,7 @@ exports[`appeal-details GET /:appealId Timetable Valid date should render a "Tim
     </div>
     <div class="govuk-summary-list__row appeal-start-date"><dt class="govuk-summary-list__key"> Start date</dt>
         <dd class="govuk-summary-list__value">Not started</dd>
-        <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/3/start-case/add"
+        <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/3/start-case/add?backUrl=/appeals-service/appeal-details/3"
             data-cy="start-start-case-date">Start<span class="govuk-visually-hidden"> Start date</span></a>
         </dd>
     </div>
@@ -1139,7 +1139,7 @@ data-index="0">
     </div>
     <div class="govuk-notification-banner__content">
         <p class="govuk-notification-banner__heading">Appeal valid</p>
-        <p><a class="govuk-notification-banner__link" data-cy="ready-to-start" href="/appeals-service/appeal-details/2/start-case/add">Start case</a>
+        <p><a class="govuk-notification-banner__link" data-cy="ready-to-start" href="/appeals-service/appeal-details/2/start-case/add?backUrl=/appeals-service/appeal-details/2">Start case</a>
         </p>
     </div>
 </div>"
@@ -7922,7 +7922,7 @@ exports[`appeal-details GET /:appealId should render the received appeal details
                             </div>
                             <div class="govuk-summary-list__row appeal-start-date"><dt class="govuk-summary-list__key"> Start date</dt>
                                 <dd class="govuk-summary-list__value">Not started</dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/start-case/add"
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/start-case/add?backUrl=/appeals-service/appeal-details/2"
                                     data-cy="start-start-case-date">Start<span class="govuk-visually-hidden"> Start date</span></a>
                                 </dd>
                             </div>

--- a/appeals/web/src/server/appeals/appeal-details/__tests__/appeal-details.test.js
+++ b/appeals/web/src/server/appeals/appeal-details/__tests__/appeal-details.test.js
@@ -2122,7 +2122,7 @@ describe('appeal-details', () => {
 			expect(element.innerHTML).toContain('Important</h3>');
 			expect(element.innerHTML).toContain('Appeal valid</p>');
 			expect(element.innerHTML).toContain(
-				'href="/appeals-service/appeal-details/2/start-case/add">Start case</a>'
+				'href="/appeals-service/appeal-details/2/start-case/add?backUrl=/appeals-service/appeal-details/2">Start case</a>'
 			);
 		});
 

--- a/appeals/web/src/server/appeals/appeal-details/appeal-details.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/appeal-details.mapper.js
@@ -48,7 +48,7 @@ export async function appealDetailsPage(
 
 	const accordion = generateAccordionItems(appealDetails, mappedData, session);
 
-	const statusDependentNotifications = mapStatusDependentNotifications(appealDetails);
+	const statusDependentNotifications = mapStatusDependentNotifications(appealDetails, currentRoute);
 	const notificationBanners = sortNotificationBanners([
 		...statusDependentNotifications,
 		...mapNotificationBannersFromSession(session, 'appealDetails', appealDetails.appealId)

--- a/appeals/web/src/server/appeals/appeal-details/issue-decision/issue-decision.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/issue-decision/issue-decision.mapper.js
@@ -428,8 +428,11 @@ export function generateIssueDecisionUrl(appealId) {
 
 /**
  * @param {string|number} appealId
+ * @param {string} [backUrl]
  * @returns {string}
  */
-export function generateStartTimetableUrl(appealId) {
-	return `/appeals-service/appeal-details/${appealId}/start-case/add`;
+export function generateStartTimetableUrl(appealId, backUrl) {
+	return `/appeals-service/appeal-details/${appealId}/start-case/add${
+		backUrl ? `?backUrl=${backUrl}` : ''
+	}`;
 }

--- a/appeals/web/src/server/appeals/appeal-details/start-case/__tests__/start-case.test.js
+++ b/appeals/web/src/server/appeals/appeal-details/start-case/__tests__/start-case.test.js
@@ -4,6 +4,7 @@ import supertest from 'supertest';
 import { createTestEnvironment } from '#testing/index.js';
 import { appealData } from '#testing/appeals/appeals.js';
 import { dateISOStringToDisplayDate } from '#lib/dates.js';
+import featureFlags from '#common/feature-flags.js';
 
 const { app, teardown } = createTestEnvironment();
 const request = supertest(app);
@@ -17,10 +18,18 @@ describe('start-case', () => {
 	afterEach(teardown);
 
 	describe('GET /start-case/add', () => {
-		it('should render the start case page with the expected content', async () => {
-			nock('http://test/').get('/appeals/1').reply(200, appealDataWithoutStartDate);
+		it('should render the start case page with the expected content if the appeal type is Householder', async () => {
+			nock('http://test/')
+				.get('/appeals/1')
+				.reply(200, {
+					...appealDataWithoutStartDate,
+					appealType: 'Householder'
+				});
 
 			const response = await request.get(`${baseUrl}/1/start-case/add`);
+
+			expect(response.statusCode).toBe(200);
+
 			const element = parseHtml(response.text);
 
 			expect(element.innerHTML).toContain('Start case</h1>');
@@ -33,6 +42,70 @@ describe('start-case', () => {
 				)}. Start letters will be sent to the relevant parties.`
 			);
 			expect(unprettifiedElement.innerHTML).toContain('Confirm</button>');
+		});
+
+		it('should render the start case page with the expected content if the appeal type is S78 and the S78 hearing feature flag is disabled', async () => {
+			featureFlags.isFeatureActive = () => false;
+
+			nock('http://test/')
+				.get('/appeals/1')
+				.reply(200, {
+					...appealDataWithoutStartDate,
+					appealType: 'Planning appeal'
+				});
+
+			const response = await request.get(`${baseUrl}/1/start-case/add`);
+
+			expect(response.statusCode).toBe(200);
+
+			const element = parseHtml(response.text);
+
+			expect(element.innerHTML).toContain('Start case</h1>');
+
+			const unprettifiedElement = parseHtml(response.text, { skipPrettyPrint: true });
+
+			expect(unprettifiedElement.innerHTML).toContain(
+				`Warning</span> Confirming will activate the timetable on ${dateISOStringToDisplayDate(
+					new Date().toISOString()
+				)}. Start letters will be sent to the relevant parties.`
+			);
+			expect(unprettifiedElement.innerHTML).toContain('Confirm</button>');
+		});
+
+		it('should redirect to the select procedure page if the appeal type is S78 and the S78 hearing feature flag is enabled', async () => {
+			featureFlags.isFeatureActive = () => true;
+
+			nock('http://test/')
+				.get('/appeals/1')
+				.reply(200, {
+					...appealDataWithoutStartDate,
+					appealType: 'Planning appeal'
+				});
+
+			const response = await request.get(`${baseUrl}/1/start-case/add`);
+
+			expect(response.statusCode).toBe(302);
+			expect(response.text).toBe(
+				'Found. Redirecting to /appeals-service/appeal-details/1/start-case/select-procedure'
+			);
+		});
+
+		it('should redirect to the select procedure page if the appeal type is S78 and the S78 hearing feature flag is enabled, passing the backLink query parameter if provided', async () => {
+			featureFlags.isFeatureActive = () => true;
+
+			nock('http://test/')
+				.get('/appeals/1')
+				.reply(200, {
+					...appealDataWithoutStartDate,
+					appealType: 'Planning appeal'
+				});
+
+			const response = await request.get(`${baseUrl}/1/start-case/add?backUrl=/test/back/url`);
+
+			expect(response.statusCode).toBe(302);
+			expect(response.text).toBe(
+				'Found. Redirecting to /appeals-service/appeal-details/1/start-case/select-procedure?backUrl=/test/back/url'
+			);
 		});
 	});
 
@@ -77,6 +150,82 @@ describe('start-case', () => {
 
 			expect(response.statusCode).toBe(302);
 			expect(response.text).toBe('Found. Redirecting to /appeals-service/appeal-details/1');
+		});
+	});
+
+	describe('GET /start-case/select-procedure', () => {
+		it('should render the select procedure page with the expected content', async () => {
+			nock('http://test/')
+				.get('/appeals/1')
+				.reply(200, {
+					...appealDataWithoutStartDate,
+					appealType: 'Planning appeal'
+				});
+
+			const response = await request.get(
+				'/appeals-service/appeal-details/1/start-case/select-procedure'
+			);
+
+			expect(response.statusCode).toBe(200);
+
+			const unprettifiedElement = parseHtml(response.text, {
+				rootElement: 'body',
+				skipPrettyPrint: true
+			});
+
+			expect(unprettifiedElement.innerHTML).toContain('href="/" class="govuk-back-link">Back</a>');
+			expect(unprettifiedElement.innerHTML).toContain(
+				'<span class="govuk-caption-l">Appeal 351062 - start case</span>'
+			);
+			expect(unprettifiedElement.innerHTML).toContain('Appeal procedure</h1>');
+			expect(unprettifiedElement.innerHTML).toContain(
+				'name="appealProcedure" type="radio" value="written">'
+			);
+			expect(unprettifiedElement.innerHTML).toContain(
+				'name="appealProcedure" type="radio" value="hearing">'
+			);
+			expect(unprettifiedElement.innerHTML).toContain(
+				'name="appealProcedure" type="radio" value="inquiry">'
+			);
+			expect(unprettifiedElement.innerHTML).toContain('Continue</button>');
+		});
+
+		it('should render the select procedure page with the expected back link URL, if the backLink query parameter was passed', async () => {
+			nock('http://test/')
+				.get('/appeals/1')
+				.reply(200, {
+					...appealDataWithoutStartDate,
+					appealType: 'Planning appeal'
+				});
+
+			const response = await request.get(
+				'/appeals-service/appeal-details/1/start-case/select-procedure?backUrl=/test/back/url'
+			);
+
+			expect(response.statusCode).toBe(200);
+
+			const unprettifiedElement = parseHtml(response.text, {
+				rootElement: 'body',
+				skipPrettyPrint: true
+			});
+
+			expect(unprettifiedElement.innerHTML).toContain(
+				'href="/test/back/url" class="govuk-back-link">Back</a>'
+			);
+			expect(unprettifiedElement.innerHTML).toContain(
+				'<span class="govuk-caption-l">Appeal 351062 - start case</span>'
+			);
+			expect(unprettifiedElement.innerHTML).toContain('Appeal procedure</h1>');
+			expect(unprettifiedElement.innerHTML).toContain(
+				'name="appealProcedure" type="radio" value="written">'
+			);
+			expect(unprettifiedElement.innerHTML).toContain(
+				'name="appealProcedure" type="radio" value="hearing">'
+			);
+			expect(unprettifiedElement.innerHTML).toContain(
+				'name="appealProcedure" type="radio" value="inquiry">'
+			);
+			expect(unprettifiedElement.innerHTML).toContain('Continue</button>');
 		});
 	});
 });

--- a/appeals/web/src/server/appeals/appeal-details/start-case/start-case.controller.js
+++ b/appeals/web/src/server/appeals/appeal-details/start-case/start-case.controller.js
@@ -1,12 +1,27 @@
 import { dateISOStringToDisplayDate } from '#lib/dates.js';
 import logger from '#lib/logger.js';
-import { startCasePage, changeDatePage } from './start-case.mapper.js';
+import { startCasePage, changeDatePage, selectProcedurePage } from './start-case.mapper.js';
 import * as startCaseService from './start-case.service.js';
 import { getTodaysISOString } from '#lib/dates.js';
 import { addNotificationBannerToSession } from '#lib/session-utilities.js';
+import featureFlags from '#common/feature-flags.js';
+import { FEATURE_FLAG_NAMES, APPEAL_TYPE } from '@pins/appeals/constants/common.js';
 
 /** @type {import('@pins/express').RequestHandler<Response>}  */
 export const getStartDate = async (request, response) => {
+	const { appealId, appealType } = request.currentAppeal;
+
+	if (
+		appealType === APPEAL_TYPE.S78 &&
+		featureFlags.isFeatureActive(FEATURE_FLAG_NAMES.SECTION_78_HEARING)
+	) {
+		return response.redirect(
+			`/appeals-service/appeal-details/${appealId}/start-case/select-procedure${
+				request.query?.backUrl ? `?backUrl=${request.query?.backUrl}` : ''
+			}`
+		);
+	}
+
 	renderStartDatePage(request, response);
 };
 
@@ -114,4 +129,27 @@ export const postChangeDate = async (request, response) => {
 
 		return response.render('app/500.njk');
 	}
+};
+
+/** @type {import('@pins/express').RequestHandler<Response>}  */
+export const getSelectProcedure = async (request, response) => {
+	renderSelectProcedure(request, response);
+};
+
+/**
+ *
+ * @param {import('@pins/express/types/express.js').Request} request
+ * @param {import('@pins/express/types/express.js').RenderedResponse<any, any, Number>} response
+ */
+const renderSelectProcedure = async (request, response) => {
+	const { appealReference } = request.currentAppeal;
+
+	const mappedPageContent = selectProcedurePage(
+		appealReference,
+		request.query?.backUrl ? String(request.query?.backUrl) : '/'
+	);
+
+	return response.render('patterns/change-page.pattern.njk', {
+		pageContent: mappedPageContent
+	});
 };

--- a/appeals/web/src/server/appeals/appeal-details/start-case/start-case.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/start-case/start-case.mapper.js
@@ -1,4 +1,6 @@
 import { appealShortReference } from '#lib/appeals-formatter.js';
+import { radiosInput } from '#lib/mappers/components/page-components/radio.js';
+import { APPEAL_CASE_PROCEDURE } from 'pins-data-model';
 
 /**
  * @param {number} appealId
@@ -73,6 +75,47 @@ export function changeDatePage(appealId, appealReference, today) {
 					type: 'submit'
 				}
 			}
+		]
+	};
+
+	return pageContent;
+}
+
+/**
+ * @param {string} appealReference
+ * @param {string} backLinkUrl
+ * @returns {PageContent}
+ */
+export function selectProcedurePage(appealReference, backLinkUrl) {
+	/** @type {PageContent} */
+	const pageContent = {
+		title: 'Appeal procedure',
+		backLinkUrl,
+		preHeading: `Appeal ${appealShortReference(appealReference)} - start case`,
+		pageComponents: [
+			radiosInput({
+				name: 'appealProcedure',
+				idPrefix: 'appeal-procedure',
+				legendText: 'Appeal procedure',
+				legendIsPageHeading: true,
+				items: [
+					{
+						value: APPEAL_CASE_PROCEDURE.WRITTEN,
+						text: 'Written representations',
+						checked: false
+					},
+					{
+						value: APPEAL_CASE_PROCEDURE.HEARING,
+						text: 'Hearing',
+						checked: false
+					},
+					{
+						value: APPEAL_CASE_PROCEDURE.INQUIRY,
+						text: 'Inquiry',
+						checked: false
+					}
+				]
+			})
 		]
 	};
 

--- a/appeals/web/src/server/appeals/appeal-details/start-case/start-case.router.js
+++ b/appeals/web/src/server/appeals/appeal-details/start-case/start-case.router.js
@@ -14,4 +14,6 @@ router
 	.get(asyncHandler(controller.getChangeDate))
 	.post(asyncHandler(controller.postChangeDate));
 
+router.route('/select-procedure').get(asyncHandler(controller.getSelectProcedure));
+
 export default router;

--- a/appeals/web/src/server/appeals/personal-list/__tests__/__snapshots__/personal-list.test.js.snap
+++ b/appeals/web/src/server/appeals/personal-list/__tests__/__snapshots__/personal-list.test.js.snap
@@ -84,7 +84,7 @@ exports[`personal-list GET / should render a child status tag in the lead or chi
                         <td class="govuk-table__cell"><strong><a class="govuk-link" href="/appeals-service/appeal-details/28512" aria-label="Appeal 6 0 2 8 5 1 2">6028512</a></strong>
                         </td>
                         <td class="govuk-table__cell"></td>
-                        <td class="govuk-table__cell action-required"><a class="govuk-link" href="/appeals-service/appeal-details/28512/start-case/add">Start case<span class="govuk-visually-hidden"> for appeal 28512</span></a>
+                        <td class="govuk-table__cell action-required"><a class="govuk-link" href="/appeals-service/appeal-details/28512/start-case/add?backUrl=/appeals-service/personal-list?pageNumber=1&pageSize=30">Start case<span class="govuk-visually-hidden"> for appeal 28512</span></a>
                         </td>
                         <td class="govuk-table__cell">9 March 2025</td>
                         <td class="govuk-table__cell"><strong class="govuk-tag govuk-tag--turquoise single-line">Ready to start</strong>
@@ -211,7 +211,7 @@ exports[`personal-list GET / should render a lead status tag in the lead or chil
                         <td class="govuk-table__cell"><strong><a class="govuk-link" href="/appeals-service/appeal-details/28512" aria-label="Appeal 6 0 2 8 5 1 2">6028512</a></strong>
                         </td>
                         <td class="govuk-table__cell"></td>
-                        <td class="govuk-table__cell action-required"><a class="govuk-link" href="/appeals-service/appeal-details/28512/start-case/add">Start case<span class="govuk-visually-hidden"> for appeal 28512</span></a>
+                        <td class="govuk-table__cell action-required"><a class="govuk-link" href="/appeals-service/appeal-details/28512/start-case/add?backUrl=/appeals-service/personal-list?pageNumber=1&pageSize=30">Start case<span class="govuk-visually-hidden"> for appeal 28512</span></a>
                         </td>
                         <td class="govuk-table__cell">9 March 2025</td>
                         <td class="govuk-table__cell"><strong class="govuk-tag govuk-tag--turquoise single-line">Ready to start</strong>
@@ -353,7 +353,7 @@ exports[`personal-list GET / should render an empty cell in the lead or child co
                         <td class="govuk-table__cell"><strong><a class="govuk-link" href="/appeals-service/appeal-details/28512" aria-label="Appeal 6 0 2 8 5 1 2">6028512</a></strong>
                         </td>
                         <td class="govuk-table__cell"></td>
-                        <td class="govuk-table__cell action-required"><a class="govuk-link" href="/appeals-service/appeal-details/28512/start-case/add">Start case<span class="govuk-visually-hidden"> for appeal 28512</span></a>
+                        <td class="govuk-table__cell action-required"><a class="govuk-link" href="/appeals-service/appeal-details/28512/start-case/add?backUrl=/appeals-service/personal-list?pageNumber=1&pageSize=30">Start case<span class="govuk-visually-hidden"> for appeal 28512</span></a>
                         </td>
                         <td class="govuk-table__cell">9 March 2025</td>
                         <td class="govuk-table__cell"><strong class="govuk-tag govuk-tag--turquoise single-line">Ready to start</strong>
@@ -480,7 +480,7 @@ exports[`personal-list GET / should render the first page of the personal list w
                         <td class="govuk-table__cell"><strong><a class="govuk-link" href="/appeals-service/appeal-details/28512" aria-label="Appeal 6 0 2 8 5 1 2">6028512</a></strong>
                         </td>
                         <td class="govuk-table__cell"></td>
-                        <td class="govuk-table__cell action-required"><a class="govuk-link" href="/appeals-service/appeal-details/28512/start-case/add">Start case<span class="govuk-visually-hidden"> for appeal 28512</span></a>
+                        <td class="govuk-table__cell action-required"><a class="govuk-link" href="/appeals-service/appeal-details/28512/start-case/add?backUrl=/appeals-service/personal-list?pageNumber=1&pageSize=5">Start case<span class="govuk-visually-hidden"> for appeal 28512</span></a>
                         </td>
                         <td class="govuk-table__cell">9 March 2025</td>
                         <td class="govuk-table__cell"><strong class="govuk-tag govuk-tag--turquoise single-line">Ready to start</strong>

--- a/appeals/web/src/server/appeals/personal-list/__tests__/personal-list.test.js
+++ b/appeals/web/src/server/appeals/personal-list/__tests__/personal-list.test.js
@@ -380,7 +380,7 @@ describe('personal-list', () => {
 				name: 'Start case',
 				requiredAction: 'startAppeal',
 				expectedHtml: {
-					caseOfficer: `<a class="govuk-link" href="/appeals-service/appeal-details/${appealId}/start-case/add">Start case<span class="govuk-visually-hidden"> for appeal ${appealId}</span></a>`,
+					caseOfficer: `<a class="govuk-link" href="/appeals-service/appeal-details/${appealId}/start-case/add?backUrl=/appeals-service/personal-list">Start case<span class="govuk-visually-hidden"> for appeal ${appealId}</span></a>`,
 					nonCaseOfficer: 'Start case'
 				}
 			},
@@ -397,7 +397,8 @@ describe('personal-list', () => {
 			it(`should return the expected "${testCase.name}" action link HTML when getRequiredActionsForAppeal returns "${testCase.requiredAction}" and "isCaseOfficer" is true`, async () => {
 				const result = mapActionLinksForAppeal(
 					appealDataToGetRequiredActions[testCase.requiredAction],
-					true
+					true,
+					baseUrl
 				);
 
 				expect(result).toBe(testCase.expectedHtml.caseOfficer);
@@ -407,7 +408,8 @@ describe('personal-list', () => {
 				it(`should return the expected "${testCase.name}" action link HTML when getRequiredActionsForAppeal returns "${testCase.requiredAction}" and "isCaseOfficer" is false`, async () => {
 					const result = mapActionLinksForAppeal(
 						appealDataToGetRequiredActions[testCase.requiredAction],
-						false
+						false,
+						baseUrl
 					);
 
 					expect(result).toBe(testCase.expectedHtml.nonCaseOfficer);
@@ -421,7 +423,8 @@ describe('personal-list', () => {
 					...baseAppealDataToGetRequiredActions,
 					appealId: undefined
 				},
-				true
+				true,
+				baseUrl
 			);
 
 			expect(result).toBe('');
@@ -433,7 +436,8 @@ describe('personal-list', () => {
 					...baseAppealDataToGetRequiredActions,
 					lpaQuestionnaireId: null
 				},
-				true
+				true,
+				baseUrl
 			);
 
 			expect(resultForNull).toBe('');
@@ -443,7 +447,8 @@ describe('personal-list', () => {
 					...baseAppealDataToGetRequiredActions,
 					lpaQuestionnaireId: undefined
 				},
-				true
+				true,
+				baseUrl
 			);
 
 			expect(resultForUndefined).toBe('');

--- a/appeals/web/src/server/appeals/personal-list/personal-list.controller.js
+++ b/appeals/web/src/server/appeals/personal-list/personal-list.controller.js
@@ -34,7 +34,8 @@ export const viewPersonalList = async (request, response) => {
 		assignedAppeals,
 		urlWithoutQuery,
 		appealStatusFilter,
-		request.session
+		request.session,
+		originalUrl
 	);
 
 	const pagination = mapPagination(

--- a/appeals/web/src/server/appeals/personal-list/personal-list.mapper.js
+++ b/appeals/web/src/server/appeals/personal-list/personal-list.mapper.js
@@ -21,6 +21,7 @@ import { getRequiredActionsForAppeal } from '#lib/mappers/utils/required-actions
  * @param {string} urlWithoutQuery
  * @param {string|undefined} appealStatusFilter
  * @param {import("express-session").Session & Partial<import("express-session").SessionData>} session
+ * @param {string} currentRoute
  * @returns {PageContent}
  */
 
@@ -28,7 +29,8 @@ export function personalListPage(
 	appealsAssignedToCurrentUser,
 	urlWithoutQuery,
 	appealStatusFilter,
-	session
+	session,
+	currentRoute
 ) {
 	const account = /** @type {AccountInfo} */ (authSession.getAccount(session));
 	const userGroups = account?.idTokenClaims?.groups ?? [];
@@ -166,7 +168,7 @@ export function personalListPage(
 					},
 					{
 						classes: 'action-required',
-						html: mapActionLinksForAppeal(appeal, isCaseOfficer)
+						html: mapActionLinksForAppeal(appeal, isCaseOfficer, currentRoute)
 					},
 					{
 						text: dateISOStringToDisplayDate(appeal.dueDate) || ''
@@ -238,13 +240,15 @@ export function personalListPage(
  * @param {boolean} isCaseOfficer
  * @param {number} appealId
  * @param {number|null|undefined} lpaQuestionnaireId
+ * @param {string} currentRoute
  * @returns {string}
  */
 function mapRequiredActionToPersonalListActionHtml(
 	action,
 	isCaseOfficer,
 	appealId,
-	lpaQuestionnaireId
+	lpaQuestionnaireId,
+	currentRoute
 ) {
 	switch (action) {
 		case 'addHorizonReference': {
@@ -316,7 +320,7 @@ function mapRequiredActionToPersonalListActionHtml(
 		}
 		case 'startAppeal': {
 			return isCaseOfficer
-				? `<a class="govuk-link" href="/appeals-service/appeal-details/${appealId}/start-case/add">Start case<span class="govuk-visually-hidden"> for appeal ${appealId}</span></a>`
+				? `<a class="govuk-link" href="/appeals-service/appeal-details/${appealId}/start-case/add?backUrl=${currentRoute}">Start case<span class="govuk-visually-hidden"> for appeal ${appealId}</span></a>`
 				: 'Start case';
 		}
 		case 'updateLpaStatement': {
@@ -330,10 +334,11 @@ function mapRequiredActionToPersonalListActionHtml(
 
 /**
  * @param {PersonalListAppeal} appeal
- * @param {boolean} [isCaseOfficer]
+ * @param {boolean} isCaseOfficer
+ * @param {string} currentRoute
  * @returns {string}
  */
-export function mapActionLinksForAppeal(appeal, isCaseOfficer = false) {
+export function mapActionLinksForAppeal(appeal, isCaseOfficer, currentRoute) {
 	const requiredActions = getRequiredActionsForAppeal({
 		...appeal,
 		appealTimetable: appeal.appealTimetable || {}
@@ -351,7 +356,8 @@ export function mapActionLinksForAppeal(appeal, isCaseOfficer = false) {
 				action,
 				isCaseOfficer,
 				appealId,
-				lpaQuestionnaireId
+				lpaQuestionnaireId,
+				currentRoute
 			);
 		})
 		.join('<br>');

--- a/appeals/web/src/server/lib/mappers/data/appeal/submappers/__tests__/started-at.mapper.test.js
+++ b/appeals/web/src/server/lib/mappers/data/appeal/submappers/__tests__/started-at.mapper.test.js
@@ -34,7 +34,7 @@ describe('started-at.mapper', () => {
 								attributes: {
 									'data-cy': 'start-start-case-date'
 								},
-								href: '/test/start-case/add',
+								href: '/test/start-case/add?backUrl=/test',
 								text: 'Start',
 								visuallyHiddenText: 'Start date'
 							}

--- a/appeals/web/src/server/lib/mappers/data/appeal/submappers/started-at.mapper.js
+++ b/appeals/web/src/server/lib/mappers/data/appeal/submappers/started-at.mapper.js
@@ -14,7 +14,7 @@ export const mapStartedAt = ({ appealDetails, currentRoute, userHasUpdateCasePer
 		value: dateISOStringToDisplayDate(appealDetails.startedAt, 'Not started'),
 		link: appealDetails.startedAt
 			? `${currentRoute}/start-case/change`
-			: `${currentRoute}/start-case/add`,
+			: `${currentRoute}/start-case/add?backUrl=${currentRoute}`,
 		editable: Boolean(userHasUpdateCasePermission),
 		classes: 'appeal-start-date',
 		actionText:

--- a/appeals/web/src/server/lib/mappers/utils/__tests__/map-status-dependent-notifications.test.js
+++ b/appeals/web/src/server/lib/mappers/utils/__tests__/map-status-dependent-notifications.test.js
@@ -114,7 +114,8 @@ describe('mapStatusDependentNotifications', () => {
 	for (const testCase of testCases) {
 		it(`should return "${testCase.bannerKey}" banner when getRequiredActionsForAppeal returns "${testCase.requiredAction}"`, async () => {
 			const result = mapStatusDependentNotifications(
-				appealDataToGetRequiredActions[testCase.requiredAction]
+				appealDataToGetRequiredActions[testCase.requiredAction],
+				`/appeals-service/appeal-details/${mockAppealData.appealId}`
 			);
 
 			expect(Array.isArray(result)).toBe(true);

--- a/appeals/web/src/server/lib/mappers/utils/map-status-dependent-notifications.js
+++ b/appeals/web/src/server/lib/mappers/utils/map-status-dependent-notifications.js
@@ -13,9 +13,10 @@ import { getRequiredActionsForAppeal } from './required-actions.js';
 
 /**
  * @param {import('#appeals/appeal-details/appeal-details.types.js').WebAppeal} appealDetails
+ * @param {string} currentRoute
  * @returns {PageComponent[]}
  */
-export function mapStatusDependentNotifications(appealDetails) {
+export function mapStatusDependentNotifications(appealDetails, currentRoute) {
 	const requiredActions = getRequiredActionsForAppeal(appealDetails);
 
 	/** @type {import('../components/index.js').NotificationBannerDefinitionKey[]} */
@@ -24,16 +25,17 @@ export function mapStatusDependentNotifications(appealDetails) {
 		.filter(/** @returns {item is NotificationBannerDefinitionKey} */ (item) => item !== undefined);
 
 	return bannerKeys
-		.map((bannerKey) => mapBannerKeysToNotificationBanners(bannerKey, appealDetails))
+		.map((bannerKey) => mapBannerKeysToNotificationBanners(bannerKey, appealDetails, currentRoute))
 		.filter(/** @returns {item is PageComponent} */ (item) => item !== undefined);
 }
 
 /**
  * @param {NotificationBannerDefinitionKey} bannerDefinitionKey
  * @param {import('#appeals/appeal-details/appeal-details.types.js').WebAppeal} appealDetails
- * @returns
+ * @param {string} currentRoute
+ * @returns {PageComponent|undefined}
  */
-function mapBannerKeysToNotificationBanners(bannerDefinitionKey, appealDetails) {
+function mapBannerKeysToNotificationBanners(bannerDefinitionKey, appealDetails, currentRoute) {
 	switch (bannerDefinitionKey) {
 		case 'appealAwaitingTransfer':
 			return createNotificationBanner({
@@ -111,7 +113,8 @@ function mapBannerKeysToNotificationBanners(bannerDefinitionKey, appealDetails) 
 			return createNotificationBanner({
 				bannerDefinitionKey,
 				html: `<p class="govuk-notification-banner__heading">Appeal valid</p><p><a class="govuk-notification-banner__link" data-cy="ready-to-start" href="${generateStartTimetableUrl(
-					appealDetails.appealId
+					appealDetails.appealId,
+					currentRoute
 				)}">Start case</a></p>`
 			});
 		case 'updateLpaStatement':


### PR DESCRIPTION
## Describe your changes

Adds a new page to start case flow (s78 select procedure type) and entry points, including new functionality to pass the back link URL using a query string (based on existing approach used elsewhere in the codebase), plus some unit tests.

## Issue ticket number and link
https://pins-ds.atlassian.net/browse/A2-2636
