### PR TITLE
Fix/a2 2550 test coverage for final comments flows

### DIFF
--- a/appeals/web/src/server/appeals/appeal-details/__tests__/appeal-details.test.js
+++ b/appeals/web/src/server/appeals/appeal-details/__tests__/appeal-details.test.js
@@ -2339,7 +2339,7 @@ describe('appeal-details', () => {
 						reviewPageRoute: 'final-comments/lpa',
 						cyAttribute: 'review-lpa-final-comments',
 						viewCyAttribute: 'view-lpa-final-comments',
-						actionLinkHiddenText: 'L P A final comments'
+						actionLinkHiddenText: 'LPA final comments'
 					}
 				];
 

--- a/appeals/web/src/server/lib/mappers/__tests__/mappers.test.js
+++ b/appeals/web/src/server/lib/mappers/__tests__/mappers.test.js
@@ -143,7 +143,6 @@ describe('pagination mapper', () => {
 
 describe('mapRepresentationDocumentSummaryActionLink', () => {
 	const baseRoute = '/appeals-service/appeal-details/4419';
-
 	describe('LPA Statement links', () => {
 		it('should return "Review" link for LPA statement when awaiting review', () => {
 			const link = mapRepresentationDocumentSummaryActionLink(
@@ -202,6 +201,67 @@ describe('mapRepresentationDocumentSummaryActionLink', () => {
 			);
 			expect(link).toBe('');
 		});
+	});
+});
+
+describe('Final comments links', () => {
+	const baseRoute = '/appeals-service/appeal-details/4419';
+	it('should return "Review" link for appellant statement when awaiting review', () => {
+		const link = mapRepresentationDocumentSummaryActionLink(
+			baseRoute,
+			'received',
+			APPEAL_REPRESENTATION_STATUS.AWAITING_REVIEW,
+			'appellant-final-comments'
+		);
+		expect(link).toBe(
+			`<a href="${baseRoute}/final-comments/appellant" data-cy="review-appellant-final-comments" class="govuk-link">Review<span class="govuk-visually-hidden"> appellant final comments</span></a>`
+		);
+	});
+
+	it('should return "Review" link for LPA statement when awaiting review', () => {
+		const link = mapRepresentationDocumentSummaryActionLink(
+			baseRoute,
+			'received',
+			APPEAL_REPRESENTATION_STATUS.AWAITING_REVIEW,
+			'lpa-final-comments'
+		);
+		expect(link).toBe(
+			`<a href="${baseRoute}/final-comments/lpa" data-cy="review-lpa-final-comments" class="govuk-link">Review<span class="govuk-visually-hidden"> LPA final comments</span></a>`
+		);
+	});
+
+	it('should return "View" link for appellant final comments when valid', () => {
+		const link = mapRepresentationDocumentSummaryActionLink(
+			baseRoute,
+			'received',
+			APPEAL_REPRESENTATION_STATUS.VALID,
+			'appellant-final-comments'
+		);
+		expect(link).toBe(
+			`<a href="${baseRoute}/final-comments/appellant" data-cy="view-appellant-final-comments" class="govuk-link">View<span class="govuk-visually-hidden"> appellant final comments</span></a>`
+		);
+	});
+
+	it('should return "View" link for LPA final comments when published', () => {
+		const link = mapRepresentationDocumentSummaryActionLink(
+			baseRoute,
+			'received',
+			APPEAL_REPRESENTATION_STATUS.PUBLISHED,
+			'lpa-final-comments'
+		);
+		expect(link).toBe(
+			`<a href="${baseRoute}/final-comments/lpa" data-cy="view-lpa-final-comments" class="govuk-link">View<span class="govuk-visually-hidden"> LPA final comments</span></a>`
+		);
+	});
+
+	it('should return an empty string when (any) final comment is not received', () => {
+		const link = mapRepresentationDocumentSummaryActionLink(
+			baseRoute,
+			'not_received',
+			null,
+			'appellant-final-comments'
+		);
+		expect(link).toBe('');
 	});
 });
 

--- a/appeals/web/src/server/lib/representation-utilities.js
+++ b/appeals/web/src/server/lib/representation-utilities.js
@@ -22,10 +22,6 @@ export function mapRepresentationDocumentSummaryActionLink(
 	representationStatus,
 	representationType
 ) {
-	console.log(`[representation-utilities.js] representationType: ${representationType}`);
-	console.log(`[representation-utilities.js] representationStatus: ${representationStatus}`);
-	console.log(`[representation-utilities.js] documentationStatus: ${documentationStatus}`);
-	console.log(`[representation-utilities.js] currentRoute: ${currentRoute}`);
 	if (documentationStatus !== 'received') {
 		return '';
 	}

--- a/appeals/web/src/server/lib/representation-utilities.js
+++ b/appeals/web/src/server/lib/representation-utilities.js
@@ -22,10 +22,13 @@ export function mapRepresentationDocumentSummaryActionLink(
 	representationStatus,
 	representationType
 ) {
+	console.log(`[representation-utilities.js] representationType: ${representationType}`);
+	console.log(`[representation-utilities.js] representationStatus: ${representationStatus}`);
+	console.log(`[representation-utilities.js] documentationStatus: ${documentationStatus}`);
+	console.log(`[representation-utilities.js] currentRoute: ${currentRoute}`);
 	if (documentationStatus !== 'received') {
 		return '';
 	}
-
 	const reviewRequired = [
 		APPEAL_REPRESENTATION_STATUS.AWAITING_REVIEW,
 		APPEAL_REPRESENTATION_STATUS.INCOMPLETE
@@ -35,7 +38,7 @@ export function mapRepresentationDocumentSummaryActionLink(
 	const visuallyHiddenTexts = {
 		'lpa-statement': 'LPA statement',
 		'appellant-final-comments': 'appellant final comments',
-		'lpa-final-comments': 'L P A final comments'
+		'lpa-final-comments': 'LPA final comments'
 	};
 
 	/** @type {Record<RepresentationType, string>} */


### PR DESCRIPTION
- Added tests for final comments flows with identical coverage to LPA statements 
- Changed spacing in code with rendered "L P A" 

https://pins-ds.atlassian.net/browse/A2-2550
