### PR TITLE
Fix/a2 2776 status tags

### DIFF
--- a/appeals/web/src/server/views/appeals/components/status-tag.njk
+++ b/appeals/web/src/server/views/appeals/components/status-tag.njk
@@ -36,5 +36,5 @@
 		{%- case 'awaiting_transfer' -%}
 			{%- set statusTagColor = 'red' -%}
 	{%- endswitch -%}
-	<strong class="govuk-tag govuk-tag--{{ statusTagColor }} {{ ' ' + classes if classes }}">{{ statusLabel | appealStatusToStatusTag }}</strong>
+	<strong class="govuk-tag govuk-tag--{{ statusTagColor }} {{classes if classes }}">{{ statusLabel | appealStatusToStatusTag }}</strong>
 {%- endmacro -%}

--- a/appeals/web/src/server/views/appeals/components/status-tag.njk
+++ b/appeals/web/src/server/views/appeals/components/status-tag.njk
@@ -36,5 +36,5 @@
 		{%- case 'awaiting_transfer' -%}
 			{%- set statusTagColor = 'red' -%}
 	{%- endswitch -%}
-	<strong class="govuk-tag govuk-tag--{{ statusTagColor }} single-line{{ ' ' + classes if classes }}">{{ statusLabel | appealStatusToStatusTag }}</strong>
+	<strong class="govuk-tag govuk-tag--{{ statusTagColor }} {{ ' ' + classes if classes }}">{{ statusLabel | appealStatusToStatusTag }}</strong>
 {%- endmacro -%}


### PR DESCRIPTION
## Describe your changes

- Status tag component single-line class removed to allow wrapping on overflow


## Issue ticket number and link
[Ticket] (https://pins-ds.atlassian.net/jira/software/c/projects/A2/boards/246?assignee=712020%3A04186e0f-84cf-4604-835a-10ec7cfafa90&selectedIssue=A2-2776)
