### PR TITLE
feat(appeals): disable ci pipeline test coverage in merge queues

### DIFF
--- a/azure-pipelines-ci.yml
+++ b/azure-pipelines-ci.yml
@@ -28,6 +28,12 @@ extends:
       - template: azure-pipelines-variables.yml@self
     validationJobs:
       - name: Run Linting & Tests
+        variables:
+        - name: test-script
+          ${{ if startsWith(variables['Build.SourceBranchName'], 'gh-readonly-queue') }}:
+            value: npm run test
+          ${{ else }}:
+            value: npm run test:cov
         steps:
           - template: ../steps/node_script.yml
             parameters:
@@ -51,7 +57,7 @@ extends:
               script: npm run lint:js
           - template: ../steps/node_script.yml
             parameters:
-              script: npm run test:cov
+              script: $(test-script)
               nodeVersion: 22
               environmentVariables:
                 TURBO_TEAM: $(TURBO_TEAM)


### PR DESCRIPTION
Tries to speed up merge queues by disabling test coverage in the pipeline checks.
