### PR TITLE
chore(appeals): missed node 22 upgrade on terraform-ci-commit pipeline

### DIFF
--- a/infrastructure/pipelines/terraform-ci-commit.yaml
+++ b/infrastructure/pipelines/terraform-ci-commit.yaml
@@ -32,9 +32,9 @@ extends:
         steps:
           - template: ../steps/node_script.yml
             parameters:
-              nodeVersion: 20
+              nodeVersion: 22
               script: npm ci
           - template: ../steps/node_script.yml
             parameters:
-              nodeVersion: 20
+              nodeVersion: 22
               script: npm run commitlint


### PR DESCRIPTION
We did upgrade recently from node 20 to node 22. This pipeline was missed.
