### PR TITLE
fix(appeals): missing generic notify template id (a2-2732)

### DIFF
--- a/infrastructure/app-api.tf
+++ b/infrastructure/app-api.tf
@@ -59,6 +59,7 @@ module "app_api" {
     ENABLE_TEST_ENDPOINTS = var.apps_config.integrations.enable_test_endpoints
 
     # notify templates
+    GOV_NOTIFY_APPEAL_GENERIC_ID                                               = var.apps_config.integrations.notify_template_ids.appeal_generic_id
     GOV_NOTIFY_APPEAL_CONFIRMED_ID                                             = var.apps_config.integrations.notify_template_ids.appeal_confirmed_id
     GOV_NOTIFY_APPEAL_INCOMPLETE_ID                                            = var.apps_config.integrations.notify_template_ids.appeal_incomplete_id
     GOV_NOTIFY_APPEAL_INVALID_ID                                               = var.apps_config.integrations.notify_template_ids.appeal_invalid_id

--- a/infrastructure/environments/dev.tfvars
+++ b/infrastructure/environments/dev.tfvars
@@ -25,6 +25,7 @@ apps_config = {
     service_bus_broadcast_enabled = true
     enable_test_endpoints         = true
     notify_template_ids = {
+      appeal_generic_id                                               = "3fd5fc42-d77f-42c2-984a-cf9b89e4c415"
       appeal_confirmed_id                                             = "783f94cc-1d6d-4153-8ad7-9070e449a57c"
       appeal_incomplete_id                                            = "f9cbd646-be00-45e2-96fc-f47e585e5b5e"
       appeal_invalid_id                                               = "59c8337a-e854-4fc4-8c83-aa958b91bd99"

--- a/infrastructure/environments/prod.tfvars
+++ b/infrastructure/environments/prod.tfvars
@@ -25,6 +25,7 @@ apps_config = {
     service_bus_broadcast_enabled = true
     enable_test_endpoints         = false
     notify_template_ids = {
+      appeal_generic_id                                               = "b29bbd23-6cf9-4173-b831-a915c79cf040"
       appeal_confirmed_id                                             = "1776217e-b40d-4d78-82d1-8d881dcec897"
       appeal_incomplete_id                                            = "4001ac42-0d2f-4520-b1c0-cae481dd18ba"
       appeal_invalid_id                                               = "fdce6d3b-f712-4d12-94c6-e8a994fdbdaf"

--- a/infrastructure/environments/test.tfvars
+++ b/infrastructure/environments/test.tfvars
@@ -25,6 +25,7 @@ apps_config = {
     service_bus_broadcast_enabled = true
     enable_test_endpoints         = true
     notify_template_ids = {
+      appeal_generic_id                                               = "3fd5fc42-d77f-42c2-984a-cf9b89e4c415"
       appeal_confirmed_id                                             = "783f94cc-1d6d-4153-8ad7-9070e449a57c"
       appeal_incomplete_id                                            = "f9cbd646-be00-45e2-96fc-f47e585e5b5e"
       appeal_invalid_id                                               = "59c8337a-e854-4fc4-8c83-aa958b91bd99"

--- a/infrastructure/environments/training.tfvars
+++ b/infrastructure/environments/training.tfvars
@@ -25,6 +25,7 @@ apps_config = {
     service_bus_broadcast_enabled = true
     enable_test_endpoints         = false
     notify_template_ids = {
+      appeal_generic_id                                               = "b29bbd23-6cf9-4173-b831-a915c79cf040"
       appeal_confirmed_id                                             = "1776217e-b40d-4d78-82d1-8d881dcec897"
       appeal_incomplete_id                                            = "4001ac42-0d2f-4520-b1c0-cae481dd18ba"
       appeal_invalid_id                                               = "fdce6d3b-f712-4d12-94c6-e8a994fdbdaf"


### PR DESCRIPTION
## Describe your changes
#### Missing generic notify template id (a2-2732)

Emergency fix to add missing generic template id to all environments

#### Infrastructure:
- Added generic template id

## Issue ticket number and link
[Ticket:  Create generic functionality to read in a specific mark down required and send to generic template id (A2-2732)](https://pins-ds.atlassian.net.mcas.ms/browse/A2-2732)
