### PR TITLE
feat(appeals): new notify implementation for statements and ip comments (a2-2733)

### DIFF
--- a/appeals/api/setup-tests.js
+++ b/appeals/api/setup-tests.js
@@ -2,6 +2,7 @@
 import { jest } from '@jest/globals';
 import config from '#config/config.js';
 import { NODE_ENV_PRODUCTION } from '@pins/appeals/constants/support.js';
+import { notifySend } from '#notify/notify-send.js';
 
 const mockValidateBlob = jest.fn().mockResolvedValue(true);
 const mockRepGetById = jest.fn().mockResolvedValue({});
@@ -105,6 +106,15 @@ const mockCaseNotesCreate = jest.fn().mockResolvedValue({});
 const mockRepresentationRejectionReasonFindMany = jest.fn().mockResolvedValue({});
 const mockRepresentationCreate = jest.fn().mockResolvedValue({});
 const mockRepresentationAttachmentCreateMany = jest.fn().mockResolvedValue({});
+
+const mockNotifySend = jest.fn().mockImplementation(async (params) => {
+	const { doNotMockNotifySend = false, ...options } = params || {};
+	if (doNotMockNotifySend) {
+		return notifySend(options);
+	} else {
+		return Promise.resolve();
+	}
+});
 
 class MockPrismaClient {
 	get representation() {
@@ -482,6 +492,7 @@ const mockGotGet = jest.fn();
 const mockGotPost = jest.fn();
 const mockSendEmail = jest.fn();
 global.mockSendEmail = mockSendEmail;
+global.mockNotifySend = mockNotifySend;
 
 jest.unstable_mockModule('jsonwebtoken', () => ({
 	default: {
@@ -495,6 +506,10 @@ jest.unstable_mockModule('got', () => ({
 		get: mockGotGet,
 		post: mockGotPost
 	}
+}));
+
+jest.unstable_mockModule('#notify/notify-send.js', () => ({
+	notifySend: mockNotifySend
 }));
 
 jest.unstable_mockModule('notifications-node-client', () => ({

--- a/appeals/api/src/server/endpoints/lpa-questionnaires/__tests__/lpa-questionnaires.test.js
+++ b/appeals/api/src/server/endpoints/lpa-questionnaires/__tests__/lpa-questionnaires.test.js
@@ -31,9 +31,7 @@ import {
 } from '#tests/appeals/mocks.js';
 import createManyToManyRelationData from '#utils/create-many-to-many-relation-data.js';
 import stringTokenReplacement from '#utils/string-token-replacement.js';
-
 const { databaseConnector } = await import('#utils/database-connector.js');
-import config from '#config/config.js';
 import { APPEAL_CASE_STATUS } from 'pins-data-model';
 
 describe('lpa questionnaires routes', () => {
@@ -237,7 +235,7 @@ describe('lpa questionnaires routes', () => {
 				).not.toHaveBeenCalled();
 
 				// eslint-disable-next-line no-undef
-				expect(mockSendEmail).toHaveBeenCalledTimes(2);
+				expect(mockNotifySend).toHaveBeenCalledTimes(2);
 
 				expect(response.status).toEqual(200);
 			});
@@ -299,37 +297,29 @@ describe('lpa questionnaires routes', () => {
 					.join(', ');
 
 				// eslint-disable-next-line no-undef
-				expect(mockSendEmail).toHaveBeenCalledTimes(2);
+				expect(mockNotifySend).toHaveBeenCalledTimes(2);
 				// eslint-disable-next-line no-undef
-				expect(mockSendEmail).toHaveBeenNthCalledWith(
-					1,
-					config.govNotify.template.lpaqComplete.lpa.id,
-					householdAppeal.lpa.email,
-					{
-						emailReplyToId: null,
-						personalisation: {
-							lpa_reference: householdAppeal.applicationReference,
-							appeal_reference_number: householdAppeal.reference,
-							site_address: expectedSiteAddress
-						},
-						reference: null
-					}
-				);
+				expect(mockNotifySend).toHaveBeenNthCalledWith(1, {
+					notifyClient: expect.anything(),
+					personalisation: {
+						lpa_reference: householdAppeal.applicationReference,
+						appeal_reference_number: householdAppeal.reference,
+						site_address: expectedSiteAddress
+					},
+					recipientEmail: householdAppeal.lpa.email,
+					templateName: 'lpaq-complete-lpa'
+				});
 				// eslint-disable-next-line no-undef
-				expect(mockSendEmail).toHaveBeenNthCalledWith(
-					2,
-					config.govNotify.template.lpaqComplete.appellant.id,
-					householdAppeal.appellant.email,
-					{
-						emailReplyToId: null,
-						personalisation: {
-							lpa_reference: householdAppeal.applicationReference,
-							appeal_reference_number: householdAppeal.reference,
-							site_address: expectedSiteAddress
-						},
-						reference: null
-					}
-				);
+				expect(mockNotifySend).toHaveBeenNthCalledWith(2, {
+					notifyClient: expect.anything(),
+					personalisation: {
+						lpa_reference: householdAppeal.applicationReference,
+						appeal_reference_number: householdAppeal.reference,
+						site_address: expectedSiteAddress
+					},
+					recipientEmail: householdAppeal.appellant.email,
+					templateName: 'lpaq-complete-appellant'
+				});
 
 				expect(response.status).toEqual(200);
 			});
@@ -970,26 +960,23 @@ describe('lpa questionnaires routes', () => {
 					.set('azureAdUserId', azureAdUserId);
 
 				// eslint-disable-next-line no-undef
-				expect(mockSendEmail).toHaveBeenCalledTimes(1);
+				expect(mockNotifySend).toHaveBeenCalledTimes(1);
 				// eslint-disable-next-line no-undef
-				expect(mockSendEmail).toHaveBeenCalledWith(
-					config.govNotify.template.lpaqIncomplete.id,
-					'maid@lpa-email.gov.uk',
-					{
-						emailReplyToId: null,
-						personalisation: {
-							appeal_reference_number: '1345264',
-							lpa_reference: '48269/APP/2021/1482',
-							site_address: '96 The Avenue, Leftfield, Maidstone, Kent, MD21 5XY, United Kingdom',
-							due_date: '22 June 2099',
-							reasons: [
-								'Documents or information are missing: Policy is missing',
-								'Other: Addresses are incorrect or missing'
-							]
-						},
-						reference: null
-					}
-				);
+				expect(mockNotifySend).toHaveBeenCalledWith({
+					notifyClient: expect.anything(),
+					personalisation: {
+						lpa_reference: householdAppeal.applicationReference,
+						appeal_reference_number: householdAppeal.reference,
+						site_address: '96 The Avenue, Leftfield, Maidstone, Kent, MD21 5XY, United Kingdom',
+						due_date: '22 June 2099',
+						reasons: [
+							'Documents or information are missing: Policy is missing',
+							'Other: Addresses are incorrect or missing'
+						]
+					},
+					recipientEmail: householdAppeal.lpa.email,
+					templateName: 'lpaq-incomplete'
+				});
 				expect(response.status).toEqual(200);
 			});
 

--- a/appeals/api/src/server/endpoints/representations/notify/services/index.js
+++ b/appeals/api/src/server/endpoints/representations/notify/services/index.js
@@ -6,13 +6,9 @@
  * code will the switching logic for you.
  */
 
-import config from '#config/config.js';
-import {
-	ERROR_FAILED_TO_SEND_NOTIFICATION_EMAIL,
-	FRONT_OFFICE_URL
-} from '@pins/appeals/constants/support.js';
+import { FRONT_OFFICE_URL } from '@pins/appeals/constants/support.js';
 import { formatExtendedDeadline, formatReasons, formatSiteAddress } from './utils.js';
-import notifySend from '#notify/notify-send.js';
+import { notifySend } from '#notify/notify-send.js';
 
 /**
  * @typedef {object} ServiceArgs
@@ -39,33 +35,29 @@ export const ipCommentRejection = async ({
 	const recipientEmail = representation.represented?.email;
 	if (recipientEmail) {
 		const templateName = extendedDeadline
-			? 'ip-comment-rejected-extended-deadline'
+			? 'ip-comment-rejected-deadline-extended'
 			: 'ip-comment-rejected';
 
-		try {
-			const personalisation = {
-				appeal_reference_number: appeal.reference,
-				lpa_reference: appeal.applicationReference || '',
-				site_address: siteAddress,
-				url: FRONT_OFFICE_URL,
-				reasons,
-				deadline_date: extendedDeadline
-			};
-			await notifySend({
-				templateName,
-				notifyClient,
-				recipientEmail,
-				personalisation
-			});
-		} catch (error) {
-			throw new Error(ERROR_FAILED_TO_SEND_NOTIFICATION_EMAIL);
-		}
+		const personalisation = {
+			appeal_reference_number: appeal.reference,
+			lpa_reference: appeal.applicationReference || '',
+			site_address: siteAddress,
+			url: FRONT_OFFICE_URL,
+			reasons,
+			deadline_date: extendedDeadline
+		};
+
+		await notifySend({
+			templateName,
+			notifyClient,
+			recipientEmail,
+			personalisation
+		});
 	}
 };
 
 /** @type {Service} */
 export const appellantFinalCommentRejection = async ({ notifyClient, appeal, representation }) => {
-	const templateId = config.govNotify.template.finalCommentRejected.appellant;
 	const siteAddress = formatSiteAddress(appeal);
 	const reasons = formatReasons(representation);
 
@@ -74,22 +66,22 @@ export const appellantFinalCommentRejection = async ({ notifyClient, appeal, rep
 		throw new Error(`no recipient email address found for Appeal: ${appeal.reference}`);
 	}
 
-	try {
-		await notifyClient.sendEmail(templateId, recipientEmail, {
+	await notifySend({
+		templateName: 'final-comment-rejected-appellant',
+		notifyClient,
+		recipientEmail,
+		personalisation: {
 			appeal_reference_number: appeal.reference,
 			lpa_reference: appeal.applicationReference || '',
 			site_address: siteAddress,
 			url: FRONT_OFFICE_URL,
 			reasons
-		});
-	} catch (error) {
-		throw new Error(ERROR_FAILED_TO_SEND_NOTIFICATION_EMAIL);
-	}
+		}
+	});
 };
 
 /** @type {Service} */
 export const lpaFinalCommentRejection = async ({ notifyClient, appeal, representation }) => {
-	const templateId = config.govNotify.template.finalCommentRejected.lpa;
 	const siteAddress = formatSiteAddress(appeal);
 	const reasons = formatReasons(representation);
 
@@ -98,17 +90,18 @@ export const lpaFinalCommentRejection = async ({ notifyClient, appeal, represent
 		throw new Error(`no recipient email address found for Appeal: ${appeal.reference}`);
 	}
 
-	try {
-		await notifyClient.sendEmail(templateId, recipientEmail, {
+	await notifySend({
+		templateName: 'final-comment-rejected-lpa',
+		notifyClient,
+		recipientEmail,
+		personalisation: {
 			appeal_reference_number: appeal.reference,
 			lpa_reference: appeal.applicationReference || '',
 			site_address: siteAddress,
 			url: FRONT_OFFICE_URL,
 			reasons
-		});
-	} catch (error) {
-		throw new Error(ERROR_FAILED_TO_SEND_NOTIFICATION_EMAIL);
-	}
+		}
+	});
 };
 
 /** @type {Service} */
@@ -118,7 +111,6 @@ export const lpaStatementIncomplete = async ({
 	representation,
 	allowResubmit
 }) => {
-	const templateId = config.govNotify.template.statementIncomplete.lpa;
 	const siteAddress = formatSiteAddress(appeal);
 	const reasons = formatReasons(representation);
 	const extendedDeadline = await formatExtendedDeadline(allowResubmit);
@@ -128,18 +120,17 @@ export const lpaStatementIncomplete = async ({
 		throw new Error(`no recipient email address found for Appeal: ${appeal.reference}`);
 	}
 
-	const vars = {
-		appeal_reference_number: appeal.reference,
-		lpa_reference: appeal.applicationReference || '',
-		site_address: siteAddress,
-		url: FRONT_OFFICE_URL,
-		deadline_date: extendedDeadline,
-		reasons
-	};
-
-	try {
-		await notifyClient.sendEmail(templateId, recipientEmail, vars);
-	} catch (error) {
-		throw new Error(ERROR_FAILED_TO_SEND_NOTIFICATION_EMAIL);
-	}
+	await notifySend({
+		templateName: 'lpa-statement-incomplete',
+		notifyClient,
+		recipientEmail,
+		personalisation: {
+			appeal_reference_number: appeal.reference,
+			lpa_reference: appeal.applicationReference || '',
+			site_address: siteAddress,
+			url: FRONT_OFFICE_URL,
+			deadline_date: extendedDeadline,
+			reasons
+		}
+	});
 };

--- a/appeals/api/src/server/notify/__tests__/emulate-notify.test.js
+++ b/appeals/api/src/server/notify/__tests__/emulate-notify.test.js
@@ -44,7 +44,7 @@ describe('emulate-notify.test', () => {
 			'<b>Subject:</b> We have rejected your comment: 6000437<br>',
 			'<hr><br>',
 			'We have rejected your comment.<br>',
-			'',
+			'<br>',
 			'<h1>Appeal details</h1>',
 			'<div style="margin-left: 0.25rem; border-left: 3px solid #999; padding: 0 0.75rem;">',
 			'Appeal reference number: 6000437<br>',
@@ -53,11 +53,11 @@ describe('emulate-notify.test', () => {
 			'</div>',
 			'<h2>Why we rejected your comment</h2>',
 			'We rejected your comment because:<br>',
-			'',
+			'<br>',
 			'<ul style="margin-left: 1.2rem; padding-left: 0;"><li> Includes inflammatory content</li>',
 			'<li> Duplicated or repeated comment</li>',
 			'<li> Not relevant to this appeal</li></ul>',
-			'',
+			'<br>',
 			'The Planning Inspectorate<br>'
 		].join('\n');
 

--- a/appeals/api/src/server/notify/__tests__/notify-send.test.js
+++ b/appeals/api/src/server/notify/__tests__/notify-send.test.js
@@ -1,7 +1,7 @@
 // @ts-nocheck
 import { jest } from '@jest/globals';
 import mockFileSystem from 'mock-fs';
-import notifySend from '#notify/notify-send.js';
+import { notifySend } from '#notify/notify-send.js';
 import {
 	ERROR_FAILED_TO_POPULATE_NOTIFICATION_EMAIL,
 	ERROR_FAILED_TO_SEND_NOTIFICATION_EMAIL
@@ -12,7 +12,7 @@ import stringTokenReplacement from '#utils/string-token-replacement.js';
 const __filename = fileURLToPath(import.meta.url); // get the resolved path to the file
 const __dirname = path.dirname(__filename); // get the name of the directory
 
-const templatesPath = path.join(__dirname, '../templates');
+const templatesPath = path.join(__dirname, '../', 'templates');
 
 describe('notify-send', () => {
 	let notifySendData;
@@ -34,7 +34,8 @@ describe('notify-send', () => {
 			personalisation: {
 				first_name: 'Joe',
 				last_name: 'Bloggs'
-			}
+			},
+			doNotMockNotifySend: true
 		};
 	});
 
@@ -44,7 +45,7 @@ describe('notify-send', () => {
 	});
 
 	test('should throw the failed to populate error when no parameters passed in', async () => {
-		await expect(async () => await notifySend({})).rejects.toThrow(
+		await expect(async () => await notifySend({ doNotMockNotifySend: true })).rejects.toThrow(
 			new Error(
 				stringTokenReplacement(ERROR_FAILED_TO_POPULATE_NOTIFICATION_EMAIL, [
 					'a missing template name'

--- a/appeals/api/src/server/notify/emulate-notify.js
+++ b/appeals/api/src/server/notify/emulate-notify.js
@@ -1,6 +1,6 @@
 import path from 'path';
 import fs from 'fs';
-import formatDate, { formatTime } from '#utils/date-formatter.js';
+import { formatSortableDateTime } from '#utils/date-formatter.js';
 
 /**
  * Emulate Notify for local dev testing
@@ -44,7 +44,7 @@ export function emulateSendEmail(templateName, recipientEmail, subject, content)
 			blockEnd = 0;
 			return line ? `</div>\n${line}<br>` : '</div>';
 		}
-		return line ? `${line}<br>` : '';
+		return line ? `${line}<br>` : '<br>';
 	});
 	// close blockquotes if required
 	if (blockEnd) {
@@ -63,7 +63,7 @@ export function emulateSendEmail(templateName, recipientEmail, subject, content)
 		fs.mkdirSync(outputDir, { recursive: true });
 	}
 
-	const fileName = `${templateName} ${formatDate(new Date())} ${formatTime(new Date())}.html`;
+	const fileName = `${formatSortableDateTime(new Date())} ${templateName}.html`;
 	const fullName = path.join(outputDir, fileName);
 	fs.writeFileSync(fullName, emailHtml);
 	return fullName;

--- a/appeals/api/src/server/notify/notify-send.js
+++ b/appeals/api/src/server/notify/notify-send.js
@@ -77,7 +77,11 @@ function populateTemplate(template, personalisation) {
 		const message = 'missing personalisation parameters: ' + content.match(/\((\w+)\)/g);
 		throw new Error(stringTokenReplacement(ERROR_FAILED_TO_POPULATE_NOTIFICATION_EMAIL, [message]));
 	}
-	return content;
+	// Make sure all white space at the end of each line is removed for the sake of Windows machines
+	return content
+		.split('\n')
+		.map((line) => line.trim())
+		.join('\n');
 }
 
 /**

--- a/appeals/api/src/server/notify/templates/__tests__/notify-final-comment-rejected-appellant.test.js
+++ b/appeals/api/src/server/notify/templates/__tests__/notify-final-comment-rejected-appellant.test.js
@@ -1,11 +1,11 @@
 import { notifySend } from '#notify/notify-send.js';
 import { jest } from '@jest/globals';
 
-describe('ip-comment-rejected-deadline-extended.md', () => {
+describe('final-comment-rejected-appellant.md', () => {
 	test('should call notify sendEmail with the correct data', async () => {
 		const notifySendData = {
 			doNotMockNotifySend: true,
-			templateName: 'ip-comment-rejected-deadline-extended',
+			templateName: 'final-comment-rejected-appellant',
 			notifyClient: {
 				sendEmail: jest.fn()
 			},
@@ -20,7 +20,7 @@ describe('ip-comment-rejected-deadline-extended.md', () => {
 		};
 
 		const expectedContent = [
-			'We have rejected your comment.',
+			'We have rejected your final comments.',
 			'',
 			'# Appeal details',
 			'',
@@ -28,9 +28,9 @@ describe('ip-comment-rejected-deadline-extended.md', () => {
 			'Address: 10, Test Street',
 			'Planning application reference: 12345XYZ',
 			'',
-			'## Why we rejected your comment',
+			'# Why we rejected your final comments',
 			'',
-			'We rejected your comment because:',
+			'We rejected your final comments because:',
 			'',
 			'- Reason one',
 			'- Reason two',
@@ -38,7 +38,7 @@ describe('ip-comment-rejected-deadline-extended.md', () => {
 			'',
 			'# What happens next',
 			'',
-			'You can send a different comment to caseofficers@planninginspectorate.gov.uk. You must send your comment by 01 January 2021.',
+			'You can send different final comments to caseofficers@planninginspectorate.gov.uk. The case officer will decide whether to accept any new final comments.',
 			'',
 			'The Planning Inspectorate'
 		].join('\n');
@@ -52,7 +52,7 @@ describe('ip-comment-rejected-deadline-extended.md', () => {
 			'test@136s7.com',
 			{
 				content: expectedContent,
-				subject: 'We have rejected your comment: ABC45678'
+				subject: 'We have rejected your final comments: ABC45678'
 			}
 		);
 	});

--- a/appeals/api/src/server/notify/templates/__tests__/notify-final-comment-rejected-lpa.test.js
+++ b/appeals/api/src/server/notify/templates/__tests__/notify-final-comment-rejected-lpa.test.js
@@ -1,11 +1,11 @@
 import { notifySend } from '#notify/notify-send.js';
 import { jest } from '@jest/globals';
 
-describe('ip-comment-rejected-deadline-extended.md', () => {
+describe('final-comment-rejected-lpa.md', () => {
 	test('should call notify sendEmail with the correct data', async () => {
 		const notifySendData = {
 			doNotMockNotifySend: true,
-			templateName: 'ip-comment-rejected-deadline-extended',
+			templateName: 'final-comment-rejected-lpa',
 			notifyClient: {
 				sendEmail: jest.fn()
 			},
@@ -20,7 +20,7 @@ describe('ip-comment-rejected-deadline-extended.md', () => {
 		};
 
 		const expectedContent = [
-			'We have rejected your comment.',
+			'We have rejected your final comments.',
 			'',
 			'# Appeal details',
 			'',
@@ -28,9 +28,9 @@ describe('ip-comment-rejected-deadline-extended.md', () => {
 			'Address: 10, Test Street',
 			'Planning application reference: 12345XYZ',
 			'',
-			'## Why we rejected your comment',
+			'# Why we rejected your final comments',
 			'',
-			'We rejected your comment because:',
+			'We rejected your final comments because:',
 			'',
 			'- Reason one',
 			'- Reason two',
@@ -38,7 +38,7 @@ describe('ip-comment-rejected-deadline-extended.md', () => {
 			'',
 			'# What happens next',
 			'',
-			'You can send a different comment to caseofficers@planninginspectorate.gov.uk. You must send your comment by 01 January 2021.',
+			'You can send different final comments to caseofficers@planninginspectorate.gov.uk. The case officer will decide whether to accept any new final comments.',
 			'',
 			'The Planning Inspectorate'
 		].join('\n');
@@ -52,7 +52,7 @@ describe('ip-comment-rejected-deadline-extended.md', () => {
 			'test@136s7.com',
 			{
 				content: expectedContent,
-				subject: 'We have rejected your comment: ABC45678'
+				subject: 'We have rejected your final comments: ABC45678'
 			}
 		);
 	});

--- a/appeals/api/src/server/notify/templates/__tests__/notify-final-comments-done-appellant.test.js
+++ b/appeals/api/src/server/notify/templates/__tests__/notify-final-comments-done-appellant.test.js
@@ -1,11 +1,11 @@
 import { notifySend } from '#notify/notify-send.js';
 import { jest } from '@jest/globals';
 
-describe('ip-comment-rejected-deadline-extended.md', () => {
+describe('final-comments-done-appellant.md', () => {
 	test('should call notify sendEmail with the correct data', async () => {
 		const notifySendData = {
 			doNotMockNotifySend: true,
-			templateName: 'ip-comment-rejected-deadline-extended',
+			templateName: 'final-comments-done-appellant',
 			notifyClient: {
 				sendEmail: jest.fn()
 			},
@@ -13,14 +13,12 @@ describe('ip-comment-rejected-deadline-extended.md', () => {
 			personalisation: {
 				appeal_reference_number: 'ABC45678',
 				site_address: '10, Test Street',
-				lpa_reference: '12345XYZ',
-				deadline_date: '01 January 2021',
-				reasons: ['Reason one', 'Reason two', 'Reason three']
+				lpa_reference: '12345XYZ'
 			}
 		};
 
 		const expectedContent = [
-			'We have rejected your comment.',
+			'We have received the local planning authority’s final comments.',
 			'',
 			'# Appeal details',
 			'',
@@ -28,19 +26,14 @@ describe('ip-comment-rejected-deadline-extended.md', () => {
 			'Address: 10, Test Street',
 			'Planning application reference: 12345XYZ',
 			'',
-			'## Why we rejected your comment',
-			'',
-			'We rejected your comment because:',
-			'',
-			'- Reason one',
-			'- Reason two',
-			'- Reason three',
-			'',
 			'# What happens next',
 			'',
-			'You can send a different comment to caseofficers@planninginspectorate.gov.uk. You must send your comment by 01 January 2021.',
+			'You can [view the local planning authority’s final comments](https://appeal-planning-decision.service.gov.uk/).',
 			'',
-			'The Planning Inspectorate'
+			'The inspector will visit the site and we will contact you when we have made the decision.',
+			'',
+			'The Planning Inspectorate',
+			'caseofficers@planninginspectorate.gov.uk'
 		].join('\n');
 
 		await notifySend(notifySendData);
@@ -52,7 +45,7 @@ describe('ip-comment-rejected-deadline-extended.md', () => {
 			'test@136s7.com',
 			{
 				content: expectedContent,
-				subject: 'We have rejected your comment: ABC45678'
+				subject: 'We have received the local planning authority’s final comments: ABC45678'
 			}
 		);
 	});

--- a/appeals/api/src/server/notify/templates/__tests__/notify-final-comments-done-lpa.test.js
+++ b/appeals/api/src/server/notify/templates/__tests__/notify-final-comments-done-lpa.test.js
@@ -1,11 +1,11 @@
 import { notifySend } from '#notify/notify-send.js';
 import { jest } from '@jest/globals';
 
-describe('ip-comment-rejected-deadline-extended.md', () => {
+describe('final-comments-done-lpa.md', () => {
 	test('should call notify sendEmail with the correct data', async () => {
 		const notifySendData = {
 			doNotMockNotifySend: true,
-			templateName: 'ip-comment-rejected-deadline-extended',
+			templateName: 'final-comments-done-lpa',
 			notifyClient: {
 				sendEmail: jest.fn()
 			},
@@ -13,14 +13,12 @@ describe('ip-comment-rejected-deadline-extended.md', () => {
 			personalisation: {
 				appeal_reference_number: 'ABC45678',
 				site_address: '10, Test Street',
-				lpa_reference: '12345XYZ',
-				deadline_date: '01 January 2021',
-				reasons: ['Reason one', 'Reason two', 'Reason three']
+				lpa_reference: '12345XYZ'
 			}
 		};
 
 		const expectedContent = [
-			'We have rejected your comment.',
+			'We have received the appellant’s final comments.',
 			'',
 			'# Appeal details',
 			'',
@@ -28,19 +26,14 @@ describe('ip-comment-rejected-deadline-extended.md', () => {
 			'Address: 10, Test Street',
 			'Planning application reference: 12345XYZ',
 			'',
-			'## Why we rejected your comment',
-			'',
-			'We rejected your comment because:',
-			'',
-			'- Reason one',
-			'- Reason two',
-			'- Reason three',
-			'',
 			'# What happens next',
 			'',
-			'You can send a different comment to caseofficers@planninginspectorate.gov.uk. You must send your comment by 01 January 2021.',
+			'You can [view the appellant’s final comments](https://appeal-planning-decision.service.gov.uk/manage-appeals/your-email-address).',
 			'',
-			'The Planning Inspectorate'
+			'The inspector will visit the site and we will contact you when we have made the decision.',
+			'',
+			'The Planning Inspectorate',
+			'caseofficers@planninginspectorate.gov.uk'
 		].join('\n');
 
 		await notifySend(notifySendData);
@@ -52,7 +45,7 @@ describe('ip-comment-rejected-deadline-extended.md', () => {
 			'test@136s7.com',
 			{
 				content: expectedContent,
-				subject: 'We have rejected your comment: ABC45678'
+				subject: 'We have received the appellant’s final comments: ABC45678'
 			}
 		);
 	});

--- a/appeals/api/src/server/notify/templates/__tests__/notify-ip-comment-rejected.test.js
+++ b/appeals/api/src/server/notify/templates/__tests__/notify-ip-comment-rejected.test.js
@@ -1,11 +1,11 @@
-import notifySend from '#notify/notify-send.js';
+import { notifySend } from '#notify/notify-send.js';
 import { jest } from '@jest/globals';
 
 describe('ip-comment-rejected.md', () => {
 	test('should call notify sendEmail with the correct data', async () => {
 		const notifySendData = {
+			doNotMockNotifySend: true,
 			templateName: 'ip-comment-rejected',
-			subjectTemplate: 'test',
 			notifyClient: {
 				sendEmail: jest.fn()
 			},
@@ -19,21 +19,25 @@ describe('ip-comment-rejected.md', () => {
 			}
 		};
 
-		const expectedContent = `We have rejected your comment.
-
-#Appeal details
-^Appeal reference number: ABC45678
-Address: 10, Test Street
-Planning application reference: 12345XYZ
-
-##Why we rejected your comment
-We rejected your comment because:
-
-- Reason one
-- Reason two
-- Reason three
-
-The Planning Inspectorate`;
+		const expectedContent = [
+			'We have rejected your comment.',
+			'',
+			'# Appeal details',
+			'',
+			'^Appeal reference number: ABC45678',
+			'Address: 10, Test Street',
+			'Planning application reference: 12345XYZ',
+			'',
+			'## Why we rejected your comment',
+			'',
+			'We rejected your comment because:',
+			'',
+			'- Reason one',
+			'- Reason two',
+			'- Reason three',
+			'',
+			'The Planning Inspectorate'
+		].join('\n');
 
 		await notifySend(notifySendData);
 

--- a/appeals/api/src/server/notify/templates/__tests__/notify-lpa-statement-incomplete.test.js
+++ b/appeals/api/src/server/notify/templates/__tests__/notify-lpa-statement-incomplete.test.js
@@ -1,11 +1,11 @@
 import { notifySend } from '#notify/notify-send.js';
 import { jest } from '@jest/globals';
 
-describe('ip-comment-rejected-deadline-extended.md', () => {
+describe('lpa-statement-incomplete.md', () => {
 	test('should call notify sendEmail with the correct data', async () => {
 		const notifySendData = {
 			doNotMockNotifySend: true,
-			templateName: 'ip-comment-rejected-deadline-extended',
+			templateName: 'lpa-statement-incomplete',
 			notifyClient: {
 				sendEmail: jest.fn()
 			},
@@ -20,7 +20,12 @@ describe('ip-comment-rejected-deadline-extended.md', () => {
 		};
 
 		const expectedContent = [
-			'We have rejected your comment.',
+			'We need more information before we can review your statement.',
+			'',
+			'The statement is incomplete because:',
+			'- Reason one',
+			'- Reason two',
+			'- Reason three',
 			'',
 			'# Appeal details',
 			'',
@@ -28,17 +33,9 @@ describe('ip-comment-rejected-deadline-extended.md', () => {
 			'Address: 10, Test Street',
 			'Planning application reference: 12345XYZ',
 			'',
-			'## Why we rejected your comment',
-			'',
-			'We rejected your comment because:',
-			'',
-			'- Reason one',
-			'- Reason two',
-			'- Reason three',
-			'',
 			'# What happens next',
 			'',
-			'You can send a different comment to caseofficers@planninginspectorate.gov.uk. You must send your comment by 01 January 2021.',
+			'You need to send the information to caseofficers@planninginspectorate.gov.uk by 01 January 2021.',
 			'',
 			'The Planning Inspectorate'
 		].join('\n');
@@ -52,7 +49,7 @@ describe('ip-comment-rejected-deadline-extended.md', () => {
 			'test@136s7.com',
 			{
 				content: expectedContent,
-				subject: 'We have rejected your comment: ABC45678'
+				subject: 'Complete your appeal statement: ABC45678'
 			}
 		);
 	});

--- a/appeals/api/src/server/notify/templates/__tests__/notify-lpaq-complete-appellant.test.js
+++ b/appeals/api/src/server/notify/templates/__tests__/notify-lpaq-complete-appellant.test.js
@@ -1,11 +1,11 @@
 import { notifySend } from '#notify/notify-send.js';
 import { jest } from '@jest/globals';
 
-describe('ip-comment-rejected-deadline-extended.md', () => {
+describe('lpaq-complete-appellant.md', () => {
 	test('should call notify sendEmail with the correct data', async () => {
 		const notifySendData = {
 			doNotMockNotifySend: true,
-			templateName: 'ip-comment-rejected-deadline-extended',
+			templateName: 'lpaq-complete-appellant',
 			notifyClient: {
 				sendEmail: jest.fn()
 			},
@@ -13,14 +13,14 @@ describe('ip-comment-rejected-deadline-extended.md', () => {
 			personalisation: {
 				appeal_reference_number: 'ABC45678',
 				site_address: '10, Test Street',
-				lpa_reference: '12345XYZ',
-				deadline_date: '01 January 2021',
-				reasons: ['Reason one', 'Reason two', 'Reason three']
+				lpa_reference: '12345XYZ'
 			}
 		};
 
 		const expectedContent = [
-			'We have rejected your comment.',
+			'We have received the local planning authority’s questionnaire.',
+			'',
+			'You can [view this information in the appeals service](https://appeal-planning-decision.service.gov.uk/).',
 			'',
 			'# Appeal details',
 			'',
@@ -28,19 +28,12 @@ describe('ip-comment-rejected-deadline-extended.md', () => {
 			'Address: 10, Test Street',
 			'Planning application reference: 12345XYZ',
 			'',
-			'## Why we rejected your comment',
-			'',
-			'We rejected your comment because:',
-			'',
-			'- Reason one',
-			'- Reason two',
-			'- Reason three',
-			'',
 			'# What happens next',
 			'',
-			'You can send a different comment to caseofficers@planninginspectorate.gov.uk. You must send your comment by 01 January 2021.',
+			'We will send you another email when the local planning authority submits their statement and we receive any comments from interested parties.',
 			'',
-			'The Planning Inspectorate'
+			'The Planning Inspectorate',
+			'caseofficers@planninginspectorate.gov.uk'
 		].join('\n');
 
 		await notifySend(notifySendData);
@@ -52,7 +45,7 @@ describe('ip-comment-rejected-deadline-extended.md', () => {
 			'test@136s7.com',
 			{
 				content: expectedContent,
-				subject: 'We have rejected your comment: ABC45678'
+				subject: "View the local planning authority's questionnaire: ABC45678"
 			}
 		);
 	});

--- a/appeals/api/src/server/notify/templates/__tests__/notify-lpaq-complete-lpa.test.js
+++ b/appeals/api/src/server/notify/templates/__tests__/notify-lpaq-complete-lpa.test.js
@@ -1,11 +1,11 @@
 import { notifySend } from '#notify/notify-send.js';
 import { jest } from '@jest/globals';
 
-describe('ip-comment-rejected-deadline-extended.md', () => {
+describe('lpaq-complete-lpa.md', () => {
 	test('should call notify sendEmail with the correct data', async () => {
 		const notifySendData = {
 			doNotMockNotifySend: true,
-			templateName: 'ip-comment-rejected-deadline-extended',
+			templateName: 'lpaq-complete-lpa',
 			notifyClient: {
 				sendEmail: jest.fn()
 			},
@@ -13,34 +13,23 @@ describe('ip-comment-rejected-deadline-extended.md', () => {
 			personalisation: {
 				appeal_reference_number: 'ABC45678',
 				site_address: '10, Test Street',
-				lpa_reference: '12345XYZ',
-				deadline_date: '01 January 2021',
-				reasons: ['Reason one', 'Reason two', 'Reason three']
+				lpa_reference: '12345XYZ'
 			}
 		};
 
 		const expectedContent = [
-			'We have rejected your comment.',
-			'',
 			'# Appeal details',
 			'',
 			'^Appeal reference number: ABC45678',
 			'Address: 10, Test Street',
 			'Planning application reference: 12345XYZ',
 			'',
-			'## Why we rejected your comment',
+			'We have reviewed your questionnaire.',
 			'',
-			'We rejected your comment because:',
+			'You have submitted all the information we need.',
 			'',
-			'- Reason one',
-			'- Reason two',
-			'- Reason three',
-			'',
-			'# What happens next',
-			'',
-			'You can send a different comment to caseofficers@planninginspectorate.gov.uk. You must send your comment by 01 January 2021.',
-			'',
-			'The Planning Inspectorate'
+			'The Planning Inspectorate',
+			'caseofficers@planninginspectorate.gov.uk'
 		].join('\n');
 
 		await notifySend(notifySendData);
@@ -52,7 +41,7 @@ describe('ip-comment-rejected-deadline-extended.md', () => {
 			'test@136s7.com',
 			{
 				content: expectedContent,
-				subject: 'We have rejected your comment: ABC45678'
+				subject: 'We have reviewed your questionnaire: ABC45678'
 			}
 		);
 	});

--- a/appeals/api/src/server/notify/templates/__tests__/notify-lpaq-incomplete.test.js
+++ b/appeals/api/src/server/notify/templates/__tests__/notify-lpaq-incomplete.test.js
@@ -1,11 +1,11 @@
 import { notifySend } from '#notify/notify-send.js';
 import { jest } from '@jest/globals';
 
-describe('ip-comment-rejected-deadline-extended.md', () => {
+describe('lpaq-incomplete.md', () => {
 	test('should call notify sendEmail with the correct data', async () => {
 		const notifySendData = {
 			doNotMockNotifySend: true,
-			templateName: 'ip-comment-rejected-deadline-extended',
+			templateName: 'lpaq-incomplete',
 			notifyClient: {
 				sendEmail: jest.fn()
 			},
@@ -14,31 +14,31 @@ describe('ip-comment-rejected-deadline-extended.md', () => {
 				appeal_reference_number: 'ABC45678',
 				site_address: '10, Test Street',
 				lpa_reference: '12345XYZ',
-				deadline_date: '01 January 2021',
-				reasons: ['Reason one', 'Reason two', 'Reason three']
+				due_date: '22 June 2099',
+				reasons: [
+					'Documents or information are missing: Policy is missing',
+					'Other: Addresses are incorrect or missing'
+				]
 			}
 		};
 
 		const expectedContent = [
-			'We have rejected your comment.',
-			'',
 			'# Appeal details',
 			'',
 			'^Appeal reference number: ABC45678',
 			'Address: 10, Test Street',
 			'Planning application reference: 12345XYZ',
 			'',
-			'## Why we rejected your comment',
+			'# Your questionnaire is incomplete',
 			'',
-			'We rejected your comment because:',
+			'We need more information before we can review your questionnaire about this appeal.',
 			'',
-			'- Reason one',
-			'- Reason two',
-			'- Reason three',
+			'# What we need',
 			'',
-			'# What happens next',
+			'Send the following to caseofficers@planninginspectorate.gov.uk by 22 June 2099:',
 			'',
-			'You can send a different comment to caseofficers@planninginspectorate.gov.uk. You must send your comment by 01 January 2021.',
+			'- Documents or information are missing: Policy is missing',
+			'- Other: Addresses are incorrect or missing',
 			'',
 			'The Planning Inspectorate'
 		].join('\n');
@@ -52,7 +52,7 @@ describe('ip-comment-rejected-deadline-extended.md', () => {
 			'test@136s7.com',
 			{
 				content: expectedContent,
-				subject: 'We have rejected your comment: ABC45678'
+				subject: 'Complete your appeal questionnaire: ABC45678'
 			}
 		);
 	});

--- a/appeals/api/src/server/notify/templates/__tests__/notify-received-statement-and-ip-comments-appellant.test.js
+++ b/appeals/api/src/server/notify/templates/__tests__/notify-received-statement-and-ip-comments-appellant.test.js
@@ -1,11 +1,11 @@
 import { notifySend } from '#notify/notify-send.js';
 import { jest } from '@jest/globals';
 
-describe('ip-comment-rejected-deadline-extended.md', () => {
+describe('received-statement-and-ip-comments-appellant.md', () => {
 	test('should call notify sendEmail with the correct data', async () => {
 		const notifySendData = {
 			doNotMockNotifySend: true,
-			templateName: 'ip-comment-rejected-deadline-extended',
+			templateName: 'received-statement-and-ip-comments-appellant',
 			notifyClient: {
 				sendEmail: jest.fn()
 			},
@@ -14,13 +14,14 @@ describe('ip-comment-rejected-deadline-extended.md', () => {
 				appeal_reference_number: 'ABC45678',
 				site_address: '10, Test Street',
 				lpa_reference: '12345XYZ',
-				deadline_date: '01 January 2021',
-				reasons: ['Reason one', 'Reason two', 'Reason three']
+				final_comments_deadline: '01 January 2021'
 			}
 		};
 
 		const expectedContent = [
-			'We have rejected your comment.',
+			'We have received the local planning authority’s statement and any comments from interested parties.',
+			'',
+			'You can [view this information in the appeals service](https://appeal-planning-decision.service.gov.uk/).',
 			'',
 			'# Appeal details',
 			'',
@@ -28,19 +29,12 @@ describe('ip-comment-rejected-deadline-extended.md', () => {
 			'Address: 10, Test Street',
 			'Planning application reference: 12345XYZ',
 			'',
-			'## Why we rejected your comment',
-			'',
-			'We rejected your comment because:',
-			'',
-			'- Reason one',
-			'- Reason two',
-			'- Reason three',
-			'',
 			'# What happens next',
 			'',
-			'You can send a different comment to caseofficers@planninginspectorate.gov.uk. You must send your comment by 01 January 2021.',
+			'You need to [submit your final comments](https://appeal-planning-decision.service.gov.uk/) by 01 January 2021.',
 			'',
-			'The Planning Inspectorate'
+			'The Planning Inspectorate',
+			'caseofficers@planninginspectorate.gov.uk'
 		].join('\n');
 
 		await notifySend(notifySendData);
@@ -52,7 +46,7 @@ describe('ip-comment-rejected-deadline-extended.md', () => {
 			'test@136s7.com',
 			{
 				content: expectedContent,
-				subject: 'We have rejected your comment: ABC45678'
+				subject: 'Submit your final comments: ABC45678'
 			}
 		);
 	});

--- a/appeals/api/src/server/notify/templates/__tests__/notify-received-statement-and-ip-comments-lpa.test.js
+++ b/appeals/api/src/server/notify/templates/__tests__/notify-received-statement-and-ip-comments-lpa.test.js
@@ -1,11 +1,11 @@
 import { notifySend } from '#notify/notify-send.js';
 import { jest } from '@jest/globals';
 
-describe('ip-comment-rejected-deadline-extended.md', () => {
+describe('received-statement-and-ip-comments-lpa.md', () => {
 	test('should call notify sendEmail with the correct data', async () => {
 		const notifySendData = {
 			doNotMockNotifySend: true,
-			templateName: 'ip-comment-rejected-deadline-extended',
+			templateName: 'received-statement-and-ip-comments-lpa',
 			notifyClient: {
 				sendEmail: jest.fn()
 			},
@@ -14,13 +14,14 @@ describe('ip-comment-rejected-deadline-extended.md', () => {
 				appeal_reference_number: 'ABC45678',
 				site_address: '10, Test Street',
 				lpa_reference: '12345XYZ',
-				deadline_date: '01 January 2021',
-				reasons: ['Reason one', 'Reason two', 'Reason three']
+				final_comments_deadline: '01 January 2021'
 			}
 		};
 
 		const expectedContent = [
-			'We have rejected your comment.',
+			'We’ve received comments from interested parties.',
+			'',
+			'You can [view this information in the appeals service](https://appeal-planning-decision.service.gov.uk/manage-appeals/your-email-address).',
 			'',
 			'# Appeal details',
 			'',
@@ -28,19 +29,12 @@ describe('ip-comment-rejected-deadline-extended.md', () => {
 			'Address: 10, Test Street',
 			'Planning application reference: 12345XYZ',
 			'',
-			'## Why we rejected your comment',
-			'',
-			'We rejected your comment because:',
-			'',
-			'- Reason one',
-			'- Reason two',
-			'- Reason three',
-			'',
 			'# What happens next',
 			'',
-			'You can send a different comment to caseofficers@planninginspectorate.gov.uk. You must send your comment by 01 January 2021.',
+			'You need to [submit your final comments](https://appeal-planning-decision.service.gov.uk/manage-appeals/your-email-address) by 01 January 2021.',
 			'',
-			'The Planning Inspectorate'
+			'The Planning Inspectorate',
+			'caseofficers@planninginspectorate.gov.uk'
 		].join('\n');
 
 		await notifySend(notifySendData);
@@ -52,7 +46,7 @@ describe('ip-comment-rejected-deadline-extended.md', () => {
 			'test@136s7.com',
 			{
 				content: expectedContent,
-				subject: 'We have rejected your comment: ABC45678'
+				subject: 'Submit your final comments: ABC45678'
 			}
 		);
 	});

--- a/appeals/api/src/server/notify/templates/final-comment-rejected-appellant.content.md
+++ b/appeals/api/src/server/notify/templates/final-comment-rejected-appellant.content.md
@@ -1,0 +1,19 @@
+We have rejected your final comments.
+
+# Appeal details
+
+^Appeal reference number: ((appeal_reference_number))
+Address: ((site_address))
+Planning application reference: ((lpa_reference))
+
+# Why we rejected your final comments
+
+We rejected your final comments because:
+
+((reasons))
+
+# What happens next
+
+You can send different final comments to caseofficers@planninginspectorate.gov.uk. The case officer will decide whether to accept any new final comments.
+
+The Planning Inspectorate

--- a/appeals/api/src/server/notify/templates/final-comment-rejected-appellant.subject.md
+++ b/appeals/api/src/server/notify/templates/final-comment-rejected-appellant.subject.md
@@ -1,0 +1,1 @@
+We have rejected your final comments: ((appeal_reference_number))

--- a/appeals/api/src/server/notify/templates/final-comment-rejected-lpa.content.md
+++ b/appeals/api/src/server/notify/templates/final-comment-rejected-lpa.content.md
@@ -1,0 +1,19 @@
+We have rejected your final comments.
+
+# Appeal details
+
+^Appeal reference number: ((appeal_reference_number))
+Address: ((site_address))
+Planning application reference: ((lpa_reference))
+
+# Why we rejected your final comments
+
+We rejected your final comments because:
+
+((reasons))
+
+# What happens next
+
+You can send different final comments to caseofficers@planninginspectorate.gov.uk. The case officer will decide whether to accept any new final comments.
+
+The Planning Inspectorate

--- a/appeals/api/src/server/notify/templates/final-comment-rejected-lpa.subject.md
+++ b/appeals/api/src/server/notify/templates/final-comment-rejected-lpa.subject.md
@@ -1,0 +1,1 @@
+We have rejected your final comments: ((appeal_reference_number))

--- a/appeals/api/src/server/notify/templates/final-comments-done-appellant.content.md
+++ b/appeals/api/src/server/notify/templates/final-comments-done-appellant.content.md
@@ -1,0 +1,16 @@
+We have received the local planning authority’s final comments.
+
+# Appeal details
+
+^Appeal reference number: ((appeal_reference_number))
+Address: ((site_address))
+Planning application reference: ((lpa_reference))
+
+# What happens next
+
+You can [view the local planning authority’s final comments](https://appeal-planning-decision.service.gov.uk/).
+
+The inspector will visit the site and we will contact you when we have made the decision.
+
+The Planning Inspectorate
+caseofficers@planninginspectorate.gov.uk

--- a/appeals/api/src/server/notify/templates/final-comments-done-appellant.subject.md
+++ b/appeals/api/src/server/notify/templates/final-comments-done-appellant.subject.md
@@ -1,0 +1,1 @@
+We have received the local planning authority’s final comments: ((appeal_reference_number))

--- a/appeals/api/src/server/notify/templates/final-comments-done-lpa.content.md
+++ b/appeals/api/src/server/notify/templates/final-comments-done-lpa.content.md
@@ -1,0 +1,16 @@
+We have received the appellant’s final comments.
+
+# Appeal details
+
+^Appeal reference number: ((appeal_reference_number))
+Address: ((site_address))
+Planning application reference: ((lpa_reference))
+
+# What happens next
+
+You can [view the appellant’s final comments](https://appeal-planning-decision.service.gov.uk/manage-appeals/your-email-address).
+
+The inspector will visit the site and we will contact you when we have made the decision.
+
+The Planning Inspectorate
+caseofficers@planninginspectorate.gov.uk

--- a/appeals/api/src/server/notify/templates/final-comments-done-lpa.subject.md
+++ b/appeals/api/src/server/notify/templates/final-comments-done-lpa.subject.md
@@ -1,0 +1,1 @@
+We have received the appellant’s final comments: ((appeal_reference_number))

--- a/appeals/api/src/server/notify/templates/ip-comment-rejected-deadline-extended.content.md
+++ b/appeals/api/src/server/notify/templates/ip-comment-rejected-deadline-extended.content.md
@@ -1,16 +1,18 @@
 We have rejected your comment.
 
-#Appeal details
+# Appeal details
+
 ^Appeal reference number: ((appeal_reference_number))
 Address: ((site_address))
 Planning application reference: ((lpa_reference))
 
-##Why we rejected your comment
+## Why we rejected your comment
+
 We rejected your comment because:
 
 ((reasons))
 
-#What happens next
+# What happens next
 
 You can send a different comment to caseofficers@planninginspectorate.gov.uk. You must send your comment by ((deadline_date)).
 

--- a/appeals/api/src/server/notify/templates/lpa-statement-incomplete.content.md
+++ b/appeals/api/src/server/notify/templates/lpa-statement-incomplete.content.md
@@ -1,0 +1,16 @@
+We need more information before we can review your statement.
+
+The statement is incomplete because:
+((reasons))
+
+# Appeal details
+
+^Appeal reference number: ((appeal_reference_number))
+Address: ((site_address))
+Planning application reference: ((lpa_reference))
+
+# What happens next
+
+You need to send the information to caseofficers@planninginspectorate.gov.uk by ((deadline_date)).
+
+The Planning Inspectorate

--- a/appeals/api/src/server/notify/templates/lpa-statement-incomplete.subject.md
+++ b/appeals/api/src/server/notify/templates/lpa-statement-incomplete.subject.md
@@ -1,0 +1,1 @@
+Complete your appeal statement: ((appeal_reference_number))

--- a/appeals/api/src/server/notify/templates/lpaq-complete-appellant.content.md
+++ b/appeals/api/src/server/notify/templates/lpaq-complete-appellant.content.md
@@ -1,0 +1,16 @@
+We have received the local planning authority’s questionnaire.
+
+You can [view this information in the appeals service](https://appeal-planning-decision.service.gov.uk/).
+
+# Appeal details
+
+^Appeal reference number: ((appeal_reference_number))
+Address: ((site_address))
+Planning application reference: ((lpa_reference))
+
+# What happens next
+
+We will send you another email when the local planning authority submits their statement and we receive any comments from interested parties.
+
+The Planning Inspectorate
+caseofficers@planninginspectorate.gov.uk

--- a/appeals/api/src/server/notify/templates/lpaq-complete-appellant.subject.md
+++ b/appeals/api/src/server/notify/templates/lpaq-complete-appellant.subject.md
@@ -1,0 +1,1 @@
+View the local planning authority's questionnaire: ((appeal_reference_number))

--- a/appeals/api/src/server/notify/templates/lpaq-complete-lpa.content.md
+++ b/appeals/api/src/server/notify/templates/lpaq-complete-lpa.content.md
@@ -1,15 +1,12 @@
-We have rejected your comment.
-
 # Appeal details
 
 ^Appeal reference number: ((appeal_reference_number))
 Address: ((site_address))
 Planning application reference: ((lpa_reference))
 
-## Why we rejected your comment
+We have reviewed your questionnaire.
 
-We rejected your comment because:
-
-((reasons))
+You have submitted all the information we need.
 
 The Planning Inspectorate
+caseofficers@planninginspectorate.gov.uk

--- a/appeals/api/src/server/notify/templates/lpaq-complete-lpa.subject.md
+++ b/appeals/api/src/server/notify/templates/lpaq-complete-lpa.subject.md
@@ -1,0 +1,1 @@
+We have reviewed your questionnaire: ((appeal_reference_number))

--- a/appeals/api/src/server/notify/templates/lpaq-incomplete.content.md
+++ b/appeals/api/src/server/notify/templates/lpaq-incomplete.content.md
@@ -1,0 +1,17 @@
+# Appeal details
+
+^Appeal reference number: ((appeal_reference_number))
+Address: ((site_address))
+Planning application reference: ((lpa_reference))
+
+# Your questionnaire is incomplete
+
+We need more information before we can review your questionnaire about this appeal.
+
+# What we need
+
+Send the following to caseofficers@planninginspectorate.gov.uk by ((due_date)):
+
+((reasons))
+
+The Planning Inspectorate

--- a/appeals/api/src/server/notify/templates/lpaq-incomplete.subject.md
+++ b/appeals/api/src/server/notify/templates/lpaq-incomplete.subject.md
@@ -1,0 +1,1 @@
+Complete your appeal questionnaire: ((appeal_reference_number))

--- a/appeals/api/src/server/notify/templates/received-statement-and-ip-comments-appellant.content.md
+++ b/appeals/api/src/server/notify/templates/received-statement-and-ip-comments-appellant.content.md
@@ -1,0 +1,16 @@
+We have received the local planning authority’s statement and any comments from interested parties.
+
+You can [view this information in the appeals service](https://appeal-planning-decision.service.gov.uk/).
+
+# Appeal details
+
+^Appeal reference number: ((appeal_reference_number))
+Address: ((site_address))
+Planning application reference: ((lpa_reference))
+
+# What happens next
+
+You need to [submit your final comments](https://appeal-planning-decision.service.gov.uk/) by ((final_comments_deadline)).
+
+The Planning Inspectorate
+caseofficers@planninginspectorate.gov.uk

--- a/appeals/api/src/server/notify/templates/received-statement-and-ip-comments-appellant.subject.md
+++ b/appeals/api/src/server/notify/templates/received-statement-and-ip-comments-appellant.subject.md
@@ -1,0 +1,1 @@
+Submit your final comments: ((appeal_reference_number))

--- a/appeals/api/src/server/notify/templates/received-statement-and-ip-comments-lpa.content.md
+++ b/appeals/api/src/server/notify/templates/received-statement-and-ip-comments-lpa.content.md
@@ -1,0 +1,16 @@
+We’ve received comments from interested parties.
+
+You can [view this information in the appeals service](https://appeal-planning-decision.service.gov.uk/manage-appeals/your-email-address).
+
+# Appeal details
+
+^Appeal reference number: ((appeal_reference_number))
+Address: ((site_address))
+Planning application reference: ((lpa_reference))
+
+# What happens next
+
+You need to [submit your final comments](https://appeal-planning-decision.service.gov.uk/manage-appeals/your-email-address) by ((final_comments_deadline)).
+
+The Planning Inspectorate
+caseofficers@planninginspectorate.gov.uk

--- a/appeals/api/src/server/notify/templates/received-statement-and-ip-comments-lpa.subject.md
+++ b/appeals/api/src/server/notify/templates/received-statement-and-ip-comments-lpa.subject.md
@@ -1,0 +1,1 @@
+Submit your final comments: ((appeal_reference_number))

--- a/appeals/api/src/server/utils/date-formatter.js
+++ b/appeals/api/src/server/utils/date-formatter.js
@@ -31,4 +31,17 @@ export const formatTime = (date) => {
 	return formatInTimeZone(new Date(date), DEFAULT_TIMEZONE, 'HH:mm');
 };
 
+/**
+ * Format the given date as yyyy-MM-dd HH:mm:ss:SSS string in Europe/London
+ *
+ * @param {Date | undefined} date
+ * @returns {string} formatted sortable date and time string,'yyyy-MM-dd HH:mm:ss:SSS string'
+ */
+export const formatSortableDateTime = (date) => {
+	if (!date) {
+		return '';
+	}
+	return formatInTimeZone(new Date(date), DEFAULT_TIMEZONE, 'yyyy-MM-dd HH:mm:ss:SSS');
+};
+
 export default formatDate;


### PR DESCRIPTION
## Describe your changes
#### Migrated templates for LPA Statements, IP Comments, and Final Comments (a2-2733)

#### Notify:
- Migrated templates as described in the ticket.

#### API:
- Updated calls to notifyClient.sendEmail to use notifySend instead. 
- Please note all validation, catching and throwing of appropriate errors are in notifySend and so have been removed.
- Fixed tests to mock new notifySend function
- Added tests to test the templates themselves with the unmocked notifySend function

#### TEST:
- All unit tests pass
- Tested within browser
- Tested emails with emulator
- Checked that notify generated the email

## Issue ticket number and link
[Ticket:  LPAQ, statements and IP comments (A2-2733)](https://pins-ds.atlassian.net.mcas.ms/browse/A2-2733)
