### PR TITLE
feat/A2-2694-redaction-buttons

### DIFF
--- a/appeals/web/src/client/components/redact-button/__tests__/index.test.js
+++ b/appeals/web/src/client/components/redact-button/__tests__/index.test.js
@@ -1,0 +1,451 @@
+// @ts-nocheck
+import {
+	generateOnClick,
+	setAreaText,
+	isHTMLTextAreaElement,
+	isHTMLButtonElement,
+	isHTMLDivElement,
+	initRedactButtons,
+	SELECTORS
+} from '../index.js';
+import { JSDOM } from 'jsdom';
+import { jest } from '@jest/globals';
+
+const setupJSDOMGlobals = () => {
+	const dom = new JSDOM('<!DOCTYPE html><html><body></body></html>', {});
+	const { window } = dom;
+
+	const originalGlobals = {
+		window: global.window,
+		document: global.document,
+		HTMLTextAreaElement: global.HTMLTextAreaElement,
+		HTMLButtonElement: global.HTMLButtonElement,
+		HTMLDivElement: global.HTMLDivElement,
+		MouseEvent: global.MouseEvent,
+		Node: global.Node,
+		Element: global.Element
+	};
+
+	global.window = window;
+	global.document = window.document;
+	global.HTMLTextAreaElement = window.HTMLTextAreaElement;
+	global.HTMLButtonElement = window.HTMLButtonElement;
+	global.HTMLDivElement = window.HTMLDivElement;
+	global.MouseEvent = window.MouseEvent;
+	global.Node = window.Node;
+	global.Element = window.Element;
+
+	return () => {
+		Object.keys(originalGlobals).forEach((key) => {
+			if (originalGlobals[key] === undefined) {
+				delete global[key];
+			} else {
+				global[key] = originalGlobals[key];
+			}
+		});
+	};
+};
+
+describe('generateOnClick', () => {
+	/**
+	 * @type {{HTMLTextAreaElement}}
+	 */
+	let mockTextarea;
+	/**
+	 * @type { { preventDefault: () => void } | null }
+	 */
+	let mockEvent = null;
+
+	//intialise elements for testing
+	beforeEach(() => {
+		mockTextarea = {
+			value: '',
+			selectionStart: 0,
+			selectionEnd: 0
+		};
+		mockEvent = {
+			preventDefault: jest.fn()
+		};
+	});
+	it('should return a function', () => {
+		const onClickHandler = generateOnClick(mockTextarea);
+		expect(typeof onClickHandler).toBe('function');
+	});
+	it('should call event.preventDefault when handler is invoked', () => {
+		const onClickHandler = setAreaText(mockTextarea, 'Any Text');
+		onClickHandler(mockEvent);
+		expect(mockEvent.preventDefault).toHaveBeenCalledTimes(1);
+	});
+
+	it('should set the textarea value to the provided redactedText', () => {
+		const newText = 'This is the new redacted text.';
+		const onClickHandler = setAreaText(mockTextarea, newText);
+		expect(mockTextarea.value).not.toBe(newText);
+		onClickHandler(mockEvent);
+		expect(mockTextarea.value).toBe(newText);
+	});
+
+	it('should overwrite existing textarea value', () => {
+		mockTextarea.value = 'This will be overwritten.';
+		const finalValue = 'Overwritten';
+		const onClickHandler = setAreaText(mockTextarea, finalValue);
+
+		onClickHandler(mockEvent);
+		expect(mockTextarea.value).toBe(finalValue);
+	});
+
+	it('should be able to set the textarea value to an empty string', () => {
+		mockTextarea.value = 'Some content';
+		const finalValue = '';
+		const onClickHandler = setAreaText(mockTextarea, finalValue);
+
+		onClickHandler(mockEvent);
+		expect(mockTextarea.value).toBe(finalValue);
+	});
+
+	it('should redact text from the textarea', () => {
+		const originalCommentText = 'This is a tests comment to redact';
+		const redactedCommentText = 'This █████tests comment to redact';
+		mockTextarea.value = originalCommentText;
+		mockTextarea.selectionStart = 5;
+		mockTextarea.selectionEnd = 10;
+
+		const onClickHandler = generateOnClick(mockTextarea);
+		onClickHandler(mockEvent);
+		expect(mockTextarea.value).not.toBe(originalCommentText);
+		expect(mockTextarea.value).toBe(redactedCommentText);
+	});
+
+	it('should return early if no text is selected', () => {
+		const originalCommentText = 'This is a tests comment to redact';
+		mockTextarea.value = originalCommentText;
+		mockTextarea.selectionStart = 5;
+		mockTextarea.selectionEnd = 5;
+
+		const onClickHandler = generateOnClick(mockTextarea);
+		onClickHandler(mockEvent);
+		expect(mockTextarea.value).toBe(originalCommentText);
+	});
+});
+
+describe('Type Guards', () => {
+	let cleanupJSDOM;
+
+	// Setup JSDOM globals
+	beforeAll(() => {
+		cleanupJSDOM = setupJSDOMGlobals();
+	});
+
+	// Restore original globals
+	afterAll(() => {
+		cleanupJSDOM();
+	});
+	describe('isHTMLTextAreaElement', () => {
+		it('should return true when passed an actual HTMLTextAreaElement', () => {
+			const element = document.createElement('textarea');
+			expect(isHTMLTextAreaElement(element)).toBe(true);
+		});
+
+		it('should return false when passed an HTMLButtonElement', () => {
+			const element = document.createElement('button');
+			expect(isHTMLTextAreaElement(element)).toBe(false);
+		});
+
+		it('should return false when passed a generic HTMLDivElement', () => {
+			const element = document.createElement('div');
+			expect(isHTMLTextAreaElement(element)).toBe(false);
+		});
+
+		it('should return false when passed null', () => {
+			expect(isHTMLTextAreaElement(null)).toBe(false);
+		});
+
+		it('should return false when passed undefined', () => {
+			expect(isHTMLTextAreaElement(undefined)).toBe(false);
+		});
+
+		it('should return false when passed a plain object', () => {
+			const plainObject = {};
+			expect(isHTMLTextAreaElement(plainObject)).toBe(false);
+		});
+
+		it('should return false when passed a string', () => {
+			const str = '<textarea></textarea>';
+			expect(isHTMLTextAreaElement(str)).toBe(false);
+		});
+
+		it('should return false when passed a number', () => {
+			const num = 123;
+			expect(isHTMLTextAreaElement(num)).toBe(false);
+		});
+	});
+
+	describe('isHTMLButtonElement', () => {
+		it('should return true when passed an actual HTMLButtonElement', () => {
+			const element = document.createElement('button');
+			expect(isHTMLButtonElement(element)).toBe(true);
+		});
+
+		it('should return false when passed an HTMLTextAreaElement', () => {
+			const element = document.createElement('textarea');
+			expect(isHTMLButtonElement(element)).toBe(false);
+		});
+
+		it('should return false when passed a generic HTMLParagraphElement', () => {
+			const element = document.createElement('p');
+			expect(isHTMLButtonElement(element)).toBe(false);
+		});
+		it('should return false when passed null', () => {
+			expect(isHTMLButtonElement(null)).toBe(false);
+		});
+
+		it('should return false when passed undefined', () => {
+			expect(isHTMLButtonElement(undefined)).toBe(false);
+		});
+
+		it('should return false when passed a plain object', () => {
+			const plainObject = { nodeName: 'BUTTON' };
+			expect(isHTMLButtonElement(plainObject)).toBe(false);
+		});
+
+		it('should return false when passed a string', () => {
+			const str = 'button';
+			expect(isHTMLButtonElement(str)).toBe(false);
+		});
+
+		it('should return false when passed a number', () => {
+			const num = 0;
+			expect(isHTMLButtonElement(num)).toBe(false);
+		});
+	});
+	describe('isHTMLDivElement', () => {
+		it('should return true when passed an actual HTMLDivElement', () => {
+			const element = document.createElement('div');
+			expect(isHTMLDivElement(element)).toBe(true);
+		});
+
+		it('should return false when passed an HTMLTextAreaElement', () => {
+			const element = document.createElement('textarea');
+			expect(isHTMLDivElement(element)).toBe(false);
+		});
+
+		it('should return false when passed an HTMLButtonElement', () => {
+			const element = document.createElement('button');
+			expect(isHTMLDivElement(element)).toBe(false);
+		});
+
+		it('should return false when passed a generic HTMLSpanElement', () => {
+			const element = document.createElement('span');
+			expect(isHTMLDivElement(element)).toBe(false);
+		});
+		it('should return false when passed null', () => {
+			expect(isHTMLDivElement(null)).toBe(false);
+		});
+		it('should return false when passed undefined', () => {
+			expect(isHTMLDivElement(undefined)).toBe(false);
+		});
+
+		it('should return false when passed a plain object', () => {
+			const plainObject = {};
+			expect(isHTMLDivElement(plainObject)).toBe(false);
+		});
+
+		it('should return false when passed a string', () => {
+			const str = '<div></div>';
+			expect(isHTMLDivElement(str)).toBe(false);
+		});
+
+		it('should return false when passed a number', () => {
+			const num = 100;
+			expect(isHTMLDivElement(num)).toBe(false);
+		});
+	});
+});
+
+describe('initRedactButtons (Integration Tests)', () => {
+	let mockEvent;
+	let cleanupJSDOM;
+
+	// Setup JSDOM globals
+	beforeAll(() => {
+		cleanupJSDOM = setupJSDOMGlobals();
+	});
+
+	// Restore original globals
+	afterAll(() => {
+		cleanupJSDOM();
+	});
+	const setupTestDOM = ({
+		addOriginal = true,
+		addRedact = true,
+		addUndo = true,
+		addRevert = true,
+		addTextarea = true,
+		originalType = 'div',
+		redactType = 'button',
+		undoType = 'button',
+		revertType = 'button',
+		textareaType = 'textarea',
+		originalText = 'Original Sample Text',
+		textareaText = 'Initial Textarea Content'
+	} = {}) => {
+		const originalId = SELECTORS.ORIGINAL_COMMENT_IDENTIFIER.substring(1);
+		const redactId = SELECTORS.REDACT_BUTTON_IDENTIFIER.substring(1);
+		const undoId = SELECTORS.UNDO_BUTTON_IDENTIFIER.substring(1);
+		const revertId = SELECTORS.REVERT_BUTTON.substring(1);
+		const textareaId = SELECTORS.TEXTAREA_IDENTIFIER.substring(1);
+		// Uses global document now available from beforeAll
+		document.body.innerHTML = `
+			${addOriginal ? `<${originalType} id="${originalId}">${originalText}</${originalType}>` : ''}
+			${addRedact ? `<${redactType} id="${redactId}">Redact</${redactType}>` : ''}
+			${addUndo ? `<${undoType} id="${undoId}">Undo</${undoType}>` : ''}
+			${addRevert ? `<${revertType} id="${revertId}">Revert</${revertType}>` : ''}
+			${addTextarea ? `<${textareaType} id="${textareaId}">${textareaText}</${textareaType}>` : ''}
+		`;
+	};
+	beforeEach(() => {
+		// Reset ONLY the DOM body content and mockEvent for each test
+		document.body.innerHTML = ''; // Uses global document
+		mockEvent = { preventDefault: jest.fn() };
+	});
+
+	it('should initialise handlers and redact selected text on redact button click', () => {
+		setupTestDOM({ textareaText: 'Redact the middle word.' });
+		const redactButton = document.querySelector(SELECTORS.REDACT_BUTTON_IDENTIFIER);
+		const textarea = document.querySelector(SELECTORS.TEXTAREA_IDENTIFIER);
+		textarea.selectionStart = 7;
+		textarea.selectionEnd = 10;
+		//intitialse page
+		initRedactButtons();
+
+		expect(redactButton.onclick).toBeInstanceOf(Function);
+		//redact text
+		redactButton.onclick(mockEvent);
+
+		// Check that the text is correct
+		expect(textarea.value).toBe('Redact ███ middle word.');
+		expect(mockEvent.preventDefault).toHaveBeenCalled();
+	});
+
+	it('should initialise handlers and revert text to initial state on undo button click', () => {
+		const initialText = 'Redact the middle word.';
+		setupTestDOM({ textareaText: initialText });
+		const redactButton = document.querySelector(SELECTORS.REDACT_BUTTON_IDENTIFIER);
+		const textarea = document.querySelector(SELECTORS.TEXTAREA_IDENTIFIER);
+		const undoButton = document.querySelector(SELECTORS.UNDO_BUTTON_IDENTIFIER);
+		textarea.selectionStart = 7;
+		textarea.selectionEnd = 10;
+
+		initRedactButtons();
+		expect(redactButton.onclick).toBeInstanceOf(Function);
+
+		redactButton.onclick(mockEvent);
+
+		expect(textarea.value).toBe('Redact ███ middle word.');
+
+		expect(mockEvent.preventDefault).toHaveBeenCalled();
+		expect(undoButton.onclick).toBeInstanceOf(Function);
+
+		undoButton.onclick(mockEvent);
+		expect(textarea.value).toBe(initialText);
+		expect(mockEvent.preventDefault).toHaveBeenCalled();
+	});
+
+	it('should initialise handlers and revert text to original comment on revert button click', () => {
+		const originalText = 'This is the original comment text.';
+		const textareaText = 'This ███the original comment text.';
+		setupTestDOM({ originalText: originalText, textareaText: textareaText });
+		const revertButton = document.querySelector(SELECTORS.REVERT_BUTTON);
+		const textarea = document.querySelector(SELECTORS.TEXTAREA_IDENTIFIER);
+		const redactButton = document.querySelector(SELECTORS.REDACT_BUTTON_IDENTIFIER);
+		textarea.selectionStart = 15;
+		textarea.selectionEnd = 20;
+
+		initRedactButtons();
+		expect(revertButton.onclick).toBeInstanceOf(Function);
+		expect(redactButton.onclick).toBeInstanceOf(Function);
+
+		redactButton.onclick(mockEvent);
+		expect(textarea.value).toBe('This ███the ori█████ comment text.');
+		expect(mockEvent.preventDefault).toHaveBeenCalled();
+
+		revertButton.onclick(mockEvent);
+		expect(textarea.value).toBe(originalText);
+		expect(mockEvent.preventDefault).toHaveBeenCalled();
+	});
+
+	it('should initialise handlers and undo text to textarea comment on undo button click', () => {
+		const originalText = 'This is the original comment text.';
+		const textareaText = 'This ███the original comment text.';
+		setupTestDOM({ originalText: originalText, textareaText: textareaText });
+		const undoButton = document.querySelector(SELECTORS.UNDO_BUTTON_IDENTIFIER);
+		const textarea = document.querySelector(SELECTORS.TEXTAREA_IDENTIFIER);
+		const redactButton = document.querySelector(SELECTORS.REDACT_BUTTON_IDENTIFIER);
+		textarea.selectionStart = 15;
+		textarea.selectionEnd = 20;
+
+		initRedactButtons();
+		expect(undoButton.onclick).toBeInstanceOf(Function);
+		expect(undoButton.onclick).toBeInstanceOf(Function);
+
+		redactButton.onclick(mockEvent);
+		expect(textarea.value).toBe('This ███the ori█████ comment text.');
+		expect(mockEvent.preventDefault).toHaveBeenCalled();
+
+		undoButton.onclick(mockEvent);
+		expect(textarea.value).toBe(textareaText);
+		expect(mockEvent.preventDefault).toHaveBeenCalled();
+	});
+
+	it('should initialise handlers and revert text to text area original text if undo button is clicked', () => {
+		const originalText = 'This is the original comment text.';
+		setupTestDOM({
+			originalText: originalText,
+			textareaText: 'This ███the original comment text.'
+		});
+		const revertButton = document.querySelector(SELECTORS.REVERT_BUTTON);
+		const textarea = document.querySelector(SELECTORS.TEXTAREA_IDENTIFIER);
+
+		initRedactButtons();
+		expect(revertButton.onclick).toBeInstanceOf(Function);
+
+		revertButton.onclick(mockEvent);
+		expect(textarea.value).toBe(originalText);
+		expect(mockEvent.preventDefault).toHaveBeenCalled();
+	});
+
+	it('should do nothing on redact click if no text is selected', () => {
+		const initialText = 'No selection here.';
+		setupTestDOM({ textareaText: initialText });
+		const redactButton = document.querySelector(SELECTORS.REDACT_BUTTON_IDENTIFIER);
+		const textarea = document.querySelector(SELECTORS.TEXTAREA_IDENTIFIER);
+
+		textarea.selectionStart = 5;
+		textarea.selectionEnd = 5;
+
+		initRedactButtons();
+		expect(redactButton.onclick).toBeInstanceOf(Function);
+		redactButton.onclick(mockEvent);
+
+		expect(textarea.value).toBe(initialText);
+		expect(mockEvent.preventDefault).toHaveBeenCalled();
+	});
+
+	it('should not attach handlers if an element is missing', () => {
+		setupTestDOM({ addTextarea: false });
+		initRedactButtons();
+		const redactButton = document.querySelector(SELECTORS.REDACT_BUTTON_IDENTIFIER);
+		expect(redactButton.onclick).toBeNull();
+	});
+
+	it('should not attach handlers if an element is the wrong type', () => {
+		setupTestDOM({ revertType: 'p' });
+		initRedactButtons();
+		const revertButton = document.querySelector(SELECTORS.REVERT_BUTTON);
+		expect(revertButton).not.toBeNull();
+
+		expect(revertButton.onclick).toBeNull();
+		const undoButton = document.querySelector(SELECTORS.UNDO_BUTTON_IDENTIFIER);
+		expect(undoButton.onclick).toBeNull();
+	});
+});

--- a/appeals/web/src/client/components/redact-button/index.js
+++ b/appeals/web/src/client/components/redact-button/index.js
@@ -1,4 +1,4 @@
-const SELECTORS = {
+export const SELECTORS = {
 	ORIGINAL_COMMENT_IDENTIFIER: '#original-comment',
 	REDACT_BUTTON_IDENTIFIER: '#redact-button',
 	UNDO_BUTTON_IDENTIFIER: '#undo-button',
@@ -10,7 +10,7 @@ const SELECTORS = {
  * @param {HTMLTextAreaElement} textarea
  * @returns {HTMLButtonElement['onclick']}
  */
-const generateOnClick = (textarea) => (event) => {
+export const generateOnClick = (textarea) => (event) => {
 	// Stop the form submitting
 	event.preventDefault();
 
@@ -33,7 +33,7 @@ const generateOnClick = (textarea) => (event) => {
  * @param {string} redactedText
  * @returns {HTMLButtonElement['onclick']}
  * */
-const setAreaText = (textarea, redactedText) => (event) => {
+export const setAreaText = (textarea, redactedText) => (event) => {
 	event.preventDefault();
 	textarea.value = redactedText;
 };
@@ -42,19 +42,18 @@ const setAreaText = (textarea, redactedText) => (event) => {
  * @param {Element} element
  * @returns {element is HTMLTextAreaElement}
  */
-const isHTMLTextAreaElement = (element) => element instanceof HTMLTextAreaElement;
-
+export const isHTMLTextAreaElement = (element) => element instanceof HTMLTextAreaElement;
 /**
  * @param {Element} element
  * @returns {element is HTMLButtonElement}
  */
-const isHTMLButtonElement = (element) => element instanceof HTMLButtonElement;
+export const isHTMLButtonElement = (element) => element instanceof HTMLButtonElement;
 
 /**
  * @param {Element} element
  * @returns {element is HTMLDivElement}
  * */
-const isHTMLDivElement = (element) => element instanceof HTMLDivElement;
+export const isHTMLDivElement = (element) => element instanceof HTMLDivElement;
 
 export const initRedactButtons = () => {
 	const originalCommentText = document.querySelector(SELECTORS.ORIGINAL_COMMENT_IDENTIFIER);

--- a/appeals/web/src/client/components/redact-button/index.js
+++ b/appeals/web/src/client/components/redact-button/index.js
@@ -2,7 +2,8 @@ const SELECTORS = {
 	ORIGINAL_COMMENT_IDENTIFIER: '#original-comment',
 	REDACT_BUTTON_IDENTIFIER: '#redact-button',
 	UNDO_BUTTON_IDENTIFIER: '#undo-button',
-	TEXTAREA_IDENTIFIER: '#redact-textarea'
+	TEXTAREA_IDENTIFIER: '#redact-textarea',
+	REVERT_BUTTON: '#revert-button'
 };
 
 /**
@@ -29,13 +30,12 @@ const generateOnClick = (textarea) => (event) => {
 
 /**
  * @param {HTMLTextAreaElement} textarea
- * @param {string} originalComment
+ * @param {string} redactedText
  * @returns {HTMLButtonElement['onclick']}
  * */
-const undoAllChanges = (textarea, originalComment) => (event) => {
+const setAreaText = (textarea, redactedText) => (event) => {
 	event.preventDefault();
-
-	textarea.value = originalComment;
+	textarea.value = redactedText;
 };
 
 /**
@@ -60,7 +60,9 @@ export const initRedactButtons = () => {
 	const originalCommentText = document.querySelector(SELECTORS.ORIGINAL_COMMENT_IDENTIFIER);
 	const redactButton = document.querySelector(SELECTORS.REDACT_BUTTON_IDENTIFIER);
 	const undoButton = document.querySelector(SELECTORS.UNDO_BUTTON_IDENTIFIER);
+	const revertButton = document.querySelector(SELECTORS.REVERT_BUTTON);
 	const textarea = document.querySelector(SELECTORS.TEXTAREA_IDENTIFIER);
+	const redactedText = textarea?.textContent?.trim() || '';
 
 	if (
 		!(
@@ -68,8 +70,10 @@ export const initRedactButtons = () => {
 			redactButton &&
 			textarea &&
 			undoButton &&
+			revertButton &&
 			isHTMLDivElement(originalCommentText) &&
 			isHTMLButtonElement(redactButton) &&
+			isHTMLButtonElement(revertButton) &&
 			isHTMLButtonElement(undoButton) &&
 			isHTMLTextAreaElement(textarea)
 		)
@@ -78,5 +82,6 @@ export const initRedactButtons = () => {
 	}
 
 	redactButton.onclick = generateOnClick(textarea);
-	undoButton.onclick = undoAllChanges(textarea, originalCommentText.textContent?.trim() ?? '');
+	undoButton.onclick = setAreaText(textarea, redactedText);
+	revertButton.onclick = setAreaText(textarea, originalCommentText.textContent?.trim() ?? '');
 };

--- a/appeals/web/src/server/appeals/appeal-details/representations/common/components/redact-input.js
+++ b/appeals/web/src/server/appeals/appeal-details/representations/common/components/redact-input.js
@@ -1,5 +1,6 @@
 import { textareaInput } from '#lib/mappers/index.js';
 import { wrapComponents, buttonComponent } from '#lib/mappers/index.js';
+import { REVERT_BUTTON_TEXT } from '@pins/appeals/constants/common.js';
 
 /** @typedef {import("#appeals/appeal-details/representations/types.js").Representation} Representation */
 
@@ -9,9 +10,28 @@ import { wrapComponents, buttonComponent } from '#lib/mappers/index.js';
  * @param {string} [params.labelText]
  * @param {import('express-session').Session & Record<string, string>} [params.session]
  * @param {string} [params.redactedRepresentation]
+ * @param {string} [params.buttonText]
  * @returns {PageComponent[]}
  */
-export const redactInput = ({ representation, labelText, session, redactedRepresentation }) => [
+export const redactInput = ({
+	representation,
+	labelText,
+	session,
+	redactedRepresentation,
+	buttonText
+}) => [
+	wrapComponents(
+		[
+			buttonComponent(buttonText || REVERT_BUTTON_TEXT.DEFAULT_TEXT, {
+				id: 'revert-button',
+				classes: 'govuk-button--secondary'
+			})
+		],
+		{
+			opening: '<div class="govuk-button-group">',
+			closing: '</div>'
+		}
+	),
 	textareaInput({
 		name: 'redactedRepresentation',
 		id: 'redact-textarea',
@@ -30,7 +50,7 @@ export const redactInput = ({ representation, labelText, session, redactedRepres
 				id: 'redact-button',
 				classes: 'govuk-button--secondary'
 			}),
-			buttonComponent('Undo all changes', {
+			buttonComponent('Undo changes', {
 				id: 'undo-button',
 				classes: 'govuk-button--secondary'
 			})

--- a/appeals/web/src/server/appeals/appeal-details/representations/final-comments/accept/accept.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/representations/final-comments/accept/accept.mapper.js
@@ -4,6 +4,7 @@ import { wrapComponents, simpleHtmlComponent, buttonComponent } from '#lib/mappe
 import { redactInput } from '#appeals/appeal-details/representations/common/components/redact-input.js';
 import { summaryList } from './components/summary-list.js';
 import { getAttachmentList } from '#appeals/appeal-details/representations/common/document-attachment-list.js';
+import { findButtonText } from '#lib/revert-text.js';
 
 /** @typedef {import("#appeals/appeal-details/appeal-details.types.js").WebAppeal} Appeal */
 /** @typedef {import("#appeals/appeal-details/representations/types.js").Representation} Representation */
@@ -22,7 +23,7 @@ export const acceptFinalCommentPage = (
 	session
 ) => {
 	const shortReference = appealShortReference(appealDetails.appealReference);
-
+	const buttonText = findButtonText(finalCommentsType);
 	/** @type {PageComponent[]} */
 	const pageComponents = [
 		wrapComponents(
@@ -34,7 +35,12 @@ export const acceptFinalCommentPage = (
 					},
 					'Original final comments:'
 				),
-				...redactInput({ representation, labelText: 'Redacted final comments:', session }),
+				...redactInput({
+					representation,
+					labelText: 'Redacted final comments:',
+					session,
+					buttonText: buttonText
+				}),
 				buttonComponent(
 					'Continue',
 					{ type: 'submit' },

--- a/appeals/web/src/server/appeals/appeal-details/representations/final-comments/redact/__tests__/__snapshots__/redact-final-comments.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/representations/final-comments/redact/__tests__/__snapshots__/redact-final-comments.test.js.snap
@@ -13,6 +13,10 @@ exports[`final-comments GET / should render the redact appellant final comments 
             <div id="original-comment" class="govuk-inset-text govuk-!-margin-top-2">
                 <div class="pins-show-more" data-label="Read more" data-mode="text">Awaiting final comments review</div>
             </div>
+            <div class="govuk-button-group">
+                <button type="submit" class="govuk-button govuk-button--secondary" data-module="govuk-button"
+                id="revert-button">Revert to original appellant final comments</button>
+            </div>
             <div class="govuk-form-group">
                 <label class="govuk-label govuk-label--s" for="redact-textarea">Redacted final comments:</label>
                 <textarea class="govuk-textarea" id="redact-textarea"
@@ -22,7 +26,7 @@ exports[`final-comments GET / should render the redact appellant final comments 
                 <button type="submit" class="govuk-button govuk-button--secondary" data-module="govuk-button"
                 id="redact-button">Redact selected text</button>
                 <button type="submit" class="govuk-button govuk-button--secondary"
-                data-module="govuk-button" id="undo-button">Undo all changes</button>
+                data-module="govuk-button" id="undo-button">Undo changes</button>
             </div>
             <div class="govuk-button-group">
                 <button type="submit" class="govuk-button" data-module="govuk-button">Continue</button>
@@ -45,6 +49,10 @@ exports[`final-comments GET / should render the redact lpa final comments page w
             <div id="original-comment" class="govuk-inset-text govuk-!-margin-top-2">
                 <div class="pins-show-more" data-label="Read more" data-mode="text">Awaiting final comments review</div>
             </div>
+            <div class="govuk-button-group">
+                <button type="submit" class="govuk-button govuk-button--secondary" data-module="govuk-button"
+                id="revert-button">Revert to original LPA final comments</button>
+            </div>
             <div class="govuk-form-group">
                 <label class="govuk-label govuk-label--s" for="redact-textarea">Redacted final comments:</label>
                 <textarea class="govuk-textarea" id="redact-textarea"
@@ -54,7 +62,7 @@ exports[`final-comments GET / should render the redact lpa final comments page w
                 <button type="submit" class="govuk-button govuk-button--secondary" data-module="govuk-button"
                 id="redact-button">Redact selected text</button>
                 <button type="submit" class="govuk-button govuk-button--secondary"
-                data-module="govuk-button" id="undo-button">Undo all changes</button>
+                data-module="govuk-button" id="undo-button">Undo changes</button>
             </div>
             <div class="govuk-button-group">
                 <button type="submit" class="govuk-button" data-module="govuk-button">Continue</button>

--- a/appeals/web/src/server/appeals/appeal-details/representations/final-comments/redact/__tests__/redact-final-comments.test.js
+++ b/appeals/web/src/server/appeals/appeal-details/representations/final-comments/redact/__tests__/redact-final-comments.test.js
@@ -1,4 +1,5 @@
 /* eslint-disable jest/expect-expect */
+import { findButtonText } from '#lib/revert-text.js';
 import {
 	appealDataFullPlanning,
 	finalCommentsForReview
@@ -73,7 +74,9 @@ describe('final-comments', () => {
 				);
 				expect(unprettifiedHTML).toContain('Awaiting final comments review</textarea>');
 				expect(unprettifiedHTML).toContain('Redact selected text</button>');
-				expect(unprettifiedHTML).toContain('Undo all changes</button>');
+				const buttonText = findButtonText(finalCommentsType.type);
+				expect(unprettifiedHTML).toContain(`${buttonText}</button>`);
+				expect(unprettifiedHTML).toContain('Undo changes</button>');
 				expect(unprettifiedHTML).toContain('Continue</button>');
 			});
 		}

--- a/appeals/web/src/server/appeals/appeal-details/representations/final-comments/redact/components/summary-list.js
+++ b/appeals/web/src/server/appeals/appeal-details/representations/final-comments/redact/components/summary-list.js
@@ -1,6 +1,8 @@
 /** @typedef {import("#appeals/appeal-details/appeal-details.types.js").WebAppeal} Appeal */
 /** @typedef {import("#appeals/appeal-details/representations/types.js").Representation} Representation */
 
+import { checkRedactedText } from '#lib/validators/redacted-text.validator.js';
+
 /**
  * @param {Appeal} appealDetails
  * @param {Representation} comment
@@ -15,70 +17,80 @@ export const summaryList = (
 	finalCommentsType,
 	attachmentsList,
 	session
-) => ({
-	type: 'summary-list',
-	wrapperHtml: {
-		opening: '<div class="govuk-grid-row"><div class="govuk-grid-column-full">',
-		closing: '</div></div>'
-	},
-	parameters: {
-		rows: [
-			{
-				key: { text: 'Original final comments' },
-				value: {
-					html: '',
-					pageComponents: [
-						{
-							type: 'show-more',
-							parameters: {
-								text: comment.originalRepresentation,
-								labelText: 'Read more'
+) => {
+	const displayRedactedComment = checkRedactedText(
+		comment.originalRepresentation,
+		session?.redactedRepresentation
+	);
+	return {
+		type: 'summary-list',
+		wrapperHtml: {
+			opening: '<div class="govuk-grid-row"><div class="govuk-grid-column-full">',
+			closing: '</div></div>'
+		},
+		parameters: {
+			rows: [
+				{
+					key: { text: displayRedactedComment ? 'Original final comments' : 'Comment' },
+					value: {
+						html: '',
+						pageComponents: [
+							{
+								type: 'show-more',
+								parameters: {
+									text: comment.originalRepresentation,
+									labelText: 'Read more'
+								}
 							}
-						}
-					]
-				}
-			},
-			{
-				key: { text: 'Redacted final comments' },
-				value: {
-					html: '',
-					pageComponents: [
-						{
-							type: 'show-more',
-							parameters: {
-								text: session?.redactedRepresentation,
-								labelText: 'Read more'
-							}
-						}
-					]
+						]
+					}
 				},
-				actions: {
-					items: [
-						{
-							href: `/appeals-service/appeal-details/${appealDetails.appealId}/final-comments/${finalCommentsType}/redact`,
-							text: 'Change',
-							visuallyHiddenText: 'redacted final comments'
-						}
-					]
+				...(displayRedactedComment
+					? [
+							{
+								key: { text: 'Redacted final comments' },
+								value: {
+									html: '',
+									pageComponents: [
+										{
+											type: 'show-more',
+											parameters: {
+												text: session?.redactedRepresentation,
+												labelText: 'Read more'
+											}
+										}
+									]
+								},
+								actions: {
+									items: [
+										{
+											href: `/appeals-service/appeal-details/${appealDetails.appealId}/final-comments/${finalCommentsType}/redact`,
+											text: 'Change',
+											visuallyHiddenText: 'redacted final comments'
+										}
+									]
+								}
+							}
+					  ]
+					: []),
+				{
+					key: { text: 'Supporting documents' },
+					value: attachmentsList ? { html: attachmentsList } : { text: 'Not provided' }
+				},
+				{
+					key: { text: 'Review decision' },
+					value: { text: 'Redact and accept final comments' },
+					actions: {
+						items: [
+							{
+								href: `/appeals-service/appeal-details/${appealDetails.appealId}/final-comments/${finalCommentsType}`,
+								text: 'Change',
+								visuallyHiddenText: 'review decision'
+							}
+						]
+					}
 				}
-			},
-			{
-				key: { text: 'Supporting documents' },
-				value: attachmentsList ? { html: attachmentsList } : { text: 'Not provided' }
-			},
-			{
-				key: { text: 'Review decision' },
-				value: { text: 'Redact and accept final comments' },
-				actions: {
-					items: [
-						{
-							href: `/appeals-service/appeal-details/${appealDetails.appealId}/final-comments/${finalCommentsType}`,
-							text: 'Change',
-							visuallyHiddenText: 'review decision'
-						}
-					]
-				}
-			}
-		]
-	}
-});
+			]
+		}
+	};
+};

--- a/appeals/web/src/server/appeals/appeal-details/representations/final-comments/redact/redact.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/representations/final-comments/redact/redact.mapper.js
@@ -5,6 +5,7 @@ import { redactInput } from '#appeals/appeal-details/representations/common/comp
 import { summaryList } from './components/summary-list.js';
 import { formatFinalCommentsTypeText } from '../view-and-review/view-and-review.mapper.js';
 import { getAttachmentList } from '#appeals/appeal-details/representations/common/document-attachment-list.js';
+import { findButtonText } from '#lib/revert-text.js';
 
 /** @typedef {import("#appeals/appeal-details/appeal-details.types.js").WebAppeal} Appeal */
 /** @typedef {import("#appeals/appeal-details/representations/types.js").Representation} Representation */
@@ -18,6 +19,7 @@ import { getAttachmentList } from '#appeals/appeal-details/representations/commo
  */
 export const redactFinalCommentPage = (appealDetails, comment, finalCommentsType, session) => {
 	const shortReference = appealShortReference(appealDetails.appealReference);
+	const buttonText = findButtonText(finalCommentsType);
 
 	/** @type {PageComponent[]} */
 	const pageComponents = [
@@ -47,7 +49,12 @@ export const redactFinalCommentPage = (appealDetails, comment, finalCommentsType
 						]
 					}
 				},
-				...redactInput({ representation: comment, labelText: 'Redacted final comments:', session }),
+				...redactInput({
+					representation: comment,
+					labelText: 'Redacted final comments:',
+					session,
+					buttonText: buttonText
+				}),
 				buttonComponent(
 					'Continue',
 					{ type: 'submit' },

--- a/appeals/web/src/server/appeals/appeal-details/representations/final-comments/view-and-review/__tests__/__snapshots__/view-and-review.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/representations/final-comments/view-and-review/__tests__/__snapshots__/view-and-review.test.js.snap
@@ -415,9 +415,11 @@ exports[`final-comments GET /review-comments with redacted comment should render
                         <div class="pins-show-more" data-label="Read more" data-mode="text">Awaiting final comments review</div>
                     </dd>
                 </div>
-                <div class="govuk-summary-list__row govuk-summary-list__row--no-actions"><dt class="govuk-summary-list__key"> Redacted comment</dt>
+                <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Redacted comment</dt>
                     <dd class="govuk-summary-list__value">
                         <div class="pins-show-more" data-label="Read more" data-mode="text">aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa</div>
+                    </dd>
+                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/final-comments/lpa/redact">Change<span class="govuk-visually-hidden"> final comments</span></a>
                     </dd>
                 </div>
                 <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Supporting documents</dt>

--- a/appeals/web/src/server/appeals/appeal-details/representations/final-comments/view-and-review/page-components/common.js
+++ b/appeals/web/src/server/appeals/appeal-details/representations/final-comments/view-and-review/page-components/common.js
@@ -2,6 +2,7 @@ import { buildHtmlList } from '#lib/nunjucks-template-builders/tag-builders.js';
 import { preRenderPageComponents } from '#lib/nunjucks-template-builders/page-component-rendering.js';
 import { APPEAL_REPRESENTATION_STATUS } from '@pins/appeals/constants/common.js';
 import { mapDocumentDownloadUrl } from '#appeals/appeal-documents/appeal-documents.mapper.js';
+import { checkRedactedText } from '#lib/validators/redacted-text.validator.js';
 
 /** @typedef {import('#appeals/appeal-details/representations/types.js').Representation} Representation */
 
@@ -52,10 +53,18 @@ export function generateCommentsSummaryList(appealId, comment) {
 		: null;
 
 	const commentTypePath = mapRepresentationTypeToPath(comment.representationType);
-
+	const redactedCommentDifferent = checkRedactedText(
+		comment.originalRepresentation,
+		comment.redactedRepresentation
+	);
 	const rows = [
 		{
-			key: { text: comment.redactedRepresentation ? 'Original final comments' : 'Final comments' },
+			key: {
+				text:
+					comment.redactedRepresentation && redactedCommentDifferent
+						? 'Original final comments'
+						: 'Final comments'
+			},
 			value: commentIsDocument
 				? { text: 'Added as a document' }
 				: {
@@ -84,7 +93,7 @@ export function generateCommentsSummaryList(appealId, comment) {
 						  ]
 			}
 		},
-		...(comment.redactedRepresentation
+		...(comment.redactedRepresentation && redactedCommentDifferent
 			? [
 					{
 						key: { text: 'Redacted comment' },

--- a/appeals/web/src/server/appeals/appeal-details/representations/final-comments/view-and-review/page-components/common.js
+++ b/appeals/web/src/server/appeals/appeal-details/representations/final-comments/view-and-review/page-components/common.js
@@ -81,7 +81,7 @@ export function generateCommentsSummaryList(appealId, comment) {
 				  },
 			actions: {
 				items:
-					comment.status === APPEAL_REPRESENTATION_STATUS.PUBLISHED ||
+					comment.status === APPEAL_REPRESENTATION_STATUS.PUBLISHED || redactedCommentDifferent ||
 					comment.status === APPEAL_REPRESENTATION_STATUS.AWAITING_REVIEW
 						? []
 						: [
@@ -106,6 +106,15 @@ export function generateCommentsSummaryList(appealId, comment) {
 										text: comment.redactedRepresentation,
 										labelText: 'Read more'
 									}
+								}
+							]
+						},
+						actions: {
+							items: [
+								{
+									text: 'Change',
+									href: `/appeals-service/appeal-details/${appealId}/final-comments/${commentTypePath}/redact`,
+									visuallyHiddenText: 'final comments'
 								}
 							]
 						}

--- a/appeals/web/src/server/appeals/appeal-details/representations/interested-party-comments/redact/__tests__/__snapshots__/redact-ip-comment.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/representations/interested-party-comments/redact/__tests__/__snapshots__/redact-ip-comment.test.js.snap
@@ -50,6 +50,10 @@ exports[`redact renders the redact page 1`] = `
         <form method="POST" class="govuk-grid-column-two-thirds">
             <p class="govuk-body govuk-!-margin-bottom-0">Original comment:</p>
             <div id="original-comment" class="govuk-inset-text govuk-!-margin-top-2">Awaiting review comment 47</div>
+            <div class="govuk-button-group">
+                <button type="submit" class="govuk-button govuk-button--secondary" data-module="govuk-button"
+                id="revert-button">Revert to original comment</button>
+            </div>
             <div class="govuk-form-group">
                 <label class="govuk-label govuk-label--s" for="redact-textarea">Redacted comment</label>
                 <textarea class="govuk-textarea" id="redact-textarea"
@@ -59,7 +63,7 @@ exports[`redact renders the redact page 1`] = `
                 <button type="submit" class="govuk-button govuk-button--secondary" data-module="govuk-button"
                 id="redact-button">Redact selected text</button>
                 <button type="submit" class="govuk-button govuk-button--secondary"
-                data-module="govuk-button" id="undo-button">Undo all changes</button>
+                data-module="govuk-button" id="undo-button">Undo changes</button>
             </div>
             <div class="govuk-button-group">
                 <button type="submit" class="govuk-button" data-module="govuk-button">Continue</button>

--- a/appeals/web/src/server/appeals/appeal-details/representations/interested-party-comments/redact/__tests__/redact-ip-comment.test.js
+++ b/appeals/web/src/server/appeals/appeal-details/representations/interested-party-comments/redact/__tests__/redact-ip-comment.test.js
@@ -40,7 +40,7 @@ describe('redact', () => {
 
 		const { innerHTML } = parseHtml(response.text);
 		expect(innerHTML).toMatchSnapshot();
-
+		expect(innerHTML).toContain('Revert to original comment</button>');
 		expect(innerHTML).toContain('Check details and redact comment');
 		expect(innerHTML).toContain('Awaiting review comment 47');
 	});
@@ -52,7 +52,6 @@ describe('redact', () => {
 
 		const { innerHTML } = parseHtml(response.text);
 		expect(innerHTML).toMatchSnapshot();
-
 		expect(innerHTML).toContain('Redact and accept comment');
 		expect(innerHTML).toContain(
 			'<dd class="govuk-summary-list__value">Awaiting review comment 47</dd>'

--- a/appeals/web/src/server/appeals/appeal-details/representations/interested-party-comments/redact/components/summary-list.js
+++ b/appeals/web/src/server/appeals/appeal-details/representations/interested-party-comments/redact/components/summary-list.js
@@ -7,16 +7,15 @@ import { getAttachmentList } from '#appeals/appeal-details/representations/commo
  * @param {Appeal} appealDetails
  * @param {Representation} comment
  * @param {import('express-session').Session & Record<string, string>} [session]
+ * @param {boolean} [redactMatching]
  * @returns {PageComponent}
  */
-export const summaryList = (appealDetails, comment, session) => {
+export const summaryList = (appealDetails, comment, session, redactMatching) => {
 	const attachmentsList = getAttachmentList(comment);
 
 	const folderId = comment.attachments?.[0]?.documentVersion?.document?.folderId ?? null;
 	const baseUrl = `/appeals-service/appeal-details/${appealDetails.appealId}/interested-party-comments/${comment.id}`;
-
-	/** @type {PageComponent} */
-	const pageComponents = {
+	return {
 		type: 'summary-list',
 		wrapperHtml: {
 			opening: '<div class="govuk-grid-row"><div class="govuk-grid-column-full">',
@@ -28,48 +27,64 @@ export const summaryList = (appealDetails, comment, session) => {
 					key: { text: 'Interested party' },
 					value: { text: comment.author }
 				},
-				{
-					key: { text: 'Original comment' },
-					value: { text: comment.originalRepresentation }
-				},
-				{
-					key: { text: 'Redacted comment' },
-					value: { text: session?.redactedRepresentation },
-					actions: {
-						items: [
+				...(redactMatching
+					? [
 							{
-								text: 'Change',
-								href: `/appeals-service/appeal-details/${appealDetails.appealId}/interested-party-comments/${comment.id}/redact`,
-								visuallyHiddenText: 'redacted comment'
-							}
-						]
-					}
-				},
-				{
-					key: { text: 'Supporting documents' },
-					value: attachmentsList ? { html: attachmentsList } : { text: 'Not provided' },
-					actions: {
-						items: [
-							...(comment.attachments?.length > 0
-								? [
+								key: { text: 'Original comment' },
+								value: { text: comment.originalRepresentation }
+							},
+							{
+								key: { text: 'Redacted comment' },
+								value: { text: session?.redactedRepresentation },
+								actions: {
+									items: [
 										{
-											text: 'Manage',
-											href: `${baseUrl}/manage-documents/${folderId}?backUrl=/interested-party-comments/${comment.id}/redact/confirm`,
-											visuallyHiddenText: 'supporting documents'
+											text: 'Change',
+											href: `/appeals-service/appeal-details/${appealDetails.appealId}/interested-party-comments/${comment.id}/redact`,
+											visuallyHiddenText: 'redacted comment'
 										}
-								  ]
-								: []),
-							{
-								text: 'Add',
-								href: `${baseUrl}/add-document?backUrl=/interested-party-comments/${comment.id}/redact/confirm`,
-								visuallyHiddenText: 'supporting documents'
+									]
+								}
 							}
-						]
+					  ]
+					: [
+							{
+								key: { text: 'Comment' },
+								value: { text: comment.originalRepresentation },
+								actions: {
+									items: [
+										{
+											text: 'Redact',
+											href: `/appeals-service/appeal-details/${appealDetails.appealId}/interested-party-comments/${comment.id}/redact`,
+											visuallyHiddenText: 'redacted comment'
+										}
+									]
+								}
+							}
+					  ]),
+					  {
+						key: { text: 'Supporting documents' },
+						value: attachmentsList ? { html: attachmentsList } : { text: 'Not provided' },
+						actions: {
+							items: [
+								...(comment.attachments?.length > 0
+									? [
+											{
+												text: 'Manage',
+												href: `${baseUrl}/manage-documents/${folderId}?backUrl=/interested-party-comments/${comment.id}/redact/confirm`,
+												visuallyHiddenText: 'supporting documents'
+											}
+									  ]
+									: []),
+								{
+									text: 'Add',
+									href: `${baseUrl}/add-document?backUrl=/interested-party-comments/${comment.id}/redact/confirm`,
+									visuallyHiddenText: 'supporting documents'
+								}
+							]
+						}
 					}
-				}
 			]
 		}
 	};
-
-	return pageComponents;
 };

--- a/appeals/web/src/server/appeals/appeal-details/representations/interested-party-comments/redact/confirm.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/representations/interested-party-comments/redact/confirm.mapper.js
@@ -3,6 +3,7 @@
 
 import { appealShortReference } from '#lib/appeals-formatter.js';
 import { preRenderPageComponents } from '#lib/nunjucks-template-builders/page-component-rendering.js';
+import { checkRedactedText } from '#lib/validators/redacted-text.validator.js';
 import { summaryList } from './components/summary-list.js';
 
 /**
@@ -14,8 +15,12 @@ import { summaryList } from './components/summary-list.js';
 export const confirmRedactInterestedPartyCommentPage = (appealDetails, comment, session) => {
 	const shortReference = appealShortReference(appealDetails.appealReference);
 
+	const redactMatching = checkRedactedText(
+		comment.originalRepresentation,
+		session?.redactedRepresentation
+	);
 	/** @type {PageComponent[]} */
-	const pageComponents = [summaryList(appealDetails, comment, session)];
+	const pageComponents = [summaryList(appealDetails, comment, session, redactMatching)];
 
 	preRenderPageComponents(pageComponents);
 
@@ -24,9 +29,9 @@ export const confirmRedactInterestedPartyCommentPage = (appealDetails, comment, 
 		title: 'Confirm redaction',
 		backLinkUrl: `/appeals-service/appeal-details/${appealDetails.appealId}/interested-party-comments/${comment.id}/redact`,
 		preHeading: `Appeal ${shortReference}`,
-		heading: 'Check details and redact comment',
+		heading: redactMatching ? 'Check details and redact comment' : 'Check Details',
 		forceRenderSubmitButton: true,
-		submitButtonText: 'Redact and accept comment',
+		submitButtonText: redactMatching ? 'Redact and accept comment' : 'Accept comment',
 		pageComponents
 	};
 

--- a/appeals/web/src/server/appeals/appeal-details/representations/interested-party-comments/redact/redact.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/representations/interested-party-comments/redact/redact.mapper.js
@@ -2,6 +2,7 @@ import { appealShortReference } from '#lib/appeals-formatter.js';
 import { preRenderPageComponents } from '#lib/nunjucks-template-builders/page-component-rendering.js';
 import { wrapComponents, simpleHtmlComponent, buttonComponent } from '#lib/mappers/index.js';
 import { redactInput } from '../../common/components/redact-input.js';
+import { REVERT_BUTTON_TEXT } from '@pins/appeals/constants/common.js';
 
 /** @typedef {import("#appeals/appeal-details/appeal-details.types.js").WebAppeal} Appeal */
 /** @typedef {import("#appeals/appeal-details/representations/types.js").Representation} Representation */
@@ -34,7 +35,12 @@ export const redactInterestedPartyCommentPage = (appealDetails, comment, session
 						classes: 'govuk-!-margin-top-2'
 					}
 				},
-				...redactInput({ representation: comment, labelText: 'Redacted comment', session }),
+				...redactInput({
+					representation: comment,
+					labelText: 'Redacted comment',
+					session,
+					buttonText: REVERT_BUTTON_TEXT.DEFAULT_TEXT
+				}),
 				buttonComponent(
 					'Continue',
 					{ type: 'submit' },

--- a/appeals/web/src/server/appeals/appeal-details/representations/interested-party-comments/view-and-review/__tests__/__snapshots__/view-and-review.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/representations/interested-party-comments/view-and-review/__tests__/__snapshots__/view-and-review.test.js.snap
@@ -489,8 +489,6 @@ exports[`interested-party-comments GET /view-comment with data should render vie
                 </div>
                 <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Comment</dt>
                     <dd class="govuk-summary-list__value">Awaiting review comment 47</dd>
-                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/interested-party-comments/3670/redact">Redact</a>
-                    </dd>
                 </div>
                 <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Supporting documents</dt>
                     <dd class="govuk-summary-list__value">Not provided</dd>

--- a/appeals/web/src/server/appeals/appeal-details/representations/interested-party-comments/view-and-review/page-components/__tests__/__snapshots__/common.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/representations/interested-party-comments/view-and-review/page-components/__tests__/__snapshots__/common.test.js.snap
@@ -64,12 +64,7 @@ exports[`generateCommentSummaryList should return the comment summary list inclu
       },
       {
         "actions": {
-          "items": [
-            {
-              "href": "/appeals-service/appeal-details/5/interested-party-comments/undefined/redact",
-              "text": "Redact",
-            },
-          ],
+          "items": [],
         },
         "key": {
           "text": "Comment",

--- a/appeals/web/src/server/appeals/appeal-details/representations/interested-party-comments/view-and-review/page-components/common.js
+++ b/appeals/web/src/server/appeals/appeal-details/representations/interested-party-comments/view-and-review/page-components/common.js
@@ -128,7 +128,7 @@ export function generateCommentSummaryList(
 			},
 			actions: {
 				items:
-					commentIsDocument || isReviewPage
+					commentIsDocument || isReviewPage || redactMatching
 						? []
 						: [
 								{
@@ -139,7 +139,20 @@ export function generateCommentSummaryList(
 			}
 		},
 		...(comment.redactedRepresentation && redactMatching
-			? [{ key: { text: 'Redacted comment' }, value: { text: comment.redactedRepresentation } }]
+			? [
+					{
+						key: { text: 'Redacted comment' },
+						value: { text: comment.redactedRepresentation },
+						actions: {
+							items: [
+								{
+									text: 'Change',
+									href: `/appeals-service/appeal-details/${appealId}/interested-party-comments/${comment.id}/redact`
+								}
+							]
+						}
+					}
+			  ]
 			: []),
 		{
 			key: { text: 'Supporting documents' },

--- a/appeals/web/src/server/appeals/appeal-details/representations/interested-party-comments/view-and-review/page-components/common.js
+++ b/appeals/web/src/server/appeals/appeal-details/representations/interested-party-comments/view-and-review/page-components/common.js
@@ -2,6 +2,7 @@ import { mapDocumentDownloadUrl } from '#appeals/appeal-documents/appeal-documen
 import { addressToMultilineStringHtml } from '#lib/address-formatter.js';
 import { dateISOStringToDisplayDate } from '#lib/dates.js';
 import { buildHtmlList } from '#lib/nunjucks-template-builders/tag-builders.js';
+import { checkRedactedText } from '#lib/validators/redacted-text.validator.js';
 import { COMMENT_STATUS } from '@pins/appeals/constants/common.js';
 
 /** @typedef {import('#appeals/appeal-details/representations/types.js').Representation} Representation */
@@ -65,7 +66,10 @@ export function generateCommentSummaryList(
 		: null;
 
 	const { address, name, email } = comment.represented || {};
-
+	const redactMatching = checkRedactedText(
+		comment.originalRepresentation,
+		comment.redactedRepresentation
+	);
 	const rows = [
 		{
 			key: { text: 'Interested party' },
@@ -116,7 +120,9 @@ export function generateCommentSummaryList(
 			value: { html: dateISOStringToDisplayDate(comment.created) }
 		},
 		{
-			key: { text: comment.redactedRepresentation ? 'Original comment' : 'Comment' },
+			key: {
+				text: comment.redactedRepresentation && redactMatching ? 'Original comment' : 'Comment'
+			},
 			value: {
 				text: commentIsDocument ? 'Added as a document' : comment.originalRepresentation
 			},
@@ -132,7 +138,7 @@ export function generateCommentSummaryList(
 						  ]
 			}
 		},
-		...(comment.redactedRepresentation
+		...(comment.redactedRepresentation && redactMatching
 			? [{ key: { text: 'Redacted comment' }, value: { text: comment.redactedRepresentation } }]
 			: []),
 		{

--- a/appeals/web/src/server/appeals/appeal-details/representations/lpa-statement/lpa-statement.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/representations/lpa-statement/lpa-statement.mapper.js
@@ -5,6 +5,7 @@ import { mapNotificationBannersFromSession } from '#lib/mappers/index.js';
 import { COMMENT_STATUS } from '@pins/appeals/constants/common.js';
 import { constructUrl } from '#lib/mappers/utils/url.mapper.js';
 import { mapDocumentDownloadUrl } from '#appeals/appeal-documents/appeal-documents.mapper.js';
+import { checkRedactedText } from '#lib/validators/redacted-text.validator.js';
 
 /** @typedef {import("#appeals/appeal-details/appeal-details.types.js").WebAppeal} Appeal */
 /** @typedef {import('#appeals/appeal-details/representations/types.js').Representation} Representation */
@@ -37,7 +38,11 @@ export function baseSummaryList(appealId, lpaStatement, { isReview }) {
 		: null;
 
 	const folderId = lpaStatement.attachments?.[0]?.documentVersion?.document?.folderId ?? null;
-
+	//check if the redacted statement is the same as the original - if it is the same onlyt show original statement
+	const shouldShowRedactedRow = checkRedactedText(
+		lpaStatement.originalRepresentation,
+		lpaStatement.redactedRepresentation
+	);
 	/** @type {PageComponent} */
 	const lpaStatementSummaryList = {
 		type: 'summary-list',
@@ -47,7 +52,7 @@ export function baseSummaryList(appealId, lpaStatement, { isReview }) {
 		},
 		parameters: {
 			rows: [
-				...(lpaStatement.redactedRepresentation
+				...(lpaStatement.redactedRepresentation && shouldShowRedactedRow
 					? [
 							{
 								key: { text: 'Original statement' },

--- a/appeals/web/src/server/appeals/appeal-details/representations/lpa-statement/redact/__tests__/__snapshots__/redact-lpa-statement.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/representations/lpa-statement/redact/__tests__/__snapshots__/redact-lpa-statement.test.js.snap
@@ -23,6 +23,10 @@ exports[`redact GET / should render the redact lpa statement page with expected 
                 white, and a little bit of andykebrown and a little touch of yellow. Anyone
                 can paint. Each highlight must have it&#39;s own private shadow. Don&#39;t
                 fiddle with it all day.</div>
+            <div class="govuk-button-group">
+                <button type="submit" class="govuk-button govuk-button--secondary" data-module="govuk-button"
+                id="revert-button">Revert to original LPA statement</button>
+            </div>
             <div class="govuk-form-group">
                 <label class="govuk-label govuk-label--s" for="redact-textarea">Redacted statement</label>
                 <textarea class="govuk-textarea" id="redact-textarea"
@@ -44,7 +48,7 @@ exports[`redact GET / should render the redact lpa statement page with expected 
                 <button type="submit" class="govuk-button govuk-button--secondary" data-module="govuk-button"
                 id="redact-button">Redact selected text</button>
                 <button type="submit" class="govuk-button govuk-button--secondary"
-                data-module="govuk-button" id="undo-button">Undo all changes</button>
+                data-module="govuk-button" id="undo-button">Undo changes</button>
             </div>
             <div class="govuk-button-group">
                 <button type="submit" class="govuk-button" data-module="govuk-button">Continue</button>

--- a/appeals/web/src/server/appeals/appeal-details/representations/lpa-statement/redact/__tests__/__snapshots__/redact.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/representations/lpa-statement/redact/__tests__/__snapshots__/redact.test.js.snap
@@ -1,0 +1,76 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`lpa-statements GET / should render the redact LPA ststement page successfully 1`] = `
+"<main class="govuk-main-wrapper" id="main-content">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Appeal 351062</span>
+            <h1 class="govuk-heading-l">Redact LPA statement</h1>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <form method="POST" class="govuk-grid-column-two-thirds">
+            <p class="govuk-body govuk-!-margin-bottom-0">Original statement:</p>
+            <div id="original-comment" class="govuk-inset-text govuk-!-margin-top-2">Every single thing in the world has its own personality - and it is up
+                to you to make friends with the little rascals. Steve wants reflections,
+                so let&#39;s give him eflections It&#39;s amazing what you can do with
+                a little love in your heart. Clouds are free they come and go as they please.
+                The secret to doing anything is believing that you can do it. Anything
+                hatyou believe you can do strong enough, you can do. Anything. As long
+                as you believe. It looks so good, I might as well not stop. This present
+                moment is perfect simply due to the fact you&#39;re xperiencingit. Making
+                all those little fluffies that live in the clouds. You don&#39;t want to
+                kill all your dark areas they are very important. I will take some magic
+                white, and a little bit of andykebrown and a little touch of yellow. Anyone
+                can paint. Each highlight must have it&#39;s own private shadow. Don&#39;t
+                fiddle with it all day.</div>
+            <div class="govuk-button-group">
+                <button type="submit" class="govuk-button govuk-button--secondary" data-module="govuk-button"
+                id="revert-button">Revert to original LPA statement</button>
+            </div>
+            <div class="govuk-form-group">
+                <label class="govuk-label govuk-label--s" for="redact-textarea">Redacted statement</label>
+                <textarea class="govuk-textarea" id="redact-textarea"
+                name="redactedRepresentation" rows="5" readonly="true">Every single thing in the world has its own personality - and it is up
+                    to you to make friends with the little rascals. Steve wants reflections,
+                    so let&#39;s give him eflections It&#39;s amazing what you can do with
+                    a little love in your heart. Clouds are free they come and go as they please.
+                    The secret to doing anything is believing that you can do it. Anything
+                    hatyou believe you can do strong enough, you can do. Anything. As long
+                    as you believe. It looks so good, I might as well not stop. This present
+                    moment is perfect simply due to the fact you&#39;re xperiencingit. Making
+                    all those little fluffies that live in the clouds. You don&#39;t want to
+                    kill all your dark areas they are very important. I will take some magic
+                    white, and a little bit of andykebrown and a little touch of yellow. Anyone
+                    can paint. Each highlight must have it&#39;s own private shadow. Don&#39;t
+                    fiddle with it all day.</textarea>
+            </div>
+            <div class="govuk-button-group">
+                <button type="submit" class="govuk-button govuk-button--secondary" data-module="govuk-button"
+                id="redact-button">Redact selected text</button>
+                <button type="submit" class="govuk-button govuk-button--secondary"
+                data-module="govuk-button" id="undo-button">Undo changes</button>
+            </div>
+            <div class="govuk-button-group">
+                <button type="submit" class="govuk-button" data-module="govuk-button">Continue</button>
+            </div>
+        </form>
+    </div>
+</main>"
+`;
+
+exports[`lpa-statements GET / should render the redacted LPA statement page 1`] = `
+"<main class="govuk-main-wrapper" id="main-content">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <h1 class="govuk-heading-xl">Sorry, there is a problem with the service</h1>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <p class="govuk-body">Try again later.</p>
+            <p class="govuk-body"><a href="https://has-appeal.herokuapp.com/help/contact" class="govuk-link">Contact the Planning Inspectorate Customer Support</a> if
+                the problem persists.</p>
+        </div>
+    </div>
+</main>"
+`;

--- a/appeals/web/src/server/appeals/appeal-details/representations/lpa-statement/redact/__tests__/redact-lpa-statement.test.js
+++ b/appeals/web/src/server/appeals/appeal-details/representations/lpa-statement/redact/__tests__/redact-lpa-statement.test.js
@@ -62,7 +62,7 @@ describe('redact', () => {
 				'<label class="govuk-label govuk-label--s" for="redact-textarea">Redacted statement</label>'
 			);
 			expect(innerHTML).toContain('Redact selected text</button>');
-			expect(innerHTML).toContain('Undo all changes</button>');
+			expect(innerHTML).toContain('Undo changes</button>');
 			expect(innerHTML).toContain('Continue</button>');
 		});
 	});

--- a/appeals/web/src/server/appeals/appeal-details/representations/lpa-statement/redact/__tests__/redact.test.js
+++ b/appeals/web/src/server/appeals/appeal-details/representations/lpa-statement/redact/__tests__/redact.test.js
@@ -1,0 +1,92 @@
+import {
+	appealDataFullPlanning,
+	finalCommentsForReview,
+	lpaStatementAwaitingReview,
+	getAppealRepsResponse
+} from '#testing/app/fixtures/referencedata.js';
+import { createTestEnvironment } from '#testing/index.js';
+import { parseHtml } from '@pins/platform';
+import nock from 'nock';
+import supertest from 'supertest';
+
+const { app, installMockApi, teardown } = createTestEnvironment();
+const request = supertest(app);
+const baseUrl = '/appeals-service/appeal-details';
+
+describe('lpa-statements', () => {
+	beforeEach(() => {
+		installMockApi();
+		// Common nock setup
+		nock('http://test/')
+			.get('/appeals/2')
+			.reply(200, {
+				...appealDataFullPlanning,
+				appealId: 2,
+				appealStatus: 'statements'
+			});
+
+		nock('http://test/')
+			.get('/appeals/2/document-folders')
+			.query({ path: 'representation/representationAttachments' })
+			.reply(200, [{ folderId: 1234, path: 'representation/attachments' }]);
+
+		nock('http://test/')
+			.get('/appeals/2/reps?type=lpa_statement')
+			.reply(200, finalCommentsForReview) // TODO: this should be LPA statement data, not final comment data
+			.persist();
+
+		nock('http://test/')
+			.get('/appeals/2/document-folders?path=representation/representationAttachments')
+			.reply(200, [{ folderId: 1234, path: 'representation/attachments' }]);
+	});
+
+	afterEach(teardown);
+
+	describe('GET /', () => {
+		const appealId = 3;
+
+		beforeEach(() => {
+			nock('http://test/')
+				.get(`/appeals/${appealId}`)
+				.reply(200, {
+					...appealDataFullPlanning,
+					appealId,
+					appealStatus: 'statements'
+				});
+		});
+
+		it('should render the redact LPA ststement page successfully', async () => {
+			nock('http://test/')
+				.get(`/appeals/${appealId}/reps?type=lpa_statement`)
+				.reply(200, {
+					...getAppealRepsResponse,
+					itemCount: 1,
+					items: [lpaStatementAwaitingReview]
+				});
+
+			const response = await request.get(`${baseUrl}/${appealId}/lpa-statement/redact`);
+
+			expect(response.statusCode).toBe(200);
+
+			const element = parseHtml(response.text);
+			expect(element.innerHTML).toMatchSnapshot();
+			expect(element.innerHTML).toContain('Revert to original LPA statement</button>');
+			expect(element.innerHTML).toContain('Undo changes</button>');
+			expect(element.innerHTML).toContain('Redact selected text</button>');
+			expect(element.innerHTML).toContain('Redacted statement');
+			expect(element.innerHTML).toContain('Original statement');
+		});
+
+		it('should render the redacted LPA statement page', async () => {
+			nock('http://test/').get(`/appeals/${appealId}/reps?type=lpa_statement`).reply(500, {});
+
+			const response = await request.get(`${baseUrl}/${appealId}/lpa-statement/redact`);
+
+			expect(response.statusCode).toBe(500);
+
+			const element = parseHtml(response.text);
+			expect(element.innerHTML).toMatchSnapshot();
+			expect(element.innerHTML).toContain('Sorry, there is a problem with the service');
+		});
+	});
+});

--- a/appeals/web/src/server/appeals/appeal-details/representations/lpa-statement/redact/redact.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/representations/lpa-statement/redact/redact.mapper.js
@@ -107,7 +107,7 @@ export function redactConfirmPage(appealDetails, lpaStatement, specialismData, s
 	const folderId = lpaStatement.attachments?.[0]?.documentVersion?.document?.folderId ?? null;
 
 	//check if the redacted statement is the same as the original
-	const shouldShowRedactedRow = checkRedactedText(
+	const redactMatching = checkRedactedText(
 		lpaStatement.originalRepresentation,
 		session?.redactLPAStatement?.redactedRepresentation
 	);
@@ -122,7 +122,7 @@ export function redactConfirmPage(appealDetails, lpaStatement, specialismData, s
 			parameters: {
 				rows: [
 					{
-						key: { text: shouldShowRedactedRow ? 'Original statement' : 'Statement' },
+						key: { text: redactMatching ? 'Original statement' : 'Statement' },
 						value: {
 							html: '',
 							pageComponents: [
@@ -135,7 +135,7 @@ export function redactConfirmPage(appealDetails, lpaStatement, specialismData, s
 							]
 						}
 					},
-					...(shouldShowRedactedRow
+					...(redactMatching
 						? [
 								{
 									key: { text: 'Redacted statement' },
@@ -184,7 +184,7 @@ export function redactConfirmPage(appealDetails, lpaStatement, specialismData, s
 					},
 					{
 						key: { text: 'Review decision' },
-						value: { text: 'Redact and accept statement' },
+						value: { text: redactMatching ? 'Redact and accept statement' : 'Accept statement' },
 						actions: {
 							items: [
 								{
@@ -254,12 +254,12 @@ export function redactConfirmPage(appealDetails, lpaStatement, specialismData, s
 	preRenderPageComponents(pageComponents);
 
 	return {
-		title: 'Check details and accept statement',
+		title: redactMatching ? 'Check details and accept statement' : 'Accept statement',
 		backLinkUrl: `/appeals-service/appeal-details/${appealDetails.appealId}/lpa-statement/redact`,
 		preHeading: `Appeal ${shortReference}`,
-		heading: 'Check details and accept statement',
+		heading: redactMatching ? 'Check details and accept statement' : 'Accept statement',
 		forceRenderSubmitButton: true,
-		submitButtonText: 'Redact and accept statement',
+		submitButtonText: redactMatching ? 'Redact and accept statement' : 'Accept statement',
 		pageComponents
 	};
 }

--- a/appeals/web/src/server/appeals/appeal-details/representations/lpa-statement/redact/redact.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/representations/lpa-statement/redact/redact.mapper.js
@@ -4,6 +4,7 @@ import { wrapComponents, simpleHtmlComponent, buttonComponent } from '#lib/mappe
 import { ensureArray } from '#lib/array-utilities.js';
 import { redactInput } from '../../../representations/common/components/redact-input.js';
 import { getAttachmentList } from '../../common/document-attachment-list.js';
+import { REVERT_BUTTON_TEXT } from '@pins/appeals/constants/common.js';
 
 /** @typedef {import("#appeals/appeal-details/appeal-details.types.js").WebAppeal} Appeal */
 /** @typedef {import("#appeals/appeal-details/representations/types.js").Representation} Representation */
@@ -45,7 +46,8 @@ export function redactLpaStatementPage(appealDetails, lpaStatement, session) {
 					representation: lpaStatement,
 					labelText: 'Redacted statement',
 					session,
-					redactedRepresentation: session?.redactLPAStatement?.redactedRepresentation
+					redactedRepresentation: session?.redactLPAStatement?.redactedRepresentation,
+					buttonText: REVERT_BUTTON_TEXT.LPA_STATEMENT
 				}),
 				buttonComponent(
 					'Continue',

--- a/appeals/web/src/server/lib/revert-text.js
+++ b/appeals/web/src/server/lib/revert-text.js
@@ -1,0 +1,17 @@
+import { REVERT_BUTTON_TEXT } from '@pins/appeals/constants/common.js';
+
+/**
+ *
+ * @param {string} finalCommentsType
+ * @returns
+ */
+export const findButtonText = (finalCommentsType) => {
+	switch (finalCommentsType) {
+		case 'lpa':
+			return REVERT_BUTTON_TEXT.LPA_FINAL_COMMENT;
+		case 'appellant':
+			return REVERT_BUTTON_TEXT.APPELLANT_FINAL_COMMENT;
+		default:
+			return REVERT_BUTTON_TEXT.DEFAULT_TEXT;
+	}
+};

--- a/appeals/web/src/server/lib/validators/redacted-text.validator.js
+++ b/appeals/web/src/server/lib/validators/redacted-text.validator.js
@@ -1,0 +1,12 @@
+/**
+ * @param {string} originalRepresentation
+ * @param {string | undefined} redactedRepresentation
+ * @returns {boolean}
+ */
+export const checkRedactedText = (originalRepresentation, redactedRepresentation) => {
+	const normalizeNewlines = (/** @type {string | undefined} */ str) =>
+		(str || '').replace(/\r\n/g, '\n').replace(/\r/g, '\n');
+	const normalizedOriginal = normalizeNewlines(originalRepresentation);
+	const normalizedRedacted = normalizeNewlines(redactedRepresentation);
+	return normalizedOriginal !== normalizedRedacted;
+};

--- a/packages/appeals/constants/common.js
+++ b/packages/appeals/constants/common.js
@@ -63,3 +63,10 @@ export const COMMENT_STATUS = Object.freeze({
 	VALID_REQUIRES_REDACTION: 'valid_requires_redaction',
 	INCOMPLETE: 'incomplete'
 });
+
+export const REVERT_BUTTON_TEXT = Object.freeze({
+	LPA_STATEMENT: 'Revert to original LPA statement',
+	LPA_FINAL_COMMENT: 'Revert to original LPA final comments',
+	APPELLANT_FINAL_COMMENT: 'Revert to original appellant final comments',
+	DEFAULT_TEXT: 'Revert to original comment'
+});


### PR DESCRIPTION
Changes:

Updated the redact-input component to now have a revert button and undo changes button - both use the setTextArea function to set the text are to the original text or the previously saved version of the text.

RedactInput was set to take in a value for the button text - this was coded into a constant that is referenced in multiple files and provided consistency.

A function was created that could be used by the final comments pages to get the correct message if the page is LPA or appellant final comments

Added new tests for the lpa statement redact page and updated other tests to accommodate changes

[A2-2694](https://pins-ds.atlassian.net/browse/A2-2694)



[A2-2694]: https://pins-ds.atlassian.net/browse/A2-2694?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ