### PR TITLE
feat(appeals): change LPA reference number

### DIFF
--- a/appeals/web/src/server/appeals/appeal-details/__tests__/__snapshots__/appeal-details.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/__tests__/__snapshots__/appeal-details.test.js.snap
@@ -447,7 +447,7 @@ data-index="0">
         <h3 class="govuk-notification-banner__title" id="govuk-notification-banner-title"> Success</h3>
     </div>
     <div class="govuk-notification-banner__content">
-        <p class="govuk-notification-banner__heading">LPA application reference updated</p>
+        <p class="govuk-notification-banner__heading">Appeal updated</p>
     </div>
 </div>"
 `;

--- a/appeals/web/src/server/appeals/appeal-details/__tests__/appeal-details.test.js
+++ b/appeals/web/src/server/appeals/appeal-details/__tests__/appeal-details.test.js
@@ -879,6 +879,11 @@ describe('appeal-details', () => {
 
 			it('should render a success notification banner when the lpa application reference was updated', async () => {
 				const appealId = appealData.appealId.toString();
+				nock.cleanAll();
+				nock('http://test/')
+					.get(`/appeals/${appealId}`)
+					.reply(200, { ...appealData, lpaQuestionnaireId: undefined })
+					.persist();
 				nock('http://test/').patch(`/appeals/${appealId}`).reply(200, {
 					planningApplicationReference: '12345/A/67890'
 				});
@@ -898,7 +903,7 @@ describe('appeal-details', () => {
 				}).innerHTML;
 				expect(notificationBannerElementHTML).toMatchSnapshot();
 				expect(notificationBannerElementHTML).toContain('Success</h3>');
-				expect(notificationBannerElementHTML).toContain('LPA application reference updated</p>');
+				expect(notificationBannerElementHTML).toContain('Appeal updated</p>');
 			});
 
 			it('should render a success notification banner when the inspector access was updated', async () => {

--- a/appeals/web/src/server/appeals/appeal-details/appellant-case/__tests__/__snapshots__/appellant-case.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/appellant-case/__tests__/__snapshots__/appellant-case.test.js.snap
@@ -149,7 +149,7 @@ exports[`appellant-case GET /appellant-case notification banners should render a
                         <div class="govuk-summary-list__row govuk-summary-list__row--no-actions"><dt class="govuk-summary-list__key"> Which local planning authority (LPA) do you want to appeal against?</dt>
                             <dd                             class="govuk-summary-list__value">Worthing Borough Council</dd>
                         </div>
-                        <div class="govuk-summary-list__row govuk-summary-list__row--no-actions"><dt class="govuk-summary-list__key"> What is the application reference number?</dt>
+                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> What is the application reference number?</dt>
                             <dd                             class="govuk-summary-list__value">48269/APP/2021/1482</dd>
                         </div>
                         <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> What date did you submit your application?</dt>
@@ -296,7 +296,7 @@ exports[`appellant-case GET /appellant-case notification banners should render a
                     <h3 class="govuk-notification-banner__title" id="govuk-notification-banner-title"> Success</h3>
                 </div>
                 <div class="govuk-notification-banner__content">
-                    <p class="govuk-notification-banner__heading">LPA application reference updated</p>
+                    <p class="govuk-notification-banner__heading">Appeal updated</p>
                 </div>
             </div>
         </div>
@@ -408,8 +408,11 @@ exports[`appellant-case GET /appellant-case notification banners should render a
                         <div class="govuk-summary-list__row govuk-summary-list__row--no-actions"><dt class="govuk-summary-list__key"> Which local planning authority (LPA) do you want to appeal against?</dt>
                             <dd                             class="govuk-summary-list__value">Worthing Borough Council</dd>
                         </div>
-                        <div class="govuk-summary-list__row govuk-summary-list__row--no-actions"><dt class="govuk-summary-list__key"> What is the application reference number?</dt>
+                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> What is the application reference number?</dt>
                             <dd                             class="govuk-summary-list__value">48269/APP/2021/1482</dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/lpa-reference/change"
+                                    data-cy="change-application-reference">Change<span class="govuk-visually-hidden"> What is the application reference number? (3. Application details)</span></a>
+                                </dd>
                         </div>
                         <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> What date did you submit your application?</dt>
                             <dd                             class="govuk-summary-list__value"></dd>
@@ -706,7 +709,7 @@ exports[`appellant-case GET /appellant-case notification banners should render a
                         <div class="govuk-summary-list__row govuk-summary-list__row--no-actions"><dt class="govuk-summary-list__key"> Which local planning authority (LPA) do you want to appeal against?</dt>
                             <dd                             class="govuk-summary-list__value">Worthing Borough Council</dd>
                         </div>
-                        <div class="govuk-summary-list__row govuk-summary-list__row--no-actions"><dt class="govuk-summary-list__key"> What is the application reference number?</dt>
+                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> What is the application reference number?</dt>
                             <dd                             class="govuk-summary-list__value">48269/APP/2021/1482</dd>
                         </div>
                         <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> What date did you submit your application?</dt>
@@ -978,7 +981,7 @@ exports[`appellant-case GET /appellant-case notification banners should render a
                         <div class="govuk-summary-list__row govuk-summary-list__row--no-actions"><dt class="govuk-summary-list__key"> Which local planning authority (LPA) do you want to appeal against?</dt>
                             <dd                             class="govuk-summary-list__value">Worthing Borough Council</dd>
                         </div>
-                        <div class="govuk-summary-list__row govuk-summary-list__row--no-actions"><dt class="govuk-summary-list__key"> What is the application reference number?</dt>
+                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> What is the application reference number?</dt>
                             <dd                             class="govuk-summary-list__value">48269/APP/2021/1482</dd>
                         </div>
                         <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> What date did you submit your application?</dt>
@@ -1321,7 +1324,7 @@ exports[`appellant-case GET /appellant-case should render review outcome form fi
                         <div class="govuk-summary-list__row govuk-summary-list__row--no-actions"><dt class="govuk-summary-list__key"> Which local planning authority (LPA) do you want to appeal against?</dt>
                             <dd                             class="govuk-summary-list__value">Worthing Borough Council</dd>
                         </div>
-                        <div class="govuk-summary-list__row govuk-summary-list__row--no-actions"><dt class="govuk-summary-list__key"> What is the application reference number?</dt>
+                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> What is the application reference number?</dt>
                             <dd                             class="govuk-summary-list__value">48269/APP/2021/1482</dd>
                         </div>
                         <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> What date did you submit your application?</dt>
@@ -1607,7 +1610,7 @@ exports[`appellant-case GET /appellant-case should render the appellant case pag
                         <div class="govuk-summary-list__row govuk-summary-list__row--no-actions"><dt class="govuk-summary-list__key"> Which local planning authority (LPA) do you want to appeal against?</dt>
                             <dd                             class="govuk-summary-list__value">Worthing Borough Council</dd>
                         </div>
-                        <div class="govuk-summary-list__row govuk-summary-list__row--no-actions"><dt class="govuk-summary-list__key"> What is the application reference number?</dt>
+                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> What is the application reference number?</dt>
                             <dd                             class="govuk-summary-list__value">48269/APP/2021/1482</dd>
                         </div>
                         <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> What date did you submit your application?</dt>
@@ -1906,7 +1909,7 @@ exports[`appellant-case GET /appellant-case should render the appellant case pag
                         <div class="govuk-summary-list__row govuk-summary-list__row--no-actions"><dt class="govuk-summary-list__key"> Which local planning authority (LPA) do you want to appeal against?</dt>
                             <dd                             class="govuk-summary-list__value">Worthing Borough Council</dd>
                         </div>
-                        <div class="govuk-summary-list__row govuk-summary-list__row--no-actions"><dt class="govuk-summary-list__key"> What is the application reference number?</dt>
+                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> What is the application reference number?</dt>
                             <dd                             class="govuk-summary-list__value">48269/APP/2021/1482</dd>
                         </div>
                         <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> What date did you submit your application?</dt>
@@ -4279,7 +4282,7 @@ exports[`appellant-case POST /appellant-case should re-render the appellant case
                         <div class="govuk-summary-list__row govuk-summary-list__row--no-actions"><dt class="govuk-summary-list__key"> Which local planning authority (LPA) do you want to appeal against?</dt>
                             <dd                             class="govuk-summary-list__value">Worthing Borough Council</dd>
                         </div>
-                        <div class="govuk-summary-list__row govuk-summary-list__row--no-actions"><dt class="govuk-summary-list__key"> What is the application reference number?</dt>
+                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> What is the application reference number?</dt>
                             <dd                             class="govuk-summary-list__value">48269/APP/2021/1482</dd>
                         </div>
                         <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> What date did you submit your application?</dt>

--- a/appeals/web/src/server/appeals/appeal-details/appellant-case/__tests__/appellant-case.test.js
+++ b/appeals/web/src/server/appeals/appeal-details/appellant-case/__tests__/appellant-case.test.js
@@ -229,9 +229,23 @@ describe('appellant-case', () => {
 		describe('notification banners', () => {
 			it('should render a "LPA application reference" success notification banner when the planning application reference is updated', async () => {
 				const appealId = appealData.appealId.toString();
+				nock.cleanAll();
+				nock('http://test/')
+					.get(`/appeals/${appealId}`)
+					.reply(200, {
+						...appealData,
+						lpaQuestionnaireId: undefined
+					})
+					.persist();
 				nock('http://test/').patch(`/appeals/${appealId}`).reply(200, {
 					planningApplicationReference: '12345/A/67890'
 				});
+				nock('http://test/')
+					.get('/appeals/1/appellant-cases/0')
+					.reply(200, appellantCaseDataNotValidated);
+				nock('http://test/')
+					.get('/appeals/document-redaction-statuses')
+					.reply(200, documentRedactionStatuses);
 
 				const validData = {
 					planningApplicationReference: '12345/A/67890'
@@ -250,7 +264,7 @@ describe('appellant-case', () => {
 					rootElement: '.govuk-notification-banner'
 				}).innerHTML;
 				expect(notificationBannerElementHTML).toContain('Success</h3>');
-				expect(notificationBannerElementHTML).toContain('LPA application reference updated</p>');
+				expect(notificationBannerElementHTML).toContain('Appeal updated</p>');
 			});
 
 			it('should render a "Application decision date updated" notification banner when the application decision date is updated', async () => {

--- a/appeals/web/src/server/appeals/appeal-details/appellant-case/page-components/has.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/appellant-case/page-components/has.mapper.js
@@ -99,9 +99,7 @@ export function generateHASComponents(
 				removeSummaryListActions(
 					mappedAppellantCaseData.localPlanningAuthority.display.summaryListItem
 				),
-				removeSummaryListActions(
-					mappedAppellantCaseData.applicationReference.display.summaryListItem
-				),
+				mappedAppellantCaseData.applicationReference.display.summaryListItem,
 				mappedAppellantCaseData.applicationDate.display.summaryListItem,
 				mappedAppellantCaseData.developmentDescription.display.summaryListItem,
 				mappedAppellantCaseData.applicationDecisionDate.display.summaryListItem,

--- a/appeals/web/src/server/appeals/appeal-details/appellant-case/page-components/s78.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/appellant-case/page-components/s78.mapper.js
@@ -98,9 +98,7 @@ export function generateS78Components(
 					removeSummaryListActions(
 						mappedAppellantCaseData.localPlanningAuthority.display.summaryListItem
 					),
-					removeSummaryListActions(
-						mappedAppellantCaseData.applicationReference.display.summaryListItem
-					),
+					mappedAppellantCaseData.applicationReference.display.summaryListItem,
 					mappedAppellantCaseData.applicationDate.display.summaryListItem,
 					mappedAppellantCaseData.developmentDescription.display.summaryListItem,
 					mappedAppellantCaseData.relatedAppeals.display.summaryListItem,

--- a/appeals/web/src/server/appeals/appeal-details/lpa-reference/__tests__/__snapshots__/change-lpa-reference.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-reference/__tests__/__snapshots__/change-lpa-reference.test.js.snap
@@ -4,7 +4,7 @@ exports[`change-lpa-reference GET /change should render changeLpaReference page 
 "<main class="govuk-main-wrapper" id="main-content">
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Appeal 351062</span>
-            <h1 class="govuk-heading-l">Change the LPA application reference</h1>
+            <h1 class="govuk-heading-l">What is the application reference number?</h1>
         </div>
     </div>
     <div class="govuk-grid-row">
@@ -13,9 +13,8 @@ exports[`change-lpa-reference GET /change should render changeLpaReference page 
                 <div class="govuk-grid-column-full">
                     <form method="POST" novalidate="novalidate">
                         <div class="govuk-form-group">
-                            <label class="govuk-label" for="planning-application-reference">LPA application reference</label>
-                            <input class="govuk-input" id="planning-application-reference"
-                            name="planningApplicationReference" type="text" value="48269/APP/2021/1482">
+                            <input class="govuk-input" id="planning-application-reference" name="planningApplicationReference"
+                            type="text" value="48269/APP/2021/1482">
                         </div>
                         <button type="submit" data-prevent-double-click="true" class="govuk-button"
                         data-module="govuk-button">Continue</button>
@@ -31,7 +30,7 @@ exports[`change-lpa-reference GET /change should render changeLpaReference page 
 "<main class="govuk-main-wrapper" id="main-content">
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Appeal 351062</span>
-            <h1 class="govuk-heading-l">Change the LPA application reference</h1>
+            <h1 class="govuk-heading-l">What is the application reference number?</h1>
         </div>
     </div>
     <div class="govuk-grid-row">
@@ -40,9 +39,8 @@ exports[`change-lpa-reference GET /change should render changeLpaReference page 
                 <div class="govuk-grid-column-full">
                     <form method="POST" novalidate="novalidate">
                         <div class="govuk-form-group">
-                            <label class="govuk-label" for="planning-application-reference">LPA application reference</label>
-                            <input class="govuk-input" id="planning-application-reference"
-                            name="planningApplicationReference" type="text" value="48269/APP/2021/1482">
+                            <input class="govuk-input" id="planning-application-reference" name="planningApplicationReference"
+                            type="text" value="48269/APP/2021/1482">
                         </div>
                         <button type="submit" data-prevent-double-click="true" class="govuk-button"
                         data-module="govuk-button">Continue</button>
@@ -63,7 +61,7 @@ exports[`change-lpa-reference POST /change should re-render changeLpaReference p
                     <h2 class="govuk-error-summary__title"> There is a problem</h2>
                     <div class="govuk-error-summary__body">
                         <ul class="govuk-list govuk-error-summary__list">
-                            <li><a href="#planning-application-reference">Enter the LPA application reference</a>
+                            <li><a href="#planning-application-reference">Enter the application reference number</a>
                             </li>
                         </ul>
                     </div>
@@ -73,7 +71,7 @@ exports[`change-lpa-reference POST /change should re-render changeLpaReference p
     </div>
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Appeal 351062</span>
-            <h1 class="govuk-heading-l">Change the LPA application reference</h1>
+            <h1 class="govuk-heading-l">What is the application reference number?</h1>
         </div>
     </div>
     <div class="govuk-grid-row">
@@ -82,12 +80,55 @@ exports[`change-lpa-reference POST /change should re-render changeLpaReference p
                 <div class="govuk-grid-column-full">
                     <form method="POST" novalidate="novalidate">
                         <div class="govuk-form-group govuk-form-group--error">
-                            <label class="govuk-label" for="planning-application-reference">LPA application reference</label>
-                            <p id="planning-application-reference-error"
-                            class="govuk-error-message"><span class="govuk-visually-hidden">Error:</span> Enter the LPA application
-                                reference</p>
+                            <p id="planning-application-reference-error" class="govuk-error-message"><span class="govuk-visually-hidden">Error:</span> Enter the application
+                                reference number</p>
                             <input class="govuk-input govuk-input--error" id="planning-application-reference"
                             name="planningApplicationReference" type="text" value="" aria-describedby="planning-application-reference-error">
+                        </div>
+                        <button type="submit" data-prevent-double-click="true" class="govuk-button"
+                        data-module="govuk-button">Continue</button>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </div>
+</main>"
+`;
+
+exports[`change-lpa-reference POST /change should re-render changeLpaReference page with an error when planningApplicationReference is over 100 characters 1`] = `
+"<main class="govuk-main-wrapper" id="main-content">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <div class="govuk-error-summary" data-module="govuk-error-summary">
+                <div role="alert">
+                    <h2 class="govuk-error-summary__title"> There is a problem</h2>
+                    <div class="govuk-error-summary__body">
+                        <ul class="govuk-list govuk-error-summary__list">
+                            <li><a href="#planning-application-reference">Application reference number must be 100 characters or less</a>
+                            </li>
+                        </ul>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Appeal 351062</span>
+            <h1 class="govuk-heading-l">What is the application reference number?</h1>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <div class="govuk-grid-row">
+                <div class="govuk-grid-column-full">
+                    <form method="POST" novalidate="novalidate">
+                        <div class="govuk-form-group govuk-form-group--error">
+                            <p id="planning-application-reference-error" class="govuk-error-message"><span class="govuk-visually-hidden">Error:</span> Application reference
+                                number must be 100 characters or less</p>
+                            <input class="govuk-input govuk-input--error"
+                            id="planning-application-reference" name="planningApplicationReference"
+                            type="text" value="12345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901"
+                            aria-describedby="planning-application-reference-error">
                         </div>
                         <button type="submit" data-prevent-double-click="true" class="govuk-button"
                         data-module="govuk-button">Continue</button>

--- a/appeals/web/src/server/appeals/appeal-details/lpa-reference/lpa-reference.controller.js
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-reference/lpa-reference.controller.js
@@ -77,7 +77,7 @@ export const postChangeLpaReference = async (request, response) => {
 			session: request.session,
 			bannerDefinitionKey: 'changePage',
 			appealId,
-			text: `LPA application reference updated`
+			text: `Appeal updated`
 		});
 
 		delete request.session.planningApplicationReference;

--- a/appeals/web/src/server/appeals/appeal-details/lpa-reference/lpa-reference.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-reference/lpa-reference.mapper.js
@@ -22,10 +22,10 @@ export const changeLpaReferencePage = (
 
 	/** @type {PageContent} */
 	const pageContent = {
-		title: 'Change the LPA application reference',
+		title: 'What is the application reference number?',
 		backLinkUrl: origin,
 		preHeading: `Appeal ${shortAppealReference}`,
-		heading: 'Change the LPA application reference',
+		heading: 'What is the application reference number?',
 		pageComponents: [
 			{
 				type: 'input',
@@ -33,9 +33,6 @@ export const changeLpaReferencePage = (
 					id: 'planning-application-reference',
 					name: 'planningApplicationReference',
 					type: 'text',
-					label: {
-						text: 'LPA application reference'
-					},
 					value: storedPlanningApplicationReference ?? appealData.planningApplicationReference,
 					errorMessage: errorPlanningApplicationReference(errors)
 				}

--- a/appeals/web/src/server/appeals/appeal-details/lpa-reference/lpa-reference.middleware.js
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-reference/lpa-reference.middleware.js
@@ -1,0 +1,17 @@
+import { APPEAL_CASE_STATUS } from 'pins-data-model';
+import { permissionNames } from '#environment/permissions.js';
+import { userHasPermission } from '#lib/mappers/index.js';
+/**
+ * @type {import("express").RequestHandler}
+ * @returns {Promise<object|void>}§
+ */
+export const ensureBeforeLpaq = async (req, res, next) => {
+	if (
+		!userHasPermission(permissionNames.updateCase, req.session) ||
+		req.currentAppeal.lpaQuestionnaireId ||
+		req.currentAppeal.appealStatus === APPEAL_CASE_STATUS.LPA_QUESTIONNAIRE
+	) {
+		return res.status(403).render('app/403.njk');
+	}
+	next();
+};

--- a/appeals/web/src/server/appeals/appeal-details/lpa-reference/lpa-reference.router.js
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-reference/lpa-reference.router.js
@@ -2,12 +2,16 @@ import { Router as createRouter } from 'express';
 import * as controllers from './lpa-reference.controller.js';
 import { asyncHandler } from '@pins/express';
 import * as validators from './lpa-reference.validators.js';
-
+import { ensureBeforeLpaq } from './lpa-reference.middleware.js';
 const router = createRouter({ mergeParams: true });
 
 router
 	.route('/change')
-	.get(asyncHandler(controllers.getChangeLpaReference))
-	.post(validators.validateChangeLpaReference, asyncHandler(controllers.postChangeLpaReference));
+	.get(ensureBeforeLpaq, asyncHandler(controllers.getChangeLpaReference))
+	.post(
+		ensureBeforeLpaq,
+		validators.validateChangeLpaReference,
+		asyncHandler(controllers.postChangeLpaReference)
+	);
 
 export default router;

--- a/appeals/web/src/server/appeals/appeal-details/lpa-reference/lpa-reference.validators.js
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-reference/lpa-reference.validators.js
@@ -5,5 +5,7 @@ export const validateChangeLpaReference = createValidator(
 	body('planningApplicationReference')
 		.trim()
 		.notEmpty()
-		.withMessage('Enter the LPA application reference')
+		.withMessage('Enter the application reference number')
+		.isLength({ max: 100 })
+		.withMessage('Application reference number must be 100 characters or less')
 );

--- a/appeals/web/src/server/lib/error-handlers/change-screen-error-handlers.js
+++ b/appeals/web/src/server/lib/error-handlers/change-screen-error-handlers.js
@@ -74,7 +74,7 @@ export const errorPhoneNumberAllowEmpty = (/** @type {Error}*/ errors) => {
 export const errorPlanningApplicationReference = (/** @type {Error}*/ errors) => {
 	return errors?.planningApplicationReference
 		? {
-				text: 'Enter the LPA application reference'
+				text: errors.planningApplicationReference.msg
 		  }
 		: undefined;
 };

--- a/appeals/web/src/server/lib/mappers/data/appellant-case/submappers/application-reference.js
+++ b/appeals/web/src/server/lib/mappers/data/appellant-case/submappers/application-reference.js
@@ -1,11 +1,23 @@
 import { textSummaryListItem } from '#lib/mappers/components/index.js';
+import { APPEAL_CASE_STATUS } from 'pins-data-model';
 
 /** @type {import('../mapper.js').SubMapper} */
-export const mapApplicationReference = ({ appellantCaseData, currentRoute, userHasUpdateCase }) =>
-	textSummaryListItem({
+export const mapApplicationReference = ({
+	appealDetails,
+	appellantCaseData,
+	currentRoute,
+	userHasUpdateCase
+}) => {
+	const editable =
+		userHasUpdateCase &&
+		!appealDetails.lpaQuestionnaireId &&
+		appealDetails.appealStatus !== APPEAL_CASE_STATUS.LPA_QUESTIONNAIRE;
+
+	return textSummaryListItem({
 		id: 'application-reference',
 		text: 'What is the application reference number?',
 		value: appellantCaseData.planningApplicationReference,
 		link: `${currentRoute}/lpa-reference/change`,
-		editable: userHasUpdateCase
+		editable
 	});
+};

--- a/packages/appeals/constants/support.js
+++ b/packages/appeals/constants/support.js
@@ -79,6 +79,7 @@ export const AUDIT_TRAIL_APPEAL_LINK_ADDED = 'A linked appeal was added';
 export const AUDIT_TRAIL_APPEAL_LINK_REMOVED = 'A linked appeal was removed';
 export const AUDIT_TRAIL_APPEAL_RELATION_ADDED = 'A related appeal was added';
 export const AUDIT_TRAIL_APPEAL_RELATION_REMOVED = 'A related appeal was removed';
+export const AUDIT_TRAIL_APPLICATION_REFERENCE_UPDATED = 'Planning application reference updated';
 export const AUDIT_TRAIL_NEIGHBOURING_ADDRESS_ADDED = 'A neighbouring address was added';
 export const AUDIT_TRAIL_NEIGHBOURING_ADDRESS_UPDATED = 'A neighbouring address was updated';
 export const AUDIT_TRAIL_NEIGHBOURING_ADDRESS_REMOVED = 'A neighbouring address was removed';


### PR DESCRIPTION
The page already existed so I reinstated the link and added some validation.

It now looks in support.js to see if there is a more specific message for the audit trail - this may also affect the audit trail message for other property updates.

## Describe your changes

The page to change LPA reference number already existed, so I reinstated the change link, added some validation, and changed the wording as per the ticket.

The reference can only be changed up to the point where the LPAQ has been sent to the LPA, so it checks that an LPAQ does not yet exist and that the appeal status is not `LPA_QUESTIONNAIRE`.

It now looks in support.js to see if there is a more specific message for the audit trail - this may also affect the audit trail message for other property updates if they already have a custom audit message defined in that file.

## Issue ticket number and link
[A2-2606](https://pins-ds.atlassian.net.mcas.ms/browse/A2-2606?McasTsid=20596&McasCtx=4)


[A2-2606]: https://pins-ds.atlassian.net/browse/A2-2606?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ