### PR TITLE
A2-2979(fix): updating show more logic to highlight text

### DIFF
--- a/appeals/web/src/client/components/show-more/show-more.js
+++ b/appeals/web/src/client/components/show-more/show-more.js
@@ -224,8 +224,8 @@ const initialiseOptions = (/** @type {ShowMoreComponentInstance} */ componentIns
 const shouldInitialiseComponentInstance = (
 	/** @type {ShowMoreComponentInstance} */ componentInstance
 ) => {
-	if (isHtmlMode(componentInstance)) {
-		const rowSelector = componentInstance.elements.root.getAttribute(ATTRIBUTES.contentRowSelector);
+	const rowSelector = componentInstance.elements.root.getAttribute(ATTRIBUTES.contentRowSelector);
+	if (rowSelector != null && isHtmlMode(componentInstance)) {
 		const rows = componentInstance.elements.root.querySelectorAll(rowSelector);
 
 		if (rows.length <= componentInstance.options.maximumRowsBeforeHiding) {

--- a/appeals/web/src/styles/7-components/show-more.scss
+++ b/appeals/web/src/styles/7-components/show-more.scss
@@ -13,10 +13,8 @@
 		text-decoration: underline;
 	}
 
-	&__content {
-		mark {
-			background-color: #f4cdc6
-		}
+	mark {
+		background-color: #f4cdc6
 	}
 }
 


### PR DESCRIPTION
Fixing issue where show-more component was not initialised when it was needed. 
- Updated logic so that if rowSelector is null (i.e. contentRowSelector has not been specified) which means we have not said what should be used to define individual rows, we now check the number of characters as we do for text mode
- Updated the css for the show-more component so that highlight applies even when the component is not fully initialised
## Describe your changes

<!--
    Please include a summary of the change along with any relevant context.
    List any dependencies that are required for this change.
-->

## Issue ticket number and link
[Ticket](https://pins-ds.atlassian.net.mcas.ms/browse/A2-2979)
