### PR TITLE
feat(appeals): improve notify emulator formatting

### DIFF
--- a/appeals/api/src/server/notify/__tests__/emulate-notify.test.js
+++ b/appeals/api/src/server/notify/__tests__/emulate-notify.test.js
@@ -50,7 +50,7 @@ describe('emulate-notify.test', () => {
 			'Appeal reference number: 6000437<br>',
 			'Address: 72 Clapham High St, Wandsworth, SW4 7UL<br>',
 			'Planning application reference: 35606/APP/1/549765<br>',
-			'</div>',
+			'</div><br>',
 			'<h2>Why we rejected your comment</h2>',
 			'We rejected your comment because:<br>',
 			'<br>',

--- a/appeals/api/src/server/notify/emulate-notify.js
+++ b/appeals/api/src/server/notify/emulate-notify.js
@@ -42,7 +42,7 @@ export function emulateSendEmail(templateName, recipientEmail, subject, content)
 		}
 		if (blockEnd && blockEnd <= index) {
 			blockEnd = 0;
-			return line ? `</div>\n${line}<br>` : '</div>';
+			return line ? `</div>\n${line}<br>` : '</div><br>';
 		}
 		return line ? `${line}<br>` : '<br>';
 	});


### PR DESCRIPTION
## Describe your changes

Add an additional line break to make sure there is a gap between the inset appeal details and the rest of the email when emulating notify while developing.
