### PR TITLE
feat(web): global back link fixes - flow entry points

### DIFF
--- a/appeals/web/package.json
+++ b/appeals/web/package.json
@@ -20,6 +20,7 @@
     "sass": "node ./scripts/rollup/compile-css.js",
     "start": "node ./src/server/server.js",
     "test": "cross-env NODE_ENV=test NODE_OPTIONS=\"--experimental-vm-modules --expose-gc\" npx jest --logHeapUsage --ci",
+		"test:local": "cross-env NODE_ENV=test NODE_OPTIONS=\"--experimental-vm-modules --expose-gc\" npx jest -u --logHeapUsage --ci",
     "test:watch": "npm run test -- --watch",
     "test:cov": "cross-env NODE_ENV=test NODE_OPTIONS=\"--experimental-vm-modules --expose-gc\" npx jest --logHeapUsage --ci --coverage --forceExit",
     "tscheck": "npx tsc -p jsconfig.json --maxNodeModuleJsDepth 0",

--- a/appeals/web/src/server/appeals/appeal-details/__tests__/__snapshots__/appeal-details.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/__tests__/__snapshots__/appeal-details.test.js.snap
@@ -7,7 +7,8 @@ data-index="0">
     <div class="govuk-notification-banner__header">
         <h3 class="govuk-notification-banner__title" id="govuk-notification-banner-title"> Important</h3>
     </div>
-    <div class="govuk-notification-banner__content"><a href="/appeals-service/appeal-details/1/share" class="govuk-heading-s govuk-notification-banner__link">Progress case</a>
+    <div class="govuk-notification-banner__content"><a href="/appeals-service/appeal-details/1/share?backUrl=%2Fappeals-service%2Fappeal-details%2F1"
+        class="govuk-heading-s govuk-notification-banner__link">Progress case</a>
     </div>
 </div>"
 `;
@@ -19,7 +20,8 @@ data-index="0">
     <div class="govuk-notification-banner__header">
         <h3 class="govuk-notification-banner__title" id="govuk-notification-banner-title"> Important</h3>
     </div>
-    <div class="govuk-notification-banner__content"><a href="/appeals-service/appeal-details/1/share" class="govuk-heading-s govuk-notification-banner__link">Share final comments</a>
+    <div class="govuk-notification-banner__content"><a href="/appeals-service/appeal-details/1/share?backUrl=%2Fappeals-service%2Fappeal-details%2F1"
+        class="govuk-heading-s govuk-notification-banner__link">Share final comments</a>
     </div>
 </div>"
 `;
@@ -31,7 +33,8 @@ data-index="0">
     <div class="govuk-notification-banner__header">
         <h3 class="govuk-notification-banner__title" id="govuk-notification-banner-title"> Important</h3>
     </div>
-    <div class="govuk-notification-banner__content"><a href="/appeals-service/appeal-details/1/share" class="govuk-heading-s govuk-notification-banner__link">Share final comments</a>
+    <div class="govuk-notification-banner__content"><a href="/appeals-service/appeal-details/1/share?backUrl=%2Fappeals-service%2Fappeal-details%2F1"
+        class="govuk-heading-s govuk-notification-banner__link">Share final comments</a>
     </div>
 </div>"
 `;
@@ -43,7 +46,8 @@ data-index="0">
     <div class="govuk-notification-banner__header">
         <h3 class="govuk-notification-banner__title" id="govuk-notification-banner-title"> Important</h3>
     </div>
-    <div class="govuk-notification-banner__content"><a href="/appeals-service/appeal-details/1/share" class="govuk-heading-s govuk-notification-banner__link">Share final comments</a>
+    <div class="govuk-notification-banner__content"><a href="/appeals-service/appeal-details/1/share?backUrl=%2Fappeals-service%2Fappeal-details%2F1"
+        class="govuk-heading-s govuk-notification-banner__link">Share final comments</a>
     </div>
 </div>"
 `;
@@ -52,13 +56,13 @@ exports[`appeal-details GET /:appealId Appeal decision should render a row in th
 
 exports[`appeal-details GET /:appealId Appeal decision should render a row in the case documentation accordion with "Awaiting decision" in the Status column, if a decision has not yet been issued 1`] = `"<td class="govuk-table__cell appeal-decision-status">Awaiting decision</td>"`;
 
-exports[`appeal-details GET /:appealId Appeal decision should render a row in the case documentation accordion with "Issue" link to the issue decision start page in the Actions column, if the appeal status is "issue_determination" 1`] = `"<td class="govuk-table__cell govuk-!-text-align-right appeal-decision-actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/issue-decision/decision">Issue<span class="govuk-visually-hidden"> decision</span></a></td>"`;
+exports[`appeal-details GET /:appealId Appeal decision should render a row in the case documentation accordion with "Issue" link to the issue decision start page in the Actions column, if the appeal status is "issue_determination" 1`] = `"<td class="govuk-table__cell govuk-!-text-align-right appeal-decision-actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/issue-decision/decision?backUrl=%2Fappeals-service%2Fappeal-details%2F2">Issue<span class="govuk-visually-hidden"> decision</span></a></td>"`;
 
 exports[`appeal-details GET /:appealId Appeal decision should render a row in the case documentation accordion with "Not applicable" in the Due date column 1`] = `"<td class="govuk-table__cell appeal-decision-due-date">Not applicable</td>"`;
 
 exports[`appeal-details GET /:appealId Appeal decision should render a row in the case documentation accordion with "Sent" in the Status column, if a decision has been issued 1`] = `"<td class="govuk-table__cell appeal-decision-status">Issued</td>"`;
 
-exports[`appeal-details GET /:appealId Appeal decision should render a row in the case documentation accordion with "View" download link to the decision document in the Actions column, if the appeal status is "complete" and the document virus scan is complete and the scan result indicates the document is safe 1`] = `"<td class="govuk-table__cell govuk-!-text-align-right appeal-decision-actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/issue-decision/decision">View<span class="govuk-visually-hidden"> decision</span></a></td>"`;
+exports[`appeal-details GET /:appealId Appeal decision should render a row in the case documentation accordion with "View" download link to the decision document in the Actions column, if the appeal status is "complete" and the document virus scan is complete and the scan result indicates the document is safe 1`] = `"<td class="govuk-table__cell govuk-!-text-align-right appeal-decision-actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/issue-decision/decision?backUrl=%2Fappeals-service%2Fappeal-details%2F2">View<span class="govuk-visually-hidden"> decision</span></a></td>"`;
 
 exports[`appeal-details GET /:appealId Appeal decision should render a row in the case documentation accordion with no link in the Actions column, if the appeal status is anything other than "issue_determination", "complete" or "invalid" 1`] = `"<td class="govuk-table__cell govuk-!-text-align-right appeal-decision-actions"></td>"`;
 
@@ -108,7 +112,7 @@ exports[`appeal-details GET /:appealId Appeal decision should render a row in th
 
 exports[`appeal-details GET /:appealId Appeal decision should render a row in the case overview accordion with no action link, if the appeal status is anything other than "issue_determination" (witnesses) 1`] = `"<div class="govuk-summary-list__row appeal-decision"><dt class="govuk-summary-list__key"> Decision</dt><dd class="govuk-summary-list__value"> Not yet issued</dd></div>"`;
 
-exports[`appeal-details GET /:appealId Appeal decision should render a row in the case overview accordion with with "Issue" action link to the issue decision start page, if the appeal status is "issue_determination" 1`] = `"<div class="govuk-summary-list__row appeal-decision"><dt class="govuk-summary-list__key"> Decision</dt><dd class="govuk-summary-list__value"> Not yet issued</dd><dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/issue-decision/decision" data-cy="issue-decision">Issue<span class="govuk-visually-hidden"> Decision</span></a></dd></div>"`;
+exports[`appeal-details GET /:appealId Appeal decision should render a row in the case overview accordion with with "Issue" action link to the issue decision start page, if the appeal status is "issue_determination" 1`] = `"<div class="govuk-summary-list__row appeal-decision"><dt class="govuk-summary-list__key"> Decision</dt><dd class="govuk-summary-list__value"> Not yet issued</dd><dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/issue-decision/decision?backUrl=%2Fappeals-service%2Fappeal-details%2F2" data-cy="issue-decision">Issue<span class="govuk-visually-hidden"> Decision</span></a></dd></div>"`;
 
 exports[`appeal-details GET /:appealId Case notes should render the case note details 1`] = `"<details class="govuk-details"><summary class="govuk-details__summary"><span class="govuk-details__summary-text"> 2 case notes</span></summary><div class="govuk-details__text"><form method="POST" novalidate="novalidate"><div class="govuk-grid-row"><div class="govuk-grid-column-two-thirds"><div class="govuk-form-group govuk-character-count" data-module="govuk-character-count" data-maxlength="300"><textarea class="govuk-textarea govuk-js-character-count" id="comment" name="comment" rows="5" aria-describedby="comment-info"></textarea><div id="comment-info" class="govuk-hint govuk-character-count__message"> You can enter up to 300 characters</div></div></div></div><button type="submit" data-prevent-double-click="true" class="govuk-button govuk-button--secondary govuk-!-margin-bottom-1" data-module="govuk-button"> Add case note</button></form><div><hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible"><section><p class="govuk-body govuk-!-margin-bottom-1"> A case note you should see.</p><p class="govuk-hint govuk-!-margin-bottom-6"> 11:00am on Tuesday 1 October 2024 by John.Smith</p><hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible"></section><section><p class="govuk-body govuk-!-margin-bottom-1"> A case note you should see.</p><p class="govuk-hint govuk-!-margin-bottom-6"> 11:00am on Tuesday 1 October 2024 by John.Smith</p><hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible"></section></div></div></details>"`;
 
@@ -140,7 +144,7 @@ data-index="0">
     </div>
     <div class="govuk-notification-banner__content">
         <p class="govuk-notification-banner__heading">Appeal ready for validation</p>
-        <p><a class="govuk-notification-banner__link" data-cy="validate-appeal" href="/appeals-service/appeal-details/2/appellant-case">Validate <span class="govuk-visually-hidden">appeal</span></a>
+        <p><a class="govuk-notification-banner__link" data-cy="validate-appeal" href="/appeals-service/appeal-details/2/appellant-case?backUrl=%2Fappeals-service%2Fappeal-details%2F2">Validate <span class="govuk-visually-hidden">appeal</span></a>
         </p>
     </div>
 </div>"
@@ -155,7 +159,7 @@ data-index="0">
     </div>
     <div class="govuk-notification-banner__content">
         <p class="govuk-notification-banner__heading">Appeal ready to be assigned to case officer</p>
-        <p><a class="govuk-notification-banner__link" href="/appeals-service/appeal-details/2/assign-user/case-officer"
+        <p><a class="govuk-notification-banner__link" href="/appeals-service/appeal-details/2/assign-user/case-officer?backUrl=%2Fappeals-service%2Fappeal-details%2F2"
             data-cy="banner-assign-case-officer">Assign case officer</a>
         </p>
     </div>
@@ -194,7 +198,7 @@ data-index="0">
     <div class="govuk-notification-banner__content">
         <p class="govuk-notification-banner__heading">LPA questionnaire ready for review</p>
         <p><a class="govuk-notification-banner__link" data-cy="review-lpa-questionnaire-banner"
-            href="/appeals-service/appeal-details/2/lpa-questionnaire/123">Review <span class="govuk-visually-hidden">LPA questionnaire</span></a>
+            href="/appeals-service/appeal-details/2/lpa-questionnaire/123?backUrl=%2Fappeals-service%2Fappeal-details%2F2">Review <span class="govuk-visually-hidden">LPA questionnaire</span></a>
         </p>
     </div>
 </div>"
@@ -249,7 +253,7 @@ data-index="0">
     <div class="govuk-notification-banner__content">
         <p class="govuk-notification-banner__heading">Site visit ready to set up</p>
         <p><a class="govuk-notification-banner__link" data-cy="set-up-site-visit-banner"
-            href="/appeals-service/appeal-details/2/site-visit/schedule-visit">Set up site visit</a>
+            href="/appeals-service/appeal-details/2/site-visit/schedule-visit?backUrl=%2Fappeals-service%2Fappeal-details%2F2">Set up site visit</a>
         </p>
     </div>
 </div>"
@@ -265,7 +269,7 @@ data-index="0">
     <div class="govuk-notification-banner__content">
         <p class="govuk-notification-banner__heading">This appeal is awaiting transfer</p>
         <p class="govuk-body">The appeal must be transferred to Horizon. When this is done, <a class="govuk-link"
-            data-cy="awaiting-transfer" href="/appeals-service/appeal-details/2/change-appeal-type/add-horizon-reference">update the appeal with the new horizon reference</a>.</p>
+            data-cy="awaiting-transfer" href="/appeals-service/appeal-details/2/change-appeal-type/add-horizon-reference?backUrl=%2Fappeals-service%2Fappeal-details%2F2">update the appeal with the new horizon reference</a>.</p>
     </div>
 </div>"
 `;
@@ -526,7 +530,7 @@ data-index="0">
     </div>
     <div class="govuk-notification-banner__content">
         <p class="govuk-notification-banner__heading">Interested party comments awaiting review</p>
-        <p><a class="govuk-notification-banner__link" href="/appeals-service/appeal-details/2/interested-party-comments"
+        <p><a class="govuk-notification-banner__link" href="/appeals-service/appeal-details/2/interested-party-comments?backUrl=%2Fappeals-service%2Fappeal-details%2F2"
             data-cy="banner-review-ip-comments">Review <span class="govuk-visually-hidden">interested party comments</span></a>
         </p>
     </div>
@@ -780,7 +784,7 @@ exports[`appeal-details GET /:appealId should not render action links to the man
                             <dl class="govuk-summary-list">
                                 <div class="govuk-summary-list__row appeal-visit-type"><dt class="govuk-summary-list__key"> Visit type</dt>
                                     <dd class="govuk-summary-list__value">Accompanied</dd>
-                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/visit-booked"
+                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/visit-booked?backUrl=%2Fappeals-service%2Fappeal-details%2F1"
                                         data-cy="change-set-visit-type">Change<span class="govuk-visually-hidden"> Visit type</span></a>
                                     </dd>
                                 </div>
@@ -853,7 +857,7 @@ exports[`appeal-details GET /:appealId should not render action links to the man
                                             <li>9:38am - 10:00am</li>
                                         </ul>
                                     </dd>
-                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/manage-visit"
+                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/manage-visit?backUrl=%2Fappeals-service%2Fappeal-details%2F1"
                                         data-cy="change-schedule-visit">Change<span class="govuk-visually-hidden"> Site visit</span></a>
                                     </dd>
                                 </div>
@@ -879,8 +883,8 @@ exports[`appeal-details GET /:appealId should not render action links to the man
                                         <th scope="row" class="govuk-table__header">Appeal</th>
                                         <td class="govuk-table__cell">Ready to review</td>
                                         <td class="govuk-table__cell">2 August 2024</td>
-                                        <td class="govuk-table__cell govuk-!-text-align-right"><a href="/appeals-service/appeal-details/1/appellant-case" data-cy="review-appellant-case"
-                                            class="govuk-link">Review<span class="govuk-visually-hidden"> appellant case</span></a>
+                                        <td class="govuk-table__cell govuk-!-text-align-right"><a href="/appeals-service/appeal-details/1/appellant-case?backUrl=%2Fappeals-service%2Fappeal-details%2F1"
+                                            data-cy="review-appellant-case" class="govuk-link">Review<span class="govuk-visually-hidden"> appellant case</span></a>
                                         </td>
                                     </tr>
                                     <tr class="govuk-table__row">
@@ -1054,7 +1058,7 @@ data-index="0">
     </div>
     <div class="govuk-notification-banner__content">
         <p class="govuk-notification-banner__heading">Appeal valid</p>
-        <p><a class="govuk-notification-banner__link" data-cy="ready-to-start" href="/appeals-service/appeal-details/2/start-case/add?backUrl=/appeals-service/appeal-details/2">Start case</a>
+        <p><a class="govuk-notification-banner__link" data-cy="ready-to-start" href="/appeals-service/appeal-details/2/start-case/add?backUrl=%2Fappeals-service%2Fappeal-details%2F2">Start case</a>
         </p>
     </div>
 </div>"
@@ -1191,7 +1195,7 @@ exports[`appeal-details GET /:appealId should render a Decision inset panel when
                         <dl class="govuk-summary-list">
                             <div class="govuk-summary-list__row appeal-visit-type"><dt class="govuk-summary-list__key"> Visit type</dt>
                                 <dd class="govuk-summary-list__value">Accompanied</dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/site-visit/visit-booked"
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/site-visit/visit-booked?backUrl=%2Fappeals-service%2Fappeal-details%2F2"
                                     data-cy="change-set-visit-type">Change<span class="govuk-visually-hidden"> Visit type</span></a>
                                 </dd>
                             </div>
@@ -1264,7 +1268,7 @@ exports[`appeal-details GET /:appealId should render a Decision inset panel when
                                         <li>9:38am - 10:00am</li>
                                     </ul>
                                 </dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/site-visit/manage-visit"
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/site-visit/manage-visit?backUrl=%2Fappeals-service%2Fappeal-details%2F2"
                                     data-cy="change-schedule-visit">Change<span class="govuk-visually-hidden"> Site visit</span></a>
                                 </dd>
                             </div>
@@ -1290,8 +1294,8 @@ exports[`appeal-details GET /:appealId should render a Decision inset panel when
                                     <th scope="row" class="govuk-table__header">Appeal</th>
                                     <td class="govuk-table__cell">Ready to review</td>
                                     <td class="govuk-table__cell">2 August 2024</td>
-                                    <td class="govuk-table__cell govuk-!-text-align-right"><a href="/appeals-service/appeal-details/2/appellant-case" data-cy="review-appellant-case"
-                                        class="govuk-link">Review<span class="govuk-visually-hidden"> appellant case</span></a>
+                                    <td class="govuk-table__cell govuk-!-text-align-right"><a href="/appeals-service/appeal-details/2/appellant-case?backUrl=%2Fappeals-service%2Fappeal-details%2F2"
+                                        data-cy="review-appellant-case" class="govuk-link">Review<span class="govuk-visually-hidden"> appellant case</span></a>
                                     </td>
                                 </tr>
                                 <tr class="govuk-table__row">
@@ -1304,7 +1308,7 @@ exports[`appeal-details GET /:appealId should render a Decision inset panel when
                                     <th scope="row" class="govuk-table__header appeal-decision-documentation">Decision</th>
                                     <td class="govuk-table__cell appeal-decision-status">Issued</td>
                                     <td class="govuk-table__cell appeal-decision-due-date">25 December 2023</td>
-                                    <td class="govuk-table__cell govuk-!-text-align-right appeal-decision-actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/issue-decision/decision">View<span class="govuk-visually-hidden"> decision</span></a>
+                                    <td class="govuk-table__cell govuk-!-text-align-right appeal-decision-actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/issue-decision/decision?backUrl=%2Fappeals-service%2Fappeal-details%2F2">View<span class="govuk-visually-hidden"> decision</span></a>
                                     </td>
                                 </tr>
                             </tbody>
@@ -1593,7 +1597,7 @@ exports[`appeal-details GET /:appealId should render a child tag next to the app
                             <dl class="govuk-summary-list">
                                 <div class="govuk-summary-list__row appeal-visit-type"><dt class="govuk-summary-list__key"> Visit type</dt>
                                     <dd class="govuk-summary-list__value">Accompanied</dd>
-                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/visit-booked"
+                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/visit-booked?backUrl=%2Fappeals-service%2Fappeal-details%2F1"
                                         data-cy="change-set-visit-type">Change<span class="govuk-visually-hidden"> Visit type</span></a>
                                     </dd>
                                 </div>
@@ -1666,7 +1670,7 @@ exports[`appeal-details GET /:appealId should render a child tag next to the app
                                             <li>9:38am - 10:00am</li>
                                         </ul>
                                     </dd>
-                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/manage-visit"
+                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/manage-visit?backUrl=%2Fappeals-service%2Fappeal-details%2F1"
                                         data-cy="change-schedule-visit">Change<span class="govuk-visually-hidden"> Site visit</span></a>
                                     </dd>
                                 </div>
@@ -1692,8 +1696,8 @@ exports[`appeal-details GET /:appealId should render a child tag next to the app
                                         <th scope="row" class="govuk-table__header">Appeal</th>
                                         <td class="govuk-table__cell">Ready to review</td>
                                         <td class="govuk-table__cell">2 August 2024</td>
-                                        <td class="govuk-table__cell govuk-!-text-align-right"><a href="/appeals-service/appeal-details/1/appellant-case" data-cy="review-appellant-case"
-                                            class="govuk-link">Review<span class="govuk-visually-hidden"> appellant case</span></a>
+                                        <td class="govuk-table__cell govuk-!-text-align-right"><a href="/appeals-service/appeal-details/1/appellant-case?backUrl=%2Fappeals-service%2Fappeal-details%2F1"
+                                            data-cy="review-appellant-case" class="govuk-link">Review<span class="govuk-visually-hidden"> appellant case</span></a>
                                         </td>
                                     </tr>
                                     <tr class="govuk-table__row">
@@ -1997,7 +2001,7 @@ exports[`appeal-details GET /:appealId should render a lead tag next to the appe
                             <dl class="govuk-summary-list">
                                 <div class="govuk-summary-list__row appeal-visit-type"><dt class="govuk-summary-list__key"> Visit type</dt>
                                     <dd class="govuk-summary-list__value">Accompanied</dd>
-                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/visit-booked"
+                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/visit-booked?backUrl=%2Fappeals-service%2Fappeal-details%2F1"
                                         data-cy="change-set-visit-type">Change<span class="govuk-visually-hidden"> Visit type</span></a>
                                     </dd>
                                 </div>
@@ -2070,7 +2074,7 @@ exports[`appeal-details GET /:appealId should render a lead tag next to the appe
                                             <li>9:38am - 10:00am</li>
                                         </ul>
                                     </dd>
-                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/manage-visit"
+                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/manage-visit?backUrl=%2Fappeals-service%2Fappeal-details%2F1"
                                         data-cy="change-schedule-visit">Change<span class="govuk-visually-hidden"> Site visit</span></a>
                                     </dd>
                                 </div>
@@ -2096,8 +2100,8 @@ exports[`appeal-details GET /:appealId should render a lead tag next to the appe
                                         <th scope="row" class="govuk-table__header">Appeal</th>
                                         <td class="govuk-table__cell">Ready to review</td>
                                         <td class="govuk-table__cell">2 August 2024</td>
-                                        <td class="govuk-table__cell govuk-!-text-align-right"><a href="/appeals-service/appeal-details/1/appellant-case" data-cy="review-appellant-case"
-                                            class="govuk-link">Review<span class="govuk-visually-hidden"> appellant case</span></a>
+                                        <td class="govuk-table__cell govuk-!-text-align-right"><a href="/appeals-service/appeal-details/1/appellant-case?backUrl=%2Fappeals-service%2Fappeal-details%2F1"
+                                            data-cy="review-appellant-case" class="govuk-link">Review<span class="govuk-visually-hidden"> appellant case</span></a>
                                         </td>
                                     </tr>
                                     <tr class="govuk-table__row">
@@ -2421,7 +2425,7 @@ exports[`appeal-details GET /:appealId should render action links to the manage 
                             <dl class="govuk-summary-list">
                                 <div class="govuk-summary-list__row appeal-visit-type"><dt class="govuk-summary-list__key"> Visit type</dt>
                                     <dd class="govuk-summary-list__value">Accompanied</dd>
-                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/visit-booked"
+                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/visit-booked?backUrl=%2Fappeals-service%2Fappeal-details%2F1"
                                         data-cy="change-set-visit-type">Change<span class="govuk-visually-hidden"> Visit type</span></a>
                                     </dd>
                                 </div>
@@ -2494,7 +2498,7 @@ exports[`appeal-details GET /:appealId should render action links to the manage 
                                             <li>9:38am - 10:00am</li>
                                         </ul>
                                     </dd>
-                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/manage-visit"
+                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/manage-visit?backUrl=%2Fappeals-service%2Fappeal-details%2F1"
                                         data-cy="change-schedule-visit">Change<span class="govuk-visually-hidden"> Site visit</span></a>
                                     </dd>
                                 </div>
@@ -2520,8 +2524,8 @@ exports[`appeal-details GET /:appealId should render action links to the manage 
                                         <th scope="row" class="govuk-table__header">Appeal</th>
                                         <td class="govuk-table__cell">Ready to review</td>
                                         <td class="govuk-table__cell">2 August 2024</td>
-                                        <td class="govuk-table__cell govuk-!-text-align-right"><a href="/appeals-service/appeal-details/1/appellant-case" data-cy="review-appellant-case"
-                                            class="govuk-link">Review<span class="govuk-visually-hidden"> appellant case</span></a>
+                                        <td class="govuk-table__cell govuk-!-text-align-right"><a href="/appeals-service/appeal-details/1/appellant-case?backUrl=%2Fappeals-service%2Fappeal-details%2F1"
+                                            data-cy="review-appellant-case" class="govuk-link">Review<span class="govuk-visually-hidden"> appellant case</span></a>
                                         </td>
                                     </tr>
                                     <tr class="govuk-table__row">
@@ -2699,7 +2703,7 @@ exports[`appeal-details GET /:appealId should render an Issue a decision notific
                 <div class="govuk-notification-banner__content">
                     <p class="govuk-notification-banner__heading">Ready for decision</p>
                     <p><a class="govuk-notification-banner__link" data-cy="issue-determination"
-                        href="/appeals-service/appeal-details/1/issue-decision/decision">Issue decision</a>
+                        href="/appeals-service/appeal-details/1/issue-decision/decision?backUrl=%2Fappeals-service%2Fappeal-details%2F2">Issue decision</a>
                     </p>
                 </div>
             </div>
@@ -2828,7 +2832,7 @@ exports[`appeal-details GET /:appealId should render an Issue a decision notific
                         <dl class="govuk-summary-list">
                             <div class="govuk-summary-list__row appeal-visit-type"><dt class="govuk-summary-list__key"> Visit type</dt>
                                 <dd class="govuk-summary-list__value">Accompanied</dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/site-visit/visit-booked"
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/site-visit/visit-booked?backUrl=%2Fappeals-service%2Fappeal-details%2F2"
                                     data-cy="change-set-visit-type">Change<span class="govuk-visually-hidden"> Visit type</span></a>
                                 </dd>
                             </div>
@@ -2901,7 +2905,7 @@ exports[`appeal-details GET /:appealId should render an Issue a decision notific
                                         <li>9:38am - 10:00am</li>
                                     </ul>
                                 </dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/site-visit/manage-visit"
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/site-visit/manage-visit?backUrl=%2Fappeals-service%2Fappeal-details%2F2"
                                     data-cy="change-schedule-visit">Change<span class="govuk-visually-hidden"> Site visit</span></a>
                                 </dd>
                             </div>
@@ -2927,8 +2931,8 @@ exports[`appeal-details GET /:appealId should render an Issue a decision notific
                                     <th scope="row" class="govuk-table__header">Appeal</th>
                                     <td class="govuk-table__cell">Ready to review</td>
                                     <td class="govuk-table__cell">2 August 2024</td>
-                                    <td class="govuk-table__cell govuk-!-text-align-right"><a href="/appeals-service/appeal-details/2/appellant-case" data-cy="review-appellant-case"
-                                        class="govuk-link">Review<span class="govuk-visually-hidden"> appellant case</span></a>
+                                    <td class="govuk-table__cell govuk-!-text-align-right"><a href="/appeals-service/appeal-details/2/appellant-case?backUrl=%2Fappeals-service%2Fappeal-details%2F2"
+                                        data-cy="review-appellant-case" class="govuk-link">Review<span class="govuk-visually-hidden"> appellant case</span></a>
                                     </td>
                                 </tr>
                                 <tr class="govuk-table__row">
@@ -2941,7 +2945,7 @@ exports[`appeal-details GET /:appealId should render an Issue a decision notific
                                     <th scope="row" class="govuk-table__header appeal-decision-documentation">Decision</th>
                                     <td class="govuk-table__cell appeal-decision-status">Awaiting decision</td>
                                     <td class="govuk-table__cell appeal-decision-due-date">25 December 2023</td>
-                                    <td class="govuk-table__cell govuk-!-text-align-right appeal-decision-actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/issue-decision/decision">Issue<span class="govuk-visually-hidden"> decision</span></a>
+                                    <td class="govuk-table__cell govuk-!-text-align-right appeal-decision-actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/issue-decision/decision?backUrl=%2Fappeals-service%2Fappeal-details%2F2">Issue<span class="govuk-visually-hidden"> decision</span></a>
                                     </td>
                                 </tr>
                             </tbody>
@@ -3219,7 +3223,7 @@ exports[`appeal-details GET /:appealId should render an action link to the add l
                         <dl class="govuk-summary-list">
                             <div class="govuk-summary-list__row appeal-visit-type"><dt class="govuk-summary-list__key"> Visit type</dt>
                                 <dd class="govuk-summary-list__value">Accompanied</dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/visit-booked"
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/visit-booked?backUrl=%2Fappeals-service%2Fappeal-details%2F1"
                                     data-cy="change-set-visit-type">Change<span class="govuk-visually-hidden"> Visit type</span></a>
                                 </dd>
                             </div>
@@ -3292,7 +3296,7 @@ exports[`appeal-details GET /:appealId should render an action link to the add l
                                         <li>9:38am - 10:00am</li>
                                     </ul>
                                 </dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/manage-visit"
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/manage-visit?backUrl=%2Fappeals-service%2Fappeal-details%2F1"
                                     data-cy="change-schedule-visit">Change<span class="govuk-visually-hidden"> Site visit</span></a>
                                 </dd>
                             </div>
@@ -3318,8 +3322,8 @@ exports[`appeal-details GET /:appealId should render an action link to the add l
                                     <th scope="row" class="govuk-table__header">Appeal</th>
                                     <td class="govuk-table__cell">Ready to review</td>
                                     <td class="govuk-table__cell">2 August 2024</td>
-                                    <td class="govuk-table__cell govuk-!-text-align-right"><a href="/appeals-service/appeal-details/1/appellant-case" data-cy="review-appellant-case"
-                                        class="govuk-link">Review<span class="govuk-visually-hidden"> appellant case</span></a>
+                                    <td class="govuk-table__cell govuk-!-text-align-right"><a href="/appeals-service/appeal-details/1/appellant-case?backUrl=%2Fappeals-service%2Fappeal-details%2F1"
+                                        data-cy="review-appellant-case" class="govuk-link">Review<span class="govuk-visually-hidden"> appellant case</span></a>
                                     </td>
                                 </tr>
                                 <tr class="govuk-table__row">
@@ -3609,7 +3613,7 @@ exports[`appeal-details GET /:appealId should render the appellant case status a
                         <dl class="govuk-summary-list">
                             <div class="govuk-summary-list__row appeal-visit-type"><dt class="govuk-summary-list__key"> Visit type</dt>
                                 <dd class="govuk-summary-list__value">Accompanied</dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/site-visit/visit-booked"
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/site-visit/visit-booked?backUrl=%2Fappeals-service%2Fappeal-details%2F2"
                                     data-cy="change-set-visit-type">Change<span class="govuk-visually-hidden"> Visit type</span></a>
                                 </dd>
                             </div>
@@ -3682,7 +3686,7 @@ exports[`appeal-details GET /:appealId should render the appellant case status a
                                         <li>9:38am - 10:00am</li>
                                     </ul>
                                 </dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/site-visit/manage-visit"
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/site-visit/manage-visit?backUrl=%2Fappeals-service%2Fappeal-details%2F2"
                                     data-cy="change-schedule-visit">Change<span class="govuk-visually-hidden"> Site visit</span></a>
                                 </dd>
                             </div>
@@ -3708,8 +3712,8 @@ exports[`appeal-details GET /:appealId should render the appellant case status a
                                     <th scope="row" class="govuk-table__header">Appeal</th>
                                     <td class="govuk-table__cell">Incomplete</td>
                                     <td class="govuk-table__cell"></td>
-                                    <td class="govuk-table__cell govuk-!-text-align-right"><a href="/appeals-service/appeal-details/2/appellant-case" data-cy="review-appellant-case"
-                                        class="govuk-link">View<span class="govuk-visually-hidden"> appellant case</span></a>
+                                    <td class="govuk-table__cell govuk-!-text-align-right"><a href="/appeals-service/appeal-details/2/appellant-case?backUrl=%2Fappeals-service%2Fappeal-details%2F2"
+                                        data-cy="review-appellant-case" class="govuk-link">View<span class="govuk-visually-hidden"> appellant case</span></a>
                                     </td>
                                 </tr>
                                 <tr class="govuk-table__row">
@@ -3999,7 +4003,7 @@ exports[`appeal-details GET /:appealId should render the appellant case status a
                         <dl class="govuk-summary-list">
                             <div class="govuk-summary-list__row appeal-visit-type"><dt class="govuk-summary-list__key"> Visit type</dt>
                                 <dd class="govuk-summary-list__value">Accompanied</dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/site-visit/visit-booked"
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/site-visit/visit-booked?backUrl=%2Fappeals-service%2Fappeal-details%2F2"
                                     data-cy="change-set-visit-type">Change<span class="govuk-visually-hidden"> Visit type</span></a>
                                 </dd>
                             </div>
@@ -4072,7 +4076,7 @@ exports[`appeal-details GET /:appealId should render the appellant case status a
                                         <li>9:38am - 10:00am</li>
                                     </ul>
                                 </dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/site-visit/manage-visit"
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/site-visit/manage-visit?backUrl=%2Fappeals-service%2Fappeal-details%2F2"
                                     data-cy="change-schedule-visit">Change<span class="govuk-visually-hidden"> Site visit</span></a>
                                 </dd>
                             </div>
@@ -4098,8 +4102,8 @@ exports[`appeal-details GET /:appealId should render the appellant case status a
                                     <th scope="row" class="govuk-table__header">Appeal</th>
                                     <td class="govuk-table__cell">Incomplete</td>
                                     <td class="govuk-table__cell"></td>
-                                    <td class="govuk-table__cell govuk-!-text-align-right"><a href="/appeals-service/appeal-details/2/appellant-case" data-cy="review-appellant-case"
-                                        class="govuk-link">View<span class="govuk-visually-hidden"> appellant case</span></a>
+                                    <td class="govuk-table__cell govuk-!-text-align-right"><a href="/appeals-service/appeal-details/2/appellant-case?backUrl=%2Fappeals-service%2Fappeal-details%2F2"
+                                        data-cy="review-appellant-case" class="govuk-link">View<span class="govuk-visually-hidden"> appellant case</span></a>
                                     </td>
                                 </tr>
                                 <tr class="govuk-table__row">
@@ -4405,7 +4409,7 @@ exports[`appeal-details GET /:appealId should render the case reference for each
                             <dl class="govuk-summary-list">
                                 <div class="govuk-summary-list__row appeal-visit-type"><dt class="govuk-summary-list__key"> Visit type</dt>
                                     <dd class="govuk-summary-list__value">Accompanied</dd>
-                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/visit-booked"
+                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/visit-booked?backUrl=%2Fappeals-service%2Fappeal-details%2F1"
                                         data-cy="change-set-visit-type">Change<span class="govuk-visually-hidden"> Visit type</span></a>
                                     </dd>
                                 </div>
@@ -4478,7 +4482,7 @@ exports[`appeal-details GET /:appealId should render the case reference for each
                                             <li>9:38am - 10:00am</li>
                                         </ul>
                                     </dd>
-                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/manage-visit"
+                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/manage-visit?backUrl=%2Fappeals-service%2Fappeal-details%2F1"
                                         data-cy="change-schedule-visit">Change<span class="govuk-visually-hidden"> Site visit</span></a>
                                     </dd>
                                 </div>
@@ -4504,8 +4508,8 @@ exports[`appeal-details GET /:appealId should render the case reference for each
                                         <th scope="row" class="govuk-table__header">Appeal</th>
                                         <td class="govuk-table__cell">Ready to review</td>
                                         <td class="govuk-table__cell">2 August 2024</td>
-                                        <td class="govuk-table__cell govuk-!-text-align-right"><a href="/appeals-service/appeal-details/1/appellant-case" data-cy="review-appellant-case"
-                                            class="govuk-link">Review<span class="govuk-visually-hidden"> appellant case</span></a>
+                                        <td class="govuk-table__cell govuk-!-text-align-right"><a href="/appeals-service/appeal-details/1/appellant-case?backUrl=%2Fappeals-service%2Fappeal-details%2F1"
+                                            data-cy="review-appellant-case" class="govuk-link">Review<span class="govuk-visually-hidden"> appellant case</span></a>
                                         </td>
                                     </tr>
                                     <tr class="govuk-table__row">
@@ -4839,7 +4843,7 @@ exports[`appeal-details GET /:appealId should render the lead or child status af
                             <dl class="govuk-summary-list">
                                 <div class="govuk-summary-list__row appeal-visit-type"><dt class="govuk-summary-list__key"> Visit type</dt>
                                     <dd class="govuk-summary-list__value">Accompanied</dd>
-                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/visit-booked"
+                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/visit-booked?backUrl=%2Fappeals-service%2Fappeal-details%2F1"
                                         data-cy="change-set-visit-type">Change<span class="govuk-visually-hidden"> Visit type</span></a>
                                     </dd>
                                 </div>
@@ -4912,7 +4916,7 @@ exports[`appeal-details GET /:appealId should render the lead or child status af
                                             <li>9:38am - 10:00am</li>
                                         </ul>
                                     </dd>
-                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/manage-visit"
+                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/manage-visit?backUrl=%2Fappeals-service%2Fappeal-details%2F1"
                                         data-cy="change-schedule-visit">Change<span class="govuk-visually-hidden"> Site visit</span></a>
                                     </dd>
                                 </div>
@@ -4938,8 +4942,8 @@ exports[`appeal-details GET /:appealId should render the lead or child status af
                                         <th scope="row" class="govuk-table__header">Appeal</th>
                                         <td class="govuk-table__cell">Ready to review</td>
                                         <td class="govuk-table__cell">2 August 2024</td>
-                                        <td class="govuk-table__cell govuk-!-text-align-right"><a href="/appeals-service/appeal-details/1/appellant-case" data-cy="review-appellant-case"
-                                            class="govuk-link">Review<span class="govuk-visually-hidden"> appellant case</span></a>
+                                        <td class="govuk-table__cell govuk-!-text-align-right"><a href="/appeals-service/appeal-details/1/appellant-case?backUrl=%2Fappeals-service%2Fappeal-details%2F1"
+                                            data-cy="review-appellant-case" class="govuk-link">Review<span class="govuk-visually-hidden"> appellant case</span></a>
                                         </td>
                                     </tr>
                                     <tr class="govuk-table__row">
@@ -5257,7 +5261,7 @@ exports[`appeal-details GET /:appealId should render the received appeal details
                             <dl class="govuk-summary-list">
                                 <div class="govuk-summary-list__row appeal-visit-type"><dt class="govuk-summary-list__key"> Visit type</dt>
                                     <dd class="govuk-summary-list__value">Accompanied</dd>
-                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/3/site-visit/visit-booked"
+                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/3/site-visit/visit-booked?backUrl=%2Fappeals-service%2Fappeal-details%2F3"
                                         data-cy="change-set-visit-type">Change<span class="govuk-visually-hidden"> Visit type</span></a>
                                     </dd>
                                 </div>
@@ -5330,7 +5334,7 @@ exports[`appeal-details GET /:appealId should render the received appeal details
                                             <li>9:38am - 10:00am</li>
                                         </ul>
                                     </dd>
-                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/3/site-visit/manage-visit"
+                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/3/site-visit/manage-visit?backUrl=%2Fappeals-service%2Fappeal-details%2F3"
                                         data-cy="change-schedule-visit">Change<span class="govuk-visually-hidden"> Site visit</span></a>
                                     </dd>
                                 </div>
@@ -5356,8 +5360,8 @@ exports[`appeal-details GET /:appealId should render the received appeal details
                                         <th scope="row" class="govuk-table__header">Appeal</th>
                                         <td class="govuk-table__cell">Ready to review</td>
                                         <td class="govuk-table__cell">2 August 2024</td>
-                                        <td class="govuk-table__cell govuk-!-text-align-right"><a href="/appeals-service/appeal-details/3/appellant-case" data-cy="review-appellant-case"
-                                            class="govuk-link">Review<span class="govuk-visually-hidden"> appellant case</span></a>
+                                        <td class="govuk-table__cell govuk-!-text-align-right"><a href="/appeals-service/appeal-details/3/appellant-case?backUrl=%2Fappeals-service%2Fappeal-details%2F3"
+                                            data-cy="review-appellant-case" class="govuk-link">Review<span class="govuk-visually-hidden"> appellant case</span></a>
                                         </td>
                                     </tr>
                                     <tr class="govuk-table__row">
@@ -5647,7 +5651,7 @@ exports[`appeal-details GET /:appealId should render the received appeal details
                         <dl class="govuk-summary-list">
                             <div class="govuk-summary-list__row appeal-visit-type"><dt class="govuk-summary-list__key"> Visit type</dt>
                                 <dd class="govuk-summary-list__value">Accompanied</dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/visit-booked"
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/visit-booked?backUrl=%2Fappeals-service%2Fappeal-details%2F1"
                                     data-cy="change-set-visit-type">Change<span class="govuk-visually-hidden"> Visit type</span></a>
                                 </dd>
                             </div>
@@ -5720,7 +5724,7 @@ exports[`appeal-details GET /:appealId should render the received appeal details
                                         <li>9:38am - 10:00am</li>
                                     </ul>
                                 </dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/manage-visit"
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/manage-visit?backUrl=%2Fappeals-service%2Fappeal-details%2F1"
                                     data-cy="change-schedule-visit">Change<span class="govuk-visually-hidden"> Site visit</span></a>
                                 </dd>
                             </div>
@@ -5746,8 +5750,8 @@ exports[`appeal-details GET /:appealId should render the received appeal details
                                     <th scope="row" class="govuk-table__header">Appeal</th>
                                     <td class="govuk-table__cell">Ready to review</td>
                                     <td class="govuk-table__cell">2 August 2024</td>
-                                    <td class="govuk-table__cell govuk-!-text-align-right"><a href="/appeals-service/appeal-details/1/appellant-case" data-cy="review-appellant-case"
-                                        class="govuk-link">Review<span class="govuk-visually-hidden"> appellant case</span></a>
+                                    <td class="govuk-table__cell govuk-!-text-align-right"><a href="/appeals-service/appeal-details/1/appellant-case?backUrl=%2Fappeals-service%2Fappeal-details%2F1"
+                                        data-cy="review-appellant-case" class="govuk-link">Review<span class="govuk-visually-hidden"> appellant case</span></a>
                                     </td>
                                 </tr>
                                 <tr class="govuk-table__row">
@@ -6060,7 +6064,7 @@ exports[`appeal-details GET /:appealId should render the received appeal details
                             <dl class="govuk-summary-list">
                                 <div class="govuk-summary-list__row appeal-visit-type"><dt class="govuk-summary-list__key"> Visit type</dt>
                                     <dd class="govuk-summary-list__value">Accompanied</dd>
-                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/site-visit/visit-booked"
+                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/site-visit/visit-booked?backUrl=%2Fappeals-service%2Fappeal-details%2F2"
                                         data-cy="change-set-visit-type">Change<span class="govuk-visually-hidden"> Visit type</span></a>
                                     </dd>
                                 </div>
@@ -6133,7 +6137,7 @@ exports[`appeal-details GET /:appealId should render the received appeal details
                                             <li>9:38am - 10:00am</li>
                                         </ul>
                                     </dd>
-                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/site-visit/manage-visit"
+                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/site-visit/manage-visit?backUrl=%2Fappeals-service%2Fappeal-details%2F2"
                                         data-cy="change-schedule-visit">Change<span class="govuk-visually-hidden"> Site visit</span></a>
                                     </dd>
                                 </div>
@@ -6159,8 +6163,8 @@ exports[`appeal-details GET /:appealId should render the received appeal details
                                         <th scope="row" class="govuk-table__header">Appeal</th>
                                         <td class="govuk-table__cell">Ready to review</td>
                                         <td class="govuk-table__cell">2 August 2024</td>
-                                        <td class="govuk-table__cell govuk-!-text-align-right"><a href="/appeals-service/appeal-details/2/appellant-case" data-cy="review-appellant-case"
-                                            class="govuk-link">Review<span class="govuk-visually-hidden"> appellant case</span></a>
+                                        <td class="govuk-table__cell govuk-!-text-align-right"><a href="/appeals-service/appeal-details/2/appellant-case?backUrl=%2Fappeals-service%2Fappeal-details%2F2"
+                                            data-cy="review-appellant-case" class="govuk-link">Review<span class="govuk-visually-hidden"> appellant case</span></a>
                                         </td>
                                     </tr>
                                     <tr class="govuk-table__row">
@@ -6450,7 +6454,7 @@ exports[`appeal-details GET /:appealId should render the received appeal details
                         <dl class="govuk-summary-list">
                             <div class="govuk-summary-list__row appeal-visit-type"><dt class="govuk-summary-list__key"> Visit type</dt>
                                 <dd class="govuk-summary-list__value">Accompanied</dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/site-visit/visit-booked"
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/site-visit/visit-booked?backUrl=%2Fappeals-service%2Fappeal-details%2F2"
                                     data-cy="change-set-visit-type">Change<span class="govuk-visually-hidden"> Visit type</span></a>
                                 </dd>
                             </div>
@@ -6532,8 +6536,8 @@ exports[`appeal-details GET /:appealId should render the received appeal details
                                     <th scope="row" class="govuk-table__header">Appeal</th>
                                     <td class="govuk-table__cell">Ready to review</td>
                                     <td class="govuk-table__cell">2 August 2024</td>
-                                    <td class="govuk-table__cell govuk-!-text-align-right"><a href="/appeals-service/appeal-details/2/appellant-case" data-cy="review-appellant-case"
-                                        class="govuk-link">Review<span class="govuk-visually-hidden"> appellant case</span></a>
+                                    <td class="govuk-table__cell govuk-!-text-align-right"><a href="/appeals-service/appeal-details/2/appellant-case?backUrl=%2Fappeals-service%2Fappeal-details%2F2"
+                                        data-cy="review-appellant-case" class="govuk-link">Review<span class="govuk-visually-hidden"> appellant case</span></a>
                                     </td>
                                 </tr>
                                 <tr class="govuk-table__row">
@@ -6859,7 +6863,7 @@ exports[`appeal-details should not render a back button 1`] = `
                                     <dl class="govuk-summary-list">
                                         <div class="govuk-summary-list__row appeal-visit-type"><dt class="govuk-summary-list__key"> Visit type</dt>
                                             <dd class="govuk-summary-list__value">Accompanied</dd>
-                                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/site-visit/visit-booked"
+                                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/site-visit/visit-booked?backUrl=%2Fappeals-service%2Fappeal-details%2F2"
                                                 data-cy="change-set-visit-type">Change<span class="govuk-visually-hidden"> Visit type</span></a>
                                             </dd>
                                         </div>
@@ -6932,7 +6936,7 @@ exports[`appeal-details should not render a back button 1`] = `
                                                     <li>9:38am - 10:00am</li>
                                                 </ul>
                                             </dd>
-                                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/site-visit/manage-visit"
+                                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/site-visit/manage-visit?backUrl=%2Fappeals-service%2Fappeal-details%2F2"
                                                 data-cy="change-schedule-visit">Change<span class="govuk-visually-hidden"> Site visit</span></a>
                                             </dd>
                                         </div>
@@ -6958,8 +6962,8 @@ exports[`appeal-details should not render a back button 1`] = `
                                                 <th scope="row" class="govuk-table__header">Appeal</th>
                                                 <td class="govuk-table__cell">Ready to review</td>
                                                 <td class="govuk-table__cell">2 August 2024</td>
-                                                <td class="govuk-table__cell govuk-!-text-align-right"><a href="/appeals-service/appeal-details/2/appellant-case" data-cy="review-appellant-case"
-                                                    class="govuk-link">Review<span class="govuk-visually-hidden"> appellant case</span></a>
+                                                <td class="govuk-table__cell govuk-!-text-align-right"><a href="/appeals-service/appeal-details/2/appellant-case?backUrl=%2Fappeals-service%2Fappeal-details%2F2"
+                                                    data-cy="review-appellant-case" class="govuk-link">Review<span class="govuk-visually-hidden"> appellant case</span></a>
                                                 </td>
                                             </tr>
                                             <tr class="govuk-table__row">

--- a/appeals/web/src/server/appeals/appeal-details/__tests__/appeal-details.test.js
+++ b/appeals/web/src/server/appeals/appeal-details/__tests__/appeal-details.test.js
@@ -114,7 +114,7 @@ describe('appeal-details', () => {
 					'Appeal ready to be assigned to case officer</p>'
 				);
 				expect(notificationBannerElementHTML).toContain(
-					'href="/appeals-service/appeal-details/2/assign-user/case-officer"'
+					`href="/appeals-service/appeal-details/2/assign-user/case-officer?backUrl=%2Fappeals-service%2Fappeal-details%2F${appealId}"`
 				);
 				expect(notificationBannerElementHTML).toContain('Assign case officer</a>');
 			});
@@ -1079,7 +1079,7 @@ describe('appeal-details', () => {
 					'<p class="govuk-notification-banner__heading">Interested party comments awaiting review</p>'
 				);
 				expect(unprettifiedElementHtml).toContain(
-					'<p><a class="govuk-notification-banner__link" href="/appeals-service/appeal-details/2/interested-party-comments" data-cy="banner-review-ip-comments">Review <span class="govuk-visually-hidden">interested party comments</span></a></p>'
+					'<p><a class="govuk-notification-banner__link" href="/appeals-service/appeal-details/2/interested-party-comments?backUrl=%2Fappeals-service%2Fappeal-details%2F2" data-cy="banner-review-ip-comments">Review <span class="govuk-visually-hidden">interested party comments</span></a></p>'
 				);
 			});
 
@@ -1112,7 +1112,7 @@ describe('appeal-details', () => {
 				expect(notificationBannerElementHTML).toContain('Important</h3>');
 				expect(notificationBannerElementHTML).toContain('Appeal ready for validation</p>');
 				expect(notificationBannerElementHTML).toContain(
-					`href="/appeals-service/appeal-details/${appealId}/appellant-case"`
+					`href="/appeals-service/appeal-details/${appealId}/appellant-case?backUrl=%2Fappeals-service%2Fappeal-details%2F${appealId}"`
 				);
 				expect(notificationBannerElementHTML).toContain('data-cy="validate-appeal"');
 				expect(notificationBannerElementHTML).toContain(
@@ -1151,7 +1151,7 @@ describe('appeal-details', () => {
 				expect(notificationBannerElementHTML).toContain('Important</h3>');
 				expect(notificationBannerElementHTML).toContain('LPA questionnaire ready for review</p>');
 				expect(notificationBannerElementHTML).toContain(
-					`href="/appeals-service/appeal-details/${appealId}/lpa-questionnaire/${lpaQuestionnaireId}"`
+					`href="/appeals-service/appeal-details/${appealId}/lpa-questionnaire/${lpaQuestionnaireId}?backUrl=%2Fappeals-service%2Fappeal-details%2F${appealId}"`
 				);
 				expect(notificationBannerElementHTML).toContain(
 					'data-cy="review-lpa-questionnaire-banner"'
@@ -1201,7 +1201,7 @@ describe('appeal-details', () => {
 				expect(notificationBannerElementHTML).toContain('Important</h3>');
 				expect(notificationBannerElementHTML).toContain('Site visit ready to set up</p>');
 				expect(notificationBannerElementHTML).toContain(
-					`href="/appeals-service/appeal-details/${appealId}/site-visit/schedule-visit"`
+					`href="/appeals-service/appeal-details/${appealId}/site-visit/schedule-visit?backUrl=%2Fappeals-service%2Fappeal-details%2F${appealId}"`
 				);
 				expect(notificationBannerElementHTML).toContain('data-cy="set-up-site-visit-banner"');
 				expect(notificationBannerElementHTML).toContain('Set up site visit</a>');
@@ -1273,7 +1273,7 @@ describe('appeal-details', () => {
 							`<p class="govuk-notification-banner__heading">${testCase.importantBannerHeading}</p>`
 						);
 						expect(unprettifiedElementHtml).toContain(
-							`<p><a class="govuk-notification-banner__link" href="/appeals-service/appeal-details/${appealId}/final-comments/${testCase.name}" data-cy="banner-review-${testCase.name}-final-comments">Review <span class="govuk-visually-hidden">${testCase.visuallyHiddenText}</span></a></p>`
+							`<p><a class="govuk-notification-banner__link" href="/appeals-service/appeal-details/${appealId}/final-comments/${testCase.name}?backUrl=%2Fappeals-service%2Fappeal-details%2F${appealId}" data-cy="banner-review-${testCase.name}-final-comments">Review <span class="govuk-visually-hidden">${testCase.visuallyHiddenText}</span></a></p>`
 						);
 					});
 
@@ -1764,7 +1764,7 @@ describe('appeal-details', () => {
 			expect(notificationBannerElementHTML).toContain('Important</h3>');
 			expect(notificationBannerElementHTML).toContain('Ready for decision</p>');
 			expect(notificationBannerElementHTML).toContain(
-				'href="/appeals-service/appeal-details/1/issue-decision/decision">Issue decision</a>'
+				`href="/appeals-service/appeal-details/1/issue-decision/decision?backUrl=%2Fappeals-service%2Fappeal-details%2F${appealId}">Issue decision</a>`
 			);
 		});
 
@@ -2096,7 +2096,7 @@ describe('appeal-details', () => {
 			expect(element.innerHTML).toContain('Important</h3>');
 			expect(element.innerHTML).toContain('Appeal valid</p>');
 			expect(element.innerHTML).toContain(
-				'href="/appeals-service/appeal-details/2/start-case/add?backUrl=/appeals-service/appeal-details/2">Start case</a>'
+				`href="/appeals-service/appeal-details/2/start-case/add?backUrl=%2Fappeals-service%2Fappeal-details%2F${appealId}">Start case</a>`
 			);
 		});
 
@@ -2215,7 +2215,9 @@ describe('appeal-details', () => {
 
 					expect(element.innerHTML).toMatchSnapshot();
 					expect(element.innerHTML).toContain('Important</h3>');
-					expect(element.innerHTML).toContain(`href="/appeals-service/appeal-details/1/share"`);
+					expect(element.innerHTML).toContain(
+						`href="/appeals-service/appeal-details/1/share?backUrl=%2Fappeals-service%2Fappeal-details%2F${appealId}"`
+					);
 					expect(element.innerHTML).toContain(`${testCase.bannerText}</a>`);
 				});
 			}
@@ -2405,7 +2407,7 @@ describe('appeal-details', () => {
 
 						expect(unprettifiedHTML).toContain('Documentation</th>');
 						expect(unprettifiedHTML).toContain(
-							`${testCase.rowLabel}</th><td class="govuk-table__cell">Ready to review</td><td class="govuk-table__cell">Due by 12 October 2023</td><td class="govuk-table__cell govuk-!-text-align-right"><a href="/appeals-service/appeal-details/${appealId}/${testCase.reviewPageRoute}" data-cy="${testCase.cyAttribute}" class="govuk-link">Review<span class="govuk-visually-hidden"> ${testCase.actionLinkHiddenText}</span></a></td>`
+							`${testCase.rowLabel}</th><td class="govuk-table__cell">Ready to review</td><td class="govuk-table__cell">Due by 12 October 2023</td><td class="govuk-table__cell govuk-!-text-align-right"><a href="/appeals-service/appeal-details/${appealId}/${testCase.reviewPageRoute}?backUrl=%2Fappeals-service%2Fappeal-details%2F${appealId}" data-cy="${testCase.cyAttribute}" class="govuk-link">Review<span class="govuk-visually-hidden"> ${testCase.actionLinkHiddenText}</span></a></td>`
 						);
 					});
 
@@ -2435,7 +2437,7 @@ describe('appeal-details', () => {
 
 						expect(unprettifiedHTML).toContain('Documentation</th>');
 						expect(unprettifiedHTML).toContain(
-							`${testCase.rowLabel}</th><td class="govuk-table__cell">Accepted</td><td class="govuk-table__cell">17 December 2024</td><td class="govuk-table__cell govuk-!-text-align-right"><a href="/appeals-service/appeal-details/${appealId}/${testCase.reviewPageRoute}" data-cy="${testCase.viewCyAttribute}" class="govuk-link">View<span class="govuk-visually-hidden"> ${testCase.actionLinkHiddenText}</span></a></td>`
+							`${testCase.rowLabel}</th><td class="govuk-table__cell">Accepted</td><td class="govuk-table__cell">17 December 2024</td><td class="govuk-table__cell govuk-!-text-align-right"><a href="/appeals-service/appeal-details/${appealId}/${testCase.reviewPageRoute}?backUrl=%2Fappeals-service%2Fappeal-details%2F${appealId}" data-cy="${testCase.viewCyAttribute}" class="govuk-link">View<span class="govuk-visually-hidden"> ${testCase.actionLinkHiddenText}</span></a></td>`
 						);
 					});
 
@@ -2465,7 +2467,7 @@ describe('appeal-details', () => {
 
 						expect(unprettifiedHTML).toContain('Documentation</th>');
 						expect(unprettifiedHTML).toContain(
-							`${testCase.rowLabel}</th><td class="govuk-table__cell">Rejected</td><td class="govuk-table__cell">17 December 2024</td><td class="govuk-table__cell govuk-!-text-align-right"><a href="/appeals-service/appeal-details/${appealId}/${testCase.reviewPageRoute}" data-cy="${testCase.viewCyAttribute}" class="govuk-link">View<span class="govuk-visually-hidden"> ${testCase.actionLinkHiddenText}</span></a></td>`
+							`${testCase.rowLabel}</th><td class="govuk-table__cell">Rejected</td><td class="govuk-table__cell">17 December 2024</td><td class="govuk-table__cell govuk-!-text-align-right"><a href="/appeals-service/appeal-details/${appealId}/${testCase.reviewPageRoute}?backUrl=%2Fappeals-service%2Fappeal-details%2F${appealId}" data-cy="${testCase.viewCyAttribute}" class="govuk-link">View<span class="govuk-visually-hidden"> ${testCase.actionLinkHiddenText}</span></a></td>`
 						);
 					});
 				}
@@ -2947,7 +2949,7 @@ describe('appeal-details', () => {
 				expect(rowHtml).toMatchSnapshot();
 				expect(rowHtml).toContain('Decision</dt>');
 				expect(rowHtml).toContain(
-					'<a class="govuk-link" href="/appeals-service/appeal-details/2/issue-decision/decision" data-cy="issue-decision">Issue<span class="govuk-visually-hidden"> Decision</span></a>'
+					`<a class="govuk-link" href="/appeals-service/appeal-details/2/issue-decision/decision?backUrl=%2Fappeals-service%2Fappeal-details%2F${appealId}" data-cy="issue-decision">Issue<span class="govuk-visually-hidden"> Decision</span></a>`
 				);
 			});
 
@@ -3097,7 +3099,7 @@ describe('appeal-details', () => {
 
 				expect(columnHtml).toMatchSnapshot();
 				expect(columnHtml).toContain(
-					'href="/appeals-service/appeal-details/2/issue-decision/decision">Issue<span class="govuk-visually-hidden"> decision</span></a>'
+					`href="/appeals-service/appeal-details/2/issue-decision/decision?backUrl=%2Fappeals-service%2Fappeal-details%2F${appealId}">Issue<span class="govuk-visually-hidden"> decision</span></a>`
 				);
 			});
 
@@ -3175,7 +3177,7 @@ describe('appeal-details', () => {
 
 				expect(columnHtml).toMatchSnapshot();
 				expect(columnHtml).toContain(
-					'<td class="govuk-table__cell govuk-!-text-align-right appeal-decision-actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/issue-decision/decision">View<span class="govuk-visually-hidden"> decision</span></a></td>'
+					`<td class="govuk-table__cell govuk-!-text-align-right appeal-decision-actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/issue-decision/decision?backUrl=%2Fappeals-service%2Fappeal-details%2F${appealId}">View<span class="govuk-visually-hidden"> decision</span></a></td>`
 				);
 			});
 		});

--- a/appeals/web/src/server/appeals/appeal-details/appeal-details.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/appeal-details.mapper.js
@@ -34,6 +34,7 @@ export async function appealDetailsPage(
 		appealDetails,
 		currentRoute,
 		session,
+		request,
 		false,
 		appellantFinalComments,
 		lpaFinalComments
@@ -47,7 +48,7 @@ export async function appealDetailsPage(
 
 	const accordion = generateAccordionItems(appealDetails, mappedData, session);
 
-	const statusDependentNotifications = mapStatusDependentNotifications(appealDetails, currentRoute);
+	const statusDependentNotifications = mapStatusDependentNotifications(appealDetails, request);
 	const notificationBanners = sortNotificationBanners([
 		...statusDependentNotifications,
 		...mapNotificationBannersFromSession(session, 'appealDetails', appealDetails.appealId)

--- a/appeals/web/src/server/appeals/appeal-details/appellant-case/appellant-case.controller.js
+++ b/appeals/web/src/server/appeals/appeal-details/appellant-case/appellant-case.controller.js
@@ -29,6 +29,7 @@ import {
 import { capitalize } from 'lodash-es';
 import { addNotificationBannerToSession } from '#lib/session-utilities.js';
 import { mapFolderNameToDisplayLabel } from '#lib/mappers/utils/documents-and-folders.js';
+import { getBackLinkUrlFromQuery } from '#lib/url-utilities.js';
 
 /**
  *
@@ -55,6 +56,7 @@ const renderAppellantCase = async (request, response) => {
 			appellantCaseResponse,
 			currentAppeal,
 			request.originalUrl,
+			getBackLinkUrlFromQuery(request),
 			request.session
 		);
 

--- a/appeals/web/src/server/appeals/appeal-details/appellant-case/appellant-case.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/appellant-case/appellant-case.mapper.js
@@ -51,10 +51,17 @@ import { ensureArray } from '#lib/array-utilities.js';
  * @param {SingleAppellantCaseResponse} appellantCaseData
  * @param {Appeal} appealDetails
  * @param {string} currentRoute
+ * @param {string|undefined} backUrl
  * @param {import("express-session").Session & Partial<import("express-session").SessionData>} session
  * @returns {Promise<PageContent>}
  */
-export async function appellantCasePage(appellantCaseData, appealDetails, currentRoute, session) {
+export async function appellantCasePage(
+	appellantCaseData,
+	appealDetails,
+	currentRoute,
+	backUrl,
+	session
+) {
 	const mappedAppellantCaseData = initialiseAndMapData(
 		appellantCaseData,
 		appealDetails,
@@ -173,7 +180,7 @@ export async function appellantCasePage(appellantCaseData, appealDetails, curren
 	/** @type {PageContent} */
 	const pageContent = {
 		title: `Appellant case - ${shortAppealReference}`,
-		backLinkUrl: `/appeals-service/appeal-details/${appealDetails.appealId}`,
+		backLinkUrl: backUrl || `/appeals-service/appeal-details/${appealDetails.appealId}`,
 		preHeading: `Appeal ${shortAppealReference}`,
 		heading: 'Appellant case',
 		headingClasses: 'govuk-heading-xl govuk-!-margin-bottom-3',

--- a/appeals/web/src/server/appeals/appeal-details/change-appeal-type/change-appeal-type.controller.js
+++ b/appeals/web/src/server/appeals/appeal-details/change-appeal-type/change-appeal-type.controller.js
@@ -14,6 +14,7 @@ import {
 } from './change-appeal-type.mapper.js';
 import { addNotificationBannerToSession } from '#lib/session-utilities.js';
 import { dayMonthYearHourMinuteToISOString } from '#lib/dates.js';
+import { getBackLinkUrlFromQuery } from '#lib/url-utilities.js';
 
 /**
  * @param {import('@pins/express/types/express.js').Request} request
@@ -251,7 +252,7 @@ const renderAddHorizonReference = async (request, response) => {
 
 	const appealData = request.currentAppeal;
 
-	const mappedPageContent = addHorizonReferencePage(appealData);
+	const mappedPageContent = addHorizonReferencePage(appealData, getBackLinkUrlFromQuery(request));
 
 	return response.status(200).render('patterns/change-page.pattern.njk', {
 		pageContent: mappedPageContent,

--- a/appeals/web/src/server/appeals/appeal-details/change-appeal-type/change-appeal-type.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/change-appeal-type/change-appeal-type.mapper.js
@@ -116,15 +116,16 @@ export function resubmitAppealPage(appealDetails, changeAppeal) {
 
 /**
  * @param {Appeal} appealDetails
+ * @param {string|undefined} backUrl
  * @returns {PageContent}
  */
-export function addHorizonReferencePage(appealDetails) {
+export function addHorizonReferencePage(appealDetails, backUrl) {
 	const shortAppealReference = appealShortReference(appealDetails.appealReference);
 
 	/** @type {PageContent} */
 	const pageContent = {
 		title: `What is the reference of the new appeal on Horizon? - ${shortAppealReference}`,
-		backLinkUrl: `/appeals-service/appeal-details/${appealDetails.appealId}`,
+		backLinkUrl: backUrl || `/appeals-service/appeal-details/${appealDetails.appealId}`,
 		preHeading: `Appeal ${shortAppealReference}`,
 		pageComponents: [
 			{

--- a/appeals/web/src/server/appeals/appeal-details/issue-decision/issue-decision.controller.js
+++ b/appeals/web/src/server/appeals/appeal-details/issue-decision/issue-decision.controller.js
@@ -23,6 +23,7 @@ import {
 import { objectContainsAllKeys } from '#lib/object-utilities.js';
 import { APPEAL_CASE_STAGE, APPEAL_DOCUMENT_TYPE } from 'pins-data-model';
 import { addNotificationBannerToSession } from '#lib/session-utilities.js';
+import { getBackLinkUrlFromQuery } from '#lib/url-utilities.js';
 
 /**
  * @param {import('@pins/express/types/express.js').Request} request
@@ -86,7 +87,11 @@ const renderIssueDecision = async (request, response) => {
 		request.session.inspectorDecision = {};
 	}
 
-	const mappedPageContent = issueDecisionPage(appealData, request.session.inspectorDecision);
+	const mappedPageContent = issueDecisionPage(
+		appealData,
+		request.session.inspectorDecision,
+		getBackLinkUrlFromQuery(request)
+	);
 
 	return response.status(200).render('patterns/change-page.pattern.njk', {
 		pageContent: mappedPageContent,

--- a/appeals/web/src/server/appeals/appeal-details/issue-decision/issue-decision.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/issue-decision/issue-decision.mapper.js
@@ -14,9 +14,10 @@ import { dateISOStringToDisplayDate } from '#lib/dates.js';
  *
  * @param {Appeal} appealDetails
  * @param {InspectorDecisionRequest} inspectorDecision
+ * @param {string|undefined} backUrl
  * @returns {PageContent}
  */
-export function issueDecisionPage(appealDetails, inspectorDecision) {
+export function issueDecisionPage(appealDetails, inspectorDecision, backUrl) {
 	/** @type {PageComponent} */
 	const selectVisitTypeComponent = {
 		type: 'radios',
@@ -60,7 +61,7 @@ export function issueDecisionPage(appealDetails, inspectorDecision) {
 	/** @type {PageContent} */
 	const pageContent = {
 		title: `What is the decision? - ${shortAppealReference}`,
-		backLinkUrl: `/appeals-service/appeal-details/${appealDetails.appealId}`,
+		backLinkUrl: backUrl || `/appeals-service/appeal-details/${appealDetails.appealId}`,
 		preHeading: `Appeal ${shortAppealReference}`,
 		pageComponents: [selectVisitTypeComponent]
 	};
@@ -424,15 +425,4 @@ export function mapDecisionOutcome(outcome) {
  */
 export function generateIssueDecisionUrl(appealId) {
 	return `/appeals-service/appeal-details/${appealId}/issue-decision/decision`;
-}
-
-/**
- * @param {string|number} appealId
- * @param {string} [backUrl]
- * @returns {string}
- */
-export function generateStartTimetableUrl(appealId, backUrl) {
-	return `/appeals-service/appeal-details/${appealId}/start-case/add${
-		backUrl ? `?backUrl=${backUrl}` : ''
-	}`;
 }

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/lpa-questionnaire.controller.js
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/lpa-questionnaire.controller.js
@@ -30,6 +30,7 @@ import { addNotificationBannerToSession } from '#lib/session-utilities.js';
 import { APPEAL_TYPE } from '@pins/appeals/constants/common.js';
 import * as appealDetailsService from '#appeals/appeal-details/appeal-details.service.js';
 import { mapFolderNameToDisplayLabel } from '#lib/mappers/utils/documents-and-folders.js';
+import { getBackLinkUrlFromQuery } from '#lib/url-utilities.js';
 
 /**
  * @param {import('@pins/express/types/express.js').Request} request
@@ -57,7 +58,9 @@ const renderLpaQuestionnaire = async (request, response, errors = null) => {
 		lpaQuestionnaire,
 		currentAppeal,
 		request.originalUrl,
-		session
+		session,
+		request,
+		getBackLinkUrlFromQuery(request)
 	);
 
 	return response.status(200).render('patterns/display-page.pattern.njk', {

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/lpa-questionnaire.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/lpa-questionnaire.mapper.js
@@ -45,9 +45,18 @@ import { permissionNames } from '#environment/permissions.js';
  * @param {Appeal} appealDetails
  * @param {string} currentRoute
  * @param {import("express-session").Session & Partial<import("express-session").SessionData>} session
+ * @param {import('@pins/express/types/express.js').Request} request
+ * @param {string|undefined} backUrl
  * @returns {Promise<PageContent>}
  */
-export async function lpaQuestionnairePage(lpaqDetails, appealDetails, currentRoute, session) {
+export async function lpaQuestionnairePage(
+	lpaqDetails,
+	appealDetails,
+	currentRoute,
+	session,
+	request,
+	backUrl
+) {
 	const mappedLpaqDetails = initialiseAndMapLPAQData(
 		lpaqDetails,
 		appealDetails,
@@ -58,6 +67,7 @@ export async function lpaQuestionnairePage(lpaqDetails, appealDetails, currentRo
 		appealDetails,
 		currentRoute,
 		session,
+		request,
 		true
 	);
 
@@ -183,7 +193,7 @@ export async function lpaQuestionnairePage(lpaqDetails, appealDetails, currentRo
 	/** @type {PageContent} */
 	const pageContent = {
 		title: `LPA questionnaire - ${shortAppealReference}`,
-		backLinkUrl: `/appeals-service/appeal-details/${appealDetails.appealId}`,
+		backLinkUrl: backUrl || `/appeals-service/appeal-details/${appealDetails.appealId}`,
 		preHeading: `Appeal ${shortAppealReference}`,
 		heading: 'LPA questionnaire',
 		headingClasses: 'govuk-heading-xl govuk-!-margin-bottom-3',

--- a/appeals/web/src/server/appeals/appeal-details/representations/final-comments/view-and-review/view-and-review.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/representations/final-comments/view-and-review/view-and-review.mapper.js
@@ -4,7 +4,6 @@ import { generateCommentsSummaryList } from './page-components/common.js';
 import { mapNotificationBannersFromSession } from '#lib/mappers/index.js';
 import { isRepresentationReviewRequired } from '#lib/representation-utilities.js';
 import { capitalizeFirstLetter } from '#lib/string-utilities.js';
-import { constructUrl } from '#lib/mappers/utils/url.mapper.js';
 
 /** @typedef {import("#appeals/appeal-details/appeal-details.types.js").WebAppeal} Appeal */
 /** @typedef {import('#appeals/appeal-details/representations/types.js').Representation} Representation */
@@ -33,8 +32,6 @@ export function reviewFinalCommentsPage(
 		appealDetails.appealId
 	);
 
-	const backLinkUrl = constructUrl(backUrl, appealDetails.appealId);
-
 	const reviewRequired = isRepresentationReviewRequired(comment.status);
 
 	const title = reviewRequired
@@ -43,7 +40,7 @@ export function reviewFinalCommentsPage(
 
 	const pageContent = {
 		title,
-		backLinkUrl,
+		backLinkUrl: backUrl || `/appeals-service/appeal-details/${appealDetails.appealId}`,
 		preHeading: `Appeal ${shortReference}`,
 		heading: title,
 		submitButtonText: 'Continue',

--- a/appeals/web/src/server/appeals/appeal-details/representations/interested-party-comments/interested-party-comments.controller.js
+++ b/appeals/web/src/server/appeals/appeal-details/representations/interested-party-comments/interested-party-comments.controller.js
@@ -3,6 +3,7 @@ import {
 	sharedIpCommentsPage
 } from './interested-party-comments.mapper.js';
 import * as interestedPartyCommentsService from './interested-party-comments.service.js';
+import { getBackLinkUrlFromQuery } from '#lib/url-utilities.js';
 
 /**
  *
@@ -20,7 +21,7 @@ export const handleInterestedPartyComments = (request, response) =>
  * @param {import('@pins/express/types/express.js').RenderedResponse<any, any, Number>} response
  */
 export async function renderInterestedPartyComments(request, response) {
-	const { errors, currentAppeal, session, query } = request;
+	const { errors, currentAppeal, session } = request;
 	const paginationParameters = {
 		pageNumber: 1,
 		pageSize: 1000
@@ -54,15 +55,13 @@ export async function renderInterestedPartyComments(request, response) {
 		)
 	]);
 
-	const backUrl = query.backUrl ? String(query.backUrl) : '/';
-
 	const mappedPageContent = await interestedPartyCommentsPage(
 		currentAppeal,
 		awaitingReviewComments,
 		validComments,
 		invalidComments,
 		session,
-		backUrl
+		getBackLinkUrlFromQuery(request)
 	);
 
 	return response.status(200).render('appeals/appeal/interested-party-comments.njk', {

--- a/appeals/web/src/server/appeals/appeal-details/representations/interested-party-comments/interested-party-comments.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/representations/interested-party-comments/interested-party-comments.mapper.js
@@ -4,7 +4,6 @@ import { dateISOStringToDisplayDate } from '#lib/dates.js';
 import { mapNotificationBannersFromSession } from '#lib/mappers/index.js';
 import { addressInputs } from '#lib/mappers/index.js';
 import { simpleHtmlComponent } from '#lib/mappers/index.js';
-import { constructUrl } from '#lib/mappers/utils/url.mapper.js';
 import { preRenderPageComponents } from '#lib/nunjucks-template-builders/page-component-rendering.js';
 import { buildHtmlList } from '#lib/nunjucks-template-builders/tag-builders.js';
 import { highlightRedactedSections } from '#lib/redaction-string-formatter.js';
@@ -36,8 +35,6 @@ export async function interestedPartyCommentsPage(
 ) {
 	const shortReference = appealShortReference(appealDetails.appealReference);
 
-	const backLinkUrl = constructUrl(backUrl, appealDetails.appealId);
-
 	const notificationBanners = mapNotificationBannersFromSession(
 		session,
 		'ipComments',
@@ -46,7 +43,7 @@ export async function interestedPartyCommentsPage(
 
 	const pageContent = {
 		title: 'Interested party comments',
-		backLinkUrl,
+		backLinkUrl: backUrl || `/appeals-service/appeal-details/${appealDetails.appealId}`,
 		addCommentUrl: `/appeals-service/appeal-details/${appealDetails.appealId}/interested-party-comments/add`,
 		preHeading: `Appeal ${shortReference}`,
 		heading: 'Interested party comments',

--- a/appeals/web/src/server/appeals/appeal-details/representations/lpa-statement/lpa-statement.controller.js
+++ b/appeals/web/src/server/appeals/appeal-details/representations/lpa-statement/lpa-statement.controller.js
@@ -1,14 +1,13 @@
 import { COMMENT_STATUS, APPEAL_REPRESENTATION_STATUS } from '@pins/appeals/constants/common.js';
 import { reviewLpaStatementPage, viewLpaStatementPage } from './lpa-statement.mapper.js';
+import { getBackLinkUrlFromQuery } from '#lib/url-utilities.js';
 
 /**
  * @param {import('@pins/express/types/express.js').Request} request
  * @param {import('@pins/express/types/express.js').RenderedResponse<any, any, Number>} response
  */
 export const renderReviewLpaStatement = async (request, response) => {
-	const { errors, currentAppeal, currentRepresentation, session, query } = request;
-
-	const backUrl = query.backUrl ? String(query.backUrl) : '/';
+	const { errors, currentAppeal, currentRepresentation, session } = request;
 
 	const isReview = [
 		APPEAL_REPRESENTATION_STATUS.AWAITING_REVIEW,
@@ -19,7 +18,7 @@ export const renderReviewLpaStatement = async (request, response) => {
 		currentAppeal,
 		currentRepresentation,
 		session,
-		backUrl
+		getBackLinkUrlFromQuery(request)
 	);
 
 	return response

--- a/appeals/web/src/server/appeals/appeal-details/representations/lpa-statement/lpa-statement.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/representations/lpa-statement/lpa-statement.mapper.js
@@ -3,7 +3,6 @@ import { preRenderPageComponents } from '#lib/nunjucks-template-builders/page-co
 import { buildHtmlList } from '#lib/nunjucks-template-builders/tag-builders.js';
 import { mapNotificationBannersFromSession } from '#lib/mappers/index.js';
 import { COMMENT_STATUS } from '@pins/appeals/constants/common.js';
-import { constructUrl } from '#lib/mappers/utils/url.mapper.js';
 import { mapDocumentDownloadUrl } from '#appeals/appeal-documents/appeal-documents.mapper.js';
 
 /** @typedef {import("#appeals/appeal-details/appeal-details.types.js").WebAppeal} Appeal */
@@ -162,8 +161,6 @@ export function baseSummaryList(appealId, lpaStatement, { isReview }) {
 export function viewLpaStatementPage(appealDetails, lpaStatement, session, backUrl) {
 	const shortReference = appealShortReference(appealDetails.appealReference);
 
-	const backLinkUrl = constructUrl(backUrl, appealDetails.appealId);
-
 	const lpaStatementSummaryList = baseSummaryList(appealDetails.appealId, lpaStatement, {
 		isReview: false
 	});
@@ -176,7 +173,7 @@ export function viewLpaStatementPage(appealDetails, lpaStatement, session, backU
 
 	const pageContent = {
 		title: 'LPA statement',
-		backLinkUrl,
+		backLinkUrl: backUrl || `/appeals-service/appeal-details/${appealDetails.appealId}`,
 		preHeading: `Appeal ${shortReference}`,
 		heading: 'LPA statement',
 		pageComponents
@@ -194,9 +191,6 @@ export function viewLpaStatementPage(appealDetails, lpaStatement, session, backU
  */
 export function reviewLpaStatementPage(appealDetails, lpaStatement, session, backUrl) {
 	const shortReference = appealShortReference(appealDetails.appealReference);
-
-	const backLinkUrl = constructUrl(backUrl, appealDetails.appealId);
-
 	const lpaStatementSummaryList = baseSummaryList(appealDetails.appealId, lpaStatement, {
 		isReview: true
 	});
@@ -244,7 +238,7 @@ export function reviewLpaStatementPage(appealDetails, lpaStatement, session, bac
 
 	const pageContent = {
 		title: 'Review LPA statement',
-		backLinkUrl,
+		backLinkUrl: backUrl || `/appeals-service/appeal-details/${appealDetails.appealId}`,
 		preHeading: `Appeal ${shortReference}`,
 		heading: 'Review LPA statement',
 		submitButtonText: 'Continue',

--- a/appeals/web/src/server/appeals/appeal-details/representations/representations.controller.js
+++ b/appeals/web/src/server/appeals/appeal-details/representations/representations.controller.js
@@ -4,17 +4,16 @@ import { dateIsInThePast, dateISOStringToDayMonthYearHourMinute } from '#lib/dat
 import { addNotificationBannerToSession } from '#lib/session-utilities.js';
 import { statementAndCommentsSharePage, finalCommentsSharePage } from './representations.mapper.js';
 import { publishRepresentations } from './representations.service.js';
+import { getBackLinkUrlFromQuery } from '#lib/url-utilities.js';
 
 /** @type {import('@pins/express').RequestHandler<{}>} */
 export function renderShareRepresentations(request, response) {
-	const { errors, currentAppeal, query } = request;
-
-	const backUrl = query.backUrl ? String(query.backUrl) : '/';
+	const { errors, currentAppeal } = request;
 
 	const pageContent = (() => {
 		switch (currentAppeal.appealStatus) {
 			case APPEAL_CASE_STATUS.STATEMENTS:
-				return statementAndCommentsSharePage(currentAppeal, backUrl);
+				return statementAndCommentsSharePage(currentAppeal, getBackLinkUrlFromQuery(request));
 			case APPEAL_CASE_STATUS.FINAL_COMMENTS: {
 				const finalCommentsDueDate = currentAppeal.appealTimetable?.finalCommentsDueDate;
 				if (
@@ -24,7 +23,7 @@ export function renderShareRepresentations(request, response) {
 					throw new Error('Final comments cannot be shared before the due date has passed');
 				}
 
-				return finalCommentsSharePage(currentAppeal, backUrl);
+				return finalCommentsSharePage(currentAppeal, getBackLinkUrlFromQuery(request));
 			}
 			default:
 				throw new Error(

--- a/appeals/web/src/server/appeals/appeal-details/representations/representations.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/representations/representations.mapper.js
@@ -2,7 +2,6 @@ import { COMMENT_STATUS } from '@pins/appeals/constants/common.js';
 import { ensureArray } from '#lib/array-utilities.js';
 import { appealShortReference } from '#lib/appeals-formatter.js';
 import { APPEAL_REPRESENTATION_STATUS } from '@pins/appeals/constants/common.js';
-import { constructUrl } from '#lib/mappers/utils/url.mapper.js';
 
 /** @typedef {import("#appeals/appeal-details/appeal-details.types.js").WebAppeal} Appeal */
 /** @typedef {import("#appeals/appeal-details/representations/types.js").Representation} Representation */
@@ -115,7 +114,7 @@ export function mapRejectionReasonPayload(rejectionReasons) {
 
 /**
  * @param {Appeal} appeal
- * @param {string | undefined} backUrl
+ * @param {string} [backUrl]
  * @returns {PageContent}
  * */
 export function statementAndCommentsSharePage(appeal, backUrl) {
@@ -158,11 +157,9 @@ export function statementAndCommentsSharePage(appeal, backUrl) {
 	const heading =
 		valueTexts.length > 0 ? 'Share IP comments and statements' : 'Progress to final comments';
 
-	const backLinkUrl = constructUrl(backUrl, appeal.appealId);
-
 	return {
 		title: heading,
-		backLinkUrl,
+		backLinkUrl: backUrl || `/appeals-service/appeal-details/${appeal.appealId}`,
 		preHeading: `Appeal ${shortAppealReference}`,
 		heading,
 		pageComponents: [
@@ -215,12 +212,10 @@ export function finalCommentsSharePage(appeal, backUrl) {
 		: 'Do not progress the case if you are awaiting any late final comments.';
 	const submitButtonText = hasItemsToShare ? 'Share final comments' : 'Progress case';
 
-	const backLinkUrl = constructUrl(backUrl, appeal.appealId);
-
 	/** @type {PageContent} */
 	const pageContent = {
 		title,
-		backLinkUrl,
+		backLinkUrl: backUrl || `/appeals-service/appeal-details/${appeal.appealId}`,
 		preHeading: `Appeal ${appealShortReference(appeal.appealReference)}`,
 		heading: title,
 		pageComponents: [

--- a/appeals/web/src/server/appeals/appeal-details/site-visit/site-visit.controller.js
+++ b/appeals/web/src/server/appeals/appeal-details/site-visit/site-visit.controller.js
@@ -11,6 +11,7 @@ import {
 } from './site-visit.mapper.js';
 import { addNotificationBannerToSession } from '#lib/session-utilities.js';
 import usersService from '#appeals/appeal-users/users-service.js';
+import { getBackLinkUrlFromQuery } from '#lib/url-utilities.js';
 
 /**
  *
@@ -41,7 +42,9 @@ const renderScheduleOrManageSiteVisit = async (request, response, pageType) => {
 			pageType,
 			appealDetails,
 			request.originalUrl,
+			getBackLinkUrlFromQuery(request),
 			request.session,
+			request,
 			visitType,
 			visitDateDay,
 			visitDateMonth,

--- a/appeals/web/src/server/appeals/appeal-details/site-visit/site-visit.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/site-visit/site-visit.mapper.js
@@ -50,7 +50,9 @@ export function mapGetApiVisitTypeToWebVisitType(getApiVisitType) {
  * @param {'schedule' | 'manage'} pageType
  * @param {Appeal} appealDetails
  * @param {string} currentRoute
+ * @param {string|undefined} backUrl
  * @param {import("express-session").Session & Partial<import("express-session").SessionData>} session
+ * @param {import('@pins/express/types/express.js').Request} request
  * @param {WebSiteVisitType|null|undefined} visitType
  * @param {string|number|null|undefined} visitDateDay
  * @param {string|number|null|undefined} visitDateMonth
@@ -65,7 +67,9 @@ export async function scheduleOrManageSiteVisitPage(
 	pageType,
 	appealDetails,
 	currentRoute,
+	backUrl,
 	session,
+	request,
 	visitType,
 	visitDateDay,
 	visitDateMonth,
@@ -75,7 +79,13 @@ export async function scheduleOrManageSiteVisitPage(
 	visitEndTimeHour,
 	visitEndTimeMinute
 ) {
-	const mappedData = await initialiseAndMapAppealData(appealDetails, currentRoute, session, true);
+	const mappedData = await initialiseAndMapAppealData(
+		appealDetails,
+		currentRoute,
+		session,
+		request,
+		true
+	);
 	const titlePrefix = capitalize(pageType);
 
 	visitType ??= mapGetApiVisitTypeToWebVisitType(appealDetails.siteVisit?.visitType);
@@ -255,7 +265,7 @@ export async function scheduleOrManageSiteVisitPage(
 	/** @type {PageContent} */
 	const pageContent = {
 		title: `${titlePrefix} site visit - ${shortAppealReference}`,
-		backLinkUrl: `/appeals-service/appeal-details/${appealDetails.appealId}`,
+		backLinkUrl: backUrl || `/appeals-service/appeal-details/${appealDetails.appealId}`,
 		preHeading: `Appeal ${shortAppealReference}`,
 		heading: `${titlePrefix} site visit`,
 		submitButtonText: 'Confirm',

--- a/appeals/web/src/server/appeals/appeal-details/start-case/start-case.controller.js
+++ b/appeals/web/src/server/appeals/appeal-details/start-case/start-case.controller.js
@@ -12,6 +12,7 @@ import { addNotificationBannerToSession } from '#lib/session-utilities.js';
 import featureFlags from '#common/feature-flags.js';
 import { FEATURE_FLAG_NAMES, APPEAL_TYPE } from '@pins/appeals/constants/common.js';
 import { APPEAL_CASE_PROCEDURE } from 'pins-data-model';
+import { getBackLinkUrlFromQuery } from '#lib/url-utilities.js';
 
 /** @type {import('@pins/express').RequestHandler<Response>}  */
 export const getStartDate = async (request, response) => {
@@ -54,7 +55,8 @@ const renderStartDatePage = async (request, response) => {
 	const mappedPageContent = startCasePage(
 		appealId,
 		appealReference,
-		dateISOStringToDisplayDate(getTodaysISOString())
+		dateISOStringToDisplayDate(getTodaysISOString()),
+		getBackLinkUrlFromQuery(request)
 	);
 
 	return response.status(200).render('patterns/display-page.pattern.njk', {

--- a/appeals/web/src/server/appeals/appeal-details/start-case/start-case.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/start-case/start-case.mapper.js
@@ -9,13 +9,14 @@ import { APPEAL_CASE_PROCEDURE } from 'pins-data-model';
  * @param {number} appealId
  * @param {string} appealReference
  * @param {string} today
+ * @param {string|undefined} backUrl
  * @returns {PageContent}
  */
-export function startCasePage(appealId, appealReference, today) {
+export function startCasePage(appealId, appealReference, today, backUrl) {
 	/** @type {PageContent} */
 	const pageContent = {
 		title: 'Start case',
-		backLinkUrl: `/appeals-service/appeal-details/${appealId}`,
+		backLinkUrl: backUrl || `/appeals-service/appeal-details/${appealId}`,
 		preHeading: `Appeal ${appealShortReference(appealReference)}`,
 		heading: 'Start case',
 		pageComponents: [

--- a/appeals/web/src/server/appeals/personal-list/__tests__/__snapshots__/personal-list.test.js.snap
+++ b/appeals/web/src/server/appeals/personal-list/__tests__/__snapshots__/personal-list.test.js.snap
@@ -53,7 +53,7 @@ exports[`personal-list GET / should render a child status tag in the lead or chi
                         </td>
                         <td class="govuk-table__cell"><strong class="govuk-tag govuk-tag--grey single-line">Lead</strong>
                         </td>
-                        <td class="govuk-table__cell action-required"><a class="govuk-link" href="/appeals-service/appeal-details/28535/share?backUrl=/personal-list">Progress case</a>
+                        <td class="govuk-table__cell action-required"><a class="govuk-link" href="/appeals-service/appeal-details/28535/share?backUrl=%2Fappeals-service%2Fpersonal-list%3FpageNumber%3D1%26pageSize%3D30">Progress case</a>
                         </td>
                         <td class="govuk-table__cell">23 September 2024</td>
                         <td class="govuk-table__cell"><strong class="govuk-tag govuk-tag--grey single-line">Final comments</strong>
@@ -64,7 +64,7 @@ exports[`personal-list GET / should render a child status tag in the lead or chi
                         </td>
                         <td class="govuk-table__cell"><strong class="govuk-tag govuk-tag--grey single-line">Child</strong>
                         </td>
-                        <td class="govuk-table__cell action-required"><a class="govuk-link" href="/appeals-service/appeal-details/28524/lpa-questionnaire/25063">Review LPA questionnaire<span class="govuk-visually-hidden"> for appeal 28524</span></a>
+                        <td class="govuk-table__cell action-required"><a class="govuk-link" href="/appeals-service/appeal-details/28524/lpa-questionnaire/25063?backUrl=%2Fappeals-service%2Fpersonal-list%3FpageNumber%3D1%26pageSize%3D30">Review LPA questionnaire<span class="govuk-visually-hidden"> for appeal 28524</span></a>
                         </td>
                         <td class="govuk-table__cell">10 January 2025</td>
                         <td class="govuk-table__cell"><strong class="govuk-tag govuk-tag--yellow single-line">LPA questionnaire</strong>
@@ -74,7 +74,7 @@ exports[`personal-list GET / should render a child status tag in the lead or chi
                         <td class="govuk-table__cell"><strong><a class="govuk-link" href="/appeals-service/appeal-details/28526" aria-label="Appeal 6 0 2 8 5 2 6">6028526</a></strong>
                         </td>
                         <td class="govuk-table__cell"></td>
-                        <td class="govuk-table__cell action-required"><a class="govuk-link" href="/appeals-service/appeal-details/28526/interested-party-comments?backUrl=/personal-list">Review IP comments<span class="govuk-visually-hidden"> for appeal 28526</span></a>
+                        <td class="govuk-table__cell action-required"><a class="govuk-link" href="/appeals-service/appeal-details/28526/interested-party-comments?backUrl=%2Fappeals-service%2Fpersonal-list%3FpageNumber%3D1%26pageSize%3D30">Review IP comments<span class="govuk-visually-hidden"> for appeal 28526</span></a>
                         </td>
                         <td class="govuk-table__cell">7 February 2025</td>
                         <td class="govuk-table__cell"><strong class="govuk-tag govuk-tag--grey single-line">Statements</strong>
@@ -84,7 +84,7 @@ exports[`personal-list GET / should render a child status tag in the lead or chi
                         <td class="govuk-table__cell"><strong><a class="govuk-link" href="/appeals-service/appeal-details/28512" aria-label="Appeal 6 0 2 8 5 1 2">6028512</a></strong>
                         </td>
                         <td class="govuk-table__cell"></td>
-                        <td class="govuk-table__cell action-required"><a class="govuk-link" href="/appeals-service/appeal-details/28512/start-case/add?backUrl=/appeals-service/personal-list?pageNumber=1&pageSize=30">Start case<span class="govuk-visually-hidden"> for appeal 28512</span></a>
+                        <td class="govuk-table__cell action-required"><a class="govuk-link" href="/appeals-service/appeal-details/28512/start-case/add?backUrl=%2Fappeals-service%2Fpersonal-list%3FpageNumber%3D1%26pageSize%3D30">Start case<span class="govuk-visually-hidden"> for appeal 28512</span></a>
                         </td>
                         <td class="govuk-table__cell">9 March 2025</td>
                         <td class="govuk-table__cell"><strong class="govuk-tag govuk-tag--turquoise single-line">Ready to start</strong>
@@ -94,7 +94,7 @@ exports[`personal-list GET / should render a child status tag in the lead or chi
                         <td class="govuk-table__cell"><strong><a class="govuk-link" href="/appeals-service/appeal-details/28515" aria-label="Appeal 6 0 2 8 5 1 5">6028515</a></strong>
                         </td>
                         <td class="govuk-table__cell"></td>
-                        <td class="govuk-table__cell action-required"><a class="govuk-link" href="/appeals-service/appeal-details/28515/appellant-case">Review appellant case<span class="govuk-visually-hidden"> for appeal 28515</span></a>
+                        <td class="govuk-table__cell action-required"><a class="govuk-link" href="/appeals-service/appeal-details/28515/appellant-case?backUrl=%2Fappeals-service%2Fpersonal-list%3FpageNumber%3D1%26pageSize%3D30">Review appellant case<span class="govuk-visually-hidden"> for appeal 28515</span></a>
                         </td>
                         <td class="govuk-table__cell"></td>
                         <td class="govuk-table__cell"><strong class="govuk-tag govuk-tag--orange single-line">Validation</strong>
@@ -180,7 +180,7 @@ exports[`personal-list GET / should render a lead status tag in the lead or chil
                         </td>
                         <td class="govuk-table__cell"><strong class="govuk-tag govuk-tag--grey single-line">Lead</strong>
                         </td>
-                        <td class="govuk-table__cell action-required"><a class="govuk-link" href="/appeals-service/appeal-details/28535/share?backUrl=/personal-list">Progress case</a>
+                        <td class="govuk-table__cell action-required"><a class="govuk-link" href="/appeals-service/appeal-details/28535/share?backUrl=%2Fappeals-service%2Fpersonal-list%3FpageNumber%3D1%26pageSize%3D30">Progress case</a>
                         </td>
                         <td class="govuk-table__cell">23 September 2024</td>
                         <td class="govuk-table__cell"><strong class="govuk-tag govuk-tag--grey single-line">Final comments</strong>
@@ -191,7 +191,7 @@ exports[`personal-list GET / should render a lead status tag in the lead or chil
                         </td>
                         <td class="govuk-table__cell"><strong class="govuk-tag govuk-tag--grey single-line">Child</strong>
                         </td>
-                        <td class="govuk-table__cell action-required"><a class="govuk-link" href="/appeals-service/appeal-details/28524/lpa-questionnaire/25063">Review LPA questionnaire<span class="govuk-visually-hidden"> for appeal 28524</span></a>
+                        <td class="govuk-table__cell action-required"><a class="govuk-link" href="/appeals-service/appeal-details/28524/lpa-questionnaire/25063?backUrl=%2Fappeals-service%2Fpersonal-list%3FpageNumber%3D1%26pageSize%3D30">Review LPA questionnaire<span class="govuk-visually-hidden"> for appeal 28524</span></a>
                         </td>
                         <td class="govuk-table__cell">10 January 2025</td>
                         <td class="govuk-table__cell"><strong class="govuk-tag govuk-tag--yellow single-line">LPA questionnaire</strong>
@@ -201,7 +201,7 @@ exports[`personal-list GET / should render a lead status tag in the lead or chil
                         <td class="govuk-table__cell"><strong><a class="govuk-link" href="/appeals-service/appeal-details/28526" aria-label="Appeal 6 0 2 8 5 2 6">6028526</a></strong>
                         </td>
                         <td class="govuk-table__cell"></td>
-                        <td class="govuk-table__cell action-required"><a class="govuk-link" href="/appeals-service/appeal-details/28526/interested-party-comments?backUrl=/personal-list">Review IP comments<span class="govuk-visually-hidden"> for appeal 28526</span></a>
+                        <td class="govuk-table__cell action-required"><a class="govuk-link" href="/appeals-service/appeal-details/28526/interested-party-comments?backUrl=%2Fappeals-service%2Fpersonal-list%3FpageNumber%3D1%26pageSize%3D30">Review IP comments<span class="govuk-visually-hidden"> for appeal 28526</span></a>
                         </td>
                         <td class="govuk-table__cell">7 February 2025</td>
                         <td class="govuk-table__cell"><strong class="govuk-tag govuk-tag--grey single-line">Statements</strong>
@@ -211,7 +211,7 @@ exports[`personal-list GET / should render a lead status tag in the lead or chil
                         <td class="govuk-table__cell"><strong><a class="govuk-link" href="/appeals-service/appeal-details/28512" aria-label="Appeal 6 0 2 8 5 1 2">6028512</a></strong>
                         </td>
                         <td class="govuk-table__cell"></td>
-                        <td class="govuk-table__cell action-required"><a class="govuk-link" href="/appeals-service/appeal-details/28512/start-case/add?backUrl=/appeals-service/personal-list?pageNumber=1&pageSize=30">Start case<span class="govuk-visually-hidden"> for appeal 28512</span></a>
+                        <td class="govuk-table__cell action-required"><a class="govuk-link" href="/appeals-service/appeal-details/28512/start-case/add?backUrl=%2Fappeals-service%2Fpersonal-list%3FpageNumber%3D1%26pageSize%3D30">Start case<span class="govuk-visually-hidden"> for appeal 28512</span></a>
                         </td>
                         <td class="govuk-table__cell">9 March 2025</td>
                         <td class="govuk-table__cell"><strong class="govuk-tag govuk-tag--turquoise single-line">Ready to start</strong>
@@ -221,7 +221,7 @@ exports[`personal-list GET / should render a lead status tag in the lead or chil
                         <td class="govuk-table__cell"><strong><a class="govuk-link" href="/appeals-service/appeal-details/28515" aria-label="Appeal 6 0 2 8 5 1 5">6028515</a></strong>
                         </td>
                         <td class="govuk-table__cell"></td>
-                        <td class="govuk-table__cell action-required"><a class="govuk-link" href="/appeals-service/appeal-details/28515/appellant-case">Review appellant case<span class="govuk-visually-hidden"> for appeal 28515</span></a>
+                        <td class="govuk-table__cell action-required"><a class="govuk-link" href="/appeals-service/appeal-details/28515/appellant-case?backUrl=%2Fappeals-service%2Fpersonal-list%3FpageNumber%3D1%26pageSize%3D30">Review appellant case<span class="govuk-visually-hidden"> for appeal 28515</span></a>
                         </td>
                         <td class="govuk-table__cell"></td>
                         <td class="govuk-table__cell"><strong class="govuk-tag govuk-tag--orange single-line">Validation</strong>
@@ -322,7 +322,7 @@ exports[`personal-list GET / should render an empty cell in the lead or child co
                         </td>
                         <td class="govuk-table__cell"><strong class="govuk-tag govuk-tag--grey single-line">Lead</strong>
                         </td>
-                        <td class="govuk-table__cell action-required"><a class="govuk-link" href="/appeals-service/appeal-details/28535/share?backUrl=/personal-list">Progress case</a>
+                        <td class="govuk-table__cell action-required"><a class="govuk-link" href="/appeals-service/appeal-details/28535/share?backUrl=%2Fappeals-service%2Fpersonal-list%3FpageNumber%3D1%26pageSize%3D30">Progress case</a>
                         </td>
                         <td class="govuk-table__cell">23 September 2024</td>
                         <td class="govuk-table__cell"><strong class="govuk-tag govuk-tag--grey single-line">Final comments</strong>
@@ -333,7 +333,7 @@ exports[`personal-list GET / should render an empty cell in the lead or child co
                         </td>
                         <td class="govuk-table__cell"><strong class="govuk-tag govuk-tag--grey single-line">Child</strong>
                         </td>
-                        <td class="govuk-table__cell action-required"><a class="govuk-link" href="/appeals-service/appeal-details/28524/lpa-questionnaire/25063">Review LPA questionnaire<span class="govuk-visually-hidden"> for appeal 28524</span></a>
+                        <td class="govuk-table__cell action-required"><a class="govuk-link" href="/appeals-service/appeal-details/28524/lpa-questionnaire/25063?backUrl=%2Fappeals-service%2Fpersonal-list%3FpageNumber%3D1%26pageSize%3D30">Review LPA questionnaire<span class="govuk-visually-hidden"> for appeal 28524</span></a>
                         </td>
                         <td class="govuk-table__cell">10 January 2025</td>
                         <td class="govuk-table__cell"><strong class="govuk-tag govuk-tag--yellow single-line">LPA questionnaire</strong>
@@ -343,7 +343,7 @@ exports[`personal-list GET / should render an empty cell in the lead or child co
                         <td class="govuk-table__cell"><strong><a class="govuk-link" href="/appeals-service/appeal-details/28526" aria-label="Appeal 6 0 2 8 5 2 6">6028526</a></strong>
                         </td>
                         <td class="govuk-table__cell"></td>
-                        <td class="govuk-table__cell action-required"><a class="govuk-link" href="/appeals-service/appeal-details/28526/interested-party-comments?backUrl=/personal-list">Review IP comments<span class="govuk-visually-hidden"> for appeal 28526</span></a>
+                        <td class="govuk-table__cell action-required"><a class="govuk-link" href="/appeals-service/appeal-details/28526/interested-party-comments?backUrl=%2Fappeals-service%2Fpersonal-list%3FpageNumber%3D1%26pageSize%3D30">Review IP comments<span class="govuk-visually-hidden"> for appeal 28526</span></a>
                         </td>
                         <td class="govuk-table__cell">7 February 2025</td>
                         <td class="govuk-table__cell"><strong class="govuk-tag govuk-tag--grey single-line">Statements</strong>
@@ -353,7 +353,7 @@ exports[`personal-list GET / should render an empty cell in the lead or child co
                         <td class="govuk-table__cell"><strong><a class="govuk-link" href="/appeals-service/appeal-details/28512" aria-label="Appeal 6 0 2 8 5 1 2">6028512</a></strong>
                         </td>
                         <td class="govuk-table__cell"></td>
-                        <td class="govuk-table__cell action-required"><a class="govuk-link" href="/appeals-service/appeal-details/28512/start-case/add?backUrl=/appeals-service/personal-list?pageNumber=1&pageSize=30">Start case<span class="govuk-visually-hidden"> for appeal 28512</span></a>
+                        <td class="govuk-table__cell action-required"><a class="govuk-link" href="/appeals-service/appeal-details/28512/start-case/add?backUrl=%2Fappeals-service%2Fpersonal-list%3FpageNumber%3D1%26pageSize%3D30">Start case<span class="govuk-visually-hidden"> for appeal 28512</span></a>
                         </td>
                         <td class="govuk-table__cell">9 March 2025</td>
                         <td class="govuk-table__cell"><strong class="govuk-tag govuk-tag--turquoise single-line">Ready to start</strong>
@@ -363,7 +363,7 @@ exports[`personal-list GET / should render an empty cell in the lead or child co
                         <td class="govuk-table__cell"><strong><a class="govuk-link" href="/appeals-service/appeal-details/28515" aria-label="Appeal 6 0 2 8 5 1 5">6028515</a></strong>
                         </td>
                         <td class="govuk-table__cell"></td>
-                        <td class="govuk-table__cell action-required"><a class="govuk-link" href="/appeals-service/appeal-details/28515/appellant-case">Review appellant case<span class="govuk-visually-hidden"> for appeal 28515</span></a>
+                        <td class="govuk-table__cell action-required"><a class="govuk-link" href="/appeals-service/appeal-details/28515/appellant-case?backUrl=%2Fappeals-service%2Fpersonal-list%3FpageNumber%3D1%26pageSize%3D30">Review appellant case<span class="govuk-visually-hidden"> for appeal 28515</span></a>
                         </td>
                         <td class="govuk-table__cell"></td>
                         <td class="govuk-table__cell"><strong class="govuk-tag govuk-tag--orange single-line">Validation</strong>
@@ -449,7 +449,7 @@ exports[`personal-list GET / should render the first page of the personal list w
                         </td>
                         <td class="govuk-table__cell"><strong class="govuk-tag govuk-tag--grey single-line">Lead</strong>
                         </td>
-                        <td class="govuk-table__cell action-required"><a class="govuk-link" href="/appeals-service/appeal-details/28535/share?backUrl=/personal-list">Progress case</a>
+                        <td class="govuk-table__cell action-required"><a class="govuk-link" href="/appeals-service/appeal-details/28535/share?backUrl=%2Fappeals-service%2Fpersonal-list%3FpageNumber%3D1%26pageSize%3D5">Progress case</a>
                         </td>
                         <td class="govuk-table__cell">23 September 2024</td>
                         <td class="govuk-table__cell"><strong class="govuk-tag govuk-tag--grey single-line">Final comments</strong>
@@ -460,7 +460,7 @@ exports[`personal-list GET / should render the first page of the personal list w
                         </td>
                         <td class="govuk-table__cell"><strong class="govuk-tag govuk-tag--grey single-line">Child</strong>
                         </td>
-                        <td class="govuk-table__cell action-required"><a class="govuk-link" href="/appeals-service/appeal-details/28524/lpa-questionnaire/25063">Review LPA questionnaire<span class="govuk-visually-hidden"> for appeal 28524</span></a>
+                        <td class="govuk-table__cell action-required"><a class="govuk-link" href="/appeals-service/appeal-details/28524/lpa-questionnaire/25063?backUrl=%2Fappeals-service%2Fpersonal-list%3FpageNumber%3D1%26pageSize%3D5">Review LPA questionnaire<span class="govuk-visually-hidden"> for appeal 28524</span></a>
                         </td>
                         <td class="govuk-table__cell">10 January 2025</td>
                         <td class="govuk-table__cell"><strong class="govuk-tag govuk-tag--yellow single-line">LPA questionnaire</strong>
@@ -470,7 +470,7 @@ exports[`personal-list GET / should render the first page of the personal list w
                         <td class="govuk-table__cell"><strong><a class="govuk-link" href="/appeals-service/appeal-details/28526" aria-label="Appeal 6 0 2 8 5 2 6">6028526</a></strong>
                         </td>
                         <td class="govuk-table__cell"></td>
-                        <td class="govuk-table__cell action-required"><a class="govuk-link" href="/appeals-service/appeal-details/28526/interested-party-comments?backUrl=/personal-list">Review IP comments<span class="govuk-visually-hidden"> for appeal 28526</span></a>
+                        <td class="govuk-table__cell action-required"><a class="govuk-link" href="/appeals-service/appeal-details/28526/interested-party-comments?backUrl=%2Fappeals-service%2Fpersonal-list%3FpageNumber%3D1%26pageSize%3D5">Review IP comments<span class="govuk-visually-hidden"> for appeal 28526</span></a>
                         </td>
                         <td class="govuk-table__cell">7 February 2025</td>
                         <td class="govuk-table__cell"><strong class="govuk-tag govuk-tag--grey single-line">Statements</strong>
@@ -480,7 +480,7 @@ exports[`personal-list GET / should render the first page of the personal list w
                         <td class="govuk-table__cell"><strong><a class="govuk-link" href="/appeals-service/appeal-details/28512" aria-label="Appeal 6 0 2 8 5 1 2">6028512</a></strong>
                         </td>
                         <td class="govuk-table__cell"></td>
-                        <td class="govuk-table__cell action-required"><a class="govuk-link" href="/appeals-service/appeal-details/28512/start-case/add?backUrl=/appeals-service/personal-list?pageNumber=1&pageSize=5">Start case<span class="govuk-visually-hidden"> for appeal 28512</span></a>
+                        <td class="govuk-table__cell action-required"><a class="govuk-link" href="/appeals-service/appeal-details/28512/start-case/add?backUrl=%2Fappeals-service%2Fpersonal-list%3FpageNumber%3D1%26pageSize%3D5">Start case<span class="govuk-visually-hidden"> for appeal 28512</span></a>
                         </td>
                         <td class="govuk-table__cell">9 March 2025</td>
                         <td class="govuk-table__cell"><strong class="govuk-tag govuk-tag--turquoise single-line">Ready to start</strong>
@@ -490,7 +490,7 @@ exports[`personal-list GET / should render the first page of the personal list w
                         <td class="govuk-table__cell"><strong><a class="govuk-link" href="/appeals-service/appeal-details/28515" aria-label="Appeal 6 0 2 8 5 1 5">6028515</a></strong>
                         </td>
                         <td class="govuk-table__cell"></td>
-                        <td class="govuk-table__cell action-required"><a class="govuk-link" href="/appeals-service/appeal-details/28515/appellant-case">Review appellant case<span class="govuk-visually-hidden"> for appeal 28515</span></a>
+                        <td class="govuk-table__cell action-required"><a class="govuk-link" href="/appeals-service/appeal-details/28515/appellant-case?backUrl=%2Fappeals-service%2Fpersonal-list%3FpageNumber%3D1%26pageSize%3D5">Review appellant case<span class="govuk-visually-hidden"> for appeal 28515</span></a>
                         </td>
                         <td class="govuk-table__cell"></td>
                         <td class="govuk-table__cell"><strong class="govuk-tag govuk-tag--orange single-line">Validation</strong>
@@ -602,7 +602,7 @@ exports[`personal-list GET / should render the second page of the personal list 
                         <td class="govuk-table__cell"><strong><a class="govuk-link" href="/appeals-service/appeal-details/28513" aria-label="Appeal 6 0 2 8 5 1 3">6028513</a></strong>
                         </td>
                         <td class="govuk-table__cell"></td>
-                        <td class="govuk-table__cell action-required"><a class="govuk-link" href="/appeals-service/appeal-details/28513/change-appeal-type/add-horizon-reference">Update Horizon reference<span class="govuk-visually-hidden"> for appeal 28513</span></a>
+                        <td class="govuk-table__cell action-required"><a class="govuk-link" href="/appeals-service/appeal-details/28513/change-appeal-type/add-horizon-reference?backUrl=%2Fappeals-service%2Fpersonal-list%3FpageNumber%3D2%26pageSize%3D1%26appealStatusFilter%3Dlpa_questionnaire">Update Horizon reference<span class="govuk-visually-hidden"> for appeal 28513</span></a>
                         </td>
                         <td class="govuk-table__cell"></td>
                         <td class="govuk-table__cell"><strong class="govuk-tag govuk-tag--red single-line">Awaiting transfer</strong>
@@ -612,7 +612,7 @@ exports[`personal-list GET / should render the second page of the personal list 
                         <td class="govuk-table__cell"><strong><a class="govuk-link" href="/appeals-service/appeal-details/28510" aria-label="Appeal 6 0 2 8 5 1 0">6028510</a></strong>
                         </td>
                         <td class="govuk-table__cell"></td>
-                        <td class="govuk-table__cell action-required"><a class="govuk-link" href="/appeals-service/appeal-details/28510/site-visit/schedule-visit">Set up site visit<span class="govuk-visually-hidden"> for appeal 28510</span></a>
+                        <td class="govuk-table__cell action-required"><a class="govuk-link" href="/appeals-service/appeal-details/28510/site-visit/schedule-visit?backUrl=%2Fappeals-service%2Fpersonal-list%3FpageNumber%3D2%26pageSize%3D1%26appealStatusFilter%3Dlpa_questionnaire">Set up site visit<span class="govuk-visually-hidden"> for appeal 28510</span></a>
                         </td>
                         <td class="govuk-table__cell"></td>
                         <td class="govuk-table__cell"><strong class="govuk-tag govuk-tag--grey single-line">Site visit ready to set up</strong>
@@ -640,7 +640,7 @@ exports[`personal-list GET / should render the second page of the personal list 
                         <td class="govuk-table__cell"><strong><a class="govuk-link" href="/appeals-service/appeal-details/28533" aria-label="Appeal 6 0 2 8 5 3 3">6028533</a></strong>
                         </td>
                         <td class="govuk-table__cell"></td>
-                        <td class="govuk-table__cell action-required"><a class="govuk-link" href="/appeals-service/appeal-details/28533/final-comments/lpa">Review LPA final comments<span class="govuk-visually-hidden"> for appeal 28533</span></a>
+                        <td class="govuk-table__cell action-required"><a class="govuk-link" href="/appeals-service/appeal-details/28533/final-comments/lpa?backUrl=%2Fappeals-service%2Fpersonal-list%3FpageNumber%3D2%26pageSize%3D1%26appealStatusFilter%3Dlpa_questionnaire">Review LPA final comments<span class="govuk-visually-hidden"> for appeal 28533</span></a>
                         </td>
                         <td class="govuk-table__cell">25 March 2025</td>
                         <td class="govuk-table__cell"><strong class="govuk-tag govuk-tag--grey single-line">Final comments</strong>
@@ -727,7 +727,7 @@ exports[`personal-list GET / should render the second page of the personal list 
                         <td class="govuk-table__cell"><strong><a class="govuk-link" href="/appeals-service/appeal-details/28513" aria-label="Appeal 6 0 2 8 5 1 3">6028513</a></strong>
                         </td>
                         <td class="govuk-table__cell"></td>
-                        <td class="govuk-table__cell action-required"><a class="govuk-link" href="/appeals-service/appeal-details/28513/change-appeal-type/add-horizon-reference">Update Horizon reference<span class="govuk-visually-hidden"> for appeal 28513</span></a>
+                        <td class="govuk-table__cell action-required"><a class="govuk-link" href="/appeals-service/appeal-details/28513/change-appeal-type/add-horizon-reference?backUrl=%2Fappeals-service%2Fpersonal-list%3FpageNumber%3D2%26pageSize%3D5">Update Horizon reference<span class="govuk-visually-hidden"> for appeal 28513</span></a>
                         </td>
                         <td class="govuk-table__cell"></td>
                         <td class="govuk-table__cell"><strong class="govuk-tag govuk-tag--red single-line">Awaiting transfer</strong>
@@ -737,7 +737,7 @@ exports[`personal-list GET / should render the second page of the personal list 
                         <td class="govuk-table__cell"><strong><a class="govuk-link" href="/appeals-service/appeal-details/28510" aria-label="Appeal 6 0 2 8 5 1 0">6028510</a></strong>
                         </td>
                         <td class="govuk-table__cell"></td>
-                        <td class="govuk-table__cell action-required"><a class="govuk-link" href="/appeals-service/appeal-details/28510/site-visit/schedule-visit">Set up site visit<span class="govuk-visually-hidden"> for appeal 28510</span></a>
+                        <td class="govuk-table__cell action-required"><a class="govuk-link" href="/appeals-service/appeal-details/28510/site-visit/schedule-visit?backUrl=%2Fappeals-service%2Fpersonal-list%3FpageNumber%3D2%26pageSize%3D5">Set up site visit<span class="govuk-visually-hidden"> for appeal 28510</span></a>
                         </td>
                         <td class="govuk-table__cell"></td>
                         <td class="govuk-table__cell"><strong class="govuk-tag govuk-tag--grey single-line">Site visit ready to set up</strong>
@@ -765,7 +765,7 @@ exports[`personal-list GET / should render the second page of the personal list 
                         <td class="govuk-table__cell"><strong><a class="govuk-link" href="/appeals-service/appeal-details/28533" aria-label="Appeal 6 0 2 8 5 3 3">6028533</a></strong>
                         </td>
                         <td class="govuk-table__cell"></td>
-                        <td class="govuk-table__cell action-required"><a class="govuk-link" href="/appeals-service/appeal-details/28533/final-comments/lpa">Review LPA final comments<span class="govuk-visually-hidden"> for appeal 28533</span></a>
+                        <td class="govuk-table__cell action-required"><a class="govuk-link" href="/appeals-service/appeal-details/28533/final-comments/lpa?backUrl=%2Fappeals-service%2Fpersonal-list%3FpageNumber%3D2%26pageSize%3D5">Review LPA final comments<span class="govuk-visually-hidden"> for appeal 28533</span></a>
                         </td>
                         <td class="govuk-table__cell">25 March 2025</td>
                         <td class="govuk-table__cell"><strong class="govuk-tag govuk-tag--grey single-line">Final comments</strong>

--- a/appeals/web/src/server/appeals/personal-list/__tests__/personal-list.test.js
+++ b/appeals/web/src/server/appeals/personal-list/__tests__/personal-list.test.js
@@ -238,21 +238,21 @@ describe('personal-list', () => {
 				name: 'Update Horizon reference',
 				requiredAction: 'addHorizonReference',
 				expectedHtml: {
-					caseOfficer: `<a class="govuk-link" href="/appeals-service/appeal-details/${appealId}/change-appeal-type/add-horizon-reference">Update Horizon reference<span class="govuk-visually-hidden"> for appeal ${appealId}</span></a>`
+					caseOfficer: `<a class="govuk-link" href="/appeals-service/appeal-details/${appealId}/change-appeal-type/add-horizon-reference?backUrl=%2Fappeals-service%2Fpersonal-list">Update Horizon reference<span class="govuk-visually-hidden"> for appeal ${appealId}</span></a>`
 				}
 			},
 			{
 				name: 'Set up site visit',
 				requiredAction: 'arrangeSiteVisit',
 				expectedHtml: {
-					caseOfficer: `<a class="govuk-link" href="/appeals-service/appeal-details/${appealId}/site-visit/schedule-visit">Set up site visit<span class="govuk-visually-hidden"> for appeal ${appealId}</span></a>`
+					caseOfficer: `<a class="govuk-link" href="/appeals-service/appeal-details/${appealId}/site-visit/schedule-visit?backUrl=%2Fappeals-service%2Fpersonal-list">Set up site visit<span class="govuk-visually-hidden"> for appeal ${appealId}</span></a>`
 				}
 			},
 			{
 				name: 'Awaiting appellant update',
 				requiredAction: 'awaitingAppellantUpdate',
 				expectedHtml: {
-					caseOfficer: `<a class="govuk-link" href="/appeals-service/appeal-details/${appealId}/appellant-case">Awaiting appellant update<span class="govuk-visually-hidden"> for appeal ${appealId}</span></a>`,
+					caseOfficer: `<a class="govuk-link" href="/appeals-service/appeal-details/${appealId}/appellant-case?backUrl=%2Fappeals-service%2Fpersonal-list">Awaiting appellant update<span class="govuk-visually-hidden"> for appeal ${appealId}</span></a>`,
 					nonCaseOfficer: 'Awaiting appellant update'
 				}
 			},
@@ -267,7 +267,7 @@ describe('personal-list', () => {
 				name: 'Awaiting IP comments',
 				requiredAction: 'awaitingIpComments',
 				expectedHtml: {
-					caseOfficer: `<a class="govuk-link" href="/appeals-service/appeal-details/${appealId}/interested-party-comments">Awaiting IP comments<span class="govuk-visually-hidden"> for appeal ${appealId}</span></a>`
+					caseOfficer: `<a class="govuk-link" href="/appeals-service/appeal-details/${appealId}/interested-party-comments?backUrl=%2Fappeals-service%2Fpersonal-list">Awaiting IP comments<span class="govuk-visually-hidden"> for appeal ${appealId}</span></a>`
 				}
 			},
 			{
@@ -295,7 +295,7 @@ describe('personal-list', () => {
 				name: 'Issue decision',
 				requiredAction: 'issueDecision',
 				expectedHtml: {
-					caseOfficer: `<a class="govuk-link" href="/appeals-service/appeal-details/${appealId}/issue-decision/decision">Issue decision<span class="govuk-visually-hidden"> for appeal ${appealId}</span></a>`
+					caseOfficer: `<a class="govuk-link" href="/appeals-service/appeal-details/${appealId}/issue-decision/decision?backUrl=%2Fappeals-service%2Fpersonal-list">Issue decision<span class="govuk-visually-hidden"> for appeal ${appealId}</span></a>`
 				}
 			},
 			{
@@ -309,49 +309,49 @@ describe('personal-list', () => {
 				name: 'Progress case',
 				requiredAction: 'progressFromFinalComments',
 				expectedHtml: {
-					caseOfficer: `<a class="govuk-link" href="/appeals-service/appeal-details/${appealId}/share?backUrl=/personal-list">Progress case</a>`
+					caseOfficer: `<a class="govuk-link" href="/appeals-service/appeal-details/${appealId}/share?backUrl=%2Fappeals-service%2Fpersonal-list">Progress case</a>`
 				}
 			},
 			{
 				name: 'Progress to final comments',
 				requiredAction: 'progressFromStatements',
 				expectedHtml: {
-					caseOfficer: `<a class="govuk-link" href="/appeals-service/appeal-details/${appealId}/share?backUrl=/personal-list">Progress to final comments<span class="govuk-visually-hidden"> for appeal ${appealId}</span></a>`
+					caseOfficer: `<a class="govuk-link" href="/appeals-service/appeal-details/${appealId}/share?backUrl=%2Fappeals-service%2Fpersonal-list">Progress to final comments<span class="govuk-visually-hidden"> for appeal ${appealId}</span></a>`
 				}
 			},
 			{
 				name: 'Review appellant case',
 				requiredAction: 'reviewAppellantCase',
 				expectedHtml: {
-					caseOfficer: `<a class="govuk-link" href="/appeals-service/appeal-details/${appealId}/appellant-case">Review appellant case<span class="govuk-visually-hidden"> for appeal ${appealId}</span></a>`
+					caseOfficer: `<a class="govuk-link" href="/appeals-service/appeal-details/${appealId}/appellant-case?backUrl=%2Fappeals-service%2Fpersonal-list">Review appellant case<span class="govuk-visually-hidden"> for appeal ${appealId}</span></a>`
 				}
 			},
 			{
 				name: 'Review appellant final comments',
 				requiredAction: 'reviewAppellantFinalComments',
 				expectedHtml: {
-					caseOfficer: `<a class="govuk-link" href="/appeals-service/appeal-details/${appealId}/final-comments/appellant">Review appellant final comments<span class="govuk-visually-hidden"> for appeal ${appealId}</span></a>`
+					caseOfficer: `<a class="govuk-link" href="/appeals-service/appeal-details/${appealId}/final-comments/appellant?backUrl=%2Fappeals-service%2Fpersonal-list">Review appellant final comments<span class="govuk-visually-hidden"> for appeal ${appealId}</span></a>`
 				}
 			},
 			{
 				name: 'Review IP comments',
 				requiredAction: 'reviewIpComments',
 				expectedHtml: {
-					caseOfficer: `<a class="govuk-link" href="/appeals-service/appeal-details/${appealId}/interested-party-comments?backUrl=/personal-list">Review IP comments<span class="govuk-visually-hidden"> for appeal ${appealId}</span></a>`
+					caseOfficer: `<a class="govuk-link" href="/appeals-service/appeal-details/${appealId}/interested-party-comments?backUrl=%2Fappeals-service%2Fpersonal-list">Review IP comments<span class="govuk-visually-hidden"> for appeal ${appealId}</span></a>`
 				}
 			},
 			{
 				name: 'Review LPA final comments',
 				requiredAction: 'reviewLpaFinalComments',
 				expectedHtml: {
-					caseOfficer: `<a class="govuk-link" href="/appeals-service/appeal-details/${appealId}/final-comments/lpa">Review LPA final comments<span class="govuk-visually-hidden"> for appeal ${appealId}</span></a>`
+					caseOfficer: `<a class="govuk-link" href="/appeals-service/appeal-details/${appealId}/final-comments/lpa?backUrl=%2Fappeals-service%2Fpersonal-list">Review LPA final comments<span class="govuk-visually-hidden"> for appeal ${appealId}</span></a>`
 				}
 			},
 			{
 				name: 'Review LPA questionnaire',
 				requiredAction: 'reviewLpaQuestionnaire',
 				expectedHtml: {
-					caseOfficer: `<a class="govuk-link" href="/appeals-service/appeal-details/${appealId}/lpa-questionnaire/${lpaQuestionnaireId}">Review LPA questionnaire<span class="govuk-visually-hidden"> for appeal ${appealId}</span></a>`,
+					caseOfficer: `<a class="govuk-link" href="/appeals-service/appeal-details/${appealId}/lpa-questionnaire/${lpaQuestionnaireId}?backUrl=%2Fappeals-service%2Fpersonal-list">Review LPA questionnaire<span class="govuk-visually-hidden"> for appeal ${appealId}</span></a>`,
 					nonCaseOfficer: 'Review LPA questionnaire'
 				}
 			},
@@ -359,28 +359,28 @@ describe('personal-list', () => {
 				name: 'Review LPA statement',
 				requiredAction: 'reviewLpaStatement',
 				expectedHtml: {
-					caseOfficer: `<a class="govuk-link" href="/appeals-service/appeal-details/${appealId}/lpa-statement?backUrl=/personal-list">Review LPA statement<span class="govuk-visually-hidden"> for appeal ${appealId}</span></a>`
+					caseOfficer: `<a class="govuk-link" href="/appeals-service/appeal-details/${appealId}/lpa-statement?backUrl=%2Fappeals-service%2Fpersonal-list">Review LPA statement<span class="govuk-visually-hidden"> for appeal ${appealId}</span></a>`
 				}
 			},
 			{
 				name: 'Share final comments',
 				requiredAction: 'shareFinalComments',
 				expectedHtml: {
-					caseOfficer: `<a class="govuk-link" href="/appeals-service/appeal-details/${appealId}/share?backUrl=/personal-list">Share final comments</a>`
+					caseOfficer: `<a class="govuk-link" href="/appeals-service/appeal-details/${appealId}/share?backUrl=%2Fappeals-service%2Fpersonal-list">Share final comments</a>`
 				}
 			},
 			{
 				name: 'Share IP comments and LPA statement',
 				requiredAction: 'shareIpCommentsAndLpaStatement',
 				expectedHtml: {
-					caseOfficer: `<a class="govuk-link" href="/appeals-service/appeal-details/${appealId}/share?backUrl=/personal-list">Share IP comments and LPA statement<span class="govuk-visually-hidden"> for appeal ${appealId}</span></a>`
+					caseOfficer: `<a class="govuk-link" href="/appeals-service/appeal-details/${appealId}/share?backUrl=%2Fappeals-service%2Fpersonal-list">Share IP comments and LPA statement<span class="govuk-visually-hidden"> for appeal ${appealId}</span></a>`
 				}
 			},
 			{
 				name: 'Start case',
 				requiredAction: 'startAppeal',
 				expectedHtml: {
-					caseOfficer: `<a class="govuk-link" href="/appeals-service/appeal-details/${appealId}/start-case/add?backUrl=/appeals-service/personal-list">Start case<span class="govuk-visually-hidden"> for appeal ${appealId}</span></a>`,
+					caseOfficer: `<a class="govuk-link" href="/appeals-service/appeal-details/${appealId}/start-case/add?backUrl=%2Fappeals-service%2Fpersonal-list">Start case<span class="govuk-visually-hidden"> for appeal ${appealId}</span></a>`,
 					nonCaseOfficer: 'Start case'
 				}
 			},
@@ -388,7 +388,7 @@ describe('personal-list', () => {
 				name: 'Update LPA statement',
 				requiredAction: 'updateLpaStatement',
 				expectedHtml: {
-					caseOfficer: `<a class="govuk-link" href="/appeals-service/appeal-details/${appealId}/lpa-statement">Update LPA statement<span class="govuk-visually-hidden"> for appeal ${appealId}</span></a>`
+					caseOfficer: `<a class="govuk-link" href="/appeals-service/appeal-details/${appealId}/lpa-statement?backUrl=%2Fappeals-service%2Fpersonal-list">Update LPA statement<span class="govuk-visually-hidden"> for appeal ${appealId}</span></a>`
 				}
 			}
 		];
@@ -398,7 +398,7 @@ describe('personal-list', () => {
 				const result = mapActionLinksForAppeal(
 					appealDataToGetRequiredActions[testCase.requiredAction],
 					true,
-					baseUrl
+					{ originalUrl: baseUrl }
 				);
 
 				expect(result).toBe(testCase.expectedHtml.caseOfficer);
@@ -409,7 +409,7 @@ describe('personal-list', () => {
 					const result = mapActionLinksForAppeal(
 						appealDataToGetRequiredActions[testCase.requiredAction],
 						false,
-						baseUrl
+						{ originalUrl: baseUrl }
 					);
 
 					expect(result).toBe(testCase.expectedHtml.nonCaseOfficer);
@@ -424,7 +424,7 @@ describe('personal-list', () => {
 					appealId: undefined
 				},
 				true,
-				baseUrl
+				{ originalUrl: baseUrl }
 			);
 
 			expect(result).toBe('');
@@ -437,7 +437,7 @@ describe('personal-list', () => {
 					lpaQuestionnaireId: null
 				},
 				true,
-				baseUrl
+				{ originalUrl: baseUrl }
 			);
 
 			expect(resultForNull).toBe('');
@@ -448,7 +448,7 @@ describe('personal-list', () => {
 					lpaQuestionnaireId: undefined
 				},
 				true,
-				baseUrl
+				{ originalUrl: baseUrl }
 			);
 
 			expect(resultForUndefined).toBe('');

--- a/appeals/web/src/server/appeals/personal-list/personal-list.controller.js
+++ b/appeals/web/src/server/appeals/personal-list/personal-list.controller.js
@@ -35,7 +35,7 @@ export const viewPersonalList = async (request, response) => {
 		urlWithoutQuery,
 		appealStatusFilter,
 		request.session,
-		originalUrl
+		request
 	);
 
 	const pagination = mapPagination(

--- a/appeals/web/src/server/appeals/personal-list/personal-list.mapper.js
+++ b/appeals/web/src/server/appeals/personal-list/personal-list.mapper.js
@@ -9,6 +9,7 @@ import { appealStatusToStatusTag } from '#lib/nunjucks-filters/status-tag.js';
 import { capitalizeFirstLetter } from '#lib/string-utilities.js';
 import { mapStatusText } from '#lib/appeal-status.js';
 import { getRequiredActionsForAppeal } from '#lib/mappers/utils/required-actions.js';
+import { addBackLinkQueryToUrl } from '#lib/url-utilities.js';
 
 /** @typedef {import('@pins/appeals').AppealSummary} AppealSummary */
 /** @typedef {import('@pins/appeals').AppealList} AppealList */
@@ -21,7 +22,7 @@ import { getRequiredActionsForAppeal } from '#lib/mappers/utils/required-actions
  * @param {string} urlWithoutQuery
  * @param {string|undefined} appealStatusFilter
  * @param {import("express-session").Session & Partial<import("express-session").SessionData>} session
- * @param {string} currentRoute
+ * @param {import('@pins/express/types/express.js').Request} request
  * @returns {PageContent}
  */
 
@@ -30,7 +31,7 @@ export function personalListPage(
 	urlWithoutQuery,
 	appealStatusFilter,
 	session,
-	currentRoute
+	request
 ) {
 	const account = /** @type {AccountInfo} */ (authSession.getAccount(session));
 	const userGroups = account?.idTokenClaims?.groups ?? [];
@@ -168,7 +169,7 @@ export function personalListPage(
 					},
 					{
 						classes: 'action-required',
-						html: mapActionLinksForAppeal(appeal, isCaseOfficer, currentRoute)
+						html: mapActionLinksForAppeal(appeal, isCaseOfficer, request)
 					},
 					{
 						text: dateISOStringToDisplayDate(appeal.dueDate) || ''
@@ -240,7 +241,7 @@ export function personalListPage(
  * @param {boolean} isCaseOfficer
  * @param {number} appealId
  * @param {number|null|undefined} lpaQuestionnaireId
- * @param {string} currentRoute
+ * @param {import('@pins/express/types/express.js').Request} request
  * @returns {string}
  */
 function mapRequiredActionToPersonalListActionHtml(
@@ -248,25 +249,37 @@ function mapRequiredActionToPersonalListActionHtml(
 	isCaseOfficer,
 	appealId,
 	lpaQuestionnaireId,
-	currentRoute
+	request
 ) {
 	switch (action) {
 		case 'addHorizonReference': {
-			return `<a class="govuk-link" href="/appeals-service/appeal-details/${appealId}/change-appeal-type/add-horizon-reference">Update Horizon reference<span class="govuk-visually-hidden"> for appeal ${appealId}</span></a>`;
+			return `<a class="govuk-link" href="${addBackLinkQueryToUrl(
+				request,
+				`/appeals-service/appeal-details/${appealId}/change-appeal-type/add-horizon-reference`
+			)}">Update Horizon reference<span class="govuk-visually-hidden"> for appeal ${appealId}</span></a>`;
 		}
 		case 'arrangeSiteVisit': {
-			return `<a class="govuk-link" href="/appeals-service/appeal-details/${appealId}/site-visit/schedule-visit">Set up site visit<span class="govuk-visually-hidden"> for appeal ${appealId}</span></a>`;
+			return `<a class="govuk-link" href="${addBackLinkQueryToUrl(
+				request,
+				`/appeals-service/appeal-details/${appealId}/site-visit/schedule-visit`
+			)}">Set up site visit<span class="govuk-visually-hidden"> for appeal ${appealId}</span></a>`;
 		}
 		case 'awaitingAppellantUpdate': {
 			return isCaseOfficer
-				? `<a class="govuk-link" href="/appeals-service/appeal-details/${appealId}/appellant-case">Awaiting appellant update<span class="govuk-visually-hidden"> for appeal ${appealId}</span></a>`
+				? `<a class="govuk-link" href="${addBackLinkQueryToUrl(
+						request,
+						`/appeals-service/appeal-details/${appealId}/appellant-case`
+				  )}">Awaiting appellant update<span class="govuk-visually-hidden"> for appeal ${appealId}</span></a>`
 				: 'Awaiting appellant update';
 		}
 		case 'awaitingFinalComments': {
 			return 'Awaiting final comments';
 		}
 		case 'awaitingIpComments': {
-			return `<a class="govuk-link" href="/appeals-service/appeal-details/${appealId}/interested-party-comments">Awaiting IP comments<span class="govuk-visually-hidden"> for appeal ${appealId}</span></a>`;
+			return `<a class="govuk-link" href="${addBackLinkQueryToUrl(
+				request,
+				`/appeals-service/appeal-details/${appealId}/interested-party-comments`
+			)}">Awaiting IP comments<span class="govuk-visually-hidden"> for appeal ${appealId}</span></a>`;
 		}
 		case 'awaitingLpaQuestionnaire': {
 			return 'Awaiting LPA questionnaire';
@@ -278,53 +291,92 @@ function mapRequiredActionToPersonalListActionHtml(
 			return 'Awaiting LPA update';
 		}
 		case 'issueDecision': {
-			return `<a class="govuk-link" href="/appeals-service/appeal-details/${appealId}/issue-decision/decision">Issue decision<span class="govuk-visually-hidden"> for appeal ${appealId}</span></a>`;
+			return `<a class="govuk-link" href="${addBackLinkQueryToUrl(
+				request,
+				`/appeals-service/appeal-details/${appealId}/issue-decision/decision`
+			)}">Issue decision<span class="govuk-visually-hidden"> for appeal ${appealId}</span></a>`;
 		}
 		case 'lpaQuestionnaireOverdue': {
 			return 'LPA questionnaire overdue';
 		}
 		case 'progressFromFinalComments': {
-			return `<a class="govuk-link" href="/appeals-service/appeal-details/${appealId}/share?backUrl=/personal-list">Progress case</a>`;
+			return `<a class="govuk-link" href="${addBackLinkQueryToUrl(
+				request,
+				`/appeals-service/appeal-details/${appealId}/share`
+			)}">Progress case</a>`;
 		}
 		case 'progressFromStatements': {
-			return `<a class="govuk-link" href="/appeals-service/appeal-details/${appealId}/share?backUrl=/personal-list">Progress to final comments<span class="govuk-visually-hidden"> for appeal ${appealId}</span></a>`;
+			return `<a class="govuk-link" href="${addBackLinkQueryToUrl(
+				request,
+				`/appeals-service/appeal-details/${appealId}/share`
+			)}">Progress to final comments<span class="govuk-visually-hidden"> for appeal ${appealId}</span></a>`;
 		}
 		case 'reviewAppellantCase': {
-			return `<a class="govuk-link" href="/appeals-service/appeal-details/${appealId}/appellant-case">Review appellant case<span class="govuk-visually-hidden"> for appeal ${appealId}</span></a>`;
+			return `<a class="govuk-link" href="${addBackLinkQueryToUrl(
+				request,
+				`/appeals-service/appeal-details/${appealId}/appellant-case`
+			)}">Review appellant case<span class="govuk-visually-hidden"> for appeal ${appealId}</span></a>`;
 		}
 		case 'reviewAppellantFinalComments': {
-			return `<a class="govuk-link" href="/appeals-service/appeal-details/${appealId}/final-comments/appellant">Review appellant final comments<span class="govuk-visually-hidden"> for appeal ${appealId}</span></a>`;
+			return `<a class="govuk-link" href="${addBackLinkQueryToUrl(
+				request,
+				`/appeals-service/appeal-details/${appealId}/final-comments/appellant`
+			)}">Review appellant final comments<span class="govuk-visually-hidden"> for appeal ${appealId}</span></a>`;
 		}
 		case 'reviewIpComments': {
-			return `<a class="govuk-link" href="/appeals-service/appeal-details/${appealId}/interested-party-comments?backUrl=/personal-list">Review IP comments<span class="govuk-visually-hidden"> for appeal ${appealId}</span></a>`;
+			return `<a class="govuk-link" href="${addBackLinkQueryToUrl(
+				request,
+				`/appeals-service/appeal-details/${appealId}/interested-party-comments`
+			)}">Review IP comments<span class="govuk-visually-hidden"> for appeal ${appealId}</span></a>`;
 		}
 		case 'reviewLpaFinalComments': {
-			return `<a class="govuk-link" href="/appeals-service/appeal-details/${appealId}/final-comments/lpa">Review LPA final comments<span class="govuk-visually-hidden"> for appeal ${appealId}</span></a>`;
+			return `<a class="govuk-link" href="${addBackLinkQueryToUrl(
+				request,
+				`/appeals-service/appeal-details/${appealId}/final-comments/lpa`
+			)}">Review LPA final comments<span class="govuk-visually-hidden"> for appeal ${appealId}</span></a>`;
 		}
 		case 'reviewLpaQuestionnaire': {
 			if (!lpaQuestionnaireId) {
 				return '';
 			}
 			return isCaseOfficer
-				? `<a class="govuk-link" href="/appeals-service/appeal-details/${appealId}/lpa-questionnaire/${lpaQuestionnaireId}">Review LPA questionnaire<span class="govuk-visually-hidden"> for appeal ${appealId}</span></a>`
+				? `<a class="govuk-link" href="${addBackLinkQueryToUrl(
+						request,
+						`/appeals-service/appeal-details/${appealId}/lpa-questionnaire/${lpaQuestionnaireId}`
+				  )}">Review LPA questionnaire<span class="govuk-visually-hidden"> for appeal ${appealId}</span></a>`
 				: 'Review LPA questionnaire';
 		}
 		case 'reviewLpaStatement': {
-			return `<a class="govuk-link" href="/appeals-service/appeal-details/${appealId}/lpa-statement?backUrl=/personal-list">Review LPA statement<span class="govuk-visually-hidden"> for appeal ${appealId}</span></a>`;
+			return `<a class="govuk-link" href="${addBackLinkQueryToUrl(
+				request,
+				`/appeals-service/appeal-details/${appealId}/lpa-statement`
+			)}">Review LPA statement<span class="govuk-visually-hidden"> for appeal ${appealId}</span></a>`;
 		}
 		case 'shareFinalComments': {
-			return `<a class="govuk-link" href="/appeals-service/appeal-details/${appealId}/share?backUrl=/personal-list">Share final comments</a>`;
+			return `<a class="govuk-link" href="${addBackLinkQueryToUrl(
+				request,
+				`/appeals-service/appeal-details/${appealId}/share`
+			)}">Share final comments</a>`;
 		}
 		case 'shareIpCommentsAndLpaStatement': {
-			return `<a class="govuk-link" href="/appeals-service/appeal-details/${appealId}/share?backUrl=/personal-list">Share IP comments and LPA statement<span class="govuk-visually-hidden"> for appeal ${appealId}</span></a>`;
+			return `<a class="govuk-link" href="${addBackLinkQueryToUrl(
+				request,
+				`/appeals-service/appeal-details/${appealId}/share`
+			)}">Share IP comments and LPA statement<span class="govuk-visually-hidden"> for appeal ${appealId}</span></a>`;
 		}
 		case 'startAppeal': {
 			return isCaseOfficer
-				? `<a class="govuk-link" href="/appeals-service/appeal-details/${appealId}/start-case/add?backUrl=${currentRoute}">Start case<span class="govuk-visually-hidden"> for appeal ${appealId}</span></a>`
+				? `<a class="govuk-link" href="${addBackLinkQueryToUrl(
+						request,
+						`/appeals-service/appeal-details/${appealId}/start-case/add`
+				  )}">Start case<span class="govuk-visually-hidden"> for appeal ${appealId}</span></a>`
 				: 'Start case';
 		}
 		case 'updateLpaStatement': {
-			return `<a class="govuk-link" href="/appeals-service/appeal-details/${appealId}/lpa-statement">Update LPA statement<span class="govuk-visually-hidden"> for appeal ${appealId}</span></a>`;
+			return `<a class="govuk-link" href="${addBackLinkQueryToUrl(
+				request,
+				`/appeals-service/appeal-details/${appealId}/lpa-statement`
+			)}">Update LPA statement<span class="govuk-visually-hidden"> for appeal ${appealId}</span></a>`;
 		}
 		default: {
 			return '';
@@ -335,10 +387,10 @@ function mapRequiredActionToPersonalListActionHtml(
 /**
  * @param {PersonalListAppeal} appeal
  * @param {boolean} isCaseOfficer
- * @param {string} currentRoute
+ * @param {import('@pins/express/types/express.js').Request} request
  * @returns {string}
  */
-export function mapActionLinksForAppeal(appeal, isCaseOfficer, currentRoute) {
+export function mapActionLinksForAppeal(appeal, isCaseOfficer, request) {
 	const requiredActions = getRequiredActionsForAppeal({
 		...appeal,
 		appealTimetable: appeal.appealTimetable || {}
@@ -357,7 +409,7 @@ export function mapActionLinksForAppeal(appeal, isCaseOfficer, currentRoute) {
 				isCaseOfficer,
 				appealId,
 				lpaQuestionnaireId,
-				currentRoute
+				request
 			);
 		})
 		.join('<br>');

--- a/appeals/web/src/server/lib/__tests__/libraries.test.js
+++ b/appeals/web/src/server/lib/__tests__/libraries.test.js
@@ -32,7 +32,13 @@ import { paginationDefaultSettings } from '#appeals/appeal.constants.js';
 import { getPaginationParametersFromQuery } from '#lib/pagination-utilities.js';
 import { linkedAppealStatus } from '#lib/appeals-formatter.js';
 import httpMocks from 'node-mocks-http';
-import { getOriginPathname, isInternalUrl, safeRedirect } from '#lib/url-utilities.js';
+import {
+	getOriginPathname,
+	isInternalUrl,
+	safeRedirect,
+	addBackLinkQueryToUrl,
+	getBackLinkUrlFromQuery
+} from '#lib/url-utilities.js';
 import { stringIsValidPostcodeFormat } from '#lib/postcode.js';
 import { addInvisibleSpacesAfterRedactionCharacters } from '#lib/redaction-string-formatter.js';
 
@@ -1573,5 +1579,31 @@ describe('safeRedirect', () => {
 		safeRedirect(request, response, url);
 
 		expect(response._getRedirectUrl()).toBe('/');
+	});
+});
+
+describe('addBackLinkQueryToUrl', () => {
+	it('should append a backUrl query with the URI-encoded originalUrl value from the supplied request to the supplied url', () => {
+		expect(
+			addBackLinkQueryToUrl(
+				// @ts-ignore
+				{ originalUrl: '/test/original/url?withOwnQuery=true' },
+				'/supplied/url'
+			)
+		).toBe('/supplied/url?backUrl=%2Ftest%2Foriginal%2Furl%3FwithOwnQuery%3Dtrue');
+	});
+});
+
+describe('getBackLinkUrlFromQuery', () => {
+	it('should return undefined if the supplied request.query does not contain a backUrl property', () => {
+		// @ts-ignore
+		expect(getBackLinkUrlFromQuery({ query: {} })).toBe(undefined);
+	});
+	it('should return the URI-decoded value from the supplied request.query.backUrl property, if request.query contains a backUrl property', () => {
+		const query = { backUrl: '%2Ftest%2Foriginal%2Furl%3FwithOwnQuery%3Dtrue' };
+		expect(
+			// @ts-ignore
+			getBackLinkUrlFromQuery({ query })
+		).toBe('/test/original/url?withOwnQuery=true');
 	});
 });

--- a/appeals/web/src/server/lib/mappers/__tests__/mappers.test.js
+++ b/appeals/web/src/server/lib/mappers/__tests__/mappers.test.js
@@ -32,7 +32,15 @@ describe('appeal-mapper', () => {
 			currentRoute = 'testroute/';
 			// @ts-ignore
 			session = { account: createAccountInfo() };
-			validMappedData = await initialiseAndMapAppealData(appealData, currentRoute, session);
+			validMappedData = await initialiseAndMapAppealData(
+				appealData,
+				currentRoute,
+				session,
+				// @ts-ignore
+				{
+					originalUrl: currentRoute
+				}
+			);
 		});
 
 		it('should return a valid MappedAppealInstructions object for valid inputs', async () => {
@@ -149,10 +157,14 @@ describe('mapRepresentationDocumentSummaryActionLink', () => {
 				baseRoute,
 				'received',
 				APPEAL_REPRESENTATION_STATUS.AWAITING_REVIEW,
-				'lpa-statement'
+				'lpa-statement',
+				// @ts-ignore
+				{
+					originalUrl: baseRoute
+				}
 			);
 			expect(link).toBe(
-				`<a href="${baseRoute}/lpa-statement" data-cy="review-lpa-statement" class="govuk-link">Review<span class="govuk-visually-hidden"> LPA statement</span></a>`
+				`<a href="${baseRoute}/lpa-statement?backUrl=%2Fappeals-service%2Fappeal-details%2F4419" data-cy="review-lpa-statement" class="govuk-link">Review<span class="govuk-visually-hidden"> LPA statement</span></a>`
 			);
 		});
 
@@ -161,10 +173,14 @@ describe('mapRepresentationDocumentSummaryActionLink', () => {
 				baseRoute,
 				'received',
 				APPEAL_REPRESENTATION_STATUS.INCOMPLETE,
-				'lpa-statement'
+				'lpa-statement',
+				// @ts-ignore
+				{
+					originalUrl: baseRoute
+				}
 			);
 			expect(link).toBe(
-				`<a href="${baseRoute}/lpa-statement" data-cy="review-lpa-statement" class="govuk-link">Review<span class="govuk-visually-hidden"> LPA statement</span></a>`
+				`<a href="${baseRoute}/lpa-statement?backUrl=%2Fappeals-service%2Fappeal-details%2F4419" data-cy="review-lpa-statement" class="govuk-link">Review<span class="govuk-visually-hidden"> LPA statement</span></a>`
 			);
 		});
 
@@ -173,10 +189,14 @@ describe('mapRepresentationDocumentSummaryActionLink', () => {
 				baseRoute,
 				'received',
 				APPEAL_REPRESENTATION_STATUS.VALID,
-				'lpa-statement'
+				'lpa-statement',
+				// @ts-ignore
+				{
+					originalUrl: baseRoute
+				}
 			);
 			expect(link).toBe(
-				`<a href="${baseRoute}/lpa-statement" data-cy="view-lpa-statement" class="govuk-link">View<span class="govuk-visually-hidden"> LPA statement</span></a>`
+				`<a href="${baseRoute}/lpa-statement?backUrl=%2Fappeals-service%2Fappeal-details%2F4419" data-cy="view-lpa-statement" class="govuk-link">View<span class="govuk-visually-hidden"> LPA statement</span></a>`
 			);
 		});
 
@@ -185,10 +205,14 @@ describe('mapRepresentationDocumentSummaryActionLink', () => {
 				baseRoute,
 				'received',
 				APPEAL_REPRESENTATION_STATUS.PUBLISHED,
-				'lpa-statement'
+				'lpa-statement',
+				// @ts-ignore
+				{
+					originalUrl: baseRoute
+				}
 			);
 			expect(link).toBe(
-				`<a href="${baseRoute}/lpa-statement" data-cy="view-lpa-statement" class="govuk-link">View<span class="govuk-visually-hidden"> LPA statement</span></a>`
+				`<a href="${baseRoute}/lpa-statement?backUrl=%2Fappeals-service%2Fappeal-details%2F4419" data-cy="view-lpa-statement" class="govuk-link">View<span class="govuk-visually-hidden"> LPA statement</span></a>`
 			);
 		});
 
@@ -197,7 +221,11 @@ describe('mapRepresentationDocumentSummaryActionLink', () => {
 				baseRoute,
 				'not_received',
 				null,
-				'lpa-statement'
+				'lpa-statement',
+				// @ts-ignore
+				{
+					originalUrl: baseRoute
+				}
 			);
 			expect(link).toBe('');
 		});
@@ -211,10 +239,14 @@ describe('Final comments links', () => {
 			baseRoute,
 			'received',
 			APPEAL_REPRESENTATION_STATUS.AWAITING_REVIEW,
-			'appellant-final-comments'
+			'appellant-final-comments',
+			// @ts-ignore
+			{
+				originalUrl: baseRoute
+			}
 		);
 		expect(link).toBe(
-			`<a href="${baseRoute}/final-comments/appellant" data-cy="review-appellant-final-comments" class="govuk-link">Review<span class="govuk-visually-hidden"> appellant final comments</span></a>`
+			`<a href="${baseRoute}/final-comments/appellant?backUrl=%2Fappeals-service%2Fappeal-details%2F4419" data-cy="review-appellant-final-comments" class="govuk-link">Review<span class="govuk-visually-hidden"> appellant final comments</span></a>`
 		);
 	});
 
@@ -223,10 +255,14 @@ describe('Final comments links', () => {
 			baseRoute,
 			'received',
 			APPEAL_REPRESENTATION_STATUS.AWAITING_REVIEW,
-			'lpa-final-comments'
+			'lpa-final-comments',
+			// @ts-ignore
+			{
+				originalUrl: baseRoute
+			}
 		);
 		expect(link).toBe(
-			`<a href="${baseRoute}/final-comments/lpa" data-cy="review-lpa-final-comments" class="govuk-link">Review<span class="govuk-visually-hidden"> LPA final comments</span></a>`
+			`<a href="${baseRoute}/final-comments/lpa?backUrl=%2Fappeals-service%2Fappeal-details%2F4419" data-cy="review-lpa-final-comments" class="govuk-link">Review<span class="govuk-visually-hidden"> LPA final comments</span></a>`
 		);
 	});
 
@@ -235,10 +271,14 @@ describe('Final comments links', () => {
 			baseRoute,
 			'received',
 			APPEAL_REPRESENTATION_STATUS.VALID,
-			'appellant-final-comments'
+			'appellant-final-comments',
+			// @ts-ignore
+			{
+				originalUrl: baseRoute
+			}
 		);
 		expect(link).toBe(
-			`<a href="${baseRoute}/final-comments/appellant" data-cy="view-appellant-final-comments" class="govuk-link">View<span class="govuk-visually-hidden"> appellant final comments</span></a>`
+			`<a href="${baseRoute}/final-comments/appellant?backUrl=%2Fappeals-service%2Fappeal-details%2F4419" data-cy="view-appellant-final-comments" class="govuk-link">View<span class="govuk-visually-hidden"> appellant final comments</span></a>`
 		);
 	});
 
@@ -247,10 +287,14 @@ describe('Final comments links', () => {
 			baseRoute,
 			'received',
 			APPEAL_REPRESENTATION_STATUS.PUBLISHED,
-			'lpa-final-comments'
+			'lpa-final-comments',
+			// @ts-ignore
+			{
+				originalUrl: baseRoute
+			}
 		);
 		expect(link).toBe(
-			`<a href="${baseRoute}/final-comments/lpa" data-cy="view-lpa-final-comments" class="govuk-link">View<span class="govuk-visually-hidden"> LPA final comments</span></a>`
+			`<a href="${baseRoute}/final-comments/lpa?backUrl=%2Fappeals-service%2Fappeal-details%2F4419" data-cy="view-lpa-final-comments" class="govuk-link">View<span class="govuk-visually-hidden"> LPA final comments</span></a>`
 		);
 	});
 
@@ -259,7 +303,11 @@ describe('Final comments links', () => {
 			baseRoute,
 			'not_received',
 			null,
-			'appellant-final-comments'
+			'appellant-final-comments',
+			// @ts-ignore
+			{
+				originalUrl: baseRoute
+			}
 		);
 		expect(link).toBe('');
 	});

--- a/appeals/web/src/server/lib/mappers/data/appeal/mapper.js
+++ b/appeals/web/src/server/lib/mappers/data/appeal/mapper.js
@@ -18,6 +18,7 @@ import { submaps as hasSubmaps } from './has.js';
  * @property {SessionWithAuth} session
  * @property {boolean} userHasUpdateCasePermission
  * @property {boolean} skipAssignedUsersData
+ * @property {import('@pins/express/types/express.js').Request} request
  * @property {{
  *     [x: string]: any;
  *   } | null} [caseOfficerUser]
@@ -42,6 +43,7 @@ const submaps = {
  * @param {WebAppeal} appealDetails
  * @param {string} currentRoute
  * @param {SessionWithAuth} session
+ * @param {import('@pins/express/types/express.js').Request} request
  * @param {boolean} [skipAssignedUsersData]
  * @param {import('#appeals/appeal-details/representations/representations.service.js').Representation} [appellantFinalComments]
  * @param {import('#appeals/appeal-details/representations/representations.service.js').Representation} [lpaFinalComments]
@@ -51,6 +53,7 @@ export async function initialiseAndMapAppealData(
 	appealDetails,
 	currentRoute,
 	session,
+	request,
 	skipAssignedUsersData = false,
 	appellantFinalComments,
 	lpaFinalComments
@@ -94,6 +97,7 @@ export async function initialiseAndMapAppealData(
 			appealDetails,
 			currentRoute,
 			session,
+			request,
 			skipAssignedUsersData,
 			userHasUpdateCasePermission,
 			caseOfficerUser,

--- a/appeals/web/src/server/lib/mappers/data/appeal/submappers/__tests__/site-visit-date.mapper.test.js
+++ b/appeals/web/src/server/lib/mappers/data/appeal/submappers/__tests__/site-visit-date.mapper.test.js
@@ -4,6 +4,7 @@ import { mapSiteVisitDate } from '#lib/mappers/data/appeal/submappers/site-visit
 const data = {
 	currentRoute: '/test',
 	appealDetails: {
+		appealId: 1,
 		validAt: '2025-01-01',
 		appealTimetable: { finalCommentsDueDate: '2025-01-10' },
 		siteVisit: { visitDate: '2025-01-10' },
@@ -15,7 +16,8 @@ const data = {
 
 describe('site-visit-date.mapper', () => {
 	it('should display Site Visit date with Change action link', () => {
-		const mappedData = mapSiteVisitDate(data, null, undefined);
+		data.appealDetails.startedAt = '2025-01-01';
+		const mappedData = mapSiteVisitDate(data);
 		expect(mappedData).toEqual({
 			display: {
 				summaryListItem: {
@@ -25,7 +27,7 @@ describe('site-visit-date.mapper', () => {
 								attributes: {
 									'data-cy': 'change-site-visit-date'
 								},
-								href: '/appeals-service/appeal-details/undefined/site-visit/visit-booked',
+								href: '/appeals-service/appeal-details/1/site-visit/visit-booked',
 								text: 'Change',
 								visuallyHiddenText: 'Date'
 							}

--- a/appeals/web/src/server/lib/mappers/data/appeal/submappers/appeal-decision.mapper.js
+++ b/appeals/web/src/server/lib/mappers/data/appeal/submappers/appeal-decision.mapper.js
@@ -2,9 +2,10 @@ import { generateIssueDecisionUrl } from '#appeals/appeal-details/issue-decision
 import { APPEAL_CASE_STATUS } from 'pins-data-model';
 import { dateISOStringToDisplayDate } from '#lib/dates.js';
 import { documentationFolderTableItem } from '#lib/mappers/index.js';
+import { addBackLinkQueryToUrl } from '#lib/url-utilities.js';
 
 /** @type {import('../mapper.js').SubMapper} */
-export const mapAppealDecision = ({ appealDetails }) => {
+export const mapAppealDecision = ({ appealDetails, request }) => {
 	const actionText = (() => {
 		switch (appealDetails.appealStatus) {
 			case APPEAL_CASE_STATUS.ISSUE_DETERMINATION:
@@ -32,8 +33,9 @@ export const mapAppealDecision = ({ appealDetails }) => {
 			: 'Not applicable',
 		receivedTextClasses: 'appeal-decision-due-date',
 		actionHtml: actionText
-			? `<a class="govuk-link" href="${generateIssueDecisionUrl(
-					appealDetails.appealId
+			? `<a class="govuk-link" href="${addBackLinkQueryToUrl(
+					request,
+					generateIssueDecisionUrl(appealDetails.appealId)
 			  )}">${actionText}<span class="govuk-visually-hidden"> decision</span></a>`
 			: '',
 		actionHtmlClasses: 'appeal-decision-actions'

--- a/appeals/web/src/server/lib/mappers/data/appeal/submappers/appellant-case.mapper.js
+++ b/appeals/web/src/server/lib/mappers/data/appeal/submappers/appellant-case.mapper.js
@@ -1,8 +1,9 @@
+import { addBackLinkQueryToUrl } from '#lib/url-utilities.js';
 import { dateISOStringToDisplayDate } from '#lib/dates.js';
 import { documentationFolderTableItem } from '#lib/mappers/index.js';
 
 /** @type {import('../mapper.js').SubMapper} */
-export const mapAppellantCase = ({ appealDetails, currentRoute }) => {
+export const mapAppellantCase = ({ appealDetails, currentRoute, request }) => {
 	const { status } = appealDetails.documentationSummary?.appellantCase ?? {};
 
 	const statusText = (() => {
@@ -31,7 +32,10 @@ export const mapAppellantCase = ({ appealDetails, currentRoute }) => {
 			return '';
 		}
 
-		return `<a href="${currentRoute}/appellant-case" data-cy="review-appellant-case" class="govuk-link">${
+		return `<a href="${addBackLinkQueryToUrl(
+			request,
+			`${currentRoute}/appellant-case`
+		)}" data-cy="review-appellant-case" class="govuk-link">${
 			_status === 'received' ? 'Review' : 'View'
 		}<span class="govuk-visually-hidden"> appellant case</span></a>`;
 	})();

--- a/appeals/web/src/server/lib/mappers/data/appeal/submappers/appellant-final-comments.mapper.js
+++ b/appeals/web/src/server/lib/mappers/data/appeal/submappers/appellant-final-comments.mapper.js
@@ -8,7 +8,7 @@ import {
 import { mapRepresentationDocumentSummaryActionLink } from '#lib/representation-utilities.js';
 
 /** @type {import('../mapper.js').SubMapper} */
-export const mapAppellantFinalComments = ({ appealDetails, currentRoute }) => {
+export const mapAppellantFinalComments = ({ appealDetails, currentRoute, request }) => {
 	const { status, isRedacted } = appealDetails.documentationSummary?.appellantFinalComments ?? {};
 
 	const statusText = (() => {
@@ -75,7 +75,8 @@ export const mapAppellantFinalComments = ({ appealDetails, currentRoute }) => {
 			currentRoute,
 			appealDetails?.documentationSummary?.appellantFinalComments?.status,
 			appealDetails?.documentationSummary?.appellantFinalComments?.counts,
-			'appellant-final-comments'
+			'appellant-final-comments',
+			request
 		)
 	});
 };

--- a/appeals/web/src/server/lib/mappers/data/appeal/submappers/decision.mapper.js
+++ b/appeals/web/src/server/lib/mappers/data/appeal/submappers/decision.mapper.js
@@ -6,9 +6,10 @@ import { APPEAL_CASE_STATUS } from 'pins-data-model';
 import { textSummaryListItem } from '#lib/mappers/index.js';
 import { userHasPermission } from '#lib/mappers/index.js';
 import { permissionNames } from '#environment/permissions.js';
+import { addBackLinkQueryToUrl } from '#lib/url-utilities.js';
 
 /** @type {import('../mapper.js').SubMapper} */
-export const mapDecision = ({ appealDetails, session }) => {
+export const mapDecision = ({ appealDetails, session, request }) => {
 	const canIssueDecision = !(
 		appealDetails.decision?.outcome ||
 		appealDetails.appealStatus !== APPEAL_CASE_STATUS.ISSUE_DETERMINATION
@@ -18,7 +19,7 @@ export const mapDecision = ({ appealDetails, session }) => {
 		id: 'decision',
 		text: 'Decision',
 		value: mapDecisionOutcome(appealDetails.decision?.outcome || '') || 'Not yet issued',
-		link: generateIssueDecisionUrl(appealDetails.appealId),
+		link: addBackLinkQueryToUrl(request, generateIssueDecisionUrl(appealDetails.appealId)),
 		editable: userHasPermission(permissionNames.setCaseOutcome, session) && canIssueDecision,
 		actionText: 'Issue',
 		classes: 'appeal-decision'

--- a/appeals/web/src/server/lib/mappers/data/appeal/submappers/ip-comments.mapper.js
+++ b/appeals/web/src/server/lib/mappers/data/appeal/submappers/ip-comments.mapper.js
@@ -5,9 +5,10 @@ import {
 	dateIsInThePast
 } from '#lib/dates.js';
 import { documentationFolderTableItem } from '#lib/mappers/index.js';
+import { addBackLinkQueryToUrl } from '#lib/url-utilities.js';
 
 /** @type {import('../mapper.js').SubMapper} */
-export const mapIpComments = ({ appealDetails, currentRoute }) => {
+export const mapIpComments = ({ appealDetails, currentRoute, request }) => {
 	const actionText = (() => {
 		const { status, counts } = appealDetails?.documentationSummary?.ipComments ?? {};
 
@@ -87,6 +88,9 @@ export const mapIpComments = ({ appealDetails, currentRoute }) => {
 		text: 'Interested party comments',
 		statusText,
 		receivedText,
-		actionHtml: `<a href="${currentRoute}/interested-party-comments" data-cy="review-ip-comments" class="govuk-link">${actionText}<span class="govuk-visually-hidden"> interested party comments</span></a>`
+		actionHtml: `<a href="${addBackLinkQueryToUrl(
+			request,
+			`${currentRoute}/interested-party-comments`
+		)}" data-cy="review-ip-comments" class="govuk-link">${actionText}<span class="govuk-visually-hidden"> interested party comments</span></a>`
 	});
 };

--- a/appeals/web/src/server/lib/mappers/data/appeal/submappers/lpa-final-comments.mapper.js
+++ b/appeals/web/src/server/lib/mappers/data/appeal/submappers/lpa-final-comments.mapper.js
@@ -8,7 +8,7 @@ import {
 import { mapRepresentationDocumentSummaryActionLink } from '#lib/representation-utilities.js';
 
 /** @type {import('../mapper.js').SubMapper} */
-export const mapLPAFinalComments = ({ appealDetails, currentRoute }) => {
+export const mapLPAFinalComments = ({ appealDetails, currentRoute, request }) => {
 	const { status, isRedacted } = appealDetails.documentationSummary?.lpaFinalComments ?? {};
 
 	const statusText = (() => {
@@ -75,7 +75,8 @@ export const mapLPAFinalComments = ({ appealDetails, currentRoute }) => {
 			currentRoute,
 			appealDetails?.documentationSummary?.lpaFinalComments?.status,
 			appealDetails?.documentationSummary?.lpaFinalComments?.counts,
-			'lpa-final-comments'
+			'lpa-final-comments',
+			request
 		)
 	});
 };

--- a/appeals/web/src/server/lib/mappers/data/appeal/submappers/lpa-questionnaire.mapper.js
+++ b/appeals/web/src/server/lib/mappers/data/appeal/submappers/lpa-questionnaire.mapper.js
@@ -4,9 +4,10 @@ import {
 	dateIsInThePast
 } from '#lib/dates.js';
 import { documentationFolderTableItem } from '#lib/mappers/index.js';
+import { addBackLinkQueryToUrl } from '#lib/url-utilities.js';
 
 /** @type {import('../mapper.js').SubMapper} */
-export const mapLpaQuestionnaire = ({ appealDetails, currentRoute }) => {
+export const mapLpaQuestionnaire = ({ appealDetails, currentRoute, request }) => {
 	const { status } = appealDetails.documentationSummary?.lpaQuestionnaire ?? {};
 
 	const statusText = (() => {
@@ -39,9 +40,15 @@ export const mapLpaQuestionnaire = ({ appealDetails, currentRoute }) => {
 	const actionHtml = (() => {
 		switch (status) {
 			case 'received':
-				return `<a href="${currentRoute}/lpa-questionnaire/${appealDetails?.lpaQuestionnaireId}" data-cy="review-lpa-questionnaire" class="govuk-link">Review<span class="govuk-visually-hidden"> L P A questionnaire</span></a>`;
+				return `<a href="${addBackLinkQueryToUrl(
+					request,
+					`${currentRoute}/lpa-questionnaire/${appealDetails?.lpaQuestionnaireId}`
+				)}" data-cy="review-lpa-questionnaire" class="govuk-link">Review<span class="govuk-visually-hidden"> L P A questionnaire</span></a>`;
 			case 'Complete':
-				return `<a href="${currentRoute}/lpa-questionnaire/${appealDetails?.lpaQuestionnaireId}" data-cy="review-lpa-questionnaire" class="govuk-link">View<span class="govuk-visually-hidden"> L P A questionnaire</span></a>`;
+				return `<a href="${addBackLinkQueryToUrl(
+					request,
+					`${currentRoute}/lpa-questionnaire/${appealDetails?.lpaQuestionnaireId}`
+				)}" data-cy="review-lpa-questionnaire" class="govuk-link">View<span class="govuk-visually-hidden"> L P A questionnaire</span></a>`;
 			default:
 				return '';
 		}

--- a/appeals/web/src/server/lib/mappers/data/appeal/submappers/lpa-statement.mapper.js
+++ b/appeals/web/src/server/lib/mappers/data/appeal/submappers/lpa-statement.mapper.js
@@ -7,7 +7,7 @@ import {
 import { mapRepresentationDocumentSummaryActionLink } from '#lib/representation-utilities.js';
 
 /** @type {import('../mapper.js').SubMapper} */
-export const mapLpaStatement = ({ appealDetails, currentRoute }) => {
+export const mapLpaStatement = ({ appealDetails, currentRoute, request }) => {
 	const { status, representationStatus, isRedacted } =
 		appealDetails.documentationSummary?.lpaStatement ?? {};
 
@@ -67,7 +67,8 @@ export const mapLpaStatement = ({ appealDetails, currentRoute }) => {
 			currentRoute,
 			appealDetails?.documentationSummary?.lpaStatement?.status,
 			appealDetails?.documentationSummary?.lpaStatement?.representationStatus,
-			'lpa-statement'
+			'lpa-statement',
+			request
 		)
 	});
 };

--- a/appeals/web/src/server/lib/mappers/data/appeal/submappers/site-visit-timetable.mapper.js
+++ b/appeals/web/src/server/lib/mappers/data/appeal/submappers/site-visit-timetable.mapper.js
@@ -2,6 +2,7 @@ import { dateISOStringToDisplayDate, dateISOStringToDisplayTime12hr } from '#lib
 import { textSummaryListItem } from '#lib/mappers/index.js';
 import { userHasPermission } from '#lib/mappers/index.js';
 import { permissionNames } from '#environment/permissions.js';
+import { addBackLinkQueryToUrl } from '#lib/url-utilities.js';
 
 /**
  * @param {string} date
@@ -15,7 +16,7 @@ export function dateAndTimeFormatter(date, startTime, endTime) {
 }
 
 /** @type {import('../mapper.js').SubMapper} */
-export const mapSiteVisitTimetable = ({ appealDetails, currentRoute, session }) => {
+export const mapSiteVisitTimetable = ({ appealDetails, currentRoute, session, request }) => {
 	const id = 'schedule-visit';
 	if (!appealDetails.startedAt) {
 		return { id, display: {} };
@@ -34,7 +35,10 @@ export const mapSiteVisitTimetable = ({ appealDetails, currentRoute, session }) 
 		id,
 		text: 'Site visit',
 		value: { html: value },
-		link: `${currentRoute}/site-visit/${hasVisit ? 'manage' : 'schedule'}-visit`,
+		link: addBackLinkQueryToUrl(
+			request,
+			`${currentRoute}/site-visit/${hasVisit ? 'manage' : 'schedule'}-visit`
+		),
 		actionText: hasVisit ? 'Change' : 'Arrange',
 		editable: userHasPermission(permissionNames.setEvents, session),
 		classes: 'appeal-site-visit'

--- a/appeals/web/src/server/lib/mappers/data/appeal/submappers/visit-type.mapper.js
+++ b/appeals/web/src/server/lib/mappers/data/appeal/submappers/visit-type.mapper.js
@@ -1,16 +1,20 @@
 import { permissionNames } from '#environment/permissions.js';
 import { textSummaryListItem } from '#lib/mappers/index.js';
 import { userHasPermission } from '#lib/mappers/index.js';
+import { addBackLinkQueryToUrl } from '#lib/url-utilities.js';
 
 /** @type {import('../mapper.js').SubMapper} */
-export const mapVisitType = ({ appealDetails, currentRoute, session }) =>
+export const mapVisitType = ({ appealDetails, currentRoute, session, request }) =>
 	textSummaryListItem({
 		id: 'set-visit-type',
 		text: 'Visit type',
 		value: appealDetails.siteVisit?.visitType || '',
-		link: `${currentRoute}/site-visit/${
-			appealDetails.siteVisit?.visitType ? 'visit-booked' : 'schedule-visit'
-		}`,
+		link: addBackLinkQueryToUrl(
+			request,
+			`${currentRoute}/site-visit/${
+				appealDetails.siteVisit?.visitType ? 'visit-booked' : 'schedule-visit'
+			}`
+		),
 		editable: userHasPermission(permissionNames.setEvents, session),
 		classes: 'appeal-visit-type'
 	});

--- a/appeals/web/src/server/lib/mappers/utils/__tests__/map-status-dependent-notifications.test.js
+++ b/appeals/web/src/server/lib/mappers/utils/__tests__/map-status-dependent-notifications.test.js
@@ -33,12 +33,12 @@ describe('mapStatusDependentNotifications', () => {
 		{
 			bannerKey: 'progressFromFinalComments',
 			requiredAction: 'progressFromFinalComments',
-			expectedContainedHtml: `<a href="/appeals-service/appeal-details/${mockAppealData.appealId}/share" class="govuk-heading-s govuk-notification-banner__link">Progress case</a>`
+			expectedContainedHtml: `<a href="/appeals-service/appeal-details/${mockAppealData.appealId}/share?backUrl=%2Fappeals-service%2Fappeal-details%2F${mockAppealData.appealId}" class="govuk-heading-s govuk-notification-banner__link">Progress case</a>`
 		},
 		{
 			bannerKey: 'progressFromStatements',
 			requiredAction: 'progressFromStatements',
-			expectedContainedHtml: `<a href="/appeals-service/appeal-details/${mockAppealData.appealId}/share" class="govuk-heading-s govuk-notification-banner__link">Progress to final comments</a>`
+			expectedContainedHtml: `<a href="/appeals-service/appeal-details/${mockAppealData.appealId}/share?backUrl=%2Fappeals-service%2Fappeal-details%2F${mockAppealData.appealId}" class="govuk-heading-s govuk-notification-banner__link">Progress to final comments</a>`
 		},
 		{
 			bannerKey: 'readyForValidation',
@@ -91,12 +91,12 @@ describe('mapStatusDependentNotifications', () => {
 		{
 			bannerKey: 'shareFinalComments',
 			requiredAction: 'shareFinalComments',
-			expectedContainedHtml: `<a href="/appeals-service/appeal-details/${mockAppealData.appealId}/share" class="govuk-heading-s govuk-notification-banner__link">Share final comments</a>`
+			expectedContainedHtml: `<a href="/appeals-service/appeal-details/${mockAppealData.appealId}/share?backUrl=%2Fappeals-service%2Fappeal-details%2F${mockAppealData.appealId}" class="govuk-heading-s govuk-notification-banner__link">Share final comments</a>`
 		},
 		{
 			bannerKey: 'shareCommentsAndLpaStatement',
 			requiredAction: 'shareIpCommentsAndLpaStatement',
-			expectedContainedHtml: `<a href="/appeals-service/appeal-details/${mockAppealData.appealId}/share" class="govuk-heading-s govuk-notification-banner__link">Share IP comments and LPA statement</a>`
+			expectedContainedHtml: `<a href="/appeals-service/appeal-details/${mockAppealData.appealId}/share?backUrl=%2Fappeals-service%2Fappeal-details%2F${mockAppealData.appealId}" class="govuk-heading-s govuk-notification-banner__link">Share IP comments and LPA statement</a>`
 		},
 		{
 			bannerKey: 'appealValidAndReadyToStart',
@@ -115,7 +115,9 @@ describe('mapStatusDependentNotifications', () => {
 		it(`should return "${testCase.bannerKey}" banner when getRequiredActionsForAppeal returns "${testCase.requiredAction}"`, async () => {
 			const result = mapStatusDependentNotifications(
 				appealDataToGetRequiredActions[testCase.requiredAction],
-				`/appeals-service/appeal-details/${mockAppealData.appealId}`
+				{
+					originalUrl: `/appeals-service/appeal-details/${mockAppealData.appealId}`
+				}
 			);
 
 			expect(Array.isArray(result)).toBe(true);

--- a/appeals/web/src/server/lib/mappers/utils/map-status-dependent-notifications.js
+++ b/appeals/web/src/server/lib/mappers/utils/map-status-dependent-notifications.js
@@ -1,22 +1,20 @@
-import {
-	generateIssueDecisionUrl,
-	generateStartTimetableUrl
-} from '#appeals/appeal-details/issue-decision/issue-decision.mapper.js';
+import { generateIssueDecisionUrl } from '#appeals/appeal-details/issue-decision/issue-decision.mapper.js';
 import {
 	createNotificationBanner,
 	mapRequiredActionToNotificationBannerKey
 } from '#lib/mappers/index.js';
 import { getRequiredActionsForAppeal } from './required-actions.js';
+import { addBackLinkQueryToUrl } from '#lib/url-utilities.js';
 
 /** @typedef {import('./required-actions.js').AppealRequiredAction} AppealRequiredAction */
 /** @typedef {import('../components/index.js').NotificationBannerDefinitionKey} NotificationBannerDefinitionKey */
 
 /**
  * @param {import('#appeals/appeal-details/appeal-details.types.js').WebAppeal} appealDetails
- * @param {string} currentRoute
+ * @param {import('@pins/express/types/express.js').Request} request
  * @returns {PageComponent[]}
  */
-export function mapStatusDependentNotifications(appealDetails, currentRoute) {
+export function mapStatusDependentNotifications(appealDetails, request) {
 	const requiredActions = getRequiredActionsForAppeal(appealDetails);
 
 	/** @type {import('../components/index.js').NotificationBannerDefinitionKey[]} */
@@ -25,102 +23,145 @@ export function mapStatusDependentNotifications(appealDetails, currentRoute) {
 		.filter(/** @returns {item is NotificationBannerDefinitionKey} */ (item) => item !== undefined);
 
 	return bannerKeys
-		.map((bannerKey) => mapBannerKeysToNotificationBanners(bannerKey, appealDetails, currentRoute))
+		.map((bannerKey) => mapBannerKeysToNotificationBanners(bannerKey, appealDetails, request))
 		.filter(/** @returns {item is PageComponent} */ (item) => item !== undefined);
 }
 
 /**
  * @param {NotificationBannerDefinitionKey} bannerDefinitionKey
  * @param {import('#appeals/appeal-details/appeal-details.types.js').WebAppeal} appealDetails
- * @param {string} currentRoute
+ * @param {import('@pins/express/types/express.js').Request} request
  * @returns {PageComponent|undefined}
  */
-function mapBannerKeysToNotificationBanners(bannerDefinitionKey, appealDetails, currentRoute) {
+function mapBannerKeysToNotificationBanners(bannerDefinitionKey, appealDetails, request) {
 	switch (bannerDefinitionKey) {
 		case 'appealAwaitingTransfer':
 			return createNotificationBanner({
 				bannerDefinitionKey,
-				html: `<p class="govuk-notification-banner__heading">This appeal is awaiting transfer</p><p class="govuk-body">The appeal must be transferred to Horizon. When this is done, <a class="govuk-link" data-cy="awaiting-transfer" href="/appeals-service/appeal-details/${appealDetails.appealId}/change-appeal-type/add-horizon-reference">update the appeal with the new horizon reference</a>.</p>`
+				html: `<p class="govuk-notification-banner__heading">This appeal is awaiting transfer</p><p class="govuk-body">The appeal must be transferred to Horizon. When this is done, <a class="govuk-link" data-cy="awaiting-transfer" href="${addBackLinkQueryToUrl(
+					request,
+					`/appeals-service/appeal-details/${appealDetails.appealId}/change-appeal-type/add-horizon-reference`
+				)}">update the appeal with the new horizon reference</a>.</p>`
 			});
 		case 'readyForSetUpSiteVisit':
 			return createNotificationBanner({
 				bannerDefinitionKey,
-				html: `<p class="govuk-notification-banner__heading">Site visit ready to set up</p><p><a class="govuk-notification-banner__link" data-cy="set-up-site-visit-banner" href="/appeals-service/appeal-details/${appealDetails.appealId}/site-visit/schedule-visit">Set up site visit</a></p>`
+				html: `<p class="govuk-notification-banner__heading">Site visit ready to set up</p><p><a class="govuk-notification-banner__link" data-cy="set-up-site-visit-banner" href="${addBackLinkQueryToUrl(
+					request,
+					`/appeals-service/appeal-details/${appealDetails.appealId}/site-visit/schedule-visit`
+				)}">Set up site visit</a></p>`
 			});
 		case 'assignCaseOfficer':
 			return createNotificationBanner({
 				bannerDefinitionKey,
-				html: `<p class="govuk-notification-banner__heading">Appeal ready to be assigned to case officer</p><p><a class="govuk-notification-banner__link" href="/appeals-service/appeal-details/${appealDetails.appealId}/assign-user/case-officer" data-cy="banner-assign-case-officer">Assign case officer</a></p>`
+				html: `<p class="govuk-notification-banner__heading">Appeal ready to be assigned to case officer</p><p><a class="govuk-notification-banner__link" href="${addBackLinkQueryToUrl(
+					request,
+					`/appeals-service/appeal-details/${appealDetails.appealId}/assign-user/case-officer`
+				)}" data-cy="banner-assign-case-officer">Assign case officer</a></p>`
 			});
 		case 'readyForDecision':
 			return createNotificationBanner({
 				bannerDefinitionKey,
-				html: `<p class="govuk-notification-banner__heading">Ready for decision</p><p><a class="govuk-notification-banner__link" data-cy="issue-determination" href="${generateIssueDecisionUrl(
-					appealDetails.appealId
+				html: `<p class="govuk-notification-banner__heading">Ready for decision</p><p><a class="govuk-notification-banner__link" data-cy="issue-determination" href="${addBackLinkQueryToUrl(
+					request,
+					generateIssueDecisionUrl(appealDetails.appealId)
 				)}">Issue decision</a></p>`
 			});
 		case 'progressFromFinalComments':
 			return createNotificationBanner({
 				bannerDefinitionKey,
-				html: `<a href="/appeals-service/appeal-details/${appealDetails.appealId}/share" class="govuk-heading-s govuk-notification-banner__link">Progress case</a>`
+				html: `<a href="${addBackLinkQueryToUrl(
+					request,
+					`/appeals-service/appeal-details/${appealDetails.appealId}/share`
+				)}" class="govuk-heading-s govuk-notification-banner__link">Progress case</a>`
 			});
 		case 'progressFromStatements':
 			return createNotificationBanner({
 				bannerDefinitionKey,
-				html: `<a href="/appeals-service/appeal-details/${appealDetails.appealId}/share" class="govuk-heading-s govuk-notification-banner__link">Progress to final comments</a>`
+				html: `<a href="${addBackLinkQueryToUrl(
+					request,
+					`/appeals-service/appeal-details/${appealDetails.appealId}/share`
+				)}" class="govuk-heading-s govuk-notification-banner__link">Progress to final comments</a>`
 			});
 		case 'readyForValidation':
 			return createNotificationBanner({
 				bannerDefinitionKey,
-				html: `<p class="govuk-notification-banner__heading">Appeal ready for validation</p><p><a class="govuk-notification-banner__link" data-cy="validate-appeal" href="/appeals-service/appeal-details/${appealDetails.appealId}/appellant-case">Validate <span class="govuk-visually-hidden">appeal</span></a></p>`
+				html: `<p class="govuk-notification-banner__heading">Appeal ready for validation</p><p><a class="govuk-notification-banner__link" data-cy="validate-appeal" href="${addBackLinkQueryToUrl(
+					request,
+					`/appeals-service/appeal-details/${appealDetails.appealId}/appellant-case`
+				)}">Validate <span class="govuk-visually-hidden">appeal</span></a></p>`
 			});
 		case 'appellantFinalCommentsAwaitingReview':
 			return createNotificationBanner({
 				bannerDefinitionKey,
-				html: `<p class="govuk-notification-banner__heading">Appellant final comments awaiting review</p><p><a class="govuk-notification-banner__link" href="/appeals-service/appeal-details/${appealDetails.appealId}/final-comments/appellant" data-cy="banner-review-appellant-final-comments">Review <span class="govuk-visually-hidden">appellant final comments</span></a></p>`
+				html: `<p class="govuk-notification-banner__heading">Appellant final comments awaiting review</p><p><a class="govuk-notification-banner__link" href="${addBackLinkQueryToUrl(
+					request,
+					`/appeals-service/appeal-details/${appealDetails.appealId}/final-comments/appellant`
+				)}" data-cy="banner-review-appellant-final-comments">Review <span class="govuk-visually-hidden">appellant final comments</span></a></p>`
 			});
 		case 'lpaFinalCommentsAwaitingReview':
 			return createNotificationBanner({
 				bannerDefinitionKey,
-				html: `<p class="govuk-notification-banner__heading">LPA final comments awaiting review</p><p><a class="govuk-notification-banner__link" href="/appeals-service/appeal-details/${appealDetails.appealId}/final-comments/lpa" data-cy="banner-review-lpa-final-comments">Review <span class="govuk-visually-hidden">L P A final comments</span></a></p>`
+				html: `<p class="govuk-notification-banner__heading">LPA final comments awaiting review</p><p><a class="govuk-notification-banner__link" href="${addBackLinkQueryToUrl(
+					request,
+					`/appeals-service/appeal-details/${appealDetails.appealId}/final-comments/lpa`
+				)}" data-cy="banner-review-lpa-final-comments">Review <span class="govuk-visually-hidden">L P A final comments</span></a></p>`
 			});
 		case 'interestedPartyCommentsAwaitingReview':
 			return createNotificationBanner({
 				bannerDefinitionKey,
-				html: `<p class="govuk-notification-banner__heading">Interested party comments awaiting review</p><p><a class="govuk-notification-banner__link" href="/appeals-service/appeal-details/${appealDetails.appealId}/interested-party-comments" data-cy="banner-review-ip-comments">Review <span class="govuk-visually-hidden">interested party comments</span></a></p>`
+				html: `<p class="govuk-notification-banner__heading">Interested party comments awaiting review</p><p><a class="govuk-notification-banner__link" href="${addBackLinkQueryToUrl(
+					request,
+					`/appeals-service/appeal-details/${appealDetails.appealId}/interested-party-comments`
+				)}" data-cy="banner-review-ip-comments">Review <span class="govuk-visually-hidden">interested party comments</span></a></p>`
 			});
 		case 'readyForLpaQuestionnaireReview':
 			return createNotificationBanner({
 				bannerDefinitionKey,
-				html: `<p class="govuk-notification-banner__heading">LPA questionnaire ready for review</p><p><a class="govuk-notification-banner__link" data-cy="review-lpa-questionnaire-banner" href="/appeals-service/appeal-details/${appealDetails.appealId}/lpa-questionnaire/${appealDetails.lpaQuestionnaireId}">Review <span class="govuk-visually-hidden">LPA questionnaire</span></a></p>`
+				html: `<p class="govuk-notification-banner__heading">LPA questionnaire ready for review</p><p><a class="govuk-notification-banner__link" data-cy="review-lpa-questionnaire-banner" href="${addBackLinkQueryToUrl(
+					request,
+					`/appeals-service/appeal-details/${appealDetails.appealId}/lpa-questionnaire/${appealDetails.lpaQuestionnaireId}`
+				)}">Review <span class="govuk-visually-hidden">LPA questionnaire</span></a></p>`
 			});
 		case 'lpaStatementAwaitingReview':
 			return createNotificationBanner({
 				bannerDefinitionKey,
-				html: `<p class="govuk-notification-banner__heading">LPA statement awaiting review</p><p><a class="govuk-notification-banner__link" href="/appeals-service/appeal-details/${appealDetails.appealId}/lpa-statement" data-cy="banner-review-lpa-statement">Review <span class="govuk-visually-hidden">LPA statement</span></a></p>`
+				html: `<p class="govuk-notification-banner__heading">LPA statement awaiting review</p><p><a class="govuk-notification-banner__link" href="${addBackLinkQueryToUrl(
+					request,
+					`/appeals-service/appeal-details/${appealDetails.appealId}/lpa-statement`
+				)}" data-cy="banner-review-lpa-statement">Review <span class="govuk-visually-hidden">LPA statement</span></a></p>`
 			});
 		case 'shareFinalComments':
 			return createNotificationBanner({
 				bannerDefinitionKey,
-				html: `<a href="/appeals-service/appeal-details/${appealDetails.appealId}/share" class="govuk-heading-s govuk-notification-banner__link">Share final comments</a>`
+				html: `<a href="${addBackLinkQueryToUrl(
+					request,
+					`/appeals-service/appeal-details/${appealDetails.appealId}/share`
+				)}" class="govuk-heading-s govuk-notification-banner__link">Share final comments</a>`
 			});
 		case 'shareCommentsAndLpaStatement':
 			return createNotificationBanner({
 				bannerDefinitionKey,
-				html: `<a href="/appeals-service/appeal-details/${appealDetails.appealId}/share" class="govuk-heading-s govuk-notification-banner__link">Share IP comments and LPA statement</a>`
+				html: `<a href="${addBackLinkQueryToUrl(
+					request,
+					`/appeals-service/appeal-details/${appealDetails.appealId}/share`
+				)}" class="govuk-heading-s govuk-notification-banner__link">Share IP comments and LPA statement</a>`
 			});
 		case 'appealValidAndReadyToStart':
 			return createNotificationBanner({
 				bannerDefinitionKey,
-				html: `<p class="govuk-notification-banner__heading">Appeal valid</p><p><a class="govuk-notification-banner__link" data-cy="ready-to-start" href="${generateStartTimetableUrl(
-					appealDetails.appealId,
-					currentRoute
+				html: `<p class="govuk-notification-banner__heading">Appeal valid</p><p><a class="govuk-notification-banner__link" data-cy="ready-to-start" href="${addBackLinkQueryToUrl(
+					request,
+					`/appeals-service/appeal-details/${appealDetails.appealId}/start-case/add`
 				)}">Start case</a></p>`
 			});
 		case 'updateLpaStatement':
 			return createNotificationBanner({
 				bannerDefinitionKey,
-				html: `<p class="govuk-notification-banner__heading">LPA statement incomplete</p> <a href="/appeals-service/appeal-details/${appealDetails.appealId}/lpa-statement" class="govuk-heading-s govuk-notification-banner__link">Update LPA statement</a>`
+				html: `<p class="govuk-notification-banner__heading">LPA statement incomplete</p> <a href="${addBackLinkQueryToUrl(
+					request,
+					`/appeals-service/appeal-details/${appealDetails.appealId}/lpa-statement`
+				)}" class="govuk-heading-s govuk-notification-banner__link">Update LPA statement</a>`
 			});
 	}
 }

--- a/appeals/web/src/server/lib/representation-utilities.js
+++ b/appeals/web/src/server/lib/representation-utilities.js
@@ -1,4 +1,6 @@
 import { APPEAL_REPRESENTATION_STATUS } from '@pins/appeals/constants/common.js';
+import { addBackLinkQueryToUrl } from '#lib/url-utilities.js';
+
 /**
  * @param {string} representationStatus
  * @returns {boolean}
@@ -14,13 +16,15 @@ export function isRepresentationReviewRequired(representationStatus) {
  * @param {string|undefined} documentationStatus
  * @param {string|Record<string, number>|null|undefined} representationStatus
  * @param {RepresentationType} representationType
+ * @param {import('@pins/express/types/express.js').Request} request
  * @returns {string} action link html
  */
 export function mapRepresentationDocumentSummaryActionLink(
 	currentRoute,
 	documentationStatus,
 	representationStatus,
-	representationType
+	representationType,
+	request
 ) {
 	if (documentationStatus !== 'received') {
 		return '';
@@ -55,7 +59,7 @@ export function mapRepresentationDocumentSummaryActionLink(
 		'appellant-final-comments': `${currentRoute}/final-comments/appellant`
 	};
 
-	return `<a href="${hrefs[representationType]}" data-cy="${
+	return `<a href="${addBackLinkQueryToUrl(request, hrefs[representationType])}" data-cy="${
 		reviewRequired ? 'review' : 'view'
 	}-${representationType}" class="govuk-link">${
 		reviewRequired ? 'Review' : 'View'

--- a/appeals/web/src/server/lib/url-utilities.js
+++ b/appeals/web/src/server/lib/url-utilities.js
@@ -41,3 +41,23 @@ export function safeRedirect(request, response, url) {
 		return response.redirect('/');
 	}
 }
+
+/**
+ * @param {import('@pins/express/types/express.js').Request} request
+ * @param {string} url
+ * @returns {string}
+ */
+export function addBackLinkQueryToUrl(request, url) {
+	return `${url}?backUrl=${encodeURIComponent(request.originalUrl)}`;
+}
+
+/**
+ * @param {import('@pins/express/types/express.js').Request} request
+ * @returns {string|undefined}
+ */
+export function getBackLinkUrlFromQuery(request) {
+	if (!request.query.backUrl) {
+		return;
+	}
+	return decodeURIComponent(request.query.backUrl.toString());
+}


### PR DESCRIPTION
## Describe your changes

- Adds helper functions `addBackLinkQueryToUrl` and `getBackLinkUrlFromQuery` to support easily adding and retrieving a uniform `backUrl` query to any href, to allow for implementing arbitrary back links where required
- Applies proper back link behaviour (using the helpers mentioned above) to all flow entry points (from personal list, case details important banners, and case details row action links) 

## Issue ticket number and link
https://pins-ds.atlassian.net/browse/A2-2945
