### PR TITLE
fix(appeals): allow notify emulator to write to linux, mac, and windows

### DIFF
--- a/appeals/api/src/server/notify/__tests__/emulate-notify.test.js
+++ b/appeals/api/src/server/notify/__tests__/emulate-notify.test.js
@@ -50,7 +50,7 @@ describe('emulate-notify.test', () => {
 			'Appeal reference number: 6000437<br>',
 			'Address: 72 Clapham High St, Wandsworth, SW4 7UL<br>',
 			'Planning application reference: 35606/APP/1/549765<br>',
-			'</div>',
+			'</div><br>',
 			'<h2>Why we rejected your comment</h2>',
 			'We rejected your comment because:<br>',
 			'<br>',

--- a/appeals/api/src/server/notify/emulate-notify.js
+++ b/appeals/api/src/server/notify/emulate-notify.js
@@ -63,8 +63,13 @@ export function emulateSendEmail(templateName, recipientEmail, subject, content)
 		fs.mkdirSync(outputDir, { recursive: true });
 	}
 
-	const fileName = `${formatSortableDateTime(new Date())} ${templateName}.html`;
-	const fullName = path.join(outputDir, fileName);
+	// Allow for both Linux (Mac) and Windows file systems
+	const fileName = `${formatSortableDateTime(new Date())} ${templateName}.html`.replaceAll(
+		':',
+		'_'
+	);
+
+	const fullName = path.join(process.cwd(), 'temp', fileName);
 	fs.writeFileSync(fullName, emailHtml);
 	return fullName;
 }

--- a/appeals/api/src/server/notify/emulate-notify.js
+++ b/appeals/api/src/server/notify/emulate-notify.js
@@ -42,7 +42,7 @@ export function emulateSendEmail(templateName, recipientEmail, subject, content)
 		}
 		if (blockEnd && blockEnd <= index) {
 			blockEnd = 0;
-			return line ? `</div>\n${line}<br>` : '</div>';
+			return line ? `</div>\n${line}<br>` : '</div><br>';
 		}
 		return line ? `${line}<br>` : '<br>';
 	});


### PR DESCRIPTION
## Describe your changes
#### 1) Make sure templates contain valid formatted variable names (A2-3022)
#### 2) Allow notify emulator to write to Linux, Mac, and Windows in local dev

#### API:
- Replace ':' in notify emulator temp filename with '_' to allow for windows when testing locally
- Add an additional line break to make sure there is a gap between the inset appeal details and the rest of the email when emulating notify while developing.
- Make sure templates contain valid formatted variable names where the variable names must:
  - Be within double brackets (( ... ))
  - Start with a lowercase letter
  - Only contain lowercase letters, digits, underscores
  - Underscore is allowed, but not at the start or end and no double underscores
- Add unit tests for above

#### TEST:
- All unit tests pass
- Tested within browser
- Checked that the notify emulator generated the email

## Issue ticket number and link
[Ticket:  Make sure notify templates contain valid formatted variable names (A2-3022)](https://pins-ds.atlassian.net.mcas.ms/browse/A2-3022)
