### PR TITLE
A2-2078(fix): Uncommitted files persisting when moving out of flow

### DIFF
--- a/appeals/web/src/server/appeals/appeal-details/appeal-details.router.js
+++ b/appeals/web/src/server/appeals/appeal-details/appeal-details.router.js
@@ -34,6 +34,7 @@ import finalCommentsRouter from './representations/final-comments/final-comments
 import { postCaseNote } from '#appeals/appeal-details/case-notes/case-notes.controller.js';
 import { validateCaseNoteTextArea } from '#appeals/appeal-details/appeals-details.validator.js';
 import representationsRouter from './representations/representations.router.js';
+import { clearUncommittedFilesFromSession } from '#appeals/appeal-documents/appeal-documents.middleware.js';
 
 const router = createRouter();
 
@@ -41,6 +42,7 @@ router
 	.route('/:appealId')
 	.get(
 		validateAppeal,
+		clearUncommittedFilesFromSession,
 		assertUserHasPermission(
 			permissionNames.viewCaseDetails,
 			permissionNames.viewAssignedCaseDetails

--- a/appeals/web/src/server/appeals/appeal-details/appellant-case/appellant-case.router.js
+++ b/appeals/web/src/server/appeals/appeal-details/appellant-case/appellant-case.router.js
@@ -10,6 +10,7 @@ import { assertUserHasPermission } from '#app/auth/auth.guards.js';
 import { validateAppeal } from '../appeal-details.middleware.js';
 import { permissionNames } from '#environment/permissions.js';
 import {
+	clearUncommittedFilesFromSession,
 	validateCaseDocumentId,
 	validateCaseFolderId
 } from '../../appeal-documents/appeal-documents.middleware.js';
@@ -156,7 +157,7 @@ router.use(
 
 router
 	.route('/')
-	.get(validateAppeal, asyncHandler(controller.getAppellantCase))
+	.get(validateAppeal, clearUncommittedFilesFromSession, asyncHandler(controller.getAppellantCase))
 	.post(
 		validateAppeal,
 		assertUserHasPermission(permissionNames.updateCase),

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/lpa-questionnaire.router.js
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/lpa-questionnaire.router.js
@@ -10,7 +10,8 @@ import { permissionNames } from '#environment/permissions.js';
 
 import {
 	validateCaseFolderId,
-	validateCaseDocumentId
+	validateCaseDocumentId,
+	clearUncommittedFilesFromSession
 } from '../../appeal-documents/appeal-documents.middleware.js';
 import inspectorAccessRouter from '../inspector-access/inspector-access.router.js';
 import neighbouringSitesRouter from '../neighbouring-sites/neighbouring-sites.router.js';
@@ -211,7 +212,11 @@ router.use(
 
 router
 	.route('/:lpaQuestionnaireId')
-	.get(validateAppeal, asyncHandler(controller.getLpaQuestionnaire))
+	.get(
+		validateAppeal,
+		clearUncommittedFilesFromSession,
+		asyncHandler(controller.getLpaQuestionnaire)
+	)
 	.post(
 		validateAppeal,
 		assertUserHasPermission(permissionNames.updateCase),

--- a/appeals/web/src/server/appeals/appeal-details/representations/final-comments/final-comments.router.js
+++ b/appeals/web/src/server/appeals/appeal-details/representations/final-comments/final-comments.router.js
@@ -10,6 +10,7 @@ import {
 import addDocumentRouter from '../document-attachments/add-document.router.js';
 import manageDocumentsRouter from '../document-attachments/manage-documents.router.js';
 import acceptFinalCommentsRouter from './accept/accept.router.js';
+// import { clearUncommittedFilesFromSession } from '#appeals/appeal-documents/appeal-documents.middleware.js';
 
 const router = createRouter({ mergeParams: true });
 
@@ -17,6 +18,7 @@ router.use(
 	'/:finalCommentsType',
 	validateAppeal,
 	withSingularRepresentation,
+	// clearUncommittedFilesFromSession,
 	viewAndReviewFinalCommentsRouter
 );
 

--- a/appeals/web/src/server/appeals/appeal-details/representations/final-comments/final-comments.router.js
+++ b/appeals/web/src/server/appeals/appeal-details/representations/final-comments/final-comments.router.js
@@ -10,7 +10,6 @@ import {
 import addDocumentRouter from '../document-attachments/add-document.router.js';
 import manageDocumentsRouter from '../document-attachments/manage-documents.router.js';
 import acceptFinalCommentsRouter from './accept/accept.router.js';
-// import { clearUncommittedFilesFromSession } from '#appeals/appeal-documents/appeal-documents.middleware.js';
 
 const router = createRouter({ mergeParams: true });
 
@@ -18,7 +17,6 @@ router.use(
 	'/:finalCommentsType',
 	validateAppeal,
 	withSingularRepresentation,
-	// clearUncommittedFilesFromSession,
 	viewAndReviewFinalCommentsRouter
 );
 

--- a/appeals/web/src/server/appeals/appeal-details/representations/interested-party-comments/interested-party-comments.router.js
+++ b/appeals/web/src/server/appeals/appeal-details/representations/interested-party-comments/interested-party-comments.router.js
@@ -7,6 +7,7 @@ import viewAndReviewIpCommentRouter from './view-and-review/view-and-review.rout
 import redactIpCommentRouter from './redact/redact.router.js';
 import * as controller from './interested-party-comments.controller.js';
 import { validateComment } from './interested-party-comments.middleware.js';
+import { clearUncommittedFilesFromSession } from '#appeals/appeal-documents/appeal-documents.middleware.js';
 
 const router = createRouter({ mergeParams: true });
 
@@ -18,6 +19,12 @@ router.use('/:commentId/edit', validateAppeal, validateComment, editIpCommentRou
 
 router.use('/:commentId', validateAppeal, validateComment, viewAndReviewIpCommentRouter);
 
-router.route('/').get(validateAppeal, asyncHandler(controller.handleInterestedPartyComments));
+router
+	.route('/')
+	.get(
+		validateAppeal,
+		clearUncommittedFilesFromSession,
+		asyncHandler(controller.handleInterestedPartyComments)
+	);
 
 export default router;

--- a/appeals/web/src/server/appeals/appeal-details/representations/lpa-statement/lpa-statement.router.js
+++ b/appeals/web/src/server/appeals/appeal-details/representations/lpa-statement/lpa-statement.router.js
@@ -8,12 +8,13 @@ import redactRouter from './redact/redact.router.js';
 import { getRepresentationAttachmentsFolder } from '#appeals/appeal-details/representations/final-comments/final-comments.middleware.js';
 import addDocumentRouter from '../document-attachments/add-document.router.js';
 import manageDocumentsRouter from '../document-attachments/manage-documents.router.js';
+import { clearUncommittedFilesFromSession } from '#appeals/appeal-documents/appeal-documents.middleware.js';
 
 const router = Router({ mergeParams: true });
 
 router
 	.route('/')
-	.get(renderReviewLpaStatement)
+	.get(clearUncommittedFilesFromSession, renderReviewLpaStatement)
 	.post(
 		validateStatus,
 		saveBodyToSession('lpaStatement', { scopeToAppeal: true }),

--- a/appeals/web/src/server/appeals/appeal-documents/appeal-documents.middleware.js
+++ b/appeals/web/src/server/appeals/appeal-documents/appeal-documents.middleware.js
@@ -32,3 +32,14 @@ export const validateCaseDocumentId = async (req, res, next) => {
 
 	next();
 };
+
+/**
+ * @type {import("express").RequestHandler}
+ * @returns {void}
+ */
+export const clearUncommittedFilesFromSession = (req, res, next) => {
+	if (req.session.fileUploadInfo) {
+		delete req.session.fileUploadInfo;
+	}
+	next();
+};


### PR DESCRIPTION
## Describe your changes
- Added common middleware to remove uncommitted files from session
- Applying middleware function to top-level pages GETs to ensure session is clear of uncommitted files
<!--
    Please include a summary of the change along with any relevant context.
    List any dependencies that are required for this change.
-->

## Issue ticket number and link
[Ticket](https://pins-ds.atlassian.net.mcas.ms/browse/A2-2078)
