### PR TITLE
fix(appeals): implement lpaq complete householder appellant email (a2…

### DIFF
--- a/appeals/api/src/server/endpoints/lpa-questionnaires/lpa-questionnaires.service.js
+++ b/appeals/api/src/server/endpoints/lpa-questionnaires/lpa-questionnaires.service.js
@@ -16,6 +16,7 @@ import * as documentRepository from '#repositories/document.repository.js';
 import { broadcasters } from '#endpoints/integrations/integrations.broadcasters.js';
 import { EventType } from '@pins/event-client';
 import { notifySend } from '#notify/notify-send.js';
+import { APPEAL_TYPE } from '@pins/appeals/constants/common.js';
 
 /** @typedef {import('express').RequestHandler} RequestHandler */
 /** @typedef {import('@pins/appeals.api').Appeals.UpdateLPAQuestionnaireValidationOutcomeParams} UpdateLPAQuestionnaireValidationOutcomeParams */
@@ -150,7 +151,11 @@ function sendLpaqCompleteEmailToLPA(notifyClient, appeal, siteAddress) {
  * */
 function sendLpaqCompleteEmailToAppellant(notifyClient, appeal, siteAddress) {
 	const email = appeal.appellant?.email ?? appeal.agent?.email;
-	return sendLpaqCompleteEmail(notifyClient, appeal, siteAddress, 'lpaq-complete-appellant', email);
+	const templateName =
+		appeal.appealType?.type === APPEAL_TYPE.HOUSEHOLDER
+			? 'lpaq-complete-has-appellant'
+			: 'lpaq-complete-appellant';
+	return sendLpaqCompleteEmail(notifyClient, appeal, siteAddress, templateName, email);
 }
 
 /**

--- a/appeals/api/src/server/notify/templates/__tests__/notify-lpaq-complete-has-appellant.test.js
+++ b/appeals/api/src/server/notify/templates/__tests__/notify-lpaq-complete-has-appellant.test.js
@@ -1,0 +1,52 @@
+import { notifySend } from '#notify/notify-send.js';
+import { jest } from '@jest/globals';
+
+describe('lpaq-complete-has-appellant.md', () => {
+	test('should call notify sendEmail with the correct data', async () => {
+		const notifySendData = {
+			doNotMockNotifySend: true,
+			templateName: 'lpaq-complete-has-appellant',
+			notifyClient: {
+				sendEmail: jest.fn()
+			},
+			recipientEmail: 'test@136s7.com',
+			personalisation: {
+				appeal_reference_number: 'ABC45678',
+				site_address: '10, Test Street',
+				lpa_reference: '12345XYZ'
+			}
+		};
+
+		const expectedContent = [
+			'We have received the local planning authority’s questionnaire.',
+			'',
+			'You can [view this information in the appeals service](https://appeal-planning-decision.service.gov.uk/).',
+			'',
+			'# Appeal details',
+			'',
+			'^Appeal reference number: ABC45678',
+			'Address: 10, Test Street',
+			'Planning application reference: 12345XYZ',
+			'',
+			'# What happens next',
+			'',
+			'We will send you another email when we set up your site visit.',
+			'',
+			'The Planning Inspectorate',
+			'caseofficers@planninginspectorate.gov.uk'
+		].join('\n');
+
+		await notifySend(notifySendData);
+
+		expect(notifySendData.notifyClient.sendEmail).toHaveBeenCalledWith(
+			{
+				id: 'mock-appeal-generic-id'
+			},
+			'test@136s7.com',
+			{
+				content: expectedContent,
+				subject: "View the local planning authority's questionnaire: ABC45678"
+			}
+		);
+	});
+});

--- a/appeals/api/src/server/notify/templates/lpaq-complete-has-appellant.content.md
+++ b/appeals/api/src/server/notify/templates/lpaq-complete-has-appellant.content.md
@@ -1,0 +1,16 @@
+We have received the local planning authority’s questionnaire.
+
+You can [view this information in the appeals service](https://appeal-planning-decision.service.gov.uk/).
+
+# Appeal details
+
+^Appeal reference number: ((appeal_reference_number))
+Address: ((site_address))
+Planning application reference: ((lpa_reference))
+
+# What happens next
+
+We will send you another email when we set up your site visit.
+
+The Planning Inspectorate
+caseofficers@planninginspectorate.gov.uk

--- a/appeals/api/src/server/notify/templates/lpaq-complete-has-appellant.subject.md
+++ b/appeals/api/src/server/notify/templates/lpaq-complete-has-appellant.subject.md
@@ -1,0 +1,1 @@
+View the local planning authority's questionnaire: ((appeal_reference_number))

--- a/appeals/web/src/server/appeals/appeal-details/appellant-case/__tests__/appellant-case.test.js
+++ b/appeals/web/src/server/appeals/appeal-details/appellant-case/__tests__/appellant-case.test.js
@@ -32,7 +32,8 @@ import usersService from '#appeals/appeal-users/users-service.js';
 import {
 	dateISOStringToDayMonthYearHourMinute,
 	dateISOStringToDisplayDate,
-	calculateIncompleteDueDate
+	calculateIncompleteDueDate,
+	oneMonthBefore
 } from '#lib/dates.js';
 import { APPEAL_CASE_STATUS, APPEAL_CASE_STAGE, APPEAL_DOCUMENT_TYPE } from 'pins-data-model';
 
@@ -1828,7 +1829,7 @@ describe('appellant-case', () => {
 		});
 
 		it('should render the update due date page with pre-populated date values if there is no existing due date and applicationDecisionDate is set', async () => {
-			const decisionDate = '2024-10-12T11:44:21.173Z';
+			const decisionDate = oneMonthBefore(new Date()).toISOString();
 			const expectedDate = calculateIncompleteDueDate(decisionDate, 'Planning appeal');
 			const expectedValues = dateISOStringToDayMonthYearHourMinute(expectedDate?.toISOString());
 

--- a/appeals/web/src/server/lib/dates.js
+++ b/appeals/web/src/server/lib/dates.js
@@ -1,6 +1,6 @@
 import { formatInTimeZone, utcToZonedTime, zonedTimeToUtc } from 'date-fns-tz';
 import enGB from 'date-fns/locale/en-GB/index.js';
-import { isValid, isBefore, isAfter, parseISO, add } from 'date-fns';
+import { add, isAfter, isBefore, isValid, parseISO } from 'date-fns';
 import { padNumberWithZero } from '#lib/string-utilities.js';
 import { DEFAULT_TIMEZONE } from '@pins/appeals/constants/dates.js';
 import { APPEAL_TYPE } from '@pins/appeals/constants/common.js';
@@ -273,4 +273,15 @@ const getExtendedDeadlineConfiguration = (appealType) => {
 			return null;
 		}
 	}
+};
+
+/**
+ *
+ * @param {Date} date
+ * @returns {Date}
+ */
+export const oneMonthBefore = (date) => {
+	const dateOneMonthBefore = new Date(date.getTime());
+	dateOneMonthBefore.setMonth(dateOneMonthBefore.getMonth() - 1);
+	return dateOneMonthBefore;
 };


### PR DESCRIPTION
## Describe your changes
#### Implement LPAQ complete householder email for appellant (a2-2763)

#### API:
- Call notifySend with the correct LPAQ complete email for the appellant depending on the appeal type
- Added tests to test the template 'lpaq-complete-has-appellant'

#### WEB:
- Fixed the broken decision date test by replacing the hard coded date with a oneMonthBefore today calculation

#### TEST:
- All unit tests pass
- Tested within browser
- Tested emails with emulator

## Issue ticket number and link
[Ticket:  LPAQ published (appellant) (A2-2763)](https://pins-ds.atlassian.net.mcas.ms/browse/A2-2763)
