### PR TITLE
fix(api): code failing after prisma update

### DIFF
--- a/appeals/api/src/server/repositories/common.repository.js
+++ b/appeals/api/src/server/repositories/common.repository.js
@@ -89,6 +89,7 @@ const createIncompleteInvalidReasons = ({
 	// @ts-ignore
 	databaseConnector[incompleteInvalidReasonTextTable].createMany({
 		data: data
+			.filter((reason) => reason.text && reason.text !== null)
 			.map(
 				({ id: reasonId, text }) =>
 					text &&


### PR DESCRIPTION
Upgrading to a newer version of Prisma brought this bug. Fixed by avoiding executing a DB call when there is no need.

