### PR TITLE
Fix/A2-2975-Incorrect-status-for-LPA-statement-Documentation-section

### DIFF
--- a/appeals/web/src/server/lib/__tests__/libraries.test.js
+++ b/appeals/web/src/server/lib/__tests__/libraries.test.js
@@ -35,7 +35,10 @@ import httpMocks from 'node-mocks-http';
 import { getOriginPathname, isInternalUrl, safeRedirect } from '#lib/url-utilities.js';
 import { stringIsValidPostcodeFormat } from '#lib/postcode.js';
 import { addInvisibleSpacesAfterRedactionCharacters } from '#lib/redaction-string-formatter.js';
-import { mapRepresentationDocumentSummaryStatus } from '#lib/representation-utilities.js';
+import {
+	mapLPARepresentationDocumentSummaryStatus,
+	mapRepresentationDocumentSummaryStatus
+} from '#lib/representation-utilities.js';
 
 describe('Libraries', () => {
 	describe('addressFormatter', () => {
@@ -1595,5 +1598,26 @@ describe('mapRepresentationDocumentSummaryStatus', () => {
 	});
 	it('Should return "Received" if final comment is received', () => {
 		expect(mapRepresentationDocumentSummaryStatus('received', 'default')).toBe('Received');
+	});
+});
+
+describe('mapLPARepresentationDocumentSummaryStatus', () => {
+	it('Should return "No final comments" if no final comments were received', () => {
+		expect(mapLPARepresentationDocumentSummaryStatus('not_received', null)).toBe('No statement');
+	});
+	it('Should return "Accepted" if final comment was accepted', () => {
+		expect(mapLPARepresentationDocumentSummaryStatus('received', 'valid')).toBe('Accepted');
+	});
+	it('Should return "Rejected" if final comment was rejected', () => {
+		expect(mapLPARepresentationDocumentSummaryStatus('received', 'invalid')).toBe('Rejected');
+	});
+	it('Should return "Shared" if final comment was shared', () => {
+		expect(mapLPARepresentationDocumentSummaryStatus('received', 'published')).toBe('Shared');
+	});
+	it('Should return "Incomplete" if final comment is incomplete', () => {
+		expect(mapLPARepresentationDocumentSummaryStatus('received', 'incomplete')).toBe('Incomplete');
+	});
+	it('Should return "Received" if final comment is received', () => {
+		expect(mapLPARepresentationDocumentSummaryStatus('received', 'default')).toBe('Received');
 	});
 });

--- a/appeals/web/src/server/lib/mappers/data/appeal/submappers/__tests__/lpa-statement.mapper.test.js
+++ b/appeals/web/src/server/lib/mappers/data/appeal/submappers/__tests__/lpa-statement.mapper.test.js
@@ -1,0 +1,281 @@
+// @ts-nocheck
+import { APPEAL_REPRESENTATION_STATUS } from '@pins/appeals/constants/common.js';
+import { mapLpaStatement } from '../lpa-statement.mapper.js';
+
+describe('lpa-statement.mapper', () => {
+	it('should map LPA statement correctly', () => {
+		let data = {
+			appealDetails: {
+				documentationSummary: {
+					lpaStatement: {
+						status: 'received',
+						receivedAt: '2023-01-01',
+						representationStatus: APPEAL_REPRESENTATION_STATUS.AWAITING_REVIEW
+					}
+				}
+			},
+			currentRoute: '/test'
+		};
+		const result = mapLpaStatement(data);
+		expect(result).toEqual({
+			id: 'lpa-statement',
+			display: {
+				tableItem: [
+					{
+						text: 'LPA statement'
+					},
+					{
+						text: 'Received'
+					},
+					{
+						text: '1 January 2023'
+					},
+					{
+						classes: 'govuk-!-text-align-right',
+						html: '<a href="/test/lpa-statement" data-cy="review-lpa-statement" class="govuk-link">Review<span class="govuk-visually-hidden"> LPA statement</span></a>'
+					}
+				]
+			}
+		});
+	});
+	it('should map lpa statement correctly when there is no data', () => {
+		let data = {
+			appealDetails: {
+				documentationSummary: {}
+			},
+			currentRoute: '/test'
+		};
+		const result = mapLpaStatement(data);
+		expect(result).toEqual({
+			id: 'lpa-statement',
+			display: {
+				tableItem: [
+					{
+						text: 'LPA statement'
+					},
+					{
+						text: 'No statement'
+					},
+					{
+						text: 'Not Applicable'
+					},
+					{
+						classes: 'govuk-!-text-align-right',
+						html: ''
+					}
+				]
+			}
+		});
+	});
+	it('should map LPA statement correctly when no date available', () => {
+		let data = {
+			appealDetails: {
+				documentationSummary: {
+					lpaStatement: {
+						status: 'received',
+						receivedAt: '',
+						representationStatus: APPEAL_REPRESENTATION_STATUS.AWAITING_REVIEW
+					}
+				}
+			},
+			currentRoute: '/test'
+		};
+		const result = mapLpaStatement(data);
+		expect(result).toEqual({
+			id: 'lpa-statement',
+			display: {
+				tableItem: [
+					{
+						text: 'LPA statement'
+					},
+					{
+						text: 'Received'
+					},
+					{
+						text: 'Not Applicable'
+					},
+					{
+						classes: 'govuk-!-text-align-right',
+						html: '<a href="/test/lpa-statement" data-cy="review-lpa-statement" class="govuk-link">Review<span class="govuk-visually-hidden"> LPA statement</span></a>'
+					}
+				]
+			}
+		});
+	});
+	it('should map LPA statement correctly when no status is valid', () => {
+		let data = {
+			appealDetails: {
+				documentationSummary: {
+					lpaStatement: {
+						status: 'received',
+						receivedAt: '',
+						representationStatus: APPEAL_REPRESENTATION_STATUS.VALID
+					}
+				}
+			},
+			currentRoute: '/test'
+		};
+		const result = mapLpaStatement(data);
+		expect(result).toEqual({
+			id: 'lpa-statement',
+			display: {
+				tableItem: [
+					{
+						text: 'LPA statement'
+					},
+					{
+						text: 'Accepted'
+					},
+					{
+						text: 'Not Applicable'
+					},
+					{
+						classes: 'govuk-!-text-align-right',
+						html: '<a href="/test/lpa-statement" data-cy="view-lpa-statement" class="govuk-link">View<span class="govuk-visually-hidden"> LPA statement</span></a>'
+					}
+				]
+			}
+		});
+	});
+	it('should map LPA statement correctly when no status is invalid', () => {
+		let data = {
+			appealDetails: {
+				documentationSummary: {
+					lpaStatement: {
+						status: 'received',
+						receivedAt: '',
+						representationStatus: APPEAL_REPRESENTATION_STATUS.INVALID
+					}
+				}
+			},
+			currentRoute: '/test'
+		};
+		const result = mapLpaStatement(data);
+		expect(result).toEqual({
+			id: 'lpa-statement',
+			display: {
+				tableItem: [
+					{
+						text: 'LPA statement'
+					},
+					{
+						text: 'Rejected'
+					},
+					{
+						text: 'Not Applicable'
+					},
+					{
+						classes: 'govuk-!-text-align-right',
+						html: '<a href="/test/lpa-statement" data-cy="view-lpa-statement" class="govuk-link">View<span class="govuk-visually-hidden"> LPA statement</span></a>'
+					}
+				]
+			}
+		});
+	});
+	it('should map LPA statement correctly when no status is published', () => {
+		let data = {
+			appealDetails: {
+				documentationSummary: {
+					lpaStatement: {
+						status: 'received',
+						receivedAt: '',
+						representationStatus: APPEAL_REPRESENTATION_STATUS.PUBLISHED
+					}
+				}
+			},
+			currentRoute: '/test'
+		};
+		const result = mapLpaStatement(data);
+		expect(result).toEqual({
+			id: 'lpa-statement',
+			display: {
+				tableItem: [
+					{
+						text: 'LPA statement'
+					},
+					{
+						text: 'Shared'
+					},
+					{
+						text: 'Not Applicable'
+					},
+					{
+						classes: 'govuk-!-text-align-right',
+						html: '<a href="/test/lpa-statement" data-cy="view-lpa-statement" class="govuk-link">View<span class="govuk-visually-hidden"> LPA statement</span></a>'
+					}
+				]
+			}
+		});
+	});
+
+	it('should map LPA statement correctly when no status is incomplete', () => {
+		let data = {
+			appealDetails: {
+				documentationSummary: {
+					lpaStatement: {
+						status: 'received',
+						receivedAt: '',
+						representationStatus: APPEAL_REPRESENTATION_STATUS.INCOMPLETE
+					}
+				}
+			},
+			currentRoute: '/test'
+		};
+		const result = mapLpaStatement(data);
+		expect(result).toEqual({
+			id: 'lpa-statement',
+			display: {
+				tableItem: [
+					{
+						text: 'LPA statement'
+					},
+					{
+						text: 'Incomplete'
+					},
+					{
+						text: 'Not Applicable'
+					},
+					{
+						classes: 'govuk-!-text-align-right',
+						html: '<a href="/test/lpa-statement" data-cy="review-lpa-statement" class="govuk-link">Review<span class="govuk-visually-hidden"> LPA statement</span></a>'
+					}
+				]
+			}
+		});
+	});
+	it('should map LPA statement correctly when no date is a date type', () => {
+		let data = {
+			appealDetails: {
+				documentationSummary: {
+					lpaStatement: {
+						status: 'received',
+						receivedAt: new Date('2023-01-01'),
+						representationStatus: APPEAL_REPRESENTATION_STATUS.INCOMPLETE
+					}
+				}
+			},
+			currentRoute: '/test'
+		};
+		const result = mapLpaStatement(data);
+		expect(result).toEqual({
+			id: 'lpa-statement',
+			display: {
+				tableItem: [
+					{
+						text: 'LPA statement'
+					},
+					{
+						text: 'Incomplete'
+					},
+					{
+						text: 'Not Applicable'
+					},
+					{
+						classes: 'govuk-!-text-align-right',
+						html: '<a href="/test/lpa-statement" data-cy="review-lpa-statement" class="govuk-link">Review<span class="govuk-visually-hidden"> LPA statement</span></a>'
+					}
+				]
+			}
+		});
+	});
+});

--- a/appeals/web/src/server/lib/mappers/data/appeal/submappers/lpa-statement.mapper.js
+++ b/appeals/web/src/server/lib/mappers/data/appeal/submappers/lpa-statement.mapper.js
@@ -1,7 +1,7 @@
 import { documentationFolderTableItem } from '#lib/mappers/index.js';
 import { dateISOStringToDisplayDate } from '#lib/dates.js';
 import {
-	mapRepresentationDocumentSummaryStatus,
+	mapLPARepresentationDocumentSummaryStatus,
 	mapRepresentationDocumentSummaryActionLink
 } from '#lib/representation-utilities.js';
 
@@ -10,15 +10,16 @@ export const mapLpaStatement = ({ appealDetails, currentRoute }) =>
 	documentationFolderTableItem({
 		id: 'lpa-statement',
 		text: 'LPA statement',
-		statusText: mapRepresentationDocumentSummaryStatus(
+		statusText: mapLPARepresentationDocumentSummaryStatus(
 			appealDetails?.documentationSummary?.lpaStatement?.status,
 			appealDetails?.documentationSummary?.lpaStatement?.representationStatus
 		),
-		receivedText: dateISOStringToDisplayDate(
-			appealDetails?.documentationSummary?.lpaStatement?.receivedAt instanceof Date
-				? appealDetails?.documentationSummary?.lpaStatement?.receivedAt.toDateString()
-				: appealDetails?.documentationSummary?.lpaStatement?.receivedAt
-		),
+		receivedText:
+			dateISOStringToDisplayDate(
+				appealDetails?.documentationSummary?.lpaStatement?.receivedAt instanceof Date
+					? appealDetails?.documentationSummary?.lpaStatement?.receivedAt.toDateString()
+					: appealDetails?.documentationSummary?.lpaStatement?.receivedAt
+			) || 'Not Applicable',
 		actionHtml: mapRepresentationDocumentSummaryActionLink(
 			currentRoute,
 			appealDetails?.documentationSummary?.lpaStatement?.status,

--- a/appeals/web/src/server/lib/representation-utilities.js
+++ b/appeals/web/src/server/lib/representation-utilities.js
@@ -74,3 +74,30 @@ export function mapRepresentationDocumentSummaryStatus(documentationStatus, repr
 			return 'Received';
 	}
 }
+
+/**
+ * @param {string|undefined} documentationStatus
+ * @param {string|null|undefined} representationStatus
+ * @returns {string}
+ */
+export function mapLPARepresentationDocumentSummaryStatus(
+	documentationStatus,
+	representationStatus
+) {
+	if (documentationStatus !== 'received' || !representationStatus) {
+		return 'No statement';
+	}
+
+	switch (representationStatus) {
+		case APPEAL_REPRESENTATION_STATUS.VALID:
+			return 'Accepted';
+		case APPEAL_REPRESENTATION_STATUS.INVALID:
+			return 'Rejected';
+		case APPEAL_REPRESENTATION_STATUS.PUBLISHED:
+			return 'Shared';
+		case APPEAL_REPRESENTATION_STATUS.INCOMPLETE:
+			return 'Incomplete';
+		default:
+			return 'Received';
+	}
+}


### PR DESCRIPTION
## Changes

Updated the LPA statment row in Case Details Documentation to display no Statement when the docuemtn has not been recived and Not applicable when the statement has not been reviced 


## Issue ticket number and link
[A2-2975](https://pins-ds.atlassian.net/browse/A2-2975)
