### PR TITLE
feat(web): hide extension when changing filenames

### DIFF
--- a/appeals/web/src/client/components/file-uploader/_client-actions.js
+++ b/appeals/web/src/client/components/file-uploader/_client-actions.js
@@ -284,7 +284,8 @@ const clientActions = (container) => {
 				stagedFiles.errors.push({
 					message: validationError.message || '',
 					name: addedFile.file.name,
-					guid: addedFile.guid
+					guid: addedFile.guid,
+					metadata: validationError.metadata,
 				});
 			}
 		}
@@ -372,7 +373,7 @@ const clientActions = (container) => {
 
 	/**
 	 * @param {File} selectedFile
-	 * @returns {{message: string} | null}
+	 * @returns {{message: string, metadata?: {fileExtension?: string}} | null}
 	 */
 	function validateSelectedFile(selectedFile) {
 		const allowedMimeTypes = (container.dataset.allowedTypes || '').split(',');
@@ -394,6 +395,13 @@ const clientActions = (container) => {
 		}
 		if (!allowedMimeTypes.includes(selectedFile.type)) {
 			return { message: 'TYPE_SINGLE_FILE' };
+		}
+		const originalFileExtension = container.dataset.documentOriginalFileName?.split('.').pop();
+		if (originalFileExtension && selectedFile.name.split('.').pop() !== originalFileExtension) {
+			return {
+				message: 'DIFFERENT_FILE_EXTENSION',
+				metadata: { fileExtension: originalFileExtension.toUpperCase() }
+			};
 		}
 
 		return null;
@@ -433,7 +441,8 @@ const clientActions = (container) => {
 					...stagedFiles.errors.map((errorItem) => ({
 						message: errorItem.message,
 						name: errorItem.name,
-						guid: errorItem.guid
+						guid: errorItem.guid,
+						metadata: errorItem.metadata
 					})),
 					...failedUploads
 				].flat()

--- a/appeals/web/src/client/components/file-uploader/_errors.js
+++ b/appeals/web/src/client/components/file-uploader/_errors.js
@@ -104,7 +104,7 @@ export const showErrors = (error, uploadForm) => {
 
 	const errors =
 		error.details?.map((errorDetails) => ({
-			message: errorMessage(errorDetails.message || '', errorDetails.name),
+			message: errorMessage(errorDetails.message || '', errorDetails.name, errorDetails.metadata),
 			guid: errorDetails.guid
 		})) || [];
 

--- a/appeals/web/src/client/components/file-uploader/_html.js
+++ b/appeals/web/src/client/components/file-uploader/_html.js
@@ -20,9 +20,10 @@ const SELECTORS = {
 /**
  * @param {string} type
  * @param {string?} replaceValue
+ * @param {Record<string,string>?} additionalValues
  * @returns {string}
  */
-export const errorMessage = (type, replaceValue) => {
+export const errorMessage = (type, replaceValue, additionalValues = {}) => {
 	/** @type {Record<string,string>} */
 	const index = {
 		GENERIC: 'Something went wrong, please try again',
@@ -35,10 +36,23 @@ export const errorMessage = (type, replaceValue) => {
 		GENERIC_SINGLE_FILE: `{REPLACE_VALUE} could not be added`,
 		NAME_SINGLE_FILE: `{REPLACE_VALUE} could not be added because the file name is too long or contains special characters. Rename the file and try again.`,
 		TYPE_SINGLE_FILE: `{REPLACE_VALUE} could not be added because it is not an allowed file type`,
-		DUPLICATE_NAME_SINGLE_FILE: `"{REPLACE_VALUE}" could not be added because a file with this name already exists. Files cannot have duplicate names.`
+		DUPLICATE_NAME_SINGLE_FILE: `"{REPLACE_VALUE}" could not be added because a file with this name already exists. Files cannot have duplicate names.`,
+		DIFFERENT_FILE_EXTENSION: `The selected file must be a {fileExtension}`
 	};
 
-	return index[type] ? index[type].replace('{REPLACE_VALUE}', replaceValue || '') : index.GENERIC;
+	let message = index[type];
+
+	if (!message) {
+		return index.GENERIC;
+	}
+
+	if (additionalValues) {
+		for (const [key, value] of Object.entries(additionalValues)) {
+			message = message.replace(`{${key}}`, value);
+		}
+	}
+
+	return message.replace('{REPLACE_VALUE}', replaceValue || '');
 };
 
 /**
@@ -104,7 +118,7 @@ export const buildErrorListItem = (error) => {
 
 	const p = document.createElement('p');
 	p.className = CLASSES.errorMessage;
-	p.textContent = errorMessage(error.message, error.name);
+	p.textContent = errorMessage(error.message, error.name, error.metadata);
 
 	li.appendChild(p);
 

--- a/appeals/web/src/server/appeals/appeal-details/costs/__tests__/__snapshots__/costs.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/costs/__tests__/__snapshots__/costs.test.js.snap
@@ -215,7 +215,7 @@ exports[`costs application, withdrawal and correspondence GET /costs/:costsCateg
         <div class="govuk-grid-column-two-thirds">
             <form method="post" novalidate="novalidate">
                 <div class="govuk-form-group">
-                    <h2 class="govuk-heading-m">ph0-documentFileInfo.jpeg</h2>
+                    <h2 class="govuk-heading-m">ph0-documentFileInfo</h2>
                     <div class="govuk-form-group">
                         <input class="govuk-input" id="documentId" name="documentId" type="hidden"
                         value="d51f408c-7c6f-4f49-bcc0-abbb5bea3be6">
@@ -223,7 +223,7 @@ exports[`costs application, withdrawal and correspondence GET /costs/:costsCateg
                     <div class="govuk-form-group">
                         <label class="govuk-label govuk-caption-m govuk-!-margin-bottom-3" for="file-name">File name</label>
                         <input class="govuk-input" id="file-name" name="fileName"
-                        type="text" value="ph0-documentFileInfo.jpeg">
+                        type="text" value="ph0-documentFileInfo">
                     </div>
                 </div>
                 <button type="submit" class="govuk-button" data-module="govuk-button">Confirm</button>
@@ -244,7 +244,7 @@ exports[`costs application, withdrawal and correspondence GET /costs/:costsCateg
         <div class="govuk-grid-column-two-thirds">
             <form method="post" novalidate="novalidate">
                 <div class="govuk-form-group">
-                    <h2 class="govuk-heading-m">ph0-documentFileInfo.jpeg</h2>
+                    <h2 class="govuk-heading-m">ph0-documentFileInfo</h2>
                     <div class="govuk-form-group">
                         <input class="govuk-input" id="documentId" name="documentId" type="hidden"
                         value="d51f408c-7c6f-4f49-bcc0-abbb5bea3be6">
@@ -252,7 +252,7 @@ exports[`costs application, withdrawal and correspondence GET /costs/:costsCateg
                     <div class="govuk-form-group">
                         <label class="govuk-label govuk-caption-m govuk-!-margin-bottom-3" for="file-name">File name</label>
                         <input class="govuk-input" id="file-name" name="fileName"
-                        type="text" value="ph0-documentFileInfo.jpeg">
+                        type="text" value="ph0-documentFileInfo">
                     </div>
                 </div>
                 <button type="submit" class="govuk-button" data-module="govuk-button">Confirm</button>
@@ -273,7 +273,7 @@ exports[`costs application, withdrawal and correspondence GET /costs/:costsCateg
         <div class="govuk-grid-column-two-thirds">
             <form method="post" novalidate="novalidate">
                 <div class="govuk-form-group">
-                    <h2 class="govuk-heading-m">ph0-documentFileInfo.jpeg</h2>
+                    <h2 class="govuk-heading-m">ph0-documentFileInfo</h2>
                     <div class="govuk-form-group">
                         <input class="govuk-input" id="documentId" name="documentId" type="hidden"
                         value="d51f408c-7c6f-4f49-bcc0-abbb5bea3be6">
@@ -281,7 +281,7 @@ exports[`costs application, withdrawal and correspondence GET /costs/:costsCateg
                     <div class="govuk-form-group">
                         <label class="govuk-label govuk-caption-m govuk-!-margin-bottom-3" for="file-name">File name</label>
                         <input class="govuk-input" id="file-name" name="fileName"
-                        type="text" value="ph0-documentFileInfo.jpeg">
+                        type="text" value="ph0-documentFileInfo">
                     </div>
                 </div>
                 <button type="submit" class="govuk-button" data-module="govuk-button">Confirm</button>
@@ -302,7 +302,7 @@ exports[`costs application, withdrawal and correspondence GET /costs/:costsCateg
         <div class="govuk-grid-column-two-thirds">
             <form method="post" novalidate="novalidate">
                 <div class="govuk-form-group">
-                    <h2 class="govuk-heading-m">ph0-documentFileInfo.jpeg</h2>
+                    <h2 class="govuk-heading-m">ph0-documentFileInfo</h2>
                     <div class="govuk-form-group">
                         <input class="govuk-input" id="documentId" name="documentId" type="hidden"
                         value="d51f408c-7c6f-4f49-bcc0-abbb5bea3be6">
@@ -310,7 +310,7 @@ exports[`costs application, withdrawal and correspondence GET /costs/:costsCateg
                     <div class="govuk-form-group">
                         <label class="govuk-label govuk-caption-m govuk-!-margin-bottom-3" for="file-name">File name</label>
                         <input class="govuk-input" id="file-name" name="fileName"
-                        type="text" value="ph0-documentFileInfo.jpeg">
+                        type="text" value="ph0-documentFileInfo">
                     </div>
                 </div>
                 <button type="submit" class="govuk-button" data-module="govuk-button">Confirm</button>
@@ -331,7 +331,7 @@ exports[`costs application, withdrawal and correspondence GET /costs/:costsCateg
         <div class="govuk-grid-column-two-thirds">
             <form method="post" novalidate="novalidate">
                 <div class="govuk-form-group">
-                    <h2 class="govuk-heading-m">ph0-documentFileInfo.jpeg</h2>
+                    <h2 class="govuk-heading-m">ph0-documentFileInfo</h2>
                     <div class="govuk-form-group">
                         <input class="govuk-input" id="documentId" name="documentId" type="hidden"
                         value="d51f408c-7c6f-4f49-bcc0-abbb5bea3be6">
@@ -339,7 +339,7 @@ exports[`costs application, withdrawal and correspondence GET /costs/:costsCateg
                     <div class="govuk-form-group">
                         <label class="govuk-label govuk-caption-m govuk-!-margin-bottom-3" for="file-name">File name</label>
                         <input class="govuk-input" id="file-name" name="fileName"
-                        type="text" value="ph0-documentFileInfo.jpeg">
+                        type="text" value="ph0-documentFileInfo">
                     </div>
                 </div>
                 <button type="submit" class="govuk-button" data-module="govuk-button">Confirm</button>
@@ -360,7 +360,7 @@ exports[`costs application, withdrawal and correspondence GET /costs/:costsCateg
         <div class="govuk-grid-column-two-thirds">
             <form method="post" novalidate="novalidate">
                 <div class="govuk-form-group">
-                    <h2 class="govuk-heading-m">ph0-documentFileInfo.jpeg</h2>
+                    <h2 class="govuk-heading-m">ph0-documentFileInfo</h2>
                     <div class="govuk-form-group">
                         <input class="govuk-input" id="documentId" name="documentId" type="hidden"
                         value="d51f408c-7c6f-4f49-bcc0-abbb5bea3be6">
@@ -368,7 +368,7 @@ exports[`costs application, withdrawal and correspondence GET /costs/:costsCateg
                     <div class="govuk-form-group">
                         <label class="govuk-label govuk-caption-m govuk-!-margin-bottom-3" for="file-name">File name</label>
                         <input class="govuk-input" id="file-name" name="fileName"
-                        type="text" value="ph0-documentFileInfo.jpeg">
+                        type="text" value="ph0-documentFileInfo">
                     </div>
                 </div>
                 <button type="submit" class="govuk-button" data-module="govuk-button">Confirm</button>

--- a/appeals/web/src/server/appeals/appeal-details/costs/__tests__/costs.test.js
+++ b/appeals/web/src/server/appeals/appeal-details/costs/__tests__/costs.test.js
@@ -1549,7 +1549,7 @@ describe('costs', () => {
 
 						expect(unprettifiedElement.innerHTML).toContain('Change document details</span><h1');
 						expect(unprettifiedElement.innerHTML).toContain('File name');
-						expect(unprettifiedElement.innerHTML).toContain('value="ph0-documentFileInfo.jpeg">');
+						expect(unprettifiedElement.innerHTML).toContain('value="ph0-documentFileInfo">');
 					});
 				}
 			}
@@ -1572,7 +1572,7 @@ describe('costs', () => {
 							.post(
 								`${baseUrl}/1/costs/${costsCategory}/${costsDocumentType}/change-document-name/1/1`
 							)
-							.send({ fileName: 'new-name.jpeg', documentId: '1' });
+							.send({ fileName: 'new-name', documentId: '1' });
 
 						expect(response.statusCode).toBe(302);
 						expect(response.text).toContain(

--- a/appeals/web/src/server/appeals/appeal-details/internal-correspondence/__tests__/__snapshots__/internal-correspondence.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/internal-correspondence/__tests__/__snapshots__/internal-correspondence.test.js.snap
@@ -235,7 +235,7 @@ exports[`internal correspondence GET /internal-correspondence/:correspondenceCat
         <div class="govuk-grid-column-two-thirds">
             <form method="post" novalidate="novalidate">
                 <div class="govuk-form-group">
-                    <h2 class="govuk-heading-m">ph0-documentFileInfo.jpeg</h2>
+                    <h2 class="govuk-heading-m">ph0-documentFileInfo</h2>
                     <div class="govuk-form-group">
                         <input class="govuk-input" id="documentId" name="documentId" type="hidden"
                         value="d51f408c-7c6f-4f49-bcc0-abbb5bea3be6">
@@ -243,7 +243,7 @@ exports[`internal correspondence GET /internal-correspondence/:correspondenceCat
                     <div class="govuk-form-group">
                         <label class="govuk-label govuk-caption-m govuk-!-margin-bottom-3" for="file-name">File name</label>
                         <input class="govuk-input" id="file-name" name="fileName"
-                        type="text" value="ph0-documentFileInfo.jpeg">
+                        type="text" value="ph0-documentFileInfo">
                     </div>
                 </div>
                 <button type="submit" class="govuk-button" data-module="govuk-button">Confirm</button>
@@ -264,7 +264,7 @@ exports[`internal correspondence GET /internal-correspondence/:correspondenceCat
         <div class="govuk-grid-column-two-thirds">
             <form method="post" novalidate="novalidate">
                 <div class="govuk-form-group">
-                    <h2 class="govuk-heading-m">ph0-documentFileInfo.jpeg</h2>
+                    <h2 class="govuk-heading-m">ph0-documentFileInfo</h2>
                     <div class="govuk-form-group">
                         <input class="govuk-input" id="documentId" name="documentId" type="hidden"
                         value="d51f408c-7c6f-4f49-bcc0-abbb5bea3be6">
@@ -272,7 +272,7 @@ exports[`internal correspondence GET /internal-correspondence/:correspondenceCat
                     <div class="govuk-form-group">
                         <label class="govuk-label govuk-caption-m govuk-!-margin-bottom-3" for="file-name">File name</label>
                         <input class="govuk-input" id="file-name" name="fileName"
-                        type="text" value="ph0-documentFileInfo.jpeg">
+                        type="text" value="ph0-documentFileInfo">
                     </div>
                 </div>
                 <button type="submit" class="govuk-button" data-module="govuk-button">Confirm</button>

--- a/appeals/web/src/server/appeals/appeal-details/internal-correspondence/__tests__/internal-correspondence.test.js
+++ b/appeals/web/src/server/appeals/appeal-details/internal-correspondence/__tests__/internal-correspondence.test.js
@@ -1982,7 +1982,7 @@ describe('internal correspondence', () => {
 
 				expect(unprettifiedElement.innerHTML).toContain('Change document details</span><h1');
 				expect(unprettifiedElement.innerHTML).toContain('File name');
-				expect(unprettifiedElement.innerHTML).toContain('value="ph0-documentFileInfo.jpeg">');
+				expect(unprettifiedElement.innerHTML).toContain('value="ph0-documentFileInfo">');
 			});
 		}
 	});
@@ -2011,7 +2011,7 @@ describe('internal correspondence', () => {
 					.post(
 						`${baseUrl}/1/internal-correspondence/${correspondenceCategory}/change-document-name/${folder.folderId}/1`
 					)
-					.send({ fileName: 'new-name.jpeg', documentId: '1' });
+					.send({ fileName: 'new-name', documentId: '1' });
 
 				expect(response.statusCode).toBe(302);
 				expect(response.text).toContain(

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/__tests__/__snapshots__/lpa-questionnaire.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/__tests__/__snapshots__/lpa-questionnaire.test.js.snap
@@ -3773,7 +3773,7 @@ exports[`LPA Questionnaire review GET /lpa-questionnaire/2/change-document-name/
         <div class="govuk-grid-column-two-thirds">
             <form method="post" novalidate="novalidate">
                 <div class="govuk-form-group">
-                    <h2 class="govuk-heading-m">ph0-documentFileInfo.jpeg</h2>
+                    <h2 class="govuk-heading-m">ph0-documentFileInfo</h2>
                     <div class="govuk-form-group">
                         <input class="govuk-input" id="documentId" name="documentId" type="hidden"
                         value="d51f408c-7c6f-4f49-bcc0-abbb5bea3be6">
@@ -3781,7 +3781,7 @@ exports[`LPA Questionnaire review GET /lpa-questionnaire/2/change-document-name/
                     <div class="govuk-form-group">
                         <label class="govuk-label govuk-caption-m govuk-!-margin-bottom-3" for="file-name">File name</label>
                         <input class="govuk-input" id="file-name" name="fileName"
-                        type="text" value="ph0-documentFileInfo.jpeg">
+                        type="text" value="ph0-documentFileInfo">
                     </div>
                 </div>
                 <button type="submit" class="govuk-button" data-module="govuk-button">Confirm</button>

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/__tests__/lpa-questionnaire.test.js
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/__tests__/lpa-questionnaire.test.js
@@ -3051,7 +3051,7 @@ describe('LPA Questionnaire review', () => {
 
 			expect(unprettifiedElement.innerHTML).toContain('Change document details</span><h1');
 			expect(unprettifiedElement.innerHTML).toContain('File name');
-			expect(unprettifiedElement.innerHTML).toContain('value="ph0-documentFileInfo.jpeg">');
+			expect(unprettifiedElement.innerHTML).toContain('value="ph0-documentFileInfo">');
 		});
 	});
 
@@ -3066,7 +3066,7 @@ describe('LPA Questionnaire review', () => {
 		it(`should send a patch request to the appeal documents endpoint and redirect to the manage individual document page, if a new valid document name is provided`, async () => {
 			const response = await request
 				.post(`${baseUrl}/change-document-name/1/1`)
-				.send({ fileName: 'new-name.jpeg', documentId: '1' });
+				.send({ fileName: 'new-name', documentId: '1' });
 
 			expect(response.statusCode).toBe(302);
 			expect(response.text).toContain(`Found. Redirecting to ${baseUrl}/manage-documents/1/1`);

--- a/appeals/web/src/server/appeals/appeal-details/representations/final-comments/view-and-review/__tests__/__snapshots__/view-and-review.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/representations/final-comments/view-and-review/__tests__/__snapshots__/view-and-review.test.js.snap
@@ -553,7 +553,7 @@ exports[`final-comments GET change-document-name/:folderId/:documentId should re
         <div class="govuk-grid-column-two-thirds">
             <form method="post" novalidate="novalidate">
                 <div class="govuk-form-group">
-                    <h2 class="govuk-heading-m">ph0-documentFileInfo.jpeg</h2>
+                    <h2 class="govuk-heading-m">ph0-documentFileInfo</h2>
                     <div class="govuk-form-group">
                         <input class="govuk-input" id="documentId" name="documentId" type="hidden"
                         value="d51f408c-7c6f-4f49-bcc0-abbb5bea3be6">
@@ -561,7 +561,7 @@ exports[`final-comments GET change-document-name/:folderId/:documentId should re
                     <div class="govuk-form-group">
                         <label class="govuk-label govuk-caption-m govuk-!-margin-bottom-3" for="file-name">File name</label>
                         <input class="govuk-input" id="file-name" name="fileName"
-                        type="text" value="ph0-documentFileInfo.jpeg">
+                        type="text" value="ph0-documentFileInfo">
                     </div>
                 </div>
                 <button type="submit" class="govuk-button" data-module="govuk-button">Confirm</button>

--- a/appeals/web/src/server/appeals/appeal-details/representations/final-comments/view-and-review/__tests__/view-and-review.test.js
+++ b/appeals/web/src/server/appeals/appeal-details/representations/final-comments/view-and-review/__tests__/view-and-review.test.js
@@ -309,7 +309,7 @@ describe('final-comments', () => {
 
 			expect(unprettifiedElement.innerHTML).toContain('Change document details</span><h1');
 			expect(unprettifiedElement.innerHTML).toContain('File name');
-			expect(unprettifiedElement.innerHTML).toContain('value="ph0-documentFileInfo.jpeg">');
+			expect(unprettifiedElement.innerHTML).toContain('value="ph0-documentFileInfo">');
 		});
 	});
 

--- a/appeals/web/src/server/appeals/appeal-details/representations/interested-party-comments/view-and-review/__tests__/__snapshots__/view-and-review.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/representations/interested-party-comments/view-and-review/__tests__/__snapshots__/view-and-review.test.js.snap
@@ -590,7 +590,7 @@ exports[`interested-party-comments GET change-document-name/:folderId/:documentI
         <div class="govuk-grid-column-two-thirds">
             <form method="post" novalidate="novalidate">
                 <div class="govuk-form-group">
-                    <h2 class="govuk-heading-m">ph0-documentFileInfo.jpeg</h2>
+                    <h2 class="govuk-heading-m">ph0-documentFileInfo</h2>
                     <div class="govuk-form-group">
                         <input class="govuk-input" id="documentId" name="documentId" type="hidden"
                         value="d51f408c-7c6f-4f49-bcc0-abbb5bea3be6">
@@ -598,7 +598,7 @@ exports[`interested-party-comments GET change-document-name/:folderId/:documentI
                     <div class="govuk-form-group">
                         <label class="govuk-label govuk-caption-m govuk-!-margin-bottom-3" for="file-name">File name</label>
                         <input class="govuk-input" id="file-name" name="fileName"
-                        type="text" value="ph0-documentFileInfo.jpeg">
+                        type="text" value="ph0-documentFileInfo">
                     </div>
                 </div>
                 <button type="submit" class="govuk-button" data-module="govuk-button">Confirm</button>

--- a/appeals/web/src/server/appeals/appeal-details/representations/interested-party-comments/view-and-review/__tests__/view-and-review.test.js
+++ b/appeals/web/src/server/appeals/appeal-details/representations/interested-party-comments/view-and-review/__tests__/view-and-review.test.js
@@ -437,7 +437,7 @@ describe('interested-party-comments', () => {
 
 			expect(unprettifiedElement.innerHTML).toContain('Change document details</span><h1');
 			expect(unprettifiedElement.innerHTML).toContain('File name');
-			expect(unprettifiedElement.innerHTML).toContain('value="ph0-documentFileInfo.jpeg">');
+			expect(unprettifiedElement.innerHTML).toContain('value="ph0-documentFileInfo">');
 		});
 	});
 

--- a/appeals/web/src/server/appeals/appeal-details/representations/lpa-statement/__tests__/__snapshots__/lpa-statement.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/representations/lpa-statement/__tests__/__snapshots__/lpa-statement.test.js.snap
@@ -458,7 +458,7 @@ exports[`lpa-statements GET change-document-name/:folderId/:documentId should re
         <div class="govuk-grid-column-two-thirds">
             <form method="post" novalidate="novalidate">
                 <div class="govuk-form-group">
-                    <h2 class="govuk-heading-m">ph0-documentFileInfo.jpeg</h2>
+                    <h2 class="govuk-heading-m">ph0-documentFileInfo</h2>
                     <div class="govuk-form-group">
                         <input class="govuk-input" id="documentId" name="documentId" type="hidden"
                         value="d51f408c-7c6f-4f49-bcc0-abbb5bea3be6">
@@ -466,7 +466,7 @@ exports[`lpa-statements GET change-document-name/:folderId/:documentId should re
                     <div class="govuk-form-group">
                         <label class="govuk-label govuk-caption-m govuk-!-margin-bottom-3" for="file-name">File name</label>
                         <input class="govuk-input" id="file-name" name="fileName"
-                        type="text" value="ph0-documentFileInfo.jpeg">
+                        type="text" value="ph0-documentFileInfo">
                     </div>
                 </div>
                 <button type="submit" class="govuk-button" data-module="govuk-button">Confirm</button>

--- a/appeals/web/src/server/appeals/appeal-details/representations/lpa-statement/__tests__/lpa-statement.test.js
+++ b/appeals/web/src/server/appeals/appeal-details/representations/lpa-statement/__tests__/lpa-statement.test.js
@@ -591,7 +591,7 @@ describe('lpa-statements', () => {
 
 			expect(unprettifiedElement.innerHTML).toContain('Change document details</span><h1');
 			expect(unprettifiedElement.innerHTML).toContain('File name');
-			expect(unprettifiedElement.innerHTML).toContain('value="ph0-documentFileInfo.jpeg">');
+			expect(unprettifiedElement.innerHTML).toContain('value="ph0-documentFileInfo">');
 		});
 	});
 

--- a/appeals/web/src/server/appeals/appeal-documents/__tests__/appeal-documents.test.js
+++ b/appeals/web/src/server/appeals/appeal-documents/__tests__/appeal-documents.test.js
@@ -246,13 +246,13 @@ describe('appeal-documents', () => {
 
 			expect(element).toContain('Change document details');
 			expect(element).toContain(fileInfo.latestDocumentVersion.originalFilename);
-			expect(element).toContain(fileInfo.name);
+			expect(element).toContain(fileInfo.name.substring(0, fileInfo.name.lastIndexOf('.')));
 		});
 
 		it('should redirect to manage documents page after change document name success', async () => {
 			const response = await request
 				.post(fullUrl)
-				.send({ fileName: 'valid-fileName_123.jpg', documentId });
+				.send({ fileName: 'valid-fileName_123', documentId });
 			expect(response.statusCode).toBe(302);
 			expect(response.text).toContain(
 				`Found. Redirecting to ${fullUrl.replace('change-document-name', 'manage-documents')}`
@@ -279,7 +279,7 @@ describe('appeal-documents', () => {
 			}).innerHTML;
 
 			expect(element).toContain(
-				'>File name must only include letters a to z, numbers 0 to 9 and special characters such as hyphens, underscores and one full stop'
+				'>File name must only include letters a to z, numbers 0 to 9 and special characters such as hyphens and underscores'
 			);
 		});
 
@@ -293,13 +293,13 @@ describe('appeal-documents', () => {
 			}).innerHTML;
 
 			expect(element).toContain(
-				'>File name must only include letters a to z, numbers 0 to 9 and special characters such as hyphens, underscores and one full stop'
+				'>File name must only include letters a to z, numbers 0 to 9 and special characters such as hyphens and underscores'
 			);
 		});
 
 		it('should render change filename page with duplicate filename error', async () => {
 			const response = await request.post(fullUrl).send({
-				fileName: documentName,
+				fileName: documentName.substring(0, documentName.lastIndexOf('.')),
 				documentId
 			});
 			expect(response.statusCode).toBe(200);

--- a/appeals/web/src/server/appeals/appeal-documents/appeal-documents.controller.js
+++ b/appeals/web/src/server/appeals/appeal-documents/appeal-documents.controller.js
@@ -706,6 +706,14 @@ export const renderChangeDocumentFileName = async ({ request, response, backButt
 };
 
 /**
+ * @param {string} fileName
+ * @returns {string | undefined}
+ */
+const getFileExtension = (fileName) => {
+	return fileName.split('.').pop();
+};
+
+/**
  * @param {Object} params
  * @param {import('@pins/express/types/express.js').Request} params.request
  * @param {import('@pins/express/types/express.js').RenderedResponse<any, any, Number>} params.response
@@ -736,7 +744,12 @@ export const postChangeDocumentFileName = async ({
 			return response.status(500).render('app/500.njk');
 		}
 
-		const apiRequest = mapDocumentFileNameFormDataToAPIRequest(body);
+		const fileDetails = {
+			...body,
+			fileName: `${body.fileName}.${getFileExtension(currentFile.name)}`
+		};
+
+		const apiRequest = mapDocumentFileNameFormDataToAPIRequest(fileDetails);
 		const updateDocumentsResult = await updateDocument(apiClient, appealId, apiRequest);
 
 		if (updateDocumentsResult) {

--- a/appeals/web/src/server/appeals/appeal-documents/appeal-documents.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-documents/appeal-documents.mapper.js
@@ -295,6 +295,14 @@ function mapManageFolderPageHeading(folderPath) {
 }
 
 /**
+ * @param {string} fileName
+ * @returns {string}
+ */
+function stripFileExtension(fileName) {
+	return fileName.replace(/\.\w+$/, '');
+}
+
+/**
  * @param {Object} params
  * @param {string} params.backLinkUrl
  * @param {FolderInfo} params.folder
@@ -595,7 +603,9 @@ function mapDocumentNameItemToDocumentNamePageComponents(item, fileName) {
 	const pageComponents = [
 		{
 			wrapperHtml: {
-				opening: `<div class="govuk-form-group"><h2 class="govuk-heading-m">${item.originalFilename}</h2>`,
+				opening: `<div class="govuk-form-group"><h2 class="govuk-heading-m">${stripFileExtension(
+					item.originalFilename
+				)}</h2>`,
 				closing: ''
 			},
 			type: 'input',
@@ -618,7 +628,7 @@ function mapDocumentNameItemToDocumentNamePageComponents(item, fileName) {
 					text: 'File name',
 					classes: 'govuk-caption-m govuk-!-margin-bottom-3'
 				},
-				value: fileName
+				value: stripFileExtension(fileName)
 			}
 		}
 	];

--- a/appeals/web/src/server/appeals/appeal-documents/appeal-documents.types.d.ts
+++ b/appeals/web/src/server/appeals/appeal-documents/appeal-documents.types.d.ts
@@ -47,6 +47,7 @@ export interface FileUploadInfo {
 }
 
 export interface FileUploadError {
+	metadata?: Record<string, string>;
 	message: string;
 	guid: string;
 	name: string;
@@ -92,6 +93,7 @@ export interface StagedFileError {
 	name: string;
 	message: string;
 	guid: string;
+	metadata?: Record<string, string>;
 }
 
 export interface FileUploadParameters {

--- a/appeals/web/src/server/appeals/appeal-documents/appeal-documents.validators.js
+++ b/appeals/web/src/server/appeals/appeal-documents/appeal-documents.validators.js
@@ -19,16 +19,17 @@ export const validateDocumentName = createValidator(
 		.notEmpty()
 		.withMessage('File name must be entered')
 		.bail()
-		// Filename must only contain alphanumeric characters, underscores, hyphens and one period followed by a suffix
-		.matches('^[a-zA-Z0-9_-]+\\.[a-zA-Z0-9_-]+$')
+		// Filename must only contain alphanumeric characters, underscores and hyphens
+		.matches('^[a-zA-Z0-9_-]+$')
 		.withMessage(
-			'File name must only include letters a to z, numbers 0 to 9 and special characters such as hyphens, underscores and one full stop'
+			'File name must only include letters a to z, numbers 0 to 9 and special characters such as hyphens and underscores'
 		)
 		.bail()
 		.custom((value, { req }) => {
 			const hasDuplicate = req.currentFolder.documents.some(
 				(/** @type {import('@pins/appeals.api').Appeals.DocumentInfo} */ document) =>
-					document.name.toLowerCase() === value.toLowerCase() && document.id !== req.body.documentId
+					document.name.toLowerCase().substring(0, document.name.lastIndexOf('.')) ===
+						value.toLowerCase() && document.id !== req.body.documentId
 			);
 			if (hasDuplicate) {
 				return Promise.reject(


### PR DESCRIPTION
## Describe your changes

- The file extension is now hidden when changing the filename of a document
- New versions of a document must have the same file extension as the original document

## Issue ticket number and link
[A2-2926](https://pins-ds.atlassian.net.mcas.ms/browse/A2-2926?McasTsid=20596&McasCtx=4)


[A2-2926]: https://pins-ds.atlassian.net/browse/A2-2926?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ