### PR TITLE
fix(api): throws an error if trying to validate a LPAQ in the incorrect state

### DIFF
--- a/appeals/api/src/server/endpoints/lpa-questionnaires/__tests__/lpa-questionnaires.test.js
+++ b/appeals/api/src/server/endpoints/lpa-questionnaires/__tests__/lpa-questionnaires.test.js
@@ -1679,14 +1679,6 @@ describe('lpa questionnaires routes', () => {
 					.send(body)
 					.set('azureAdUserId', azureAdUserId);
 
-				expect(databaseConnector.lPAQuestionnaire.update).toHaveBeenCalledWith({
-					data: {
-						lpaQuestionnaireValidationOutcomeId: lpaQuestionnaireValidationOutcomes[0].id
-					},
-					where: {
-						id: householdAppeal.lpaQuestionnaire.id
-					}
-				});
 				expect(response.status).toEqual(500);
 				expect(response.body).toEqual({
 					errors: {

--- a/appeals/api/src/server/endpoints/lpa-questionnaires/lpa-questionnaires.service.js
+++ b/appeals/api/src/server/endpoints/lpa-questionnaires/lpa-questionnaires.service.js
@@ -17,6 +17,8 @@ import { broadcasters } from '#endpoints/integrations/integrations.broadcasters.
 import { EventType } from '@pins/event-client';
 import { notifySend } from '#notify/notify-send.js';
 import { APPEAL_TYPE } from '@pins/appeals/constants/common.js';
+import { APPEAL_CASE_STATUS } from 'pins-data-model';
+import logger from '#utils/logger.js';
 
 /** @typedef {import('express').RequestHandler} RequestHandler */
 /** @typedef {import('@pins/appeals.api').Appeals.UpdateLPAQuestionnaireValidationOutcomeParams} UpdateLPAQuestionnaireValidationOutcomeParams */
@@ -52,8 +54,13 @@ const updateLPAQuestionnaireValidationOutcome = async (
 ) => {
 	let timetable = undefined;
 
-	const { id: appealId, applicationReference: lpaReference } = appeal;
+	const { id: appealId, applicationReference: lpaReference, appealStatus } = appeal;
 	const { lpaQuestionnaireDueDate, incompleteReasons } = data;
+
+	if (appealStatus[0].status != APPEAL_CASE_STATUS.LPA_QUESTIONNAIRE) {
+		logger.error('LPAQ already validated');
+		throw new Error('LPAQ already validated');
+	}
 
 	if (lpaQuestionnaireDueDate) {
 		timetable = {

--- a/appeals/api/src/server/tests/appeals/mocks.js
+++ b/appeals/api/src/server/tests/appeals/mocks.js
@@ -290,6 +290,12 @@ export const householdAppealLPAQuestionnaireComplete = {
 
 export const householdAppealLPAQuestionnaireIncomplete = {
 	...householdAppeal,
+	appealStatus: [
+		{
+			status: APPEAL_CASE_STATUS.LPA_QUESTIONNAIRE,
+			valid: true
+		}
+	],
 	lpaQuestionnaire: {
 		...householdAppeal.lpaQuestionnaire,
 		...incompleteLPAQuestionnaireOutcome


### PR DESCRIPTION
## Describe your changes
Adds a check for appeal status when validating a LPAQ. If incorrect status, throw an error and log it.

## Issue ticket number and link
[Ticket](https://pins-ds.atlassian.net/browse/A2-3091)
