### PR TITLE
fix(appeals): page not found when removing a document from accepted ip comment (a2-2302)

### DIFF
--- a/appeals/web/src/server/appeals/appeal-details/representations/interested-party-comments/interested-party-comments.router.js
+++ b/appeals/web/src/server/appeals/appeal-details/representations/interested-party-comments/interested-party-comments.router.js
@@ -19,6 +19,11 @@ router.use('/:commentId/edit', validateAppeal, validateComment, editIpCommentRou
 
 router.use('/:commentId', validateAppeal, validateComment, viewAndReviewIpCommentRouter);
 
+// Redirect as shared manage documents routes return to the wrong page after a successful delete
+router.get('/:commentId', (request, response) => {
+	response.redirect(`${request.baseUrl}/${request.params.commentId}/view`);
+});
+
 router
 	.route('/')
 	.get(

--- a/appeals/web/src/server/appeals/appeal-details/representations/interested-party-comments/view-and-review/view-and-review.controller.js
+++ b/appeals/web/src/server/appeals/appeal-details/representations/interested-party-comments/view-and-review/view-and-review.controller.js
@@ -5,10 +5,6 @@ import {
 	viewInterestedPartyCommentPage
 } from './view-and-review.mapper.js';
 import { patchInterestedPartyCommentStatus } from './view-and-review.service.js';
-import {
-	postDeleteDocument,
-	renderDeleteDocument
-} from '#appeals/appeal-documents/appeal-documents.controller.js';
 import { render } from '#appeals/appeal-details/representations/common/render.js';
 
 /** @typedef {import("../../../appeal-details.types.js").WebAppeal} Appeal */
@@ -70,31 +66,4 @@ export const postReviewInterestedPartyComment = async (request, response, next) 
 	});
 
 	return response.redirect(`/appeals-service/appeal-details/${appealId}/interested-party-comments`);
-};
-
-/** @type {import('@pins/express').RequestHandler<Response>} */
-export const getDeleteDocument = async (request, response) => {
-	const {
-		params: { commentId }
-	} = request;
-
-	await renderDeleteDocument({
-		request,
-		response,
-		backButtonUrl: `/appeals-service/appeal-details/${request.params.appealId}/interested-party-comments/${commentId}/manage-documents/{{folderId}}/{{documentId}}`
-	});
-};
-/** @type {import('@pins/express').RequestHandler<Response>} */
-export const postDeleteDocumentPage = async (request, response) => {
-	const {
-		params: { commentId }
-	} = request;
-
-	await postDeleteDocument({
-		request,
-		response,
-		returnUrl: `/appeals-service/appeal-details/${request.params.appealId}/interested-party-comments`,
-		cancelUrl: `/appeals-service/appeal-details/${request.params.appealId}/interested-party-comments/${commentId}/manage-documents/{{folderId}}/{{documentId}}`,
-		uploadNewDocumentUrl: `/appeals-service/appeal-details/${request.params.appealId}/interested-party-comments/add-documents/{{folderId}}`
-	});
 };

--- a/appeals/web/src/server/appeals/appeal-details/representations/interested-party-comments/view-and-review/view-and-review.router.js
+++ b/appeals/web/src/server/appeals/appeal-details/representations/interested-party-comments/view-and-review/view-and-review.router.js
@@ -2,17 +2,10 @@ import { Router as createRouter } from 'express';
 import { asyncHandler } from '@pins/express';
 import * as controller from './view-and-review.controller.js';
 import rejectRouter from './reject/reject.router.js';
-import * as documentsValidators from '../../../../appeal-documents/appeal-documents.validators.js';
 import {
 	redirectIfCommentIsReviewed,
 	redirectIfCommentIsUnreviewed
 } from './view-and-review.middleware.js';
-import { assertUserHasPermission } from '#app/auth/auth.guards.js';
-import { permissionNames } from '#environment/permissions.js';
-import {
-	validateCaseDocumentId,
-	validateCaseFolderId
-} from '#appeals/appeal-documents/appeal-documents.middleware.js';
 import { validateAppeal } from '#appeals/appeal-details/appeal-details.middleware.js';
 import { validateStatus } from '#appeals/appeal-details/representations/common/validators.js';
 import manageDocumentsRouter from '#appeals/appeal-details/representations/document-attachments/manage-documents.router.js';
@@ -39,23 +32,5 @@ router
 	.post(validateStatus, asyncHandler(controller.postReviewInterestedPartyComment));
 
 router.use('/manage-documents', manageDocumentsRouter);
-
-router
-	.route('/manage-documents/:folderId/:documentId/:versionId/delete')
-	.get(
-		validateAppeal,
-		assertUserHasPermission(permissionNames.updateCase),
-		validateCaseFolderId,
-		validateCaseDocumentId,
-		asyncHandler(controller.getDeleteDocument)
-	)
-	.post(
-		validateAppeal,
-		assertUserHasPermission(permissionNames.updateCase),
-		validateCaseFolderId,
-		validateCaseDocumentId,
-		documentsValidators.validateDocumentDeleteAnswer,
-		asyncHandler(controller.postDeleteDocumentPage)
-	);
 
 export default router;


### PR DESCRIPTION
## Describe your changes
#### Page not found when removing document from Accepted IP comment (A2-2302)

#### Web:
- Removed unnecessary routes and controller functions as deletion is done with the shared manage document routes
- Added a redirect route so that the return from a successful deletion in the shared code returns to the correct page 

#### TEST:
- All unit tests pass
- Tested within browser

## Issue ticket number and link
[Ticket:  S78w - Web - Page not found when removing document from Accepted IP comment (A2-2302)](https://pins-ds.atlassian.net.mcas.ms/browse/A2-2302)
