### PR TITLE
fix(appeals): document removed banner should be on view ip comment page (a2-3057)

### DIFF
--- a/appeals/web/src/server/lib/mappers/components/page-components/notification-banners.mapper.js
+++ b/appeals/web/src/server/lib/mappers/components/page-components/notification-banners.mapper.js
@@ -100,7 +100,7 @@ export const notificationBannerDefinitions = {
 			'lpaQuestionnaire',
 			'lpaStatement',
 			'viewFinalComments',
-			'ipComments'
+			'viewIpComment'
 		],
 		text: 'Document removed'
 	},


### PR DESCRIPTION
## Describe your changes

Further to the previous [PR](<https://github.com.mcas.ms/Planning-Inspectorate/appeals-back-office/pull/1238>), this PR makes sure the Document removed banner displays on the correct page

## Issue ticket number and link
[Ticket](<[!--Paste your ticket link here--](https://pins-ds.atlassian.net/browse/A2-3057)>)
