### PR TITLE
fix(appeals): ip comment rejected extended deadline in notify (a2-2767)

### DIFF
--- a/appeals/api/src/server/endpoints/representations/notify/services/index.js
+++ b/appeals/api/src/server/endpoints/representations/notify/services/index.js
@@ -31,7 +31,8 @@ export const ipCommentRejection = async ({
 }) => {
 	const siteAddress = formatSiteAddress(appeal);
 	const reasons = formatReasons(representation);
-	const extendedDeadline = await formatExtendedDeadline(allowResubmit);
+	const { ipCommentsDueDate = null } = appeal.appealTimetable || {};
+	const extendedDeadline = await formatExtendedDeadline(allowResubmit, ipCommentsDueDate);
 	const recipientEmail = representation.represented?.email;
 	if (recipientEmail) {
 		const templateName = extendedDeadline
@@ -113,7 +114,8 @@ export const lpaStatementIncomplete = async ({
 }) => {
 	const siteAddress = formatSiteAddress(appeal);
 	const reasons = formatReasons(representation);
-	const extendedDeadline = await formatExtendedDeadline(allowResubmit);
+	const { lpaStatementDueDate = null } = appeal.appealTimetable || {};
+	const extendedDeadline = await formatExtendedDeadline(allowResubmit, lpaStatementDueDate);
 
 	const recipientEmail = appeal.lpa?.email;
 	if (!recipientEmail) {

--- a/appeals/api/src/server/endpoints/representations/notify/services/utils.js
+++ b/appeals/api/src/server/endpoints/representations/notify/services/utils.js
@@ -27,15 +27,20 @@ export const formatReasons = (representation) => {
 
 /**
  * @param {boolean} allowResubmit
+ * @param {Date | null} dueDate
  * @returns {Promise<string>}
  */
-export const formatExtendedDeadline = async (allowResubmit) => {
-	if (!allowResubmit) {
-		return '';
+export const formatExtendedDeadline = async (allowResubmit, dueDate) => {
+	if (!allowResubmit) return '';
+
+	const extendedDate = await addDays(new Date().toISOString(), 7);
+
+	if (!dueDate) {
+		return formatDate(extendedDate, false);
 	}
 
-	const date = await addDays(new Date().toISOString(), 7);
-	return formatDate(date, false);
+	const finalDate = extendedDate.getTime() > dueDate.getTime() ? extendedDate : dueDate;
+	return formatDate(finalDate, false);
 };
 
 /**


### PR DESCRIPTION
## Describe your changes
#### Fixed IP comment rejected extended deadline in notify email (a2-2767)
The new logic for the date given to the IP for submission of another comment is either todays date +7 days or the existing date from the timetable, whichever is later.

### API:
- Updated calculation of extended deadline as described above and within the comments of the ticket.
- Added a test to test the email containing the extended deadline date

### TEST:
- All unit tests pass
- Tested within browser
- Tested emails with emulator

## Issue ticket number and link
[Comment rejected (interested parties) (A2-2767)](https://pins-ds.atlassian.net/browse/A2-2767)
