### PR TITLE
Feat/listed buildings dataset

### DIFF
--- a/appeals/api/package.json
+++ b/appeals/api/package.json
@@ -87,6 +87,8 @@
     "nodemon": "^2.0.18",
     "prisma": "6.5.0",
     "rimraf": "^6.0.1",
+    "stream-chain": "^3.4.0",
+    "stream-json": "^1.9.1",
     "supertest": "7.0.0",
     "swagger-autogen": "^2.21.4",
     "swagger-typescript-api": "^13.0.5"

--- a/appeals/api/src/database/migrations/20250414131935_listed_buildings_migration/migration.sql
+++ b/appeals/api/src/database/migrations/20250414131935_listed_buildings_migration/migration.sql
@@ -1,0 +1,49 @@
+/*
+  Warnings:
+
+  - Made the column `listEntry` on table `ListedBuildingSelected` required. This step will fail if there are existing NULL values in that column.
+
+*/
+BEGIN TRY
+
+BEGIN TRAN;
+
+
+-- CreateTable
+CREATE TABLE [dbo].[ListedBuilding] (
+    [reference] NVARCHAR(1000) NOT NULL,
+    [name] NVARCHAR(1000) NOT NULL,
+    [grade] NVARCHAR(1000) NOT NULL,
+    CONSTRAINT [ListedBuilding_pkey] PRIMARY KEY CLUSTERED ([reference])
+);
+
+-- CreateTable
+CREATE TABLE [dbo].[MigrateListedBuildingSelected] (
+    [lpaQuestionnaireId] INT NOT NULL,
+    [listEntry] NVARCHAR(1000) NOT NULL,
+    [affectsListedBuilding] BIT NOT NULL,
+    CONSTRAINT [MigrateListedBuildingSelected_pkey] PRIMARY KEY CLUSTERED ([lpaQuestionnaireId],[listEntry])
+);
+
+-- Fill migration data with existing records
+INSERT INTO [dbo].[MigrateListedBuildingSelected] SELECT lpaQuestionnaireId, listEntry, affectsListedBuilding FROM [dbo].[ListedBuildingSelected];
+DELETE FROM [dbo].[ListedBuildingSelected];
+
+-- AlterTable
+ALTER TABLE [dbo].[ListedBuildingSelected] ALTER COLUMN [listEntry] NVARCHAR(1000) NOT NULL;
+
+-- AddForeignKey
+ALTER TABLE [dbo].[ListedBuildingSelected] ADD CONSTRAINT [ListedBuildingSelected_listEntry_fkey] FOREIGN KEY ([listEntry]) REFERENCES [dbo].[ListedBuilding]([reference]) ON DELETE NO ACTION ON UPDATE NO ACTION;
+
+COMMIT TRAN;
+
+END TRY
+BEGIN CATCH
+
+IF @@TRANCOUNT > 0
+BEGIN
+    ROLLBACK TRAN;
+END;
+THROW
+
+END CATCH

--- a/appeals/api/src/database/schema.d.ts
+++ b/appeals/api/src/database/schema.d.ts
@@ -100,7 +100,10 @@ export interface LPAQuestionnaireIncompleteReasonsSelected
 }
 export interface LPAQuestionnaireIncompleteReasonText
 	extends schema.LPAQuestionnaireIncompleteReasonText {}
-export interface ListedBuildingSelected extends schema.ListedBuildingSelected {}
+export interface ListedBuilding extends schema.ListedBuilding {}
+export interface ListedBuildingSelected extends schema.ListedBuildingSelected {
+	listedBuilding: ListedBuilding;
+}
 export interface LPANotificationMethods extends schema.LPANotificationMethods {}
 export interface LPANotificationMethodsSelected extends schema.LPANotificationMethodsSelected {
 	lpaNotificationMethod: LPANotificationMethods;

--- a/appeals/api/src/database/schema.prisma
+++ b/appeals/api/src/database/schema.prisma
@@ -494,7 +494,8 @@ model LPAQuestionnaireIncompleteReasonText {
 model ListedBuildingSelected {
   id                    Int               @id @default(autoincrement())
   lpaQuestionnaireId    Int?
-  listEntry             String?
+  listEntry             String
+  listedBuilding        ListedBuilding    @relation(fields: [listEntry], references: [reference], onUpdate: NoAction, onDelete: NoAction)
   affectsListedBuilding Boolean           @default(true)
   lpaQuestionnaire      LPAQuestionnaire? @relation(fields: [lpaQuestionnaireId], references: [id])
 }
@@ -795,4 +796,22 @@ model CaseNote {
   archived  Boolean  @default(false)
 
   @@index([caseId])
+}
+
+/// ListedBuilding model
+/// Stores the listed buildings dataset
+model ListedBuilding {
+  reference String                   @id
+  name      String
+  grade     String
+  selected  ListedBuildingSelected[]
+}
+
+/// Temporary migration storage for ListedBuildingSelected
+model MigrateListedBuildingSelected {
+  lpaQuestionnaireId    Int
+  listEntry             String
+  affectsListedBuilding Boolean
+
+  @@id([lpaQuestionnaireId, listEntry])
 }

--- a/appeals/api/src/database/seed/data-static.js
+++ b/appeals/api/src/database/seed/data-static.js
@@ -7,6 +7,7 @@ import {
 } from 'pins-data-model';
 import { APPEAL_TYPE } from '@pins/appeals/constants/common.js';
 import { FOLDERS } from '@pins/appeals/constants/documents.js';
+import { importListedBuildingsDataset } from './seed-listed-buildings.js';
 /**
  * Static data required by the back-office service
  */
@@ -445,8 +446,11 @@ export const representationRejectionReasons = [
  * @param {import('../../server/utils/db-client/index.js').PrismaClient} databaseConnector
  */
 export async function seedStaticData(databaseConnector) {
-	const systemUserId = '00000000-0000-0000-0000-000000000000';
+	await importListedBuildingsDataset(
+		'https://files.planning.data.gov.uk/dataset/listed-building.json'
+	);
 
+	const systemUserId = '00000000-0000-0000-0000-000000000000';
 	await databaseConnector.user.upsert({
 		where: {
 			azureAdUserId: systemUserId

--- a/appeals/api/src/database/seed/data-test.js
+++ b/appeals/api/src/database/seed/data-test.js
@@ -752,7 +752,7 @@ export async function seedTestData(databaseConnector) {
 
 	for (const lpaQuestionnaire of lpaQuestionnaires) {
 		await databaseConnector.listedBuildingSelected.createMany({
-			data: ['1264111', '1356956', '1202152', '1356318'].map((listEntry, index) => ({
+			data: ['1021469', '1021470', '1021472', '1021473'].map((listEntry, index) => ({
 				lpaQuestionnaireId: lpaQuestionnaire.id,
 				listEntry,
 				affectsListedBuilding: index > 1

--- a/appeals/api/src/database/seed/seed-listed-buildings.js
+++ b/appeals/api/src/database/seed/seed-listed-buildings.js
@@ -1,0 +1,82 @@
+import { Readable } from 'node:stream';
+import { databaseConnector } from '../../server/utils/database-connector.js';
+
+// json streaming
+import { chain } from 'stream-chain';
+import Parser from 'stream-json';
+import Pick from 'stream-json/filters/Pick.js';
+import Ignore from 'stream-json/filters/Ignore.js';
+import StreamArray from 'stream-json/streamers/StreamArray.js';
+
+/**
+ *
+ * @param {string} url
+ */
+export const importListedBuildingsDataset = async (url) => {
+	const existingListdBuildingsCount = await databaseConnector.listedBuilding.count();
+
+	if (existingListdBuildingsCount > 0) {
+		console.log('ListedBuilding table not empty. Please delete all records to refresh.');
+	} else {
+		console.log('Starting download of listed buildings dataset...\n\n');
+		fetch(url).then(async (response) => {
+			if (response.body) {
+				const totalRecords = await importListedBuildings(Readable.from(response.body));
+				console.log(`\n\nComplete! ${totalRecords} records imported.`);
+
+				// Migration code - could be removed in the future, together with the MigrateListedBuildingSelected table
+				const migrateSQL = `INSERT INTO [dbo].[ListedBuildingSelected]
+						SELECT * FROM [dbo].[MigrateListedBuildingSelected]
+						WHERE [listEntry] IN (SELECT [reference] FROM [dbo].[ListedBuilding])
+						AND [lpaQuestionnaireId] IN (SELECT [id] FROM [dbo].[LpaQuestionnaire]);
+
+						DELETE FROM [dbo].[MigrateListedBuildingSelected];`;
+
+				await databaseConnector.$executeRawUnsafe(migrateSQL);
+			}
+		});
+	}
+};
+
+/**
+ *
+ * @param {Readable} fileStream
+ * @returns
+ */
+const importListedBuildings = async (fileStream) => {
+	const pipeline = chain([
+		fileStream,
+		Parser(),
+		new Pick({ filter: 'entities' }),
+		new Ignore({
+			filter:
+				/dataset|geometry|entry-date|end-date|entity|organisation-entity|point|prefix|typology|documentation-url|start-date/i
+		}),
+		new StreamArray()
+	]);
+
+	const batchSize = 50;
+	let batch = [];
+	let totalRecords = 0;
+
+	for await (const { value } of pipeline) {
+		const record = {
+			reference: value.reference,
+			name: value.name,
+			grade: value['listed-building-grade']
+		};
+
+		batch.push(record);
+
+		if (batch.length === batchSize) {
+			await databaseConnector.listedBuilding.createMany({
+				data: batch
+			});
+
+			totalRecords += batch.length;
+			batch = [];
+		}
+	}
+
+	return totalRecords;
+};

--- a/appeals/api/src/server/endpoints/listed-buildings/listed-buildings.controller.js
+++ b/appeals/api/src/server/endpoints/listed-buildings/listed-buildings.controller.js
@@ -10,6 +10,22 @@ import {
 } from '@pins/appeals/constants/support.js';
 import { broadcasters } from '#endpoints/integrations/integrations.broadcasters.js';
 import * as listedBuildingRepository from '#repositories/listed-buildings.repository.js';
+
+/**
+ * @param {Request} req
+ * @param {Response} res
+ * @returns {Promise<Response>}
+ */
+export const findListedBuilding = async (req, res) => {
+	const { reference } = req.params;
+
+	const result = await listedBuildingRepository.getListedBuilding(reference);
+	if (!result) {
+		return res.status(404).send();
+	}
+	return res.status(201).send(result);
+};
+
 /**
  * @param {Request} req
  * @param {Response} res

--- a/appeals/api/src/server/endpoints/listed-buildings/listed-buildings.routes.js
+++ b/appeals/api/src/server/endpoints/listed-buildings/listed-buildings.routes.js
@@ -3,6 +3,7 @@ import { asyncHandler } from '@pins/express';
 import { checkAppealExistsByIdAndAddToRequest } from '#middleware/check-appeal-exists-and-add-to-request.js';
 import {
 	addListedBuilding,
+	findListedBuilding,
 	removeListedBuilding,
 	updateListedBuilding
 } from './listed-buildings.controller.js';
@@ -12,6 +13,29 @@ import {
 	removeListedBuildingValidator
 } from './listed-buildings.validators.js';
 const router = createRouter();
+
+router.get(
+	'/:appealId/listed-buildings/:reference',
+	/*
+		#swagger.tags = ['Listed buildings']
+		#swagger.path = '/appeals/{appealId}/listed-buildings/{reference}'
+		#swagger.description = Retrieves the listed building info, given the reference
+		#swagger.parameters['azureAdUserId'] = {
+			in: 'header',
+			required: true,
+			example: '434bff4e-8191-4ce0-9a0a-91e5d6cdd882'
+		}
+		#swagger.responses[400] = {}
+		#swagger.responses[201] = {
+			description: 'Returns the listedBuilding data',
+			schema: { $ref: '#/components/schemas/ListedBuilding' }
+		}
+		#swagger.responses[400] = {}
+		#swagger.responses[404] = {}
+	 */
+	checkAppealExistsByIdAndAddToRequest,
+	asyncHandler(findListedBuilding)
+);
 
 router.post(
 	'/:appealId/listed-buildings',

--- a/appeals/api/src/server/openapi.json
+++ b/appeals/api/src/server/openapi.json
@@ -4330,6 +4330,62 @@
 				}
 			}
 		},
+		"/appeals/{appealId}/listed-buildings/{reference}": {
+			"get": {
+				"tags": ["Listed buildings"],
+				"description": "Retrieves the listed building info, given the reference",
+				"parameters": [
+					{
+						"name": "appealId",
+						"in": "path",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"name": "reference",
+						"in": "path",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"name": "azureAdUserId",
+						"in": "header",
+						"required": true,
+						"example": "434bff4e-8191-4ce0-9a0a-91e5d6cdd882",
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"responses": {
+					"201": {
+						"description": "Returns the listedBuilding data",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ListedBuilding"
+								}
+							},
+							"application/xml": {
+								"schema": {
+									"$ref": "#/components/schemas/ListedBuilding"
+								}
+							}
+						}
+					},
+					"400": {
+						"description": "Bad Request"
+					},
+					"404": {
+						"description": "Not Found"
+					}
+				}
+			}
+		},
 		"/appeals/{appealId}/listed-buildings": {
 			"post": {
 				"tags": ["Listed buildings"],

--- a/appeals/api/src/server/repositories/appeal.repository.js
+++ b/appeals/api/src/server/repositories/appeal.repository.js
@@ -80,7 +80,11 @@ const appealDetailsInclude = {
 	inspectorDecision: true,
 	lpaQuestionnaire: {
 		include: {
-			listedBuildingDetails: true,
+			listedBuildingDetails: {
+				include: {
+					listedBuilding: true
+				}
+			},
 			designatedSiteNames: {
 				include: {
 					designatedSite: true

--- a/appeals/api/src/server/repositories/listed-buildings.repository.js
+++ b/appeals/api/src/server/repositories/listed-buildings.repository.js
@@ -1,19 +1,33 @@
 import { databaseConnector } from '#utils/database-connector.js';
 
-/** @typedef {import('@pins/appeals.api').Schema.ListedBuildingSelected} ListedBuilding */
+/** @typedef {import('@pins/appeals.api').Schema.ListedBuildingSelected} ListedBuildingSelected */
+/** @typedef {import('@pins/appeals.api').Schema.ListedBuilding} ListedBuilding */
 /**
  * @typedef {import('#db-client').Prisma.PrismaPromise<T>} PrismaPromise
  * @template T
  */
 
 /**
+ * Gets a listed building by reference
+ * @param {string} reference
+ * @returns {Promise<ListedBuilding>}
+ */
+export const getListedBuilding = async (reference) => {
+	// @ts-ignore
+	return databaseConnector.listedBuilding.findFirst({
+		where: { reference }
+	});
+};
+
+/**
  * Adds a listed building with a list entry
  * @param {number} lpaQuestionnaireId
  * @param {string} listEntry
  * @param {boolean} affectsListedBuilding
- * @returns {Promise<ListedBuilding>}
+ * @returns {Promise<ListedBuildingSelected>}
  */
 export const addListedBuilding = async (lpaQuestionnaireId, listEntry, affectsListedBuilding) => {
+	// @ts-ignore
 	return databaseConnector.listedBuildingSelected.create({
 		data: {
 			lpaQuestionnaireId: Number(lpaQuestionnaireId),

--- a/appeals/api/src/server/utils/format-listed-building.js
+++ b/appeals/api/src/server/utils/format-listed-building.js
@@ -8,9 +8,11 @@
 export const formatListedBuildingDetails = (values) =>
 	// @ts-ignore
 	(values &&
-		values.map(({ listEntry, id, affectsListedBuilding }) => ({
+		values.map(({ listEntry, id, affectsListedBuilding, listedBuilding }) => ({
 			id,
 			listEntry,
-			affectsListedBuilding
+			affectsListedBuilding,
+			name: listedBuilding?.name,
+			grade: listedBuilding?.grade
 		}))) ||
 	null;

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
 				"@commitlint/cli": "17.0.1",
 				"@commitlint/config-conventional": "17.0.0",
 				"@types/prettier": "^2.7.3",
+				"@types/stream-json": "^1.7.8",
 				"commitizen": "^4.2.4",
 				"cz-conventional-changelog": "^3.3.0",
 				"dotenv-cli": "^8.0.0",
@@ -98,6 +99,8 @@
 				"nodemon": "^2.0.18",
 				"prisma": "6.5.0",
 				"rimraf": "^6.0.1",
+				"stream-chain": "^3.4.0",
+				"stream-json": "^1.9.1",
 				"supertest": "7.0.0",
 				"swagger-autogen": "^2.21.4",
 				"swagger-typescript-api": "^13.0.5"
@@ -7859,6 +7862,27 @@
 			"version": "2.0.1",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/@types/stream-chain": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/@types/stream-chain/-/stream-chain-2.1.0.tgz",
+			"integrity": "sha512-guDyAl6s/CAzXUOWpGK2bHvdiopLIwpGu8v10+lb9hnQOyo4oj/ZUQFOvqFjKGsE3wJP1fpIesCcMvbXuWsqOg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/node": "*"
+			}
+		},
+		"node_modules/@types/stream-json": {
+			"version": "1.7.8",
+			"resolved": "https://registry.npmjs.org/@types/stream-json/-/stream-json-1.7.8.tgz",
+			"integrity": "sha512-MU1OB1eFLcYWd1LjwKXrxdoPtXSRzRmAnnxs4Js/ayB5O/NvHraWwuOaqMWIebpYwM6khFlsJOHEhI9xK/ab4Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/node": "*",
+				"@types/stream-chain": "*"
+			}
 		},
 		"node_modules/@types/superagent": {
 			"version": "4.1.15",
@@ -23327,6 +23351,33 @@
 				"npm": ">=6"
 			}
 		},
+		"node_modules/stream-chain": {
+			"version": "3.4.0",
+			"resolved": "https://registry.npmjs.org/stream-chain/-/stream-chain-3.4.0.tgz",
+			"integrity": "sha512-cyDiaDqAfgmeiv0PWFXCg9oKNVYNzYxHK9j5CMsYMHZDk+/yYcSV+CXQZliZ0U4mNU8DLqiVNZXUfs8BqhgwMw==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"funding": {
+				"url": "https://github.com/sponsors/uhop"
+			}
+		},
+		"node_modules/stream-json": {
+			"version": "1.9.1",
+			"resolved": "https://registry.npmjs.org/stream-json/-/stream-json-1.9.1.tgz",
+			"integrity": "sha512-uWkjJ+2Nt/LO9Z/JyKZbMusL8Dkh97uUBTv3AJQ74y07lVahLY4eEFsPsE97pxYBwr8nnjMAIch5eqI0gPShyw==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"stream-chain": "^2.2.5"
+			}
+		},
+		"node_modules/stream-json/node_modules/stream-chain": {
+			"version": "2.2.5",
+			"resolved": "https://registry.npmjs.org/stream-chain/-/stream-chain-2.2.5.tgz",
+			"integrity": "sha512-1TJmBx6aSWqZ4tx7aTpBDXK0/e2hhcNSTV8+CbFJtDjbb+I1mZ8lHit0Grw9GRT+6JbIrrDd8esncgBi8aBXGA==",
+			"dev": true,
+			"license": "BSD-3-Clause"
+		},
 		"node_modules/stream-shift": {
 			"version": "1.0.1",
 			"license": "MIT"
@@ -30432,6 +30483,8 @@
 				"prisma": "6.5.0",
 				"rhea": "3.0.1",
 				"rimraf": "^6.0.1",
+				"stream-chain": "^3.4.0",
+				"stream-json": "^1.9.1",
 				"supertest": "7.0.0",
 				"swagger-autogen": "^2.21.4",
 				"swagger-typescript-api": "^13.0.5",
@@ -32584,6 +32637,25 @@
 		"@types/stack-utils": {
 			"version": "2.0.1",
 			"dev": true
+		},
+		"@types/stream-chain": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/@types/stream-chain/-/stream-chain-2.1.0.tgz",
+			"integrity": "sha512-guDyAl6s/CAzXUOWpGK2bHvdiopLIwpGu8v10+lb9hnQOyo4oj/ZUQFOvqFjKGsE3wJP1fpIesCcMvbXuWsqOg==",
+			"dev": true,
+			"requires": {
+				"@types/node": "*"
+			}
+		},
+		"@types/stream-json": {
+			"version": "1.7.8",
+			"resolved": "https://registry.npmjs.org/@types/stream-json/-/stream-json-1.7.8.tgz",
+			"integrity": "sha512-MU1OB1eFLcYWd1LjwKXrxdoPtXSRzRmAnnxs4Js/ayB5O/NvHraWwuOaqMWIebpYwM6khFlsJOHEhI9xK/ab4Q==",
+			"dev": true,
+			"requires": {
+				"@types/node": "*",
+				"@types/stream-chain": "*"
+			}
 		},
 		"@types/superagent": {
 			"version": "4.1.15",
@@ -43231,6 +43303,29 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/stoppable/-/stoppable-1.1.0.tgz",
 			"integrity": "sha512-KXDYZ9dszj6bzvnEMRYvxgeTHU74QBFL54XKtP3nyMuJ81CFYtABZ3bAzL2EdFUaEwJOBOgENyFj3R7oTzDyyw=="
+		},
+		"stream-chain": {
+			"version": "3.4.0",
+			"resolved": "https://registry.npmjs.org/stream-chain/-/stream-chain-3.4.0.tgz",
+			"integrity": "sha512-cyDiaDqAfgmeiv0PWFXCg9oKNVYNzYxHK9j5CMsYMHZDk+/yYcSV+CXQZliZ0U4mNU8DLqiVNZXUfs8BqhgwMw==",
+			"dev": true
+		},
+		"stream-json": {
+			"version": "1.9.1",
+			"resolved": "https://registry.npmjs.org/stream-json/-/stream-json-1.9.1.tgz",
+			"integrity": "sha512-uWkjJ+2Nt/LO9Z/JyKZbMusL8Dkh97uUBTv3AJQ74y07lVahLY4eEFsPsE97pxYBwr8nnjMAIch5eqI0gPShyw==",
+			"dev": true,
+			"requires": {
+				"stream-chain": "^2.2.5"
+			},
+			"dependencies": {
+				"stream-chain": {
+					"version": "2.2.5",
+					"resolved": "https://registry.npmjs.org/stream-chain/-/stream-chain-2.2.5.tgz",
+					"integrity": "sha512-1TJmBx6aSWqZ4tx7aTpBDXK0/e2hhcNSTV8+CbFJtDjbb+I1mZ8lHit0Grw9GRT+6JbIrrDd8esncgBi8aBXGA==",
+					"dev": true
+				}
+			}
 		},
 		"stream-shift": {
 			"version": "1.0.1"

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
 		"@commitlint/cli": "17.0.1",
 		"@commitlint/config-conventional": "17.0.0",
 		"@types/prettier": "^2.7.3",
+		"@types/stream-json": "^1.7.8",
 		"commitizen": "^4.2.4",
 		"cz-conventional-changelog": "^3.3.0",
 		"dotenv-cli": "^8.0.0",


### PR DESCRIPTION
- Adds an initial import for the listed buildings dataset
- Expose a new API endpoint to find a record by reference

Uses a custom migration to handle existing data recorded in the database (the references used in LPAQs). 
Once merged, it is suggested to run:

`npm ci`
`npm run db:migrate`
`npm run db:seed:prod`

[A2-1447](https://pins-ds.atlassian.net/browse/A2-1447)


[A2-1447]: https://pins-ds.atlassian.net/browse/A2-1447?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ