### PR TITLE
feat(appeals): adding application reference column to national list and search

### DIFF
--- a/appeals/api/src/server/endpoints/appeals.d.ts
+++ b/appeals/api/src/server/endpoints/appeals.d.ts
@@ -516,6 +516,7 @@ interface AppealListResponse {
 	documentationSummary: DocumentationSummary;
 	isParentAppeal: boolean | null;
 	isChildAppeal: boolean | null;
+	planningApplicationReference: string | null;
 }
 
 interface DocumentationSummary {

--- a/appeals/api/src/server/endpoints/appeals/__tests__/appeals.test.js
+++ b/appeals/api/src/server/endpoints/appeals/__tests__/appeals.test.js
@@ -2,7 +2,7 @@
 import { jest } from '@jest/globals';
 import { request } from '../../../app-test.js';
 import {
-	ERROR_LENGTH_BETWEEN_2_AND_8_CHARACTERS,
+	ERROR_LENGTH_BETWEEN_MIN_AND_MAX_CHARACTERS,
 	ERROR_MUST_BE_BOOLEAN,
 	ERROR_MUST_BE_GREATER_THAN_ZERO,
 	ERROR_MUST_BE_NUMBER,
@@ -108,7 +108,8 @@ describe('appeals list routes', () => {
 								}
 							},
 							isParentAppeal: false,
-							isChildAppeal: false
+							isChildAppeal: false,
+							planningApplicationReference: householdAppeal.applicationReference
 						},
 						{
 							appealId: fullPlanningAppeal.id,
@@ -158,7 +159,8 @@ describe('appeals list routes', () => {
 								}
 							},
 							isParentAppeal: false,
-							isChildAppeal: false
+							isChildAppeal: false,
+							planningApplicationReference: fullPlanningAppeal.applicationReference
 						}
 					],
 					lpas,
@@ -231,7 +233,8 @@ describe('appeals list routes', () => {
 								}
 							},
 							isParentAppeal: false,
-							isChildAppeal: false
+							isChildAppeal: false,
+							planningApplicationReference: fullPlanningAppeal.applicationReference
 						}
 					],
 					lpas,
@@ -270,6 +273,11 @@ describe('appeals list routes', () => {
 											contains: 'MD21'
 										}
 									}
+								},
+								{
+									applicationReference: {
+										contains: 'MD21'
+									}
 								}
 							],
 							appealStatus: {
@@ -332,7 +340,8 @@ describe('appeals list routes', () => {
 								}
 							},
 							isParentAppeal: false,
-							isChildAppeal: false
+							isChildAppeal: false,
+							planningApplicationReference: householdAppeal.applicationReference
 						}
 					],
 					lpas,
@@ -371,6 +380,11 @@ describe('appeals list routes', () => {
 											contains: 'md21'
 										}
 									}
+								},
+								{
+									applicationReference: {
+										contains: 'md21'
+									}
 								}
 							],
 							appealStatus: {
@@ -433,7 +447,8 @@ describe('appeals list routes', () => {
 								}
 							},
 							isParentAppeal: false,
-							isChildAppeal: false
+							isChildAppeal: false,
+							planningApplicationReference: householdAppeal.applicationReference
 						}
 					],
 					lpas,
@@ -472,6 +487,11 @@ describe('appeals list routes', () => {
 											contains: 'MD21 5XY'
 										}
 									}
+								},
+								{
+									applicationReference: {
+										contains: 'MD21 5XY'
+									}
 								}
 							],
 							appealStatus: {
@@ -534,7 +554,8 @@ describe('appeals list routes', () => {
 								}
 							},
 							isParentAppeal: false,
-							isChildAppeal: false
+							isChildAppeal: false,
+							planningApplicationReference: householdAppeal.applicationReference
 						}
 					],
 					lpas,
@@ -622,7 +643,8 @@ describe('appeals list routes', () => {
 								}
 							},
 							isParentAppeal: false,
-							isChildAppeal: false
+							isChildAppeal: false,
+							planningApplicationReference: householdAppeal.applicationReference
 						}
 					],
 					lpas,
@@ -712,7 +734,8 @@ describe('appeals list routes', () => {
 								}
 							},
 							isParentAppeal: false,
-							isChildAppeal: false
+							isChildAppeal: false,
+							planningApplicationReference: householdAppeal.applicationReference
 						}
 					],
 					lpas,
@@ -800,7 +823,8 @@ describe('appeals list routes', () => {
 							},
 							dueDate: null,
 							isParentAppeal: false,
-							isChildAppeal: false
+							isChildAppeal: false,
+							planningApplicationReference: householdAppeal.applicationReference
 						}
 					],
 					lpas,
@@ -899,20 +923,20 @@ describe('appeals list routes', () => {
 				expect(response.status).toEqual(400);
 				expect(response.body).toEqual({
 					errors: {
-						searchTerm: ERROR_LENGTH_BETWEEN_2_AND_8_CHARACTERS
+						searchTerm: ERROR_LENGTH_BETWEEN_MIN_AND_MAX_CHARACTERS('2', '50')
 					}
 				});
 			});
 
-			test('returns an error if searchTerm is more than 8 characters', async () => {
+			test('returns an error if searchTerm is more than 50 characters', async () => {
 				const response = await request
-					.get('/appeals?searchTerm=aaaaaaaaa')
+					.get(`/appeals?searchTerm=${'a'.repeat(51)}`)
 					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(400);
 				expect(response.body).toEqual({
 					errors: {
-						searchTerm: ERROR_LENGTH_BETWEEN_2_AND_8_CHARACTERS
+						searchTerm: ERROR_LENGTH_BETWEEN_MIN_AND_MAX_CHARACTERS('2', '50')
 					}
 				});
 			});
@@ -1030,7 +1054,8 @@ test('gets appeals when given a appealTypeId param', async () => {
 					}
 				},
 				isParentAppeal: false,
-				isChildAppeal: false
+				isChildAppeal: false,
+				planningApplicationReference: householdAppeal.applicationReference
 			}
 		],
 		lpas,

--- a/appeals/api/src/server/endpoints/appeals/appeals.formatter.js
+++ b/appeals/api/src/server/endpoints/appeals/appeals.formatter.js
@@ -55,7 +55,8 @@ const formatAppeal = (appeal, linkedAppeals) => ({
 	documentationSummary: formatDocumentationSummary(appeal),
 	appealTimetable: formatAppealTimetable(appeal),
 	isParentAppeal: linkedAppeals.filter((link) => link.parentRef === appeal.reference).length > 0,
-	isChildAppeal: linkedAppeals.filter((link) => link.childRef === appeal.reference).length > 0
+	isChildAppeal: linkedAppeals.filter((link) => link.childRef === appeal.reference).length > 0,
+	planningApplicationReference: appeal.applicationReference
 });
 
 /**
@@ -80,7 +81,8 @@ const formatMyAppeals = (appeal, linkedAppeals) => ({
 	),
 	appealTimetable: formatAppealTimetable(appeal),
 	isParentAppeal: linkedAppeals.filter((link) => link.parentRef === appeal.reference).length > 0,
-	isChildAppeal: linkedAppeals.filter((link) => link.childRef === appeal.reference).length > 0
+	isChildAppeal: linkedAppeals.filter((link) => link.childRef === appeal.reference).length > 0,
+	planningApplicationReference: appeal.applicationReference
 });
 
 /**

--- a/appeals/api/src/server/endpoints/appeals/appeals.validators.js
+++ b/appeals/api/src/server/endpoints/appeals/appeals.validators.js
@@ -2,7 +2,7 @@ import { composeMiddleware } from '@pins/express';
 import { query } from 'express-validator';
 import { validationErrorHandler } from '#middleware/error-handler.js';
 import {
-	ERROR_LENGTH_BETWEEN_2_AND_8_CHARACTERS,
+	ERROR_LENGTH_BETWEEN_MIN_AND_MAX_CHARACTERS,
 	ERROR_MUST_BE_GREATER_THAN_ZERO,
 	ERROR_MUST_BE_NUMBER,
 	ERROR_PAGENUMBER_AND_PAGESIZE_ARE_REQUIRED
@@ -52,8 +52,8 @@ const getAppealsValidator = composeMiddleware(
 	query('searchTerm')
 		.optional()
 		.isString()
-		.isLength({ min: 2, max: 8 })
-		.withMessage(ERROR_LENGTH_BETWEEN_2_AND_8_CHARACTERS),
+		.isLength({ min: 2, max: 50 })
+		.withMessage(ERROR_LENGTH_BETWEEN_MIN_AND_MAX_CHARACTERS('2', '50')),
 	validationErrorHandler
 );
 

--- a/appeals/api/src/server/repositories/appeal-lists.repository.js
+++ b/appeals/api/src/server/repositories/appeal-lists.repository.js
@@ -54,6 +54,11 @@ const getAllAppeals = async (
 							contains: searchTerm
 						}
 					}
+				},
+				{
+					applicationReference: {
+						contains: searchTerm
+					}
 				}
 			]
 		}),

--- a/appeals/web/src/server/appeals/national-list/__tests__/__snapshots__/national-list.test.js.snap
+++ b/appeals/web/src/server/appeals/national-list/__tests__/__snapshots__/national-list.test.js.snap
@@ -12,9 +12,10 @@ exports[`national-list GET / should render national list - 10 pages - all page i
             <form method="GET">
                 <div class="govuk-form-group">
                     <label class="govuk-label govuk-caption-m govuk-!-margin-bottom-3 colour--secondary"
-                    for="searchTerm">Enter appeal reference or postcode (include spaces)</label>
-                    <input class="govuk-input"
-                    id="searchTerm" name="searchTerm" type="text" value="" data-cy="search-term">
+                    for="searchTerm">Enter the appeal reference, planning application reference or postcode
+                        (including spaces)</label>
+                    <input class="govuk-input" id="searchTerm" name="searchTerm"
+                    type="text" value="" data-cy="search-term">
                 </div>
                 <div class="govuk-button-group">
                     <button type="submit" class="govuk-button govuk-button" data-module="govuk-button"
@@ -112,6 +113,7 @@ exports[`national-list GET / should render national list - 10 pages - all page i
                 <thead class="govuk-table__head">
                     <tr class="govuk-table__row">
                         <th scope="col" class="govuk-table__header">Appeal reference</th>
+                        <th scope="col" class="govuk-table__header">Planning application reference</th>
                         <th scope="col" class="govuk-table__header">Site address</th>
                         <th scope="col" class="govuk-table__header">Local planning authority (LPA)</th>
                         <th scope="col" class="govuk-table__header">Appeal type</th>
@@ -123,6 +125,9 @@ exports[`national-list GET / should render national list - 10 pages - all page i
                         <td class="govuk-table__cell"><a class="govuk-link" href="/appeals-service/appeal-details/1" aria-label="Appeal 9 4 3 2 4 5"
                             data-cy="943245">943245</a>
                         </td>
+                        <td class="govuk-table__cell"><a class="govuk-link" href="/appeals-service/appeal-details/1" aria-label="Appeal "
+                            data-cy="undefined">undefined</a>
+                        </td>
                         <td class="govuk-table__cell">Copthalls, Clevedon Road, West Hill, BS48 1PN</td>
                         <td class="govuk-table__cell">Wiltshire Council</td>
                         <td class="govuk-table__cell">Householder</td>
@@ -132,6 +137,9 @@ exports[`national-list GET / should render national list - 10 pages - all page i
                     <tr class="govuk-table__row">
                         <td class="govuk-table__cell"><a class="govuk-link" href="/appeals-service/appeal-details/2" aria-label="Appeal 1 2 9 2 8 5"
                             data-cy="129285">129285</a>
+                        </td>
+                        <td class="govuk-table__cell"><a class="govuk-link" href="/appeals-service/appeal-details/2" aria-label="Appeal "
+                            data-cy="undefined">undefined</a>
                         </td>
                         <td class="govuk-table__cell">19 Beauchamp Road, Bristol, BS7 8LQ</td>
                         <td class="govuk-table__cell">Dorset Council</td>
@@ -199,9 +207,10 @@ exports[`national-list GET / should render national list - 15 pages - pagination
             <form method="GET">
                 <div class="govuk-form-group">
                     <label class="govuk-label govuk-caption-m govuk-!-margin-bottom-3 colour--secondary"
-                    for="searchTerm">Enter appeal reference or postcode (include spaces)</label>
-                    <input class="govuk-input"
-                    id="searchTerm" name="searchTerm" type="text" value="" data-cy="search-term">
+                    for="searchTerm">Enter the appeal reference, planning application reference or postcode
+                        (including spaces)</label>
+                    <input class="govuk-input" id="searchTerm" name="searchTerm"
+                    type="text" value="" data-cy="search-term">
                 </div>
                 <div class="govuk-button-group">
                     <button type="submit" class="govuk-button govuk-button" data-module="govuk-button"
@@ -299,6 +308,7 @@ exports[`national-list GET / should render national list - 15 pages - pagination
                 <thead class="govuk-table__head">
                     <tr class="govuk-table__row">
                         <th scope="col" class="govuk-table__header">Appeal reference</th>
+                        <th scope="col" class="govuk-table__header">Planning application reference</th>
                         <th scope="col" class="govuk-table__header">Site address</th>
                         <th scope="col" class="govuk-table__header">Local planning authority (LPA)</th>
                         <th scope="col" class="govuk-table__header">Appeal type</th>
@@ -310,6 +320,9 @@ exports[`national-list GET / should render national list - 15 pages - pagination
                         <td class="govuk-table__cell"><a class="govuk-link" href="/appeals-service/appeal-details/1" aria-label="Appeal 9 4 3 2 4 5"
                             data-cy="943245">943245</a>
                         </td>
+                        <td class="govuk-table__cell"><a class="govuk-link" href="/appeals-service/appeal-details/1" aria-label="Appeal "
+                            data-cy="undefined">undefined</a>
+                        </td>
                         <td class="govuk-table__cell">Copthalls, Clevedon Road, West Hill, BS48 1PN</td>
                         <td class="govuk-table__cell">Wiltshire Council</td>
                         <td class="govuk-table__cell">Householder</td>
@@ -319,6 +332,9 @@ exports[`national-list GET / should render national list - 15 pages - pagination
                     <tr class="govuk-table__row">
                         <td class="govuk-table__cell"><a class="govuk-link" href="/appeals-service/appeal-details/2" aria-label="Appeal 1 2 9 2 8 5"
                             data-cy="129285">129285</a>
+                        </td>
+                        <td class="govuk-table__cell"><a class="govuk-link" href="/appeals-service/appeal-details/2" aria-label="Appeal "
+                            data-cy="undefined">undefined</a>
                         </td>
                         <td class="govuk-table__cell">19 Beauchamp Road, Bristol, BS7 8LQ</td>
                         <td class="govuk-table__cell">Dorset Council</td>
@@ -368,9 +384,10 @@ exports[`national-list GET / should render national list - appeal type filter ap
             <form method="GET">
                 <div class="govuk-form-group">
                     <label class="govuk-label govuk-caption-m govuk-!-margin-bottom-3 colour--secondary"
-                    for="searchTerm">Enter appeal reference or postcode (include spaces)</label>
-                    <input class="govuk-input"
-                    id="searchTerm" name="searchTerm" type="text" value="" data-cy="search-term">
+                    for="searchTerm">Enter the appeal reference, planning application reference or postcode
+                        (including spaces)</label>
+                    <input class="govuk-input" id="searchTerm" name="searchTerm"
+                    type="text" value="" data-cy="search-term">
                 </div>
                 <div class="govuk-button-group">
                     <button type="submit" class="govuk-button govuk-button" data-module="govuk-button"
@@ -476,6 +493,7 @@ exports[`national-list GET / should render national list - appeal type filter ap
                 <thead class="govuk-table__head">
                     <tr class="govuk-table__row">
                         <th scope="col" class="govuk-table__header">Appeal reference</th>
+                        <th scope="col" class="govuk-table__header">Planning application reference</th>
                         <th scope="col" class="govuk-table__header">Site address</th>
                         <th scope="col" class="govuk-table__header">Local planning authority (LPA)</th>
                         <th scope="col" class="govuk-table__header">Appeal type</th>
@@ -486,6 +504,9 @@ exports[`national-list GET / should render national list - appeal type filter ap
                     <tr class="govuk-table__row">
                         <td class="govuk-table__cell"><a class="govuk-link" href="/appeals-service/appeal-details/1" aria-label="Appeal 9 4 3 2 4 5"
                             data-cy="943245">943245</a>
+                        </td>
+                        <td class="govuk-table__cell"><a class="govuk-link" href="/appeals-service/appeal-details/1" aria-label="Appeal "
+                            data-cy="undefined">undefined</a>
                         </td>
                         <td class="govuk-table__cell">Copthalls, Clevedon Road, West Hill, BS48 1PN</td>
                         <td class="govuk-table__cell">Wiltshire Council</td>
@@ -512,9 +533,10 @@ exports[`national-list GET / should render national list - no pagination 1`] = `
             <form method="GET">
                 <div class="govuk-form-group">
                     <label class="govuk-label govuk-caption-m govuk-!-margin-bottom-3 colour--secondary"
-                    for="searchTerm">Enter appeal reference or postcode (include spaces)</label>
-                    <input class="govuk-input"
-                    id="searchTerm" name="searchTerm" type="text" value="" data-cy="search-term">
+                    for="searchTerm">Enter the appeal reference, planning application reference or postcode
+                        (including spaces)</label>
+                    <input class="govuk-input" id="searchTerm" name="searchTerm"
+                    type="text" value="" data-cy="search-term">
                 </div>
                 <div class="govuk-button-group">
                     <button type="submit" class="govuk-button govuk-button" data-module="govuk-button"
@@ -612,6 +634,7 @@ exports[`national-list GET / should render national list - no pagination 1`] = `
                 <thead class="govuk-table__head">
                     <tr class="govuk-table__row">
                         <th scope="col" class="govuk-table__header">Appeal reference</th>
+                        <th scope="col" class="govuk-table__header">Planning application reference</th>
                         <th scope="col" class="govuk-table__header">Site address</th>
                         <th scope="col" class="govuk-table__header">Local planning authority (LPA)</th>
                         <th scope="col" class="govuk-table__header">Appeal type</th>
@@ -623,6 +646,9 @@ exports[`national-list GET / should render national list - no pagination 1`] = `
                         <td class="govuk-table__cell"><a class="govuk-link" href="/appeals-service/appeal-details/1" aria-label="Appeal 9 4 3 2 4 5"
                             data-cy="943245">943245</a>
                         </td>
+                        <td class="govuk-table__cell"><a class="govuk-link" href="/appeals-service/appeal-details/1" aria-label="Appeal "
+                            data-cy="undefined">undefined</a>
+                        </td>
                         <td class="govuk-table__cell">Copthalls, Clevedon Road, West Hill, BS48 1PN</td>
                         <td class="govuk-table__cell">Wiltshire Council</td>
                         <td class="govuk-table__cell">Householder</td>
@@ -632,6 +658,9 @@ exports[`national-list GET / should render national list - no pagination 1`] = `
                     <tr class="govuk-table__row">
                         <td class="govuk-table__cell"><a class="govuk-link" href="/appeals-service/appeal-details/2" aria-label="Appeal 1 2 9 2 8 5"
                             data-cy="129285">129285</a>
+                        </td>
+                        <td class="govuk-table__cell"><a class="govuk-link" href="/appeals-service/appeal-details/2" aria-label="Appeal "
+                            data-cy="undefined">undefined</a>
                         </td>
                         <td class="govuk-table__cell">19 Beauchamp Road, Bristol, BS7 8LQ</td>
                         <td class="govuk-table__cell">Dorset Council</td>
@@ -658,9 +687,10 @@ exports[`national-list GET / should render national list - no search term - filt
             <form method="GET">
                 <div class="govuk-form-group">
                     <label class="govuk-label govuk-caption-m govuk-!-margin-bottom-3 colour--secondary"
-                    for="searchTerm">Enter appeal reference or postcode (include spaces)</label>
-                    <input class="govuk-input"
-                    id="searchTerm" name="searchTerm" type="text" value="" data-cy="search-term">
+                    for="searchTerm">Enter the appeal reference, planning application reference or postcode
+                        (including spaces)</label>
+                    <input class="govuk-input" id="searchTerm" name="searchTerm"
+                    type="text" value="" data-cy="search-term">
                 </div>
                 <div class="govuk-button-group">
                     <button type="submit" class="govuk-button govuk-button" data-module="govuk-button"
@@ -766,6 +796,7 @@ exports[`national-list GET / should render national list - no search term - filt
                 <thead class="govuk-table__head">
                     <tr class="govuk-table__row">
                         <th scope="col" class="govuk-table__header">Appeal reference</th>
+                        <th scope="col" class="govuk-table__header">Planning application reference</th>
                         <th scope="col" class="govuk-table__header">Site address</th>
                         <th scope="col" class="govuk-table__header">Local planning authority (LPA)</th>
                         <th scope="col" class="govuk-table__header">Appeal type</th>
@@ -776,6 +807,9 @@ exports[`national-list GET / should render national list - no search term - filt
                     <tr class="govuk-table__row">
                         <td class="govuk-table__cell"><a class="govuk-link" href="/appeals-service/appeal-details/1" aria-label="Appeal 9 4 3 2 4 5"
                             data-cy="943245">943245</a>
+                        </td>
+                        <td class="govuk-table__cell"><a class="govuk-link" href="/appeals-service/appeal-details/1" aria-label="Appeal "
+                            data-cy="undefined">undefined</a>
                         </td>
                         <td class="govuk-table__cell">Copthalls, Clevedon Road, West Hill, BS48 1PN</td>
                         <td class="govuk-table__cell">Wiltshire Council</td>
@@ -802,9 +836,10 @@ exports[`national-list GET / should render national list - search term - filter 
             <form method="GET">
                 <div class="govuk-form-group">
                     <label class="govuk-label govuk-caption-m govuk-!-margin-bottom-3 colour--secondary"
-                    for="searchTerm">Enter appeal reference or postcode (include spaces)</label>
-                    <input class="govuk-input"
-                    id="searchTerm" name="searchTerm" type="text" value="BS7 8LQ" data-cy="search-term">
+                    for="searchTerm">Enter the appeal reference, planning application reference or postcode
+                        (including spaces)</label>
+                    <input class="govuk-input" id="searchTerm" name="searchTerm"
+                    type="text" value="BS7 8LQ" data-cy="search-term">
                 </div>
                 <div class="govuk-button-group">
                     <button type="submit" class="govuk-button govuk-button" data-module="govuk-button"
@@ -912,6 +947,7 @@ exports[`national-list GET / should render national list - search term - filter 
                 <thead class="govuk-table__head">
                     <tr class="govuk-table__row">
                         <th scope="col" class="govuk-table__header">Appeal reference</th>
+                        <th scope="col" class="govuk-table__header">Planning application reference</th>
                         <th scope="col" class="govuk-table__header">Site address</th>
                         <th scope="col" class="govuk-table__header">Local planning authority (LPA)</th>
                         <th scope="col" class="govuk-table__header">Appeal type</th>
@@ -922,6 +958,9 @@ exports[`national-list GET / should render national list - search term - filter 
                     <tr class="govuk-table__row">
                         <td class="govuk-table__cell"><a class="govuk-link" href="/appeals-service/appeal-details/1" aria-label="Appeal 9 4 3 2 4 5"
                             data-cy="943245">943245</a>
+                        </td>
+                        <td class="govuk-table__cell"><a class="govuk-link" href="/appeals-service/appeal-details/1" aria-label="Appeal "
+                            data-cy="undefined">undefined</a>
                         </td>
                         <td class="govuk-table__cell">Copthalls, Clevedon Road, West Hill, BS48 1PN</td>
                         <td class="govuk-table__cell">Wiltshire Council</td>
@@ -948,9 +987,10 @@ exports[`national-list GET / should render national list - search term - no resu
             <form method="GET">
                 <div class="govuk-form-group">
                     <label class="govuk-label govuk-caption-m govuk-!-margin-bottom-3 colour--secondary"
-                    for="searchTerm">Enter appeal reference or postcode (include spaces)</label>
-                    <input class="govuk-input"
-                    id="searchTerm" name="searchTerm" type="text" value="NORESULT" data-cy="search-term">
+                    for="searchTerm">Enter the appeal reference, planning application reference or postcode
+                        (including spaces)</label>
+                    <input class="govuk-input" id="searchTerm" name="searchTerm"
+                    type="text" value="NORESULT" data-cy="search-term">
                 </div>
                 <div class="govuk-button-group">
                     <button type="submit" class="govuk-button govuk-button" data-module="govuk-button"
@@ -1067,9 +1107,10 @@ exports[`national-list GET / should render national list - search term 1`] = `
             <form method="GET">
                 <div class="govuk-form-group">
                     <label class="govuk-label govuk-caption-m govuk-!-margin-bottom-3 colour--secondary"
-                    for="searchTerm">Enter appeal reference or postcode (include spaces)</label>
-                    <input class="govuk-input"
-                    id="searchTerm" name="searchTerm" type="text" value="BS7 8LQ" data-cy="search-term">
+                    for="searchTerm">Enter the appeal reference, planning application reference or postcode
+                        (including spaces)</label>
+                    <input class="govuk-input" id="searchTerm" name="searchTerm"
+                    type="text" value="BS7 8LQ" data-cy="search-term">
                 </div>
                 <div class="govuk-button-group">
                     <button type="submit" class="govuk-button govuk-button" data-module="govuk-button"
@@ -1172,6 +1213,7 @@ exports[`national-list GET / should render national list - search term 1`] = `
                 <thead class="govuk-table__head">
                     <tr class="govuk-table__row">
                         <th scope="col" class="govuk-table__header">Appeal reference</th>
+                        <th scope="col" class="govuk-table__header">Planning application reference</th>
                         <th scope="col" class="govuk-table__header">Site address</th>
                         <th scope="col" class="govuk-table__header">Local planning authority (LPA)</th>
                         <th scope="col" class="govuk-table__header">Appeal type</th>
@@ -1183,6 +1225,9 @@ exports[`national-list GET / should render national list - search term 1`] = `
                         <td class="govuk-table__cell"><a class="govuk-link" href="/appeals-service/appeal-details/1" aria-label="Appeal 9 4 3 2 4 5"
                             data-cy="943245">943245</a>
                         </td>
+                        <td class="govuk-table__cell"><a class="govuk-link" href="/appeals-service/appeal-details/1" aria-label="Appeal "
+                            data-cy="undefined">undefined</a>
+                        </td>
                         <td class="govuk-table__cell">Copthalls, Clevedon Road, West Hill, BS48 1PN</td>
                         <td class="govuk-table__cell">Wiltshire Council</td>
                         <td class="govuk-table__cell">Householder</td>
@@ -1192,6 +1237,9 @@ exports[`national-list GET / should render national list - search term 1`] = `
                     <tr class="govuk-table__row">
                         <td class="govuk-table__cell"><a class="govuk-link" href="/appeals-service/appeal-details/2" aria-label="Appeal 1 2 9 2 8 5"
                             data-cy="129285">129285</a>
+                        </td>
+                        <td class="govuk-table__cell"><a class="govuk-link" href="/appeals-service/appeal-details/2" aria-label="Appeal "
+                            data-cy="undefined">undefined</a>
                         </td>
                         <td class="govuk-table__cell">19 Beauchamp Road, Bristol, BS7 8LQ</td>
                         <td class="govuk-table__cell">Dorset Council</td>
@@ -1218,9 +1266,10 @@ exports[`national-list GET / should render the header with navigation containing
             <form method="GET">
                 <div class="govuk-form-group">
                     <label class="govuk-label govuk-caption-m govuk-!-margin-bottom-3 colour--secondary"
-                    for="searchTerm">Enter appeal reference or postcode (include spaces)</label>
-                    <input class="govuk-input"
-                    id="searchTerm" name="searchTerm" type="text" value="" data-cy="search-term">
+                    for="searchTerm">Enter the appeal reference, planning application reference or postcode
+                        (including spaces)</label>
+                    <input class="govuk-input" id="searchTerm" name="searchTerm"
+                    type="text" value="" data-cy="search-term">
                 </div>
                 <div class="govuk-button-group">
                     <button type="submit" class="govuk-button govuk-button" data-module="govuk-button"
@@ -1318,6 +1367,7 @@ exports[`national-list GET / should render the header with navigation containing
                 <thead class="govuk-table__head">
                     <tr class="govuk-table__row">
                         <th scope="col" class="govuk-table__header">Appeal reference</th>
+                        <th scope="col" class="govuk-table__header">Planning application reference</th>
                         <th scope="col" class="govuk-table__header">Site address</th>
                         <th scope="col" class="govuk-table__header">Local planning authority (LPA)</th>
                         <th scope="col" class="govuk-table__header">Appeal type</th>
@@ -1329,6 +1379,9 @@ exports[`national-list GET / should render the header with navigation containing
                         <td class="govuk-table__cell"><a class="govuk-link" href="/appeals-service/appeal-details/1" aria-label="Appeal 9 4 3 2 4 5"
                             data-cy="943245">943245</a>
                         </td>
+                        <td class="govuk-table__cell"><a class="govuk-link" href="/appeals-service/appeal-details/1" aria-label="Appeal "
+                            data-cy="undefined">undefined</a>
+                        </td>
                         <td class="govuk-table__cell">Copthalls, Clevedon Road, West Hill, BS48 1PN</td>
                         <td class="govuk-table__cell">Wiltshire Council</td>
                         <td class="govuk-table__cell">Householder</td>
@@ -1338,6 +1391,9 @@ exports[`national-list GET / should render the header with navigation containing
                     <tr class="govuk-table__row">
                         <td class="govuk-table__cell"><a class="govuk-link" href="/appeals-service/appeal-details/2" aria-label="Appeal 1 2 9 2 8 5"
                             data-cy="129285">129285</a>
+                        </td>
+                        <td class="govuk-table__cell"><a class="govuk-link" href="/appeals-service/appeal-details/2" aria-label="Appeal "
+                            data-cy="undefined">undefined</a>
                         </td>
                         <td class="govuk-table__cell">19 Beauchamp Road, Bristol, BS7 8LQ</td>
                         <td class="govuk-table__cell">Dorset Council</td>

--- a/appeals/web/src/server/appeals/national-list/__tests__/national-list.test.js
+++ b/appeals/web/src/server/appeals/national-list/__tests__/national-list.test.js
@@ -71,7 +71,7 @@ describe('national-list', () => {
 			const unprettifiedElement = parseHtml(response.text, { skipPrettyPrint: true });
 
 			expect(unprettifiedElement.innerHTML).toContain(
-				'Enter appeal reference or postcode (include spaces)</label>'
+				'Enter the appeal reference, planning application reference or postcode (including spaces)</label>'
 			);
 			expect(unprettifiedElement.innerHTML).toContain('name="searchTerm" type="text"');
 			expect(unprettifiedElement.innerHTML).toContain('Search</button>');

--- a/appeals/web/src/server/appeals/national-list/national-list.controller.js
+++ b/appeals/web/src/server/appeals/national-list/national-list.controller.js
@@ -42,9 +42,10 @@ export const viewNationalList = async (request, response) => {
 	let searchTerm = query?.searchTerm ? String(query.searchTerm).trim() : '';
 	let searchTermError = '';
 
-	if (searchTerm && searchTerm.length && (searchTerm.length === 1 || searchTerm.length >= 9)) {
+	if (searchTerm && searchTerm.length && (searchTerm.length === 1 || searchTerm.length > 50)) {
 		searchTerm = '';
-		searchTermError = 'Search query must be between 2 and 8 characters';
+		searchTermError =
+			'Appeal reference, planning application reference or postcode must be between 2 and 50 characters';
 	}
 
 	const appealTypes = await getAppealTypes(request.apiClient);

--- a/appeals/web/src/server/appeals/national-list/national-list.mapper.js
+++ b/appeals/web/src/server/appeals/national-list/national-list.mapper.js
@@ -161,7 +161,7 @@ export function nationalListPage(
 				id: 'searchTerm',
 				name: 'searchTerm',
 				label: {
-					text: 'Enter appeal reference or postcode (include spaces)',
+					text: 'Enter the appeal reference, planning application reference or postcode (including spaces)',
 					classes: 'govuk-caption-m govuk-!-margin-bottom-3 colour--secondary'
 				},
 				value: searchTerm,
@@ -377,6 +377,9 @@ export function nationalListPage(
 								text: 'Appeal reference'
 							},
 							{
+								text: 'Planning application reference'
+							},
+							{
 								text: 'Site address'
 							},
 							{
@@ -399,6 +402,14 @@ export function nationalListPage(
 									}" aria-label="Appeal ${numberToAccessibleDigitLabel(
 										shortReference || ''
 									)}" data-cy="${shortReference}" >${shortReference}</a>`
+								},
+								{
+									html: `<a class="govuk-link" href="/appeals-service/appeal-details/${
+										appeal.appealId
+									}" aria-label="Appeal ${numberToAccessibleDigitLabel(
+										appeal.planningApplicationReference || ''
+									)}" 
+									data-cy="${appeal.planningApplicationReference}" >${appeal.planningApplicationReference}</a>`
 								},
 								{
 									text: addressToString(appeal.appealSite)

--- a/packages/appeals/constants/support.js
+++ b/packages/appeals/constants/support.js
@@ -185,6 +185,10 @@ export const ERROR_INVALID_REPRESENTATION_TYPE = `must be one of ${Object.values
 	APPEAL_REPRESENTATION_TYPE
 ).join(', ')}`;
 export const ERROR_LENGTH_BETWEEN_2_AND_8_CHARACTERS = 'must be between 2 and 8 characters';
+export const ERROR_LENGTH_BETWEEN_MIN_AND_MAX_CHARACTERS = (
+	/** @type {string} */ min,
+	/** @type {string} */ max
+) => `must be between ${min} and ${max} characters`;
 export const ERROR_MAX_LENGTH_CHARACTERS = 'must be {replacement0} characters or less';
 export const ERROR_MUST_BE_ARRAY_OF_NUMBERS = 'must be an array of numbers';
 export const ERROR_MUST_BE_ARRAY_OF_STRINGS = 'must be an array of strings';

--- a/packages/appeals/types/appeal.d.ts
+++ b/packages/appeals/types/appeal.d.ts
@@ -22,6 +22,7 @@ export interface AppealSummary {
 	documentationSummary: DocumentationSummary;
 	isParentAppeal: boolean;
 	isChildAppeal: boolean;
+	planningApplicationReference: string | null;
 }
 
 export interface AppealList {


### PR DESCRIPTION

## Describe your changes
API:
- Added applicationReference to returned results from calling endpoint - formatter
- increased max string length for searchTerm to 50 
- Created new constant for error message
- Updated appeal repository class to include applicationReference when doing a search
- Updated snapshots and unit tests

Web:
- Updated search hint text copy
- updated national-list unit tests and snapshots
- Updated mapper to include new planning application reference column on UI

<!--
    Please include a summary of the change along with any relevant context.
    List any dependencies that are required for this change.
-->

## Issue ticket number and link
[Ticket](https://pins-ds.atlassian.net.mcas.ms/browse/A2-2398)
