### PR TITLE
fix(api):A2-2559 link LPA decision notify email directly to appeal pages

### DIFF
--- a/appeals/api/src/server/endpoints/appeal-decision/appeal-decision.service.js
+++ b/appeals/api/src/server/endpoints/appeal-decision/appeal-decision.service.js
@@ -61,7 +61,7 @@ export const publishDecision = async (
 			await notifySend({
 				templateName: 'decision-is-allowed-split-dismissed-lpa',
 				notifyClient,
-				recipientEmail,
+				recipientEmail: lpaEmail,
 				personalisation
 			});
 		}

--- a/appeals/api/src/server/notify/templates/__tests__/notify-decision-is-allowed-split-dismissed-appellant.test.js
+++ b/appeals/api/src/server/notify/templates/__tests__/notify-decision-is-allowed-split-dismissed-appellant.test.js
@@ -1,5 +1,6 @@
 import { notifySend } from '#notify/notify-send.js';
 import { jest } from '@jest/globals';
+import { householdAppeal } from '#tests/appeals/mocks.js';
 
 describe('decision-is-allowed-split-dismissed-appellant.md', () => {
 	test('should call notify sendEmail with the correct data', async () => {
@@ -9,7 +10,7 @@ describe('decision-is-allowed-split-dismissed-appellant.md', () => {
 			notifyClient: {
 				sendEmail: jest.fn()
 			},
-			recipientEmail: 'test@136s7.com',
+			recipientEmail: householdAppeal.appellant.email,
 			personalisation: {
 				appeal_reference_number: 'ABC45678',
 				site_address: '10, Test Street',
@@ -29,7 +30,7 @@ describe('decision-is-allowed-split-dismissed-appellant.md', () => {
 			'',
 			'We have made a decision on your appeal.',
 			'',
-			'[Sign in to our service](<https://appeals-service-test.planninginspectorate.gov.uk/appeals/ABC45678>) to view the decision letter dated 01 January 2021.',
+			'[Sign in to our service](https://appeals-service-test.planninginspectorate.gov.uk/appeals/ABC45678) to view the decision letter dated 01 January 2021.',
 			'',
 			'We have also informed the local planning authority of the decision.',
 			'',
@@ -51,7 +52,7 @@ describe('decision-is-allowed-split-dismissed-appellant.md', () => {
 			{
 				id: 'mock-appeal-generic-id'
 			},
-			'test@136s7.com',
+			householdAppeal.appellant.email,
 			{
 				content: expectedContent,
 				subject: 'Appeal decision: ABC45678'

--- a/appeals/api/src/server/notify/templates/__tests__/notify-decision-is-allowed-split-dismissed-lpa.test.js
+++ b/appeals/api/src/server/notify/templates/__tests__/notify-decision-is-allowed-split-dismissed-lpa.test.js
@@ -1,5 +1,6 @@
 import { notifySend } from '#notify/notify-send.js';
 import { jest } from '@jest/globals';
+import { householdAppeal } from '#tests/appeals/mocks.js';
 
 describe('decision-is-allowed-split-dismissed-lpa.md', () => {
 	test('should call notify sendEmail with the correct data', async () => {
@@ -9,7 +10,7 @@ describe('decision-is-allowed-split-dismissed-lpa.md', () => {
 			notifyClient: {
 				sendEmail: jest.fn()
 			},
-			recipientEmail: 'test@136s7.com',
+			recipientEmail: householdAppeal.lpa.email,
 			personalisation: {
 				appeal_reference_number: 'ABC45678',
 				site_address: '10, Test Street',
@@ -29,7 +30,7 @@ describe('decision-is-allowed-split-dismissed-lpa.md', () => {
 			'',
 			'A decision has been made on this appeal.',
 			'',
-			'[Sign in to our service](<https://appeals-service-test.planninginspectorate.gov.uk/manage-appeals/ABC45678>) to view the decision letter dated 01 January 2021.',
+			'[Sign in to our service](https://appeals-service-test.planninginspectorate.gov.uk/manage-appeals/ABC45678) to view the decision letter dated 01 January 2021.',
 			'',
 			'The appellant has been informed of the decision.',
 			'',
@@ -51,7 +52,7 @@ describe('decision-is-allowed-split-dismissed-lpa.md', () => {
 			{
 				id: 'mock-appeal-generic-id'
 			},
-			'test@136s7.com',
+			householdAppeal.lpa.email,
 			{
 				content: expectedContent,
 				subject: 'Appeal decision: ABC45678'

--- a/appeals/api/src/server/notify/templates/decision-is-allowed-split-dismissed-appellant.content.md
+++ b/appeals/api/src/server/notify/templates/decision-is-allowed-split-dismissed-appellant.content.md
@@ -8,7 +8,7 @@ Planning application reference: ((lpa_reference))
 
 We have made a decision on your appeal.
 
-[Sign in to our service](<https://appeals-service-test.planninginspectorate.gov.uk/appeals/((appeal_reference_number))>) to view the decision letter dated ((decision_date)).
+[Sign in to our service](https://appeals-service-test.planninginspectorate.gov.uk/appeals/((appeal_reference_number))) to view the decision letter dated ((decision_date)).
 
 We have also informed the local planning authority of the decision.
 

--- a/appeals/api/src/server/notify/templates/decision-is-allowed-split-dismissed-lpa.content.md
+++ b/appeals/api/src/server/notify/templates/decision-is-allowed-split-dismissed-lpa.content.md
@@ -8,7 +8,7 @@ Planning application reference: ((lpa_reference))
 
 A decision has been made on this appeal.
 
-[Sign in to our service](<https://appeals-service-test.planninginspectorate.gov.uk/manage-appeals/((appeal_reference_number))>) to view the decision letter dated ((decision_date)).
+[Sign in to our service](https://appeals-service-test.planninginspectorate.gov.uk/manage-appeals/((appeal_reference_number))) to view the decision letter dated ((decision_date)).
 
 The appellant has been informed of the decision.
 


### PR DESCRIPTION
## Describe your changes

Fixed incorrect appellant email in notify payload, updated tests to use named mock emails for clarity and corrected markdown URL syntax in templates. 

## Issue ticket number and link
[A2-2559](https://pins-ds.atlassian.net/browse/A2-2559)

[A2-2559]: https://pins-ds.atlassian.net/browse/A2-2559?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ