### PR TITLE
fix(web): fix back link from ip comments and statements to share page

### DIFF
--- a/appeals/web/src/server/appeals/appeal-details/representations/__tests__/__snapshots__/representations.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/representations/__tests__/__snapshots__/representations.test.js.snap
@@ -9,7 +9,7 @@ exports[`representations GET /share should contain link to interested-party-comm
     </div>
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">
-            <div class="govuk-inset-text">We’ll share the <a href="/appeals-service/appeal-details/1/interested-party-comments?backUrl=/share#valid"
+            <div class="govuk-inset-text">We’ll share the <a href="/appeals-service/appeal-details/1/interested-party-comments?backUrl=%2Fappeals-service%2Fappeal-details%2F1%2Fshare#valid"
                 class="govuk-link">1 interested party comments</a> with the relevant parties.</div>
             <div             class="govuk-warning-text"><span class="govuk-warning-text__icon" aria-hidden="true">!</span>
                 <strong                 class="govuk-warning-text__text"><span class="govuk-visually-hidden">Warning</span> Do not confirm until

--- a/appeals/web/src/server/appeals/appeal-details/representations/__tests__/representations.test.js
+++ b/appeals/web/src/server/appeals/appeal-details/representations/__tests__/representations.test.js
@@ -44,7 +44,7 @@ describe('representations', () => {
 			expect(element.innerHTML).toMatchSnapshot();
 			expect(element.innerHTML).toContain('Share IP comments and statements</h1>');
 			expect(element.innerHTML).toContain(
-				`<a href="/appeals-service/appeal-details/1/interested-party-comments?backUrl=/share#valid"`
+				`<a href="/appeals-service/appeal-details/1/interested-party-comments?backUrl=%2Fappeals-service%2Fappeal-details%2F1%2Fshare#valid"`
 			);
 		});
 	});

--- a/appeals/web/src/server/appeals/appeal-details/representations/representations.controller.js
+++ b/appeals/web/src/server/appeals/appeal-details/representations/representations.controller.js
@@ -13,7 +13,11 @@ export function renderShareRepresentations(request, response) {
 	const pageContent = (() => {
 		switch (currentAppeal.appealStatus) {
 			case APPEAL_CASE_STATUS.STATEMENTS:
-				return statementAndCommentsSharePage(currentAppeal, getBackLinkUrlFromQuery(request));
+				return statementAndCommentsSharePage(
+					currentAppeal,
+					request,
+					getBackLinkUrlFromQuery(request)
+				);
 			case APPEAL_CASE_STATUS.FINAL_COMMENTS: {
 				const finalCommentsDueDate = currentAppeal.appealTimetable?.finalCommentsDueDate;
 				if (

--- a/appeals/web/src/server/appeals/appeal-details/representations/representations.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/representations/representations.mapper.js
@@ -2,6 +2,7 @@ import { COMMENT_STATUS } from '@pins/appeals/constants/common.js';
 import { ensureArray } from '#lib/array-utilities.js';
 import { appealShortReference } from '#lib/appeals-formatter.js';
 import { APPEAL_REPRESENTATION_STATUS } from '@pins/appeals/constants/common.js';
+import { addBackLinkQueryToUrl } from '#lib/url-utilities.js';
 
 /** @typedef {import('#appeals/appeal-details/appeal-details.types.js').WebAppeal} Appeal */
 /** @typedef {import('#appeals/appeal-details/representations/types.js').Representation} Representation */
@@ -114,17 +115,21 @@ export function mapRejectionReasonPayload(rejectionReasons) {
 
 /**
  * @param {Appeal} appeal
+ * @param {import('@pins/express/types/express.js').Request} request
  * @param {string} [backUrl]
  * @returns {PageContent}
  * */
-export function statementAndCommentsSharePage(appeal, backUrl) {
+export function statementAndCommentsSharePage(appeal, request, backUrl) {
 	const shortAppealReference = appealShortReference(appeal.appealReference);
 
 	const ipCommentsText = (() => {
 		const numIpComments = appeal.documentationSummary?.ipComments?.counts?.valid ?? 0;
 
 		return numIpComments > 0
-			? `<a href="/appeals-service/appeal-details/${appeal.appealId}/interested-party-comments?backUrl=/share#valid" class="govuk-link">${numIpComments} interested party comments</a>`
+			? `<a href="${addBackLinkQueryToUrl(
+					request,
+					`/appeals-service/appeal-details/${appeal.appealId}/interested-party-comments#valid`
+			  )}" class="govuk-link">${numIpComments} interested party comments</a>`
 			: null;
 	})();
 
@@ -133,7 +138,10 @@ export function statementAndCommentsSharePage(appeal, backUrl) {
 			APPEAL_REPRESENTATION_STATUS.VALID ||
 		appeal.documentationSummary?.lpaStatement?.representationStatus ===
 			APPEAL_REPRESENTATION_STATUS.INCOMPLETE
-			? `<a href="/appeals-service/appeal-details/${appeal.appealId}/lpa-statement?backUrl=/share" class="govuk-link">1 statement</a>`
+			? `<a href="${addBackLinkQueryToUrl(
+					request,
+					`/appeals-service/appeal-details/${appeal.appealId}/lpa-statement`
+			  )}" class="govuk-link">1 statement</a>`
 			: null;
 
 	const valueTexts = [ipCommentsText, lpaStatementText].filter(Boolean);

--- a/appeals/web/src/server/lib/__tests__/libraries.test.js
+++ b/appeals/web/src/server/lib/__tests__/libraries.test.js
@@ -1594,6 +1594,16 @@ describe('url-utilities', () => {
 				)
 			).toBe('/supplied/url?backUrl=%2Ftest%2Foriginal%2Furl%3FwithOwnQuery%3Dtrue');
 		});
+
+		it('should move the URL hash to the end of the URL (after the query string) if a hash is present in the supplied URL', () => {
+			expect(
+				addBackLinkQueryToUrl(
+					// @ts-ignore
+					{ originalUrl: '/test/original/url?withOwnQuery=true' },
+					'/supplied/url#with-hash'
+				)
+			).toBe('/supplied/url?backUrl=%2Ftest%2Foriginal%2Furl%3FwithOwnQuery%3Dtrue#with-hash');
+		});
 	});
 
 	describe('getBackLinkUrlFromQuery', () => {

--- a/appeals/web/src/server/lib/url-utilities.js
+++ b/appeals/web/src/server/lib/url-utilities.js
@@ -48,7 +48,11 @@ export function safeRedirect(request, response, url) {
  * @returns {string}
  */
 export function addBackLinkQueryToUrl(request, url) {
-	return `${url}?backUrl=${encodeURIComponent(request.originalUrl)}`;
+	const urlParts = url.split('#');
+
+	return `${urlParts[0]}?backUrl=${encodeURIComponent(request.originalUrl)}${
+		urlParts.length > 1 ? `#${urlParts[1]}` : ''
+	}`;
 }
 
 /**


### PR DESCRIPTION
## Describe your changes

- replace old hardcoded back link query in links to ip comments and statements page from share page with new standardised equivalent using `addBackLinkQueryToUrl` helper function
- update `addBackLinkQueryToUrl` helper to work correctly in situations where the supplied URL has a hash, by moving it after the query that is added to the URL (everything after the hash is ignored by the server)

## Issue ticket number and link
https://pins-ds.atlassian.net/browse/A2-2369
