### PR TITLE
fix(web): fix back link from final comments to share page

### DIFF
--- a/appeals/web/src/server/appeals/appeal-details/representations/representations.controller.js
+++ b/appeals/web/src/server/appeals/appeal-details/representations/representations.controller.js
@@ -27,7 +27,7 @@ export function renderShareRepresentations(request, response) {
 					throw new Error('Final comments cannot be shared before the due date has passed');
 				}
 
-				return finalCommentsSharePage(currentAppeal, getBackLinkUrlFromQuery(request));
+				return finalCommentsSharePage(currentAppeal, request, getBackLinkUrlFromQuery(request));
 			}
 			default:
 				throw new Error(

--- a/appeals/web/src/server/appeals/appeal-details/representations/representations.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/representations/representations.mapper.js
@@ -189,10 +189,11 @@ export function statementAndCommentsSharePage(appeal, request, backUrl) {
 
 /**
  * @param {Appeal} appeal
+ * @param {import('@pins/express/types/express.js').Request} request
  * @param {string | undefined} backUrl
  * @returns {PageContent}
  * */
-export function finalCommentsSharePage(appeal, backUrl) {
+export function finalCommentsSharePage(appeal, request, backUrl) {
 	const hasValidFinalCommentsAppellant =
 		appeal.documentationSummary.appellantFinalComments?.representationStatus ===
 		COMMENT_STATUS.VALID;
@@ -200,16 +201,25 @@ export function finalCommentsSharePage(appeal, backUrl) {
 		appeal.documentationSummary.lpaFinalComments?.representationStatus === COMMENT_STATUS.VALID;
 
 	const infoText = (() => {
+		const appellantFinalCommentsLink = `<a class="govuk-link" href="${addBackLinkQueryToUrl(
+			request,
+			`/appeals-service/appeal-details/${appeal.appealId}/final-comments/appellant`
+		)}">appellant final comments</a>`;
+		const lpaFinalCommentsLink = `<a class="govuk-link" href="${addBackLinkQueryToUrl(
+			request,
+			`/appeals-service/appeal-details/${appeal.appealId}/final-comments/lpa`
+		)}">LPA final comments</a>`;
+
 		if (hasValidFinalCommentsAppellant && hasValidFinalCommentsLPA) {
-			return `We’ll share <a class="govuk-link" href="/appeals-service/appeal-details/${appeal.appealId}/final-comments/appellant?backUrl=/share">appellant final comments</a> and <a class="govuk-link" href="/appeals-service/appeal-details/${appeal.appealId}/final-comments/lpa?backUrl=/share">LPA final comments</a> with the relevant parties.`;
+			return `We’ll share ${appellantFinalCommentsLink} and ${lpaFinalCommentsLink} with the relevant parties.`;
 		}
 
 		if (hasValidFinalCommentsAppellant && !hasValidFinalCommentsLPA) {
-			return `We’ll share <a class="govuk-link" href="/appeals-service/appeal-details/${appeal.appealId}/final-comments/appellant?backUrl=/share">appellant final comments</a> with the relevant parties.`;
+			return `We’ll share ${appellantFinalCommentsLink} with the relevant parties.`;
 		}
 
 		if (!hasValidFinalCommentsAppellant && hasValidFinalCommentsLPA) {
-			return `We’ll share <a class="govuk-link" href="/appeals-service/appeal-details/${appeal.appealId}/final-comments/lpa?backUrl=/share">LPA final comments</a> with the relevant parties.`;
+			return `We’ll share ${lpaFinalCommentsLink} with the relevant parties.`;
 		}
 
 		return `There are no final comments to share.`;


### PR DESCRIPTION
## Describe your changes

replaces old hardcoded back link query in links to final comments pages from share page with new standardised equivalent using addBackLinkQueryToUrl helper function

## Issue ticket number and link
https://pins-ds.atlassian.net/browse/A2-3054
