### PR TITLE
fix(infrastructure): removing diagnostic settings

### DIFF
--- a/infrastructure/front-door-web.tf
+++ b/infrastructure/front-door-web.tf
@@ -164,26 +164,3 @@ resource "azurerm_cdn_frontdoor_security_policy" "web" {
     }
   }
 }
-
-# moinitoring
-resource "azurerm_monitor_diagnostic_setting" "web_front_door" {
-  name                       = "${local.org}-fd-mds-${local.service_name}-web-${var.environment}"
-  target_resource_id         = data.azurerm_cdn_frontdoor_profile.shared.id
-  log_analytics_workspace_id = azurerm_log_analytics_workspace.main.id
-  provider                   = azurerm.front_door
-
-  enabled_log {
-    category = "FrontdoorWebApplicationFirewallLog"
-  }
-
-  metric {
-    category = "AllMetrics"
-  }
-
-  lifecycle {
-    ignore_changes = [
-      enabled_log,
-      metric
-    ]
-  }
-}


### PR DESCRIPTION
## Describe your changes

Removing diagnostic setting terraform configurations 

Configuration is added in Frontdoor as logs were duplicated in all the instance
Non-prod front door diagnostic setting: pins-fd-mds-common-tooling

Prod: [PR](https://github.com/Planning-Inspectorate/infrastructure-environments/pull/959)  to create the instance 


<!--
    Please include a summary of the change along with any relevant context.
    List any dependencies that are required for this change.
-->

## Issue ticket number and link
[Ticket](https://pins-ds.atlassian.net/browse/DEV-320)

[Terraform Plan- Dev, Test, training and prod](https://dev.azure.com/planninginspectorate/appeals-back-office/_build/results?buildId=112791&view=logs&j=912cd5a8-ca36-5904-6537-633e2db44bcf&t=3b9b33d7-43b5-59b1-29a3-5cf0cadb8bc7)
