### PR TITLE
chore(appeals): clear local emails on start

### DIFF
--- a/appeals/api/src/server.js
+++ b/appeals/api/src/server.js
@@ -1,6 +1,9 @@
 import { app } from './server/app.js';
 import config from './server/config/config.js';
 import logger from './server/utils/logger.js';
+import initNotify from './server/notify/index.js';
+
+initNotify();
 
 app.listen(config.PORT, () => {
 	logger.info(`Server is live at http://localhost:${config.PORT}`);

--- a/appeals/api/src/server/notify/emulate-notify.js
+++ b/appeals/api/src/server/notify/emulate-notify.js
@@ -2,8 +2,6 @@ import path from 'path';
 import fs from 'fs';
 import { formatSortableDateTime } from '#utils/date-formatter.js';
 
-let notifyCount = 0;
-
 /**
  * Emulate Notify for local dev testing
  * This generates an approximate view of what a completed email will look like sent via notify.
@@ -61,11 +59,6 @@ export function emulateSendEmail(templateName, recipientEmail, subject, content)
 	].join('<br>\n');
 
 	const outputDir = path.join(process.cwd(), 'temp');
-	if (fs.existsSync(outputDir)) {
-		if (!notifyCount) {
-			fs.rmdirSync(outputDir, { recursive: true });
-		}
-	}
 
 	if (!fs.existsSync(outputDir)) {
 		fs.mkdirSync(outputDir, { recursive: true });
@@ -79,6 +72,17 @@ export function emulateSendEmail(templateName, recipientEmail, subject, content)
 
 	const fullName = path.join(process.cwd(), 'temp', fileName);
 	fs.writeFileSync(fullName, emailHtml);
-	notifyCount++;
 	return fullName;
+}
+
+/**
+ * Deletes the local temporary folder and the emails within it
+ *
+ * @returns {void}
+ */
+export function initNotifyEmulator() {
+	const outputDir = path.join(process.cwd(), 'temp');
+	if (fs.existsSync(outputDir)) {
+		fs.rmdirSync(outputDir, { recursive: true });
+	}
 }

--- a/appeals/api/src/server/notify/index.js
+++ b/appeals/api/src/server/notify/index.js
@@ -1,0 +1,8 @@
+import config from '#config/config.js';
+import { initNotifyEmulator } from '#notify/emulate-notify.js';
+
+export default function () {
+	if (config.useNotifyEmulator) {
+		return initNotifyEmulator();
+	}
+}


### PR DESCRIPTION
## Describe your changes

It makes more sense to delete the previous local notify emails stored in the temp folder when starting the api than when the first notify email is created.
