### PR TITLE
fix(api): updating api validator to accept max 8000 chars for extra conditions details

### DIFF
--- a/appeals/api/src/server/endpoints/lpa-questionnaires/lpa-questionnaires.validators.js
+++ b/appeals/api/src/server/endpoints/lpa-questionnaires/lpa-questionnaires.validators.js
@@ -18,6 +18,7 @@ import validateEnumParameter from '#common/validators/enum-parameter.js';
 import validateNumberParameter from '#common/validators/number-parameter.js';
 import validateNumberRangeParameter from '#common/validators/number-range-parameter.js';
 import { APPEAL_CASE_PROCEDURE } from 'pins-data-model';
+import { LENGTH_8000 } from '@pins/appeals/constants/support.js';
 
 const getLPAQuestionnaireValidator = composeMiddleware(
 	validateIdParameter('appealId'),
@@ -59,7 +60,7 @@ const patchLPAQuestionnaireValidator = composeMiddleware(
 	validateBooleanParameter('isCorrectAppealType').optional(),
 	validateNullableTextAreaParameter('siteAccessDetails').optional(),
 	validateNullableTextAreaParameter('siteSafetyDetails').optional(),
-	validateNullableTextAreaParameter('extraConditions').optional(),
+	validateNullableTextAreaParameter('extraConditions', LENGTH_8000).optional(),
 	validateBooleanParameter('affectsScheduledMonument').optional(),
 	validateBooleanParameter('hasProtectedSpecies').optional(),
 	validateBooleanParameter('isAonbNationalLandscape').optional(),

--- a/packages/appeals/constants/support.js
+++ b/packages/appeals/constants/support.js
@@ -266,6 +266,7 @@ export const LENGTH_10 = 10;
 export const LENGTH_250 = 250;
 export const LENGTH_300 = 300;
 export const LENGTH_1000 = 1000;
+export const LENGTH_8000 = 8000;
 
 export const NODE_ENV_PRODUCTION = 'production';
 


### PR DESCRIPTION

## Describe your changes
- Small fix to increase the char limit on the API side for extra condition details 
<!--
    Please include a summary of the change along with any relevant context.
    List any dependencies that are required for this change.
-->

## Issue ticket number and link
[Ticket](https://pins-ds.atlassian.net.mcas.ms/browse/A2-1909)
