### PR TITLE
fix/a2-2778-restore-redact-button-to-review-final-comment-view

### DIFF
--- a/appeals/web/src/server/appeals/appeal-details/representations/final-comments/redact/redact.controller.js
+++ b/appeals/web/src/server/appeals/appeal-details/representations/final-comments/redact/redact.controller.js
@@ -2,7 +2,6 @@ import logger from '#lib/logger.js';
 import { redactFinalCommentPage, confirmRedactFinalCommentPage } from './redact.mapper.js';
 import { redactAndAccept } from '#appeals/appeal-details/representations/representations.service.js';
 import { addNotificationBannerToSession } from '#lib/session-utilities.js';
-import { APPEAL_REPRESENTATION_STATUS } from '@pins/appeals/constants/common.js';
 import { formatFinalCommentsTypeText } from '../view-and-review/view-and-review.mapper.js';
 
 /** @type {import('@pins/express').RequestHandler<Response>}  */
@@ -14,11 +13,6 @@ export const getRedactFinalComment = async (request, response) => {
 		session,
 		params: { finalCommentsType }
 	} = request;
-
-	if (currentRepresentation.status === APPEAL_REPRESENTATION_STATUS.PUBLISHED) {
-		logger.info('returning 404 as final comments cannot be redacted after sharing');
-		return response.status(404).render('app/404.njk');
-	}
 
 	const pageContent = redactFinalCommentPage(
 		currentAppeal,
@@ -41,13 +35,8 @@ export const postRedactFinalComment = async (request, response) => {
 	const {
 		params: { appealId, finalCommentsType },
 		body: { redactedRepresentation },
-		session,
-		currentRepresentation
+		session
 	} = request;
-
-	if (currentRepresentation.status === APPEAL_REPRESENTATION_STATUS.PUBLISHED) {
-		throw new Error('cannot redact a final comment that has already been shared');
-	}
 
 	session.redactedRepresentation = redactedRepresentation;
 

--- a/appeals/web/src/server/appeals/appeal-details/representations/final-comments/view-and-review/__tests__/__snapshots__/view-and-review.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/representations/final-comments/view-and-review/__tests__/__snapshots__/view-and-review.test.js.snap
@@ -294,6 +294,8 @@ exports[`final-comments GET /review-comments with data should render review LPA 
                     <dd class="govuk-summary-list__value">
                         <div class="pins-show-more" data-label="Read more" data-mode="text">Awaiting final comments review</div>
                     </dd>
+                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/final-comments/lpa/redact">Redact<span class="govuk-visually-hidden"> final comments</span></a>
+                    </dd>
                 </div>
                 <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Supporting documents</dt>
                     <dd class="govuk-summary-list__value">
@@ -361,6 +363,8 @@ exports[`final-comments GET /review-comments with data should render review appe
                     <dd class="govuk-summary-list__value">
                         <div class="pins-show-more" data-label="Read more" data-mode="text">Awaiting final comments review</div>
                     </dd>
+                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/final-comments/lpa/redact">Redact<span class="govuk-visually-hidden"> final comments</span></a>
+                    </dd>
                 </div>
                 <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Supporting documents</dt>
                     <dd class="govuk-summary-list__value">No documents</dd>
@@ -415,6 +419,8 @@ exports[`final-comments GET /review-comments with redacted comment should render
                 <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Original final comments</dt>
                     <dd class="govuk-summary-list__value">
                         <div class="pins-show-more" data-label="Read more" data-mode="text">Awaiting final comments review</div>
+                    </dd>
+                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/final-comments/lpa/redact">Redact<span class="govuk-visually-hidden"> final comments</span></a>
                     </dd>
                 </div>
                 <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Redacted comment</dt>
@@ -599,6 +605,8 @@ exports[`final-comments POST /review-comments with data should render review LPA
                 <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Final comments</dt>
                     <dd class="govuk-summary-list__value">
                         <div class="pins-show-more" data-label="Read more" data-mode="text">Awaiting final comments review</div>
+                    </dd>
+                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/final-comments/lpa/redact">Redact<span class="govuk-visually-hidden"> final comments</span></a>
                     </dd>
                 </div>
                 <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Supporting documents</dt>

--- a/appeals/web/src/server/appeals/appeal-details/representations/final-comments/view-and-review/page-components/common.js
+++ b/appeals/web/src/server/appeals/appeal-details/representations/final-comments/view-and-review/page-components/common.js
@@ -1,6 +1,5 @@
 import { buildHtmlList } from '#lib/nunjucks-template-builders/tag-builders.js';
 import { preRenderPageComponents } from '#lib/nunjucks-template-builders/page-component-rendering.js';
-import { APPEAL_REPRESENTATION_STATUS } from '@pins/appeals/constants/common.js';
 import { mapDocumentDownloadUrl } from '#appeals/appeal-documents/appeal-documents.mapper.js';
 import { checkRedactedText } from '#lib/validators/redacted-text.validator.js';
 
@@ -80,17 +79,13 @@ export function generateCommentsSummaryList(appealId, comment) {
 						]
 				  },
 			actions: {
-				items:
-					comment.status === APPEAL_REPRESENTATION_STATUS.PUBLISHED || redactedCommentDifferent ||
-					comment.status === APPEAL_REPRESENTATION_STATUS.AWAITING_REVIEW
-						? []
-						: [
-								{
-									text: 'Redact',
-									href: `/appeals-service/appeal-details/${appealId}/final-comments/${commentTypePath}/redact`,
-									visuallyHiddenText: 'final comments'
-								}
-						  ]
+				items: [
+					{
+						text: 'Redact',
+						href: `/appeals-service/appeal-details/${appealId}/final-comments/${commentTypePath}/redact`,
+						visuallyHiddenText: 'final comments'
+					}
+				]
 			}
 		},
 		...(comment.redactedRepresentation && redactedCommentDifferent


### PR DESCRIPTION

- removed conditions on displaying redact button
- removed 404 catches to allow redacting after sharing
- updated snapshot

https://pins-ds.atlassian.net/browse/A2-2778