### PR TITLE
fix(web): fix back link from allocation specialisms page in review lpa statement flow

### DIFF
--- a/appeals/web/src/server/appeals/appeal-details/representations/lpa-statement/allocation/allocation.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/representations/lpa-statement/allocation/allocation.mapper.js
@@ -91,9 +91,10 @@ export function allocationLevelPage(appealDetails, allocationLevels, sessionData
  * @param {Appeal} appealDetails
  * @param {{ id: number, name: string }[]} specialisms
  * @param {Record<string, string>} sessionData
+ * @param {'valid'|'redact'} flowRoute
  * @returns {PageContent}
  * */
-export function allocationSpecialismsPage(appealDetails, specialisms, sessionData) {
+export function allocationSpecialismsPage(appealDetails, specialisms, sessionData, flowRoute) {
 	// move "General allocation" to the top as per A2-1426
 	let specialismsSorted = specialisms.slice();
 	const generalAllocationIndex = specialisms.findIndex(
@@ -132,7 +133,7 @@ export function allocationSpecialismsPage(appealDetails, specialisms, sessionDat
 
 	return {
 		title: 'Allocation specialisms',
-		backLinkUrl: `/appeals-service/appeal-details/${appealDetails.appealId}/lpa-statement/valid/allocation-level`,
+		backLinkUrl: `/appeals-service/appeal-details/${appealDetails.appealId}/lpa-statement/${flowRoute}/allocation-level`,
 		preHeading: `Appeal ${shortReference}`,
 		heading: 'Allocation specialisms',
 		submitButtonText: 'Continue',

--- a/appeals/web/src/server/appeals/appeal-details/representations/lpa-statement/redact/__tests__/lpa-statement-redact.test.js
+++ b/appeals/web/src/server/appeals/appeal-details/representations/lpa-statement/redact/__tests__/lpa-statement-redact.test.js
@@ -360,6 +360,30 @@ describe('redact', () => {
 			);
 			expect(innerHTML).toContain('Continue</button>');
 		});
+
+		it('should render a back link to the redact journey version of the allocation level page', async () => {
+			nock('http://test/')
+				.get(`/appeals/${appealId}`)
+				.reply(200, {
+					...appealDataFullPlanning,
+					appealId,
+					appealStatus: 'statements'
+				});
+
+			const response = await request.get(
+				`${baseUrl}/${appealId}/lpa-statement/redact/allocation-specialisms`
+			);
+			expect(response.statusCode).toBe(200);
+
+			const { innerHTML } = parseHtml(response.text, {
+				rootElement: 'body',
+				skipPrettyPrint: true
+			});
+
+			expect(innerHTML).toContain(
+				`href="/appeals-service/appeal-details/${appealId}/lpa-statement/redact/allocation-level" class="govuk-back-link"`
+			);
+		});
 	});
 
 	describe('GET /confirm', () => {

--- a/appeals/web/src/server/appeals/appeal-details/representations/lpa-statement/redact/redact.controller.js
+++ b/appeals/web/src/server/appeals/appeal-details/representations/lpa-statement/redact/redact.controller.js
@@ -158,7 +158,8 @@ export async function renderAllocationSpecialisms(request, response) {
 	const pageContent = allocationSpecialismsPage(
 		currentAppeal,
 		specialisms,
-		session.redactLPAStatement
+		session.redactLPAStatement,
+		'redact'
 	);
 
 	return response.status(200).render('patterns/change-page.pattern.njk', {

--- a/appeals/web/src/server/appeals/appeal-details/representations/lpa-statement/valid/__tests__/__snapshots__/lpa-statement-valid.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/representations/lpa-statement/valid/__tests__/__snapshots__/lpa-statement-valid.test.js.snap
@@ -74,3 +74,44 @@ exports[`lpa statement valid GET /allocation-level should render the allocation 
     </div>
 </main>"
 `;
+
+exports[`lpa statement valid GET /allocation-specialisms should render the allocation specialisms page with expected content 1`] = `
+"<main class="govuk-main-wrapper" id="main-content">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Appeal 351062</span>
+            <h1 class="govuk-heading-l">Allocation specialisms</h1>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <div class="govuk-grid-row">
+                <div class="govuk-grid-column-full">
+                    <form method="POST" novalidate="novalidate">
+                        <div class="govuk-form-group">
+                            <div class="govuk-checkboxes" data-module="govuk-checkboxes">
+                                <div class="govuk-checkboxes__item">
+                                    <input class="govuk-checkboxes__input" id="allocationSpecialisms" name="allocationSpecialisms"
+                                    type="checkbox" value="1">
+                                    <label class="govuk-label govuk-checkboxes__label" for="allocationSpecialisms">Specialism 1</label>
+                                </div>
+                                <div class="govuk-checkboxes__item">
+                                    <input class="govuk-checkboxes__input" id="allocationSpecialisms-2" name="allocationSpecialisms"
+                                    type="checkbox" value="2">
+                                    <label class="govuk-label govuk-checkboxes__label" for="allocationSpecialisms-2">Specialism 2</label>
+                                </div>
+                                <div class="govuk-checkboxes__item">
+                                    <input class="govuk-checkboxes__input" id="allocationSpecialisms-3" name="allocationSpecialisms"
+                                    type="checkbox" value="3">
+                                    <label class="govuk-label govuk-checkboxes__label" for="allocationSpecialisms-3">Specialism 3</label>
+                                </div>
+                            </div>
+                        </div>
+                        <button type="submit" data-prevent-double-click="true" class="govuk-button"
+                        data-module="govuk-button">Continue</button>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </div>
+</main>"
+`;

--- a/appeals/web/src/server/appeals/appeal-details/representations/lpa-statement/valid/__tests__/lpa-statement-valid.test.js
+++ b/appeals/web/src/server/appeals/appeal-details/representations/lpa-statement/valid/__tests__/lpa-statement-valid.test.js
@@ -208,4 +208,61 @@ describe('lpa statement valid', () => {
 			);
 		});
 	});
+
+	describe('GET /allocation-specialisms', () => {
+		it('should render the allocation specialisms page with expected content', async () => {
+			nock('http://test/')
+				.get(`/appeals/${appealId}`)
+				.reply(200, {
+					...appealDataFullPlanning,
+					appealId,
+					appealStatus: 'statements'
+				});
+
+			const response = await request.get(
+				`${baseUrl}/${appealId}/lpa-statement/valid/allocation-specialisms`
+			);
+			expect(response.statusCode).toBe(200);
+
+			const { innerHTML } = parseHtml(response.text);
+
+			expect(innerHTML).toMatchSnapshot();
+			expect(innerHTML).toContain('Appeal 351062</span>');
+			expect(innerHTML).toContain(`Allocation specialisms</h1>`);
+			expect(innerHTML).toContain(
+				`<label class="govuk-label govuk-checkboxes__label" for="allocationSpecialisms">Specialism 1</label>`
+			);
+			expect(innerHTML).toContain(
+				`<label class="govuk-label govuk-checkboxes__label" for="allocationSpecialisms-2">Specialism 2</label>`
+			);
+			expect(innerHTML).toContain(
+				`<label class="govuk-label govuk-checkboxes__label" for="allocationSpecialisms-3">Specialism 3</label>`
+			);
+			expect(innerHTML).toContain('Continue</button>');
+		});
+
+		it('should render a back link to the valid journey version of the allocation level page', async () => {
+			nock('http://test/')
+				.get(`/appeals/${appealId}`)
+				.reply(200, {
+					...appealDataFullPlanning,
+					appealId,
+					appealStatus: 'statements'
+				});
+
+			const response = await request.get(
+				`${baseUrl}/${appealId}/lpa-statement/valid/allocation-specialisms`
+			);
+			expect(response.statusCode).toBe(200);
+
+			const { innerHTML } = parseHtml(response.text, {
+				rootElement: 'body',
+				skipPrettyPrint: true
+			});
+
+			expect(innerHTML).toContain(
+				`href="/appeals-service/appeal-details/${appealId}/lpa-statement/valid/allocation-level" class="govuk-back-link"`
+			);
+		});
+	});
 });

--- a/appeals/web/src/server/appeals/appeal-details/representations/lpa-statement/valid/valid.controller.js
+++ b/appeals/web/src/server/appeals/appeal-details/representations/lpa-statement/valid/valid.controller.js
@@ -112,7 +112,8 @@ export async function renderAllocationSpecialisms(request, response) {
 	const pageContent = allocationSpecialismsPage(
 		currentAppeal,
 		specialisms,
-		session.acceptLPAStatement
+		session.acceptLPAStatement,
+		'valid'
 	);
 
 	return response.status(200).render('patterns/change-page.pattern.njk', {


### PR DESCRIPTION
## Describe your changes

Updated allocation specialisms mapper to render the correct back link depending on whether the user is in the accept (valid) or redact and accept version of the review LPA statement flow

## Issue ticket number and link
https://pins-ds.atlassian.net/browse/A2-3052
