### PR TITLE
fix(api): A2-3114 lpaq start email incorrectly sent to appellant instead of lpa

### DIFF
--- a/appeals/api/src/server/endpoints/appeal-timetables/__tests__/appeal-timetables.test.js
+++ b/appeals/api/src/server/endpoints/appeal-timetables/__tests__/appeal-timetables.test.js
@@ -672,7 +672,7 @@ describe('appeal timetables routes', () => {
 					personalisation: {
 						appeal_reference_number: '1345264',
 						appeal_type: 'Householder',
-						appellant_email_address: 'test@136s7.com',
+						appellant_email_address: householdAppeal.appellant.email,
 						comment_deadline: '',
 						due_date: '12 June 2024',
 						final_comments_deadline: '',
@@ -686,7 +686,7 @@ describe('appeal timetables routes', () => {
 						start_date: '5 June 2024',
 						url: 'https://www.gov.uk/appeal-planning-inspectorate'
 					},
-					recipientEmail: 'test@136s7.com',
+					recipientEmail: householdAppeal.appellant.email,
 					templateName: 'appeal-start-date-change-appellant'
 				});
 				// eslint-disable-next-line no-undef
@@ -695,7 +695,7 @@ describe('appeal timetables routes', () => {
 					personalisation: {
 						appeal_reference_number: '1345264',
 						appeal_type: 'Householder',
-						appellant_email_address: 'test@136s7.com',
+						appellant_email_address: householdAppeal.appellant.email,
 						comment_deadline: '',
 						due_date: '12 June 2024',
 						final_comments_deadline: '',
@@ -709,7 +709,7 @@ describe('appeal timetables routes', () => {
 						start_date: '5 June 2024',
 						url: 'https://www.gov.uk/appeal-planning-inspectorate'
 					},
-					recipientEmail: 'test@136s7.com',
+					recipientEmail: householdAppeal.lpa.email,
 					templateName: 'appeal-start-date-change-lpa'
 				});
 			});
@@ -739,7 +739,7 @@ describe('appeal timetables routes', () => {
 					personalisation: {
 						appeal_reference_number: '1345264',
 						appeal_type: 'Householder',
-						appellant_email_address: 'test@136s7.com',
+						appellant_email_address: householdAppeal.appellant.email,
 						comment_deadline: '',
 						due_date: '12 June 2024',
 						final_comments_deadline: '',
@@ -753,7 +753,7 @@ describe('appeal timetables routes', () => {
 						start_date: '5 June 2024',
 						url: 'https://www.gov.uk/appeal-planning-inspectorate'
 					},
-					recipientEmail: 'test@136s7.com',
+					recipientEmail: householdAppeal.appellant.email,
 					templateName: 'appeal-valid-start-case-appellant'
 				});
 				// eslint-disable-next-line no-undef
@@ -762,7 +762,7 @@ describe('appeal timetables routes', () => {
 					personalisation: {
 						appeal_reference_number: '1345264',
 						appeal_type: 'Householder',
-						appellant_email_address: 'test@136s7.com',
+						appellant_email_address: householdAppeal.appellant.email,
 						comment_deadline: '',
 						due_date: '12 June 2024',
 						final_comments_deadline: '',
@@ -776,7 +776,7 @@ describe('appeal timetables routes', () => {
 						start_date: '5 June 2024',
 						url: 'https://www.gov.uk/appeal-planning-inspectorate'
 					},
-					recipientEmail: 'test@136s7.com',
+					recipientEmail: householdAppeal.lpa.email,
 					templateName: 'appeal-valid-start-case-lpa'
 				});
 			});

--- a/appeals/api/src/server/endpoints/appeal-timetables/appeal-timetables.service.js
+++ b/appeals/api/src/server/endpoints/appeal-timetables/appeal-timetables.service.js
@@ -108,7 +108,7 @@ const startCase = async (
 				details: AUDIT_TRAIL_CASE_TIMELINE_CREATED
 			});
 
-			const recipientEmail = appeal.agent?.email || appeal.appellant?.email;
+			const appellantEmail = appeal.appellant?.email || appeal.agent?.email;
 			const lpaEmail = appeal.lpa?.email || '';
 			const { type } = appeal.appealType || {};
 			const appealType = type?.endsWith(' appeal') ? type.replace(' appeal', '') : type;
@@ -119,7 +119,7 @@ const startCase = async (
 				lpa_reference: appeal.applicationReference || '',
 				site_address: siteAddress,
 				start_date: formatDate(new Date(startDate || ''), false),
-				appellant_email_address: recipientEmail || '',
+				appellant_email_address: appellantEmail || '',
 				url: FRONT_OFFICE_URL,
 				appeal_type: appealType || '',
 				procedure_type: PROCEDURE_TYPE_MAP[appeal.procedureType?.key || 'written'],
@@ -135,11 +135,11 @@ const startCase = async (
 				final_comments_deadline: formatDate(new Date(timetable.finalCommentsDueDate || ''), false)
 			};
 
-			if (recipientEmail) {
+			if (appellantEmail) {
 				await notifySend({
 					templateName: appellantTemplate,
 					notifyClient,
-					recipientEmail,
+					recipientEmail: appellantEmail,
 					personalisation: commonEmailVariables
 				});
 			}
@@ -148,7 +148,7 @@ const startCase = async (
 				await notifySend({
 					templateName: lpaTemplate,
 					notifyClient,
-					recipientEmail,
+					recipientEmail: lpaEmail,
 					personalisation: commonEmailVariables
 				});
 			}

--- a/appeals/api/src/server/endpoints/site-visits/__tests__/site-visits.test.js
+++ b/appeals/api/src/server/endpoints/site-visits/__tests__/site-visits.test.js
@@ -322,7 +322,7 @@ describe('site visit routes', () => {
 				// eslint-disable-next-line no-undef
 				expect(mockSendEmail).toHaveBeenCalledWith(
 					config.govNotify.template.siteVisitSchedule.unaccompanied.appellant.id,
-					'test@136s7.com',
+					householdAppeal.agent.email,
 					{
 						emailReplyToId: null,
 						personalisation: {
@@ -373,7 +373,7 @@ describe('site visit routes', () => {
 				// eslint-disable-next-line no-undef
 				expect(mockSendEmail).toHaveBeenCalledWith(
 					config.govNotify.template.siteVisitSchedule.accompanied.appellant.id,
-					'test@136s7.com',
+					householdAppeal.agent.email,
 					{
 						emailReplyToId: null,
 						personalisation: {
@@ -391,7 +391,7 @@ describe('site visit routes', () => {
 				// eslint-disable-next-line no-undef
 				expect(mockSendEmail).toHaveBeenCalledWith(
 					config.govNotify.template.siteVisitSchedule.accompanied.lpa.id,
-					'maid@lpa-email.gov.uk',
+					householdAppeal.lpa.email,
 					{
 						emailReplyToId: null,
 						personalisation: {
@@ -445,7 +445,7 @@ describe('site visit routes', () => {
 				// eslint-disable-next-line no-undef
 				expect(mockSendEmail).toHaveBeenCalledWith(
 					config.govNotify.template.siteVisitSchedule.accessRequired.appellant.id,
-					'test@136s7.com',
+					householdAppeal.agent.email,
 					{
 						emailReplyToId: null,
 						personalisation: {
@@ -1256,7 +1256,7 @@ describe('site visit routes', () => {
 				// eslint-disable-next-line no-undef
 				expect(mockSendEmail).toHaveBeenCalledWith(
 					config.govNotify.template.siteVisitChange.unaccompaniedToAccessRequired.appellant.id,
-					'test@136s7.com',
+					householdAppeal.agent.email,
 					{
 						emailReplyToId: null,
 						personalisation: {
@@ -1332,7 +1332,7 @@ describe('site visit routes', () => {
 				// eslint-disable-next-line no-undef
 				expect(mockSendEmail).toHaveBeenCalledWith(
 					config.govNotify.template.siteVisitChange.accompaniedToUnaccompanied.appellant.id,
-					'test@136s7.com',
+					householdAppeal.agent.email,
 					{
 						emailReplyToId: null,
 						personalisation: {
@@ -1351,7 +1351,7 @@ describe('site visit routes', () => {
 				// eslint-disable-next-line no-undef
 				expect(mockSendEmail).toHaveBeenCalledWith(
 					config.govNotify.template.siteVisitChange.accompaniedToUnaccompanied.lpa.id,
-					'maid@lpa-email.gov.uk',
+					householdAppeal.lpa.email,
 					{
 						emailReplyToId: null,
 						personalisation: {
@@ -1428,7 +1428,7 @@ describe('site visit routes', () => {
 				// eslint-disable-next-line no-undef
 				expect(mockSendEmail).toHaveBeenCalledWith(
 					config.govNotify.template.siteVisitChange.accessRequiredDateChange.appellant.id,
-					'test@136s7.com',
+					householdAppeal.agent.email,
 					{
 						emailReplyToId: null,
 						personalisation: {
@@ -1504,7 +1504,7 @@ describe('site visit routes', () => {
 				// eslint-disable-next-line no-undef
 				expect(mockSendEmail).toHaveBeenCalledWith(
 					config.govNotify.template.siteVisitChange.accompaniedDateChange.appellant.id,
-					'test@136s7.com',
+					householdAppeal.agent.email,
 					{
 						emailReplyToId: null,
 						personalisation: {
@@ -1523,7 +1523,7 @@ describe('site visit routes', () => {
 				// eslint-disable-next-line no-undef
 				expect(mockSendEmail).toHaveBeenCalledWith(
 					config.govNotify.template.siteVisitChange.accompaniedDateChange.lpa.id,
-					'maid@lpa-email.gov.uk',
+					householdAppeal.lpa.email,
 					{
 						emailReplyToId: null,
 						personalisation: {
@@ -1599,7 +1599,7 @@ describe('site visit routes', () => {
 				// eslint-disable-next-line no-undef
 				expect(mockSendEmail).toHaveBeenCalledWith(
 					config.govNotify.template.siteVisitChange.accompaniedToUnaccompanied.appellant.id,
-					'test@136s7.com',
+					householdAppeal.agent.email,
 					{
 						emailReplyToId: null,
 						personalisation: {
@@ -1618,7 +1618,7 @@ describe('site visit routes', () => {
 				// eslint-disable-next-line no-undef
 				expect(mockSendEmail).toHaveBeenCalledWith(
 					config.govNotify.template.siteVisitChange.accompaniedToUnaccompanied.lpa.id,
-					'maid@lpa-email.gov.uk',
+					householdAppeal.lpa.email,
 					{
 						emailReplyToId: null,
 						personalisation: {
@@ -1694,7 +1694,7 @@ describe('site visit routes', () => {
 				// eslint-disable-next-line no-undef
 				expect(mockSendEmail).toHaveBeenCalledWith(
 					config.govNotify.template.siteVisitChange.unaccompaniedToAccompanied.appellant.id,
-					'test@136s7.com',
+					householdAppeal.agent.email,
 					{
 						emailReplyToId: null,
 						personalisation: {
@@ -1713,7 +1713,7 @@ describe('site visit routes', () => {
 				// eslint-disable-next-line no-undef
 				expect(mockSendEmail).toHaveBeenCalledWith(
 					config.govNotify.template.siteVisitChange.unaccompaniedToAccompanied.lpa.id,
-					'maid@lpa-email.gov.uk',
+					householdAppeal.lpa.email,
 					{
 						emailReplyToId: null,
 						personalisation: {
@@ -1790,7 +1790,7 @@ describe('site visit routes', () => {
 				// eslint-disable-next-line no-undef
 				expect(mockSendEmail).toHaveBeenCalledWith(
 					config.govNotify.template.siteVisitChange.accessRequiredToAccompanied.appellant.id,
-					'test@136s7.com',
+					householdAppeal.agent.email,
 					{
 						emailReplyToId: null,
 						personalisation: {
@@ -1809,7 +1809,7 @@ describe('site visit routes', () => {
 				// eslint-disable-next-line no-undef
 				expect(mockSendEmail).toHaveBeenCalledWith(
 					config.govNotify.template.siteVisitChange.accessRequiredToAccompanied.lpa.id,
-					'maid@lpa-email.gov.uk',
+					householdAppeal.lpa.email,
 					{
 						emailReplyToId: null,
 						personalisation: {
@@ -1885,7 +1885,7 @@ describe('site visit routes', () => {
 				// eslint-disable-next-line no-undef
 				expect(mockSendEmail).toHaveBeenCalledWith(
 					config.govNotify.template.siteVisitChange.accompaniedToAccessRequired.appellant.id,
-					'test@136s7.com',
+					householdAppeal.agent.email,
 					{
 						emailReplyToId: null,
 						personalisation: {
@@ -1904,7 +1904,7 @@ describe('site visit routes', () => {
 				// eslint-disable-next-line no-undef
 				expect(mockSendEmail).toHaveBeenCalledWith(
 					config.govNotify.template.siteVisitChange.accompaniedToAccessRequired.lpa.id,
-					'maid@lpa-email.gov.uk',
+					householdAppeal.lpa.email,
 					{
 						emailReplyToId: null,
 						personalisation: {
@@ -1980,7 +1980,7 @@ describe('site visit routes', () => {
 				// eslint-disable-next-line no-undef
 				expect(mockSendEmail).toHaveBeenCalledWith(
 					config.govNotify.template.siteVisitChange.accessRequiredToUnaccompanied.appellant.id,
-					'test@136s7.com',
+					householdAppeal.agent.email,
 					{
 						emailReplyToId: null,
 						personalisation: {
@@ -2057,7 +2057,7 @@ describe('site visit routes', () => {
 				// eslint-disable-next-line no-undef
 				expect(mockSendEmail).toHaveBeenCalledWith(
 					config.govNotify.template.siteVisitChange.unaccompaniedToAccessRequired.appellant.id,
-					'test@136s7.com',
+					householdAppeal.agent.email,
 					{
 						emailReplyToId: null,
 						personalisation: {


### PR DESCRIPTION
## Describe your changes

LPAQ start email now sent to LPA not appellant; updated tests with clearer mock addresses for clarity. 

## Issue ticket number and link
[A2-3114](https://pins-ds.atlassian.net/browse/A2-3114)


[A2-3114]: https://pins-ds.atlassian.net/browse/A2-3114?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ