### PR TITLE
fix(web): remove duplicate hearing estimates heading

### DIFF
--- a/appeals/web/src/server/appeals/appeal-details/__tests__/__snapshots__/appeal-details.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/__tests__/__snapshots__/appeal-details.test.js.snap
@@ -133,7 +133,6 @@ exports[`appeal-details GET /:appealId Hearing should render the Hearing accordi
     draggable="false" class="govuk-button" data-module="govuk-button"> Set up hearing</a>
     <h3     class="govuk-heading-m">Hearing estimates</h3>
         <div>
-            <h3 class="govuk-heading-m">Hearing estimates</h3>
             <p><a id="addHearingEstimates" class="govuk-body govuk-link" href="/appeals-service/appeal-details/3/hearing/estimates/add">Add hearing estimates</a>
             </p>
         </div>

--- a/appeals/web/src/server/lib/mappers/data/appeal/submappers/hearing-add-hearing-estimates.js
+++ b/appeals/web/src/server/lib/mappers/data/appeal/submappers/hearing-add-hearing-estimates.js
@@ -8,6 +8,6 @@ export const mapAddHearingEstimates = ({ currentRoute, userHasUpdateCasePermissi
 	}
 	return simpleHtml({
 		id,
-		content: `<h3 class="govuk-heading-m">Hearing estimates</h3><p><a id="addHearingEstimates" class="govuk-body govuk-link" href="${currentRoute}/hearing/estimates/add">Add hearing estimates</a></p>`
+		content: `<p><a id="addHearingEstimates" class="govuk-body govuk-link" href="${currentRoute}/hearing/estimates/add">Add hearing estimates</a></p>`
 	});
 };


### PR DESCRIPTION
## Describe your changes

The hearing estimates heading was duplicated on the appeal details page when there were no hearing estimates.

## Issue ticket number and link
[A2-2825](https://pins-ds.atlassian.net/browse/A2-2825)


[A2-2825]: https://pins-ds.atlassian.net/browse/A2-2825?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ