### PR TITLE
test(appeals): refactor smoke test & .skip remaining

### DIFF
--- a/appeals/e2e/cypress/e2e/back-office-appeals/linkAppeals.spec.js
+++ b/appeals/e2e/cypress/e2e/back-office-appeals/linkAppeals.spec.js
@@ -23,8 +23,9 @@ describe('link appeals', () => {
 				caseDetailsPage.clickAddLinkedAppeal();
 				caseDetailsPage.fillInput(caseRefToLink);
 				caseDetailsPage.clickButtonByText('Continue');
-				caseDetailsPage.selectRadioButtonByValue('Yes, make this the lead appeal for ' + caseRef);
+				caseDetailsPage.selectRadioButtonByValue(caseRef);
 				caseDetailsPage.clickButtonByText('Continue');
+				caseDetailsPage.clickButtonByText('Add linked appeal');
 				caseDetailsPage.validateBannerMessage(
 					'This appeal is now a child appeal of ' + caseRefToLink
 				);
@@ -41,8 +42,9 @@ describe('link appeals', () => {
 				caseDetailsPage.clickAddLinkedAppeal();
 				caseDetailsPage.fillInput(caseRefToLink);
 				caseDetailsPage.clickButtonByText('Continue');
-				caseDetailsPage.selectRadioButtonByValue('Yes, make this the lead appeal for ' + caseRef);
+				caseDetailsPage.selectRadioButtonByValue(caseRef);
 				caseDetailsPage.clickButtonByText('Continue');
+				caseDetailsPage.clickButtonByText('Add linked appeal');
 				caseDetailsPage.validateBannerMessage(
 					'This appeal is now a child appeal of' + caseRefToLink
 				);
@@ -53,7 +55,7 @@ describe('link appeals', () => {
 		});
 	});
 
-	it('link as a child appeal to a new unlinked appeal', () => {
+	it.skip('link as a child appeal to a new unlinked appeal', () => {
 		cy.createCase().then((caseRef) => {
 			cy.createCase().then((caseRefToLinkAsChild) => {
 				cy.createCase().then((unlinkedCaseRefToLink) => {
@@ -62,8 +64,9 @@ describe('link appeals', () => {
 					caseDetailsPage.clickAddLinkedAppeal();
 					caseDetailsPage.fillInput(caseRefToLinkAsChild);
 					caseDetailsPage.clickButtonByText('Continue');
-					caseDetailsPage.selectRadioButtonByValue('Yes, make this the lead appeal for ' + caseRef);
+					caseDetailsPage.selectRadioButtonByValue(caseRef);
 					caseDetailsPage.clickButtonByText('Continue');
+					caseDetailsPage.clickButtonByText('Add linked appeal');
 					caseDetailsPage.validateBannerMessage(
 						'This appeal is now a child appeal of ' + caseRefToLinkAsChild
 					);
@@ -71,13 +74,16 @@ describe('link appeals', () => {
 					caseDetailsPage.clickAddLinkedAppeal();
 					caseDetailsPage.fillInput(unlinkedCaseRefToLink);
 					caseDetailsPage.clickButtonByText('Continue');
+					caseDetailsPage.selectRadioButtonByValue(unlinkedCaseRefToLink);
+					caseDetailsPage.clickButtonByText('Continue');
+					caseDetailsPage.clickButtonByText('Add linked appeal');
 					caseDetailsPage.verifyWarningText("Link this appeal to your case's lead appeal");
 				});
 			});
 		});
 	});
 
-	it('link as a lead appeal to a new unlinked appeal', () => {
+	it.skip('link as a lead appeal to a new unlinked appeal', () => {
 		cy.createCase().then((caseRef) => {
 			cy.createCase().then((caseRefToLinkAsLead) => {
 				cy.createCase().then((unlinkedCaseRefToLink) => {
@@ -86,8 +92,9 @@ describe('link appeals', () => {
 					caseDetailsPage.clickAddLinkedAppeal();
 					caseDetailsPage.fillInput(caseRefToLinkAsLead);
 					caseDetailsPage.clickButtonByText('Continue');
-					caseDetailsPage.selectRadioButtonByValue('Yes, this is a child appeal of ' + caseRef);
+					caseDetailsPage.selectRadioButtonByValue(caseRef);
 					caseDetailsPage.clickButtonByText('Continue');
+					caseDetailsPage.clickButtonByText('Add linked appeal');
 					caseDetailsPage.validateBannerMessage(
 						'This appeal is now a lead appeal of ' + caseRefToLinkAsLead
 					);
@@ -95,8 +102,9 @@ describe('link appeals', () => {
 					caseDetailsPage.clickAddLinkedAppeal();
 					caseDetailsPage.fillInput(unlinkedCaseRefToLink);
 					caseDetailsPage.clickButtonByText('Continue');
-					caseDetailsPage.selectRadioButtonByValue('Yes, this is a child appeal of ' + caseRef);
+					caseDetailsPage.selectRadioButtonByValue(caseRef);
 					caseDetailsPage.clickButtonByText('Continue');
+					caseDetailsPage.clickButtonByText('Add linked appeal');
 					caseDetailsPage.validateBannerMessage(
 						'This appeal is now the lead for appeal ' + caseRef
 					);
@@ -105,7 +113,7 @@ describe('link appeals', () => {
 		});
 	});
 
-	it('link as a lead appeal to an existing child appeal', () => {
+	it.skip('link as a lead appeal to an existing child appeal', () => {
 		cy.createCase().then((caseRefToLinkAsLead) => {
 			cy.createCase().then((caseRefToLinkAsChild) => {
 				cy.createCase().then((caseRefToLinkAsSecondLead) => {
@@ -148,7 +156,7 @@ describe('link appeals', () => {
 		});
 	});
 
-	it('link as a lead appeal to an existing lead appeal', () => {
+	it.skip('link as a lead appeal to an existing lead appeal', () => {
 		cy.createCase().then((caseRefToLinkAsLead) => {
 			cy.createCase().then((caseRefToLinkAsChild) => {
 				cy.createCase().then((caseRefToLinkAsSecondLead) => {
@@ -189,7 +197,7 @@ describe('link appeals', () => {
 		});
 	});
 
-	it('link as a child appeal to an existing child appeal', () => {
+	it.skip('link as a child appeal to an existing child appeal', () => {
 		cy.createCase().then((caseRefToLinkAsLead) => {
 			cy.createCase().then((caseRefToLinkAsChild) => {
 				cy.createCase().then((caseRefToLinkAsSecondLead) => {
@@ -232,7 +240,7 @@ describe('link appeals', () => {
 		});
 	});
 
-	it('link to an appeal that is already linked to this appeal', () => {
+	it.skip('link to an appeal that is already linked to this appeal', () => {
 		cy.createCase().then((caseRef) => {
 			cy.createCase().then((caseRefToLink) => {
 				happyPathHelper.assignCaseOfficer(caseRef);
@@ -254,7 +262,7 @@ describe('link appeals', () => {
 		});
 	});
 
-	it('link a back office appeal to a horizon appeal', () => {
+	it.skip('link a back office appeal to a horizon appeal', () => {
 		const horizonAppealId =
 			Cypress.config('apiBaseUrl').indexOf('test') > -1
 				? horizonTestAppeals.horizonAppealTest


### PR DESCRIPTION
Linked appeals are being redeveloped and the existing tests are no longer fit for purpose.

Refactored two basic tests that check an appeal can be linked and selected from case details but skipping the rest until dev work is complete.

[Ticket](https://pins-ds.atlassian.net/browse/A2-3217)
