### PR TITLE
Feat/a2 3108 issue decission flow upload screen

### DIFF
--- a/appeals/e2e/cypress/e2e/back-office-appeals/progressS78ToDecision.spec.js
+++ b/appeals/e2e/cypress/e2e/back-office-appeals/progressS78ToDecision.spec.js
@@ -68,7 +68,7 @@ describe('Progress S78 to decision', () => {
 			caseDetailsPage.clickIssueDecision(caseRef);
 			caseDetailsPage.selectRadioButtonByValue(caseDetailsPage.exactMatch('Allowed'));
 			caseDetailsPage.clickButtonByText('Continue');
-			caseDetailsPage.uploadSampleFile(caseDetailsPage.sampleFiles.document);
+			caseDetailsPage.uploadSampleFile(caseDetailsPage.sampleFiles.pdf);
 			caseDetailsPage.clickButtonByText('Continue');
 			dateTimeSection.enterDecisionLetterDate(new Date());
 			caseDetailsPage.clickButtonByText('Continue');

--- a/appeals/web/src/server/appeals/appeal-details/issue-decision/__tests__/__snapshots__/issue-decision.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/issue-decision/__tests__/__snapshots__/issue-decision.test.js.snap
@@ -181,37 +181,26 @@ exports[`issue-decision GET /decision-letter-upload should render the decision l
     </div>
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Appeal 351062</span>
-            <h1 class="govuk-heading-l">Upload decision letter</h1>
+            <h1 class="govuk-heading-l">Decision letter</h1>
         </div>
     </div>
-    <div class="govuk-warning-text"><span class="govuk-warning-text__icon" aria-hidden="true">!</span>
-        <strong         class="govuk-warning-text__text"><span class="govuk-visually-hidden">Warning</span> Before uploading, check
-            that you have:</strong>
-    </div>
-    <ul class="govuk-list govuk-list--bullet">
-        <li>added the correct appeal reference</li>
-        <li>added the decision date and visit date</li>
-        <li>added the correct site address</li>
-        <li>added the decision to the top and bottom of the letter</li>
-        <li>signed the letter</li>
-    </ul>
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-full">
             <div class="govuk-grid-row pins-file-upload" data-next-page-url="/appeals-service/appeal-details/1/issue-decision/decision-letter-date"
             data-form-id="1" data-case-id="1" data-case-reference="APP/Q9999/D/21/351062"
             data-folder-id="123" data-document-type="caseDecisionLetter" data-document-stage="appeal-decision"
             data-blob-storage-host="https://127.0.0.1:10000/devstoreaccount1" data-blob-storage-container="document-service-uploads"
-            data-allowed-types="application/pdf,application/msword,application/vnd.openxmlformats-officedocument.wordprocessingml.document,application/vnd.ms-powerpoint,application/vnd.openxmlformats-officedocument.presentationml.presentation,application/vnd.ms-excel,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,application/vnd.ms-outlook,image/jpeg,image/jpeg,video/mpeg,audio/mpeg,video/mp4,video/quicktime,image/png,image/tiff,image/tiff"
-            data-formatted-allowed-types="PDF, DOC, DOCX, PPT, PPTX, XLS, XLSX, MSG, JPG, JPEG, MPEG, MP3, MP4, MOV, PNG, TIF or TIFF">
+            data-document-title="decision letter" data-allowed-types="application/pdf"
+            data-formatted-allowed-types="PDF">
                 <form method="POST" novalidate="novalidate" class="govuk-grid-column-two-thirds"
                 data-filenames-in-folder="">
                     <div class="pins-file-upload__container">
-                        <div class="govuk-body pins-file-upload__instructions"><span>The file must be a PDF, DOC, DOCX, PPT, PPTX, XLS, XLSX, MSG, JPG, JPEG, MPEG, MP3, MP4, MOV, PNG, TIF or TIFF and smaller than 25MB.</span>
+                        <div class="govuk-body pins-file-upload__instructions"><span>The file must be a PDF and smaller than 25MB.</span>
                         </div>
                         <div class="middle-errors-hook">
                             <h2 class="pins-file-upload__container-title">Upload decision letter</h2>
                             <div class="pins-file-upload__upload">
-                                <input class="display--none" id="upload-file-1" accept="application/pdf,application/msword,application/vnd.openxmlformats-officedocument.wordprocessingml.document,application/vnd.ms-powerpoint,application/vnd.openxmlformats-officedocument.presentationml.presentation,application/vnd.ms-excel,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,application/vnd.ms-outlook,image/jpeg,image/jpeg,video/mpeg,audio/mpeg,video/mp4,video/quicktime,image/png,image/tiff,image/tiff"
+                                <input class="display--none" id="upload-file-1" accept="application/pdf"
                                 type="file" name="files" value="Choose file" aria-controls="file-list-1">
                                 <div>
                                     <button type='button' class="pins-file-upload__button govuk-button--secondary"

--- a/appeals/web/src/server/appeals/appeal-details/issue-decision/__tests__/__snapshots__/issue-decision.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/issue-decision/__tests__/__snapshots__/issue-decision.test.js.snap
@@ -271,6 +271,13 @@ exports[`issue-decision GET /issue-decision/check-your-decision should render th
                         <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/issue-decision/decision">Change<span class="govuk-visually-hidden"> decision</span></a>
                         </dd>
                     </div>
+                    <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Decision letter</dt>
+                        <dd class="govuk-summary-list__value"><a class="govuk-link" download href="/documents/APP/Q9999/D/21/351062/download-uncommitted/1/test-document.pdf"
+                            target="_blank">test-document.pdf</a>
+                        </dd>
+                        <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/issue-decision/decision-letter-upload">Change<span class="govuk-visually-hidden"> decision letter</span></a>
+                        </dd>
+                    </div>
                 </dl>
                 <button type="submit" class="govuk-button" data-module="govuk-button">Send decision</button>
             </form>

--- a/appeals/web/src/server/appeals/appeal-details/issue-decision/__tests__/issue-decision.test.js
+++ b/appeals/web/src/server/appeals/appeal-details/issue-decision/__tests__/issue-decision.test.js
@@ -64,7 +64,7 @@ describe('issue-decision', () => {
 				.expect(302);
 
 			expect(response.headers.location).toBe(
-				'/appeals-service/appeal-details/1/issue-decision/check-your-decision'
+				'/appeals-service/appeal-details/1/issue-decision/decision-letter-upload'
 			);
 		});
 
@@ -75,7 +75,7 @@ describe('issue-decision', () => {
 				.expect(302);
 
 			expect(response.headers.location).toBe(
-				'/appeals-service/appeal-details/1/issue-decision/check-your-decision'
+				'/appeals-service/appeal-details/1/issue-decision/decision-letter-upload'
 			);
 		});
 
@@ -86,7 +86,7 @@ describe('issue-decision', () => {
 				.expect(302);
 
 			expect(response.headers.location).toBe(
-				'/appeals-service/appeal-details/1/issue-decision/check-your-decision'
+				'/appeals-service/appeal-details/1/issue-decision/decision-letter-upload'
 			);
 		});
 
@@ -97,7 +97,7 @@ describe('issue-decision', () => {
 				.expect(302);
 
 			expect(response.headers.location).toBe(
-				'/appeals-service/appeal-details/1/issue-decision/check-your-decision'
+				'/appeals-service/appeal-details/1/issue-decision/decision-letter-upload'
 			);
 		});
 	});
@@ -112,23 +112,6 @@ describe('issue-decision', () => {
 			expect(element.innerHTML).toMatchSnapshot();
 
 			const unprettifiedElement = parseHtml(response.text, { skipPrettyPrint: true });
-
-			expect(unprettifiedElement.innerHTML).toContain('Upload decision letter</h1>');
-
-			expect(unprettifiedElement.innerHTML).toContain(
-				'Warning</span> Before uploading, check that you have:'
-			);
-			expect(unprettifiedElement.innerHTML).toContain(
-				'<li>added the correct appeal reference</li>'
-			);
-			expect(unprettifiedElement.innerHTML).toContain(
-				'<li>added the decision date and visit date</li>'
-			);
-			expect(unprettifiedElement.innerHTML).toContain('<li>added the correct site address</li>');
-			expect(unprettifiedElement.innerHTML).toContain(
-				'<li>added the decision to the top and bottom of the letter</li>'
-			);
-			expect(unprettifiedElement.innerHTML).toContain('<li>signed the letter</li>');
 
 			expect(unprettifiedElement.innerHTML).toContain(
 				'<div class="govuk-grid-row pins-file-upload"'

--- a/appeals/web/src/server/appeals/appeal-details/issue-decision/__tests__/issue-decision.test.js
+++ b/appeals/web/src/server/appeals/appeal-details/issue-decision/__tests__/issue-decision.test.js
@@ -113,10 +113,13 @@ describe('issue-decision', () => {
 
 			const unprettifiedElement = parseHtml(response.text, { skipPrettyPrint: true });
 
+			expect(unprettifiedElement.innerHTML).toContain('Decision letter</h1>');
+			expect(unprettifiedElement.innerHTML).toContain('Upload decision letter</h2>');
 			expect(unprettifiedElement.innerHTML).toContain(
 				'<div class="govuk-grid-row pins-file-upload"'
 			);
 			expect(unprettifiedElement.innerHTML).toContain('Choose file</button>');
+			expect(unprettifiedElement.innerHTML).toContain('or drop file</span>');
 		});
 	});
 
@@ -175,7 +178,7 @@ describe('issue-decision', () => {
 
 			expect(response.statusCode).toBe(302);
 			expect(response.text).toBe(
-				'Found. Redirecting to /appeals-service/appeal-details/1/issue-decision/decision-letter-date'
+				'Found. Redirecting to /appeals-service/appeal-details/1/issue-decision/check-your-decision'
 			);
 		});
 	});
@@ -530,7 +533,8 @@ describe('issue-decision', () => {
 			uploadDecisionLetterResponse = await request
 				.post(`${baseUrl}/1${issueDecisionPath}/${decisionLetterUploadPath}`)
 				.send({
-					'upload-info': fileUploadInfo
+					'upload-info':
+						'[{"name": "test-document.pdf", "GUID": "1", "blobStoreUrl": "/", "mimeType": "pdf", "documentType": "caseDecisionLetter", "size": 1, "stage": "appellant-case"}]'
 				});
 
 			const mockLetterDecisionDate = {
@@ -558,6 +562,9 @@ describe('issue-decision', () => {
 			expect(element.innerHTML).toMatchSnapshot();
 			expect(element.innerHTML).toContain('Check details and issue decision</h1>');
 			expect(element.innerHTML).toContain('Decision</dt>');
+			expect(element.innerHTML).toContain('Allowed</dd>');
+			expect(element.innerHTML).toContain('Decision letter</dt>');
+			expect(element.innerHTML).toContain('test-document.pdf</a>');
 			expect(element.innerHTML).toContain('Send decision</button>');
 		});
 	});

--- a/appeals/web/src/server/appeals/appeal-details/issue-decision/issue-decision.controller.js
+++ b/appeals/web/src/server/appeals/appeal-details/issue-decision/issue-decision.controller.js
@@ -92,7 +92,8 @@ export const postDecisionLetterUpload = async (request, response) => {
 	await postDocumentUpload({
 		request,
 		response,
-		nextPageUrl: `/appeals-service/appeal-details/${currentAppeal.appealId}/issue-decision/decision-letter-date`
+		nextPageUrl: `/appeals-service/appeal-details/${currentAppeal.appealId}/issue-decision/check-your-decision`
+		// nextPageUrl: `/appeals-service/appeal-details/${currentAppeal.appealId}/issue-decision/decision-letter-date`
 	});
 };
 

--- a/appeals/web/src/server/appeals/appeal-details/issue-decision/issue-decision.controller.js
+++ b/appeals/web/src/server/appeals/appeal-details/issue-decision/issue-decision.controller.js
@@ -5,7 +5,6 @@ import {
 	dateDecisionLetterPage,
 	issueDecisionPage,
 	mapDecisionOutcome,
-	decisionLetterUploadPageBodyComponents,
 	invalidReasonPage,
 	checkAndConfirmInvalidPage
 } from './issue-decision.mapper.js';
@@ -43,7 +42,7 @@ export const postIssueDecision = async (request, response) => {
 	};
 
 	return response.redirect(
-		`/appeals-service/appeal-details/${params.appealId}/issue-decision/check-your-decision`
+		`/appeals-service/appeal-details/${params.appealId}/issue-decision/decision-letter-upload`
 	);
 };
 
@@ -110,17 +109,17 @@ export const renderDecisionLetterUpload = async (request, response) => {
 		path: `${APPEAL_CASE_STAGE.APPEAL_DECISION}/${APPEAL_DOCUMENT_TYPE.CASE_DECISION_LETTER}`
 	};
 
-	const pageBodyComponents = decisionLetterUploadPageBodyComponents();
-
 	await renderDocumentUpload({
 		request,
 		response,
 		appealDetails: currentAppeal,
 		backButtonUrl: `/appeals-service/appeal-details/${request.params.appealId}/issue-decision/decision`,
 		nextPageUrl: `/appeals-service/appeal-details/${request.params.appealId}/issue-decision/decision-letter-date`,
-		pageHeadingTextOverride: 'Upload decision letter',
-		pageBodyComponents,
-		allowMultipleFiles: false
+		pageHeadingTextOverride: 'Decision letter',
+		uploadContainerHeadingTextOverride: 'Upload decision letter',
+		documentTitle: 'decision letter',
+		allowMultipleFiles: false,
+		allowedTypes: ['pdf']
 	});
 };
 

--- a/appeals/web/src/server/appeals/appeal-details/issue-decision/issue-decision.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/issue-decision/issue-decision.mapper.js
@@ -127,34 +127,6 @@ export function issueDecisionPage(appealDetails, inspectorDecision, backUrl) {
 }
 
 /**
- * @returns {PageComponent[]}
- */
-export function decisionLetterUploadPageBodyComponents() {
-	const checklistHtml = `<ul class="govuk-list govuk-list--bullet">
-	<li>added the correct appeal reference</li>
-	<li>added the decision date and visit date</li>
-	<li>added the correct site address</li>
-	<li>added the decision to the top and bottom of the letter</li>
-	<li>signed the letter</li>
-</ul>`;
-
-	return [
-		{
-			type: 'warning-text',
-			parameters: {
-				text: 'Before uploading, check that you have:'
-			}
-		},
-		{
-			type: 'html',
-			parameters: {
-				html: checklistHtml
-			}
-		}
-	];
-}
-
-/**
  *
  * @param {Appeal} appealData
  * @param {string} decisionLetterDay


### PR DESCRIPTION
## Describe your changes
#### Issuing decision flow - Part 2 (a2-3108)

### WEB:
- Updated issue decision controller to pass text overrides to the upload page and specify pdf files only.
- Remove redundant components from issue decision upload page.
- Add Decision Letter row to the check and confirm page.

### TEST:
- Updated tests and associated snapshots
- Made sure all unit tests pass
- Manually tested within browser

## Issue ticket number and link
[Issuing decision flow - Part 2 - 'Decision letter' upload screen for 'Allowed', 'Dismissed' and 'Split decision' outcomes (A2-3108)](https://pins-ds.atlassian.net/browse/A2-3108)
