### PR TITLE
fix(web): format days correctly for hearing estimates

### DIFF
--- a/appeals/web/src/server/appeals/appeal-details/__tests__/__snapshots__/appeal-details.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/__tests__/__snapshots__/appeal-details.test.js.snap
@@ -131,6 +131,33 @@ exports[`appeal-details GET /:appealId Hearing should render the Hearing accordi
 </div>"
 `;
 
+exports[`appeal-details GET /:appealId Hearing should render the Hearing estimates summary list when estimates are present 1`] = `
+"<div id="case-details-hearing-section"><a href="/appeals-service/appeal-details/3/hearing/setup" role="button"
+    draggable="false" class="govuk-button" data-module="govuk-button"> Set up hearing</a>
+    <h3     class="govuk-heading-m">Hearing estimates</h3>
+        <dl class="govuk-summary-list">
+            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Preparation time</dt>
+                <dd class="govuk-summary-list__value">1 day</dd>
+                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/3/hearing/estimates/change"
+                    data-cy="change-preparation-time">Change<span class="govuk-visually-hidden"> Preparation time</span></a>
+                </dd>
+            </div>
+            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Sitting time</dt>
+                <dd class="govuk-summary-list__value">2.5 days</dd>
+                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/3/hearing/estimates/change"
+                    data-cy="change-sitting-time">Change<span class="govuk-visually-hidden"> Sitting time</span></a>
+                </dd>
+            </div>
+            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Reporting time</dt>
+                <dd class="govuk-summary-list__value">3 days</dd>
+                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/3/hearing/estimates/change"
+                    data-cy="change-reporting-time">Change<span class="govuk-visually-hidden"> Reporting time</span></a>
+                </dd>
+            </div>
+        </dl>
+</div>"
+`;
+
 exports[`appeal-details GET /:appealId Notification banners should render a "Appeal ready for validation" important notification banner with a link to validate the appeal when the appeal status is "validation" 1`] = `
 "<div class="govuk-notification-banner govuk-!-margin-bottom-5" role="region"
 aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner"

--- a/appeals/web/src/server/appeals/appeal-details/__tests__/appeal-details.test.js
+++ b/appeals/web/src/server/appeals/appeal-details/__tests__/appeal-details.test.js
@@ -2849,6 +2849,59 @@ describe('appeal-details', () => {
 					`href="/appeals-service/appeal-details/${appealId}/hearing/estimates/add">Add hearing estimates</a>`
 				);
 			});
+
+			it('should render the Hearing estimates summary list when estimates are present', async () => {
+				nock('http://test/')
+					.get(`/appeals/${appealId}`)
+					.reply(200, {
+						...appealDataFullPlanning,
+						appealId,
+						procedureType: APPEAL_CASE_PROCEDURE.HEARING,
+						hearingEstimate: {
+							preparationTime: 1,
+							sittingTime: 2.5,
+							reportingTime: 3
+						}
+					});
+
+				const response = await request.get(`${baseUrl}/${appealId}`);
+
+				expect(response.statusCode).toBe(200);
+
+				const unprettifiedHTML = parseHtml(response.text, { skipPrettyPrint: true }).innerHTML;
+
+				expect(unprettifiedHTML).toContain('Case details</h1>');
+				expect(unprettifiedHTML).toContain('<div id="case-details-hearing-section">');
+				expect(unprettifiedHTML).toContain('Hearing</span></h2>');
+
+				const hearingSectionHtml = parseHtml(response.text, {
+					rootElement: '#case-details-hearing-section'
+				}).innerHTML;
+
+				expect(hearingSectionHtml).toMatchSnapshot();
+
+				const unprettifiedHearingSectionHtml = parseHtml(response.text, {
+					rootElement: '#case-details-hearing-section',
+					skipPrettyPrint: true
+				}).innerHTML;
+
+				expect(unprettifiedHearingSectionHtml).toContain(
+					`href="/appeals-service/appeal-details/${appealId}/hearing/setup" role="button" draggable="false" class="govuk-button" data-module="govuk-button"> Set up hearing</a>`
+				);
+				expect(unprettifiedHearingSectionHtml).toContain('Hearing estimates</h3>');
+				expect(unprettifiedHearingSectionHtml).toContain(
+					'<dd class="govuk-summary-list__value"> 1 day</dd>'
+				);
+				expect(unprettifiedHearingSectionHtml).toContain(
+					'<dd class="govuk-summary-list__value"> 2.5 days</dd>'
+				);
+				expect(unprettifiedHearingSectionHtml).toContain(
+					'<dd class="govuk-summary-list__value"> 3 days</dd>'
+				);
+				expect(unprettifiedHearingSectionHtml).toContain(
+					`<dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/${appealId}/hearing/estimates/change"`
+				);
+			});
 		});
 
 		describe('Costs', () => {

--- a/appeals/web/src/server/appeals/appeal-details/hearing/estimates/__tests__/__snapshots__/estimates.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/hearing/estimates/__tests__/__snapshots__/estimates.test.js.snap
@@ -20,13 +20,13 @@ exports[`add estimates GET /hearing/estimates/add/check-details should match the
                                     </dd>
                             </div>
                             <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Estimated sitting time</dt>
-                                <dd class="govuk-summary-list__value">2.0 days</dd>
+                                <dd class="govuk-summary-list__value">2 days</dd>
                                 <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/hearing/estimates/add/timings"
                                     data-cy="change-estimated-sitting-time">Change<span class="govuk-visually-hidden"> Estimated sitting time</span></a>
                                 </dd>
                             </div>
                             <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Estimated reporting time</dt>
-                                <dd                                 class="govuk-summary-list__value">1.0 days</dd>
+                                <dd                                 class="govuk-summary-list__value">1 day</dd>
                                     <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/hearing/estimates/add/timings"
                                         data-cy="change-estimated-reporting-time">Change<span class="govuk-visually-hidden"> Estimated reporting time</span></a>
                                     </dd>
@@ -108,13 +108,13 @@ exports[`change estimates GET /hearing/estimates/change/check-details should mat
                                     </dd>
                             </div>
                             <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Estimated sitting time</dt>
-                                <dd class="govuk-summary-list__value">2.0 days</dd>
+                                <dd class="govuk-summary-list__value">2 days</dd>
                                 <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/hearing/estimates/change/timings"
                                     data-cy="change-estimated-sitting-time">Change<span class="govuk-visually-hidden"> Estimated sitting time</span></a>
                                 </dd>
                             </div>
                             <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Estimated reporting time</dt>
-                                <dd                                 class="govuk-summary-list__value">1.0 days</dd>
+                                <dd                                 class="govuk-summary-list__value">1 day</dd>
                                     <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/hearing/estimates/change/timings"
                                         data-cy="change-estimated-reporting-time">Change<span class="govuk-visually-hidden"> Estimated reporting time</span></a>
                                     </dd>

--- a/appeals/web/src/server/appeals/appeal-details/hearing/estimates/estimates.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/hearing/estimates/estimates.mapper.js
@@ -1,4 +1,5 @@
 import { appealShortReference } from '#lib/appeals-formatter.js';
+import { formatDays } from '#lib/dates.js';
 import { capitalize } from 'lodash-es';
 
 /**
@@ -91,12 +92,12 @@ export function checkDetailsPage(appealData, values = {}, action) {
 	const shortAppealReference = appealShortReference(appealData.appealReference);
 
 	const rows = [
-		{ key: 'Estimated preparation time', value: `${values.preparationTime} days` },
-		{ key: 'Estimated sitting time', value: `${values.sittingTime} days` },
-		{ key: 'Estimated reporting time', value: `${values.reportingTime} days` }
+		{ key: 'Estimated preparation time', value: values.preparationTime },
+		{ key: 'Estimated sitting time', value: values.sittingTime },
+		{ key: 'Estimated reporting time', value: values.reportingTime }
 	].map((row) => ({
 		key: { text: row.key },
-		value: { text: row.value },
+		value: { text: formatDays(row.value) },
 		actions: {
 			items: [
 				{

--- a/appeals/web/src/server/lib/dates.js
+++ b/appeals/web/src/server/lib/dates.js
@@ -285,3 +285,19 @@ export const oneMonthBefore = (date) => {
 	dateOneMonthBefore.setMonth(dateOneMonthBefore.getMonth() - 1);
 	return dateOneMonthBefore;
 };
+
+/**
+ * Returns the days with one or no decimal places, followed by 'day' or 'days
+ * @param {string | number | undefined} days
+ * @returns {string}
+ */
+export const formatDays = (days) => {
+	if (typeof days === 'undefined') {
+		return '';
+	}
+
+	const numberOfDays = typeof days === 'string' ? parseFloat(days) : days;
+	const suffix = numberOfDays === 1 ? 'day' : 'days';
+
+	return `${numberOfDays} ${suffix}`;
+};

--- a/appeals/web/src/server/lib/mappers/data/appeal/submappers/hearing-hearing-estimates.js
+++ b/appeals/web/src/server/lib/mappers/data/appeal/submappers/hearing-hearing-estimates.js
@@ -1,3 +1,5 @@
+import { formatDays } from '#lib/dates.js';
+
 /** @type {import('../mapper.js').SubMapper} */
 export const mapHearingEstimates = ({
 	appealDetails,
@@ -29,21 +31,23 @@ export const mapHearingEstimates = ({
 		};
 	};
 
+	const { preparationTime, sittingTime, reportingTime } = appealDetails.hearingEstimate || {};
+
 	/** @type {SummaryListRowProperties[]} */
 	const rows = [
 		{
 			key: { text: 'Preparation time' },
-			value: { text: `${appealDetails.hearingEstimate?.preparationTime} days` },
+			value: { text: formatDays(preparationTime) },
 			...actions('Preparation time')
 		},
 		{
 			key: { text: 'Sitting time' },
-			value: { text: `${appealDetails.hearingEstimate?.sittingTime} days` },
+			value: { text: formatDays(sittingTime) },
 			...actions('Sitting time')
 		},
 		{
 			key: { text: 'Reporting time' },
-			value: { text: `${appealDetails.hearingEstimate?.reportingTime} days` },
+			value: { text: formatDays(reportingTime) },
 			...actions('Reporting time')
 		}
 	];


### PR DESCRIPTION
## Describe your changes

On both they check your answers page and the appeal details page, the hearing estimates summary list should format the days with either one decimal place or none (i.e. 2 or 2.5), and the suffix should be 'day' instead of 'days' if it is exactly one day.

## Issue ticket number and link

[A2-2825](https://pins-ds.atlassian.net.mcas.ms/browse/A2-2825?McasTsid=20596&McasCtx=4)


[A2-2825]: https://pins-ds.atlassian.net/browse/A2-2825?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ