### PR TITLE
chore(api): remove temp migration table for listed buildings

### DIFF
--- a/appeals/api/src/database/migrations/20250508154541_remove_temp_listed_buildings_table/migration.sql
+++ b/appeals/api/src/database/migrations/20250508154541_remove_temp_listed_buildings_table/migration.sql
@@ -1,0 +1,25 @@
+/*
+  Warnings:
+
+  - You are about to drop the `MigrateListedBuildingSelected` table. If the table is not empty, all the data it contains will be lost.
+
+*/
+BEGIN TRY
+
+BEGIN TRAN;
+
+-- DropTable
+DROP TABLE [dbo].[MigrateListedBuildingSelected];
+
+COMMIT TRAN;
+
+END TRY
+BEGIN CATCH
+
+IF @@TRANCOUNT > 0
+BEGIN
+    ROLLBACK TRAN;
+END;
+THROW
+
+END CATCH

--- a/appeals/api/src/database/schema.prisma
+++ b/appeals/api/src/database/schema.prisma
@@ -823,15 +823,6 @@ model ListedBuilding {
   selected  ListedBuildingSelected[]
 }
 
-/// Temporary migration storage for ListedBuildingSelected
-model MigrateListedBuildingSelected {
-  lpaQuestionnaireId    Int
-  listEntry             String
-  affectsListedBuilding Boolean
-
-  @@id([lpaQuestionnaireId, listEntry])
-}
-
 /// AppealNotification model
 /// Stores a log of sent notifications
 model AppealNotification {

--- a/appeals/api/src/database/seed/seed-listed-buildings.js
+++ b/appeals/api/src/database/seed/seed-listed-buildings.js
@@ -23,16 +23,6 @@ export const importListedBuildingsDataset = async (url) => {
 			if (response.body) {
 				const totalRecords = await importListedBuildings(Readable.from(response.body));
 				console.log(`\n\nComplete! ${totalRecords} records imported.`);
-
-				// Migration code - could be removed in the future, together with the MigrateListedBuildingSelected table
-				const migrateSQL = `INSERT INTO [dbo].[ListedBuildingSelected]
-						SELECT * FROM [dbo].[MigrateListedBuildingSelected]
-						WHERE [listEntry] IN (SELECT [reference] FROM [dbo].[ListedBuilding])
-						AND [lpaQuestionnaireId] IN (SELECT [id] FROM [dbo].[LpaQuestionnaire]);
-
-						DELETE FROM [dbo].[MigrateListedBuildingSelected];`;
-
-				await databaseConnector.$executeRawUnsafe(migrateSQL);
 			}
 		});
 	}


### PR DESCRIPTION
Removes a DB temp table used to migrate listed building data
Removes the code used to feed the table through db:seed 
