### PR TITLE
fix(api): deletes hearing and hearing estimate data when seeding

### DIFF
--- a/appeals/api/src/database/seed/seed-clear.js
+++ b/appeals/api/src/database/seed/seed-clear.js
@@ -64,6 +64,8 @@ export async function deleteAllRecords(databaseConnector) {
 	const deleteLPAQSelectedDesignatedNames = databaseConnector.designatedSiteSelected.deleteMany();
 	const deleteAllDesignatedNames = databaseConnector.designatedSite.deleteMany();
 	const deleteAllNotifications = databaseConnector.appealNotification.deleteMany();
+	const deleteHearings = databaseConnector.hearing.deleteMany();
+	const deleteHearingEstimates = databaseConnector.hearingEstimate.deleteMany();
 
 	await databaseConnector.$queryRawUnsafe(`
 		UPDATE Document SET latestVersionId = NULL;
@@ -79,7 +81,9 @@ export async function deleteAllRecords(databaseConnector) {
 		deleteDecisions,
 		deleteDocAudits,
 		deleteAudits,
-		deleteAllNotifications
+		deleteAllNotifications,
+		deleteHearings,
+		deleteHearingEstimates
 	]);
 
 	await batchDelete(


### PR DESCRIPTION
Fixes the seed routine by clearing data in the new tables Hearing and HearingEstimate.
