### PR TITLE
fix(web): improve hearing date/time error messages and add default time

### DIFF
--- a/appeals/web/src/server/appeals/appeal-details/hearing/setup/__tests__/__snapshots__/set-up-hearing.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/hearing/setup/__tests__/__snapshots__/set-up-hearing.test.js.snap
@@ -141,7 +141,7 @@ exports[`set up hearing GET /hearing/setup/date should match the snapshot 1`] = 
                                     <div class="govuk-form-group">
                                         <label class="govuk-label" for="hearing-time-hour">Hour</label>
                                         <input class="govuk-input govuk-input--width-2" id="hearing-time-hour"
-                                        name="hearing-time-hour" type="text" value="">
+                                        name="hearing-time-hour" type="text" value="10">
                                     </div>
                                 </div>
                                 <div class="govuk-date-input__item govuk-!-font-size-19 govuk-!-padding-0 govuk-!-margin-right-1">:</div>
@@ -149,7 +149,7 @@ exports[`set up hearing GET /hearing/setup/date should match the snapshot 1`] = 
                                     <div class="govuk-form-group">
                                         <label class="govuk-label" for="hearing-time-minute">Minute</label>
                                         <input class="govuk-input govuk-input--width-2" id="hearing-time-minute"
-                                        name="hearing-time-minute" type="text" value="">
+                                        name="hearing-time-minute" type="text" value="00">
                                     </div>
                                 </div>
                             </div>

--- a/appeals/web/src/server/appeals/appeal-details/hearing/setup/__tests__/set-up-hearing.test.js
+++ b/appeals/web/src/server/appeals/appeal-details/hearing/setup/__tests__/set-up-hearing.test.js
@@ -151,7 +151,7 @@ describe('set up hearing', () => {
 			}).innerHTML;
 
 			expect(errorSummaryHtml).toContain('There is a problem</h2>');
-			expect(errorSummaryHtml).toContain('Date must include a day, a month and a year');
+			expect(errorSummaryHtml).toContain('Hearing date must include a day, a month and a year');
 		});
 
 		it('should return 400 on date in the past with appropriate error message', async () => {
@@ -191,8 +191,9 @@ describe('set up hearing', () => {
 			}).innerHTML;
 
 			expect(errorSummaryHtml).toContain('There is a problem</h2>');
-			expect(errorSummaryHtml).toContain('The hour cannot be less than 0 or greater than 23');
-			expect(errorSummaryHtml).toContain('The minute cannot be less than 0 or greater than 59');
+			expect(errorSummaryHtml).toContain(
+				'Hearing time hour cannot be less than 0 or greater than 23'
+			);
 		});
 
 		it('should return 400 on missing time with appropriate error message', async () => {
@@ -210,8 +211,7 @@ describe('set up hearing', () => {
 			}).innerHTML;
 
 			expect(errorSummaryHtml).toContain('There is a problem</h2>');
-			expect(errorSummaryHtml).toContain('The time must include an hour');
-			expect(errorSummaryHtml).toContain('The time must include a minute');
+			expect(errorSummaryHtml).toContain('Hearing time must include an hour');
 		});
 	});
 

--- a/appeals/web/src/server/appeals/appeal-details/hearing/setup/set-up-hearing.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/hearing/setup/set-up-hearing.mapper.js
@@ -16,7 +16,10 @@ import { addressInputs } from '#lib/mappers/index.js';
 export function hearingDatePage(appealData, values) {
 	const shortAppealReference = appealShortReference(appealData.appealReference);
 	const date = { day: values.day || '', month: values.month || '', year: values.year || '' };
-	const time = { hour: values.hour || '', minute: values.minute || '' };
+	const time =
+		values.hour || values.minute
+			? { hour: values.hour || '', minute: values.minute || '' }
+			: { hour: '10', minute: '00' };
 
 	const dateComponent = dateInput({
 		name: 'hearing-date',

--- a/appeals/web/src/server/appeals/appeal-details/hearing/setup/set-up-hearing.router.js
+++ b/appeals/web/src/server/appeals/appeal-details/hearing/setup/set-up-hearing.router.js
@@ -19,10 +19,10 @@ router
 	.route('/date')
 	.get(asyncHandler(controller.getHearingDate))
 	.post(
-		createDateInputFieldsValidator('hearing-date'),
+		createDateInputFieldsValidator('hearing-date', 'hearing date'),
 		createDateInputDateValidityValidator('hearing-date', 'hearing date'),
 		createDateInputDateInFutureValidator('hearing-date', 'hearing date'),
-		createTimeInputValidator('hearing-time'),
+		createTimeInputValidator('hearing-time', 'hearing time'),
 		saveBodyToSession('setUpHearing'),
 		asyncHandler(controller.postHearingDate)
 	);


### PR DESCRIPTION
## Describe your changes

- Update hearing date error messages
- Add default hearing time of 10:00

## Issue ticket number and link

[A2-2711](https://pins-ds.atlassian.net.mcas.ms/browse/A2-2711?McasTsid=20596&McasCtx=4)


[A2-2711]: https://pins-ds.atlassian.net/browse/A2-2711?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ