### PR TITLE
fix(web): show custom 404 page if the session data is not present

### DIFF
--- a/appeals/web/src/server/appeals/appeal-details/hearing/estimates/__tests__/estimates.test.js
+++ b/appeals/web/src/server/appeals/appeal-details/hearing/estimates/__tests__/estimates.test.js
@@ -274,6 +274,23 @@ describe('add estimates', () => {
 			expect(response.text).toBe('Found. Redirecting to /appeals-service/appeal-details/1');
 		});
 
+		it('should show 404 page if error is the session data is not present', async () => {
+			nock('http://test/')
+				.post(`/appeals/${appealId}/hearing-estimates`, {
+					preparationTime: 1.5,
+					sittingTime: 2.0,
+					reportingTime: 1.0
+				})
+				.reply(500, { error: 'Internal Server Error' });
+
+			const response = await request
+				.post(`${baseUrl}/${appealId}/hearing/estimates/add/check-details`)
+				.send(estimates);
+
+			expect(response.status).toBe(404);
+			expect(response.text).toContain('You cannot check these answers');
+		});
+
 		it('should show 500 page if error is thrown', async () => {
 			nock('http://test/')
 				.post(`/appeals/${appealId}/hearing-estimates`, {
@@ -282,6 +299,9 @@ describe('add estimates', () => {
 					reportingTime: 1.0
 				})
 				.reply(500, { error: 'Internal Server Error' });
+
+			// set session data with post request to previous page
+			await request.post(`${baseUrl}/${appealId}/hearing/estimates/add/timings`).send(estimates);
 
 			const response = await request
 				.post(`${baseUrl}/${appealId}/hearing/estimates/add/check-details`)
@@ -520,6 +540,23 @@ describe('change estimates', () => {
 			expect(response.text).toBe('Found. Redirecting to /appeals-service/appeal-details/1');
 		});
 
+		it('should show 404 page if error is the session data is not present', async () => {
+			nock('http://test/')
+				.post(`/appeals/${appealId}/hearing-estimates`, {
+					preparationTime: 1.5,
+					sittingTime: 2.0,
+					reportingTime: 1.0
+				})
+				.reply(500, { error: 'Internal Server Error' });
+
+			const response = await request
+				.post(`${baseUrl}/${appealId}/hearing/estimates/change/check-details`)
+				.send(estimates);
+
+			expect(response.status).toBe(404);
+			expect(response.text).toContain('You cannot check these answers');
+		});
+
 		it('should show 500 page if error is thrown', async () => {
 			nock('http://test/')
 				.post(`/appeals/${appealId}/hearing-estimates`, {
@@ -528,6 +565,9 @@ describe('change estimates', () => {
 					reportingTime: 1.0
 				})
 				.reply(500, { error: 'Internal Server Error' });
+
+			// set session data with post request to previous page
+			await request.post(`${baseUrl}/${appealId}/hearing/estimates/change/timings`).send(estimates);
 
 			const response = await request
 				.post(`${baseUrl}/${appealId}/hearing/estimates/change/check-details`)

--- a/appeals/web/src/server/views/app/404.njk
+++ b/appeals/web/src/server/views/app/404.njk
@@ -1,15 +1,15 @@
 {% extends "app/layouts/app-two-column.layout.njk" %}
 
-{% set pageTitle = 'Page not found' %}
+{% set pageTitle = titleCopy if titleCopy else 'Page not found' %}
 {% set heading =  pageTitle %}
+{% set bodyCopy = bodyCopy if bodyCopy else ['If you typed the web address, check it is correct.', 'If you pasted the web address, check you copied the entire address.'] %}
 
 {% block pageContent %}
-	<p class="govuk-body">
-		If you typed the web address, check it is correct.
-	</p>
-	<p class="govuk-body">
-		If you pasted the web address, check you copied the entire address.
-	</p>
+	{%- for bodyCopyItem in bodyCopy -%}
+		<p class="govuk-body">
+			{{ bodyCopyItem | safe }}
+		</p>
+	{%- endfor -%}
 	<p class="govuk-body">
 		<a href="https://has-appeal.herokuapp.com/help/contact" class="govuk-link">Contact the Planning Inspectorate Customer Support</a> if the problem persists
 	</p>


### PR DESCRIPTION
## Describe your changes

Display a custom 404 page if the user clicks the browser back button and lands on the CYA page for hearing estimates but the session data has already been cleared

## Issue ticket number and link

[A2-3039](https://pins-ds.atlassian.net.mcas.ms/browse/A2-3039?McasTsid=20596&McasCtx=4)


[A2-3039]: https://pins-ds.atlassian.net/browse/A2-3039?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ