### PR TITLE
A2-3117/3118(feat): adding new timetable updates page with navigation for HAS

### DIFF
--- a/appeals/web/src/server/appeals/appeal-details/__tests__/__snapshots__/appeal-details.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/__tests__/__snapshots__/appeal-details.test.js.snap
@@ -608,7 +608,7 @@ exports[`appeal-details GET /:appealId Timetable Valid date should render a "Tim
     </div>
     <div class="govuk-summary-list__row appeal-lpa-questionnaire-due-date"><dt class="govuk-summary-list__key"> LPA questionnaire due</dt>
         <dd class="govuk-summary-list__value">11 October 2023</dd>
-        <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/3/appeal-timetables/lpa-questionnaire"
+        <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/3/timetable/edit"
             data-cy="change-lpa-questionnaire-due-date">Change<span class="govuk-visually-hidden"> LPA questionnaire due</span></a>
         </dd>
     </div>
@@ -898,7 +898,7 @@ exports[`appeal-details GET /:appealId should not render action links to the man
                                 </div>
                                 <div class="govuk-summary-list__row appeal-lpa-questionnaire-due-date"><dt class="govuk-summary-list__key"> LPA questionnaire due</dt>
                                     <dd class="govuk-summary-list__value">11 October 2023</dd>
-                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appeal-timetables/lpa-questionnaire"
+                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/timetable/edit"
                                         data-cy="change-lpa-questionnaire-due-date">Change<span class="govuk-visually-hidden"> LPA questionnaire due</span></a>
                                     </dd>
                                 </div>
@@ -1360,7 +1360,7 @@ exports[`appeal-details GET /:appealId should render a Decision inset panel when
                             </div>
                             <div class="govuk-summary-list__row appeal-lpa-questionnaire-due-date"><dt class="govuk-summary-list__key"> LPA questionnaire due</dt>
                                 <dd class="govuk-summary-list__value">11 October 2023</dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/appeal-timetables/lpa-questionnaire"
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/timetable/edit"
                                     data-cy="change-lpa-questionnaire-due-date">Change<span class="govuk-visually-hidden"> LPA questionnaire due</span></a>
                                 </dd>
                             </div>
@@ -1808,7 +1808,7 @@ exports[`appeal-details GET /:appealId should render a child tag next to the app
                                 </div>
                                 <div class="govuk-summary-list__row appeal-lpa-questionnaire-due-date"><dt class="govuk-summary-list__key"> LPA questionnaire due</dt>
                                     <dd class="govuk-summary-list__value">11 October 2023</dd>
-                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appeal-timetables/lpa-questionnaire"
+                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/timetable/edit"
                                         data-cy="change-lpa-questionnaire-due-date">Change<span class="govuk-visually-hidden"> LPA questionnaire due</span></a>
                                     </dd>
                                 </div>
@@ -2259,7 +2259,7 @@ exports[`appeal-details GET /:appealId should render a lead tag next to the appe
                                 </div>
                                 <div class="govuk-summary-list__row appeal-lpa-questionnaire-due-date"><dt class="govuk-summary-list__key"> LPA questionnaire due</dt>
                                     <dd class="govuk-summary-list__value">11 October 2023</dd>
-                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appeal-timetables/lpa-questionnaire"
+                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/timetable/edit"
                                         data-cy="change-lpa-questionnaire-due-date">Change<span class="govuk-visually-hidden"> LPA questionnaire due</span></a>
                                     </dd>
                                 </div>
@@ -2735,7 +2735,7 @@ exports[`appeal-details GET /:appealId should render an Issue a decision notific
                             </div>
                             <div class="govuk-summary-list__row appeal-lpa-questionnaire-due-date"><dt class="govuk-summary-list__key"> LPA questionnaire due</dt>
                                 <dd class="govuk-summary-list__value">11 October 2023</dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/appeal-timetables/lpa-questionnaire"
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/timetable/edit"
                                     data-cy="change-lpa-questionnaire-due-date">Change<span class="govuk-visually-hidden"> LPA questionnaire due</span></a>
                                 </dd>
                             </div>
@@ -3195,7 +3195,7 @@ exports[`appeal-details GET /:appealId should render an action link to the add l
                                 </div>
                                 <div class="govuk-summary-list__row appeal-lpa-questionnaire-due-date"><dt class="govuk-summary-list__key"> LPA questionnaire due</dt>
                                     <dd class="govuk-summary-list__value">11 October 2023</dd>
-                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appeal-timetables/lpa-questionnaire"
+                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/timetable/edit"
                                         data-cy="change-lpa-questionnaire-due-date">Change<span class="govuk-visually-hidden"> LPA questionnaire due</span></a>
                                     </dd>
                                 </div>
@@ -3648,7 +3648,7 @@ exports[`appeal-details GET /:appealId should render an action link to the manag
                                 </div>
                                 <div class="govuk-summary-list__row appeal-lpa-questionnaire-due-date"><dt class="govuk-summary-list__key"> LPA questionnaire due</dt>
                                     <dd class="govuk-summary-list__value">11 October 2023</dd>
-                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appeal-timetables/lpa-questionnaire"
+                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/timetable/edit"
                                         data-cy="change-lpa-questionnaire-due-date">Change<span class="govuk-visually-hidden"> LPA questionnaire due</span></a>
                                     </dd>
                                 </div>
@@ -4092,7 +4092,7 @@ exports[`appeal-details GET /:appealId should render the appellant case status a
                             </div>
                             <div class="govuk-summary-list__row appeal-lpa-questionnaire-due-date"><dt class="govuk-summary-list__key"> LPA questionnaire due</dt>
                                 <dd class="govuk-summary-list__value">11 October 2023</dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/appeal-timetables/lpa-questionnaire"
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/timetable/edit"
                                     data-cy="change-lpa-questionnaire-due-date">Change<span class="govuk-visually-hidden"> LPA questionnaire due</span></a>
                                 </dd>
                             </div>
@@ -4536,7 +4536,7 @@ exports[`appeal-details GET /:appealId should render the appellant case status a
                             </div>
                             <div class="govuk-summary-list__row appeal-lpa-questionnaire-due-date"><dt class="govuk-summary-list__key"> LPA questionnaire due</dt>
                                 <dd class="govuk-summary-list__value">11 October 2023</dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/appeal-timetables/lpa-questionnaire"
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/timetable/edit"
                                     data-cy="change-lpa-questionnaire-due-date">Change<span class="govuk-visually-hidden"> LPA questionnaire due</span></a>
                                 </dd>
                             </div>
@@ -4989,7 +4989,7 @@ exports[`appeal-details GET /:appealId should render the case reference for each
                                 </div>
                                 <div class="govuk-summary-list__row appeal-lpa-questionnaire-due-date"><dt class="govuk-summary-list__key"> LPA questionnaire due</dt>
                                     <dd class="govuk-summary-list__value">11 October 2023</dd>
-                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appeal-timetables/lpa-questionnaire"
+                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/timetable/edit"
                                         data-cy="change-lpa-questionnaire-due-date">Change<span class="govuk-visually-hidden"> LPA questionnaire due</span></a>
                                     </dd>
                                 </div>
@@ -5470,7 +5470,7 @@ exports[`appeal-details GET /:appealId should render the lead or child status af
                                 </div>
                                 <div class="govuk-summary-list__row appeal-lpa-questionnaire-due-date"><dt class="govuk-summary-list__key"> LPA questionnaire due</dt>
                                     <dd class="govuk-summary-list__value">11 October 2023</dd>
-                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appeal-timetables/lpa-questionnaire"
+                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/timetable/edit"
                                         data-cy="change-lpa-questionnaire-due-date">Change<span class="govuk-visually-hidden"> LPA questionnaire due</span></a>
                                     </dd>
                                 </div>
@@ -5935,7 +5935,7 @@ exports[`appeal-details GET /:appealId should render the received appeal details
                                 </div>
                                 <div class="govuk-summary-list__row appeal-lpa-questionnaire-due-date"><dt class="govuk-summary-list__key"> LPA questionnaire due</dt>
                                     <dd class="govuk-summary-list__value">11 October 2023</dd>
-                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/3/appeal-timetables/lpa-questionnaire"
+                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/3/timetable/edit"
                                         data-cy="change-lpa-questionnaire-due-date">Change<span class="govuk-visually-hidden"> LPA questionnaire due</span></a>
                                     </dd>
                                 </div>
@@ -6376,7 +6376,7 @@ exports[`appeal-details GET /:appealId should render the received appeal details
                             </div>
                             <div class="govuk-summary-list__row appeal-lpa-questionnaire-due-date"><dt class="govuk-summary-list__key"> LPA questionnaire due</dt>
                                 <dd class="govuk-summary-list__value">11 October 2023</dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appeal-timetables/lpa-questionnaire"
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/timetable/edit"
                                     data-cy="change-lpa-questionnaire-due-date">Change<span class="govuk-visually-hidden"> LPA questionnaire due</span></a>
                                 </dd>
                             </div>
@@ -6836,7 +6836,7 @@ exports[`appeal-details GET /:appealId should render the received appeal details
                                 </div>
                                 <div class="govuk-summary-list__row appeal-lpa-questionnaire-due-date"><dt class="govuk-summary-list__key"> LPA questionnaire due</dt>
                                     <dd class="govuk-summary-list__value">11 October 2023</dd>
-                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/appeal-timetables/lpa-questionnaire"
+                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/timetable/edit"
                                         data-cy="change-lpa-questionnaire-due-date">Change<span class="govuk-visually-hidden"> LPA questionnaire due</span></a>
                                     </dd>
                                 </div>
@@ -7737,7 +7737,7 @@ exports[`appeal-details should not render a back button 1`] = `
                                         </div>
                                         <div class="govuk-summary-list__row appeal-lpa-questionnaire-due-date"><dt class="govuk-summary-list__key"> LPA questionnaire due</dt>
                                             <dd class="govuk-summary-list__value">11 October 2023</dd>
-                                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/appeal-timetables/lpa-questionnaire"
+                                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/timetable/edit"
                                                 data-cy="change-lpa-questionnaire-due-date">Change<span class="govuk-visually-hidden"> LPA questionnaire due</span></a>
                                             </dd>
                                         </div>

--- a/appeals/web/src/server/appeals/appeal-details/appeal-details.router.js
+++ b/appeals/web/src/server/appeals/appeal-details/appeal-details.router.js
@@ -38,6 +38,7 @@ import { clearUncommittedFilesFromSession } from '#appeals/appeal-documents/appe
 import changeAppealDetailsRouter from './change-appeal-details/change-appeal-details.router.js';
 import hearingRouter from './hearing/hearing.router.js';
 import siteAddressRouter from './appellant-case/address/address.router.js';
+import timetableRouter from './timetable/timetable.router.js';
 
 const router = createRouter();
 
@@ -64,6 +65,7 @@ router.use(
 router.use('/:appealId/lpa-questionnaire', lpaQuestionnaireRouter);
 router.use('/:appealId/allocation-details', allocationDetailsRouter);
 router.use('/:appealId/appeal-timetables', appealTimetablesRouter);
+router.use('/:appealId/timetable', timetableRouter);
 router.use('/:appealId/appellant-case', appellantCaseRouter);
 router.use('/:appealId/interested-party-comments', interestedPartyCommentsRouter);
 router.use('/:appealId/final-comments', finalCommentsRouter);

--- a/appeals/web/src/server/appeals/appeal-details/appeal-timetables/__tests__/__snapshots__/appeal-timetables.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/appeal-timetables/__tests__/__snapshots__/appeal-timetables.test.js.snap
@@ -4,7 +4,7 @@ exports[`Appeal Timetables should render "Change LPA questionnaire Date" page 1`
 "<main class="govuk-main-wrapper" id="main-content">
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Appeal 351062</span>
-            <h1 class="govuk-heading-l govuk-!-margin-bottom-0">Change LPA questionnaire due date</h1>
+            <h1 class="govuk-heading-l">Change LPA questionnaire due date</h1>
         </div>
     </div>
     <div class="govuk-grid-row">
@@ -50,7 +50,7 @@ exports[`Appeal Timetables should render "Change final comments due date" page 1
 "<main class="govuk-main-wrapper" id="main-content">
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Appeal 351062</span>
-            <h1 class="govuk-heading-l govuk-!-margin-bottom-0">Change final comments due date</h1>
+            <h1 class="govuk-heading-l">Change final comments due date</h1>
         </div>
     </div>
     <div class="govuk-grid-row">
@@ -111,7 +111,7 @@ exports[`Appeal Timetables should render "Change final comments due date" with e
     </div>
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Appeal 351062</span>
-            <h1 class="govuk-heading-l govuk-!-margin-bottom-0">Change final comments due date</h1>
+            <h1 class="govuk-heading-l">Change final comments due date</h1>
         </div>
     </div>
     <div class="govuk-grid-row">
@@ -172,7 +172,7 @@ exports[`Appeal Timetables should render "Change final comments due date" with e
     </div>
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Appeal 351062</span>
-            <h1 class="govuk-heading-l govuk-!-margin-bottom-0">Change final comments due date</h1>
+            <h1 class="govuk-heading-l">Change final comments due date</h1>
         </div>
     </div>
     <div class="govuk-grid-row">
@@ -218,7 +218,7 @@ exports[`Appeal Timetables should render "Change statement review Date" page 1`]
 "<main class="govuk-main-wrapper" id="main-content">
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Appeal 351062</span>
-            <h1 class="govuk-heading-l govuk-!-margin-bottom-0">Change LPA statement due date</h1>
+            <h1 class="govuk-heading-l">Change LPA statement due date</h1>
         </div>
     </div>
     <div class="govuk-grid-row">
@@ -264,7 +264,7 @@ exports[`Appeal Timetables should render "Schedule LPA questionnaire Date" page 
 "<main class="govuk-main-wrapper" id="main-content">
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Appeal 351062</span>
-            <h1 class="govuk-heading-l govuk-!-margin-bottom-0">Schedule LPA questionnaire due date</h1>
+            <h1 class="govuk-heading-l">Schedule LPA questionnaire due date</h1>
         </div>
     </div>
     <div class="govuk-grid-row">
@@ -308,7 +308,7 @@ exports[`Appeal Timetables should render "Schedule statement review Date" page 1
 "<main class="govuk-main-wrapper" id="main-content">
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Appeal 351062</span>
-            <h1 class="govuk-heading-l govuk-!-margin-bottom-0">Schedule LPA statement due date</h1>
+            <h1 class="govuk-heading-l">Schedule LPA statement due date</h1>
         </div>
     </div>
     <div class="govuk-grid-row">

--- a/appeals/web/src/server/appeals/appeal-details/appellant-case/__tests__/__snapshots__/appellant-case.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/appellant-case/__tests__/__snapshots__/appellant-case.test.js.snap
@@ -3080,7 +3080,7 @@ exports[`appellant-case GET /appellant-case/incomplete/date should render the up
 "<main class="govuk-main-wrapper" id="main-content">
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Appeal 351062</span>
-            <h1 class="govuk-heading-l govuk-!-margin-bottom-0">Update appeal due date</h1>
+            <h1 class="govuk-heading-l">Update appeal due date</h1>
         </div>
     </div>
     <div class="govuk-grid-row">
@@ -3124,7 +3124,7 @@ exports[`appellant-case GET /appellant-case/incomplete/date should render the up
 "<main class="govuk-main-wrapper" id="main-content">
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Appeal 351062</span>
-            <h1 class="govuk-heading-l govuk-!-margin-bottom-0">Update appeal due date</h1>
+            <h1 class="govuk-heading-l">Update appeal due date</h1>
         </div>
     </div>
     <div class="govuk-grid-row">
@@ -5884,7 +5884,7 @@ exports[`appellant-case POST /appellant-case/incomplete/date should re-render th
     </div>
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Appeal 351062</span>
-            <h1 class="govuk-heading-l govuk-!-margin-bottom-0">Update appeal due date</h1>
+            <h1 class="govuk-heading-l">Update appeal due date</h1>
         </div>
     </div>
     <div class="govuk-grid-row">
@@ -5945,7 +5945,7 @@ exports[`appellant-case POST /appellant-case/incomplete/date should re-render th
     </div>
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Appeal 351062</span>
-            <h1 class="govuk-heading-l govuk-!-margin-bottom-0">Update appeal due date</h1>
+            <h1 class="govuk-heading-l">Update appeal due date</h1>
         </div>
     </div>
     <div class="govuk-grid-row">
@@ -6006,7 +6006,7 @@ exports[`appellant-case POST /appellant-case/incomplete/date should re-render th
     </div>
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Appeal 351062</span>
-            <h1 class="govuk-heading-l govuk-!-margin-bottom-0">Update appeal due date</h1>
+            <h1 class="govuk-heading-l">Update appeal due date</h1>
         </div>
     </div>
     <div class="govuk-grid-row">
@@ -6067,7 +6067,7 @@ exports[`appellant-case POST /appellant-case/incomplete/date should re-render th
     </div>
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Appeal 351062</span>
-            <h1 class="govuk-heading-l govuk-!-margin-bottom-0">Update appeal due date</h1>
+            <h1 class="govuk-heading-l">Update appeal due date</h1>
         </div>
     </div>
     <div class="govuk-grid-row">
@@ -6128,7 +6128,7 @@ exports[`appellant-case POST /appellant-case/incomplete/date should re-render th
     </div>
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Appeal 351062</span>
-            <h1 class="govuk-heading-l govuk-!-margin-bottom-0">Update appeal due date</h1>
+            <h1 class="govuk-heading-l">Update appeal due date</h1>
         </div>
     </div>
     <div class="govuk-grid-row">
@@ -6189,7 +6189,7 @@ exports[`appellant-case POST /appellant-case/incomplete/date should re-render th
     </div>
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Appeal 351062</span>
-            <h1 class="govuk-heading-l govuk-!-margin-bottom-0">Update appeal due date</h1>
+            <h1 class="govuk-heading-l">Update appeal due date</h1>
         </div>
     </div>
     <div class="govuk-grid-row">
@@ -6250,7 +6250,7 @@ exports[`appellant-case POST /appellant-case/incomplete/date should re-render th
     </div>
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Appeal 351062</span>
-            <h1 class="govuk-heading-l govuk-!-margin-bottom-0">Update appeal due date</h1>
+            <h1 class="govuk-heading-l">Update appeal due date</h1>
         </div>
     </div>
     <div class="govuk-grid-row">
@@ -6311,7 +6311,7 @@ exports[`appellant-case POST /appellant-case/incomplete/date should re-render th
     </div>
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Appeal 351062</span>
-            <h1 class="govuk-heading-l govuk-!-margin-bottom-0">Update appeal due date</h1>
+            <h1 class="govuk-heading-l">Update appeal due date</h1>
         </div>
     </div>
     <div class="govuk-grid-row">
@@ -6372,7 +6372,7 @@ exports[`appellant-case POST /appellant-case/incomplete/date should re-render th
     </div>
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Appeal 351062</span>
-            <h1 class="govuk-heading-l govuk-!-margin-bottom-0">Update appeal due date</h1>
+            <h1 class="govuk-heading-l">Update appeal due date</h1>
         </div>
     </div>
     <div class="govuk-grid-row">
@@ -6431,7 +6431,7 @@ exports[`appellant-case POST /appellant-case/incomplete/date should re-render th
     </div>
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Appeal 351062</span>
-            <h1 class="govuk-heading-l govuk-!-margin-bottom-0">Update appeal due date</h1>
+            <h1 class="govuk-heading-l">Update appeal due date</h1>
         </div>
     </div>
     <div class="govuk-grid-row">
@@ -6490,7 +6490,7 @@ exports[`appellant-case POST /appellant-case/incomplete/date should re-render th
     </div>
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Appeal 351062</span>
-            <h1 class="govuk-heading-l govuk-!-margin-bottom-0">Update appeal due date</h1>
+            <h1 class="govuk-heading-l">Update appeal due date</h1>
         </div>
     </div>
     <div class="govuk-grid-row">

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/__tests__/__snapshots__/lpa-questionnaire.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/__tests__/__snapshots__/lpa-questionnaire.test.js.snap
@@ -2176,7 +2176,7 @@ exports[`LPA Questionnaire review GET /appeals-service/appeal-details/1/lpa-ques
 "<main class="govuk-main-wrapper" id="main-content">
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Appeal 351062</span>
-            <h1 class="govuk-heading-l govuk-!-margin-bottom-0">Update LPA questionnaire due date</h1>
+            <h1 class="govuk-heading-l">Update LPA questionnaire due date</h1>
         </div>
     </div>
     <div class="govuk-grid-row">
@@ -5642,7 +5642,7 @@ exports[`LPA Questionnaire review POST /appeals-service/appeal-details/1/lpa-que
     </div>
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Appeal 351062</span>
-            <h1 class="govuk-heading-l govuk-!-margin-bottom-0">Update LPA questionnaire due date</h1>
+            <h1 class="govuk-heading-l">Update LPA questionnaire due date</h1>
         </div>
     </div>
     <div class="govuk-grid-row">
@@ -5705,7 +5705,7 @@ exports[`LPA Questionnaire review POST /appeals-service/appeal-details/1/lpa-que
     </div>
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Appeal 351062</span>
-            <h1 class="govuk-heading-l govuk-!-margin-bottom-0">Update LPA questionnaire due date</h1>
+            <h1 class="govuk-heading-l">Update LPA questionnaire due date</h1>
         </div>
     </div>
     <div class="govuk-grid-row">
@@ -5768,7 +5768,7 @@ exports[`LPA Questionnaire review POST /appeals-service/appeal-details/1/lpa-que
     </div>
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Appeal 351062</span>
-            <h1 class="govuk-heading-l govuk-!-margin-bottom-0">Update LPA questionnaire due date</h1>
+            <h1 class="govuk-heading-l">Update LPA questionnaire due date</h1>
         </div>
     </div>
     <div class="govuk-grid-row">
@@ -5831,7 +5831,7 @@ exports[`LPA Questionnaire review POST /appeals-service/appeal-details/1/lpa-que
     </div>
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Appeal 351062</span>
-            <h1 class="govuk-heading-l govuk-!-margin-bottom-0">Update LPA questionnaire due date</h1>
+            <h1 class="govuk-heading-l">Update LPA questionnaire due date</h1>
         </div>
     </div>
     <div class="govuk-grid-row">
@@ -5894,7 +5894,7 @@ exports[`LPA Questionnaire review POST /appeals-service/appeal-details/1/lpa-que
     </div>
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Appeal 351062</span>
-            <h1 class="govuk-heading-l govuk-!-margin-bottom-0">Update LPA questionnaire due date</h1>
+            <h1 class="govuk-heading-l">Update LPA questionnaire due date</h1>
         </div>
     </div>
     <div class="govuk-grid-row">
@@ -5957,7 +5957,7 @@ exports[`LPA Questionnaire review POST /appeals-service/appeal-details/1/lpa-que
     </div>
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Appeal 351062</span>
-            <h1 class="govuk-heading-l govuk-!-margin-bottom-0">Update LPA questionnaire due date</h1>
+            <h1 class="govuk-heading-l">Update LPA questionnaire due date</h1>
         </div>
     </div>
     <div class="govuk-grid-row">
@@ -6020,7 +6020,7 @@ exports[`LPA Questionnaire review POST /appeals-service/appeal-details/1/lpa-que
     </div>
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Appeal 351062</span>
-            <h1 class="govuk-heading-l govuk-!-margin-bottom-0">Update LPA questionnaire due date</h1>
+            <h1 class="govuk-heading-l">Update LPA questionnaire due date</h1>
         </div>
     </div>
     <div class="govuk-grid-row">
@@ -6083,7 +6083,7 @@ exports[`LPA Questionnaire review POST /appeals-service/appeal-details/1/lpa-que
     </div>
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Appeal 351062</span>
-            <h1 class="govuk-heading-l govuk-!-margin-bottom-0">Update LPA questionnaire due date</h1>
+            <h1 class="govuk-heading-l">Update LPA questionnaire due date</h1>
         </div>
     </div>
     <div class="govuk-grid-row">
@@ -6146,7 +6146,7 @@ exports[`LPA Questionnaire review POST /appeals-service/appeal-details/1/lpa-que
     </div>
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Appeal 351062</span>
-            <h1 class="govuk-heading-l govuk-!-margin-bottom-0">Update LPA questionnaire due date</h1>
+            <h1 class="govuk-heading-l">Update LPA questionnaire due date</h1>
         </div>
     </div>
     <div class="govuk-grid-row">
@@ -6207,7 +6207,7 @@ exports[`LPA Questionnaire review POST /appeals-service/appeal-details/1/lpa-que
     </div>
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Appeal 351062</span>
-            <h1 class="govuk-heading-l govuk-!-margin-bottom-0">Update LPA questionnaire due date</h1>
+            <h1 class="govuk-heading-l">Update LPA questionnaire due date</h1>
         </div>
     </div>
     <div class="govuk-grid-row">
@@ -6268,7 +6268,7 @@ exports[`LPA Questionnaire review POST /appeals-service/appeal-details/1/lpa-que
     </div>
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Appeal 351062</span>
-            <h1 class="govuk-heading-l govuk-!-margin-bottom-0">Update LPA questionnaire due date</h1>
+            <h1 class="govuk-heading-l">Update LPA questionnaire due date</h1>
         </div>
     </div>
     <div class="govuk-grid-row">

--- a/appeals/web/src/server/appeals/appeal-details/timetable/__tests__/__snapshots__/timetable.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/timetable/__tests__/__snapshots__/timetable.test.js.snap
@@ -1,0 +1,52 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Appeal Timetables should render "Timetable due dates" page for householder appeal type 1`] = `
+"<main class="govuk-main-wrapper" id="main-content">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Appeal 351062</span>
+            <h1 class="govuk-heading-l">Timetable due dates</h1>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full"></div>
+    </div>
+    <form method="post" novalidate="novalidate">
+        <div class="govuk-form-group">
+            <fieldset class="govuk-fieldset" role="group" aria-describedby="lpa-questionnaire-due-date-hint">
+                <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">LPA questionnaire due</legend>
+                <div id="lpa-questionnaire-due-date-hint"
+                class="govuk-hint">For example, 27 3 2007</div>
+                <div class="govuk-date-input" id="lpa-questionnaire-due-date">
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="lpa-questionnaire-due-date-day">Day</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                            id="lpa-questionnaire-due-date-day" name="lpa-questionnaire-due-date-day"
+                            type="text" inputmode="numeric">
+                        </div>
+                    </div>
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="lpa-questionnaire-due-date-month">Month</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                            id="lpa-questionnaire-due-date-month" name="lpa-questionnaire-due-date-month"
+                            type="text" inputmode="numeric">
+                        </div>
+                    </div>
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="lpa-questionnaire-due-date-year">Year</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-4"
+                            id="lpa-questionnaire-due-date-year" name="lpa-questionnaire-due-date-year"
+                            type="text" inputmode="numeric">
+                        </div>
+                    </div>
+                </div>
+            </fieldset>
+        </div>
+        <div class="govuk-button-group">
+            <button type="submit" class="govuk-button" data-module="govuk-button">Continue</button>
+        </div>
+    </form>
+</main>"
+`;

--- a/appeals/web/src/server/appeals/appeal-details/timetable/__tests__/timetable.test.js
+++ b/appeals/web/src/server/appeals/appeal-details/timetable/__tests__/timetable.test.js
@@ -1,0 +1,34 @@
+import { parseHtml } from '@pins/platform';
+import nock from 'nock';
+import supertest from 'supertest';
+import { appealData as baseAppealData } from '#testing/app/fixtures/referencedata.js';
+import { createTestEnvironment } from '#testing/index.js';
+
+const { app, teardown } = createTestEnvironment();
+const request = supertest(app);
+const baseUrl = '/appeals-service/appeal-details/1/timetable';
+
+describe('Appeal Timetables', () => {
+	afterEach(teardown);
+
+	it('should render "Timetable due dates" page for householder appeal type', async () => {
+		const appealData = {
+			...baseAppealData,
+			appealTimetable: {
+				appealTimetableId: 1
+			}
+		};
+
+		nock('http://test/').get('/appeals/1').reply(200, appealData);
+
+		const response = await request.get(`${baseUrl}/edit`);
+		const element = parseHtml(response.text);
+
+		expect(element.innerHTML).toMatchSnapshot();
+		expect(element.innerHTML).toContain('Timetable due dates</h1>');
+		expect(element.innerHTML).toContain('name="lpa-questionnaire-due-date-day');
+		expect(element.innerHTML).toContain('name="lpa-questionnaire-due-date-month"');
+		expect(element.innerHTML).toContain('name="lpa-questionnaire-due-date-year"');
+		expect(element.innerHTML).toContain('Continue</button>');
+	});
+});

--- a/appeals/web/src/server/appeals/appeal-details/timetable/timetable.controller.js
+++ b/appeals/web/src/server/appeals/appeal-details/timetable/timetable.controller.js
@@ -1,0 +1,122 @@
+import logger from '#lib/logger.js';
+import { objectContainsAllKeys } from '#lib/object-utilities.js';
+import { setAppealTimetables } from './timetable.service.js';
+import { routeToObjectMapper, mapEditTimetablePage, apiErrorMapper } from './timetable.mapper.js';
+import { addNotificationBannerToSession } from '#lib/session-utilities.js';
+import { dayMonthYearHourMinuteToISOString } from '#lib/dates.js';
+
+/**
+ *
+ * @param {import('@pins/express/types/express.js').Request} request
+ * @param {import('@pins/express/types/express.js').RenderedResponse<any, any, Number>} response
+ * @param {object} [apiErrors]
+ */
+const renderEditTimetable = async (request, response, apiErrors) => {
+	const appealDetails = request.currentAppeal;
+
+	if (!appealDetails) {
+		return response.status(404).render('app/404.njk');
+	}
+
+	const appealId = appealDetails.appealId;
+	const mappedPageContent = mapEditTimetablePage(appealDetails?.appealTimetable, appealDetails);
+
+	if (!appealId || !mappedPageContent) {
+		return response.status(500).render('app/500.njk');
+	}
+
+	let errors = request.errors || apiErrors;
+
+	return response.status(200).render('appeals/appeal/update-date.njk', {
+		pageContent: mappedPageContent,
+		errors
+	});
+};
+
+/**
+ *
+ * @param {import('@pins/express/types/express.js').Request} request
+ * @param {import('@pins/express/types/express.js').RenderedResponse<any, any, Number>} response
+ */
+const processEditTimetable = async (request, response) => {
+	if (request.errors) {
+		return renderEditTimetable(request, response);
+	}
+
+	const { body } = request;
+	const appealDetails = request.currentAppeal;
+	const appealId = appealDetails.appealId;
+	const { appealTimetableId } = appealDetails.appealTimetable;
+	const { timetableType } = request.params;
+
+	if (!objectContainsAllKeys(body, ['due-date-day', 'due-date-month', 'due-date-year'])) {
+		return response.status(500).render('app/500.njk');
+	}
+
+	try {
+		const updatedDueDateDay = parseInt(body['due-date-day'], 10);
+		const updatedDueDateMonth = parseInt(body['due-date-month'], 10);
+		const updatedDueDateYear = parseInt(body['due-date-year'], 10);
+
+		if (
+			Number.isNaN(updatedDueDateDay) ||
+			Number.isNaN(updatedDueDateMonth) ||
+			Number.isNaN(updatedDueDateYear)
+		) {
+			return response.status(500).render('app/500.njk');
+		}
+
+		const updatedDueDateDayString = `0${updatedDueDateDay}`.slice(-2);
+		const updatedDueDateMonthString = `0${updatedDueDateMonth}`.slice(-2);
+
+		const timetableProperty = routeToObjectMapper[timetableType];
+
+		const setAppealTimetableResponse = await setAppealTimetables(
+			request.apiClient,
+			appealId,
+			appealTimetableId,
+			{
+				[timetableProperty]: dayMonthYearHourMinuteToISOString({
+					year: updatedDueDateYear,
+					month: updatedDueDateMonthString,
+					day: updatedDueDateDayString
+				})
+			}
+		);
+
+		if (setAppealTimetableResponse.errors) {
+			const apiError = Object.values(setAppealTimetableResponse.errors)[0];
+			if (apiError) {
+				const apiErrors = apiErrorMapper(updatedDueDateDay, apiError);
+
+				return renderEditTimetable(request, response, apiErrors);
+			} else {
+				return response.status(500).render('app/500.njk');
+			}
+		}
+		addNotificationBannerToSession({
+			session: request.session,
+			bannerDefinitionKey: 'timetableDueDateUpdated',
+			appealId
+		});
+
+		return response.redirect(`/appeals-service/appeal-details/${appealId}`);
+	} catch (error) {
+		logger.error(
+			error,
+			error instanceof Error ? error.message : 'Something went wrong when changing appeal timetable'
+		);
+
+		return response.status(500).render('app/500.njk');
+	}
+};
+
+/** @type {import('@pins/express').RequestHandler<Response>}  */
+export const getEditTimetable = async (request, response) => {
+	renderEditTimetable(request, response);
+};
+
+/** @type {import('@pins/express').RequestHandler<Response>} */
+export const postEditTimetable = async (request, response) => {
+	processEditTimetable(request, response);
+};

--- a/appeals/web/src/server/appeals/appeal-details/timetable/timetable.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/timetable/timetable.mapper.js
@@ -1,0 +1,174 @@
+import { dateISOStringToDayMonthYearHourMinute } from '#lib/dates.js';
+import { appealShortReference } from '#lib/appeals-formatter.js';
+
+/**
+ * @typedef {import('../appeal-details.types.js').WebAppeal} Appeal
+ */
+
+/**
+ * @typedef {Object} AppealTimetablesMap
+ * @property {string | null | undefined} sideNote
+ * @property { object } page
+ */
+
+/**
+ * @typedef {'lpaQuestionnaireDueDate' | 'ipCommentsDueDate' | 'lpaStatementDueDate' | 'finalCommentsDueDate'} AppealTimetableType
+ */
+
+/**
+ * @type {Object.<'lpa-questionnaire' | 'ip-comments' | 'appellant-statement' | 'lpa-statement' | 'final-comments' | 'lpa-final-comments' | 's106-obligation' , 'lpaQuestionnaireDueDate' | 'ipCommentsDueDate' | 'appellantStatementDueDate' | 'lpaStatementDueDate' | 'finalCommentsDueDate' | 's106ObligationDueDate'>}
+ */
+export const routeToObjectMapper = {
+	'lpa-questionnaire': 'lpaQuestionnaireDueDate',
+	'ip-comments': 'ipCommentsDueDate',
+	'appellant-statement': 'appellantStatementDueDate',
+	'lpa-statement': 'lpaStatementDueDate',
+	'final-comments': 'finalCommentsDueDate',
+	's106-obligation': 's106ObligationDueDate'
+};
+
+/**
+ * @param {import('./timetable.service.js').AppealTimetables} appealTimetables
+ * @param {Appeal} appealDetails
+ * @returns {PageContent}
+ */
+export const mapEditTimetablePage = (appealTimetables, appealDetails) => {
+	/** @type {PageContent} */
+	let pageContent = {
+		title: `Timetable due dates`,
+		backLinkUrl: `/appeals-service/appeal-details/${appealDetails.appealId}`,
+		preHeading: `Appeal ${appealShortReference(appealDetails.appealReference)}`,
+		heading: `Timetable due dates`,
+		submitButtonProperties: {
+			text: 'Continue',
+			type: 'submit'
+		}
+	};
+
+	const timeTableTypes = getAppealTimetableTypes(appealDetails.appealType);
+
+	/** @type {PageComponent[]} */
+	const pageComponents = timeTableTypes.map((timetableType) => {
+		const currentDueDateIso = appealTimetables && appealTimetables[timetableType];
+		const currentDueDateDayMonthYear =
+			currentDueDateIso && dateISOStringToDayMonthYearHourMinute(currentDueDateIso);
+		const timetableTypeText = getTimetableTypeText(timetableType);
+		const idText = getIdText(timetableType);
+
+		return {
+			type: 'date-input',
+			parameters: {
+				id: `${idText}-due-date`,
+				namePrefix: `${idText}-due-date`,
+				hint: {
+					text: 'For example, 27 3 2007'
+				},
+				fieldset: {
+					legend: {
+						text: `${timetableTypeText} due`,
+						classes: 'govuk-fieldset__legend--m'
+					}
+				},
+				...(currentDueDateDayMonthYear && {
+					items: [
+						{
+							name: 'day',
+							classes: 'govuk-input--width-2',
+							value: currentDueDateDayMonthYear.day
+						},
+						{
+							name: 'month',
+							classes: 'govuk-input--width-2',
+							value: currentDueDateDayMonthYear.month
+						},
+						{
+							name: 'year',
+							classes: 'govuk-input--width-4',
+							value: currentDueDateDayMonthYear.year
+						}
+					]
+				})
+			}
+		};
+	});
+
+	pageContent.pageComponents = pageComponents;
+
+	return pageContent;
+};
+
+/**
+ * @param { number } updatedDueDateDay
+ * @param { string } apiError
+ * @returns { object }
+ */
+export const apiErrorMapper = (updatedDueDateDay, apiError) => ({
+	'due-date-day': {
+		value: String(updatedDueDateDay),
+		msg: `Date ${apiError}`,
+		param: '',
+		location: 'body'
+	}
+});
+
+/**
+ * @param {AppealTimetableType} timetableType
+ * @returns {string}
+ */
+const getTimetableTypeText = (timetableType) => {
+	switch (timetableType) {
+		case 'lpaQuestionnaireDueDate':
+			return 'LPA questionnaire';
+		// case 'ipCommentsDueDate':
+		// 	return 'Interested party comments';
+		// case 'lpaStatementDueDate':
+		// 	return 'LPA statement';
+		// case 'finalCommentsDueDate':
+		// 	return 'Final comments';
+		default:
+			return '';
+	}
+};
+
+/**
+ * @param {AppealTimetableType} timetableType
+ * @returns {string}
+ */
+const getIdText = (timetableType) => {
+	switch (timetableType) {
+		case 'lpaQuestionnaireDueDate':
+			return 'lpa-questionnaire';
+		// case 'ipCommentsDueDate':
+		// 	return 'ip-comments';
+		// case 'lpaStatementDueDate':
+		// 	return 'lpa-statement';
+		// case 'finalCommentsDueDate':
+		// 	return 'final-comments';
+		default:
+			return '';
+	}
+};
+
+/**
+ * @param {string|undefined|null} appealType
+ * @returns {AppealTimetableType[]}
+ */
+const getAppealTimetableTypes = (appealType) => {
+	/** @type {AppealTimetableType[]} */
+	let validAppealTimetableType = [];
+
+	switch (appealType) {
+		case 'Householder':
+			validAppealTimetableType = ['lpaQuestionnaireDueDate'];
+			break;
+		// case 'Planning appeal':
+		// 	validAppealTimetableType = [
+		// 		'lpaQuestionnaireDueDate',
+		// 		'ipCommentsDueDate',
+		// 		'lpaStatementDueDate',
+		// 		'finalCommentsDueDate'
+		// 	];
+		// 	break;
+	}
+	return validAppealTimetableType;
+};

--- a/appeals/web/src/server/appeals/appeal-details/timetable/timetable.router.js
+++ b/appeals/web/src/server/appeals/appeal-details/timetable/timetable.router.js
@@ -1,0 +1,30 @@
+import { Router as createRouter } from 'express';
+import { asyncHandler } from '@pins/express';
+import * as timetableController from './timetable.controller.js';
+import * as validators from './timetable.validators.js';
+import { assertUserHasPermission } from '#app/auth/auth.guards.js';
+import { validateAppeal } from '../appeal-details.middleware.js';
+import { permissionNames } from '#environment/permissions.js';
+
+const router = createRouter({ mergeParams: true });
+
+router
+	.route('/edit')
+	.get(
+		validateAppeal,
+		assertUserHasPermission(
+			permissionNames.viewCaseDetails,
+			permissionNames.viewAssignedCaseDetails
+		),
+		asyncHandler(timetableController.getEditTimetable)
+	)
+	.post(
+		validateAppeal,
+		validators.validateDueDateFields,
+		validators.validateDueDateValid,
+		validators.validateDueDateInFuture,
+		assertUserHasPermission(permissionNames.updateCase),
+		asyncHandler(timetableController.postEditTimetable)
+	);
+
+export default router;

--- a/appeals/web/src/server/appeals/appeal-details/timetable/timetable.service.js
+++ b/appeals/web/src/server/appeals/appeal-details/timetable/timetable.service.js
@@ -1,0 +1,24 @@
+/**
+ * @typedef {Object} AppealTimetables
+ * @property {string?} [lpaQuestionnaireDueDate]
+ * @property {string?} [ipCommentsDueDate]
+ * @property {string?} [appellantStatementDueDate]
+ * @property {string?} [lpaStatementDueDate]
+ * @property {string?} [finalCommentsDueDate]
+ * @property {string?} [s106ObligationDueDate]
+ * @property {object | string | undefined} [errors]
+ */
+
+/**
+ * @param {import('got').Got} apiClient
+ * @param {string} appealId
+ * @param {string} appealTimetableId
+ * @param {AppealTimetables} appealTimetables
+ * @returns {Promise<AppealTimetables>}
+ */
+export function setAppealTimetables(apiClient, appealId, appealTimetableId, appealTimetables) {
+	return apiClient
+		.patch(`appeals/${appealId}/appeal-timetables/${appealTimetableId}`, { json: appealTimetables })
+		.json()
+		.catch((error) => error?.response?.body || error);
+}

--- a/appeals/web/src/server/appeals/appeal-details/timetable/timetable.validators.js
+++ b/appeals/web/src/server/appeals/appeal-details/timetable/timetable.validators.js
@@ -1,0 +1,8 @@
+import {
+	createDateInputFieldsValidator,
+	createDateInputDateValidityValidator,
+	createDateInputDateInFutureValidator
+} from '#lib/validators/date-input.validator.js';
+export const validateDueDateFields = createDateInputFieldsValidator();
+export const validateDueDateValid = createDateInputDateValidityValidator();
+export const validateDueDateInFuture = createDateInputDateInFutureValidator();

--- a/appeals/web/src/server/lib/mappers/data/appeal/submappers/__tests__/lpa-questionnaire-due-date.mapper.test.js
+++ b/appeals/web/src/server/lib/mappers/data/appeal/submappers/__tests__/lpa-questionnaire-due-date.mapper.test.js
@@ -43,7 +43,7 @@ describe('lpa-questionnaire-due-date.mapper', () => {
 								attributes: {
 									'data-cy': 'change-lpa-questionnaire-due-date'
 								},
-								href: '/test/appeal-timetables/lpa-questionnaire',
+								href: '/test/timetable/edit',
 								text: 'Change',
 								visuallyHiddenText: 'LPA questionnaire due'
 							}

--- a/appeals/web/src/server/lib/mappers/data/appeal/submappers/lpa-questionnaire-due-date.mapper.js
+++ b/appeals/web/src/server/lib/mappers/data/appeal/submappers/lpa-questionnaire-due-date.mapper.js
@@ -26,7 +26,7 @@ export const mapLpaQuestionnaireDueDate = ({
 		id,
 		text: 'LPA questionnaire due',
 		value: dateISOStringToDisplayDate(appealDetails.appealTimetable?.lpaQuestionnaireDueDate),
-		link: `${currentRoute}/appeal-timetables/lpa-questionnaire`,
+		link: `${currentRoute}/timetable/edit`,
 		editable,
 		classes: 'appeal-lpa-questionnaire-due-date'
 	});

--- a/appeals/web/src/server/views/appeals/appeal/update-date.njk
+++ b/appeals/web/src/server/views/appeals/appeal/update-date.njk
@@ -13,7 +13,7 @@
 	{{ pageHeading({
 		preHeading: pageContent.preHeading,
 		heading: pageContent.heading,
-		headingClasses: 'govuk-heading-l govuk-!-margin-bottom-0'
+		headingClasses: 'govuk-heading-l'
 	}) }}
 	<div class="govuk-grid-row">
 		<div class="govuk-grid-column-full">


### PR DESCRIPTION
## Describe your changes
- Updated lpa questionnaire due date navigation to go to new time table due dates page rather than existing page.
- Added mapper, controller and router for new timetable route
- Created the base for further work to be done to make timetable due dates page work for other appeal types and multiple timetable types (hence some commented code) 
<!--
    Please include a summary of the change along with any relevant context.
    List any dependencies that are required for this change.
-->

## Issue ticket number and link
[A2-3118](https://pins-ds.atlassian.net.mcas.ms/browse/A2-3118) & [A2-3117](https://pins-ds.atlassian.net.mcas.ms/browse/A2-3117) 


[A2-3118]: https://pins-ds.atlassian.net/browse/A2-3118?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[A2-3117]: https://pins-ds.atlassian.net/browse/A2-3117?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ