### PR TITLE
fix(api): A2-3216 make LPA dashboard link in email templates environment-specific

### DIFF
--- a/appeals/api/.env.example
+++ b/appeals/api/.env.example
@@ -23,4 +23,4 @@ TEST_MAILBOX=***********************
 GOV_NOTIFY_API_KEY=*****************
 
 GOV_NOTIFY_APPEAL_GENERIC_ID="3fd5fc42-d77f-42c2-984a-cf9b89e4c415"
-
+FRONT_OFFICE_URL=http://localhost:9003/

--- a/appeals/api/src/server/endpoints/appeal-decision/__tests__/appeal-decision.test.js
+++ b/appeals/api/src/server/endpoints/appeal-decision/__tests__/appeal-decision.test.js
@@ -10,8 +10,7 @@ import {
 	ERROR_MUST_BE_CORRECT_UTC_DATE_FORMAT,
 	ERROR_MUST_NOT_BE_IN_FUTURE,
 	ERROR_CASE_OUTCOME_MUST_BE_ONE_OF,
-	ERROR_INVALID_APPEAL_STATE,
-	FRONT_OFFICE_URL
+	ERROR_INVALID_APPEAL_STATE
 } from '@pins/appeals/constants/support.js';
 import { APPEAL_CASE_STATUS } from 'pins-data-model';
 import { recalculateDateIfNotBusinessDay, setTimeInTimeZone } from '#utils/business-days.js';
@@ -22,6 +21,8 @@ describe('appeal decision routes', () => {
 	beforeEach(() => {
 		// @ts-ignore
 		databaseConnector.appealRelationship.findMany.mockResolvedValue([]);
+		process.env.FRONT_OFFICE_URL =
+			'https://appeal-planning-decision.service.gov.uk/appeals/1345264';
 	});
 	afterEach(() => {
 		jest.clearAllMocks();
@@ -185,8 +186,8 @@ describe('appeal decision routes', () => {
 					appeal_reference_number: '1345264',
 					lpa_reference: '48269/APP/2021/1482',
 					site_address: '96 The Avenue, Leftfield, Maidstone, Kent, MD21 5XY, United Kingdom',
-					url: FRONT_OFFICE_URL,
-					decision_date: formatDate(utcDate, false)
+					decision_date: formatDate(utcDate, false),
+					front_office_url: 'https://appeal-planning-decision.service.gov.uk/appeals/1345264'
 				},
 				recipientEmail: 'test@136s7.com'
 			});
@@ -198,8 +199,8 @@ describe('appeal decision routes', () => {
 					appeal_reference_number: '1345264',
 					lpa_reference: '48269/APP/2021/1482',
 					site_address: '96 The Avenue, Leftfield, Maidstone, Kent, MD21 5XY, United Kingdom',
-					url: FRONT_OFFICE_URL,
-					decision_date: formatDate(utcDate, false)
+					decision_date: formatDate(utcDate, false),
+					front_office_url: 'https://appeal-planning-decision.service.gov.uk/appeals/1345264'
 				},
 				templateName: 'decision-is-allowed-split-dismissed-appellant',
 				recipientEmail: 'test@136s7.com'

--- a/appeals/api/src/server/endpoints/appeal-decision/appeal-decision.service.js
+++ b/appeals/api/src/server/endpoints/appeal-decision/appeal-decision.service.js
@@ -1,14 +1,16 @@
 import appealRepository from '#repositories/appeal.repository.js';
 import transitionState from '#state/transition-state.js';
 import { broadcasters } from '#endpoints/integrations/integrations.broadcasters.js';
-import { FRONT_OFFICE_URL } from '@pins/appeals/constants/support.js';
 import formatDate from '#utils/date-formatter.js';
 import { APPEAL_CASE_STATUS } from 'pins-data-model';
 import { notifySend } from '#notify/notify-send.js';
+import { loadEnvironment } from '@pins/platform';
 
 /** @typedef {import('@pins/appeals.api').Schema.Appeal} Appeal */
 /** @typedef {import('@pins/appeals.api').Schema.InspectorDecision} Decision */
 /** @typedef {import('@pins/appeals.api').Schema.Document} Document */
+
+const environment = loadEnvironment(process.env.NODE_ENV);
 
 /**
  *
@@ -42,7 +44,7 @@ export const publishDecision = async (
 			appeal_reference_number: appeal.reference,
 			lpa_reference: appeal.applicationReference || '',
 			site_address: siteAddress,
-			url: FRONT_OFFICE_URL,
+			front_office_url: environment.FRONT_OFFICE_URL || '',
 			decision_date: formatDate(new Date(documentDate || ''), false)
 		};
 		const recipientEmail = appeal.agent?.email || appeal.appellant?.email;

--- a/appeals/api/src/server/endpoints/appeal-timetables/__tests__/appeal-timetables.test.js
+++ b/appeals/api/src/server/endpoints/appeal-timetables/__tests__/appeal-timetables.test.js
@@ -683,8 +683,7 @@ describe('appeal timetables routes', () => {
 						procedure_type: 'a written procedure',
 						questionnaire_due_date: '12 June 2024',
 						site_address: '96 The Avenue, Leftfield, Maidstone, Kent, MD21 5XY, United Kingdom',
-						start_date: '5 June 2024',
-						url: 'https://www.gov.uk/appeal-planning-inspectorate'
+						start_date: '5 June 2024'
 					},
 					recipientEmail: householdAppeal.appellant.email,
 					templateName: 'appeal-start-date-change-appellant'
@@ -706,8 +705,7 @@ describe('appeal timetables routes', () => {
 						procedure_type: 'a written procedure',
 						questionnaire_due_date: '12 June 2024',
 						site_address: '96 The Avenue, Leftfield, Maidstone, Kent, MD21 5XY, United Kingdom',
-						start_date: '5 June 2024',
-						url: 'https://www.gov.uk/appeal-planning-inspectorate'
+						start_date: '5 June 2024'
 					},
 					recipientEmail: householdAppeal.lpa.email,
 					templateName: 'appeal-start-date-change-lpa'
@@ -750,8 +748,7 @@ describe('appeal timetables routes', () => {
 						procedure_type: 'a written procedure',
 						questionnaire_due_date: '12 June 2024',
 						site_address: '96 The Avenue, Leftfield, Maidstone, Kent, MD21 5XY, United Kingdom',
-						start_date: '5 June 2024',
-						url: 'https://www.gov.uk/appeal-planning-inspectorate'
+						start_date: '5 June 2024'
 					},
 					recipientEmail: householdAppeal.appellant.email,
 					templateName: 'appeal-valid-start-case-appellant'
@@ -773,8 +770,7 @@ describe('appeal timetables routes', () => {
 						procedure_type: 'a written procedure',
 						questionnaire_due_date: '12 June 2024',
 						site_address: '96 The Avenue, Leftfield, Maidstone, Kent, MD21 5XY, United Kingdom',
-						start_date: '5 June 2024',
-						url: 'https://www.gov.uk/appeal-planning-inspectorate'
+						start_date: '5 June 2024'
 					},
 					recipientEmail: householdAppeal.lpa.email,
 					templateName: 'appeal-valid-start-case-lpa'

--- a/appeals/api/src/server/endpoints/appeal-timetables/appeal-timetables.service.js
+++ b/appeals/api/src/server/endpoints/appeal-timetables/appeal-timetables.service.js
@@ -11,8 +11,7 @@ import {
 	AUDIT_TRAIL_CASE_TIMELINE_CREATED,
 	AUDIT_TRAIL_CASE_TIMELINE_UPDATED,
 	AUDIT_TRAIL_SYSTEM_UUID,
-	ERROR_NOT_FOUND,
-	FRONT_OFFICE_URL
+	ERROR_NOT_FOUND
 } from '@pins/appeals/constants/support.js';
 import transitionState from '#state/transition-state.js';
 import formatDate from '#utils/date-formatter.js';
@@ -120,7 +119,6 @@ const startCase = async (
 				site_address: siteAddress,
 				start_date: formatDate(new Date(startDate || ''), false),
 				appellant_email_address: appellantEmail || '',
-				url: FRONT_OFFICE_URL,
 				appeal_type: appealType || '',
 				procedure_type: PROCEDURE_TYPE_MAP[appeal.procedureType?.key || 'written'],
 				questionnaire_due_date: formatDate(

--- a/appeals/api/src/server/endpoints/change-appeal-type/__tests__/change-appeal-type.test.js
+++ b/appeals/api/src/server/endpoints/change-appeal-type/__tests__/change-appeal-type.test.js
@@ -8,8 +8,7 @@ import {
 	ERROR_NOT_FOUND,
 	ERROR_INVALID_APPEAL_STATE,
 	ERROR_CANNOT_BE_EMPTY_STRING,
-	ERROR_MUST_BE_STRING,
-	FRONT_OFFICE_URL
+	ERROR_MUST_BE_STRING
 } from '@pins/appeals/constants/support.js';
 import { APPEAL_CASE_STATUS } from 'pins-data-model';
 const { databaseConnector } = await import('#utils/database-connector.js');
@@ -169,7 +168,6 @@ describe('appeal change type resubmit routes', () => {
 					lpa_reference: '48269/APP/2021/1482',
 					appeal_type: 'type a',
 					site_address: '96 The Avenue, Leftfield, Maidstone, Kent, MD21 5XY, United Kingdom',
-					url: FRONT_OFFICE_URL,
 					due_date: formatDate(new Date('3000-02-05'), false)
 				},
 				recipientEmail: 'test@136s7.com',

--- a/appeals/api/src/server/endpoints/change-appeal-type/change-appeal-type.service.js
+++ b/appeals/api/src/server/endpoints/change-appeal-type/change-appeal-type.service.js
@@ -1,6 +1,5 @@
 import { broadcasters } from '#endpoints/integrations/integrations.broadcasters.js';
 import { databaseConnector } from '#utils/database-connector.js';
-import { FRONT_OFFICE_URL } from '@pins/appeals/constants/support.js';
 import transitionState from '#state/transition-state.js';
 import formatDate from '#utils/date-formatter.js';
 import timetableRepository from '#repositories/appeal-timetable.repository.js';
@@ -54,7 +53,6 @@ const changeAppealType = async (
 		appeal_reference_number: appeal.reference,
 		lpa_reference: appeal.applicationReference || '',
 		site_address: siteAddress,
-		url: FRONT_OFFICE_URL,
 		due_date: formatDate(new Date(dueDate || ''), false),
 		appeal_type: newAppealType || ''
 	};

--- a/appeals/api/src/server/endpoints/representations/__tests__/representations.test.js
+++ b/appeals/api/src/server/endpoints/representations/__tests__/representations.test.js
@@ -215,7 +215,6 @@ describe('/appeals/:id/reps', () => {
 				lpa_reference: householdAppeal.applicationReference,
 				appeal_reference_number: householdAppeal.reference,
 				reasons: ['Invalid submission', 'Other: Provided documents were incomplete'],
-				url: 'https://www.gov.uk/appeal-planning-inspectorate',
 				site_address: expectedSiteAddress
 			};
 
@@ -309,7 +308,6 @@ describe('/appeals/:id/reps', () => {
 				deadline_date: '20 December 2024',
 				appeal_reference_number: mockAppealS78.reference,
 				reasons: ['Invalid submission', 'Other: Provided documents were incomplete'],
-				url: 'https://www.gov.uk/appeal-planning-inspectorate',
 				site_address: expectedSiteAddress
 			};
 

--- a/appeals/api/src/server/endpoints/representations/notify/services/index.js
+++ b/appeals/api/src/server/endpoints/representations/notify/services/index.js
@@ -6,7 +6,6 @@
  * code will the switching logic for you.
  */
 
-import { FRONT_OFFICE_URL } from '@pins/appeals/constants/support.js';
 import { formatExtendedDeadline, formatReasons, formatSiteAddress } from './utils.js';
 import { notifySend } from '#notify/notify-send.js';
 
@@ -43,7 +42,6 @@ export const ipCommentRejection = async ({
 			appeal_reference_number: appeal.reference,
 			lpa_reference: appeal.applicationReference || '',
 			site_address: siteAddress,
-			url: FRONT_OFFICE_URL,
 			reasons,
 			deadline_date: extendedDeadline
 		};
@@ -75,7 +73,6 @@ export const appellantFinalCommentRejection = async ({ notifyClient, appeal, rep
 			appeal_reference_number: appeal.reference,
 			lpa_reference: appeal.applicationReference || '',
 			site_address: siteAddress,
-			url: FRONT_OFFICE_URL,
 			reasons
 		}
 	});
@@ -99,7 +96,6 @@ export const lpaFinalCommentRejection = async ({ notifyClient, appeal, represent
 			appeal_reference_number: appeal.reference,
 			lpa_reference: appeal.applicationReference || '',
 			site_address: siteAddress,
-			url: FRONT_OFFICE_URL,
 			reasons
 		}
 	});
@@ -130,7 +126,6 @@ export const lpaStatementIncomplete = async ({
 			appeal_reference_number: appeal.reference,
 			lpa_reference: appeal.applicationReference || '',
 			site_address: siteAddress,
-			url: FRONT_OFFICE_URL,
 			deadline_date: extendedDeadline,
 			reasons
 		}

--- a/appeals/api/src/server/notify/templates/__tests__/notify-decision-is-allowed-split-dismissed-appellant.test.js
+++ b/appeals/api/src/server/notify/templates/__tests__/notify-decision-is-allowed-split-dismissed-appellant.test.js
@@ -15,7 +15,8 @@ describe('decision-is-allowed-split-dismissed-appellant.md', () => {
 				appeal_reference_number: 'ABC45678',
 				site_address: '10, Test Street',
 				lpa_reference: '12345XYZ',
-				decision_date: '01 January 2021'
+				decision_date: '01 January 2021',
+				front_office_url: 'https://appeal-planning-decision.service.gov.uk'
 			}
 		};
 
@@ -30,7 +31,7 @@ describe('decision-is-allowed-split-dismissed-appellant.md', () => {
 			'',
 			'We have made a decision on your appeal.',
 			'',
-			'[Sign in to our service](https://appeals-service.planninginspectorate.gov.uk/appeals/ABC45678) to view the decision letter dated 01 January 2021.',
+			'[Sign in to our service](https://appeal-planning-decision.service.gov.uk/appeals/ABC45678) to view the decision letter dated 01 January 2021.',
 			'',
 			'We have also informed the local planning authority of the decision.',
 			'',

--- a/appeals/api/src/server/notify/templates/__tests__/notify-decision-is-allowed-split-dismissed-lpa.test.js
+++ b/appeals/api/src/server/notify/templates/__tests__/notify-decision-is-allowed-split-dismissed-lpa.test.js
@@ -15,7 +15,8 @@ describe('decision-is-allowed-split-dismissed-lpa.md', () => {
 				appeal_reference_number: 'ABC45678',
 				site_address: '10, Test Street',
 				lpa_reference: '12345XYZ',
-				decision_date: '01 January 2021'
+				decision_date: '01 January 2021',
+				front_office_url: 'https://appeal-planning-decision.service.gov.uk'
 			}
 		};
 
@@ -30,7 +31,7 @@ describe('decision-is-allowed-split-dismissed-lpa.md', () => {
 			'',
 			'A decision has been made on this appeal.',
 			'',
-			'[Sign in to our service](https://appeals-service.planninginspectorate.gov.uk/manage-appeals/ABC45678) to view the decision letter dated 01 January 2021.',
+			'[Sign in to our service](https://appeal-planning-decision.service.gov.uk/manage-appeals/ABC45678) to view the decision letter dated 01 January 2021.',
 			'',
 			'The appellant has been informed of the decision.',
 			'',

--- a/appeals/api/src/server/notify/templates/decision-is-allowed-split-dismissed-appellant.content.md
+++ b/appeals/api/src/server/notify/templates/decision-is-allowed-split-dismissed-appellant.content.md
@@ -4,7 +4,7 @@
 
 We have made a decision on your appeal.
 
-[Sign in to our service](https://appeals-service.planninginspectorate.gov.uk/appeals/{{appeal_reference_number}}) to view the decision letter dated {{decision_date}}.
+[Sign in to our service]({{front_office_url}}/appeals/{{appeal_reference_number}}) to view the decision letter dated {{decision_date}}.
 
 We have also informed the local planning authority of the decision.
 

--- a/appeals/api/src/server/notify/templates/decision-is-allowed-split-dismissed-lpa.content.md
+++ b/appeals/api/src/server/notify/templates/decision-is-allowed-split-dismissed-lpa.content.md
@@ -4,7 +4,7 @@
 
 A decision has been made on this appeal.
 
-[Sign in to our service](https://appeals-service.planninginspectorate.gov.uk/manage-appeals/{{appeal_reference_number}}) to view the decision letter dated {{decision_date}}.
+[Sign in to our service]({{front_office_url}}/manage-appeals/{{appeal_reference_number}}) to view the decision letter dated {{decision_date}}.
 
 The appellant has been informed of the decision.
 

--- a/infrastructure/app-api.tf
+++ b/infrastructure/app-api.tf
@@ -39,7 +39,7 @@ module "app_api" {
     APPLICATIONINSIGHTS_CONNECTION_STRING      = local.key_vault_refs["app-insights-connection-string"]
     ApplicationInsightsAgent_EXTENSION_VERSION = "~3"
     NODE_ENV                                   = var.apps_config.node_environment
-    FRONT_OFFICE_URL                           = var.apps_config.front_office_url
+    FRONT_OFFICE_URL                           = var.front_office_url
 
     # documents
     BO_BLOB_CONTAINER       = azurerm_storage_container.appeal_documents.name

--- a/infrastructure/app-api.tf
+++ b/infrastructure/app-api.tf
@@ -39,6 +39,7 @@ module "app_api" {
     APPLICATIONINSIGHTS_CONNECTION_STRING      = local.key_vault_refs["app-insights-connection-string"]
     ApplicationInsightsAgent_EXTENSION_VERSION = "~3"
     NODE_ENV                                   = var.apps_config.node_environment
+    FRONT_OFFICE_URL                           = var.apps_config.front_office_url
 
     # documents
     BO_BLOB_CONTAINER       = azurerm_storage_container.appeal_documents.name

--- a/infrastructure/environments/dev.tfvars
+++ b/infrastructure/environments/dev.tfvars
@@ -5,6 +5,7 @@ apps_config = {
   node_environment           = "development"
   private_endpoint_enabled   = false
   session_max_age            = 10800000
+  front_office_url           = "https://appeals-service-dev.planninginspectorate.gov.uk/"
 
   auth = {
     client_id = "64c20f53-becf-4b7e-ba62-c1dc9b03ccf9" # Appeals Back Office DEV

--- a/infrastructure/environments/prod.tfvars
+++ b/infrastructure/environments/prod.tfvars
@@ -5,6 +5,7 @@ apps_config = {
   node_environment           = "production"
   private_endpoint_enabled   = true
   session_max_age            = 10800000
+  front_office_url           = "https://front-office.training.planninginspectorate.gov.uk"
 
   auth = {
     client_id = "ba49fd0e-11ad-48e2-8bfb-a203defb625f" # Appeals Back Office PROD

--- a/infrastructure/environments/test.tfvars
+++ b/infrastructure/environments/test.tfvars
@@ -5,6 +5,7 @@ apps_config = {
   node_environment           = "production"
   private_endpoint_enabled   = true
   session_max_age            = 10800000
+  front_office_url           = "https://appeals-service-test.planninginspectorate.gov.uk/"
 
   auth = {
     client_id = "591f9564-095c-459a-b090-ce0f0a16ee09" # Appeals Back Office TEST

--- a/infrastructure/environments/training.tfvars
+++ b/infrastructure/environments/training.tfvars
@@ -5,6 +5,7 @@ apps_config = {
   node_environment           = "production"
   private_endpoint_enabled   = true
   session_max_age            = 10800000
+  front_office_url           = "https://appeals-service-training.planninginspectorate.gov.uk/"
 
   auth = {
     client_id = "68721db0-46ce-4ac5-b404-a4eebdb5c8e1" # Appeals Back Office Training

--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -242,3 +242,8 @@ variable "beta_feedback_url" {
   description = "URL for beta feedback form"
   type        = string
 }
+
+variable "front_office_url" {
+  description = "The base URL for the front office application"
+  type        = string
+}

--- a/packages/appeals/constants/support.js
+++ b/packages/appeals/constants/support.js
@@ -291,7 +291,6 @@ export const CASE_RELATIONSHIP_RELATED = 'related';
 
 // Static config
 export const CONFIG_BANKHOLIDAYS_FEED_URL = 'https://www.gov.uk/bank-holidays.json';
-export const FRONT_OFFICE_URL = 'https://www.gov.uk/appeal-planning-inspectorate';
 
 export const CONFIG_APPEAL_TIMETABLE = {
 	W: {


### PR DESCRIPTION
## Describe your changes

Added a new env variable to the Terraform config, updated the application settings to dynamically include the URL, and updated the email templates to use the dynamic link.

## Issue ticket number and link
[A2-3216](https://pins-ds.atlassian.net/browse/A2-3216)

[A2-3216]: https://pins-ds.atlassian.net/browse/A2-3216?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ