### PR TITLE
fix(appeals): issue lpa costs decision letter upload (a2-3153)

### DIFF
--- a/appeals/web/src/server/appeals/appeal-details/issue-decision/__tests__/__snapshots__/issue-decision.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/issue-decision/__tests__/__snapshots__/issue-decision.test.js.snap
@@ -128,7 +128,7 @@ exports[`issue-decision GET /check-invalid-decision should render the check your
                         </div>
                     </div>
                 </div>
-                <button type="submit" class="govuk-button" data-module="govuk-button">Send decision</button>
+                <button type="submit" class="govuk-button" data-module="govuk-button">Issue decision</button>
             </form>
         </div>
     </div>
@@ -390,8 +390,15 @@ exports[`issue-decision GET /issue-decision/check-your-decision should render th
                             <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/issue-decision/lpa-costs-decision?backUrl=%2Fappeals-service%2Fappeal-details%2F1%2Fissue-decision%2Fcheck-your-decision">Change<span class="govuk-visually-hidden"> lpa cost decision</span></a>
                             </dd>
                     </div>
+                    <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> LPA costs decision letter</dt>
+                        <dd                         class="govuk-summary-list__value"><a class="govuk-link" download href="/documents/APP/Q9999/D/21/351062/download-uncommitted/3/test-document-lpa.pdf"
+                            target="_blank">test-document-lpa.pdf</a>
+                            </dd>
+                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/issue-decision/lpa-costs-decision-letter-upload?backUrl=%2Fappeals-service%2Fappeal-details%2F1%2Fissue-decision%2Fcheck-your-decision">Change<span class="govuk-visually-hidden"> lpa costs decision letter</span></a>
+                            </dd>
+                    </div>
                 </dl>
-                <button type="submit" class="govuk-button" data-module="govuk-button">Send decision</button>
+                <button type="submit" class="govuk-button" data-module="govuk-button">Issue decision</button>
             </form>
         </div>
     </div>
@@ -432,6 +439,58 @@ exports[`issue-decision GET /lpa-costs-decision should render the LPA cost decis
                         data-module="govuk-button">Continue</button>
                     </form>
                 </div>
+            </div>
+        </div>
+    </div>
+</main>"
+`;
+
+exports[`issue-decision GET /lpa-costs-decision-letter-upload should render the decision letter upload page with a file upload component 1`] = `
+"<main class="govuk-main-wrapper" id="main-content">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds top-errors-hook"></div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Appeal 351062 - issue decision</span>
+            <h1             class="govuk-heading-l">LPA costs decision letter</h1>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
+            <div class="govuk-grid-row pins-file-upload" data-next-page-url="/appeals-service/appeal-details/1/issue-decision/check-your-decision"
+            data-form-id="1" data-case-id="1" data-case-reference="APP/Q9999/D/21/351062"
+            data-folder-id="undefined" data-document-type="lpaCostsDecisionLetter"
+            data-document-stage="appeal-decision" data-blob-storage-host="https://127.0.0.1:10000/devstoreaccount1"
+            data-blob-storage-container="document-service-uploads" data-document-title="LPA costs decision letter"
+            data-allowed-types="application/pdf" data-formatted-allowed-types="PDF">
+                <form method="POST" novalidate="novalidate" class="govuk-grid-column-two-thirds"
+                data-filenames-in-folder="">
+                    <div class="pins-file-upload__container">
+                        <div class="govuk-body pins-file-upload__instructions"><span>The file must be a PDF and smaller than 25MB.</span>
+                        </div>
+                        <div class="middle-errors-hook">
+                            <h2 class="pins-file-upload__container-title">Upload LPA costs decision letter</h2>
+                            <div class="pins-file-upload__upload">
+                                <input class="display--none" id="upload-file-1" accept="application/pdf"
+                                type="file" name="files" value="Choose file" aria-controls="file-list-1">
+                                <div>
+                                    <button type='button' class="pins-file-upload__button govuk-button--secondary"
+                                    data-cy="upload-file-button" id="upload-file-button-1">Choose file</button><span class='govuk-body pins-file-upload__dropzone-text'>or drop file</span>
+                                </div>
+                            </div>
+                            <div id="file-list-1">
+                                <h2 class="display--sr-only" id="file-list-title-1">List of files to upload</h2>
+                                <ul class="pins-file-upload__files-rows" aria-describedby="file-list-title-1"
+                                aria-live="polite"></ul>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="display--flex">
+                        <button type="submit" class="govuk-button pins-file-upload__submit" data-module="govuk-button"
+                        id="submit-button-1">Continue</button>
+                        <div class="progress-hook"></div>
+                    </div>
+                </form>
             </div>
         </div>
     </div>
@@ -868,6 +927,40 @@ exports[`issue-decision POST /invalid-reason should re-render the invalid reason
             </div>
         </div>
     </div>
+    </div>
+</main>"
+`;
+
+exports[`issue-decision POST /lpa-costs-decision-letter-upload should render a 500 error page if request body upload-info is in an incorrect format 1`] = `
+"<main class="govuk-main-wrapper" id="main-content">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <h1 class="govuk-heading-xl">Sorry, there is a problem with the service</h1>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <p class="govuk-body">Try again later.</p>
+            <p class="govuk-body"><a href="https://has-appeal.herokuapp.com/help/contact" class="govuk-link">Contact the Planning Inspectorate Customer Support</a> if
+                the problem persists.</p>
+        </div>
+    </div>
+</main>"
+`;
+
+exports[`issue-decision POST /lpa-costs-decision-letter-upload should render a 500 error page if upload-info is not present in the request body 1`] = `
+"<main class="govuk-main-wrapper" id="main-content">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <h1 class="govuk-heading-xl">Sorry, there is a problem with the service</h1>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <p class="govuk-body">Try again later.</p>
+            <p class="govuk-body"><a href="https://has-appeal.herokuapp.com/help/contact" class="govuk-link">Contact the Planning Inspectorate Customer Support</a> if
+                the problem persists.</p>
+        </div>
     </div>
 </main>"
 `;

--- a/appeals/web/src/server/appeals/appeal-details/issue-decision/issue-decision.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/issue-decision/issue-decision.mapper.js
@@ -401,6 +401,7 @@ function checkAndConfirmPageRows(appealData, session) {
 			]
 		});
 	}
+
 	const lpaCostsDecisionOutcome = session.lpaCostsDecision?.outcome;
 	if (lpaCostsDecisionOutcome) {
 		rows.push({
@@ -412,6 +413,30 @@ function checkAndConfirmPageRows(appealData, session) {
 					text: 'Change',
 					href: `${baseRoute}/lpa-costs-decision?backUrl=${currentRoute}`,
 					visuallyHiddenText: 'lpa cost decision'
+				}
+			]
+		});
+	}
+
+	const lpaCostsDecisionLetter =
+		session.inspectorDecision.fileUploadInfo[APPEAL_DOCUMENT_TYPE.LPA_COSTS_DECISION_LETTER];
+
+	if (lpaCostsDecisionLetter) {
+		const file = lpaCostsDecisionLetter?.files[0] || {};
+		const href = mapUncommittedDocumentDownloadUrl(
+			appealData.appealReference,
+			file.GUID,
+			file.name
+		);
+		rows.push({
+			key: 'LPA costs decision letter',
+			value: file.name,
+			href,
+			actions: [
+				{
+					text: 'Change',
+					href: `${baseRoute}/lpa-costs-decision-letter-upload?backUrl=${currentRoute}`,
+					visuallyHiddenText: 'lpa costs decision letter'
 				}
 			]
 		});
@@ -450,7 +475,7 @@ export function checkAndConfirmPage(appealData, session) {
 		backLinkUrl: `/appeals-service/appeal-details/${appealData.appealId}/issue-decision/decision`,
 		preHeading: `Appeal ${appealShortReference(appealData.appealReference)}`,
 		heading: title,
-		submitButtonText: 'Send decision',
+		submitButtonText: 'Issue decision',
 		pageComponents: [summaryListComponent]
 	};
 
@@ -573,7 +598,7 @@ export function checkAndConfirmInvalidPage(request, appealData, session) {
 		backLinkText: 'Back',
 		preHeading: `Appeal ${appealShortReference(appealData.appealReference)}`,
 		heading: title,
-		submitButtonText: 'Send decision',
+		submitButtonText: 'Issue decision',
 		pageComponents: [summaryListComponent, warningTextComponent, insetConfirmComponent]
 	};
 

--- a/appeals/web/src/server/appeals/appeal-details/issue-decision/issue-decision.router.js
+++ b/appeals/web/src/server/appeals/appeal-details/issue-decision/issue-decision.router.js
@@ -62,6 +62,19 @@ router
 	);
 
 router
+	.route('/appellant-costs-decision-letter-upload')
+	.get(
+		validateAppeal,
+		assertUserHasPermission(permissionNames.setCaseOutcome),
+		asyncHandler(controller.renderAppellantCostsDecisionLetterUpload)
+	)
+	.post(
+		validateAppeal,
+		assertUserHasPermission(permissionNames.setCaseOutcome),
+		asyncHandler(controller.postAppellantCostsDecisionLetterUpload)
+	);
+
+router
 	.route('/lpa-costs-decision')
 	.get(
 		assertUserHasPermission(permissionNames.setCaseOutcome),
@@ -74,16 +87,16 @@ router
 	);
 
 router
-	.route('/appellant-costs-decision-letter-upload')
+	.route('/lpa-costs-decision-letter-upload')
 	.get(
 		validateAppeal,
 		assertUserHasPermission(permissionNames.setCaseOutcome),
-		asyncHandler(controller.renderAppellantCostsDecisionLetterUpload)
+		asyncHandler(controller.renderLpaCostsDecisionLetterUpload)
 	)
 	.post(
 		validateAppeal,
 		assertUserHasPermission(permissionNames.setCaseOutcome),
-		asyncHandler(controller.postAppellantCostsDecisionLetterUpload)
+		asyncHandler(controller.postLpaCostsDecisionLetterUpload)
 	);
 
 router


### PR DESCRIPTION
## Describe your changes
#### Implement issue lpa costs decision letter upload (a2-3153)

### WEB:
- Amended the LPA costs decision page so that it redirects to the new LPA costs decision letter upload page when "Yes" has been selected
- Added /issue-decision/lpa-costs-decision-letter-upload page
- Updated pre headers to include a suffix of - issue decision
- Added a new row to the check your decision page for above
- Handle the back url correctly from change link
- Change button text from "Send decision" to "Issue decision"

### TEST:
- Updated tests and associated snapshots
- Created new tests and associated snapshots
- Made sure all unit tests pass
- Manually tested within browser

## Issue ticket number and link
[Issuing decision flow - Part 6 - 'LPA costs decision letter' upload screen (A2-3153)](https://pins-ds.atlassian.net/browse/A2-3153)
