### PR TITLE
fix(api): adjusting FO env URLs for email templates dashboard links

### DIFF
--- a/infrastructure/app-api.tf
+++ b/infrastructure/app-api.tf
@@ -39,7 +39,7 @@ module "app_api" {
     APPLICATIONINSIGHTS_CONNECTION_STRING      = local.key_vault_refs["app-insights-connection-string"]
     ApplicationInsightsAgent_EXTENSION_VERSION = "~3"
     NODE_ENV                                   = var.apps_config.node_environment
-    FRONT_OFFICE_URL                           = var.front_office_url
+    FRONT_OFFICE_URL                           = var.apps_config.front_office_url
 
     # documents
     BO_BLOB_CONTAINER       = azurerm_storage_container.appeal_documents.name

--- a/infrastructure/environments/dev.tfvars
+++ b/infrastructure/environments/dev.tfvars
@@ -75,8 +75,6 @@ documents_config = {
 
 environment = "dev"
 
-front_office_url = "https://appeals-service-dev.planninginspectorate.gov.uk/"
-
 front_door_config = {
   name        = "pins-fd-common-tooling"
   rg          = "pins-rg-common-tooling"

--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -9,11 +9,14 @@ variable "alerts_enabled" {
 variable "apps_config" {
   description = "Config for the apps"
   type = object({
-    app_service_plan_sku       = string
-    functions_node_version     = number
-    functions_service_plan_sku = string
-    node_environment           = string
-    private_endpoint_enabled   = bool
+    app_service_plan_sku              = string
+    functions_node_version            = number
+    functions_service_plan_sku        = string
+    node_environment                  = string
+    private_endpoint_enabled          = bool
+    session_max_age                   = string
+    use_system_test_bc_for_change_lpa = bool # Whether to allow STBC/STBC2 on change LPA list
+    front_office_url                  = string
 
     auth = object({
       client_id = string
@@ -44,8 +47,6 @@ variable "apps_config" {
       featureFlagS20           = bool
     })
 
-    use_system_test_bc_for_change_lpa = bool # Whether to allow STBC/STBC2 on change LPA list
-
     logging = object({
       level_file   = string
       level_stdout = string
@@ -56,8 +57,6 @@ variable "apps_config" {
       family   = string
       sku_name = string
     })
-
-    session_max_age = string
   })
 }
 
@@ -119,10 +118,6 @@ variable "front_office_infra_config" {
   })
 }
 
-variable "front_office_url" {
-  description = "The base URL for the front office application"
-  type        = string
-}
 variable "health_check_eviction_time_in_min" {
   description = "The eviction time in minutes for the health check"
   type        = number


### PR DESCRIPTION
Moving the "front_office_url" variable to the correct place.
