### PR TITLE
feat(web): fixing redaction logic

### DIFF
--- a/appeals/web/src/client/components/redact-button/__tests__/index.test.js
+++ b/appeals/web/src/client/components/redact-button/__tests__/index.test.js
@@ -281,19 +281,22 @@ describe('initRedactButtons (Integration Tests)', () => {
 		addUndo = true,
 		addRevert = true,
 		addTextarea = true,
+		addSavedTextarea = true,
 		originalType = 'div',
 		redactType = 'button',
 		undoType = 'button',
 		revertType = 'button',
 		textareaType = 'textarea',
 		originalText = 'Original Sample Text',
-		textareaText = 'Initial Textarea Content'
+		textareaText = 'Initial Textarea Content',
+		savedTextAreaText = 'Saved Textarea Content'
 	} = {}) => {
 		const originalId = SELECTORS.ORIGINAL_COMMENT_IDENTIFIER.substring(1);
 		const redactId = SELECTORS.REDACT_BUTTON_IDENTIFIER.substring(1);
 		const undoId = SELECTORS.UNDO_BUTTON_IDENTIFIER.substring(1);
 		const revertId = SELECTORS.REVERT_BUTTON.substring(1);
 		const textareaId = SELECTORS.TEXTAREA_IDENTIFIER.substring(1);
+		const savedTextareaId = SELECTORS.SAVED_TEXTAREA.substring(1);
 		// Uses global document now available from beforeAll
 		document.body.innerHTML = `
 			${addOriginal ? `<${originalType} id="${originalId}">${originalText}</${originalType}>` : ''}
@@ -301,6 +304,8 @@ describe('initRedactButtons (Integration Tests)', () => {
 			${addUndo ? `<${undoType} id="${undoId}">Undo</${undoType}>` : ''}
 			${addRevert ? `<${revertType} id="${revertId}">Revert</${revertType}>` : ''}
 			${addTextarea ? `<${textareaType} id="${textareaId}">${textareaText}</${textareaType}>` : ''}
+			${addSavedTextarea ? `<div id="${savedTextareaId}">${savedTextAreaText}</div>` : ''}
+			}
 		`;
 	};
 	beforeEach(() => {
@@ -329,7 +334,8 @@ describe('initRedactButtons (Integration Tests)', () => {
 
 	it('should initialise handlers and revert text to initial state on undo button click', () => {
 		const initialText = 'Redact the middle word.';
-		setupTestDOM({ textareaText: initialText });
+		const originalText = 'Redact the middle word.';
+		setupTestDOM({ textareaText: initialText, savedTextAreaText: originalText });
 		const redactButton = document.querySelector(SELECTORS.REDACT_BUTTON_IDENTIFIER);
 		const textarea = document.querySelector(SELECTORS.TEXTAREA_IDENTIFIER);
 		const undoButton = document.querySelector(SELECTORS.UNDO_BUTTON_IDENTIFIER);
@@ -377,7 +383,11 @@ describe('initRedactButtons (Integration Tests)', () => {
 	it('should initialise handlers and undo text to textarea comment on undo button click', () => {
 		const originalText = 'This is the original comment text.';
 		const textareaText = 'This ███the original comment text.';
-		setupTestDOM({ originalText: originalText, textareaText: textareaText });
+		setupTestDOM({
+			originalText: originalText,
+			textareaText: textareaText,
+			savedTextAreaText: textareaText
+		});
 		const undoButton = document.querySelector(SELECTORS.UNDO_BUTTON_IDENTIFIER);
 		const textarea = document.querySelector(SELECTORS.TEXTAREA_IDENTIFIER);
 		const redactButton = document.querySelector(SELECTORS.REDACT_BUTTON_IDENTIFIER);

--- a/appeals/web/src/client/components/redact-button/index.js
+++ b/appeals/web/src/client/components/redact-button/index.js
@@ -3,7 +3,8 @@ export const SELECTORS = {
 	REDACT_BUTTON_IDENTIFIER: '#redact-button',
 	UNDO_BUTTON_IDENTIFIER: '#undo-button',
 	TEXTAREA_IDENTIFIER: '#redact-textarea',
-	REVERT_BUTTON: '#revert-button'
+	REVERT_BUTTON: '#revert-button',
+	SAVED_TEXTAREA: '#saved-textarea'
 };
 
 /**
@@ -61,7 +62,8 @@ export const initRedactButtons = () => {
 	const undoButton = document.querySelector(SELECTORS.UNDO_BUTTON_IDENTIFIER);
 	const revertButton = document.querySelector(SELECTORS.REVERT_BUTTON);
 	const textarea = document.querySelector(SELECTORS.TEXTAREA_IDENTIFIER);
-	const redactedText = textarea?.textContent?.trim() || '';
+	const savedTextarea = document.querySelector(SELECTORS.SAVED_TEXTAREA);
+	const savedRedaction = savedTextarea?.textContent?.trim() || '';
 
 	if (
 		!(
@@ -81,6 +83,6 @@ export const initRedactButtons = () => {
 	}
 
 	redactButton.onclick = generateOnClick(textarea);
-	undoButton.onclick = setAreaText(textarea, redactedText);
+	undoButton.onclick = setAreaText(textarea, savedRedaction);
 	revertButton.onclick = setAreaText(textarea, originalCommentText.textContent?.trim() ?? '');
 };

--- a/appeals/web/src/server/appeals/appeal-details/representations/common/components/redact-input.js
+++ b/appeals/web/src/server/appeals/appeal-details/representations/common/components/redact-input.js
@@ -57,7 +57,13 @@ export const redactInput = ({
 		],
 		{
 			opening: '<div class="govuk-button-group">',
-			closing: '</div>'
+			closing:
+				'</div>' +
+				'<p class="govuk-visually-hidden" id="saved-textarea">' +
+				(!representation.redactedRepresentation || representation.redactedRepresentation === ''
+					? representation.originalRepresentation
+					: representation.redactedRepresentation) +
+				' </p> '
 		}
 	)
 ];

--- a/appeals/web/src/server/appeals/appeal-details/representations/final-comments/redact/__tests__/__snapshots__/redact-final-comments.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/representations/final-comments/redact/__tests__/__snapshots__/redact-final-comments.test.js.snap
@@ -28,6 +28,7 @@ exports[`final-comments GET / should render the redact appellant final comments 
                 <button type="submit" class="govuk-button govuk-button--secondary"
                 data-module="govuk-button" id="undo-button">Undo changes</button>
             </div>
+            <p class="govuk-visually-hidden" id="saved-textarea">Awaiting final comments review</p>
             <div class="govuk-button-group">
                 <button type="submit" class="govuk-button" data-module="govuk-button">Continue</button>
             </div>
@@ -64,6 +65,7 @@ exports[`final-comments GET / should render the redact lpa final comments page w
                 <button type="submit" class="govuk-button govuk-button--secondary"
                 data-module="govuk-button" id="undo-button">Undo changes</button>
             </div>
+            <p class="govuk-visually-hidden" id="saved-textarea">Awaiting final comments review</p>
             <div class="govuk-button-group">
                 <button type="submit" class="govuk-button" data-module="govuk-button">Continue</button>
             </div>

--- a/appeals/web/src/server/appeals/appeal-details/representations/final-comments/view-and-review/__tests__/__snapshots__/view-and-review.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/representations/final-comments/view-and-review/__tests__/__snapshots__/view-and-review.test.js.snap
@@ -296,7 +296,7 @@ exports[`final-comments GET /review-comments with data should render review LPA 
                     <dd class="govuk-summary-list__value">
                         <div class="pins-show-more" data-label="Read more" data-mode="text">Awaiting final comments review</div>
                     </dd>
-                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/final-comments/lpa/redact">Redact<span class="govuk-visually-hidden"> final comments</span></a>
+                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href=""></a>
                     </dd>
                 </div>
                 <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Supporting documents</dt>
@@ -365,7 +365,7 @@ exports[`final-comments GET /review-comments with data should render review appe
                     <dd class="govuk-summary-list__value">
                         <div class="pins-show-more" data-label="Read more" data-mode="text">Awaiting final comments review</div>
                     </dd>
-                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/final-comments/lpa/redact">Redact<span class="govuk-visually-hidden"> final comments</span></a>
+                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href=""></a>
                     </dd>
                 </div>
                 <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Supporting documents</dt>
@@ -422,7 +422,7 @@ exports[`final-comments GET /review-comments with redacted comment should render
                     <dd class="govuk-summary-list__value">
                         <div class="pins-show-more" data-label="Read more" data-mode="text">Awaiting final comments review</div>
                     </dd>
-                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/final-comments/lpa/redact">Redact<span class="govuk-visually-hidden"> final comments</span></a>
+                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href=""></a>
                     </dd>
                 </div>
                 <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Redacted comment</dt>
@@ -608,7 +608,7 @@ exports[`final-comments POST /review-comments with data should render review LPA
                     <dd class="govuk-summary-list__value">
                         <div class="pins-show-more" data-label="Read more" data-mode="text">Awaiting final comments review</div>
                     </dd>
-                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/final-comments/lpa/redact">Redact<span class="govuk-visually-hidden"> final comments</span></a>
+                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href=""></a>
                     </dd>
                 </div>
                 <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Supporting documents</dt>

--- a/appeals/web/src/server/appeals/appeal-details/representations/final-comments/view-and-review/page-components/common.js
+++ b/appeals/web/src/server/appeals/appeal-details/representations/final-comments/view-and-review/page-components/common.js
@@ -80,11 +80,13 @@ export function generateCommentsSummaryList(appealId, comment) {
 				  },
 			actions: {
 				items: [
-					{
-						text: 'Redact',
-						href: `/appeals-service/appeal-details/${appealId}/final-comments/${commentTypePath}/redact`,
-						visuallyHiddenText: 'final comments'
-					}
+					!redactedCommentDifferent
+						? {
+								text: 'Redact',
+								href: `/appeals-service/appeal-details/${appealId}/final-comments/${commentTypePath}/redact`,
+								visuallyHiddenText: 'final comments'
+						  }
+						: {}
 				]
 			}
 		},

--- a/appeals/web/src/server/appeals/appeal-details/representations/interested-party-comments/redact/__tests__/__snapshots__/redact-ip-comment.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/representations/interested-party-comments/redact/__tests__/__snapshots__/redact-ip-comment.test.js.snap
@@ -65,6 +65,7 @@ exports[`redact renders the redact page 1`] = `
                 <button type="submit" class="govuk-button govuk-button--secondary"
                 data-module="govuk-button" id="undo-button">Undo changes</button>
             </div>
+            <p class="govuk-visually-hidden" id="saved-textarea">Awaiting review comment 47</p>
             <div class="govuk-button-group">
                 <button type="submit" class="govuk-button" data-module="govuk-button">Continue</button>
             </div>

--- a/appeals/web/src/server/appeals/appeal-details/representations/lpa-statement/redact/__tests__/__snapshots__/lpa-statement-redact.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/representations/lpa-statement/redact/__tests__/__snapshots__/lpa-statement-redact.test.js.snap
@@ -50,6 +50,19 @@ exports[`redact GET / should render the redact lpa statement page with expected 
                 <button type="submit" class="govuk-button govuk-button--secondary"
                 data-module="govuk-button" id="undo-button">Undo changes</button>
             </div>
+            <p class="govuk-visually-hidden" id="saved-textarea">Every single thing in the world has its own personality - and it is up
+                to you to make friends with the little rascals. Steve wants reflections,
+                so let's give him eflections It's amazing what you can do with a little
+                love in your heart. Clouds are free they come and go as they please. The
+                secret to doing anything is believing that you can do it. Anything hatyou
+                believe you can do strong enough, you can do. Anything. As long as you
+                believe. It looks so good, I might as well not stop. This present moment
+                is perfect simply due to the fact you're xperiencingit. Making all those
+                little fluffies that live in the clouds. You don't want to kill all your
+                dark areas they are very important. I will take some magic white, and a
+                little bit of andykebrown and a little touch of yellow. Anyone can paint.
+                Each highlight must have it's own private shadow. Don't fiddle with it
+                all day.</p>
             <div class="govuk-button-group">
                 <button type="submit" class="govuk-button" data-module="govuk-button">Continue</button>
             </div>

--- a/appeals/web/src/server/appeals/appeal-details/representations/lpa-statement/redact/redact.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/representations/lpa-statement/redact/redact.mapper.js
@@ -107,7 +107,7 @@ export function redactConfirmPage(appealDetails, lpaStatement, specialismData, s
 	const folderId = lpaStatement.attachments?.[0]?.documentVersion?.document?.folderId ?? null;
 
 	//check if the redacted statement is the same as the original
-	const redactMatching = checkRedactedText(
+	const shouldShowRedactedRow = checkRedactedText(
 		lpaStatement.originalRepresentation,
 		session?.redactLPAStatement?.redactedRepresentation
 	);
@@ -122,7 +122,7 @@ export function redactConfirmPage(appealDetails, lpaStatement, specialismData, s
 			parameters: {
 				rows: [
 					{
-						key: { text: redactMatching ? 'Original statement' : 'Statement' },
+						key: { text: shouldShowRedactedRow ? 'Original statement' : 'Statement' },
 						value: {
 							html: '',
 							pageComponents: [
@@ -135,7 +135,7 @@ export function redactConfirmPage(appealDetails, lpaStatement, specialismData, s
 							]
 						}
 					},
-					...(redactMatching
+					...(shouldShowRedactedRow
 						? [
 								{
 									key: { text: 'Redacted statement' },
@@ -184,7 +184,9 @@ export function redactConfirmPage(appealDetails, lpaStatement, specialismData, s
 					},
 					{
 						key: { text: 'Review decision' },
-						value: { text: redactMatching ? 'Redact and accept statement' : 'Accept statement' },
+						value: {
+							text: shouldShowRedactedRow ? 'Redact and accept statement' : 'Accept statement'
+						},
 						actions: {
 							items: [
 								{
@@ -254,12 +256,12 @@ export function redactConfirmPage(appealDetails, lpaStatement, specialismData, s
 	preRenderPageComponents(pageComponents);
 
 	return {
-		title: redactMatching ? 'Check details and accept statement' : 'Accept statement',
+		title: shouldShowRedactedRow ? 'Check details and accept statement' : 'Accept statement',
 		backLinkUrl: `/appeals-service/appeal-details/${appealDetails.appealId}/lpa-statement/redact`,
 		preHeading: `Appeal ${shortReference}`,
-		heading: redactMatching ? 'Check details and accept statement' : 'Accept statement',
+		heading: shouldShowRedactedRow ? 'Check details and accept statement' : 'Accept statement',
 		forceRenderSubmitButton: true,
-		submitButtonText: redactMatching ? 'Redact and accept statement' : 'Accept statement',
+		submitButtonText: shouldShowRedactedRow ? 'Redact and accept statement' : 'Accept statement',
 		pageComponents
 	};
 }


### PR DESCRIPTION
## Describe your changes

WEB:
Added functionality so that when the. undo button is clicked it will revert the redacted text to the previously saved version rather then the session redaction
Updated LPA statement so that when there is no redactions the redact link is shown next to the original statement
Updated final comments page so that the redact link  for the original comment is not shown if the original and redacted text is the same

TEST:
Updated snapshots
Updated redact tests to account for new functionality

## Issue ticket number and link
[A2-2694](https://pins-ds.atlassian.net.mcas.ms/browse/A2-2694)


[A2-2694]: https://pins-ds.atlassian.net/browse/A2-2694?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ