### PR TITLE
fix(web): fix start case redirect when flow is restarted after written procedure is selected

### DIFF
--- a/appeals/web/src/server/appeals/appeal-details/start-case/start-case.controller.js
+++ b/appeals/web/src/server/appeals/appeal-details/start-case/start-case.controller.js
@@ -11,7 +11,6 @@ import { getTodaysISOString } from '#lib/dates.js';
 import { addNotificationBannerToSession } from '#lib/session-utilities.js';
 import featureFlags from '#common/feature-flags.js';
 import { FEATURE_FLAG_NAMES, APPEAL_TYPE } from '@pins/appeals/constants/common.js';
-import { APPEAL_CASE_PROCEDURE } from 'pins-data-model';
 import { getBackLinkUrlFromQuery } from '#lib/url-utilities.js';
 
 /** @type {import('@pins/express').RequestHandler<Response>}  */
@@ -21,20 +20,19 @@ export const getStartDate = async (request, response) => {
 		session
 	} = request;
 
+	if (session.startCaseAppealProcedure?.[appealId]) {
+		delete session.startCaseAppealProcedure?.[appealId];
+	}
+
 	if (
 		appealType === APPEAL_TYPE.S78 &&
-		featureFlags.isFeatureActive(FEATURE_FLAG_NAMES.SECTION_78_HEARING) &&
-		session.startCaseAppealProcedure?.[appealId]?.appealProcedure !== APPEAL_CASE_PROCEDURE.WRITTEN
+		featureFlags.isFeatureActive(FEATURE_FLAG_NAMES.SECTION_78_HEARING)
 	) {
 		return response.redirect(
 			`/appeals-service/appeal-details/${appealId}/start-case/select-procedure${
 				request.query?.backUrl ? `?backUrl=${request.query?.backUrl}` : ''
 			}`
 		);
-	}
-
-	if (session.startCaseAppealProcedure?.[appealId]) {
-		delete session.startCaseAppealProcedure?.[appealId];
 	}
 
 	renderStartDatePage(request, response);


### PR DESCRIPTION
## Describe your changes

- removed session check for pre-existing procedure selection from start case controller to fix a bug where the user would not be redirected to the select procedure type if they selected a procedure type before restarting the start case flow without submitting the confirmation page (this was introduced by a previous fix)
- added unit tests to guard against regression

## Issue ticket number and link

https://pins-ds.atlassian.net/browse/A2-3113