### PR TITLE
fix(web): fix view redacted lpa statement page summary list layout

### DIFF
--- a/appeals/web/src/server/appeals/appeal-details/representations/lpa-statement/__tests__/__snapshots__/lpa-statement.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/representations/lpa-statement/__tests__/__snapshots__/lpa-statement.test.js.snap
@@ -144,7 +144,7 @@ exports[`lpa-statements GET / should render the view LPA statement page with the
         </div>
     </div>
     <dl class="govuk-summary-list">
-        <div class="govuk-summary-list__row govuk-summary-list__row--no-actions"><dt class="govuk-summary-list__key"> Statement</dt>
+        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Statement</dt>
             <dd class="govuk-summary-list__value">
                 <div class="pins-show-more" data-label="Statement" data-mode="text">Every single thing in the world has its own personality - and it is up
                     to you to make friends with the little rascals. Steve wants reflections,

--- a/appeals/web/src/server/appeals/appeal-details/representations/lpa-statement/__tests__/lpa-statement.test.js
+++ b/appeals/web/src/server/appeals/appeal-details/representations/lpa-statement/__tests__/lpa-statement.test.js
@@ -152,6 +152,12 @@ describe('lpa-statements', () => {
 			const unprettifiedElement = parseHtml(response.text, { skipPrettyPrint: true });
 
 			expect(unprettifiedElement.innerHTML).toContain('>LPA statement</h1>');
+			expect(unprettifiedElement.innerHTML).toContain(
+				'<div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Statement</dt>'
+			);
+			expect(unprettifiedElement.innerHTML).toContain(
+				'<div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Supporting documents</dt>'
+			);
 			expect(unprettifiedElement.innerHTML).not.toContain('Review decision</legend>');
 			expect(unprettifiedElement.innerHTML).not.toContain(
 				'name="status" type="radio" value="valid">'

--- a/appeals/web/src/server/appeals/appeal-details/representations/lpa-statement/lpa-statement.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/representations/lpa-statement/lpa-statement.mapper.js
@@ -67,7 +67,7 @@ export function baseSummaryList(appealId, lpaStatement, { isReview }) {
 							},
 							{
 								key: { text: 'Redacted statement' },
-								classes: 'govuk-summary-list__row--no-actions',
+								classes: isReview ? 'govuk-summary-list__row--no-actions' : '',
 								value: {
 									html: '',
 									pageComponents: [
@@ -98,7 +98,7 @@ export function baseSummaryList(appealId, lpaStatement, { isReview }) {
 					: [
 							{
 								key: { text: 'Statement' },
-								classes: 'govuk-summary-list__row--no-actions',
+								classes: isReview ? 'govuk-summary-list__row--no-actions' : '',
 								value: {
 									html: '',
 									pageComponents: [


### PR DESCRIPTION
## Describe your changes

- updated `no-actions` summary list row modifier class to render conditionally on view LPA statement page to fix layout issue
- updated unit tests to guard against regression

## Issue ticket number and link
https://pins-ds.atlassian.net/browse/A2-2676
