### PR TITLE
fix(appeals): appeal withdrawn email for lpa incorrect (a2-2739)

### DIFF
--- a/appeals/api/src/server/endpoints/withdrawal/withdrawal.service.js
+++ b/appeals/api/src/server/endpoints/withdrawal/withdrawal.service.js
@@ -31,11 +31,15 @@ export const publishWithdrawal = async (
 	const recipientEmail = appeal.agent?.email || appeal.appellant?.email;
 	const lpaEmail = appeal.lpa?.email || '';
 
+	const eventType = appeal.appealStatus[0].status === APPEAL_CASE_STATUS.EVENT ? 'site visit' : '';
+
 	const personalisation = {
 		appeal_reference_number: appeal.reference,
 		lpa_reference: appeal.applicationReference || '',
 		site_address: siteAddress,
-		withdrawal_date: formatDate(new Date(withdrawalRequestDate || ''), false)
+		withdrawal_date: formatDate(new Date(withdrawalRequestDate || ''), false),
+		event_type: eventType,
+		event_set: !!eventType
 	};
 
 	if (recipientEmail) {

--- a/appeals/api/src/server/notify/notify-send.js
+++ b/appeals/api/src/server/notify/notify-send.js
@@ -23,7 +23,7 @@ export const nunjucksEnv = nunjucks.configure(templatesDir, {
 });
 
 /**
- * @typedef {Record<string, string | string[]>} Personalisation
+ * @typedef {Record<string, string | string[] | boolean | number>} Personalisation
  */
 
 /**

--- a/appeals/api/src/server/notify/templates/__tests__/notify-appeal-withdrawn-appellant.test.js
+++ b/appeals/api/src/server/notify/templates/__tests__/notify-appeal-withdrawn-appellant.test.js
@@ -1,0 +1,64 @@
+import { jest } from '@jest/globals';
+import { notifySend } from '#notify/notify-send.js';
+
+test('should call notify sendEmail for appeal-withdrawn-appellant with the correct data', async () => {
+	const notifySendData = {
+		doNotMockNotifySend: true,
+		templateName: 'appeal-withdrawn-appellant',
+		notifyClient: {
+			sendEmail: jest.fn()
+		},
+		recipientEmail: 'test@136s7.com',
+		personalisation: {
+			appeal_reference_number: '134526',
+			lpa_reference: '48269/APP/2021/1482',
+			site_address: '96 The Avenue, Leftfield, Maidstone, Kent, MD21 5XY, United Kingdom',
+			withdrawal_date: '01 January 2025'
+		},
+		appeal: {
+			id: 'mock-appeal-generic-id',
+			reference: '134526'
+		},
+		startDate: new Date('2025-01-01')
+	};
+
+	const expectedContent = [
+		'# Appeal details',
+		'',
+		'^Appeal reference number: 134526',
+		'Address: 96 The Avenue, Leftfield, Maidstone, Kent, MD21 5XY, United Kingdom',
+		'Planning application reference: 48269/APP/2021/1482',
+		'',
+		'# Appeal withdrawn',
+		'',
+		'We have withdrawn this appeal following your request on 01 January 2025.',
+		'',
+		'# Next steps',
+		'',
+		'Your case will be closed.',
+		'',
+		'Any appointments made for this appeal will be cancelled.',
+		'',
+		'The planning department that refused your application has been informed.',
+		'',
+		'# Feedback',
+		'',
+		'We welcome your feedback on our appeals process. Tell us on this short [feedback form](https://forms.office.com/pages/responsepage.aspx?id=mN94WIhvq0iTIpmM5VcIjfMZj__F6D9LmMUUyoUrZDZUOERYMEFBN0NCOFdNU1BGWEhHUFQxWVhUUy4u).',
+		'',
+		'The Planning Inspectorate',
+		'caseofficers@planninginspectorate.gov.uk'
+	].join('\n');
+
+	await notifySend(notifySendData);
+
+	expect(notifySendData.notifyClient.sendEmail).toHaveBeenCalledWith(
+		{
+			id: 'mock-appeal-generic-id'
+		},
+		'test@136s7.com',
+		{
+			content: expectedContent,
+			subject: 'Appeal withdrawn: 134526'
+		}
+	);
+});

--- a/appeals/api/src/server/notify/templates/__tests__/notify-appeal-withdrawn-lpa.test.js
+++ b/appeals/api/src/server/notify/templates/__tests__/notify-appeal-withdrawn-lpa.test.js
@@ -1,0 +1,64 @@
+import { jest } from '@jest/globals';
+import { notifySend } from '#notify/notify-send.js';
+
+test('should call notify sendEmail for appeal-withdrawn-lpa with the correct data', async () => {
+	const notifySendData = {
+		doNotMockNotifySend: true,
+		templateName: 'appeal-withdrawn-lpa',
+		notifyClient: {
+			sendEmail: jest.fn()
+		},
+		recipientEmail: 'test@136s7.com',
+		personalisation: {
+			appeal_reference_number: '234567',
+			lpa_reference: '48269/APP/2021/1483',
+			site_address: '98 The Avenue, Leftfield, Maidstone, Kent, MD21 5YY, United Kingdom',
+			withdrawal_date: '03 January 2025',
+			event_set: true,
+			event_type: 'site visit'
+		},
+		appeal: {
+			id: 'mock-appeal-generic-id',
+			reference: '234567'
+		},
+		startDate: new Date('2025-01-01')
+	};
+
+	const expectedContent = [
+		"We have withdrawn the appeal after the appellant's request.",
+		'',
+		'# Appeal details',
+		'',
+		'^Appeal reference number: 234567',
+		'Address: 98 The Avenue, Leftfield, Maidstone, Kent, MD21 5YY, United Kingdom',
+		'Planning application reference: 48269/APP/2021/1483',
+		'',
+		'# What happens next',
+		'',
+		'The appeal is closed.',
+		'',
+		'',
+		'We have cancelled the site visit.',
+		'',
+		'',
+		'# Feedback',
+		'',
+		'We welcome your feedback on our appeals process. Tell us on this short [feedback form](https://forms.office.com/pages/responsepage.aspx?id=mN94WIhvq0iTIpmM5VcIjfMZj__F6D9LmMUUyoUrZDZUOERYMEFBN0NCOFdNU1BGWEhHUFQxWVhUUy4u).',
+		'',
+		'The Planning Inspectorate',
+		'caseofficers@planninginspectorate.gov.uk'
+	].join('\n');
+
+	await notifySend(notifySendData);
+
+	expect(notifySendData.notifyClient.sendEmail).toHaveBeenCalledWith(
+		{
+			id: 'mock-appeal-generic-id'
+		},
+		'test@136s7.com',
+		{
+			content: expectedContent,
+			subject: 'Appeal withdrawn: 234567'
+		}
+	);
+});

--- a/appeals/api/src/server/notify/templates/appeal-withdrawn-lpa.content.md
+++ b/appeals/api/src/server/notify/templates/appeal-withdrawn-lpa.content.md
@@ -1,16 +1,14 @@
+We have withdrawn the appeal after the appellant's request.
+
 {% include 'parts/appeal-details.md' %}
 
-# Appeal withdrawn
+# What happens next
 
-This appeal has been withdrawn following a request from the appellant dated {{withdrawal_date}}.
+The appeal is closed.
 
-# Next steps
-
-The case will be closed.
-
-Any appointments made for this appeal will be cancelled.
-
-The appellant has been informed.
+{% if event_set %}
+We have cancelled the {{event_type}}.
+{% endif %}
 
 # Feedback
 


### PR DESCRIPTION
## Describe your changes
#### Appeal withdrawn email for LPA is incorrect (a2-2739)

### API:
- Amended the appeal withdrawn email template to include the event type of site visit if set 

### TEST:
- Created specific template tests
- Updated withdrawn unit test
- Made sure all unit tests pass
- Manually tested within browser
- Tested with notify emulator

## Issue ticket number and link
[Appeal withdrawn email for LPA is incorrect (A2-2739)](https://pins-ds.atlassian.net/browse/A2-2739)
