### PR TITLE
fix/a2-3110-removing-null-ellipsis-field-from-pagination-markers

### DIFF
--- a/appeals/web/src/server/appeals/national-list/__tests__/__snapshots__/national-list.test.js.snap
+++ b/appeals/web/src/server/appeals/national-list/__tests__/__snapshots__/national-list.test.js.snap
@@ -361,8 +361,6 @@ exports[`national-list GET / should render national list - 15 pages - pagination
                     <li class="govuk-pagination__item govuk-pagination__item--current"><a class="govuk-link govuk-pagination__link" href="/appeals-service/all-cases?pageSize=30&amp;pageNumber=1"
                         aria-label="Page 1" aria-current="page"> 1</a>
                     </li>
-                    <li class="govuk-pagination__item"><a class="govuk-link govuk-pagination__link" href="" aria-label="Page undefined"></a>
-                    </li>
                     <li class="govuk-pagination__item"><a class="govuk-link govuk-pagination__link" href="/appeals-service/all-cases?pageSize=30&amp;pageNumber=2"
                         aria-label="Page 2"> 2</a>
                     </li>

--- a/appeals/web/src/server/lib/mappers/__tests__/mappers.test.js
+++ b/appeals/web/src/server/lib/mappers/__tests__/mappers.test.js
@@ -10,6 +10,7 @@ import { mapPagination } from '../index.js';
 import { mapRepresentationDocumentSummaryActionLink } from '#lib/representation-utilities.js';
 import { APPEAL_REPRESENTATION_STATUS } from '@pins/appeals/constants/common.js';
 import { constructUrl } from '#lib/mappers/utils/url.mapper.js';
+import { isEqual } from 'lodash-es';
 
 /** @typedef {import('../../../app/auth/auth-session.service').SessionWithAuth} SessionWithAuth */
 
@@ -146,30 +147,41 @@ describe('pagination mapper', () => {
 				`${testBaseUrl}?pageSize=10&pageNumber=5${testAdditionalQueryString}`
 			);
 		});
-		it('renders a truthy ellipsis element between pg4 & pg19 markers if page count is greater than 10 and current page is pg2', () => {
+
+		it('renders an ellipsis element before the final page marker and no ellipsis element after the first page marker when page count is greater than 10 and current page is 2', () => {
 			const testBaseUrl = 'test-base-url';
 			const result = mapPagination(2, 15, 30, testBaseUrl, testAdditionalQuery);
-			let containsNullEllipsisValue = result.items[3].ellipsis === true;
-			expect(containsNullEllipsisValue).toBeTruthy();
+
+			const containsEllipsisElementAfterFirstPageMarker = isEqual(result.items[1], {
+				ellipsis: true
+			});
+			const containsEllipsisElementBeforeLastPageMarker = isEqual(result.items[3], {
+				ellipsis: true
+			});
+			const containsBlankEllipsisElementBeforeLastPageMarker =
+				result.items.filter((item) => isEqual(item, { ellipsis: false })).length > 0;
+
+			expect(containsEllipsisElementAfterFirstPageMarker).toBeFalsy();
+			expect(containsEllipsisElementBeforeLastPageMarker).toBeTruthy();
+			expect(containsBlankEllipsisElementBeforeLastPageMarker).toBeFalsy();
 		});
 
-		it('renders a truthy ellipsis element between pg1 & pg16 markers if page count is greater than 10 and current page is pg17', () => {
+		it('renders an ellipsis element after the first page marker and no ellipsis element before the last page marker when page count is greater than 10 and current page is 17', () => {
 			const testBaseUrl = 'test-base-url';
-			const result = mapPagination(17, 19, 30, testBaseUrl, testAdditionalQuery);
-			let containsNullEllipsisValue = result.items[1].ellipsis === true;
-			expect(containsNullEllipsisValue).toBeTruthy();
-		});
-		it('does not render a falsy ellipsis element between pg4 & pg19 markers if page count is greater than 10 and current page is pg2', () => {
-			const testBaseUrl = 'test-base-url';
-			const result = mapPagination(2, 15, 30, testBaseUrl, testAdditionalQuery);
-			let containsNullEllipsisValue = result.items[1].ellipsis === false;
-			expect(containsNullEllipsisValue).toBeFalsy();
-		});
-		it('does not render a falsy ellipsis element between pg1 & pg16 markers if page count is greater than 10 and current page is pg17', () => {
-			const testBaseUrl = 'test-base-url';
-			const result = mapPagination(17, 19, 30, testBaseUrl, testAdditionalQuery);
-			let containsNullEllipsisValue = result.items[5].ellipsis === false;
-			expect(containsNullEllipsisValue).toBeFalsy();
+			const result = mapPagination(17, 15, 30, testBaseUrl, testAdditionalQuery);
+
+			const containsEllipsisElementAfterFirstPageMarker = isEqual(result.items[1], {
+				ellipsis: true
+			});
+			const containsEllipsisElementBeforeLastPageMarker = isEqual(result.items[3], {
+				ellipsis: true
+			});
+			const containsBlankEllipsisElementBeforeLastPageMarker =
+				result.items.filter((item) => isEqual(item, { ellipsis: false })).length > 0;
+
+			expect(containsEllipsisElementAfterFirstPageMarker).toBeTruthy();
+			expect(containsEllipsisElementBeforeLastPageMarker).toBeFalsy();
+			expect(containsBlankEllipsisElementBeforeLastPageMarker).toBeFalsy();
 		});
 	});
 });

--- a/appeals/web/src/server/lib/mappers/__tests__/mappers.test.js
+++ b/appeals/web/src/server/lib/mappers/__tests__/mappers.test.js
@@ -146,6 +146,31 @@ describe('pagination mapper', () => {
 				`${testBaseUrl}?pageSize=10&pageNumber=5${testAdditionalQueryString}`
 			);
 		});
+		it('renders a truthy ellipsis element between pg4 & pg19 markers if page count is greater than 10 and current page is pg2', () => {
+			const testBaseUrl = 'test-base-url';
+			const result = mapPagination(2, 15, 30, testBaseUrl, testAdditionalQuery);
+			let containsNullEllipsisValue = result.items[3].ellipsis === true;
+			expect(containsNullEllipsisValue).toBeTruthy();
+		});
+
+		it('renders a truthy ellipsis element between pg1 & pg16 markers if page count is greater than 10 and current page is pg17', () => {
+			const testBaseUrl = 'test-base-url';
+			const result = mapPagination(17, 19, 30, testBaseUrl, testAdditionalQuery);
+			let containsNullEllipsisValue = result.items[1].ellipsis === true;
+			expect(containsNullEllipsisValue).toBeTruthy();
+		});
+		it('does not render a falsy ellipsis element between pg4 & pg19 markers if page count is greater than 10 and current page is pg2', () => {
+			const testBaseUrl = 'test-base-url';
+			const result = mapPagination(2, 15, 30, testBaseUrl, testAdditionalQuery);
+			let containsNullEllipsisValue = result.items[1].ellipsis === false;
+			expect(containsNullEllipsisValue).toBeFalsy();
+		});
+		it('does not render a falsy ellipsis element between pg1 & pg16 markers if page count is greater than 10 and current page is pg17', () => {
+			const testBaseUrl = 'test-base-url';
+			const result = mapPagination(17, 19, 30, testBaseUrl, testAdditionalQuery);
+			let containsNullEllipsisValue = result.items[5].ellipsis === false;
+			expect(containsNullEllipsisValue).toBeFalsy();
+		});
 	});
 });
 

--- a/appeals/web/src/server/lib/mappers/__tests__/mappers.test.js
+++ b/appeals/web/src/server/lib/mappers/__tests__/mappers.test.js
@@ -158,12 +158,12 @@ describe('pagination mapper', () => {
 			const containsEllipsisElementBeforeLastPageMarker = isEqual(result.items[3], {
 				ellipsis: true
 			});
-			const containsBlankEllipsisElementBeforeLastPageMarker =
+			const containsBlankEllipsisElement =
 				result.items.filter((item) => isEqual(item, { ellipsis: false })).length > 0;
 
 			expect(containsEllipsisElementAfterFirstPageMarker).toBeFalsy();
 			expect(containsEllipsisElementBeforeLastPageMarker).toBeTruthy();
-			expect(containsBlankEllipsisElementBeforeLastPageMarker).toBeFalsy();
+			expect(containsBlankEllipsisElement).toBeFalsy();
 		});
 
 		it('renders an ellipsis element after the first page marker and no ellipsis element before the last page marker when page count is greater than 10 and current page is 17', () => {
@@ -176,12 +176,12 @@ describe('pagination mapper', () => {
 			const containsEllipsisElementBeforeLastPageMarker = isEqual(result.items[3], {
 				ellipsis: true
 			});
-			const containsBlankEllipsisElementBeforeLastPageMarker =
+			const containsBlankEllipsisElement =
 				result.items.filter((item) => isEqual(item, { ellipsis: false })).length > 0;
 
 			expect(containsEllipsisElementAfterFirstPageMarker).toBeTruthy();
 			expect(containsEllipsisElementBeforeLastPageMarker).toBeFalsy();
-			expect(containsBlankEllipsisElementBeforeLastPageMarker).toBeFalsy();
+			expect(containsBlankEllipsisElement).toBeFalsy();
 		});
 	});
 });

--- a/appeals/web/src/server/lib/mappers/components/page-components/pagination.mapper.js
+++ b/appeals/web/src/server/lib/mappers/components/page-components/pagination.mapper.js
@@ -73,9 +73,11 @@ export function mapPagination(currentPage, pageCount, itemsPerPage, baseUrl, que
 			}
 		} else {
 			// do not show ellipsis if you're in the beginning of the pagination
-			pagination.items.push({
-				ellipsis: currentPage > 3
-			});
+			if (currentPage > 3) {
+				pagination.items.push({
+					ellipsis: true
+				});
+			}
 
 			// logic for neighbouring indexes (previous, current and next ones)
 			if (previousPage > 1) {
@@ -109,9 +111,11 @@ export function mapPagination(currentPage, pageCount, itemsPerPage, baseUrl, que
 			}
 
 			// do not show this ellipsis if you're in the end of the pagination
-			pagination.items.push({
-				ellipsis: currentPage < pageCount - 2
-			});
+			if (currentPage < pageCount - 2) {
+				pagination.items.push({
+					ellipsis: true
+				});
+			}
 
 			// last index
 			if (currentPage < pageCount) {


### PR DESCRIPTION
- Added condition to stop null ellipsis field rendering
- added tests
- updated snapshot 

https://pins-ds.atlassian.net/browse/A2-3110