### PR TITLE
fix(web): all cases filter status dropdown to always contain all statuses of appeals in national list

### DIFF
--- a/appeals/api/src/server/endpoints/appeals/__tests__/appeals.test.js
+++ b/appeals/api/src/server/endpoints/appeals/__tests__/appeals.test.js
@@ -169,7 +169,8 @@ describe('appeals list routes', () => {
 					page: 1,
 					pageCount: 1,
 					pageSize: 30,
-					statuses: ['assign_case_officer']
+					statuses: ['assign_case_officer'],
+					statusesInNationalList: ['assign_case_officer']
 				});
 			});
 
@@ -243,7 +244,8 @@ describe('appeals list routes', () => {
 					page: 2,
 					pageCount: 2,
 					pageSize: 1,
-					statuses: ['assign_case_officer']
+					statuses: ['assign_case_officer'],
+					statusesInNationalList: ['assign_case_officer']
 				});
 			});
 
@@ -350,7 +352,8 @@ describe('appeals list routes', () => {
 					page: 1,
 					pageCount: 1,
 					pageSize: 30,
-					statuses: ['assign_case_officer']
+					statuses: ['assign_case_officer'],
+					statusesInNationalList: ['assign_case_officer']
 				});
 			});
 
@@ -457,7 +460,8 @@ describe('appeals list routes', () => {
 					page: 1,
 					pageCount: 1,
 					pageSize: 30,
-					statuses: ['assign_case_officer']
+					statuses: ['assign_case_officer'],
+					statusesInNationalList: ['assign_case_officer']
 				});
 			});
 
@@ -564,7 +568,8 @@ describe('appeals list routes', () => {
 					page: 1,
 					pageCount: 1,
 					pageSize: 30,
-					statuses: ['assign_case_officer']
+					statuses: ['assign_case_officer'],
+					statusesInNationalList: ['assign_case_officer']
 				});
 			});
 
@@ -653,7 +658,8 @@ describe('appeals list routes', () => {
 					page: 1,
 					pageCount: 1,
 					pageSize: 30,
-					statuses: ['assign_case_officer']
+					statuses: ['assign_case_officer'],
+					statusesInNationalList: ['assign_case_officer']
 				});
 			});
 
@@ -744,7 +750,8 @@ describe('appeals list routes', () => {
 					page: 1,
 					pageCount: 1,
 					pageSize: 30,
-					statuses: ['assign_case_officer']
+					statuses: ['assign_case_officer'],
+					statusesInNationalList: ['assign_case_officer']
 				});
 			});
 
@@ -833,7 +840,8 @@ describe('appeals list routes', () => {
 					page: 1,
 					pageCount: 1,
 					pageSize: 30,
-					statuses: ['assign_case_officer']
+					statuses: ['assign_case_officer'],
+					statusesInNationalList: ['assign_case_officer']
 				});
 			});
 
@@ -1064,7 +1072,8 @@ test('gets appeals when given a appealTypeId param', async () => {
 		page: 1,
 		pageCount: 1,
 		pageSize: 30,
-		statuses: ['assign_case_officer']
+		statuses: ['assign_case_officer'],
+		statusesInNationalList: ['assign_case_officer']
 	});
 });
 

--- a/appeals/api/src/server/endpoints/appeals/appeals.controller.js
+++ b/appeals/api/src/server/endpoints/appeals/appeals.controller.js
@@ -31,6 +31,7 @@ const getAppeals = async (req, res) => {
 		itemCount,
 		mappedAppeals,
 		mappedStatuses,
+		statusesInNationalList,
 		mappedLPAs,
 		mappedInspectors,
 		mappedCaseOfficers
@@ -52,6 +53,7 @@ const getAppeals = async (req, res) => {
 		itemCount,
 		items: mappedAppeals,
 		statuses: mappedStatuses,
+		statusesInNationalList,
 		lpas: mappedLPAs,
 		inspectors: mappedInspectors,
 		caseOfficers: mappedCaseOfficers,

--- a/appeals/api/src/server/endpoints/appeals/appeals.service.js
+++ b/appeals/api/src/server/endpoints/appeals/appeals.service.js
@@ -11,25 +11,25 @@ import { APPEAL_CASE_STATUS } from 'pins-data-model';
 /** @typedef {import('@pins/appeals.api').Schema.Appeal} Appeal */
 /** @typedef {import('#repositories/appeal-lists.repository.js').DBAppeals} DBAppeals */
 
+const allStatusesOrdered = [
+	APPEAL_CASE_STATUS.ASSIGN_CASE_OFFICER,
+	APPEAL_CASE_STATUS.VALIDATION,
+	APPEAL_CASE_STATUS.READY_TO_START,
+	APPEAL_CASE_STATUS.LPA_QUESTIONNAIRE,
+	APPEAL_CASE_STATUS.EVENT,
+	APPEAL_CASE_STATUS.AWAITING_EVENT,
+	APPEAL_CASE_STATUS.ISSUE_DETERMINATION,
+	APPEAL_CASE_STATUS.AWAITING_TRANSFER,
+	APPEAL_CASE_STATUS.COMPLETE,
+	APPEAL_CASE_STATUS.STATEMENTS,
+	APPEAL_CASE_STATUS.FINAL_COMMENTS
+];
+
 /**
  * @param {{ appealStatus: { status: string; }[] }[]} rawStatuses
  * @returns {string[]}
  */
 export const mapAppealStatuses = (rawStatuses) => {
-	const statusOrder = [
-		APPEAL_CASE_STATUS.ASSIGN_CASE_OFFICER,
-		APPEAL_CASE_STATUS.VALIDATION,
-		APPEAL_CASE_STATUS.READY_TO_START,
-		APPEAL_CASE_STATUS.LPA_QUESTIONNAIRE,
-		APPEAL_CASE_STATUS.EVENT,
-		APPEAL_CASE_STATUS.AWAITING_EVENT,
-		APPEAL_CASE_STATUS.ISSUE_DETERMINATION,
-		APPEAL_CASE_STATUS.AWAITING_TRANSFER,
-		APPEAL_CASE_STATUS.COMPLETE,
-		APPEAL_CASE_STATUS.STATEMENTS,
-		APPEAL_CASE_STATUS.FINAL_COMMENTS
-	];
-
 	const extractedStatuses = [
 		...new Set(
 			rawStatuses
@@ -43,7 +43,7 @@ export const mapAppealStatuses = (rawStatuses) => {
 	// return the two arrays above with duplicates removed
 	return Array.from(
 		new Set([
-			...statusOrder.filter((status) => extractedStatuses.includes(status)),
+			...allStatusesOrdered.filter((status) => extractedStatuses.includes(status)),
 			...extractedStatuses
 		])
 	);
@@ -127,7 +127,7 @@ const mapAppeals = (appeals) =>
  * @param {number} caseOfficerId
  * @param {boolean} isGreenBelt
  * @param {number} appealTypeId
- * @returns {Promise<{mappedStatuses: string[], mappedLPAs: any[], mappedInspectors: any[], mappedCaseOfficers: any[], mappedAppeals: any[], itemCount: number}>}
+ * @returns {Promise<{mappedStatuses: string[], statusesInNationalList: string[], mappedLPAs: any[], mappedInspectors: any[], mappedCaseOfficers: any[], mappedAppeals: any[], itemCount: number}>}
  */
 const retrieveAppealListData = async (
 	pageNumber,
@@ -159,9 +159,11 @@ const retrieveAppealListData = async (
 	const mappedLPAs = mapAppealLPAs(appeals);
 	const mappedInspectors = await mapInspectors(appeals);
 	const mappedCaseOfficers = await mapCaseOfficers(appeals);
+	const statusesInNationalList = await appealListRepository.getAppealsStatusesInNationalList();
 
 	return {
 		mappedStatuses,
+		statusesInNationalList,
 		mappedLPAs,
 		mappedInspectors,
 		mappedCaseOfficers,

--- a/appeals/web/src/server/appeals/national-list/__tests__/__snapshots__/national-list.test.js.snap
+++ b/appeals/web/src/server/appeals/national-list/__tests__/__snapshots__/national-list.test.js.snap
@@ -53,10 +53,14 @@ exports[`national-list GET / should render national list - 10 pages - all page i
                             name="appealStatusFilter" data-cy="filter-by-case-status">
                                 <option value="all">All</option>
                                 <option value="assign_case_officer">Assign case officer</option>
-                                <option value="ready_to_start">Ready to start</option>
                                 <option value="lpa_questionnaire">LPA questionnaire</option>
+                                <option value="statements">Statements</option>
+                                <option value="ready_to_start">Ready to start</option>
+                                <option value="validation">Validation</option>
+                                <option value="final_comments">Final comments</option>
+                                <option value="invalid">Invalid</option>
                                 <option value="issue_determination">Issue decision</option>
-                                <option value="complete">Complete</option>
+                                <option value="withdrawn">Withdrawn</option>
                             </select>
                         </div>
                         <div class="govuk-form-group">
@@ -252,10 +256,14 @@ exports[`national-list GET / should render national list - 15 pages - pagination
                             name="appealStatusFilter" data-cy="filter-by-case-status">
                                 <option value="all">All</option>
                                 <option value="assign_case_officer">Assign case officer</option>
-                                <option value="ready_to_start">Ready to start</option>
                                 <option value="lpa_questionnaire">LPA questionnaire</option>
+                                <option value="statements">Statements</option>
+                                <option value="ready_to_start">Ready to start</option>
+                                <option value="validation">Validation</option>
+                                <option value="final_comments">Final comments</option>
+                                <option value="invalid">Invalid</option>
                                 <option value="issue_determination">Issue decision</option>
-                                <option value="complete">Complete</option>
+                                <option value="withdrawn">Withdrawn</option>
                             </select>
                         </div>
                         <div class="govuk-form-group">
@@ -433,11 +441,6 @@ exports[`national-list GET / should render national list - appeal type filter ap
                             <select class="govuk-select" id="appeal-status-filter"
                             name="appealStatusFilter" data-cy="filter-by-case-status">
                                 <option value="all">All</option>
-                                <option value="assign_case_officer">Assign case officer</option>
-                                <option value="ready_to_start">Ready to start</option>
-                                <option value="lpa_questionnaire">LPA questionnaire</option>
-                                <option value="issue_determination">Issue decision</option>
-                                <option value="complete">Complete</option>
                             </select>
                         </div>
                         <div class="govuk-form-group">
@@ -582,10 +585,14 @@ exports[`national-list GET / should render national list - no pagination 1`] = `
                             name="appealStatusFilter" data-cy="filter-by-case-status">
                                 <option value="all">All</option>
                                 <option value="assign_case_officer">Assign case officer</option>
-                                <option value="ready_to_start">Ready to start</option>
                                 <option value="lpa_questionnaire">LPA questionnaire</option>
+                                <option value="statements">Statements</option>
+                                <option value="ready_to_start">Ready to start</option>
+                                <option value="validation">Validation</option>
+                                <option value="final_comments">Final comments</option>
+                                <option value="invalid">Invalid</option>
                                 <option value="issue_determination">Issue decision</option>
-                                <option value="complete">Complete</option>
+                                <option value="withdrawn">Withdrawn</option>
                             </select>
                         </div>
                         <div class="govuk-form-group">
@@ -743,10 +750,14 @@ exports[`national-list GET / should render national list - no search term - filt
                             name="appealStatusFilter" data-cy="filter-by-case-status">
                                 <option value="all">All</option>
                                 <option value="assign_case_officer">Assign case officer</option>
-                                <option value="ready_to_start">Ready to start</option>
                                 <option value="lpa_questionnaire" selected>LPA questionnaire</option>
+                                <option value="statements">Statements</option>
+                                <option value="ready_to_start">Ready to start</option>
+                                <option value="validation">Validation</option>
+                                <option value="final_comments">Final comments</option>
+                                <option value="invalid">Invalid</option>
                                 <option value="issue_determination">Issue decision</option>
-                                <option value="complete">Complete</option>
+                                <option value="withdrawn">Withdrawn</option>
                             </select>
                         </div>
                         <div class="govuk-form-group">
@@ -896,10 +907,14 @@ exports[`national-list GET / should render national list - search term - filter 
                             name="appealStatusFilter" data-cy="filter-by-case-status">
                                 <option value="all">All</option>
                                 <option value="assign_case_officer">Assign case officer</option>
-                                <option value="ready_to_start">Ready to start</option>
                                 <option value="lpa_questionnaire" selected>LPA questionnaire</option>
+                                <option value="statements">Statements</option>
+                                <option value="ready_to_start">Ready to start</option>
+                                <option value="validation">Validation</option>
+                                <option value="final_comments">Final comments</option>
+                                <option value="invalid">Invalid</option>
                                 <option value="issue_determination">Issue decision</option>
-                                <option value="complete">Complete</option>
+                                <option value="withdrawn">Withdrawn</option>
                             </select>
                         </div>
                         <div class="govuk-form-group">
@@ -1048,11 +1063,6 @@ exports[`national-list GET / should render national list - search term - no resu
                             <select class="govuk-select" id="appeal-status-filter"
                             name="appealStatusFilter" data-cy="filter-by-case-status">
                                 <option value="all">All</option>
-                                <option value="assign_case_officer">Assign case officer</option>
-                                <option value="ready_to_start">Ready to start</option>
-                                <option value="lpa_questionnaire">LPA questionnaire</option>
-                                <option value="issue_determination">Issue decision</option>
-                                <option value="complete">Complete</option>
                             </select>
                         </div>
                         <div class="govuk-form-group">
@@ -1169,10 +1179,14 @@ exports[`national-list GET / should render national list - search term 1`] = `
                             name="appealStatusFilter" data-cy="filter-by-case-status">
                                 <option value="all">All</option>
                                 <option value="assign_case_officer">Assign case officer</option>
-                                <option value="ready_to_start">Ready to start</option>
                                 <option value="lpa_questionnaire">LPA questionnaire</option>
+                                <option value="statements">Statements</option>
+                                <option value="ready_to_start">Ready to start</option>
+                                <option value="validation">Validation</option>
+                                <option value="final_comments">Final comments</option>
+                                <option value="invalid">Invalid</option>
                                 <option value="issue_determination">Issue decision</option>
-                                <option value="complete">Complete</option>
+                                <option value="withdrawn">Withdrawn</option>
                             </select>
                         </div>
                         <div class="govuk-form-group">
@@ -1327,10 +1341,14 @@ exports[`national-list GET / should render the header with navigation containing
                             name="appealStatusFilter" data-cy="filter-by-case-status">
                                 <option value="all">All</option>
                                 <option value="assign_case_officer">Assign case officer</option>
-                                <option value="ready_to_start">Ready to start</option>
                                 <option value="lpa_questionnaire">LPA questionnaire</option>
+                                <option value="statements">Statements</option>
+                                <option value="ready_to_start">Ready to start</option>
+                                <option value="validation">Validation</option>
+                                <option value="final_comments">Final comments</option>
+                                <option value="invalid">Invalid</option>
                                 <option value="issue_determination">Issue decision</option>
-                                <option value="complete">Complete</option>
+                                <option value="withdrawn">Withdrawn</option>
                             </select>
                         </div>
                         <div class="govuk-form-group">

--- a/appeals/web/src/server/appeals/national-list/__tests__/national-list.test.js
+++ b/appeals/web/src/server/appeals/national-list/__tests__/national-list.test.js
@@ -81,11 +81,11 @@ describe('national-list', () => {
 				'<select class="govuk-select" id="appeal-status-filter" name="appealStatusFilter"'
 			);
 			expect(unprettifiedElement.innerHTML).toContain('<option value="all"');
-			expect(unprettifiedElement.innerHTML).toContain('<option value="assign_case_officer"');
-			expect(unprettifiedElement.innerHTML).toContain('<option value="ready_to_start"');
-			expect(unprettifiedElement.innerHTML).toContain('<option value="lpa_questionnaire"');
-			expect(unprettifiedElement.innerHTML).toContain('<option value="issue_determination"');
-			expect(unprettifiedElement.innerHTML).toContain('<option value="complete"');
+
+			for (const status of appealsNationalList.statusesInNationalList) {
+				expect(unprettifiedElement.innerHTML).toContain(`<option value="${status}"`);
+			}
+
 			expect(unprettifiedElement.innerHTML).toContain('Inspector status</label>');
 			expect(unprettifiedElement.innerHTML).toContain(
 				'<select class="govuk-select" id="inspector-status-filter" name="inspectorStatusFilter"'
@@ -205,6 +205,7 @@ describe('national-list', () => {
 					itemCount: 1,
 					items: [appealsNationalList.items[0]],
 					statuses,
+					statusesInNationalList: appealsNationalList.statusesInNationalList,
 					lpas,
 					inspectors,
 					caseOfficers,
@@ -242,6 +243,7 @@ describe('national-list', () => {
 					itemCount: 1,
 					items: [appealsNationalList.items[0]],
 					statuses,
+					statusesInNationalList: appealsNationalList.statusesInNationalList,
 					lpas,
 					inspectors,
 					caseOfficers,

--- a/appeals/web/src/server/appeals/national-list/national-list.mapper.js
+++ b/appeals/web/src/server/appeals/national-list/national-list.mapper.js
@@ -2,7 +2,7 @@ import { appealShortReference } from '#lib/appeals-formatter.js';
 import { addressToString } from '#lib/address-formatter.js';
 import { preRenderPageComponents } from '#lib/nunjucks-template-builders/page-component-rendering.js';
 import { numberToAccessibleDigitLabel } from '#lib/accessibility.js';
-import { appealStatusToStatusTag } from '#lib/nunjucks-filters/status-tag.js';
+import { appealStatusToStatusText } from '#lib/nunjucks-filters/status-tag.js';
 import { capitalizeFirstLetter } from '#lib/string-utilities.js';
 import { mapStatusText } from '#lib/appeal-status.js';
 import { APPEAL_CASE_TYPE } from 'pins-data-model';
@@ -56,9 +56,9 @@ export function nationalListPage(
 			inspectorFilter
 		].some((filter) => filter && filter !== 'all');
 
-	const appealStatusFilterItemsArray = ['all', ...(appeals?.statuses || [])].map(
+	const appealStatusFilterItemsArray = ['all', ...(appeals?.statusesInNationalList || [])].map(
 		(appealStatus) => ({
-			text: appealStatusToStatusTag(appealStatus),
+			text: appealStatusToStatusText(appealStatus),
 			value: appealStatus,
 			selected: appealStatusFilter === appealStatus
 		})

--- a/appeals/web/src/server/appeals/personal-list/personal-list.mapper.js
+++ b/appeals/web/src/server/appeals/personal-list/personal-list.mapper.js
@@ -5,7 +5,7 @@ import { preRenderPageComponents } from '#lib/nunjucks-template-builders/page-co
 import { dateISOStringToDisplayDate } from '#lib/dates.js';
 import { numberToAccessibleDigitLabel } from '#lib/accessibility.js';
 import * as authSession from '../../app/auth/auth-session.service.js';
-import { appealStatusToStatusTag } from '#lib/nunjucks-filters/status-tag.js';
+import { appealStatusToStatusText } from '#lib/nunjucks-filters/status-tag.js';
 import { capitalizeFirstLetter } from '#lib/string-utilities.js';
 import { mapStatusText } from '#lib/appeal-status.js';
 import { getRequiredActionsForAppeal } from '#lib/mappers/utils/required-actions.js';
@@ -38,7 +38,7 @@ export function personalListPage(
 	const isCaseOfficer = userGroups.includes(config.referenceData.appeals.caseOfficerGroupId);
 	const filterItemsArray = ['all', ...(appealsAssignedToCurrentUser?.statuses || [])].map(
 		(appealStatus) => ({
-			text: capitalizeFirstLetter(appealStatusToStatusTag(appealStatus)),
+			text: capitalizeFirstLetter(appealStatusToStatusText(appealStatus)),
 			value: appealStatus,
 			selected: appealStatusFilter === appealStatus
 		})

--- a/appeals/web/src/server/lib/nunjucks-filters/index.js
+++ b/appeals/web/src/server/lib/nunjucks-filters/index.js
@@ -30,7 +30,7 @@ export { fileSize } from './file-size.js';
 export { userTypeMap } from './user-type-map.js';
 export { MIME, allowedMimeTypes, fileType, formattedFileTypes } from './mime-type.js';
 export { setAttribute } from './set-attribute.js';
-export { appealStatusToStatusTag } from './status-tag.js';
+export { appealStatusToStatusText as appealStatusToStatusTag } from './status-tag.js';
 export { default as stripQueryParamsDev } from './strip-query-parameters.js';
 export { actionsParameterForDocumentStatus } from './actions-parameter-for-document-status.js';
 export { addConditionalHtml } from './add-conditional-html.js';

--- a/appeals/web/src/server/lib/nunjucks-filters/status-tag.js
+++ b/appeals/web/src/server/lib/nunjucks-filters/status-tag.js
@@ -6,7 +6,7 @@ import { capitalizeFirstLetter } from '#lib/string-utilities.js';
  * @param {string} appealStatus
  * @returns {string}
  */
-export function appealStatusToStatusTag(appealStatus) {
+export function appealStatusToStatusText(appealStatus) {
 	return capitalizeFirstLetter(
 		appealStatus
 			.replace('issue_determination', 'issue_decision')

--- a/appeals/web/testing/app/fixtures/referencedata.js
+++ b/appeals/web/testing/app/fixtures/referencedata.js
@@ -132,6 +132,17 @@ export const appealsNationalList = {
 		'issue_determination',
 		'complete'
 	],
+	statusesInNationalList: [
+		'assign_case_officer',
+		'lpa_questionnaire',
+		'statements',
+		'ready_to_start',
+		'validation',
+		'final_comments',
+		'invalid',
+		'issue_determination',
+		'withdrawn'
+	],
 	lpas: [{ lpaCode: '1', name: 'Test LPA' }],
 	inspectors: [{ azureAdUserId: activeDirectoryUsersData[0].id, id: 0 }],
 	caseOfficers: [{ azureAdUserId: activeDirectoryUsersData[1].id, id: 1 }],

--- a/packages/appeals/types/appeal.d.ts
+++ b/packages/appeals/types/appeal.d.ts
@@ -29,6 +29,7 @@ export interface AppealList {
 	itemCount: number;
 	items: AppealSummary[];
 	statuses: string[];
+	statusesInNationalList: string[];
 	lpas: { name: string; lpaCode: string }[];
 	inspectors: { azureAdUserId: string; id: number }[];
 	caseOfficers: { azureAdUserId: string; id: number }[];


### PR DESCRIPTION
## Describe your changes

- update appeals endpoint to return a list of all appeal statuses in national list
- update national list filter status dropdown to always contain an option for each appeal status present in national list
- rename `appealStatusToStatusTag` function to better reflect its purpose

## Issue ticket number and link
https://pins-ds.atlassian.net/browse/A2-3289
