### PR TITLE
fix(web): increase checkbox conditional text inputs character limit to 1000

### DIFF
--- a/appeals/web/src/server/appeals/appeal-details/appellant-case/__tests__/__snapshots__/appellant-case.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/appellant-case/__tests__/__snapshots__/appellant-case.test.js.snap
@@ -2886,13 +2886,15 @@ exports[`appellant-case GET /appellant-case/check-your-answers should render the
                 </div>
                 <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Incomplete reasons</dt>
                     <dd class="govuk-summary-list__value">
-                        <ul class="govuk-list govuk-!-margin-top-0 govuk-list--bullet">
-                            <li>Attachments and/or appendices have not been included to the full statement
-                                of case: test reason text 1</li>
-                            <li>Attachments and/or appendices have not been included to the full statement
-                                of case: test reason text 2</li>
-                            <li>LPA's decision notice is incorrect or incomplete: test reason text 1</li>
-                        </ul>
+                        <div class="pins-show-more" data-label="Read more" data-mode="html">
+                            <ul class="govuk-list govuk-!-margin-top-0 govuk-!-margin-bottom-0 govuk-list--bullet">
+                                <li>Attachments and/or appendices have not been included to the full statement
+                                    of case: test reason text 1</li>
+                                <li>Attachments and/or appendices have not been included to the full statement
+                                    of case: test reason text 2</li>
+                                <li>LPA's decision notice is incorrect or incomplete: test reason text 1</li>
+                            </ul>
+                        </div>
                     </dd>
                     <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/incomplete">Change<span class="govuk-visually-hidden"> Incomplete reasons</span></a>
                     </dd>
@@ -2934,11 +2936,13 @@ exports[`appellant-case GET /appellant-case/check-your-answers should render the
                 </div>
                 <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Invalid reasons</dt>
                     <dd class="govuk-summary-list__value">
-                        <ul class="govuk-list govuk-!-margin-top-0 govuk-list--bullet">
-                            <li>Documents have not been submitted on time: test reason text 1</li>
-                            <li>Other: test reason text 1</li>
-                            <li>Other: test reason text 2</li>
-                        </ul>
+                        <div class="pins-show-more" data-label="Read more" data-mode="html">
+                            <ul class="govuk-list govuk-!-margin-top-0 govuk-!-margin-bottom-0 govuk-list--bullet">
+                                <li>Documents have not been submitted on time: test reason text 1</li>
+                                <li>Other: test reason text 1</li>
+                                <li>Other: test reason text 2</li>
+                            </ul>
+                        </div>
                     </dd>
                     <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/invalid">Change<span class="govuk-visually-hidden"> Invalid reasons</span></a>
                     </dd>
@@ -4706,7 +4710,7 @@ exports[`appellant-case POST /appellant-case/incomplete should re-render the inc
                     <h2 class="govuk-error-summary__title"> There is a problem</h2>
                     <div class="govuk-error-summary__body">
                         <ul class="govuk-list govuk-error-summary__list">
-                            <li><a href="#">Text in text fields cannot exceed 300 characters</a>
+                            <li><a href="#">Text in text fields cannot exceed 1000 characters</a>
                             </li>
                         </ul>
                     </div>
@@ -4750,7 +4754,7 @@ exports[`appellant-case POST /appellant-case/incomplete should re-render the inc
                                         <div class="govuk-form-group">
                                             <input class="govuk-input pins-add-another__item-input govuk-!-margin-0"
                                             id="incomplete-reason-2026-1" name="incompleteReason-2026" type="text"
-                                            value="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa">
+                                            value="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa">
                                         </div>
                                     </div>
                                 </div>
@@ -5574,7 +5578,7 @@ exports[`appellant-case POST /appellant-case/incomplete should re-render the inc
                     <h2 class="govuk-error-summary__title"> There is a problem</h2>
                     <div class="govuk-error-summary__body">
                         <ul class="govuk-list govuk-error-summary__list">
-                            <li><a href="#">Text in text fields cannot exceed 300 characters</a>
+                            <li><a href="#">Text in text fields cannot exceed 1000 characters</a>
                             </li>
                         </ul>
                     </div>
@@ -5618,7 +5622,7 @@ exports[`appellant-case POST /appellant-case/incomplete should re-render the inc
                                         <div class="govuk-form-group">
                                             <input class="govuk-input pins-add-another__item-input govuk-!-margin-0"
                                             id="incomplete-reason-2026-1" name="incompleteReason-2026" type="text"
-                                            value="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa">
+                                            value="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa">
                                         </div>
                                     </div>
                                 </div>
@@ -6604,7 +6608,7 @@ exports[`appellant-case POST /appellant-case/invalid should re-render the invali
                     <h2 class="govuk-error-summary__title"> There is a problem</h2>
                     <div class="govuk-error-summary__body">
                         <ul class="govuk-list govuk-error-summary__list">
-                            <li><a href="#">Text in text fields cannot exceed 300 characters</a>
+                            <li><a href="#">Text in text fields cannot exceed 1000 characters</a>
                             </li>
                         </ul>
                     </div>
@@ -6646,7 +6650,7 @@ exports[`appellant-case POST /appellant-case/invalid should re-render the invali
                                     <div class="govuk-grid-column-full">
                                         <div class="govuk-form-group">
                                             <input class="govuk-input pins-add-another__item-input govuk-!-margin-0"
-                                            id="invalid-reason-22-1" name="invalidReason-22" type="text" value="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa">
+                                            id="invalid-reason-22-1" name="invalidReason-22" type="text" value="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa">
                                         </div>
                                     </div>
                                 </div>
@@ -7107,7 +7111,7 @@ exports[`appellant-case POST /appellant-case/invalid should re-render the invali
                     <h2 class="govuk-error-summary__title"> There is a problem</h2>
                     <div class="govuk-error-summary__body">
                         <ul class="govuk-list govuk-error-summary__list">
-                            <li><a href="#">Text in text fields cannot exceed 300 characters</a>
+                            <li><a href="#">Text in text fields cannot exceed 1000 characters</a>
                             </li>
                         </ul>
                     </div>
@@ -7149,7 +7153,7 @@ exports[`appellant-case POST /appellant-case/invalid should re-render the invali
                                     <div class="govuk-grid-column-full">
                                         <div class="govuk-form-group">
                                             <input class="govuk-input pins-add-another__item-input govuk-!-margin-0"
-                                            id="invalid-reason-22-1" name="invalidReason-22" type="text" value="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa">
+                                            id="invalid-reason-22-1" name="invalidReason-22" type="text" value="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa">
                                         </div>
                                     </div>
                                 </div>

--- a/appeals/web/src/server/appeals/appeal-details/appellant-case/__tests__/appellant-case.test.js
+++ b/appeals/web/src/server/appeals/appeal-details/appellant-case/__tests__/appellant-case.test.js
@@ -1428,7 +1428,7 @@ describe('appellant-case', () => {
 				.send({
 					invalidReason: invalidReasonsWithTextIds[0],
 					[`invalidReason-${invalidReasonsWithTextIds[0]}`]: 'a'.repeat(
-						textInputCharacterLimits.defaultInputLength + 1
+						textInputCharacterLimits.checkboxTextItemsLength + 1
 					)
 				});
 
@@ -1441,7 +1441,7 @@ describe('appellant-case', () => {
 			}).innerHTML;
 			expect(unprettifiedErrorSummaryHtml).toContain('There is a problem</h2>');
 			expect(unprettifiedErrorSummaryHtml).toContain(
-				'Text in text fields cannot exceed 300 characters</a>'
+				`Text in text fields cannot exceed ${textInputCharacterLimits.checkboxTextItemsLength} characters</a>`
 			);
 		});
 
@@ -1452,7 +1452,7 @@ describe('appellant-case', () => {
 					invalidReason: [invalidReasonsWithTextIds[0], invalidReasonsWithTextIds[1]],
 					[`invalidReason-${invalidReasonsWithTextIds[0]}`]: 'test reason text 1',
 					[`invalidReason-${invalidReasonsWithTextIds[0]}`]: 'a'.repeat(
-						textInputCharacterLimits.defaultInputLength + 1
+						textInputCharacterLimits.checkboxTextItemsLength + 1
 					)
 				});
 
@@ -1465,7 +1465,7 @@ describe('appellant-case', () => {
 			}).innerHTML;
 			expect(unprettifiedErrorSummaryHtml).toContain('There is a problem</h2>');
 			expect(unprettifiedErrorSummaryHtml).toContain(
-				'Text in text fields cannot exceed 300 characters</a>'
+				`Text in text fields cannot exceed ${textInputCharacterLimits.checkboxTextItemsLength} characters</a>`
 			);
 		});
 
@@ -1488,7 +1488,7 @@ describe('appellant-case', () => {
 				.send({
 					invalidReason: invalidReasonsWithTextIds[0],
 					[`invalidReason-${invalidReasonsWithTextIds[0]}`]: [
-						'a'.repeat(textInputCharacterLimits.defaultInputLength)
+						'a'.repeat(textInputCharacterLimits.checkboxTextItemsLength)
 					]
 				});
 
@@ -1517,11 +1517,11 @@ describe('appellant-case', () => {
 				.send({
 					invalidReason: [invalidReasonsWithTextIds[0], invalidReasonsWithTextIds[1]],
 					[`invalidReason-${invalidReasonsWithTextIds[0]}`]: [
-						'a'.repeat(textInputCharacterLimits.defaultInputLength)
+						'a'.repeat(textInputCharacterLimits.checkboxTextItemsLength)
 					],
 					[`invalidReason-${invalidReasonsWithTextIds[1]}`]: [
-						'a'.repeat(textInputCharacterLimits.defaultInputLength),
-						'a'.repeat(textInputCharacterLimits.defaultInputLength)
+						'a'.repeat(textInputCharacterLimits.checkboxTextItemsLength),
+						'a'.repeat(textInputCharacterLimits.checkboxTextItemsLength)
 					]
 				});
 
@@ -1675,7 +1675,7 @@ describe('appellant-case', () => {
 				.send({
 					incompleteReason: incompleteReasonsWithTextIds[0],
 					[`incompleteReason-${incompleteReasonsWithTextIds[0]}`]: 'a'.repeat(
-						textInputCharacterLimits.defaultInputLength + 1
+						textInputCharacterLimits.checkboxTextItemsLength + 1
 					)
 				});
 
@@ -1688,7 +1688,7 @@ describe('appellant-case', () => {
 			}).innerHTML;
 			expect(unprettifiedErrorSummaryHtml).toContain('There is a problem</h2>');
 			expect(unprettifiedErrorSummaryHtml).toContain(
-				'Text in text fields cannot exceed 300 characters</a>'
+				`Text in text fields cannot exceed ${textInputCharacterLimits.checkboxTextItemsLength} characters</a>`
 			);
 		});
 
@@ -1699,7 +1699,7 @@ describe('appellant-case', () => {
 					incompleteReason: [incompleteReasonsWithTextIds[0], incompleteReasonsWithTextIds[1]],
 					[`incompleteReason-${incompleteReasonsWithTextIds[0]}`]: 'test reason text 1',
 					[`incompleteReason-${incompleteReasonsWithTextIds[0]}`]: 'a'.repeat(
-						textInputCharacterLimits.defaultInputLength + 1
+						textInputCharacterLimits.checkboxTextItemsLength + 1
 					)
 				});
 
@@ -1712,7 +1712,7 @@ describe('appellant-case', () => {
 			}).innerHTML;
 			expect(unprettifiedErrorSummaryHtml).toContain('There is a problem</h2>');
 			expect(unprettifiedErrorSummaryHtml).toContain(
-				'Text in text fields cannot exceed 300 characters</a>'
+				`Text in text fields cannot exceed ${textInputCharacterLimits.checkboxTextItemsLength} characters</a>`
 			);
 		});
 

--- a/appeals/web/src/server/appeals/appeal-details/appellant-case/appellant-case.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/appellant-case/appellant-case.mapper.js
@@ -371,11 +371,20 @@ export function checkAndConfirmPage(
 						text: `${capitalize(validationOutcomeAsString)} reasons`
 					},
 					value: {
-						html: mapReasonsToReasonsListHtml(
-							reasonOptions,
-							invalidOrIncompleteReasons,
-							invalidOrIncompleteReasonsText
-						)
+						html: '',
+						pageComponents: [
+							{
+								type: 'show-more',
+								parameters: {
+									html: mapReasonsToReasonsListHtml(
+										reasonOptions,
+										invalidOrIncompleteReasons,
+										invalidOrIncompleteReasonsText
+									),
+									labelText: 'Read more'
+								}
+							}
+						]
 					},
 					actions: {
 						items: [
@@ -419,6 +428,11 @@ export function checkAndConfirmPage(
 		}
 	};
 
+	/** @type {PageComponent[]} */
+	const pageComponents = [summaryListComponent, insetTextComponent];
+
+	preRenderPageComponents(pageComponents);
+
 	/** @type {PageContent} */
 	const pageContent = {
 		title: 'Check answers',
@@ -428,7 +442,7 @@ export function checkAndConfirmPage(
 				: `/appeals-service/appeal-details/${appealId}/appellant-case/${validationOutcome}`,
 		preHeading: `Appeal ${appealShortReference(appealReference)}`,
 		heading: 'Check your answers before confirming your review',
-		pageComponents: [summaryListComponent, insetTextComponent]
+		pageComponents
 	};
 
 	if (

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/__tests__/__snapshots__/lpa-questionnaire.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/__tests__/__snapshots__/lpa-questionnaire.test.js.snap
@@ -1988,11 +1988,13 @@ exports[`LPA Questionnaire review GET /appeals-service/appeal-details/1/lpa-ques
                 </div>
                 <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Incomplete reasons</dt>
                     <dd class="govuk-summary-list__value">
-                        <ul class="govuk-list govuk-!-margin-top-0 govuk-list--bullet">
-                            <li>Documents or information are missing: test reason text 1</li>
-                            <li>Documents or information are missing: test reason text 2</li>
-                            <li>Policies are missing: test reason text 1</li>
-                        </ul>
+                        <div class="pins-show-more" data-label="Read more" data-mode="html">
+                            <ul class="govuk-list govuk-!-margin-top-0 govuk-!-margin-bottom-0 govuk-list--bullet">
+                                <li>Documents or information are missing: test reason text 1</li>
+                                <li>Documents or information are missing: test reason text 2</li>
+                                <li>Policies are missing: test reason text 1</li>
+                            </ul>
+                        </div>
                     </dd>
                     <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/incomplete">Change<span class="govuk-visually-hidden"> incomplete reasons</span></a>
                     </dd>
@@ -4414,7 +4416,7 @@ exports[`LPA Questionnaire review POST /appeals-service/appeal-details/1/lpa-que
                     <h2 class="govuk-error-summary__title"> There is a problem</h2>
                     <div class="govuk-error-summary__body">
                         <ul class="govuk-list govuk-error-summary__list">
-                            <li><a href="#">Text in text fields cannot exceed 300 characters</a>
+                            <li><a href="#">Text in text fields cannot exceed 1000 characters</a>
                             </li>
                         </ul>
                     </div>
@@ -4451,7 +4453,7 @@ exports[`LPA Questionnaire review POST /appeals-service/appeal-details/1/lpa-que
                                     <div class="govuk-grid-column-full">
                                         <div class="govuk-form-group">
                                             <input class="govuk-input pins-add-another__item-input govuk-!-margin-0"
-                                            id="incomplete-reason-1-1" name="incompleteReason-1" type="text" value="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa">
+                                            id="incomplete-reason-1-1" name="incompleteReason-1" type="text" value="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa">
                                         </div>
                                     </div>
                                 </div>
@@ -5297,7 +5299,7 @@ exports[`LPA Questionnaire review POST /appeals-service/appeal-details/1/lpa-que
                     <h2 class="govuk-error-summary__title"> There is a problem</h2>
                     <div class="govuk-error-summary__body">
                         <ul class="govuk-list govuk-error-summary__list">
-                            <li><a href="#">Text in text fields cannot exceed 300 characters</a>
+                            <li><a href="#">Text in text fields cannot exceed 1000 characters</a>
                             </li>
                         </ul>
                     </div>
@@ -5361,7 +5363,7 @@ exports[`LPA Questionnaire review POST /appeals-service/appeal-details/1/lpa-que
                                     <div class="govuk-grid-column-full">
                                         <div class="govuk-form-group">
                                             <input class="govuk-input pins-add-another__item-input govuk-!-margin-0"
-                                            id="incomplete-reason-2-1" name="incompleteReason-2" type="text" value="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa">
+                                            id="incomplete-reason-2-1" name="incompleteReason-2" type="text" value="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa">
                                         </div>
                                     </div>
                                 </div>

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/__tests__/lpa-questionnaire.test.js
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/__tests__/lpa-questionnaire.test.js
@@ -1403,7 +1403,7 @@ describe('LPA Questionnaire review', () => {
 			const response = await request.post(`${baseUrl}/incomplete`).send({
 				incompleteReason: incompleteReasonsWithTextIds[0],
 				[`incompleteReason-${incompleteReasonsWithTextIds[0]}`]: 'a'.repeat(
-					textInputCharacterLimits.defaultInputLength + 1
+					textInputCharacterLimits.checkboxTextItemsLength + 1
 				)
 			});
 
@@ -1417,7 +1417,9 @@ describe('LPA Questionnaire review', () => {
 			}).innerHTML;
 
 			expect(errorSummaryHtml).toContain('There is a problem</h2>');
-			expect(errorSummaryHtml).toContain('Text in text fields cannot exceed 300 characters</a>');
+			expect(errorSummaryHtml).toContain(
+				`Text in text fields cannot exceed ${textInputCharacterLimits.checkboxTextItemsLength} characters</a>`
+			);
 		});
 
 		it('should re-render the incomplete reason page with the expected error message if multiple incomplete reasons with text were provided but any of the matching text properties exceed the character limit', async () => {
@@ -1425,7 +1427,7 @@ describe('LPA Questionnaire review', () => {
 				incompleteReason: [incompleteReasonsWithTextIds[0], incompleteReasonsWithTextIds[1]],
 				[`incompleteReason-${incompleteReasonsWithTextIds[0]}`]: 'test reason text 1',
 				[`incompleteReason-${incompleteReasonsWithTextIds[1]}`]: 'a'.repeat(
-					textInputCharacterLimits.defaultInputLength + 1
+					textInputCharacterLimits.checkboxTextItemsLength + 1
 				)
 			});
 
@@ -1439,7 +1441,9 @@ describe('LPA Questionnaire review', () => {
 			}).innerHTML;
 
 			expect(errorSummaryHtml).toContain('There is a problem</h2>');
-			expect(errorSummaryHtml).toContain('Text in text fields cannot exceed 300 characters</a>');
+			expect(errorSummaryHtml).toContain(
+				`Text in text fields cannot exceed ${textInputCharacterLimits.checkboxTextItemsLength} characters</a>`
+			);
 		});
 
 		it('should redirect to the check and confirm page if a single incomplete reason without text was provided', async () => {

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/lpa-questionnaire.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/lpa-questionnaire.mapper.js
@@ -420,11 +420,20 @@ export function checkAndConfirmPage(
 						text: 'Incomplete reasons'
 					},
 					value: {
-						html: mapReasonsToReasonsListHtml(
-							incompleteReasonOptions,
-							incompleteReasons,
-							incompleteReasonsText
-						)
+						html: '',
+						pageComponents: [
+							{
+								type: 'show-more',
+								parameters: {
+									html: mapReasonsToReasonsListHtml(
+										incompleteReasonOptions,
+										incompleteReasons,
+										incompleteReasonsText
+									),
+									labelText: 'Read more'
+								}
+							}
+						]
 					},
 					actions: {
 						items: [
@@ -468,13 +477,18 @@ export function checkAndConfirmPage(
 		}
 	};
 
+	/** @type {PageComponent[]} */
+	const pageComponents = [summaryListComponent, insetTextComponent];
+
+	preRenderPageComponents(pageComponents);
+
 	/** @type {PageContent} */
 	const pageContent = {
 		title: 'Check answers',
 		backLinkUrl: `/appeals-service/appeal-details/${appealId}/lpa-questionnaire/${lpaQuestionnaireId}/incomplete/date`,
 		preHeading: `Appeal ${appealShortReference(appealReference)}`,
 		heading: 'Check your answers before confirming your review',
-		pageComponents: [summaryListComponent, insetTextComponent],
+		pageComponents,
 		submitButtonText: 'Confirm'
 	};
 

--- a/appeals/web/src/server/appeals/appeal-details/representations/common/components/reject-reasons.js
+++ b/appeals/web/src/server/appeals/appeal-details/representations/common/components/reject-reasons.js
@@ -64,6 +64,6 @@ export const buildRejectionReasons = (reasonOptions, reasons, reasonsText) => {
 export const rejectionReasonHtml = (reasons) => {
 	return buildHtmlList({
 		...(reasons ? { items: reasons } : {}),
-		listClasses: 'govuk-list govuk-!-margin-top-0 govuk-list--bullet'
+		listClasses: 'govuk-list govuk-!-margin-top-0 govuk-!-margin-bottom-0 govuk-list--bullet'
 	});
 };

--- a/appeals/web/src/server/appeals/appeal-details/representations/final-comments/reject/reject.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/representations/final-comments/reject/reject.mapper.js
@@ -107,7 +107,16 @@ export const confirmRejectFinalCommentPage = (
 							)}'s final comments?`
 						},
 						value: {
-							html: rejectionReasonHtml(rejectionReasons)
+							html: '',
+							pageComponents: [
+								{
+									type: 'show-more',
+									parameters: {
+										html: rejectionReasonHtml(rejectionReasons),
+										labelText: 'Read more'
+									}
+								}
+							]
 						},
 						actions: {
 							items: [

--- a/appeals/web/src/server/appeals/appeal-details/representations/interested-party-comments/view-and-review/__tests__/__snapshots__/view-and-review.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/representations/interested-party-comments/view-and-review/__tests__/__snapshots__/view-and-review.test.js.snap
@@ -209,7 +209,9 @@ exports[`interested-party-comments GET /reject/check-your-answers should render 
                     </dd>
                 </div>
                 <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Why are you rejecting the comment?</dt>
-                    <dd                     class="govuk-summary-list__value"></dd>
+                    <dd                     class="govuk-summary-list__value">
+                        <div class="pins-show-more" data-label="Read more" data-mode="text"></div>
+                        </dd>
                         <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/interested-party-comments/3670/reject/select-reason">Change<span class="govuk-visually-hidden"> why you are rejecting the comment</span></a>
                         </dd>
                 </div>

--- a/appeals/web/src/server/appeals/appeal-details/representations/interested-party-comments/view-and-review/page-components/reject.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/representations/interested-party-comments/view-and-review/page-components/reject.mapper.js
@@ -4,6 +4,7 @@ import { yesNoInput } from '#lib/mappers/components/page-components/radio.js';
 import { simpleHtmlComponent } from '#lib/mappers/components/page-components/html.js';
 import { buildHtmlList } from '#lib/nunjucks-template-builders/tag-builders.js';
 import { rejectionReasonHtml } from '#appeals/appeal-details/representations/common/components/reject-reasons.js';
+import { preRenderPageComponents } from '#lib/nunjucks-template-builders/page-component-rendering.js';
 
 /** @typedef {import("#appeals/appeal-details/appeal-details.types.js").WebAppeal} Appeal */
 /** @typedef {import("#appeals/appeal-details/representations/types.js").Representation} Representation */
@@ -157,7 +158,16 @@ export function rejectCheckYourAnswersPage(appealDetails, comment, rejectionReas
 						text: 'Why are you rejecting the comment?'
 					},
 					value: {
-						html: rejectionReasonHtml(payload.rejectionReasons)
+						html: '',
+						pageComponents: [
+							{
+								type: 'show-more',
+								parameters: {
+									html: rejectionReasonHtml(payload.rejectionReasons),
+									labelText: 'Read more'
+								}
+							}
+						]
 					},
 					actions: {
 						items: [
@@ -206,6 +216,11 @@ export function rejectCheckYourAnswersPage(appealDetails, comment, rejectionReas
 
 	const backLinkPath = userProvidedEmail ? 'allow-resubmit' : 'select-reason';
 
+	/** @type {PageComponent[]} */
+	const pageComponents = [summaryListComponent, bottomText];
+
+	preRenderPageComponents(pageComponents);
+
 	/** @type {PageContent} */
 	const pageContent = {
 		heading: 'Check details and reject comment',
@@ -214,7 +229,7 @@ export function rejectCheckYourAnswersPage(appealDetails, comment, rejectionReas
 		submitButtonProperties: {
 			text: 'Reject comment'
 		},
-		pageComponents: [summaryListComponent, bottomText]
+		pageComponents
 	};
 
 	return pageContent;

--- a/appeals/web/src/server/appeals/appeal-details/representations/lpa-statement/incomplete/incomplete.controller.js
+++ b/appeals/web/src/server/appeals/appeal-details/representations/lpa-statement/incomplete/incomplete.controller.js
@@ -203,7 +203,16 @@ export const renderCheckYourAnswers = async (
 					}
 				},
 				'Why is the statement incomplete?': {
-					html: rejectionReasonHtml(rejectionReasons),
+					html: '',
+					pageComponents: [
+						{
+							type: 'show-more',
+							parameters: {
+								html: rejectionReasonHtml(rejectionReasons),
+								labelText: 'Read more'
+							}
+						}
+					],
 					actions: {
 						Change: {
 							href: `/appeals-service/appeal-details/${appealId}/lpa-statement/incomplete/reasons`,

--- a/appeals/web/src/server/appeals/appeal.constants.js
+++ b/appeals/web/src/server/appeals/appeal.constants.js
@@ -10,6 +10,7 @@ export const paginationDefaultSettings = {
 export const textInputCharacterLimits = {
 	defaultAddressInputLength: 250,
 	defaultInputLength: 300,
+	checkboxTextItemsLength: 1000,
 	defaultTextareaLength: 1000,
 	expandedTextareaLength: 8000
 };

--- a/appeals/web/src/server/lib/__tests__/libraries.test.js
+++ b/appeals/web/src/server/lib/__tests__/libraries.test.js
@@ -922,7 +922,7 @@ describe('Libraries', () => {
 				);
 
 				expect(result).toEqual(
-					'<ul class="govuk-list govuk-!-margin-top-0 govuk-list--bullet"><li>Documents have not been submitted on time</li><li>The appellant doesn\'t have the right to appeal</li></ul>'
+					'<ul class="govuk-list govuk-!-margin-top-0 govuk-!-margin-bottom-0 govuk-list--bullet"><li>Documents have not been submitted on time</li><li>The appellant doesn\'t have the right to appeal</li></ul>'
 				);
 			});
 
@@ -930,7 +930,7 @@ describe('Libraries', () => {
 				const result = mapReasonsToReasonsListHtml(appellantCaseInvalidReasons, ['22', '23'], {});
 
 				expect(result).toEqual(
-					'<ul class="govuk-list govuk-!-margin-top-0 govuk-list--bullet"><li>Documents have not been submitted on time</li><li>The appellant doesn\'t have the right to appeal</li></ul>'
+					'<ul class="govuk-list govuk-!-margin-top-0 govuk-!-margin-bottom-0 govuk-list--bullet"><li>Documents have not been submitted on time</li><li>The appellant doesn\'t have the right to appeal</li></ul>'
 				);
 			});
 
@@ -940,7 +940,7 @@ describe('Libraries', () => {
 				});
 
 				expect(result).toEqual(
-					'<ul class="govuk-list govuk-!-margin-top-0 govuk-list--bullet"><li>Documents have not been submitted on time: test reason text 1</li><li>Documents have not been submitted on time: test reason text 2</li><li>The appellant doesn\'t have the right to appeal</li></ul>'
+					'<ul class="govuk-list govuk-!-margin-top-0 govuk-!-margin-bottom-0 govuk-list--bullet"><li>Documents have not been submitted on time: test reason text 1</li><li>Documents have not been submitted on time: test reason text 2</li><li>The appellant doesn\'t have the right to appeal</li></ul>'
 				);
 			});
 		});

--- a/appeals/web/src/server/lib/validators/checkbox-text-items.validator.js
+++ b/appeals/web/src/server/lib/validators/checkbox-text-items.validator.js
@@ -38,7 +38,7 @@ export const createCheckboxTextItemsValidator = (checkboxIdsBodyKey) =>
 			.withMessage('Enter a reason')
 			.bail()
 			.custom((bodyFields) => {
-				const characterLimit = textInputCharacterLimits.defaultInputLength;
+				const characterLimit = textInputCharacterLimits.checkboxTextItemsLength;
 				let checkboxIds = bodyFields[checkboxIdsBodyKey];
 
 				if (!Array.isArray(checkboxIds)) {
@@ -64,6 +64,6 @@ export const createCheckboxTextItemsValidator = (checkboxIdsBodyKey) =>
 				return true;
 			})
 			.withMessage(
-				`Text in text fields cannot exceed ${textInputCharacterLimits.defaultInputLength} characters`
+				`Text in text fields cannot exceed ${textInputCharacterLimits.checkboxTextItemsLength} characters`
 			)
 	);


### PR DESCRIPTION
## Describe your changes

- increase checkbox conditional text inputs character limit to 1000 (affects invalid/incomplete/rejected reasons text inputs on appellant case, LPA questionnaire, and representations)
- add 'show more' component to reasons display on relevant check your answers pages
- update unit tests

## Issue ticket number and link
https://pins-ds.atlassian.net/browse/A2-3307
