### PR TITLE
chore(tooling): allow all dependabot commits

### DIFF
--- a/commitlint.config.cjs
+++ b/commitlint.config.cjs
@@ -111,5 +111,7 @@ module.exports = {
 				}
 			}
 		}
-	]
+	],
+	// ignore commits from dependabot - check for "chore(deps" which also captures "chore(deps-dev)"
+	ignores: [(commit) => commit.startsWith('chore(deps') && commit.includes('dependabot')]
 };


### PR DESCRIPTION
## Describe your changes

Allowing dependabot commits for infra provider updates and npm deps, which can have long body lines

## Issue ticket number and link
N/A
