### PR TITLE
fix(appeals): issue decision check details (a2-3162)

### DIFF
--- a/appeals/api/src/server/notify/templates/__tests__/notify-decision-is-allowed-split-dismissed-lpa.test.js
+++ b/appeals/api/src/server/notify/templates/__tests__/notify-decision-is-allowed-split-dismissed-lpa.test.js
@@ -44,7 +44,7 @@ describe('decision-is-allowed-split-dismissed-lpa.md', () => {
 			'We welcome your feedback on our appeals service. Tell us on this short [feedback form](https://forms.office.com/pages/responsepage.aspx?id=mN94WIhvq0iTIpmM5VcIjfMZj__F6D9LmMUUyoUrZDZUOERYMEFBN0NCOFdNU1BGWEhHUFQxWVhUUy4u).',
 			'',
 			'The Planning Inspectorate',
-			'caseofficers@planninginspectorate.gov.uk'
+			'allcustomerteam@planninginspectorate.gov.uk'
 		].join('\n');
 
 		await notifySend(notifySendData);

--- a/appeals/api/src/server/notify/templates/__tests__/notify-decision-is-invalid-appellant.test.js
+++ b/appeals/api/src/server/notify/templates/__tests__/notify-decision-is-invalid-appellant.test.js
@@ -53,7 +53,7 @@ describe('decision-is-invalid-appellant.md', () => {
 			'We welcome your feedback on our appeals service. Tell us on this short [feedback form](https://forms.office.com/pages/responsepage.aspx?id=mN94WIhvq0iTIpmM5VcIjfMZj__F6D9LmMUUyoUrZDZUOERYMEFBN0NCOFdNU1BGWEhHUFQxWVhUUy4u).',
 			'',
 			'The Planning Inspectorate',
-			'caseofficers@planninginspectorate.gov.uk'
+			'allcustomerteam@planninginspectorate.gov.uk'
 		].join('\n');
 
 		await notifySend(notifySendData);

--- a/appeals/api/src/server/notify/templates/__tests__/notify-decision-is-invalid-lpa.test.js
+++ b/appeals/api/src/server/notify/templates/__tests__/notify-decision-is-invalid-lpa.test.js
@@ -47,7 +47,7 @@ describe('decision-is-invalid-lpa.md', () => {
 			'We welcome your feedback on our appeals service. Tell us on this short [feedback form](https://forms.office.com/pages/responsepage.aspx?id=mN94WIhvq0iTIpmM5VcIjfMZj__F6D9LmMUUyoUrZDZUOERYMEFBN0NCOFdNU1BGWEhHUFQxWVhUUy4u).',
 			'',
 			'The Planning Inspectorate',
-			'caseofficers@planninginspectorate.gov.uk'
+			'allcustomerteam@planninginspectorate.gov.uk'
 		].join('\n');
 
 		await notifySend(notifySendData);

--- a/appeals/api/src/server/notify/templates/decision-is-allowed-split-dismissed-lpa.content.md
+++ b/appeals/api/src/server/notify/templates/decision-is-allowed-split-dismissed-lpa.content.md
@@ -17,4 +17,4 @@ The Planning Inspectorate cannot change or revoke the decision. Only the High Co
 We welcome your feedback on our appeals service. Tell us on this short [feedback form](https://forms.office.com/pages/responsepage.aspx?id=mN94WIhvq0iTIpmM5VcIjfMZj__F6D9LmMUUyoUrZDZUOERYMEFBN0NCOFdNU1BGWEhHUFQxWVhUUy4u).
 
 The Planning Inspectorate
-caseofficers@planninginspectorate.gov.uk
+allcustomerteam@planninginspectorate.gov.uk

--- a/appeals/api/src/server/notify/templates/decision-is-invalid-appellant.content.md
+++ b/appeals/api/src/server/notify/templates/decision-is-invalid-appellant.content.md
@@ -26,4 +26,4 @@ You can challenge the decision in the [High Court](https://www.justice.gov.uk/co
 We welcome your feedback on our appeals service. Tell us on this short [feedback form](https://forms.office.com/pages/responsepage.aspx?id=mN94WIhvq0iTIpmM5VcIjfMZj__F6D9LmMUUyoUrZDZUOERYMEFBN0NCOFdNU1BGWEhHUFQxWVhUUy4u).
 
 The Planning Inspectorate
-caseofficers@planninginspectorate.gov.uk
+allcustomerteam@planninginspectorate.gov.uk

--- a/appeals/api/src/server/notify/templates/decision-is-invalid-lpa.content.md
+++ b/appeals/api/src/server/notify/templates/decision-is-invalid-lpa.content.md
@@ -20,4 +20,4 @@ We cannot change or discuss the decision.
 We welcome your feedback on our appeals service. Tell us on this short [feedback form](https://forms.office.com/pages/responsepage.aspx?id=mN94WIhvq0iTIpmM5VcIjfMZj__F6D9LmMUUyoUrZDZUOERYMEFBN0NCOFdNU1BGWEhHUFQxWVhUUy4u).
 
 The Planning Inspectorate
-caseofficers@planninginspectorate.gov.uk
+allcustomerteam@planninginspectorate.gov.uk

--- a/appeals/web/src/server/app/components/file-uploader.component.js
+++ b/appeals/web/src/server/app/components/file-uploader.component.js
@@ -6,7 +6,7 @@ import logger from '#lib/logger.js';
 
 /**
  * @param {import('got').Got} apiClient
- * @param {string} caseId
+ * @param {string|number} caseId
  * @param {AddDocumentsRequest} payload
  * @returns {Promise<AddDocumentsResponse|undefined>}
  */

--- a/appeals/web/src/server/appeals/appeal-details/issue-decision/__tests__/__snapshots__/issue-decision.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/issue-decision/__tests__/__snapshots__/issue-decision.test.js.snap
@@ -54,12 +54,12 @@ exports[`issue-decision GET /appellant-costs-decision-letter-upload should rende
         <div class="govuk-grid-column-full">
             <div class="govuk-grid-row pins-file-upload" data-next-page-url="/appeals-service/appeal-details/1/issue-decision/appellant-costs-decision"
             data-form-id="1" data-case-id="1" data-case-reference="APP/Q9999/D/21/351062"
-            data-folder-id="undefined" data-document-type="appellantCostsDecisionLetter"
-            data-document-stage="appeal-decision" data-blob-storage-host="https://127.0.0.1:10000/devstoreaccount1"
-            data-blob-storage-container="document-service-uploads" data-document-title="appellant costs decision letter"
-            data-allowed-types="application/pdf" data-formatted-allowed-types="PDF">
+            data-folder-id="8" data-document-type="appellantCostsDecision" data-document-stage="costs"
+            data-blob-storage-host="https://127.0.0.1:10000/devstoreaccount1" data-blob-storage-container="document-service-uploads"
+            data-document-title="appellant costs decision letter" data-allowed-types="application/pdf"
+            data-formatted-allowed-types="PDF">
                 <form method="POST" novalidate="novalidate" class="govuk-grid-column-two-thirds"
-                data-filenames-in-folder="">
+                data-filenames-in-folder="W10=">
                     <div class="pins-file-upload__container">
                         <div class="govuk-body pins-file-upload__instructions"><span>The file must be a PDF and smaller than 25MB.</span>
                         </div>
@@ -256,7 +256,8 @@ exports[`issue-decision GET /issue-decision/check-your-decision should render th
                             </dd>
                     </div>
                 </dl>
-                <button type="submit" class="govuk-button" data-module="govuk-button">Issue decision</button>
+                <p class="govuk-body">We'll send an email to the appellant and LPA to tell them about the decision.</p>
+                <button                 type="submit" class="govuk-button" data-module="govuk-button">Issue decision</button>
             </form>
         </div>
     </div>
@@ -317,12 +318,12 @@ exports[`issue-decision GET /lpa-costs-decision-letter-upload should render the 
         <div class="govuk-grid-column-full">
             <div class="govuk-grid-row pins-file-upload" data-next-page-url="/appeals-service/appeal-details/1/issue-decision/lpa-costs-decision"
             data-form-id="1" data-case-id="1" data-case-reference="APP/Q9999/D/21/351062"
-            data-folder-id="undefined" data-document-type="lpaCostsDecisionLetter"
-            data-document-stage="appeal-decision" data-blob-storage-host="https://127.0.0.1:10000/devstoreaccount1"
-            data-blob-storage-container="document-service-uploads" data-document-title="LPA costs decision letter"
-            data-allowed-types="application/pdf" data-formatted-allowed-types="PDF">
+            data-folder-id="9" data-document-type="lpaCostsDecision" data-document-stage="costs"
+            data-blob-storage-host="https://127.0.0.1:10000/devstoreaccount1" data-blob-storage-container="document-service-uploads"
+            data-document-title="LPA costs decision letter" data-allowed-types="application/pdf"
+            data-formatted-allowed-types="PDF">
                 <form method="POST" novalidate="novalidate" class="govuk-grid-column-two-thirds"
-                data-filenames-in-folder="">
+                data-filenames-in-folder="W10=">
                     <div class="pins-file-upload__container">
                         <div class="govuk-body pins-file-upload__instructions"><span>The file must be a PDF and smaller than 25MB.</span>
                         </div>

--- a/appeals/web/src/server/appeals/appeal-details/issue-decision/issue-decision.controller.js
+++ b/appeals/web/src/server/appeals/appeal-details/issue-decision/issue-decision.controller.js
@@ -21,6 +21,8 @@ import { mapFileUploadInfoToMappedDocuments } from '#lib/mappers/utils/file-uplo
 import { createNewDocument } from '#app/components/file-uploader.component.js';
 import { getTodaysISOString } from '#lib/dates.js';
 
+/** @typedef {import('../../../appeals/appeal-documents/appeal-documents.types.js').FileUploadInfoItem} FileUploadInfoItem */
+
 /**
  *
  * @param {import('../appeal-details.types.js').WebAppeal} currentAppeal
@@ -129,14 +131,7 @@ function storeFileUploadInfo(session, decisionType) {
  * @param {string} decisionType
  */
 function restoreFileUploadInfo(session, decisionType) {
-	// eslint-disable-next-line no-unused-vars
-	const { outcome, ...fileUploadInfo } = session[decisionType] || {};
-
-	if (fileUploadInfo) {
-		session.fileUploadInfo = cloneDeep(fileUploadInfo);
-	} else {
-		delete session.fileUploadInfo;
-	}
+	session.fileUploadInfo = cloneDeep(session[decisionType] || {});
 }
 
 /** @type {import('@pins/express').RequestHandler<Response>} */
@@ -447,7 +442,7 @@ export const renderLpaCostsDecisionLetterUpload = async (request, response) => {
 /**
  * @param {object} params
  * @param {import('got').Got} params.apiClient
- * @param {{appealId: number|string, folderId: number, letterDate: string, files: { GUID: string, name: string, documentType: string, size: number, stage: string, mimeType: string, receivedDate: string, redactionStatus: number, blobStoreUrl: string }[] }} params.decision - The decision object.
+ * @param {{appealId: number|string, folderId: number, letterDate: string, files: FileUploadInfoItem[]  }} params.decision - The decision object.
  * @returns {Promise<*>}
  */
 const postDecision = async ({ apiClient, decision }) => {

--- a/appeals/web/src/server/appeals/appeal-details/issue-decision/issue-decision.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/issue-decision/issue-decision.mapper.js
@@ -4,7 +4,6 @@ import { preRenderPageComponents } from '#lib/nunjucks-template-builders/page-co
 import { addressToMultilineStringHtml } from '#lib/address-formatter.js';
 import { mapUncommittedDocumentDownloadUrl } from '#appeals/appeal-documents/appeal-documents.mapper.js';
 import { getErrorByFieldname } from '#lib/error-handlers/change-screen-error-handlers.js';
-import { APPEAL_DOCUMENT_TYPE } from 'pins-data-model';
 
 /**
  * @typedef {import('../appeal-details.types.js').WebAppeal} Appeal
@@ -277,11 +276,8 @@ function checkAndConfirmPageRows(appealData, session) {
 		}
 	];
 
-	const caseDecisionLetter =
-		session.inspectorDecision.fileUploadInfo[APPEAL_DOCUMENT_TYPE.CASE_DECISION_LETTER];
-
-	if (caseDecisionLetter) {
-		const file = caseDecisionLetter?.files[0] || {};
+	if (session.inspectorDecision) {
+		const file = session.inspectorDecision?.files[0] || {};
 		const href = mapUncommittedDocumentDownloadUrl(
 			appealData.appealReference,
 			file.GUID,
@@ -317,11 +313,7 @@ function checkAndConfirmPageRows(appealData, session) {
 		});
 
 		if (appellantCostsDecisionOutcome === 'true') {
-			const appellantCostsDecisionLetter =
-				session.inspectorDecision.fileUploadInfo[
-					APPEAL_DOCUMENT_TYPE.APPELLANT_COSTS_DECISION_LETTER
-				];
-			const file = appellantCostsDecisionLetter?.files[0] || {};
+			const file = session.appellantCostsDecision?.files[0] || {};
 			const href = mapUncommittedDocumentDownloadUrl(
 				appealData.appealReference,
 				file.GUID,
@@ -358,10 +350,7 @@ function checkAndConfirmPageRows(appealData, session) {
 		});
 
 		if (lpaCostsDecisionOutcome === 'true') {
-			const lpaCostsDecisionLetter =
-				session.inspectorDecision.fileUploadInfo[APPEAL_DOCUMENT_TYPE.LPA_COSTS_DECISION_LETTER];
-
-			const file = lpaCostsDecisionLetter?.files[0] || {};
+			const file = session.lpaCostsDecision?.files[0] || {};
 			const href = mapUncommittedDocumentDownloadUrl(
 				appealData.appealReference,
 				file.GUID,

--- a/appeals/web/src/server/appeals/appeal-details/issue-decision/issue-decision.router.js
+++ b/appeals/web/src/server/appeals/appeal-details/issue-decision/issue-decision.router.js
@@ -94,7 +94,6 @@ router
 	)
 	.post(
 		validateAppeal,
-		validators.validateCheckDecision,
 		assertUserHasPermission(permissionNames.setCaseOutcome),
 		asyncHandler(controller.postCheckDecision)
 	);

--- a/appeals/web/src/server/appeals/appeal-details/issue-decision/issue-decision.validators.js
+++ b/appeals/web/src/server/appeals/appeal-details/issue-decision/issue-decision.validators.js
@@ -1,8 +1,3 @@
-import {
-	createDateInputDateInPastOrTodayValidator,
-	createDateInputDateValidityValidator,
-	createDateInputFieldsValidator
-} from '#lib/validators/date-input.validator.js';
 import { createValidator } from '@pins/express';
 import { body } from 'express-validator';
 
@@ -22,34 +17,4 @@ export const validateLpaCostsDecision = createValidator(
 		.trim()
 		.notEmpty()
 		.withMessage("Select yes if you want to issue the LPA's cost decision")
-);
-
-export const validateDecisionLetterDate = createValidator(
-	body('decision-letter-date')
-		.trim()
-		.notEmpty()
-		.withMessage('Please tell us the date on your decision letter')
-);
-
-export const validateVisitDateFields = createDateInputFieldsValidator(
-	'decision-letter-date',
-	'Decision letter date'
-);
-
-export const validateVisitDateValid = createDateInputDateValidityValidator(
-	'decision-letter-date',
-	'Decision letter date'
-);
-
-export const validateDueDateInPastOrToday =
-	createDateInputDateInPastOrTodayValidator('decision-letter-date');
-
-export const validateCheckDecision = createValidator(
-	body('ready-to-send')
-		.trim()
-		.notEmpty()
-		.withMessage('Please confirm that the decision is ready to be sent to all parties')
-		.bail()
-		.equals('yes')
-		.withMessage('Please confirm that the decision is ready to be sent to all parties')
 );

--- a/appeals/web/src/server/appeals/appeal-details/representations/interested-party-comments/add-ip-comment/add-ip-comment.controller.js
+++ b/appeals/web/src/server/appeals/appeal-details/representations/interested-party-comments/add-ip-comment/add-ip-comment.controller.js
@@ -6,7 +6,6 @@ import { dayMonthYearHourMinuteToDisplayDate } from '#lib/dates.js';
 import logger from '#lib/logger.js';
 import { renderCheckYourAnswersComponent } from '#lib/mappers/components/page-components/check-your-answers.js';
 import { addNotificationBannerToSession } from '#lib/session-utilities.js';
-import config from '@pins/appeals.web/environment/config.js';
 import {
 	postDateSubmittedFactory,
 	postRedactionStatusFactory,
@@ -22,7 +21,6 @@ import { getAttachmentsFolder } from '../interested-party-comments.service.js';
 import {
 	checkAddressPage,
 	ipDetailsPage,
-	mapFileUploadInfoToMappedDocuments,
 	mapSessionToRepresentationRequest,
 	uploadPage
 } from './add-ip-comment.mapper.js';
@@ -30,6 +28,7 @@ import { postRepresentationComment } from './add-ip-comment.service.js';
 import { APPEAL_REDACTED_STATUS } from 'pins-data-model';
 import { dateSubmitted } from './add-ip-comment.mapper.js';
 import { getDocumentRedactionStatuses } from '#appeals/appeal-documents/appeal.documents.service.js';
+import { mapFileUploadInfoToMappedDocuments } from '#lib/mappers/utils/file-upload-info-to-documents.js';
 
 /**
  *
@@ -266,14 +265,12 @@ export async function postIPComment(request, response) {
 			);
 		}
 
-		const addDocumentsRequestPayload = mapFileUploadInfoToMappedDocuments(
-			currentAppeal.appealId,
+		const addDocumentsRequestPayload = mapFileUploadInfoToMappedDocuments({
+			caseId: currentAppeal.appealId,
 			folderId,
-			redactionStatusId,
-			config.useBlobEmulator === true ? config.blobEmulatorSasUrl : config.blobStorageUrl,
-			config.blobStorageDefaultContainer,
-			request.session.fileUploadInfo
-		);
+			redactionStatus: redactionStatusId,
+			fileUploadInfo: request.session.fileUploadInfo
+		});
 
 		try {
 			await createNewDocument(

--- a/appeals/web/src/server/appeals/appeal-details/representations/interested-party-comments/add-ip-comment/add-ip-comment.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/representations/interested-party-comments/add-ip-comment/add-ip-comment.mapper.js
@@ -22,8 +22,6 @@ import {
 /** @typedef {{ 'day': string, 'month': string, 'year': string }} RequestDate */
 /** @typedef {RequestDate} ReqBody */
 
-/** @typedef {import('@pins/appeals/index.js').AddDocumentsRequest} AddDocumentsRequest */
-
 /**
  * @param {Appeal} appealDetails
  * @param {{ firstName: string, lastName: string, emailAddress: string }} values
@@ -185,45 +183,6 @@ export const mapSessionToRepresentationRequest = (values, fileUpload) => ({
 		month: values.month,
 		year: values.year
 	})
-});
-
-/**
- * @param {number} caseId
- * @param {number} folderId
- * @param {number} redactionStatus
- * @param {string} blobStorageHost
- * @param {string} blobStorageContainer
- * @param {{ files: { GUID: string, name: string, documentType: string, size: number, stage: string, mimeType: string, receivedDate: string, redactionStatus: number, blobStoreUrl: string }[] }} fileUploadInfo - The file upload information object.
- * @returns {AddDocumentsRequest}
- */
-export const mapFileUploadInfoToMappedDocuments = (
-	caseId,
-	folderId,
-	redactionStatus,
-	blobStorageHost,
-	blobStorageContainer,
-	fileUploadInfo
-) => ({
-	blobStorageHost,
-	blobStorageContainer,
-	documents: fileUploadInfo.files.map(
-		/** @type {import('#lib/ts-utilities.js').FileUploadInfoItem} */
-		(file) =>
-			/** @type {import('@pins/appeals/index.js').MappedDocument} */
-			({
-				caseId,
-				documentName: file.name,
-				documentType: file.documentType,
-				mimeType: file.mimeType,
-				documentSize: file.size,
-				stage: file.stage,
-				folderId,
-				GUID: file.GUID,
-				receivedDate: file.receivedDate,
-				redactionStatusId: redactionStatus || 1,
-				blobStoragePath: file.blobStoreUrl
-			})
-	)
 });
 
 /**

--- a/appeals/web/src/server/lib/mappers/utils/file-upload-info-to-documents.js
+++ b/appeals/web/src/server/lib/mappers/utils/file-upload-info-to-documents.js
@@ -1,13 +1,14 @@
 import config from '@pins/appeals.web/environment/config.js';
 
 /** @typedef {import('@pins/appeals/index.js').AddDocumentsRequest} AddDocumentsRequest */
+/** @typedef {import('../../../appeals/appeal-documents/appeal-documents.types.js').FileUploadInfoItem} FileUploadInfoItem */
 
 /**
  * @param {Object} params
  * @param {string|number} params.caseId
  * @param {number} params.folderId
  * @param {number} [params.redactionStatus]
- * @param {{ files: { GUID: string, name: string, documentType: string, size: number, stage: string, mimeType: string, receivedDate: string, redactionStatus: number, blobStoreUrl: string }[] }} params.fileUploadInfo - The file upload information object.
+ * @param {{ files: FileUploadInfoItem[] }} params.fileUploadInfo
  * @returns {AddDocumentsRequest}
  */
 export const mapFileUploadInfoToMappedDocuments = ({

--- a/appeals/web/src/server/lib/mappers/utils/file-upload-info-to-documents.js
+++ b/appeals/web/src/server/lib/mappers/utils/file-upload-info-to-documents.js
@@ -1,0 +1,44 @@
+import config from '@pins/appeals.web/environment/config.js';
+
+/** @typedef {import('@pins/appeals/index.js').AddDocumentsRequest} AddDocumentsRequest */
+
+/**
+ * @param {Object} params
+ * @param {string|number} params.caseId
+ * @param {number} params.folderId
+ * @param {number} [params.redactionStatus]
+ * @param {{ files: { GUID: string, name: string, documentType: string, size: number, stage: string, mimeType: string, receivedDate: string, redactionStatus: number, blobStoreUrl: string }[] }} params.fileUploadInfo - The file upload information object.
+ * @returns {AddDocumentsRequest}
+ */
+export const mapFileUploadInfoToMappedDocuments = ({
+	caseId,
+	folderId,
+	redactionStatus,
+	fileUploadInfo
+}) => {
+	const blobStorageHost = config.useBlobEmulator
+		? config.blobEmulatorSasUrl
+		: config.blobStorageUrl;
+	return {
+		blobStorageHost,
+		blobStorageContainer: config.blobStorageDefaultContainer,
+		documents: fileUploadInfo.files.map(
+			/** @type {import('#lib/ts-utilities.js').FileUploadInfoItem} */
+			(file) =>
+				/** @type {import('@pins/appeals/index.js').MappedDocument} */
+				({
+					caseId,
+					documentName: file.name,
+					documentType: file.documentType,
+					mimeType: file.mimeType,
+					documentSize: file.size,
+					stage: file.stage,
+					folderId,
+					GUID: file.GUID,
+					receivedDate: file.receivedDate,
+					redactionStatusId: redactionStatus || 1,
+					blobStoragePath: file.blobStoreUrl
+				})
+		)
+	};
+};

--- a/appeals/web/src/server/views/appeals/appeal/issue-decision.njk
+++ b/appeals/web/src/server/views/appeals/appeal/issue-decision.njk
@@ -15,6 +15,7 @@
 		{%- for component in pageContent.pageComponents -%}
 			{%- include "../components/page-component.njk" -%}
 		{%- endfor -%}
+		<p class="govuk-body">We'll send an email to the appellant and LPA to tell them about the decision.</p>
 		{{ govukButton({
 			text: pageContent.submitButtonText if pageContent.submitButtonText else "Continue",
 			type: "submit"


### PR DESCRIPTION
## Describe your changes
#### Implement the ability to send from the issue decision check details page (a2-3162)

### WEB:
- Improve caching of decision upload file info by sharing with each existing decision property on the session 
- Add the ability to save each decision file to the DB via the API
- Add the new hint text at the bottom of the screen
- Make sure the decision is sent to the API and successfully sends the LPA and Appellant valid emails
- Updated the email address in the notify templates
- Moved mapFileUploadInfoToMappedDocuments from add-ip-comments.mapper to a reusable function so decisions can use it.

### TEST:
- Updated tests and associated snapshots
- Created new tests and associated snapshots
- Made sure all unit tests pass
- Manually tested within browser
- Made sure emails are generated using the notify emulator

## Issue ticket number and link
[Issuing decision flow - Part 7 - Check details (A2-3162)](https://pins-ds.atlassian.net/browse/A2-3162)
