### PR TITLE
chore(appeals): issue decision clean-up routes (a2-3162)

### DIFF
--- a/appeals/web/src/server/appeals/appeal-details/issue-decision/issue-decision.controller.js
+++ b/appeals/web/src/server/appeals/appeal-details/issue-decision/issue-decision.controller.js
@@ -87,22 +87,10 @@ export const postIssueDecision = async (request, response) => {
  * @param {import('@pins/express/types/express.js').RenderedResponse<any, any, Number>} response
  */
 export const renderIssueDecision = async (request, response) => {
-	const { errors } = request;
-
-	const appealId = request.params.appealId;
-	const appealData = request.currentAppeal;
-
-	if (
-		request.session?.inspectorDecision?.appealId &&
-		request.session?.inspectorDecision?.appealId !== appealId
-	) {
-		request.session.inspectorDecision = {};
-		request.session.appellantCostsDecision = {};
-		request.session.lpaCostsDecision = {};
-	}
+	const { errors, currentAppeal } = request;
 
 	const mappedPageContent = issueDecisionPage(
-		appealData,
+		currentAppeal,
 		request.session.inspectorDecision,
 		getBackLinkUrlFromQuery(request),
 		errors
@@ -120,6 +108,8 @@ export const renderIssueDecision = async (request, response) => {
  * @param {string} decisionType
  */
 function storeFileUploadInfo(session, decisionType) {
+	// Note that postDocumentUpload and renderDocumentUpload functions use the fileUploadInfo at the route of the session object.
+	// This makes sure the values are stored in the session for the decision type so the session.fileUploadInfo can be reused.
 	const { outcome } = session[decisionType] || {};
 	session[decisionType] = cloneDeep({ outcome, ...session.fileUploadInfo });
 	delete session.fileUploadInfo;
@@ -131,6 +121,8 @@ function storeFileUploadInfo(session, decisionType) {
  * @param {string} decisionType
  */
 function restoreFileUploadInfo(session, decisionType) {
+	// Note that postDocumentUpload and renderDocumentUpload functions use the fileUploadInfo at the route of the session object.
+	// This makes sure the values are restored from the session for the decision type so the session.fileUploadInfo can be reused.
 	session.fileUploadInfo = cloneDeep(session[decisionType] || {});
 }
 
@@ -245,20 +237,10 @@ export const postAppellantCostsDecision = async (request, response) => {
  * @param {import('@pins/express/types/express.js').RenderedResponse<any, any, Number>} response
  */
 export const renderAppellantCostsDecision = async (request, response) => {
-	const { errors } = request;
-
-	const appealId = request.params.appealId;
-	const appealData = request.currentAppeal;
-
-	if (
-		request.session?.appellantCostsDecision?.appealId &&
-		request.session?.appellantCostsDecision?.appealId !== appealId
-	) {
-		request.session.appellantCostsDecision = {};
-	}
+	const { errors, currentAppeal } = request;
 
 	const mappedPageContent = appellantCostsDecisionPage(
-		appealData,
+		currentAppeal,
 		request.session.appellantCostsDecision,
 		getBackLinkUrlFromQuery(request),
 		errors
@@ -364,20 +346,10 @@ export const postLpaCostsDecision = async (request, response) => {
  * @param {import('@pins/express/types/express.js').RenderedResponse<any, any, Number>} response
  */
 export const renderLpaCostsDecision = async (request, response) => {
-	const { errors } = request;
-
-	const appealId = request.params.appealId;
-	const appealData = request.currentAppeal;
-
-	if (
-		request.session?.lpaCostsDecision?.appealId &&
-		request.session?.lpaCostsDecision?.appealId !== appealId
-	) {
-		request.session.lpaCostsDecision = {};
-	}
+	const { errors, currentAppeal } = request;
 
 	const mappedPageContent = lpaCostsDecisionPage(
-		appealData,
+		currentAppeal,
 		request.session.lpaCostsDecision,
 		getBackLinkUrlFromQuery(request),
 		errors

--- a/appeals/web/src/server/appeals/appeal-details/issue-decision/issue-decision.middleware.js
+++ b/appeals/web/src/server/appeals/appeal-details/issue-decision/issue-decision.middleware.js
@@ -1,0 +1,15 @@
+/**
+ * @type {import("express").RequestHandler}
+ * @returns {Promise<void>}
+ */
+export const clearIssueDecisionCache = async (request, response, next) => {
+	const appealId = request.params.appealId;
+	const { inspectorDecision, appellantCostsDecision, lpaCostsDecision } = request.session;
+
+	// If the appealId in the session doesn't match the appealId in the request, clear the session data.
+	if (inspectorDecision?.appealId !== appealId) request.session.inspectorDecision = {};
+	if (appellantCostsDecision?.appealId !== appealId) request.session.appellantCostsDecision = {};
+	if (lpaCostsDecision?.appealId !== appealId) request.session.lpaCostsDecision = {};
+
+	next();
+};

--- a/appeals/web/src/server/appeals/appeal-details/issue-decision/issue-decision.router.js
+++ b/appeals/web/src/server/appeals/appeal-details/issue-decision/issue-decision.router.js
@@ -2,11 +2,13 @@ import { Router as createRouter } from 'express';
 import { asyncHandler } from '@pins/express';
 import * as controller from './issue-decision.controller.js';
 import * as validators from './issue-decision.validators.js';
-import { validateAppeal } from '../appeal-details.middleware.js';
 import { assertUserHasPermission } from '#app/auth/auth.guards.js';
 import { permissionNames } from '#environment/permissions.js';
+import { clearIssueDecisionCache } from '#appeals/appeal-details/issue-decision/issue-decision.middleware.js';
 
 const router = createRouter({ mergeParams: true });
+
+router.use(clearIssueDecisionCache);
 
 router
 	.route('/decision')
@@ -23,12 +25,10 @@ router
 router
 	.route('/decision-letter-upload')
 	.get(
-		validateAppeal,
 		assertUserHasPermission(permissionNames.setCaseOutcome),
 		asyncHandler(controller.renderDecisionLetterUpload)
 	)
 	.post(
-		validateAppeal,
 		assertUserHasPermission(permissionNames.setCaseOutcome),
 		asyncHandler(controller.postDecisionLetterUpload)
 	);
@@ -41,7 +41,6 @@ router
 	)
 	.post(
 		validators.validateAppellantCostsDecision,
-		validateAppeal,
 		assertUserHasPermission(permissionNames.setCaseOutcome),
 		asyncHandler(controller.postAppellantCostsDecision)
 	);
@@ -49,12 +48,10 @@ router
 router
 	.route('/appellant-costs-decision-letter-upload')
 	.get(
-		validateAppeal,
 		assertUserHasPermission(permissionNames.setCaseOutcome),
 		asyncHandler(controller.renderAppellantCostsDecisionLetterUpload)
 	)
 	.post(
-		validateAppeal,
 		assertUserHasPermission(permissionNames.setCaseOutcome),
 		asyncHandler(controller.postAppellantCostsDecisionLetterUpload)
 	);
@@ -67,7 +64,6 @@ router
 	)
 	.post(
 		validators.validateLpaCostsDecision,
-		validateAppeal,
 		assertUserHasPermission(permissionNames.setCaseOutcome),
 		asyncHandler(controller.postLpaCostsDecision)
 	);
@@ -75,12 +71,10 @@ router
 router
 	.route('/lpa-costs-decision-letter-upload')
 	.get(
-		validateAppeal,
 		assertUserHasPermission(permissionNames.setCaseOutcome),
 		asyncHandler(controller.renderLpaCostsDecisionLetterUpload)
 	)
 	.post(
-		validateAppeal,
 		assertUserHasPermission(permissionNames.setCaseOutcome),
 		asyncHandler(controller.postLpaCostsDecisionLetterUpload)
 	);
@@ -88,12 +82,10 @@ router
 router
 	.route('/check-your-decision')
 	.get(
-		validateAppeal,
 		assertUserHasPermission(permissionNames.setCaseOutcome),
 		asyncHandler(controller.renderCheckDecision)
 	)
 	.post(
-		validateAppeal,
 		assertUserHasPermission(permissionNames.setCaseOutcome),
 		asyncHandler(controller.postCheckDecision)
 	);


### PR DESCRIPTION
## Describe your changes
#### Clean up the routes and move clearing session data to middleware (a2-3162)

### WEB:
- Remove redundant "validateAppeal" middleware as it is already in the parent route.  see appeal-details.router.js
- Move clearing the session cache for the decision types when the appeal-id is different into middleware for every route
- Add some comments describing why the reuse of the appeal-documents upload page functions requires storing and restoring the uploadFileInfo object in the session for each decision type.

### TEST:
- Made sure all unit tests pass
- Manually tested within browser

## Issue ticket number and link
[Issuing decision flow - Part 7 - Check details (A2-3162)](https://pins-ds.atlassian.net/browse/A2-3162)
