### PR TITLE
feat(appeals): issue decision display rows (a2-3175)

### DIFF
--- a/appeals/api/src/server/endpoints/appeals.routes.js
+++ b/appeals/api/src/server/endpoints/appeals.routes.js
@@ -23,6 +23,7 @@ import { addressesRoutes } from './addresses/addresses.routes.js';
 import { appealTimetablesRoutes } from './appeal-timetables/appeal-timetables.routes.js';
 import { documentRedactionStatusesRoutes } from './document-redaction-statuses/document-redaction-statuses.routes.js';
 import { auditTrailsRoutes } from './audit-trails/audit-trails.routes.js';
+import { decisionRoutes } from './decision/decision.routes.js';
 import { appealsDecisionRoutes } from './appeal-decision/appeal-decision.routes.js';
 import { invalidAppealDecisionRoutes } from './invalid-appeal-decision/invalid-appeal-decision.routes.js';
 import { changeAppealTypeRoutes } from './change-appeal-type/change-appeal-type.routes.js';
@@ -73,6 +74,7 @@ router.use(localPlanningAuthoritiesRoutes);
 
 router.use(appealsRoutes);
 router.use(appealDetailsRoutes);
+router.use(decisionRoutes);
 router.use(appealsDecisionRoutes);
 router.use(invalidAppealDecisionRoutes);
 router.use(addressesRoutes);

--- a/appeals/api/src/server/endpoints/decision/__tests__/decision.test.js
+++ b/appeals/api/src/server/endpoints/decision/__tests__/decision.test.js
@@ -1,0 +1,303 @@
+// @ts-nocheck
+import { request } from '../../../app-test.js';
+import { jest } from '@jest/globals';
+import { azureAdUserId } from '#tests/shared/mocks.js';
+import { householdAppeal } from '#tests/appeals/mocks.js';
+import { documentCreated } from '#tests/documents/mocks.js';
+import formatDate from '#utils/date-formatter.js';
+import { add, sub } from 'date-fns';
+import {
+	ERROR_MUST_BE_CORRECT_UTC_DATE_FORMAT,
+	ERROR_MUST_NOT_BE_IN_FUTURE,
+	ERROR_CASE_OUTCOME_MUST_BE_ONE_OF,
+	ERROR_INVALID_APPEAL_STATE,
+	AUDIT_TRAIL_DECISION_ISSUED,
+	AUDIT_TRAIL_APPELLANT_COSTS_DECISION_ISSUED,
+	AUDIT_TRAIL_LPA_COSTS_DECISION_ISSUED,
+	AUDIT_TRAIL_PROGRESSED_TO_STATUS,
+	DECISION_TYPE_INSPECTOR,
+	DECISION_TYPE_APPELLANT_COSTS,
+	DECISION_TYPE_LPA_COSTS
+} from '@pins/appeals/constants/support.js';
+import { APPEAL_CASE_STATUS } from 'pins-data-model';
+import { recalculateDateIfNotBusinessDay, setTimeInTimeZone } from '#utils/business-days.js';
+import stringTokenReplacement from '#utils/string-token-replacement.js';
+
+const { databaseConnector } = await import('#utils/database-connector.js');
+
+describe('decision routes', () => {
+	beforeEach(() => {
+		// @ts-ignore
+		databaseConnector.appealRelationship.findMany.mockResolvedValue([]);
+		databaseConnector.user.upsert.mockResolvedValue({
+			id: 1,
+			azureAdUserId
+		});
+		process.env.FRONT_OFFICE_URL =
+			'https://appeal-planning-decision.service.gov.uk/appeals/1345264';
+	});
+	afterEach(() => {
+		jest.clearAllMocks();
+	});
+	describe('POST', () => {
+		test('returns 400 when outcome is not expected', async () => {
+			// @ts-ignore
+			databaseConnector.appeal.findUnique.mockResolvedValue(householdAppeal);
+			// @ts-ignore
+			databaseConnector.document.findUnique.mockResolvedValue(documentCreated);
+
+			const response = await request
+				.post(`/appeals/${householdAppeal.id}/decision`)
+				.send({
+					decisions: [
+						{
+							decisionType: DECISION_TYPE_INSPECTOR,
+							outcome: 'unexpected',
+							documentDate: '2023-11-10',
+							documentGuid: documentCreated.guid
+						}
+					]
+				})
+				.set('azureAdUserId', azureAdUserId);
+
+			expect(response.status).toEqual(400);
+			expect(response.body).toEqual({
+				errors: {
+					'decisions[0].outcome': ERROR_CASE_OUTCOME_MUST_BE_ONE_OF
+				}
+			});
+		});
+		test('returns 400 when outcome is invalid', async () => {
+			// @ts-ignore
+			databaseConnector.appeal.findUnique.mockResolvedValue(householdAppeal);
+			// @ts-ignore
+			databaseConnector.document.findUnique.mockResolvedValue(documentCreated);
+
+			const response = await request
+				.post(`/appeals/${householdAppeal.id}/decision`)
+				.send({
+					decisions: [
+						{
+							decisionType: DECISION_TYPE_INSPECTOR,
+							outcome: 'invalid',
+							documentDate: '2023-11-10',
+							documentGuid: documentCreated.guid
+						}
+					]
+				})
+				.set('azureAdUserId', azureAdUserId);
+
+			expect(response.status).toEqual(400);
+			expect(response.body).toEqual({
+				errors: {
+					'decisions[0].outcome': ERROR_CASE_OUTCOME_MUST_BE_ONE_OF
+				}
+			});
+		});
+		test('returns 400 when date is incorrect', async () => {
+			// @ts-ignore
+			databaseConnector.appeal.findUnique.mockResolvedValue(householdAppeal);
+			// @ts-ignore
+			databaseConnector.document.findUnique.mockResolvedValue(documentCreated);
+
+			const response = await request
+				.post(`/appeals/${householdAppeal.id}/decision`)
+				.send({
+					decisions: [
+						{
+							decisionType: DECISION_TYPE_INSPECTOR,
+							outcome: 'allowed',
+							documentDate: '2023-13-10',
+							documentGuid: documentCreated.guid
+						}
+					]
+				})
+				.set('azureAdUserId', azureAdUserId);
+
+			expect(response.status).toEqual(400);
+			expect(response.body).toEqual({
+				errors: {
+					'decisions[0].documentDate': ERROR_MUST_BE_CORRECT_UTC_DATE_FORMAT
+				}
+			});
+		});
+		test('returns 400 when date is in the future', async () => {
+			// @ts-ignore
+			databaseConnector.appeal.findUnique.mockResolvedValue(householdAppeal);
+			// @ts-ignore
+			databaseConnector.document.findUnique.mockResolvedValue(documentCreated);
+
+			const tomorrow = add(new Date(), { days: 1 });
+			const utcDate = setTimeInTimeZone(tomorrow, 0, 0);
+
+			const response = await request
+				.post(`/appeals/${householdAppeal.id}/decision`)
+				.send({
+					decisions: [
+						{
+							decisionType: DECISION_TYPE_INSPECTOR,
+							outcome: 'allowed',
+							documentDate: utcDate.toISOString(),
+							documentGuid: documentCreated.guid
+						}
+					]
+				})
+				.set('azureAdUserId', azureAdUserId);
+
+			expect(response.status).toEqual(400);
+			expect(response.body).toEqual({
+				errors: {
+					'decisions[0].documentDate': ERROR_MUST_NOT_BE_IN_FUTURE
+				}
+			});
+		});
+		test('returns 400 when state is not correct', async () => {
+			// @ts-ignore
+			databaseConnector.appeal.findUnique.mockResolvedValue(householdAppeal);
+			// @ts-ignore
+			databaseConnector.document.findUnique.mockResolvedValue(documentCreated);
+
+			const tenDaysAgo = sub(new Date(), { days: 10 });
+			const withoutWeekends = await recalculateDateIfNotBusinessDay(tenDaysAgo.toISOString());
+			const utcDate = setTimeInTimeZone(withoutWeekends, 0, 0);
+
+			const response = await request
+				.post(`/appeals/${householdAppeal.id}/decision`)
+				.send({
+					decisions: [
+						{
+							decisionType: DECISION_TYPE_INSPECTOR,
+							outcome: 'allowed',
+							documentDate: utcDate.toISOString(),
+							documentGuid: documentCreated.guid
+						}
+					]
+				})
+				.set('azureAdUserId', azureAdUserId);
+
+			expect(response.status).toEqual(400);
+			expect(response.body).toEqual({
+				errors: {
+					state: ERROR_INVALID_APPEAL_STATE
+				}
+			});
+		});
+		test('returns 200 when all good', async () => {
+			const correctAppealState = {
+				...householdAppeal,
+				appealStatus: [
+					{
+						status: APPEAL_CASE_STATUS.ISSUE_DETERMINATION,
+						valid: true
+					}
+				]
+			};
+			// @ts-ignore
+			databaseConnector.appeal.findUnique.mockResolvedValue(correctAppealState);
+			// @ts-ignore
+			databaseConnector.document.findUnique.mockResolvedValue(documentCreated);
+			// @ts-ignore
+			databaseConnector.inspectorDecision.create.mockResolvedValue({});
+
+			const tenDaysAgo = sub(new Date(), { days: 10 });
+			const withoutWeekends = await recalculateDateIfNotBusinessDay(tenDaysAgo.toISOString());
+			const utcDate = setTimeInTimeZone(withoutWeekends, 0, 0);
+			const outcome = 'allowed';
+
+			const response = await request
+				.post(`/appeals/${householdAppeal.id}/decision`)
+				.send({
+					decisions: [
+						{
+							decisionType: DECISION_TYPE_INSPECTOR,
+							outcome,
+							documentDate: utcDate.toISOString(),
+							documentGuid: documentCreated.guid
+						},
+						{
+							decisionType: DECISION_TYPE_APPELLANT_COSTS,
+							documentDate: utcDate.toISOString(),
+							documentGuid: documentCreated.guid
+						},
+						{
+							decisionType: DECISION_TYPE_LPA_COSTS,
+							documentDate: utcDate.toISOString(),
+							documentGuid: documentCreated.guid
+						}
+					]
+				})
+				.set('azureAdUserId', azureAdUserId);
+
+			// eslint-disable-next-line no-undef
+			expect(mockNotifySend).toHaveBeenCalledTimes(2);
+
+			// eslint-disable-next-line no-undef
+			expect(mockNotifySend).toHaveBeenNthCalledWith(1, {
+				notifyClient: expect.any(Object),
+				templateName: 'decision-is-allowed-split-dismissed-appellant',
+				personalisation: {
+					appeal_reference_number: '1345264',
+					lpa_reference: '48269/APP/2021/1482',
+					site_address: '96 The Avenue, Leftfield, Maidstone, Kent, MD21 5XY, United Kingdom',
+					decision_date: formatDate(utcDate, false),
+					front_office_url: 'https://appeal-planning-decision.service.gov.uk/appeals/1345264'
+				},
+				recipientEmail: householdAppeal.agent.email
+			});
+
+			// eslint-disable-next-line no-undef
+			expect(mockNotifySend).toHaveBeenNthCalledWith(2, {
+				notifyClient: expect.any(Object),
+				personalisation: {
+					appeal_reference_number: '1345264',
+					lpa_reference: '48269/APP/2021/1482',
+					site_address: '96 The Avenue, Leftfield, Maidstone, Kent, MD21 5XY, United Kingdom',
+					decision_date: formatDate(utcDate, false),
+					front_office_url: 'https://appeal-planning-decision.service.gov.uk/appeals/1345264'
+				},
+				templateName: 'decision-is-allowed-split-dismissed-lpa',
+				recipientEmail: householdAppeal.lpa.email
+			});
+
+			expect(databaseConnector.auditTrail.create).toHaveBeenCalledTimes(4);
+
+			expect(databaseConnector.auditTrail.create).toHaveBeenNthCalledWith(1, {
+				data: {
+					appealId: householdAppeal.id,
+					details: AUDIT_TRAIL_APPELLANT_COSTS_DECISION_ISSUED,
+					loggedAt: expect.any(Date),
+					userId: householdAppeal.caseOfficer.id
+				}
+			});
+
+			expect(databaseConnector.auditTrail.create).toHaveBeenNthCalledWith(2, {
+				data: {
+					appealId: householdAppeal.id,
+					details: AUDIT_TRAIL_LPA_COSTS_DECISION_ISSUED,
+					loggedAt: expect.any(Date),
+					userId: householdAppeal.caseOfficer.id
+				}
+			});
+
+			expect(databaseConnector.auditTrail.create).toHaveBeenNthCalledWith(3, {
+				data: {
+					appealId: householdAppeal.id,
+					details: stringTokenReplacement(AUDIT_TRAIL_DECISION_ISSUED, [outcome]),
+					loggedAt: expect.any(Date),
+					userId: householdAppeal.caseOfficer.id
+				}
+			});
+
+			expect(databaseConnector.auditTrail.create).toHaveBeenNthCalledWith(4, {
+				data: {
+					appealId: householdAppeal.id,
+					details: stringTokenReplacement(AUDIT_TRAIL_PROGRESSED_TO_STATUS, ['complete']),
+					loggedAt: expect.any(Date),
+					userId: householdAppeal.caseOfficer.id
+				}
+			});
+
+			expect(response.status).toEqual(201);
+		});
+	});
+});

--- a/appeals/api/src/server/endpoints/decision/decision.controller.js
+++ b/appeals/api/src/server/endpoints/decision/decision.controller.js
@@ -1,0 +1,78 @@
+import { publishDecision } from './decision.service.js';
+import {
+	AUDIT_TRAIL_APPELLANT_COSTS_DECISION_ISSUED,
+	AUDIT_TRAIL_LPA_COSTS_DECISION_ISSUED,
+	DECISION_TYPE_APPELLANT_COSTS,
+	DECISION_TYPE_INSPECTOR,
+	DECISION_TYPE_LPA_COSTS,
+	ERROR_INVALID_APPEAL_STATE
+} from '@pins/appeals/constants/support.js';
+import { formatAddressSingleLine } from '#endpoints/addresses/addresses.formatter.js';
+import { APPEAL_CASE_DECISION_OUTCOME, APPEAL_CASE_STATUS } from 'pins-data-model';
+import { createAuditTrail } from '#endpoints/audit-trails/audit-trails.service.js';
+
+/** @typedef {import('express').Request} Request */
+/** @typedef {import('express').Response} Response */
+/** @typedef {{decisionType: string, outcome: string, documentGuid: string, documentDate: Date}} Decision */
+
+/**
+ * @param {Request} req
+ * @param {Response} res
+ * @returns {Promise<Response>}
+ */
+export const postInspectorDecision = async (req, res) => {
+	const { appeal } = req;
+	const { decisions } = req.body;
+
+	if (appeal.appealStatus[0].status !== APPEAL_CASE_STATUS.ISSUE_DETERMINATION) {
+		return res.status(400).send({ errors: { state: ERROR_INVALID_APPEAL_STATE } });
+	}
+
+	const notifyClient = req.notifyClient;
+	const siteAddress = appeal.address
+		? formatAddressSingleLine(appeal.address)
+		: 'Address not available';
+
+	const azureAdUserId = req.get('azureAdUserId') || '';
+
+	const results = await Promise.all(
+		decisions.map(
+			/** @param {Decision} decision **/ async (decision) => {
+				const { decisionType, documentDate, documentGuid, outcome } = decision;
+				switch (decisionType) {
+					case DECISION_TYPE_INSPECTOR: {
+						return publishDecision(
+							appeal,
+							outcome === 'split decision' ? APPEAL_CASE_DECISION_OUTCOME.SPLIT_DECISION : outcome,
+							documentDate,
+							documentGuid,
+							notifyClient,
+							siteAddress,
+							azureAdUserId
+						);
+					}
+					case DECISION_TYPE_APPELLANT_COSTS: {
+						await createAuditTrail({
+							appealId: appeal.id,
+							azureAdUserId,
+							details: AUDIT_TRAIL_APPELLANT_COSTS_DECISION_ISSUED
+						});
+						return null;
+					}
+					case DECISION_TYPE_LPA_COSTS: {
+						await createAuditTrail({
+							appealId: appeal.id,
+							azureAdUserId,
+							details: AUDIT_TRAIL_LPA_COSTS_DECISION_ISSUED
+						});
+						return null;
+					}
+				}
+			}
+		)
+	);
+
+	const decision = results.find((result) => result !== null) ?? null;
+
+	return res.status(201).send(decision);
+};

--- a/appeals/api/src/server/endpoints/decision/decision.routes.js
+++ b/appeals/api/src/server/endpoints/decision/decision.routes.js
@@ -1,21 +1,22 @@
 import { Router as createRouter } from 'express';
 import { checkAppealExistsByIdAndAddToRequest } from '#middleware/check-appeal-exists-and-add-to-request.js';
-import { postInspectorDecision } from './appeal-decision.controller.js';
+import { postInspectorDecision } from './decision.controller.js';
 import {
 	getOutcomeValidator,
 	getDateValidator,
-	getDocumentValidator
-} from './appeal-decision.validator.js';
+	getDocumentValidator,
+	getDecisionTypeValidator,
+	getDecisionsValidator
+} from './decision.validator.js';
 import { asyncHandler } from '@pins/express';
-import { checkDocumentExistsAndAddToRequest } from '#middleware/document.js';
 
 const router = createRouter();
 
 router.post(
-	'/:appealId/inspector-decision',
+	'/:appealId/decision',
 	/*
-		#swagger.tags = ['Inspector Decision']
-		#swagger.path = '/appeals/{appealId}/inspector-decision'
+		#swagger.tags = ['Decision']
+		#swagger.path = '/appeals/{appealId}/decision'
 		#swagger.description = Closes an appeal by setting the inspector decision
 		#swagger.parameters['azureAdUserId'] = {
 			in: 'header',
@@ -25,22 +26,23 @@ router.post(
 		#swagger.requestBody = {
 			in: 'body',
 			description: 'Decision info',
-			schema: { $ref: '#/components/schemas/OldDecisionInfo' },
+			schema: { $ref: '#/components/schemas/DecisionInfo' },
 			required: true
 		}
 		#swagger.responses[201] = {
 			description: 'Gets the decision info or null',
-			schema: { $ref: '#/components/schemas/OldDecisionInfo' }
+			schema: { $ref: '#/components/schemas/DecisionInfo' }
 		}
 		#swagger.responses[400] = {}
 		#swagger.responses[404] = {}
 	 */
 	checkAppealExistsByIdAndAddToRequest,
+	getDecisionsValidator,
+	getDecisionTypeValidator,
 	getOutcomeValidator,
 	getDateValidator,
 	getDocumentValidator,
-	checkDocumentExistsAndAddToRequest,
 	asyncHandler(postInspectorDecision)
 );
 
-export { router as appealsDecisionRoutes };
+export { router as decisionRoutes };

--- a/appeals/api/src/server/endpoints/decision/decision.service.js
+++ b/appeals/api/src/server/endpoints/decision/decision.service.js
@@ -1,0 +1,87 @@
+import appealRepository from '#repositories/appeal.repository.js';
+import transitionState from '#state/transition-state.js';
+import { broadcasters } from '#endpoints/integrations/integrations.broadcasters.js';
+import formatDate from '#utils/date-formatter.js';
+import { APPEAL_CASE_STATUS } from 'pins-data-model';
+import { notifySend } from '#notify/notify-send.js';
+import { loadEnvironment } from '@pins/platform';
+import { createAuditTrail } from '#endpoints/audit-trails/audit-trails.service.js';
+import { AUDIT_TRAIL_DECISION_ISSUED } from '@pins/appeals/constants/support.js';
+import stringTokenReplacement from '#utils/string-token-replacement.js';
+
+/** @typedef {import('@pins/appeals.api').Schema.Appeal} Appeal */
+/** @typedef {import('@pins/appeals.api').Schema.InspectorDecision} Decision */
+/** @typedef {import('@pins/appeals.api').Schema.Document} Document */
+
+const environment = loadEnvironment(process.env.NODE_ENV);
+
+/**
+ *
+ * @param {Appeal} appeal
+ * @param {string} outcome
+ * @param {Date} documentDate
+ * @param {string} documentGuid
+ * @param {import('#endpoints/appeals.js').NotifyClient } notifyClient
+ * @param {string} siteAddress
+ * @param {string} azureUserId
+ * @returns
+ */
+export const publishDecision = async (
+	appeal,
+	outcome,
+	documentDate,
+	documentGuid,
+	notifyClient,
+	siteAddress,
+	azureUserId
+) => {
+	const result = await appealRepository.setAppealDecision(appeal.id, {
+		documentDate,
+		documentGuid,
+		version: 1,
+		outcome
+	});
+
+	if (result) {
+		const personalisation = {
+			appeal_reference_number: appeal.reference,
+			lpa_reference: appeal.applicationReference || '',
+			site_address: siteAddress,
+			front_office_url: environment.FRONT_OFFICE_URL || '',
+			decision_date: formatDate(new Date(documentDate || ''), false)
+		};
+		const recipientEmail = appeal.agent?.email || appeal.appellant?.email;
+		const lpaEmail = appeal.lpa?.email || '';
+
+		if (recipientEmail) {
+			await notifySend({
+				templateName: 'decision-is-allowed-split-dismissed-appellant',
+				notifyClient,
+				recipientEmail,
+				personalisation
+			});
+		}
+
+		if (lpaEmail) {
+			await notifySend({
+				templateName: 'decision-is-allowed-split-dismissed-lpa',
+				notifyClient,
+				recipientEmail: lpaEmail,
+				personalisation
+			});
+		}
+
+		await createAuditTrail({
+			appealId: appeal.id,
+			azureAdUserId: azureUserId,
+			details: stringTokenReplacement(AUDIT_TRAIL_DECISION_ISSUED, [outcome])
+		});
+
+		await transitionState(appeal.id, azureUserId, APPEAL_CASE_STATUS.COMPLETE);
+		await broadcasters.broadcastAppeal(appeal.id);
+
+		return result;
+	}
+
+	return null;
+};

--- a/appeals/api/src/server/endpoints/decision/decision.validator.js
+++ b/appeals/api/src/server/endpoints/decision/decision.validator.js
@@ -1,0 +1,60 @@
+import { composeMiddleware } from '@pins/express';
+import { body } from 'express-validator';
+import { validationErrorHandler } from '#middleware/error-handler.js';
+import {
+	CASE_OUTCOME_ALLOWED,
+	CASE_OUTCOME_DISMISSED,
+	CASE_OUTCOME_SPLIT_DECISION,
+	ERROR_MUST_BE_STRING,
+	ERROR_CASE_OUTCOME_MUST_BE_ONE_OF,
+	ERROR_MUST_BE_UUID,
+	DECISION_TYPE_INSPECTOR,
+	DECISION_TYPE_APPELLANT_COSTS,
+	DECISION_TYPE_LPA_COSTS,
+	ERROR_MUST_CONTAIN_AT_LEAST_1_VALUE
+} from '@pins/appeals/constants/support.js';
+
+import validateDateParameter from '#common/validators/date-parameter.js';
+
+const getDecisionsValidator = composeMiddleware(
+	body('decisions').isArray().withMessage(ERROR_MUST_CONTAIN_AT_LEAST_1_VALUE),
+	validationErrorHandler
+);
+
+const getDecisionTypeValidator = composeMiddleware(
+	body('decisions.*.decisionType').isString().withMessage(ERROR_MUST_BE_STRING),
+	body('decisions.*.decisionType')
+		.isIn([DECISION_TYPE_INSPECTOR, DECISION_TYPE_APPELLANT_COSTS, DECISION_TYPE_LPA_COSTS])
+		.withMessage(ERROR_CASE_OUTCOME_MUST_BE_ONE_OF),
+	validationErrorHandler
+);
+
+const getOutcomeValidator = composeMiddleware(
+	body('decisions.*.outcome').optional().isString().withMessage(ERROR_MUST_BE_STRING),
+	body('decisions.*.outcome')
+		.optional()
+		.isIn([CASE_OUTCOME_ALLOWED, CASE_OUTCOME_DISMISSED, CASE_OUTCOME_SPLIT_DECISION])
+		.withMessage(ERROR_CASE_OUTCOME_MUST_BE_ONE_OF),
+	validationErrorHandler
+);
+
+const getDateValidator = composeMiddleware(
+	validateDateParameter({
+		parameterName: 'decisions.*.documentDate',
+		mustBeNotBeFutureDate: true,
+		mustBeBusinessDay: true
+	})
+);
+
+const getDocumentValidator = composeMiddleware(
+	body('decisions.*.documentGuid').isUUID().withMessage(ERROR_MUST_BE_UUID),
+	validationErrorHandler
+);
+
+export {
+	getDecisionsValidator,
+	getDecisionTypeValidator,
+	getOutcomeValidator,
+	getDateValidator,
+	getDocumentValidator
+};

--- a/appeals/api/src/server/openapi-types.ts
+++ b/appeals/api/src/server/openapi-types.ts
@@ -348,6 +348,19 @@ export interface RepresentationData {
 }
 
 export interface DecisionInfo {
+	decisions?: {
+		/** @example "inspector-decision" */
+		decisionType?: string;
+		/** @example "allowed" */
+		outcome?: string;
+		/** @example "c957e9d0-1a02-4650-acdc-f9fdd689c210" */
+		documentGuid?: string;
+		/** @example "2024-08-17" */
+		documentDate?: string;
+	}[];
+}
+
+export interface OldDecisionInfo {
 	/** @example "allowed" */
 	outcome?: string;
 	/** @example "c957e9d0-1a02-4650-acdc-f9fdd689c210" */

--- a/appeals/api/src/server/openapi.json
+++ b/appeals/api/src/server/openapi.json
@@ -171,12 +171,12 @@
 						"content": {
 							"application/json": {
 								"schema": {
-									"$ref": "#/components/schemas/DecisionInfo"
+									"$ref": "#/components/schemas/OldDecisionInfo"
 								}
 							},
 							"application/xml": {
 								"schema": {
-									"$ref": "#/components/schemas/DecisionInfo"
+									"$ref": "#/components/schemas/OldDecisionInfo"
 								}
 							}
 						}
@@ -195,12 +195,12 @@
 					"content": {
 						"application/json": {
 							"schema": {
-								"$ref": "#/components/schemas/DecisionInfo"
+								"$ref": "#/components/schemas/OldDecisionInfo"
 							}
 						},
 						"application/xml": {
 							"schema": {
-								"$ref": "#/components/schemas/DecisionInfo"
+								"$ref": "#/components/schemas/OldDecisionInfo"
 							}
 						}
 					}
@@ -1784,6 +1784,71 @@
 					},
 					"400": {
 						"description": "Bad Request"
+					}
+				}
+			}
+		},
+		"/appeals/{appealId}/decision": {
+			"post": {
+				"tags": ["Decision"],
+				"description": "Closes an appeal by setting the inspector decision",
+				"parameters": [
+					{
+						"name": "appealId",
+						"in": "path",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"name": "azureAdUserId",
+						"in": "header",
+						"required": true,
+						"example": "434bff4e-8191-4ce0-9a0a-91e5d6cdd882",
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"responses": {
+					"201": {
+						"description": "Gets the decision info or null",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/DecisionInfo"
+								}
+							},
+							"application/xml": {
+								"schema": {
+									"$ref": "#/components/schemas/DecisionInfo"
+								}
+							}
+						}
+					},
+					"400": {
+						"description": "Bad Request"
+					},
+					"404": {
+						"description": "Not Found"
+					}
+				},
+				"requestBody": {
+					"in": "body",
+					"description": "Decision info",
+					"required": true,
+					"content": {
+						"application/json": {
+							"schema": {
+								"$ref": "#/components/schemas/DecisionInfo"
+							}
+						},
+						"application/xml": {
+							"schema": {
+								"$ref": "#/components/schemas/DecisionInfo"
+							}
+						}
 					}
 				}
 			}
@@ -6207,6 +6272,38 @@
 			"DecisionInfo": {
 				"type": "object",
 				"properties": {
+					"decisions": {
+						"type": "array",
+						"items": {
+							"type": "object",
+							"properties": {
+								"decisionType": {
+									"type": "string",
+									"example": "inspector-decision"
+								},
+								"outcome": {
+									"type": "string",
+									"example": "allowed"
+								},
+								"documentGuid": {
+									"type": "string",
+									"example": "c957e9d0-1a02-4650-acdc-f9fdd689c210"
+								},
+								"documentDate": {
+									"type": "string",
+									"example": "2024-08-17"
+								}
+							}
+						}
+					}
+				},
+				"xml": {
+					"name": "DecisionInfo"
+				}
+			},
+			"OldDecisionInfo": {
+				"type": "object",
+				"properties": {
 					"outcome": {
 						"type": "string",
 						"example": "allowed"
@@ -6221,7 +6318,7 @@
 					}
 				},
 				"xml": {
-					"name": "DecisionInfo"
+					"name": "OldDecisionInfo"
 				}
 			},
 			"InvalidDecisionInfo": {

--- a/appeals/api/src/server/swagger.js
+++ b/appeals/api/src/server/swagger.js
@@ -103,6 +103,17 @@ export const spec = {
 			...validRepresentationIp
 		},
 		DecisionInfo: {
+			decisions: [
+				{
+					decisionType: 'inspector-decision',
+					outcome: 'allowed',
+					documentGuid: 'c957e9d0-1a02-4650-acdc-f9fdd689c210',
+					documentDate: '2024-08-17'
+				}
+			]
+		},
+		//ToDo: Remove once the new version of issue decisions is released
+		OldDecisionInfo: {
 			outcome: 'allowed',
 			documentGuid: 'c957e9d0-1a02-4650-acdc-f9fdd689c210',
 			documentDate: '2024-08-17'

--- a/appeals/web/src/server/appeals/appeal-details/__tests__/__snapshots__/appeal-details.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/__tests__/__snapshots__/appeal-details.test.js.snap
@@ -1211,10 +1211,12 @@ exports[`appeal-details GET /:appealId should render a Decision inset panel when
         </div>
     </div>
     <div class="govuk-inset-text">
-        <p>Appeal completed: 25 December 2023</p>
-        <p>Decision: Dismissed</p>
-        <p><span class="govuk-body">View decision letter</span><strong class="govuk-tag govuk-tag--yellow">Virus scanning</strong>
-        </p>
+        <ul class="govuk-list">
+            <li>Decision: Dismissed</li>
+            <li>Decision issued on 25 December 2023</li>
+            <li><span class="govuk-body">View decision</span><strong class="govuk-tag govuk-tag--yellow">Virus scanning</strong>
+            </li>
+        </ul>
     </div>
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-full">

--- a/appeals/web/src/server/appeals/appeal-details/__tests__/appeal-details.test.js
+++ b/appeals/web/src/server/appeals/appeal-details/__tests__/appeal-details.test.js
@@ -1720,12 +1720,13 @@ describe('appeal-details', () => {
 			expect(element.innerHTML).toMatchSnapshot();
 
 			const insetTextElementHTML = parseHtml(response.text, {
+				skipPrettyPrint: true,
 				rootElement: '.govuk-inset-text'
 			}).innerHTML;
-			expect(insetTextElementHTML).toContain('<p>Appeal completed:');
-			expect(insetTextElementHTML).toContain('<p>Decision:');
+			expect(insetTextElementHTML).toContain('<li>Decision: Dismissed</li>');
+			expect(insetTextElementHTML).toContain('<li>Decision issued on 25 December 2023</li>');
 			expect(insetTextElementHTML).toContain(
-				'<p><span class="govuk-body">View decision letter</span>'
+				'<li><span class="govuk-body">View decision</span><strong class="govuk-tag govuk-tag--yellow">Virus scanning</strong></li>'
 			);
 		});
 
@@ -3103,6 +3104,7 @@ describe('appeal-details', () => {
 						...appealData,
 						appealId,
 						appealStatus: 'issue_determination',
+						stateList: [{ key: 'event', completed: true }],
 						decision: {
 							...appealData.decision,
 							outcome: null

--- a/appeals/web/src/server/appeals/appeal-details/issue-decision/__tests__/__snapshots__/issue-decision.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/issue-decision/__tests__/__snapshots__/issue-decision.test.js.snap
@@ -1,5 +1,22 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`POST /issue-decision/check-your-decision should render a 500 error page if no decision files are sent 1`] = `
+"<main class="govuk-main-wrapper" id="main-content">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <h1 class="govuk-heading-xl">Sorry, there is a problem with the service</h1>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <p class="govuk-body">Try again later.</p>
+            <p class="govuk-body"><a href="https://has-appeal.herokuapp.com/help/contact" class="govuk-link">Contact the Planning Inspectorate Customer Support</a> if
+                the problem persists.</p>
+        </div>
+    </div>
+</main>"
+`;
+
 exports[`issue-decision GET /appellant-costs-decision should render the appellant cost decision page 1`] = `
 "<main class="govuk-main-wrapper" id="main-content">
     <div class="govuk-grid-row">

--- a/appeals/web/src/server/appeals/appeal-details/issue-decision/issue-decision.service.js
+++ b/appeals/web/src/server/appeals/appeal-details/issue-decision/issue-decision.service.js
@@ -1,41 +1,18 @@
 /**
- * @typedef {import('./issue-decision.types.js').InspectorDecisionRequest} InspectorDecisionRequest
+ * @typedef {{decisionType: string, outcome: string|null, documentGuid: string|null, documentDate: string|null}} Decision
  */
 
 /**
  *
  * @param {import('got').Got} apiClient
  * @param {string} appealId
- * @param {string|null} outcome
- * @param {string|null} documentGuid
- * @param {string|null} documentDate
- * @returns {Promise<InspectorDecisionRequest>}
+ * @param {Decision[]} decisions
+ * @returns {Promise<{}>}
  */
-export async function postInspectorDecision(
-	apiClient,
-	appealId,
-	outcome,
-	documentGuid,
-	documentDate
-) {
+export async function postInspectorDecision(apiClient, appealId, decisions) {
 	return await apiClient
-		.post(`appeals/${appealId}/inspector-decision`, {
-			json: { outcome, documentGuid, documentDate }
-		})
-		.json();
-}
-
-/**
- *
- * @param {import('got').Got} apiClient
- * @param {string} appealId
- * @param {string} invalidReason
- * @returns {Promise<InspectorDecisionRequest>}
- */
-export async function postInspectorInvalidReason(apiClient, appealId, invalidReason) {
-	return await apiClient
-		.post(`appeals/${appealId}/inspector-decision-invalid`, {
-			json: { invalidDecisionReason: invalidReason }
+		.post(`appeals/${appealId}/decision`, {
+			json: { decisions }
 		})
 		.json();
 }

--- a/appeals/web/src/server/appeals/appeal-details/status-tags/status-tags.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/status-tags/status-tags.mapper.js
@@ -58,16 +58,34 @@ export const generateStatusTags = async (mappedData, appealDetails, request) => 
 			appealDetails.decision.virusCheckStatus || APPEAL_VIRUS_CHECK_STATUS.NOT_SCANNED
 		);
 
+		const insetTextRows = [
+			`Decision: ${mapDecisionOutcome(appealDetails.decision?.outcome || '')}`,
+			`Decision issued on ${letterDate}`
+		];
+
+		if (appealDetails.costs.appellantDecisionFolder?.documents?.length) {
+			insetTextRows.push(`Appellant costs decision: Issued`);
+		}
+
+		if (appealDetails.costs.lpaDecisionFolder?.documents?.length) {
+			insetTextRows.push(`LPA costs decision: Issued`);
+		}
+
+		if (virusCheckStatus.checked && virusCheckStatus.safe) {
+			insetTextRows.push(generateDecisionDocumentDownloadHtml(appealDetails, 'View decision'));
+		} else {
+			insetTextRows.push(
+				`<span class="govuk-body">View decision</span><strong class="govuk-tag govuk-tag--yellow">Virus scanning</strong>`
+			);
+		}
+
+		const html =
+			`<ul class="govuk-list">` + insetTextRows.map((row) => `<li>${row}</li>`).join('') + `</ul>`;
+
 		statusTagsComponentGroup.push({
 			type: 'inset-text',
 			parameters: {
-				html: `<p>Appeal completed: ${letterDate}</p>
-						<p>Decision: ${mapDecisionOutcome(appealDetails.decision?.outcome || '')}</p>
-						<p>${
-							!(virusCheckStatus.checked && virusCheckStatus.safe)
-								? '<span class="govuk-body">View decision letter</span> '
-								: ''
-						}${generateDecisionDocumentDownloadHtml(appealDetails, 'View decision letter')}</p>`
+				html
 			}
 		});
 	} else if (

--- a/appeals/web/src/server/lib/mappers/components/page-components/notification-banners.mapper.js
+++ b/appeals/web/src/server/lib/mappers/components/page-components/notification-banners.mapper.js
@@ -389,7 +389,7 @@ export const notificationBannerDefinitions = {
 	issuedDecisionValid: {
 		type: 'success',
 		pages: ['appealDetails'],
-		text: 'Decision sent'
+		text: 'Decision issued'
 	},
 	issuedDecisionInvalid: {
 		type: 'success',

--- a/appeals/web/src/server/lib/mappers/data/appeal/submappers/costs-appellant-decision.mapper.js
+++ b/appeals/web/src/server/lib/mappers/data/appeal/submappers/costs-appellant-decision.mapper.js
@@ -1,5 +1,6 @@
 import { APPEAL_CASE_STATUS } from 'pins-data-model';
 import { textSummaryListItem } from '#lib/mappers/index.js';
+import { mapDocumentDownloadUrl } from '#appeals/appeal-documents/appeal-documents.mapper.js';
 
 /** @type {import('../mapper.js').SubMapper} */
 export const mapCostsAppellantDecision = ({
@@ -19,6 +20,9 @@ export const mapCostsAppellantDecision = ({
 
 	const isIssued = appellantDecisionFolder?.documents?.length ?? 0 > 0;
 
+	const { id: documentId = '', name: documentName = '' } =
+		appellantDecisionFolder?.documents?.[0] || {};
+
 	const actionText = (() => {
 		if (isIssued) {
 			return 'View';
@@ -33,7 +37,9 @@ export const mapCostsAppellantDecision = ({
 		id: 'appellant-costs-decision',
 		text: 'Appellant costs decision',
 		value: isIssued ? 'Issued' : 'Not issued',
-		link: `${currentRoute}/costs/appellant-decision`,
+		link: isIssued
+			? mapDocumentDownloadUrl(appealDetails.appealId, documentId, documentName)
+			: `${currentRoute}/costs/appellant-decision`,
 		actionText,
 		editable: userHasUpdateCasePermission && Boolean(actionText),
 		classes: 'costs-appellant-decision'

--- a/appeals/web/src/server/lib/mappers/data/appeal/submappers/costs-lpa-decision.mapper.js
+++ b/appeals/web/src/server/lib/mappers/data/appeal/submappers/costs-lpa-decision.mapper.js
@@ -1,5 +1,6 @@
 import { APPEAL_CASE_STATUS } from 'pins-data-model';
 import { textSummaryListItem } from '#lib/mappers/index.js';
+import { mapDocumentDownloadUrl } from '#appeals/appeal-documents/appeal-documents.mapper.js';
 
 /** @type {import('../mapper.js').SubMapper} */
 export const mapCostsLpaDecision = ({
@@ -19,6 +20,8 @@ export const mapCostsLpaDecision = ({
 
 	const isIssued = (lpaDecisionFolder?.documents?.length ?? 0) > 0;
 
+	const { id: documentId = '', name: documentName = '' } = lpaDecisionFolder?.documents?.[0] || {};
+
 	const actionText = (() => {
 		if (isIssued) {
 			return 'View';
@@ -35,7 +38,9 @@ export const mapCostsLpaDecision = ({
 		id: 'lpa-costs-decision',
 		text: 'LPA costs decision',
 		value: isIssued ? 'Issued' : 'Not issued',
-		link: `${currentRoute}/costs/lpa-decision`,
+		link: isIssued
+			? mapDocumentDownloadUrl(appealDetails.appealId, documentId, documentName)
+			: `${currentRoute}/costs/lpa-decision`,
 		actionText,
 		editable: userHasUpdateCasePermission && Boolean(actionText),
 		classes: 'costs-lpa-decision'

--- a/appeals/web/src/server/lib/mappers/data/appeal/submappers/decision.mapper.js
+++ b/appeals/web/src/server/lib/mappers/data/appeal/submappers/decision.mapper.js
@@ -7,21 +7,35 @@ import { textSummaryListItem } from '#lib/mappers/index.js';
 import { userHasPermission } from '#lib/mappers/index.js';
 import { permissionNames } from '#environment/permissions.js';
 import { addBackLinkQueryToUrl } from '#lib/url-utilities.js';
+import { mapDocumentDownloadUrl } from '#appeals/appeal-documents/appeal-documents.mapper.js';
+import { isStatePassed } from '#lib/appeal-status.js';
 
 /** @type {import('../mapper.js').SubMapper} */
 export const mapDecision = ({ appealDetails, session, request }) => {
-	const canIssueDecision = !(
-		appealDetails.decision?.outcome ||
-		appealDetails.appealStatus !== APPEAL_CASE_STATUS.ISSUE_DETERMINATION
-	);
+	const { appealId, appealStatus, decision } = appealDetails;
+
+	const canIssueDecision =
+		!decision?.outcome && appealStatus === APPEAL_CASE_STATUS.ISSUE_DETERMINATION;
+
+	const editable =
+		isStatePassed(appealDetails, APPEAL_CASE_STATUS.EVENT) &&
+		userHasPermission(permissionNames.setCaseOutcome, session);
+
+	const { documentId, documentName } = decision || {};
+
+	const link = canIssueDecision
+		? addBackLinkQueryToUrl(request, generateIssueDecisionUrl(appealId))
+		: documentId && documentName
+		? mapDocumentDownloadUrl(appealId, documentId, documentName)
+		: '';
 
 	return textSummaryListItem({
 		id: 'decision',
 		text: 'Decision',
-		value: mapDecisionOutcome(appealDetails.decision?.outcome || '') || 'Not issued',
-		link: addBackLinkQueryToUrl(request, generateIssueDecisionUrl(appealDetails.appealId)),
-		editable: userHasPermission(permissionNames.setCaseOutcome, session) && canIssueDecision,
-		actionText: 'Issue',
+		value: mapDecisionOutcome(decision?.outcome || '') || 'Not issued',
+		link,
+		editable,
+		actionText: canIssueDecision ? 'Issue' : 'View',
 		classes: 'appeal-decision'
 	});
 };

--- a/packages/appeals/constants/support.js
+++ b/packages/appeals/constants/support.js
@@ -13,6 +13,10 @@ export const CASE_OUTCOME_DISMISSED = 'dismissed';
 export const CASE_OUTCOME_SPLIT_DECISION = 'split decision';
 export const CASE_OUTCOME_INVALID = 'invalid';
 
+export const DECISION_TYPE_INSPECTOR = 'inspector-decision';
+export const DECISION_TYPE_APPELLANT_COSTS = 'appellant-costs-decision';
+export const DECISION_TYPE_LPA_COSTS = 'lpa-costs-decision';
+
 export const AUDIT_TRAIL_REP_SHARED = '{replacement0} shared';
 export const AUDIT_TRAIL_REP_LPA_STATEMENT_STATUS_UPDATED =
 	'LPA statement status updated to {replacement0}';
@@ -147,6 +151,10 @@ export const AUDIT_TRAIL_LPA_UPDATED = 'LPA updated to {replacement0}';
 export const AUDIT_TRAIL_HEARING_ESTIMATES_ADDED = 'Hearing estimates added';
 export const AUDIT_TRAIL_HEARING_ESTIMATES_UPDATED = 'Hearing estimates updated';
 export const AUDIT_TRAIL_HEARING_ESTIMATES_REMOVED = 'Hearing estimates removed';
+
+export const AUDIT_TRAIL_DECISION_ISSUED = 'Decision issued: {replacement0}';
+export const AUDIT_TRAIL_APPELLANT_COSTS_DECISION_ISSUED = 'Appellant costs decision issued';
+export const AUDIT_TRAIL_LPA_COSTS_DECISION_ISSUED = 'LPA costs decision issued';
 
 export const BANK_HOLIDAY_FEED_DIVISION_ENGLAND = 'england-and-wales';
 


### PR DESCRIPTION
## Describe your changes
#### Implement issue decision links and audit trails (a2-3175)

### API:
- Create new decisions route to allow decisions to be sent as an array
- Validate the decisions data via array members
- Add audit trail for decision, appellant cost decision, and lpa cost decision
- Create constants for above

### WEB:
- Update the case details inset content for decisions to match the ticket
- Update the decision issued links to link to the uploaded files

### TEST:
- Updated tests and associated snapshots
- Created new tests and associated snapshots
- Made sure all unit tests pass
- Manually tested within browser
- Checked the audit trail is updated correctly
- Made sure emails are generated using the notify emulator

## Issue ticket number and link
[Issuing Decision - Part 8 - Issue decision (A2-3175)](https://pins-ds.atlassian.net/browse/A2-3175)
