### PR TITLE
fix(web): bypassing file name duplicate check on rep attachments upload

### DIFF
--- a/appeals/web/src/client/components/file-uploader/_client-actions.js
+++ b/appeals/web/src/client/components/file-uploader/_client-actions.js
@@ -374,6 +374,10 @@ const clientActions = (container) => {
 	 */
 	function validateSelectedFile(selectedFile) {
 		const allowedMimeTypes = (container.dataset.allowedTypes || '').split(',');
+		if (container.dataset?.documentStage === 'representation') {
+			return null;
+		}
+
 		const filenamesInFolderBase64String = form?.dataset.filenamesInFolder || '';
 		const filenamesInFolderString = window.atob(filenamesInFolderBase64String);
 		const filenamesInFolderArray =


### PR DESCRIPTION
Fixes a representation upload issue by removing duplicate file name validation for these type of documents.

## Issue ticket number and link
[A2-3338](https://pins-ds.atlassian.net/browse/A2-3338)


[A2-3338]: https://pins-ds.atlassian.net/browse/A2-3338?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ