### PR TITLE
feat(web): File Upload - Error messages and success banners

### DIFF
--- a/appeals/web/src/client/components/file-uploader/_client-actions.js
+++ b/appeals/web/src/client/components/file-uploader/_client-actions.js
@@ -514,7 +514,7 @@ const clientActions = (container) => {
 					message: 'NO_FILE',
 					formId: container.dataset?.formId || '',
 					metadata: {
-						fileTitle: container.dataset?.documentTitle || 'a file'
+						fileTitle: container.dataset?.documentTitle || 'file'
 					}
 				},
 				container

--- a/appeals/web/src/client/components/file-uploader/_html.js
+++ b/appeals/web/src/client/components/file-uploader/_html.js
@@ -32,7 +32,7 @@ export const errorMessage = (type, replaceValue, additionalValues = {}) => {
 		ADDITIONAL_DOCUMENTS_CONFIRMATION_REQUIRED:
 			'Please confirm that the document does not belong anywhere else',
 		TIMEOUT: 'There was a timeout and your files could not be uploaded',
-		NO_FILE: 'Select {fileTitle}',
+		NO_FILE: 'Select the {fileTitle}',
 		SIZE_SINGLE_FILE: `The selected file must be smaller than 25MB`,
 		GENERIC_SINGLE_FILE: `{REPLACE_VALUE} could not be added`,
 		NAME_SINGLE_FILE: `{REPLACE_VALUE} could not be added because the file name is too long or contains special characters. Rename the file and try again.`,

--- a/appeals/web/src/server/appeals/appeal-details/appellant-case/__tests__/__snapshots__/appellant-case.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/appellant-case/__tests__/__snapshots__/appellant-case.test.js.snap
@@ -2242,6 +2242,7 @@ exports[`appellant-case GET /appellant-case/add-documents/:folderId/ should rend
             data-form-id="1" data-case-id="1" data-case-reference="APP/Q9999/D/21/351062"
             data-folder-id="2864" data-document-type="changedDescription" data-document-stage="appellant-case"
             data-blob-storage-host="https://127.0.0.1:10000/devstoreaccount1" data-blob-storage-container="document-service-uploads"
+            data-document-title="evidence of your agreement to change the description of development"
             data-allowed-types="application/pdf,application/msword,application/vnd.openxmlformats-officedocument.wordprocessingml.document,application/vnd.ms-powerpoint,application/vnd.openxmlformats-officedocument.presentationml.presentation,application/vnd.ms-excel,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,application/vnd.ms-outlook,image/jpeg,image/jpeg,video/mpeg,audio/mpeg,video/mp4,video/quicktime,image/png,image/tiff,image/tiff"
             data-formatted-allowed-types="PDF, DOC, DOCX, PPT, PPTX, XLS, XLSX, MSG, JPG, JPEG, MPEG, MP3, MP4, MOV, PNG, TIF or TIFF">
                 <form method="POST" novalidate="novalidate" class="govuk-grid-column-two-thirds"

--- a/appeals/web/src/server/appeals/appeal-details/appellant-case/appellant-case.controller.js
+++ b/appeals/web/src/server/appeals/appeal-details/appellant-case/appellant-case.controller.js
@@ -241,9 +241,7 @@ export const getAddDocuments = async (request, response) => {
 	if (!appellantCaseDetails) {
 		return response.status(404).render('app/404.njk');
 	}
-
 	const pageHeadingTextOverride = getPageHeadingTextOverrideForAddDocuments(currentFolder);
-
 	await renderDocumentUpload({
 		request,
 		response,
@@ -251,7 +249,8 @@ export const getAddDocuments = async (request, response) => {
 		backButtonUrl: `/appeals-service/appeal-details/${request.params.appealId}/appellant-case/`,
 		nextPageUrl: `/appeals-service/appeal-details/${request.params.appealId}/appellant-case/add-document-details/{{folderId}}`,
 		isLateEntry: getValidationOutcomeFromAppellantCase(appellantCaseDetails) === 'valid',
-		pageHeadingTextOverride
+		pageHeadingTextOverride,
+		documentTitle: getDocumentNameFromFolder(currentFolder.path) || ''
 	});
 };
 


### PR DESCRIPTION
## Describe your changes

File Upload - Error messages and success banners
verified that error messages and success banners function correctly when uploading documents
Added value for document names for error messages


## Issue ticket number and link
[A2-3001](https://pins-ds.atlassian.net.mcas.ms/browse/A2-3001)


[A2-3001]: https://pins-ds.atlassian.net/browse/A2-3001?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ