### PR TITLE
fix(api): sets redaction status for docs where unset A2-3358

### DIFF
--- a/appeals/api/src/server/endpoints/representations/__tests__/representations.test.js
+++ b/appeals/api/src/server/endpoints/representations/__tests__/representations.test.js
@@ -4,6 +4,7 @@ import { request } from '#tests/../app-test.js';
 import { householdAppeal, appealS78 } from '#tests/appeals/mocks.js';
 import { jest } from '@jest/globals';
 import { cloneDeep } from 'lodash-es';
+import { APPEAL_REDACTED_STATUS } from 'pins-data-model';
 
 const { databaseConnector } = await import('#utils/database-connector.js');
 
@@ -718,6 +719,10 @@ describe('/appeals/:id/reps/publish', () => {
 				{ representationType: 'lpa_statement' }
 			]);
 			databaseConnector.representation.updateMany.mockResolvedValue([]);
+			databaseConnector.documentRedactionStatus.findMany.mockResolvedValue([
+				{ key: APPEAL_REDACTED_STATUS.NO_REDACTION_REQUIRED }
+			]);
+			databaseConnector.documentVersion.findMany.mockResolvedValue([]);
 
 			const response = await request
 				.post('/appeals/1/reps/publish')


### PR DESCRIPTION
Sets the redaction status of attachments where a redaction status has not been previously set to 'No redaction required'.
Triggered when publishing statements/comments and final comments.


## Issue ticket number and link
[A2-3358](https://pins-ds.atlassian.net/browse/A2-3358)


[A2-3358]: https://pins-ds.atlassian.net/browse/A2-3358?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ