### PR TITLE
fix(web): make sure that radio still checked when going back

### DIFF
--- a/appeals/web/src/server/appeals/appeal-details/hearing/setup/__tests__/__snapshots__/set-up-hearing.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/hearing/setup/__tests__/__snapshots__/set-up-hearing.test.js.snap
@@ -19,7 +19,7 @@ exports[`set up hearing GET /hearing/setup/address should match the snapshot 1`]
                                 <div class="govuk-radios" data-module="govuk-radios">
                                     <div class="govuk-radios__item">
                                         <input class="govuk-radios__input" id="address-known" name="addressKnown"
-                                        type="radio" value="yes">
+                                        type="radio" value="yes" checked>
                                         <label class="govuk-label govuk-radios__label" for="address-known">Yes</label>
                                     </div>
                                     <div class="govuk-radios__item">

--- a/appeals/web/src/server/appeals/appeal-details/hearing/setup/__tests__/set-up-hearing.test.js
+++ b/appeals/web/src/server/appeals/appeal-details/hearing/setup/__tests__/set-up-hearing.test.js
@@ -224,7 +224,13 @@ describe('set up hearing', () => {
 		beforeAll(async () => {
 			nock('http://test/')
 				.get(`/appeals/${appealId}`)
+				.twice()
 				.reply(200, { ...appealData, appealId });
+
+			// set session data with post request
+			await request.post(`${baseUrl}/${appealId}/hearing/setup/address`).send({
+				addressKnown: 'yes'
+			});
 
 			const response = await request.get(`${baseUrl}/${appealId}/hearing/setup/address`);
 			pageHtml = parseHtml(response.text);
@@ -246,6 +252,12 @@ describe('set up hearing', () => {
 
 		it('should render a radio button for address unknown', () => {
 			expect(pageHtml.querySelector('input[name="addressKnown"]')).not.toBeNull();
+		});
+
+		it('should check the submitted value', () => {
+			expect(
+				pageHtml.querySelector('input[name="addressKnown"][value="yes"]')?.getAttribute('checked')
+			).toBeDefined();
 		});
 	});
 

--- a/appeals/web/src/server/appeals/appeal-details/hearing/setup/set-up-hearing.controller.js
+++ b/appeals/web/src/server/appeals/appeal-details/hearing/setup/set-up-hearing.controller.js
@@ -128,7 +128,7 @@ export const postChangeHearingDate = async (request, response) => {
  * @param {import('@pins/express/types/express.js').RenderedResponse<any, any, Number>} response
  */
 export const getHearingAddress = async (request, response) => {
-	return renderHearingAddress(request, response, 'setup');
+	return renderHearingAddress(request, response, 'setup', request.session.setUpHearing || {});
 };
 
 /**


### PR DESCRIPTION
## Describe your changes

Make sure that the yes/no radio is checked when going back to the yes/no page when setting up a hearing

## Issue ticket number and link

[A2-3023](https://pins-ds.atlassian.net/browse/A2-3023)


[A2-3023]: https://pins-ds.atlassian.net/browse/A2-3023?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ