### PR TITLE
fix(appeals): only bypass duplicate file validation when doc stage is representation (a2-3404)

### DIFF
--- a/appeals/web/src/client/components/file-uploader/_client-actions.js
+++ b/appeals/web/src/client/components/file-uploader/_client-actions.js
@@ -374,10 +374,6 @@ const clientActions = (container) => {
 	 */
 	function validateSelectedFile(selectedFile) {
 		const allowedMimeTypes = (container.dataset.allowedTypes || '').split(',');
-		if (container.dataset?.documentStage === 'representation') {
-			return null;
-		}
-
 		const filenamesInFolderBase64String = form?.dataset.filenamesInFolder || '';
 		const filenamesInFolderString = window.atob(filenamesInFolderBase64String);
 		const filenamesInFolderArray =
@@ -385,30 +381,27 @@ const clientActions = (container) => {
 		const filenamesInFolder = Array.isArray(filenamesInFolderArray) ? filenamesInFolderArray : [];
 		const filenamesInStagedFiles = stagedFiles.files.map((stagedFile) => stagedFile.name);
 
-		if (filenamesInStagedFiles.includes(selectedFile.name)) {
-			return { message: 'DUPLICATE_NAME_SINGLE_FILE' };
-		}
-		if (filenamesInFolder.includes(selectedFile.name)) {
-			return { message: 'DUPLICATE_NAME_SINGLE_FILE' };
-		}
 		if (selectedFile.name.length > maximumAllowedFileNameLength) {
 			return { message: 'NAME_SINGLE_FILE' };
 		}
-		const originalFileExtension = container.dataset.documentOriginalFileName?.split('.').pop();
-		if (originalFileExtension && selectedFile.name.split('.').pop() !== originalFileExtension) {
-			return {
-				message: 'DIFFERENT_FILE_EXTENSION',
-				metadata: { fileExtension: originalFileExtension.toUpperCase() }
-			};
-		}
+
 		if (!allowedMimeTypes.includes(selectedFile.type)) {
 			return {
 				message: 'DIFFERENT_FILE_EXTENSION',
 				metadata: { fileExtension: container.dataset.formattedAllowedTypes }
 			};
 		}
+
 		if (selectedFile.size > MAX_FILE_SIZE) {
 			return { message: 'SIZE_SINGLE_FILE' };
+		}
+
+		if (container.dataset?.documentStage === 'representation') {
+			return null;
+		}
+
+		if ([...filenamesInStagedFiles, ...filenamesInFolder].includes(selectedFile.name)) {
+			return { message: 'DUPLICATE_NAME_SINGLE_FILE' };
 		}
 
 		return null;


### PR DESCRIPTION
## Describe your changes
#### Only by-pass duplicate file validation when the document stage is representation (a2-3404)

Web:
- Moved bypass and duplicate file validation after the other client-side file validation is complete

## Issue ticket number and link
[Ticket (A2-3404): Can update version to different file type or exceed filesize limits](https://pins-ds.atlassian.net/browse/A2-3404)