### PR TITLE
feat(api): add endpoint for cancelling a hearing

### DIFF
--- a/appeals/api/setup-tests.js
+++ b/appeals/api/setup-tests.js
@@ -74,6 +74,7 @@ const mockSiteVisitFindUnique = jest.fn().mockResolvedValue({});
 const mockHearingCreate = jest.fn().mockResolvedValue({});
 const mockHearingUpdate = jest.fn().mockResolvedValue({});
 const mockHearingFindUnique = jest.fn().mockResolvedValue({});
+const mockHearingDelete = jest.fn().mockResolvedValue({});
 const mockSiteVisitTypeFindUnique = jest.fn().mockResolvedValue({});
 const mockSiteVisitTypeFindMany = jest.fn().mockResolvedValue({});
 const mockSpecialismsFindUnique = jest.fn().mockResolvedValue({});
@@ -330,7 +331,8 @@ class MockPrismaClient {
 		return {
 			create: mockHearingCreate,
 			update: mockHearingUpdate,
-			findUnique: mockHearingFindUnique
+			findUnique: mockHearingFindUnique,
+			delete: mockHearingDelete
 		};
 	}
 

--- a/appeals/api/src/database/migrations/20250527141249_remove_unique_from_hearing_address/migration.sql
+++ b/appeals/api/src/database/migrations/20250527141249_remove_unique_from_hearing_address/migration.sql
@@ -1,0 +1,19 @@
+BEGIN TRY
+
+BEGIN TRAN;
+
+-- DropIndex
+ALTER TABLE [dbo].[Hearing] DROP CONSTRAINT [Hearing_addressId_key];
+
+COMMIT TRAN;
+
+END TRY
+BEGIN CATCH
+
+IF @@TRANCOUNT > 0
+BEGIN
+    ROLLBACK TRAN;
+END;
+THROW
+
+END CATCH

--- a/appeals/api/src/database/schema.prisma
+++ b/appeals/api/src/database/schema.prisma
@@ -232,7 +232,7 @@ model Address {
   Appeal            Appeal[]
   ServiceUser       ServiceUser[]
   NeighbouringSites NeighbouringSite[]
-  Hearing           Hearing?
+  Hearing           Hearing[]
 }
 
 /// NeighbouringSite model
@@ -809,7 +809,7 @@ model Hearing {
   appealId         Int       @unique
   hearingStartTime DateTime
   hearingEndTime   DateTime?
-  addressId        Int?      @unique
+  addressId        Int?
   address          Address?  @relation(fields: [addressId], references: [id], onDelete: NoAction, onUpdate: NoAction)
   appeal           Appeal    @relation(fields: [appealId], references: [id], onDelete: NoAction, onUpdate: NoAction)
 }

--- a/appeals/api/src/server/endpoints/appeals.d.ts
+++ b/appeals/api/src/server/endpoints/appeals.d.ts
@@ -886,6 +886,11 @@ type UpdateHearing = {
 	address?: Omit<Schema.Address, 'id'> | null;
 };
 
+type CancelHearing = {
+	appealId?: number;
+	hearingId: number;
+};
+
 type HearingResponse = {
 	appealId: number;
 	hearingId: number;
@@ -980,5 +985,6 @@ export {
 	HearingAddress,
 	CreateHearing,
 	UpdateHearing,
+	CancelHearing,
 	HearingResponse
 };

--- a/appeals/api/src/server/endpoints/hearings/hearing.controller.js
+++ b/appeals/api/src/server/endpoints/hearings/hearing.controller.js
@@ -1,7 +1,7 @@
 import logger from '#utils/logger.js';
 import { ERROR_FAILED_TO_SAVE_DATA } from '@pins/appeals/constants/support.js';
 import { formatHearing } from './hearing.formatter.js';
-import { createHearing, updateHearing } from './hearing.service.js';
+import { createHearing, deleteHearing, updateHearing } from './hearing.service.js';
 
 /** @typedef {import('express').Request} Request */
 /** @typedef {import('express').Response} Response */
@@ -98,4 +98,24 @@ export const rearrangeHearing = async (req, res) => {
 	}
 
 	return res.status(201).send({ appealId, hearingStartTime, hearingEndTime });
+};
+
+/**
+ * @param {Request} req
+ * @param {Response} res
+ * @returns {Promise<Response>}
+ */
+export const cancelHearing = async (req, res) => {
+	const {
+		params: { appealId, hearingId }
+	} = req;
+
+	try {
+		await deleteHearing({ hearingId: Number(hearingId) });
+	} catch (error) {
+		logger.error(error);
+		return res.status(500).send({ errors: { body: ERROR_FAILED_TO_SAVE_DATA } });
+	}
+
+	return res.status(200).send({ appealId, hearingId });
 };

--- a/appeals/api/src/server/endpoints/hearings/hearing.routes.js
+++ b/appeals/api/src/server/endpoints/hearings/hearing.routes.js
@@ -1,10 +1,17 @@
 import { Router as createRouter } from 'express';
 import { asyncHandler } from '@pins/express';
-import { getHearingById, postHearing, rearrangeHearing } from './hearing.controller.js';
+import {
+	cancelHearing,
+	getHearingById,
+	postHearing,
+	rearrangeHearing
+} from './hearing.controller.js';
 import {
 	getHearingValidator,
 	patchHearingValidator,
-	postHearingValidator
+	postHearingValidator,
+	deleteHearingParamsValidator,
+	deleteHearingDateValidator
 } from './hearing.validator.js';
 import { checkAppealExistsByIdAndAddToRequest } from '#middleware/check-appeal-exists-and-add-to-request.js';
 import { checkHearingExists } from './hearing.service.js';
@@ -92,6 +99,31 @@ router.patch(
 	checkAppealExistsByIdAndAddToRequest,
 	checkHearingExists,
 	asyncHandler(rearrangeHearing)
+);
+
+router.delete(
+	'/:appealId/hearing/:hearingId',
+	/*
+        #swagger.tags = ['Hearing Details']
+        #swagger.path = '/appeals/{appealId}/hearing/{hearingId}'
+        #swagger.description = 'Cancels a single hearing by id'
+        #swagger.parameters['azureAdUserId'] = {
+            in: 'header',
+            required: true,
+            example: '434bff4e-8191-4ce0-9a0a-91e5d6cdd882'
+        }
+        #swagger.responses[200] = {
+            description: 'Cancels a single hearing by id',
+            schema: { $ref: '#/components/schemas/CancelHearing' }
+        }
+        #swagger.responses[400] = {}
+        #swagger.responses[500] = {}
+     */
+	deleteHearingParamsValidator,
+	checkAppealExistsByIdAndAddToRequest,
+	checkHearingExists,
+	deleteHearingDateValidator,
+	asyncHandler(cancelHearing)
 );
 
 export { router as hearingRoutes };

--- a/appeals/api/src/server/endpoints/hearings/hearing.service.js
+++ b/appeals/api/src/server/endpoints/hearings/hearing.service.js
@@ -5,6 +5,7 @@ import { ERROR_FAILED_TO_SAVE_DATA } from '@pins/appeals/constants/support.js';
 /** @typedef {import('@pins/appeals.api').Schema.Hearing} Hearing */
 /** @typedef {import('@pins/appeals.api').Appeals.CreateHearing} CreateHearing */
 /** @typedef {import('@pins/appeals.api').Appeals.UpdateHearing} UpdateHearing */
+/** @typedef {import('@pins/appeals.api').Appeals.CancelHearing} CancelHearing */
 /** @typedef {import('express').Request} Request */
 /** @typedef {import('express').Response} Response */
 /** @typedef {import('express').NextFunction} NextFunction */
@@ -81,4 +82,17 @@ const updateHearing = async (updateHearingData) => {
 	}
 };
 
-export { checkHearingExists, createHearing, updateHearing };
+/**
+ * @param {CancelHearing} deleteHearingData
+ */
+const deleteHearing = async (deleteHearingData) => {
+	try {
+		const { hearingId } = deleteHearingData;
+
+		await hearingRepository.deleteHearingById(hearingId);
+	} catch (error) {
+		throw new Error(ERROR_FAILED_TO_SAVE_DATA);
+	}
+};
+
+export { checkHearingExists, createHearing, updateHearing, deleteHearing };

--- a/appeals/api/src/server/endpoints/hearings/hearing.validator.js
+++ b/appeals/api/src/server/endpoints/hearings/hearing.validator.js
@@ -7,6 +7,8 @@ import {
 	validateStringParameterAllowingEmpty
 } from '#common/validators/string-parameter.js';
 import { validationErrorHandler } from '#middleware/error-handler.js';
+import { dateIsAfterDate } from '#utils/date-comparison.js';
+import { ERROR_MUST_BE_IN_FUTURE } from '@pins/appeals/constants/support.js';
 import {
 	ERROR_INVALID_POSTCODE,
 	ERROR_MUST_BE_NUMBER,
@@ -15,7 +17,7 @@ import {
 	UK_POSTCODE_REGEX
 } from '@pins/appeals/constants/support.js';
 import { composeMiddleware } from '@pins/express';
-import { body } from 'express-validator';
+import { body, check } from 'express-validator';
 
 export const getHearingValidator = composeMiddleware(
 	validateIdParameter('appealId'),
@@ -57,5 +59,21 @@ export const patchHearingValidator = composeMiddleware(
 	validateRegex('address.postcode', UK_POSTCODE_REGEX, 'address').withMessage(
 		ERROR_INVALID_POSTCODE
 	),
+	validationErrorHandler
+);
+
+export const deleteHearingParamsValidator = composeMiddleware(
+	validateIdParameter('appealId'),
+	validateIdParameter('hearingId'),
+	validationErrorHandler
+);
+
+export const deleteHearingDateValidator = composeMiddleware(
+	check('hearingStartTime').custom(async (_value, { req }) => {
+		const { hearingStartTime } = req.appeal.hearing;
+		if (!dateIsAfterDate(hearingStartTime, new Date())) {
+			throw new Error(ERROR_MUST_BE_IN_FUTURE);
+		}
+	}),
 	validationErrorHandler
 );

--- a/appeals/api/src/server/openapi-types.ts
+++ b/appeals/api/src/server/openapi-types.ts
@@ -2573,6 +2573,13 @@ export interface HearingEstimateResponse {
 	hearingEstimateId?: number;
 }
 
+export interface CancelHearing {
+	/** @example 1 */
+	appealId?: number;
+	/** @example 1 */
+	hearingId?: number;
+}
+
 export interface Address {
 	addressId?: number;
 	addressLine1: string;

--- a/appeals/api/src/server/openapi.json
+++ b/appeals/api/src/server/openapi.json
@@ -5034,6 +5034,63 @@
 						}
 					}
 				}
+			},
+			"delete": {
+				"tags": ["Hearing Details"],
+				"description": "Cancels a single hearing by id",
+				"parameters": [
+					{
+						"name": "appealId",
+						"in": "path",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"name": "hearingId",
+						"in": "path",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"name": "azureAdUserId",
+						"in": "header",
+						"required": true,
+						"example": "434bff4e-8191-4ce0-9a0a-91e5d6cdd882",
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "Cancels a single hearing by id",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/CancelHearing"
+								}
+							},
+							"application/xml": {
+								"schema": {
+									"$ref": "#/components/schemas/CancelHearing"
+								}
+							}
+						}
+					},
+					"400": {
+						"description": "Bad Request"
+					},
+					"404": {
+						"description": "Not Found"
+					},
+					"500": {
+						"description": "Internal Server Error"
+					}
+				}
 			}
 		},
 		"/appeals/{appealId}/hearing": {
@@ -10976,6 +11033,19 @@
 				"type": "object",
 				"properties": {
 					"hearingEstimateId": {
+						"type": "number",
+						"example": 1
+					}
+				}
+			},
+			"CancelHearing": {
+				"type": "object",
+				"properties": {
+					"appealId": {
+						"type": "number",
+						"example": 1
+					},
+					"hearingId": {
 						"type": "number",
 						"example": 1
 					}

--- a/appeals/api/src/server/repositories/hearing.repository.js
+++ b/appeals/api/src/server/repositories/hearing.repository.js
@@ -115,4 +115,11 @@ const updateHearingById = (id, data) => {
 	});
 };
 
-export default { getHearingById, createHearingById, updateHearingById };
+/**
+ * @param {number} id
+ */
+const deleteHearingById = (id) => {
+	return databaseConnector.hearing.delete({ where: { id } });
+};
+
+export default { getHearingById, createHearingById, updateHearingById, deleteHearingById };

--- a/appeals/api/src/server/swagger.js
+++ b/appeals/api/src/server/swagger.js
@@ -1417,6 +1417,19 @@ export const spec = {
 				}
 			}
 		},
+		CancelHearing: {
+			type: 'object',
+			properties: {
+				appealId: {
+					type: 'number',
+					example: 1
+				},
+				hearingId: {
+					type: 'number',
+					example: 1
+				}
+			}
+		},
 		...ApiDefinitions
 	},
 	components: {}


### PR DESCRIPTION
## Describe your changes

- Had to make the address non-unique because it was not allowing more than one hearing to have null address
- Added endpoint for cancelling hearing

## Issue ticket number and link

[A2-2927](https://pins-ds.atlassian.net/browse/A2-2927)

## Deployment risk

- This includes a DB migration, but it is backwards-compatible

[A2-2927]: https://pins-ds.atlassian.net/browse/A2-2927?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ