### PR TITLE
fix(api): add missing document folder display label for rep attachments

### DIFF
--- a/packages/appeals/constants/documents.js
+++ b/packages/appeals/constants/documents.js
@@ -128,5 +128,5 @@ export const DOCUMENT_FOLDER_DISPLAY_LABELS = Object.freeze({
 	[APPEAL_DOCUMENT_TYPE.UNCATEGORISED]: 'Documents',
 	[APPEAL_DOCUMENT_TYPE.CASE_DECISION_LETTER]: 'Decision letter',
 	[APPEAL_DOCUMENT_TYPE.MAIN_PARTY_CORRESPONDENCE]: 'Main party correspondence',
-	representationAttachments: ''
+	representationAttachments: 'Supporting document'
 });


### PR DESCRIPTION
## Describe your changes

Adds a document folder display label constant for rep attachments. This fixes an issue where the associated case history logs for rep attachments were corrupted due to the missing constant causing changes in the log string format which aren't expected by the mapping code.

## Issue ticket number and link
https://pins-ds.atlassian.net/browse/A2-3410
