### PR TITLE
fix(api): update appealType seed where clause to use key

### DIFF
--- a/appeals/api/src/database/seed/data-static.js
+++ b/appeals/api/src/database/seed/data-static.js
@@ -464,7 +464,7 @@ export async function seedStaticData(databaseConnector) {
 	for (const appealType of appealTypes) {
 		await databaseConnector.appealType.upsert({
 			create: appealType,
-			where: { type: appealType.type },
+			where: { type: appealType.key },
 			update: appealType
 		});
 	}


### PR DESCRIPTION
## Describe your changes

Updates appealType where clause to use appealType.key to avoid Unique constraint failed on the constraint: dbo.AppealType when changing the appealType naming

## Issue ticket number and link
[Ticket](https://pins-ds.atlassian.net/jira/software/c/projects/A2/boards/246?selectedIssue=A2-3013&sprints=2257)
