### PR TITLE
fix(api): filters falsy nearby refs when importing lpaqs - A2-3255

### DIFF
--- a/appeals/api/src/server/repositories/integrations.repository.js
+++ b/appeals/api/src/server/repositories/integrations.repository.js
@@ -184,7 +184,7 @@ const setAppealRelationships = async (tx, appealId, caseReference, relatedRefere
 					return item;
 				}
 			})
-			.filter((r) => r !== null);
+			.filter((r) => !!r);
 
 		if (appealRelationships.length > 0) {
 			await tx.appealRelationship.createMany({


### PR DESCRIPTION
Fixes an incorrect null check when importing LPAQ with nearby references.

## Issue ticket number and link
[Ticket](https://pins-ds.atlassian.net/browse/A2-3255)
