### PR TITLE
A2-3094(feat): adding dynamic validation for edit timetable page

### DIFF
--- a/appeals/web/src/server/appeals/appeal-details/__tests__/__snapshots__/appeal-details.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/__tests__/__snapshots__/appeal-details.test.js.snap
@@ -699,19 +699,19 @@ exports[`appeal-details GET /:appealId Timetable Valid date should render a "Tim
     </div>
     <div class="govuk-summary-list__row appeal-lpa-statement-due-date"><dt class="govuk-summary-list__key"> LPA statement due</dt>
         <dd class="govuk-summary-list__value"></dd>
-        <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/3/appeal-timetables/lpa-statement"
+        <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/3/timetable/edit"
             data-cy="change-lpa-statement-due-date">Change<span class="govuk-visually-hidden"> LPA statement due</span></a>
         </dd>
     </div>
     <div class="govuk-summary-list__row appeal-ip-comments-due-date"><dt class="govuk-summary-list__key"> Interested party comments due</dt>
         <dd         class="govuk-summary-list__value">29 April 2025</dd>
-            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/3/appeal-timetables/ip-comments"
+            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/3/timetable/edit"
                 data-cy="change-ip-comments-due-date">Change<span class="govuk-visually-hidden"> Interested party comments due</span></a>
             </dd>
     </div>
     <div class="govuk-summary-list__row appeal-final-comments-due-date"><dt class="govuk-summary-list__key"> Final comments due</dt>
         <dd class="govuk-summary-list__value">12 October 2023</dd>
-        <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/3/appeal-timetables/final-comments"
+        <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/3/timetable/edit"
             data-cy="change-final-comments-due-date">Change<span class="govuk-visually-hidden"> Final comments due</span></a>
         </dd>
     </div>
@@ -737,7 +737,7 @@ exports[`appeal-details GET /:appealId Timetable Valid date should render a "Tim
     </div>
     <div class="govuk-summary-list__row appeal-lpa-statement-due-date"><dt class="govuk-summary-list__key"> LPA statement due</dt>
         <dd class="govuk-summary-list__value"></dd>
-        <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/3/appeal-timetables/lpa-statement"
+        <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/3/timetable/edit"
             data-cy="change-lpa-statement-due-date">Change<span class="govuk-visually-hidden"> LPA statement due</span></a>
         </dd>
     </div>
@@ -746,7 +746,7 @@ exports[`appeal-details GET /:appealId Timetable Valid date should render a "Tim
     </div>
     <div class="govuk-summary-list__row appeal-final-comments-due-date"><dt class="govuk-summary-list__key"> Final comments due</dt>
         <dd class="govuk-summary-list__value">12 October 2023</dd>
-        <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/3/appeal-timetables/final-comments"
+        <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/3/timetable/edit"
             data-cy="change-final-comments-due-date">Change<span class="govuk-visually-hidden"> Final comments due</span></a>
         </dd>
     </div>

--- a/appeals/web/src/server/appeals/appeal-details/__tests__/appeal-details.test.js
+++ b/appeals/web/src/server/appeals/appeal-details/__tests__/appeal-details.test.js
@@ -2873,7 +2873,7 @@ describe('appeal-details', () => {
 						'<dd class="govuk-summary-list__value"> 20 January 2025</dd>'
 					);
 					expect(unprettifiedHTML).toContain(
-						`href="/appeals-service/appeal-details/${appealId}/appeal-timetables/final-comments" data-cy="change-final-comments-due-date">Change<span class="govuk-visually-hidden"> Final comments due</span></a>`
+						`href="/appeals-service/appeal-details/${appealId}/timetable/edit" data-cy="change-final-comments-due-date">Change<span class="govuk-visually-hidden"> Final comments due</span></a>`
 					);
 				});
 

--- a/appeals/web/src/server/appeals/appeal-details/change-appeal-type/change-appeal-type.validators.js
+++ b/appeals/web/src/server/appeals/appeal-details/change-appeal-type/change-appeal-type.validators.js
@@ -35,8 +35,9 @@ export const validateChangeAppealFinalDateInFuture = createDateInputDateInFuture
 	'change-appeal-final-date'
 );
 
-export const validateChangeAppealFinalDateIsBusinessDay =
-	await createDateInputDateBusinessDayValidator('change-appeal-final-date');
+export const validateChangeAppealFinalDateIsBusinessDay = createDateInputDateBusinessDayValidator(
+	'change-appeal-final-date'
+);
 
 export const validateHorizonReference = createValidator(
 	body()

--- a/appeals/web/src/server/appeals/appeal-details/issue-decision-old/issue-decision.validators.js
+++ b/appeals/web/src/server/appeals/appeal-details/issue-decision-old/issue-decision.validators.js
@@ -51,6 +51,5 @@ export const validateCheckDecision = createValidator(
 		.withMessage('Please confirm that the decision is ready to be sent to all parties')
 );
 
-export const validateDecisionDateIsBusinessDay = await createDateInputDateBusinessDayValidator(
-	'decision-letter-date'
-);
+export const validateDecisionDateIsBusinessDay =
+	createDateInputDateBusinessDayValidator('decision-letter-date');

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/outcome-incomplete/outcome-incomplete.validators.js
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/outcome-incomplete/outcome-incomplete.validators.js
@@ -22,6 +22,4 @@ export const validateIncompleteReasonTextItems =
 export const validateDueDateFields = createDateInputFieldsValidator('due-date');
 export const validateDueDateValid = createDateInputDateValidityValidator('due-date');
 export const validateDueDateInFuture = createDateInputDateInFutureValidator('due-date');
-export const validateDueDateIsBusinessDay = await createDateInputDateBusinessDayValidator(
-	'due-date'
-);
+export const validateDueDateIsBusinessDay = createDateInputDateBusinessDayValidator('due-date');

--- a/appeals/web/src/server/appeals/appeal-details/timetable/timetable.middleware.js
+++ b/appeals/web/src/server/appeals/appeal-details/timetable/timetable.middleware.js
@@ -1,0 +1,18 @@
+import { selectTimetableValidators } from './timetable.validators.js';
+
+/**
+ * @type {import('express').RequestHandler}
+ */
+export const runTimetableValidators = (req, res, next) => {
+	const validators = selectTimetableValidators(req);
+	let index = 0;
+
+	// @ts-ignore
+	const runNext = (err) => {
+		if (err) return next(err);
+		const validator = validators[index++];
+		if (!validator) return next();
+		validator(req, res, runNext);
+	};
+	runNext();
+};

--- a/appeals/web/src/server/appeals/appeal-details/timetable/timetable.router.js
+++ b/appeals/web/src/server/appeals/appeal-details/timetable/timetable.router.js
@@ -1,10 +1,10 @@
 import { Router as createRouter } from 'express';
 import { asyncHandler } from '@pins/express';
 import * as timetableController from './timetable.controller.js';
-import * as validators from './timetable.validators.js';
 import { assertUserHasPermission } from '#app/auth/auth.guards.js';
 import { validateAppeal } from '../appeal-details.middleware.js';
 import { permissionNames } from '#environment/permissions.js';
+import { runTimetableValidators } from './timetable.middleware.js';
 
 const router = createRouter({ mergeParams: true });
 
@@ -20,10 +20,7 @@ router
 	)
 	.post(
 		validateAppeal,
-		validators.validateLpaqDueDateFields,
-		validators.validateLpaqDueDateValid,
-		validators.validateLpaqDueDateInFuture,
-		validators.validateLpaqDueDateBusinessDay,
+		runTimetableValidators,
 		assertUserHasPermission(permissionNames.updateCase),
 		asyncHandler(timetableController.postEditTimetable)
 	);

--- a/appeals/web/src/server/appeals/appeal-details/timetable/timetable.validators.js
+++ b/appeals/web/src/server/appeals/appeal-details/timetable/timetable.validators.js
@@ -4,19 +4,56 @@ import {
 	createDateInputDateInFutureValidator,
 	createDateInputDateBusinessDayValidator
 } from '#lib/validators/date-input.validator.js';
-export const validateLpaqDueDateFields = createDateInputFieldsValidator(
-	'lpa-questionnaire-due-date',
-	'LPA questionnaire due date'
-);
-export const validateLpaqDueDateValid = createDateInputDateValidityValidator(
-	'lpa-questionnaire-due-date',
-	'LPA questionnaire due date'
-);
-export const validateLpaqDueDateInFuture = createDateInputDateInFutureValidator(
-	'lpa-questionnaire-due-date',
-	'LPA questionnaire due date'
-);
-export const validateLpaqDueDateBusinessDay = await createDateInputDateBusinessDayValidator(
-	'lpa-questionnaire-due-date',
-	'LPA questionnaire due date'
-);
+import { APPEAL_CASE_STATUS } from 'pins-data-model';
+
+/**
+ *
+ * @param {string} fieldName
+ * @param {string} label
+ * @returns
+ */
+export const createTimetableValidators = (fieldName, label) => [
+	createDateInputFieldsValidator(fieldName, label),
+	createDateInputDateValidityValidator(fieldName, label),
+	createDateInputDateInFutureValidator(fieldName, label),
+	createDateInputDateBusinessDayValidator(fieldName, label)
+];
+
+/**
+ * @param {import('express').Request} req
+ * @returns {import('express').RequestHandler[]}
+ */
+export const selectTimetableValidators = (req) => {
+	const { currentAppeal } = req || {};
+	const validatorsList = [];
+
+	if (currentAppeal.appealType === 'Householder') {
+		validatorsList.push(
+			...createTimetableValidators('lpa-questionnaire-due-date', 'LPA questionnaire due date')
+		);
+	} else if (currentAppeal.appealType === 'Planning appeal') {
+		if (
+			currentAppeal.appealStatus === APPEAL_CASE_STATUS.LPA_QUESTIONNAIRE &&
+			currentAppeal.documentationSummary?.lpaQuestionnaire?.status !== 'received'
+		) {
+			validatorsList.push(
+				...createTimetableValidators('lpa-questionnaire-due-date', 'LPA questionnaire due date')
+			);
+		}
+
+		if (
+			currentAppeal.appealStatus === APPEAL_CASE_STATUS.LPA_QUESTIONNAIRE ||
+			currentAppeal.appealStatus === APPEAL_CASE_STATUS.STATEMENTS
+		) {
+			validatorsList.push(
+				...createTimetableValidators('lpa-statement-due-date', 'Statements due date'),
+				...createTimetableValidators('ip-comments-due-date', 'Interested party comments due date')
+			);
+		}
+
+		validatorsList.push(
+			...createTimetableValidators('final-comments-due-date', 'Final comments due date')
+		);
+	}
+	return validatorsList;
+};

--- a/appeals/web/src/server/lib/mappers/data/appeal/submappers/__tests__/final-comments-due-date.mapper.test.js
+++ b/appeals/web/src/server/lib/mappers/data/appeal/submappers/__tests__/final-comments-due-date.mapper.test.js
@@ -23,38 +23,38 @@ describe('final-comments-due-date.mapper', () => {
 		});
 	});
 
-	// it('should display Final Comments due date with new Change action link', () => {
-	// 	data.appealDetails.startedAt = '2025-01-01';
-	// 	data.appealDetails.procedureType = 'written';
-	// 	data.appealDetails.appealType = 'Planning appeal';
-	// 	const mappedData = mapFinalCommentDueDate(data);
-	// 	expect(mappedData).toEqual({
-	// 		display: {
-	// 			summaryListItem: {
-	// 				actions: {
-	// 					items: [
-	// 						{
-	// 							attributes: {
-	// 								'data-cy': 'change-final-comments-due-date'
-	// 							},
-	// 							href: '/test/timetable/edit',
-	// 							text: 'Change',
-	// 							visuallyHiddenText: 'Final comments due'
-	// 						}
-	// 					]
-	// 				},
-	// 				classes: 'appeal-final-comments-due-date',
-	// 				key: {
-	// 					text: 'Final comments due'
-	// 				},
-	// 				value: {
-	// 					text: '10 January 2025'
-	// 				}
-	// 			}
-	// 		},
-	// 		id: 'final-comments-due-date'
-	// 	});
-	// });
+	it('should display Final Comments due date with new Change action link', () => {
+		data.appealDetails.startedAt = '2025-01-01';
+		data.appealDetails.procedureType = 'written';
+		data.appealDetails.appealType = 'Planning appeal';
+		const mappedData = mapFinalCommentDueDate(data);
+		expect(mappedData).toEqual({
+			display: {
+				summaryListItem: {
+					actions: {
+						items: [
+							{
+								attributes: {
+									'data-cy': 'change-final-comments-due-date'
+								},
+								href: '/test/timetable/edit',
+								text: 'Change',
+								visuallyHiddenText: 'Final comments due'
+							}
+						]
+					},
+					classes: 'appeal-final-comments-due-date',
+					key: {
+						text: 'Final comments due'
+					},
+					value: {
+						text: '10 January 2025'
+					}
+				}
+			},
+			id: 'final-comments-due-date'
+		});
+	});
 
 	it('should display Final Comments due date with old Change action link', () => {
 		data.appealDetails.startedAt = '2025-01-01';

--- a/appeals/web/src/server/lib/mappers/data/appeal/submappers/__tests__/ip-comments-due-date.mapper.test.js
+++ b/appeals/web/src/server/lib/mappers/data/appeal/submappers/__tests__/ip-comments-due-date.mapper.test.js
@@ -23,38 +23,38 @@ describe('ip-comments-due-date.mapper', () => {
 		});
 	});
 
-	// it('should display IP Comments due date with new Change action link when appeal has started and 0 published IP comments', () => {
-	// 	data.appealDetails.startedAt = '2025-01-01';
-	// 	data.appealDetails.procedureType = 'written';
-	// 	data.appealDetails.appealType = 'Planning appeal';
-	// 	const mappedData = mapIpCommentsDueDate(data);
-	// 	expect(mappedData).toEqual({
-	// 		display: {
-	// 			summaryListItem: {
-	// 				actions: {
-	// 					items: [
-	// 						{
-	// 							attributes: {
-	// 								'data-cy': 'change-ip-comments-due-date'
-	// 							},
-	// 							href: '/test/timetable/edit',
-	// 							text: 'Change',
-	// 							visuallyHiddenText: 'Interested party comments due'
-	// 						}
-	// 					]
-	// 				},
-	// 				classes: 'appeal-ip-comments-due-date',
-	// 				key: {
-	// 					text: 'Interested party comments due'
-	// 				},
-	// 				value: {
-	// 					text: '10 January 2025'
-	// 				}
-	// 			}
-	// 		},
-	// 		id: 'ip-comments-due-date'
-	// 	});
-	// });
+	it('should display IP Comments due date with new Change action link when appeal has started and 0 published IP comments', () => {
+		data.appealDetails.startedAt = '2025-01-01';
+		data.appealDetails.procedureType = 'written';
+		data.appealDetails.appealType = 'Planning appeal';
+		const mappedData = mapIpCommentsDueDate(data);
+		expect(mappedData).toEqual({
+			display: {
+				summaryListItem: {
+					actions: {
+						items: [
+							{
+								attributes: {
+									'data-cy': 'change-ip-comments-due-date'
+								},
+								href: '/test/timetable/edit',
+								text: 'Change',
+								visuallyHiddenText: 'Interested party comments due'
+							}
+						]
+					},
+					classes: 'appeal-ip-comments-due-date',
+					key: {
+						text: 'Interested party comments due'
+					},
+					value: {
+						text: '10 January 2025'
+					}
+				}
+			},
+			id: 'ip-comments-due-date'
+		});
+	});
 
 	it('should display IP Comments due date with old Change action link when appeal has started and 0 published IP comments', () => {
 		data.appealDetails.startedAt = '2025-01-01';
@@ -103,7 +103,7 @@ describe('ip-comments-due-date.mapper', () => {
 								attributes: {
 									'data-cy': 'change-ip-comments-due-date'
 								},
-								href: '/test/appeal-timetables/ip-comments',
+								href: '/test/timetable/edit',
 								text: 'Change',
 								visuallyHiddenText: 'Interested party comments due'
 							}

--- a/appeals/web/src/server/lib/mappers/data/appeal/submappers/__tests__/lpa-questionnaire-due-date.mapper.test.js
+++ b/appeals/web/src/server/lib/mappers/data/appeal/submappers/__tests__/lpa-questionnaire-due-date.mapper.test.js
@@ -27,46 +27,46 @@ describe('lpa-questionnaire-due-date.mapper', () => {
 		});
 	});
 
-	// it('should display LPA Questionnaire due date with new Change action link', () => {
-	// 	data.appealDetails.startedAt = '2025-01-01';
-	// 	data.appealDetails.procedureType = 'written';
-	// 	data.appealDetails.appealType = 'Planning appeal';
-	// 	data.appealDetails.documentationSummary = {
-	// 		lpaQuestionnaire: {
-	// 			status: DOCUMENT_STATUS_NOT_RECEIVED
-	// 		}
-	// 	};
-	// 	data.appealDetails.appealStatus = APPEAL_CASE_STATUS.LPA_QUESTIONNAIRE;
-	// 	data.appealDetails.appealType = 'Householder';
+	it('should display LPA Questionnaire due date with new Change action link', () => {
+		data.appealDetails.startedAt = '2025-01-01';
+		data.appealDetails.procedureType = 'written';
+		data.appealDetails.appealType = 'Planning appeal';
+		data.appealDetails.documentationSummary = {
+			lpaQuestionnaire: {
+				status: DOCUMENT_STATUS_NOT_RECEIVED
+			}
+		};
+		data.appealDetails.appealStatus = APPEAL_CASE_STATUS.LPA_QUESTIONNAIRE;
+		data.appealDetails.appealType = 'Householder';
 
-	// 	const mappedData = mapLpaQuestionnaireDueDate(data);
-	// 	expect(mappedData).toEqual({
-	// 		display: {
-	// 			summaryListItem: {
-	// 				actions: {
-	// 					items: [
-	// 						{
-	// 							attributes: {
-	// 								'data-cy': 'change-lpa-questionnaire-due-date'
-	// 							},
-	// 							href: '/test/timetable/edit',
-	// 							text: 'Change',
-	// 							visuallyHiddenText: 'LPA questionnaire due'
-	// 						}
-	// 					]
-	// 				},
-	// 				classes: 'appeal-lpa-questionnaire-due-date',
-	// 				key: {
-	// 					text: 'LPA questionnaire due'
-	// 				},
-	// 				value: {
-	// 					text: '10 January 2025'
-	// 				}
-	// 			}
-	// 		},
-	// 		id: 'lpa-questionnaire-due-date'
-	// 	});
-	// });
+		const mappedData = mapLpaQuestionnaireDueDate(data);
+		expect(mappedData).toEqual({
+			display: {
+				summaryListItem: {
+					actions: {
+						items: [
+							{
+								attributes: {
+									'data-cy': 'change-lpa-questionnaire-due-date'
+								},
+								href: '/test/timetable/edit',
+								text: 'Change',
+								visuallyHiddenText: 'LPA questionnaire due'
+							}
+						]
+					},
+					classes: 'appeal-lpa-questionnaire-due-date',
+					key: {
+						text: 'LPA questionnaire due'
+					},
+					value: {
+						text: '10 January 2025'
+					}
+				}
+			},
+			id: 'lpa-questionnaire-due-date'
+		});
+	});
 
 	it('should display LPA Questionnaire due date with old Change action link', () => {
 		data.appealDetails.startedAt = '2025-01-01';

--- a/appeals/web/src/server/lib/mappers/data/appeal/submappers/__tests__/lpa-statement-due-date.mapper.test.js
+++ b/appeals/web/src/server/lib/mappers/data/appeal/submappers/__tests__/lpa-statement-due-date.mapper.test.js
@@ -22,39 +22,39 @@ describe('lpa-statement-due-date.mapper', () => {
 		});
 	});
 
-	// it('should display LPA Statement due date with new Change action link', () => {
-	// 	data.appealDetails.startedAt = '2025-01-01';
-	// 	data.appealDetails.procedureType = 'written';
-	// 	data.appealDetails.appealType = 'Planning appeal';
+	it('should display LPA Statement due date with new Change action link', () => {
+		data.appealDetails.startedAt = '2025-01-01';
+		data.appealDetails.procedureType = 'written';
+		data.appealDetails.appealType = 'Planning appeal';
 
-	// 	const mappedData = mapLpaStatementDueDate(data);
-	// 	expect(mappedData).toEqual({
-	// 		display: {
-	// 			summaryListItem: {
-	// 				actions: {
-	// 					items: [
-	// 						{
-	// 							attributes: {
-	// 								'data-cy': 'change-lpa-statement-due-date'
-	// 							},
-	// 							href: '/test/timetable/edit',
-	// 							text: 'Change',
-	// 							visuallyHiddenText: 'LPA statement due'
-	// 						}
-	// 					]
-	// 				},
-	// 				classes: 'appeal-lpa-statement-due-date',
-	// 				key: {
-	// 					text: 'LPA statement due'
-	// 				},
-	// 				value: {
-	// 					text: '10 January 2025'
-	// 				}
-	// 			}
-	// 		},
-	// 		id: 'lpa-statement-due-date'
-	// 	});
-	// });
+		const mappedData = mapLpaStatementDueDate(data);
+		expect(mappedData).toEqual({
+			display: {
+				summaryListItem: {
+					actions: {
+						items: [
+							{
+								attributes: {
+									'data-cy': 'change-lpa-statement-due-date'
+								},
+								href: '/test/timetable/edit',
+								text: 'Change',
+								visuallyHiddenText: 'LPA statement due'
+							}
+						]
+					},
+					classes: 'appeal-lpa-statement-due-date',
+					key: {
+						text: 'LPA statement due'
+					},
+					value: {
+						text: '10 January 2025'
+					}
+				}
+			},
+			id: 'lpa-statement-due-date'
+		});
+	});
 
 	it('should display LPA Statement due date with old Change action link', () => {
 		data.appealDetails.startedAt = '2025-01-01';

--- a/appeals/web/src/server/lib/mappers/data/appeal/submappers/final-comment-due-date.mapper.js
+++ b/appeals/web/src/server/lib/mappers/data/appeal/submappers/final-comment-due-date.mapper.js
@@ -1,4 +1,4 @@
-import { APPEAL_CASE_STATUS } from 'pins-data-model';
+import { APPEAL_CASE_PROCEDURE, APPEAL_CASE_STATUS } from 'pins-data-model';
 import { dateISOStringToDisplayDate } from '#lib/dates.js';
 import { isStatePassed } from '#lib/appeal-status.js';
 import { textSummaryListItem } from '#lib/mappers/index.js';
@@ -10,9 +10,10 @@ export const mapFinalCommentDueDate = ({
 	userHasUpdateCasePermission
 }) => {
 	const id = 'final-comments-due-date';
-	const useNewTimetableRoute = appealDetails.appealType === 'Householder';
-	// || (appealDetails.appealType === 'Planning appeal' &&
-	// 	appealDetails.procedureType?.toLowerCase() === APPEAL_CASE_PROCEDURE.WRITTEN);
+	const useNewTimetableRoute =
+		appealDetails.appealType === 'Householder' ||
+		(appealDetails.appealType === 'Planning appeal' &&
+			appealDetails.procedureType?.toLowerCase() === APPEAL_CASE_PROCEDURE.WRITTEN);
 	if (!appealDetails.startedAt) {
 		return { id, display: {} };
 	}

--- a/appeals/web/src/server/lib/mappers/data/appeal/submappers/ip-comments-due-date.mapper.js
+++ b/appeals/web/src/server/lib/mappers/data/appeal/submappers/ip-comments-due-date.mapper.js
@@ -1,5 +1,6 @@
 import { dateISOStringToDisplayDate } from '#lib/dates.js';
 import { textSummaryListItem } from '#lib/mappers/index.js';
+import { APPEAL_CASE_PROCEDURE } from 'pins-data-model';
 
 /** @type {import('../mapper.js').SubMapper} */
 export const mapIpCommentsDueDate = ({
@@ -8,9 +9,10 @@ export const mapIpCommentsDueDate = ({
 	userHasUpdateCasePermission
 }) => {
 	const id = 'ip-comments-due-date';
-	const useNewTimetableRoute = appealDetails.appealType === 'Householder';
-	// || (appealDetails.appealType === 'Planning appeal' &&
-	// 	appealDetails.procedureType?.toLowerCase() === APPEAL_CASE_PROCEDURE.WRITTEN);
+	const useNewTimetableRoute =
+		appealDetails.appealType === 'Householder' ||
+		(appealDetails.appealType === 'Planning appeal' &&
+			appealDetails.procedureType?.toLowerCase() === APPEAL_CASE_PROCEDURE.WRITTEN);
 	if (!appealDetails.startedAt) {
 		return { id, display: {} };
 	}

--- a/appeals/web/src/server/lib/mappers/data/appeal/submappers/lpa-questionnaire-due-date.mapper.js
+++ b/appeals/web/src/server/lib/mappers/data/appeal/submappers/lpa-questionnaire-due-date.mapper.js
@@ -4,7 +4,7 @@ import {
 	DOCUMENT_STATUS_RECEIVED
 	// @ts-ignore
 } from '@pins/appeals/constants/support.js';
-import { APPEAL_CASE_STATUS } from 'pins-data-model';
+import { APPEAL_CASE_PROCEDURE, APPEAL_CASE_STATUS } from 'pins-data-model';
 
 /** @type {import('../mapper.js').SubMapper} */
 export const mapLpaQuestionnaireDueDate = ({
@@ -25,9 +25,10 @@ export const mapLpaQuestionnaireDueDate = ({
 	) {
 		editable = false;
 	}
-	const useNewTimetableRoute = appealDetails.appealType === 'Householder';
-	// || (appealDetails.appealType === 'Planning appeal' &&
-	// 	appealDetails.procedureType?.toLowerCase() === APPEAL_CASE_PROCEDURE.WRITTEN);
+	const useNewTimetableRoute =
+		appealDetails.appealType === 'Householder' ||
+		(appealDetails.appealType === 'Planning appeal' &&
+			appealDetails.procedureType?.toLowerCase() === APPEAL_CASE_PROCEDURE.WRITTEN);
 
 	return textSummaryListItem({
 		id,

--- a/appeals/web/src/server/lib/mappers/data/appeal/submappers/lpa-statement-due-date.mapper.js
+++ b/appeals/web/src/server/lib/mappers/data/appeal/submappers/lpa-statement-due-date.mapper.js
@@ -1,4 +1,4 @@
-import { APPEAL_CASE_STATUS } from 'pins-data-model';
+import { APPEAL_CASE_PROCEDURE, APPEAL_CASE_STATUS } from 'pins-data-model';
 import { dateISOStringToDisplayDate } from '#lib/dates.js';
 import { isStatePassed } from '#lib/appeal-status.js';
 import { textSummaryListItem } from '#lib/mappers/index.js';
@@ -10,12 +10,15 @@ export const mapLpaStatementDueDate = ({
 	userHasUpdateCasePermission
 }) => {
 	const id = 'lpa-statement-due-date';
-	const useNewTimetableRoute = appealDetails.appealType === 'Householder';
-	// || (appealDetails.appealType === 'Planning appeal' &&
-	// 	appealDetails.procedureType?.toLowerCase() === APPEAL_CASE_PROCEDURE.WRITTEN);
+	const useNewTimetableRoute =
+		appealDetails.appealType === 'Householder' ||
+		(appealDetails.appealType === 'Planning appeal' &&
+			appealDetails.procedureType?.toLowerCase() === APPEAL_CASE_PROCEDURE.WRITTEN);
+
 	if (!appealDetails.startedAt) {
 		return { id, display: {} };
 	}
+
 	return textSummaryListItem({
 		id,
 		text: 'LPA statement due',

--- a/appeals/web/src/server/lib/validators/date-input.validator.js
+++ b/appeals/web/src/server/lib/validators/date-input.validator.js
@@ -120,14 +120,14 @@ const dateIsABusinessDay = async (apiClient, value) => {
 	}
 };
 
-export const createDateInputDateBusinessDayValidator = async (
+export const createDateInputDateBusinessDayValidator = (
 	fieldNamePrefix = 'date',
 	messageFieldNamePrefix = 'Date',
 	dayFieldName = '-day',
 	monthFieldName = '-month',
 	yearFieldName = '-year'
 ) =>
-	await createValidator(
+	createValidator(
 		body()
 			.custom(async (bodyFields, { req }) => {
 				const day = bodyFields[`${fieldNamePrefix}${dayFieldName}`];


### PR DESCRIPTION
## Describe your changes

- Individual validators are added to middleware array and then and run sequentially depending on appeal type
- Procedure type was not added as a condition because route to this journey is only accessible for (S78 & written) | Householder
- Toggling ON Routing for S78 written appeals
- Uncommented previously commented tests
- Updated businessDate validator to remove unnecessary async and updated usages 

## Issue ticket number and link
[Ticket](https://pins-ds.atlassian.net.mcas.ms/browse/A2-3094)
