### PR TITLE
feat(appeals): issue decision clear caching and improve routing logic (a2-3367)

### DIFF
--- a/appeals/web/src/server/appeals/appeal-details/__tests__/__snapshots__/appeal-details.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/__tests__/__snapshots__/appeal-details.test.js.snap
@@ -1373,7 +1373,8 @@ exports[`appeal-details GET /:appealId should render a Decision inset panel when
                             </div>
                             <div class="govuk-summary-list__row appeal-decision"><dt class="govuk-summary-list__key"> Decision</dt>
                                 <dd class="govuk-summary-list__value">Dismissed</dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="" data-cy="view-decision">View<span class="govuk-visually-hidden"> Decision</span></a>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/issue-decision/view-decision?backUrl=%2Fappeals-service%2Fappeal-details%2F2"
+                                    data-cy="view-decision">View<span class="govuk-visually-hidden"> Decision</span></a>
                                 </dd>
                             </div>
                         </dl>

--- a/appeals/web/src/server/appeals/appeal-details/issue-decision/__tests__/issue-decision.test.js
+++ b/appeals/web/src/server/appeals/appeal-details/issue-decision/__tests__/issue-decision.test.js
@@ -3,7 +3,6 @@ import { parseHtml } from '@pins/platform';
 import nock from 'nock';
 import supertest from 'supertest';
 import { createTestEnvironment } from '#testing/index.js';
-import { mapDecisionOutcome } from '../issue-decision.mapper.js';
 import {
 	appealData,
 	documentFileInfo,
@@ -12,6 +11,7 @@ import {
 	fileUploadInfo
 } from '#testing/appeals/appeals.js';
 import { cloneDeep } from 'lodash-es';
+import { mapDecisionOutcome } from '#appeals/appeal-details/issue-decision/issue-decision.utils.js';
 
 const { app, installMockApi, teardown } = createTestEnvironment();
 const request = supertest(app);
@@ -170,6 +170,7 @@ describe('issue-decision', () => {
 
 	describe('POST /decision-letter-upload', () => {
 		let issueDecisionAppealData;
+
 		beforeEach(() => {
 			issueDecisionAppealData = cloneDeep(appealData);
 			issueDecisionAppealData.costs.appellantApplicationFolder.documents = [{}];
@@ -331,6 +332,7 @@ describe('issue-decision', () => {
 
 	describe('POST /appellant-costs-decision-letter-upload', () => {
 		let issueDecisionAppealData;
+
 		beforeEach(() => {
 			issueDecisionAppealData = cloneDeep(appealData);
 			issueDecisionAppealData.costs.lpaApplicationFolder.documents = [{}];
@@ -548,8 +550,14 @@ describe('issue-decision', () => {
 	});
 
 	describe('GET /issue-decision/check-your-decision', () => {
+		let issueDecisionAppealData;
+
 		beforeEach(async () => {
-			nock('http://test/').get('/appeals/1').reply(200, inspectorDecisionData);
+			issueDecisionAppealData = cloneDeep(appealData);
+			issueDecisionAppealData.costs.appellantApplicationFolder.documents = [{}];
+			issueDecisionAppealData.costs.lpaApplicationFolder.documents = [{}];
+			nock.cleanAll();
+			nock('http://test/').get('/appeals/1').reply(200, issueDecisionAppealData).persist();
 			nock('http://test/').get('/appeals/1/documents/1').reply(200, documentFileInfo);
 			nock('http://test/').post(`/appeals/validate-business-date`).reply(200, { result: true });
 			nock('http://test/')
@@ -746,6 +754,7 @@ describe('issue-decision', () => {
 
 	describe('POST /issue-appellant-costs-decision-letter-upload', () => {
 		let issueDecisionAppealData;
+
 		beforeEach(() => {
 			issueDecisionAppealData = cloneDeep(appealData);
 			issueDecisionAppealData.costs.lpaApplicationFolder.documents = [{}];
@@ -808,8 +817,13 @@ describe('issue-decision', () => {
 	});
 
 	describe('GET /issue-decision/check-your-appellant-costs-decision', () => {
+		let issueDecisionAppealData;
+
 		beforeEach(async () => {
-			nock('http://test/').get('/appeals/1').reply(200, inspectorDecisionData);
+			issueDecisionAppealData = cloneDeep(appealData);
+			issueDecisionAppealData.costs.appellantApplicationFolder.documents = [{}];
+			nock.cleanAll();
+			nock('http://test/').get('/appeals/1').reply(200, issueDecisionAppealData).persist();
 			nock('http://test/').get('/appeals/1/documents/1').reply(200, documentFileInfo);
 			nock('http://test/').post(`/appeals/validate-business-date`).reply(200, { result: true });
 			nock('http://test/')
@@ -943,6 +957,7 @@ describe('issue-decision', () => {
 
 	describe('POST /issue-lpa-costs-decision-letter-upload', () => {
 		let issueDecisionAppealData;
+
 		beforeEach(() => {
 			issueDecisionAppealData = cloneDeep(appealData);
 			issueDecisionAppealData.costs.lpaApplicationFolder.documents = [{}];
@@ -1005,8 +1020,13 @@ describe('issue-decision', () => {
 	});
 
 	describe('GET /issue-decision/check-your-lpa-costs-decision', () => {
+		let issueDecisionAppealData;
+
 		beforeEach(async () => {
-			nock('http://test/').get('/appeals/1').reply(200, inspectorDecisionData);
+			issueDecisionAppealData = cloneDeep(appealData);
+			issueDecisionAppealData.costs.lpaApplicationFolder.documents = [{}];
+			nock.cleanAll();
+			nock('http://test/').get('/appeals/1').reply(200, issueDecisionAppealData).persist();
 			nock('http://test/').get('/appeals/1/documents/1').reply(200, documentFileInfo);
 			nock('http://test/').post(`/appeals/validate-business-date`).reply(200, { result: true });
 			nock('http://test/')

--- a/appeals/web/src/server/appeals/appeal-details/issue-decision/issue-decision.utils.js
+++ b/appeals/web/src/server/appeals/appeal-details/issue-decision/issue-decision.utils.js
@@ -7,11 +7,12 @@ import {
 /**
  * @typedef {import('@pins/express/types/express.js').Request & {specificDecisionType?: string}} Request
  * @typedef {import("express-session").Session & Partial<import("express-session").SessionData>} Session
+ * @typedef {import('../appeal-details.types.js').WebAppeal} WebAppeal
  */
 
 /**
  *
- * @param {import('../appeal-details.types.js').WebAppeal} currentAppeal
+ * @param {WebAppeal} currentAppeal
  * @returns {string}
  */
 export function baseUrl(currentAppeal) {
@@ -46,4 +47,59 @@ export function getDecisions(session) {
 		{ ...appellantCostsDecision, decisionType: DECISION_TYPE_APPELLANT_COSTS },
 		{ ...lpaCostsDecision, decisionType: DECISION_TYPE_LPA_COSTS }
 	].filter((decision) => decision?.files?.length);
+}
+
+/**
+ * Checks if the given outcome is a valid InspectorDecisionRequest and returns the corresponding mapped value.
+ * @param {string | undefined} outcome The outcome to check.
+ * @returns {string} The mapped decision string, or a default value if the outcome is invalid or undefined.
+ */
+export function mapDecisionOutcome(outcome) {
+	switch (outcome?.toLowerCase()) {
+		case 'allowed':
+			return 'Allowed';
+		case 'dismissed':
+			return 'Dismissed';
+		case 'split':
+		case 'split_decision':
+			return 'Split decision';
+		case 'invalid':
+			return 'Invalid';
+		default:
+			return '';
+	}
+}
+
+/**
+ * @param {string|number} appealId
+ * @returns {string}
+ */
+export function generateIssueDecisionUrl(appealId) {
+	return `/appeals-service/appeal-details/${appealId}/issue-decision/decision`;
+}
+
+/**
+ *
+ * @param {WebAppeal} currentAppeal
+ * @returns {{appellantHasAppliedForCosts: boolean, lpaHasAppliedForCosts: boolean, appellantDecisionHasAlreadyBeenIssued: boolean, lpaDecisionHasAlreadyBeenIssued: boolean}}
+ */
+export function buildLogicData(currentAppeal) {
+	const appellantApplicationDocumentsExists =
+		!!currentAppeal.costs?.appellantApplicationFolder?.documents?.length;
+	const appellantWithdrawalDocumentsExists =
+		!!currentAppeal.costs?.appellantWithdrawalFolder?.documents?.length;
+	const lpaApplicationDocumentsExists =
+		!!currentAppeal.costs?.lpaApplicationFolder?.documents?.length;
+	const lpaWithdrawalDocumentsExists =
+		!!currentAppeal.costs?.lpaWithdrawalFolder?.documents?.length;
+	const appellantDecisionLetterExists =
+		!!currentAppeal.costs?.appellantDecisionFolder?.documents?.length;
+	const lpaDecisionLetterExists = !!currentAppeal.costs?.lpaDecisionFolder?.documents?.length;
+	return {
+		appellantHasAppliedForCosts:
+			appellantApplicationDocumentsExists && !appellantWithdrawalDocumentsExists,
+		lpaHasAppliedForCosts: lpaApplicationDocumentsExists && !lpaWithdrawalDocumentsExists,
+		appellantDecisionHasAlreadyBeenIssued: appellantDecisionLetterExists,
+		lpaDecisionHasAlreadyBeenIssued: lpaDecisionLetterExists
+	};
 }

--- a/appeals/web/src/server/appeals/appeal-details/status-tags/status-tags.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/status-tags/status-tags.mapper.js
@@ -4,8 +4,8 @@ import logger from '#lib/logger.js';
 import { generateDecisionDocumentDownloadHtml } from '#lib/mappers/data/appeal/common.js';
 import { APPEAL_CASE_STATUS, APPEAL_VIRUS_CHECK_STATUS } from 'pins-data-model';
 import { getAppealTypesFromId } from '../change-appeal-type/change-appeal-type.service.js';
-import { mapDecisionOutcome } from '../issue-decision/issue-decision.mapper.js';
 import { isStatePassed } from '#lib/appeal-status.js';
+import { mapDecisionOutcome } from '#appeals/appeal-details/issue-decision/issue-decision.utils.js';
 
 /**
  * @param {{ appeal: MappedInstructions }} mappedData

--- a/appeals/web/src/server/lib/mappers/data/appeal/submappers/appeal-decision.mapper.js
+++ b/appeals/web/src/server/lib/mappers/data/appeal/submappers/appeal-decision.mapper.js
@@ -1,8 +1,8 @@
-import { generateIssueDecisionUrl } from '#appeals/appeal-details/issue-decision/issue-decision.mapper.js';
 import { APPEAL_CASE_STATUS } from 'pins-data-model';
 import { dateISOStringToDisplayDate } from '#lib/dates.js';
 import { documentationFolderTableItem, textSummaryListItem } from '#lib/mappers/index.js';
 import { addBackLinkQueryToUrl } from '#lib/url-utilities.js';
+import { generateIssueDecisionUrl } from '#appeals/appeal-details/issue-decision/issue-decision.utils.js';
 
 /** @type {import('../mapper.js').SubMapper} */
 // @ts-ignore

--- a/appeals/web/src/server/lib/mappers/data/appeal/submappers/decision.mapper.js
+++ b/appeals/web/src/server/lib/mappers/data/appeal/submappers/decision.mapper.js
@@ -1,14 +1,14 @@
-import {
-	generateIssueDecisionUrl,
-	mapDecisionOutcome
-} from '#appeals/appeal-details/issue-decision/issue-decision.mapper.js';
 import { APPEAL_CASE_STATUS } from 'pins-data-model';
 import { textSummaryListItem } from '#lib/mappers/index.js';
 import { userHasPermission } from '#lib/mappers/index.js';
 import { permissionNames } from '#environment/permissions.js';
 import { addBackLinkQueryToUrl } from '#lib/url-utilities.js';
-import { mapDocumentDownloadUrl } from '#appeals/appeal-documents/appeal-documents.mapper.js';
 import { isStatePassed } from '#lib/appeal-status.js';
+import {
+	baseUrl,
+	generateIssueDecisionUrl,
+	mapDecisionOutcome
+} from '#appeals/appeal-details/issue-decision/issue-decision.utils.js';
 
 /** @type {import('../mapper.js').SubMapper} */
 export const mapDecision = ({ appealDetails, session, request }) => {
@@ -21,13 +21,9 @@ export const mapDecision = ({ appealDetails, session, request }) => {
 		isStatePassed(appealDetails, APPEAL_CASE_STATUS.AWAITING_EVENT) &&
 		userHasPermission(permissionNames.setCaseOutcome, session);
 
-	const { documentId, documentName } = decision || {};
-
 	const link = canIssueDecision
 		? addBackLinkQueryToUrl(request, generateIssueDecisionUrl(appealId))
-		: documentId && documentName
-		? mapDocumentDownloadUrl(appealId, documentId, documentName)
-		: '';
+		: addBackLinkQueryToUrl(request, `${baseUrl(appealDetails)}/view-decision`);
 
 	return textSummaryListItem({
 		id: 'decision',

--- a/appeals/web/src/server/lib/mappers/utils/map-status-dependent-notifications.js
+++ b/appeals/web/src/server/lib/mappers/utils/map-status-dependent-notifications.js
@@ -1,10 +1,10 @@
-import { generateIssueDecisionUrl } from '#appeals/appeal-details/issue-decision/issue-decision.mapper.js';
 import {
 	createNotificationBanner,
 	mapRequiredActionToNotificationBannerKey
 } from '#lib/mappers/index.js';
 import { getRequiredActionsForAppeal } from './required-actions.js';
 import { addBackLinkQueryToUrl } from '#lib/url-utilities.js';
+import { generateIssueDecisionUrl } from '#appeals/appeal-details/issue-decision/issue-decision.utils.js';
 
 /** @typedef {import('./required-actions.js').AppealRequiredAction} AppealRequiredAction */
 /** @typedef {import('../components/index.js').NotificationBannerDefinitionKey} NotificationBannerDefinitionKey */


### PR DESCRIPTION
## Describe your changes
#### Issue decision clear caching and improve routing logic (A2-3367)

Please note that this PR is only relevant to the Issue decision flow!

### WEB:
- Clear cache where data is no longer needed based on changes such as removing application and adding withdrawal files
- Retain the cache where data is still required so the user does not need to re-enter the data including selecting files
- Fix routing particularly the back button within the flow
- Only show and submit the data required by the decisions taken within the flow in the check your decisions page
- Moved reusable code to issue-decision.utils.js such as buildLogicData and mapDecisionOutcome

### TEST:
- Made sure all unit tests pass
- Manually tested within browser
- Walk through with tester to make sure it's working as it should

## Issue ticket number and link:
- [(A2-3367) Issue Appellant Costs Decision](https://pins-ds.atlassian.net/browse/A2-3367)

