### PR TITLE
fix(web): update add action link in ip comments doc summary to link to correct page

### DIFF
--- a/appeals/web/src/server/appeals/appeal-details/representations/interested-party-comments/__tests__/__snapshots__/interested-party-comments.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/representations/interested-party-comments/__tests__/__snapshots__/interested-party-comments.test.js.snap
@@ -365,3 +365,40 @@ exports[`interested-party-comments GET /interested-party-comments with data shou
     </div>
 </main>"
 `;
+
+exports[`interested-party-comments GET /interested-party-comments/add/ip-details should render the "Interested party details" page with the expected content and back link URL 1`] = `
+"<main class="govuk-main-wrapper" id="main-content">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Appeal 351062</span>
+            <h1 class="govuk-heading-l">Interested party&#39;s details</h1>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <div class="govuk-grid-row">
+                <div class="govuk-grid-column-full">
+                    <form method="POST" novalidate="novalidate">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label" for="first-name">First name</label>
+                            <input class="govuk-input" id="first-name" name="firstName"
+                            type="text">
+                        </div>
+                        <div class="govuk-form-group">
+                            <label class="govuk-label" for="last-name">Last name</label>
+                            <input class="govuk-input" id="last-name" name="lastName"
+                            type="text">
+                        </div>
+                        <div class="govuk-form-group">
+                            <label class="govuk-label" for="email-address">Email address (optional)</label>
+                            <input class="govuk-input" id="email-address"
+                            name="emailAddress" type="text">
+                        </div>
+                        <button type="submit" data-prevent-double-click="true" class="govuk-button"
+                        data-module="govuk-button">Continue</button>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </div>
+</main>"
+`;

--- a/appeals/web/src/server/appeals/appeal-details/representations/interested-party-comments/__tests__/interested-party-comments.test.js
+++ b/appeals/web/src/server/appeals/appeal-details/representations/interested-party-comments/__tests__/interested-party-comments.test.js
@@ -194,4 +194,23 @@ describe('interested-party-comments', () => {
 			expect(invalidMessage?.textContent?.trim()).toBe('No invalid comments');
 		});
 	});
+
+	describe('GET /interested-party-comments/add/ip-details', () => {
+		const appealId = 2;
+
+		it('should render the "Interested party details" page with the expected content and back link URL', async () => {
+			const response = await request.get(
+				`${baseUrl}/${appealId}/interested-party-comments/add/ip-details?backUrl=/test/back/url`
+			);
+
+			const elementInnerHtml = parseHtml(response.text).innerHTML;
+
+			expect(elementInnerHtml).toMatchSnapshot();
+			expect(elementInnerHtml).toContain('Interested party&#39;s details</h1>');
+
+			const backLinkHtml = parseHtml(response.text, { rootElement: '.govuk-back-link' }).innerHTML;
+
+			expect(backLinkHtml).toContain('href="/test/back/url"');
+		});
+	});
 });

--- a/appeals/web/src/server/appeals/appeal-details/representations/interested-party-comments/add-ip-comment/add-ip-comment.controller.js
+++ b/appeals/web/src/server/appeals/appeal-details/representations/interested-party-comments/add-ip-comment/add-ip-comment.controller.js
@@ -46,7 +46,7 @@ export async function renderIpDetails(request, response) {
 		lastName: addIpComment?.lastName,
 		emailAddress: addIpComment?.emailAddress
 	};
-	const pageContent = ipDetailsPage(currentAppeal, values, errors);
+	const pageContent = ipDetailsPage(currentAppeal, values, request, errors);
 	return response.status(errors ? 400 : 200).render('patterns/change-page.pattern.njk', {
 		errors: errors,
 		pageContent

--- a/appeals/web/src/server/appeals/appeal-details/representations/interested-party-comments/add-ip-comment/add-ip-comment.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/representations/interested-party-comments/add-ip-comment/add-ip-comment.mapper.js
@@ -14,6 +14,7 @@ import {
 	getTodaysISOString,
 	dayMonthYearHourMinuteToISOString
 } from '#lib/dates.js';
+import { getBackLinkUrlFromQuery } from '#lib/url-utilities.js';
 
 /** @typedef {import("../../../appeal-details.types.js").WebAppeal} Appeal */
 /** @typedef {import('#appeals/appeal-details/representations/types.js').interestedPartyComment} IpComment */
@@ -25,12 +26,15 @@ import {
 /**
  * @param {Appeal} appealDetails
  * @param {{ firstName: string, lastName: string, emailAddress: string }} values
+ * @param {import('@pins/express/types/express.js').Request} request
  * @param {import('@pins/express').ValidationErrors | undefined} errors
  * @returns {PageContent}
  * */
-export const ipDetailsPage = (appealDetails, values, errors) => ({
+export const ipDetailsPage = (appealDetails, values, request, errors) => ({
 	title: "Interested party's details",
-	backLinkUrl: `/appeals-service/appeal-details/${appealDetails.appealId}/interested-party-comments`,
+	backLinkUrl:
+		getBackLinkUrlFromQuery(request) ||
+		`/appeals-service/appeal-details/${appealDetails.appealId}/interested-party-comments`,
 	preHeading: `Appeal ${appealShortReference(appealDetails.appealReference)}`,
 	heading: "Interested party's details",
 	pageComponents: [

--- a/appeals/web/src/server/lib/mappers/data/appeal/submappers/ip-comments.mapper.js
+++ b/appeals/web/src/server/lib/mappers/data/appeal/submappers/ip-comments.mapper.js
@@ -90,7 +90,9 @@ export const mapIpComments = ({ appealDetails, currentRoute, request }) => {
 		receivedText,
 		actionHtml: `<a href="${addBackLinkQueryToUrl(
 			request,
-			`${currentRoute}/interested-party-comments`
+			`${currentRoute}/interested-party-comments${
+				status === 'not_received' ? '/add/ip-details' : ''
+			}`
 		)}" data-cy="review-ip-comments" class="govuk-link">${actionText}<span class="govuk-visually-hidden"> interested party comments</span></a>`
 	});
 };


### PR DESCRIPTION
## Describe your changes

- update 'Add' action link in case details page documentation summary IP comments row to link to first page of add IP comment journey
- update mapper for first page of add IP comment journey to render back link URL from query string if present

## Issue ticket number and link
https://pins-ds.atlassian.net/browse/A2-3311