### PR TITLE
A2-3095(feat): Configuring CYA page for S78 edit timetable flow

### DIFF
--- a/appeals/web/src/server/appeals/appeal-details/timetable/__tests__/__snapshots__/timetable.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/timetable/__tests__/__snapshots__/timetable.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Appeal Timetables should render "Timetable due dates" page for householder appeal type 1`] = `
+exports[`Timetable GET /edit should render "Timetable due dates" page for householder appeal type 1`] = `
 "<main class="govuk-main-wrapper" id="main-content">
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Appeal 351062</span>
@@ -51,7 +51,7 @@ exports[`Appeal Timetables should render "Timetable due dates" page for househol
 </main>"
 `;
 
-exports[`Appeal Timetables should render correct "Timetable due dates" page for S78 appeal type and status final_comments 1`] = `
+exports[`Timetable GET /edit should render correct "Timetable due dates" page for S78 appeal type and status final_comments 1`] = `
 "<main class="govuk-main-wrapper" id="main-content">
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Appeal 351062</span>
@@ -102,7 +102,7 @@ exports[`Appeal Timetables should render correct "Timetable due dates" page for 
 </main>"
 `;
 
-exports[`Appeal Timetables should render correct "Timetable due dates" page for S78 appeal type and status lpa_questionnaire 1`] = `
+exports[`Timetable GET /edit should render correct "Timetable due dates" page for S78 appeal type and status lpa_questionnaire 1`] = `
 "<main class="govuk-main-wrapper" id="main-content">
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Appeal 351062</span>
@@ -250,7 +250,7 @@ exports[`Appeal Timetables should render correct "Timetable due dates" page for 
 </main>"
 `;
 
-exports[`Appeal Timetables should render correct "Timetable due dates" page for S78 appeal type and status lpa_questionnaire and lpaq received 1`] = `
+exports[`Timetable GET /edit should render correct "Timetable due dates" page for S78 appeal type and status lpa_questionnaire and lpaq received 1`] = `
 "<main class="govuk-main-wrapper" id="main-content">
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Appeal 351062</span>
@@ -365,7 +365,7 @@ exports[`Appeal Timetables should render correct "Timetable due dates" page for 
 </main>"
 `;
 
-exports[`Appeal Timetables should render correct "Timetable due dates" page for S78 appeal type and status statements 1`] = `
+exports[`Timetable GET /edit should render correct "Timetable due dates" page for S78 appeal type and status statements 1`] = `
 "<main class="govuk-main-wrapper" id="main-content">
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Appeal 351062</span>
@@ -446,6 +446,4471 @@ exports[`Appeal Timetables should render correct "Timetable due dates" page for 
                 <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">Final comments due</legend>
                 <div id="final-comments-due-date-hint" class="govuk-hint">For example, 27 3 2007</div>
                 <div class="govuk-date-input" id="final-comments-due-date">
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="final-comments-due-date-day">Day</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                            id="final-comments-due-date-day" name="final-comments-due-date-day" type="text"
+                            inputmode="numeric">
+                        </div>
+                    </div>
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="final-comments-due-date-month">Month</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                            id="final-comments-due-date-month" name="final-comments-due-date-month"
+                            type="text" inputmode="numeric">
+                        </div>
+                    </div>
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="final-comments-due-date-year">Year</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-4"
+                            id="final-comments-due-date-year" name="final-comments-due-date-year" type="text"
+                            inputmode="numeric">
+                        </div>
+                    </div>
+                </div>
+            </fieldset>
+        </div>
+        <div class="govuk-button-group">
+            <button type="submit" class="govuk-button" data-module="govuk-button">Continue</button>
+        </div>
+    </form>
+</main>"
+`;
+
+exports[`Timetable GET /edit/check should render "Timetable CYA" page for householder appeal type 1`] = `
+"<main class="govuk-main-wrapper" id="main-content">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Appeal APP/Q9999/D/21/351062</span>
+            <h1 class="govuk-heading-l">Check details and update timetable due dates</h1>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <dl class="govuk-summary-list">
+                <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> LPA questionnaire due</dt>
+                    <dd class="govuk-summary-list__value">13 October 2030</dd>
+                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/timetable/edit">Change <span class="govuk-visually-hidden">LPA questionnaire due date</span></a>
+                    </dd>
+                </div>
+            </dl>
+            <p class="govuk-body">We’ll send an email to the appellant and LPA to tell them about the new
+                timetable</p>
+            <div class="govuk-grid-row">
+                <div class="govuk-grid-column-full">
+                    <form method="post" novalidate="novalidate">
+                        <button type="submit" class="govuk-button" data-module="govuk-button">Update timetable due dates</button>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </div>
+</main>"
+`;
+
+exports[`Timetable GET /edit/check should render correct "Timetable CYA" page for S78 appeal type and status final_comments 1`] = `
+"<main class="govuk-main-wrapper" id="main-content">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Appeal APP/Q9999/D/21/351062</span>
+            <h1 class="govuk-heading-l">Check details and update timetable due dates</h1>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <dl class="govuk-summary-list">
+                <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Final comments due</dt>
+                    <dd class="govuk-summary-list__value">16 October 2030</dd>
+                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/timetable/edit">Change <span class="govuk-visually-hidden">Final comments due date</span></a>
+                    </dd>
+                </div>
+            </dl>
+            <p class="govuk-body">We’ll send an email to the appellant and LPA to tell them about the new
+                timetable</p>
+            <div class="govuk-grid-row">
+                <div class="govuk-grid-column-full">
+                    <form method="post" novalidate="novalidate">
+                        <button type="submit" class="govuk-button" data-module="govuk-button">Update timetable due dates</button>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </div>
+</main>"
+`;
+
+exports[`Timetable GET /edit/check should render correct "Timetable CYA" page for S78 appeal type and status lpa_questionnaire and lpaq NOT received 1`] = `
+"<main class="govuk-main-wrapper" id="main-content">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Appeal APP/Q9999/D/21/351062</span>
+            <h1 class="govuk-heading-l">Check details and update timetable due dates</h1>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <dl class="govuk-summary-list">
+                <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> LPA questionnaire due</dt>
+                    <dd class="govuk-summary-list__value">13 October 2030</dd>
+                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/timetable/edit">Change <span class="govuk-visually-hidden">LPA questionnaire due date</span></a>
+                    </dd>
+                </div>
+                <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Statements due</dt>
+                    <dd class="govuk-summary-list__value">14 October 2030</dd>
+                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/timetable/edit">Change <span class="govuk-visually-hidden">Statements due date</span></a>
+                    </dd>
+                </div>
+                <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Interested party comments due</dt>
+                    <dd                     class="govuk-summary-list__value">15 October 2030</dd>
+                        <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/timetable/edit">Change <span class="govuk-visually-hidden">Interested party comments due date</span></a>
+                        </dd>
+                </div>
+                <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Final comments due</dt>
+                    <dd class="govuk-summary-list__value">16 October 2030</dd>
+                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/timetable/edit">Change <span class="govuk-visually-hidden">Final comments due date</span></a>
+                    </dd>
+                </div>
+            </dl>
+            <p class="govuk-body">We’ll send an email to the appellant and LPA to tell them about the new
+                timetable</p>
+            <div class="govuk-grid-row">
+                <div class="govuk-grid-column-full">
+                    <form method="post" novalidate="novalidate">
+                        <button type="submit" class="govuk-button" data-module="govuk-button">Update timetable due dates</button>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </div>
+</main>"
+`;
+
+exports[`Timetable GET /edit/check should render correct "Timetable CYA" page for S78 appeal type and status lpa_questionnaire and lpaq received 1`] = `
+"<main class="govuk-main-wrapper" id="main-content">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Appeal APP/Q9999/D/21/351062</span>
+            <h1 class="govuk-heading-l">Check details and update timetable due dates</h1>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <dl class="govuk-summary-list">
+                <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Statements due</dt>
+                    <dd class="govuk-summary-list__value">14 October 2030</dd>
+                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/timetable/edit">Change <span class="govuk-visually-hidden">Statements due date</span></a>
+                    </dd>
+                </div>
+                <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Interested party comments due</dt>
+                    <dd                     class="govuk-summary-list__value">15 October 2030</dd>
+                        <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/timetable/edit">Change <span class="govuk-visually-hidden">Interested party comments due date</span></a>
+                        </dd>
+                </div>
+                <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Final comments due</dt>
+                    <dd class="govuk-summary-list__value">16 October 2030</dd>
+                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/timetable/edit">Change <span class="govuk-visually-hidden">Final comments due date</span></a>
+                    </dd>
+                </div>
+            </dl>
+            <p class="govuk-body">We’ll send an email to the appellant and LPA to tell them about the new
+                timetable</p>
+            <div class="govuk-grid-row">
+                <div class="govuk-grid-column-full">
+                    <form method="post" novalidate="novalidate">
+                        <button type="submit" class="govuk-button" data-module="govuk-button">Update timetable due dates</button>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </div>
+</main>"
+`;
+
+exports[`Timetable GET /edit/check should render correct "Timetable CYA" page for S78 appeal type and status statements 1`] = `
+"<main class="govuk-main-wrapper" id="main-content">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Appeal APP/Q9999/D/21/351062</span>
+            <h1 class="govuk-heading-l">Check details and update timetable due dates</h1>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <dl class="govuk-summary-list">
+                <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Statements due</dt>
+                    <dd class="govuk-summary-list__value">14 October 2030</dd>
+                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/timetable/edit">Change <span class="govuk-visually-hidden">Statements due date</span></a>
+                    </dd>
+                </div>
+                <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Interested party comments due</dt>
+                    <dd                     class="govuk-summary-list__value">15 October 2030</dd>
+                        <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/timetable/edit">Change <span class="govuk-visually-hidden">Interested party comments due date</span></a>
+                        </dd>
+                </div>
+                <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Final comments due</dt>
+                    <dd class="govuk-summary-list__value">16 October 2030</dd>
+                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/timetable/edit">Change <span class="govuk-visually-hidden">Final comments due date</span></a>
+                    </dd>
+                </div>
+            </dl>
+            <p class="govuk-body">We’ll send an email to the appellant and LPA to tell them about the new
+                timetable</p>
+            <div class="govuk-grid-row">
+                <div class="govuk-grid-column-full">
+                    <form method="post" novalidate="novalidate">
+                        <button type="submit" class="govuk-button" data-module="govuk-button">Update timetable due dates</button>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </div>
+</main>"
+`;
+
+exports[`Timetable POST /edit Householder should re-render edit timetable page with missing day error based on payload 1`] = `
+"<main class="govuk-main-wrapper" id="main-content">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <div class="govuk-error-summary" data-module="govuk-error-summary">
+                <div role="alert">
+                    <h2 class="govuk-error-summary__title"> There is a problem</h2>
+                    <div class="govuk-error-summary__body">
+                        <ul class="govuk-list govuk-error-summary__list">
+                            <li><a href="#lpa-questionnaire-due-date-day">LPA questionnaire due date must include a day</a>
+                            </li>
+                        </ul>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Appeal 351062</span>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full"></div>
+    </div>
+    <form method="post" novalidate="novalidate">
+        <div class="govuk-form-group govuk-form-group--error">
+            <fieldset class="govuk-fieldset" role="group" aria-describedby="lpa-questionnaire-due-date-hint lpa-questionnaire-due-date-error">
+                <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
+                    <h1 class="govuk-fieldset__heading"> LPA questionnaire due</h1>
+                </legend>
+                <div id="lpa-questionnaire-due-date-hint" class="govuk-hint">For example, 27 3 2007</div>
+                <p id="lpa-questionnaire-due-date-error" class="govuk-error-message"><span class="govuk-visually-hidden">Error:</span> LPA questionnaire due
+                    date must include a day</p>
+                <div class="govuk-date-input" id="lpa-questionnaire-due-date">
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="lpa-questionnaire-due-date-day">Day</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                            id="lpa-questionnaire-due-date-day" name="lpa-questionnaire-due-date-day"
+                            type="text" inputmode="numeric">
+                        </div>
+                    </div>
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="lpa-questionnaire-due-date-month">Month</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                            id="lpa-questionnaire-due-date-month" name="lpa-questionnaire-due-date-month"
+                            type="text" inputmode="numeric">
+                        </div>
+                    </div>
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="lpa-questionnaire-due-date-year">Year</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-4"
+                            id="lpa-questionnaire-due-date-year" name="lpa-questionnaire-due-date-year"
+                            type="text" inputmode="numeric">
+                        </div>
+                    </div>
+                </div>
+            </fieldset>
+        </div>
+        <div class="govuk-button-group">
+            <button type="submit" class="govuk-button" data-module="govuk-button">Continue</button>
+        </div>
+    </form>
+</main>"
+`;
+
+exports[`Timetable POST /edit Householder should re-render edit timetable page with missing month error based on payload 1`] = `
+"<main class="govuk-main-wrapper" id="main-content">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <div class="govuk-error-summary" data-module="govuk-error-summary">
+                <div role="alert">
+                    <h2 class="govuk-error-summary__title"> There is a problem</h2>
+                    <div class="govuk-error-summary__body">
+                        <ul class="govuk-list govuk-error-summary__list">
+                            <li><a href="#lpa-questionnaire-due-date-month">LPA questionnaire due date must include a month</a>
+                            </li>
+                        </ul>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Appeal 351062</span>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full"></div>
+    </div>
+    <form method="post" novalidate="novalidate">
+        <div class="govuk-form-group govuk-form-group--error">
+            <fieldset class="govuk-fieldset" role="group" aria-describedby="lpa-questionnaire-due-date-hint lpa-questionnaire-due-date-error">
+                <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
+                    <h1 class="govuk-fieldset__heading"> LPA questionnaire due</h1>
+                </legend>
+                <div id="lpa-questionnaire-due-date-hint" class="govuk-hint">For example, 27 3 2007</div>
+                <p id="lpa-questionnaire-due-date-error" class="govuk-error-message"><span class="govuk-visually-hidden">Error:</span> LPA questionnaire due
+                    date must include a month</p>
+                <div class="govuk-date-input" id="lpa-questionnaire-due-date">
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="lpa-questionnaire-due-date-day">Day</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                            id="lpa-questionnaire-due-date-day" name="lpa-questionnaire-due-date-day"
+                            type="text" inputmode="numeric">
+                        </div>
+                    </div>
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="lpa-questionnaire-due-date-month">Month</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                            id="lpa-questionnaire-due-date-month" name="lpa-questionnaire-due-date-month"
+                            type="text" inputmode="numeric">
+                        </div>
+                    </div>
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="lpa-questionnaire-due-date-year">Year</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-4"
+                            id="lpa-questionnaire-due-date-year" name="lpa-questionnaire-due-date-year"
+                            type="text" inputmode="numeric">
+                        </div>
+                    </div>
+                </div>
+            </fieldset>
+        </div>
+        <div class="govuk-button-group">
+            <button type="submit" class="govuk-button" data-module="govuk-button">Continue</button>
+        </div>
+    </form>
+</main>"
+`;
+
+exports[`Timetable POST /edit Householder should re-render edit timetable page with missing year error based on payload 1`] = `
+"<main class="govuk-main-wrapper" id="main-content">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <div class="govuk-error-summary" data-module="govuk-error-summary">
+                <div role="alert">
+                    <h2 class="govuk-error-summary__title"> There is a problem</h2>
+                    <div class="govuk-error-summary__body">
+                        <ul class="govuk-list govuk-error-summary__list">
+                            <li><a href="#lpa-questionnaire-due-date-year">LPA questionnaire due date must include a year</a>
+                            </li>
+                        </ul>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Appeal 351062</span>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full"></div>
+    </div>
+    <form method="post" novalidate="novalidate">
+        <div class="govuk-form-group govuk-form-group--error">
+            <fieldset class="govuk-fieldset" role="group" aria-describedby="lpa-questionnaire-due-date-hint lpa-questionnaire-due-date-error">
+                <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
+                    <h1 class="govuk-fieldset__heading"> LPA questionnaire due</h1>
+                </legend>
+                <div id="lpa-questionnaire-due-date-hint" class="govuk-hint">For example, 27 3 2007</div>
+                <p id="lpa-questionnaire-due-date-error" class="govuk-error-message"><span class="govuk-visually-hidden">Error:</span> LPA questionnaire due
+                    date must include a year</p>
+                <div class="govuk-date-input" id="lpa-questionnaire-due-date">
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="lpa-questionnaire-due-date-day">Day</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                            id="lpa-questionnaire-due-date-day" name="lpa-questionnaire-due-date-day"
+                            type="text" inputmode="numeric">
+                        </div>
+                    </div>
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="lpa-questionnaire-due-date-month">Month</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                            id="lpa-questionnaire-due-date-month" name="lpa-questionnaire-due-date-month"
+                            type="text" inputmode="numeric">
+                        </div>
+                    </div>
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="lpa-questionnaire-due-date-year">Year</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-4"
+                            id="lpa-questionnaire-due-date-year" name="lpa-questionnaire-due-date-year"
+                            type="text" inputmode="numeric">
+                        </div>
+                    </div>
+                </div>
+            </fieldset>
+        </div>
+        <div class="govuk-button-group">
+            <button type="submit" class="govuk-button" data-module="govuk-button">Continue</button>
+        </div>
+    </form>
+</main>"
+`;
+
+exports[`Timetable POST /edit Householder should re-render edit timetable page with must be in the future error based on payload 1`] = `
+"<main class="govuk-main-wrapper" id="main-content">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <div class="govuk-error-summary" data-module="govuk-error-summary">
+                <div role="alert">
+                    <h2 class="govuk-error-summary__title"> There is a problem</h2>
+                    <div class="govuk-error-summary__body">
+                        <ul class="govuk-list govuk-error-summary__list">
+                            <li><a href="#">The lpa questionnaire due date must be in the future</a>
+                            </li>
+                        </ul>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Appeal 351062</span>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full"></div>
+    </div>
+    <form method="post" novalidate="novalidate">
+        <div class="govuk-form-group">
+            <fieldset class="govuk-fieldset" role="group" aria-describedby="lpa-questionnaire-due-date-hint">
+                <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
+                    <h1 class="govuk-fieldset__heading"> LPA questionnaire due</h1>
+                </legend>
+                <div id="lpa-questionnaire-due-date-hint" class="govuk-hint">For example, 27 3 2007</div>
+                <div class="govuk-date-input" id="lpa-questionnaire-due-date">
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="lpa-questionnaire-due-date-day">Day</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                            id="lpa-questionnaire-due-date-day" name="lpa-questionnaire-due-date-day"
+                            type="text" inputmode="numeric">
+                        </div>
+                    </div>
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="lpa-questionnaire-due-date-month">Month</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                            id="lpa-questionnaire-due-date-month" name="lpa-questionnaire-due-date-month"
+                            type="text" inputmode="numeric">
+                        </div>
+                    </div>
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="lpa-questionnaire-due-date-year">Year</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-4"
+                            id="lpa-questionnaire-due-date-year" name="lpa-questionnaire-due-date-year"
+                            type="text" inputmode="numeric">
+                        </div>
+                    </div>
+                </div>
+            </fieldset>
+        </div>
+        <div class="govuk-button-group">
+            <button type="submit" class="govuk-button" data-module="govuk-button">Continue</button>
+        </div>
+    </form>
+</main>"
+`;
+
+exports[`Timetable POST /edit Householder should re-render edit timetable page with not a real date error based on payload 1`] = `
+"<main class="govuk-main-wrapper" id="main-content">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <div class="govuk-error-summary" data-module="govuk-error-summary">
+                <div role="alert">
+                    <h2 class="govuk-error-summary__title"> There is a problem</h2>
+                    <div class="govuk-error-summary__body">
+                        <ul class="govuk-list govuk-error-summary__list">
+                            <li><a href="#">LPA questionnaire due date must be a real date</a>
+                            </li>
+                        </ul>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Appeal 351062</span>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full"></div>
+    </div>
+    <form method="post" novalidate="novalidate">
+        <div class="govuk-form-group">
+            <fieldset class="govuk-fieldset" role="group" aria-describedby="lpa-questionnaire-due-date-hint">
+                <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
+                    <h1 class="govuk-fieldset__heading"> LPA questionnaire due</h1>
+                </legend>
+                <div id="lpa-questionnaire-due-date-hint" class="govuk-hint">For example, 27 3 2007</div>
+                <div class="govuk-date-input" id="lpa-questionnaire-due-date">
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="lpa-questionnaire-due-date-day">Day</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                            id="lpa-questionnaire-due-date-day" name="lpa-questionnaire-due-date-day"
+                            type="text" inputmode="numeric">
+                        </div>
+                    </div>
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="lpa-questionnaire-due-date-month">Month</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                            id="lpa-questionnaire-due-date-month" name="lpa-questionnaire-due-date-month"
+                            type="text" inputmode="numeric">
+                        </div>
+                    </div>
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="lpa-questionnaire-due-date-year">Year</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-4"
+                            id="lpa-questionnaire-due-date-year" name="lpa-questionnaire-due-date-year"
+                            type="text" inputmode="numeric">
+                        </div>
+                    </div>
+                </div>
+            </fieldset>
+        </div>
+        <div class="govuk-button-group">
+            <button type="submit" class="govuk-button" data-module="govuk-button">Continue</button>
+        </div>
+    </form>
+</main>"
+`;
+
+exports[`Timetable POST /edit S78 Final comments should re-render edit timetable page with missing day error for Final comments 1`] = `
+"<main class="govuk-main-wrapper" id="main-content">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <div class="govuk-error-summary" data-module="govuk-error-summary">
+                <div role="alert">
+                    <h2 class="govuk-error-summary__title"> There is a problem</h2>
+                    <div class="govuk-error-summary__body">
+                        <ul class="govuk-list govuk-error-summary__list">
+                            <li><a href="#lpa-questionnaire-due-date-day">LPA questionnaire due date must include a day</a>
+                            </li>
+                            <li><a href="#lpa-questionnaire-due-date-month">LPA questionnaire due date must include a month</a>
+                            </li>
+                            <li><a href="#lpa-questionnaire-due-date-year">LPA questionnaire due date must include a year</a>
+                            </li>
+                            <li><a href="#lpa-statement-due-date-day">Statements due date must include a day</a>
+                            </li>
+                            <li><a href="#lpa-statement-due-date-month">Statements due date must include a month</a>
+                            </li>
+                            <li><a href="#lpa-statement-due-date-year">Statements due date must include a year</a>
+                            </li>
+                            <li><a href="#ip-comments-due-date-day">Interested party comments due date must include a day</a>
+                            </li>
+                            <li><a href="#ip-comments-due-date-month">Interested party comments due date must include a month</a>
+                            </li>
+                            <li><a href="#ip-comments-due-date-year">Interested party comments due date must include a year</a>
+                            </li>
+                            <li><a href="#final-comments-due-date-day">Final comments due date must include a day</a>
+                            </li>
+                        </ul>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Appeal 351062</span>
+            <h1 class="govuk-heading-l">Timetable due dates</h1>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full"></div>
+    </div>
+    <form method="post" novalidate="novalidate">
+        <div class="govuk-form-group govuk-form-group--error">
+            <fieldset class="govuk-fieldset" role="group" aria-describedby="lpa-questionnaire-due-date-hint lpa-questionnaire-due-date-error">
+                <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">LPA questionnaire due</legend>
+                <div id="lpa-questionnaire-due-date-hint"
+                class="govuk-hint">For example, 27 3 2007</div>
+                <p id="lpa-questionnaire-due-date-error" class="govuk-error-message"><span class="govuk-visually-hidden">Error:</span> LPA questionnaire due
+                    date must include a day
+                    <br>LPA questionnaire due date must include a month
+                    <br>LPA questionnaire due date must include a year</p>
+                <div class="govuk-date-input"
+                id="lpa-questionnaire-due-date">
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="lpa-questionnaire-due-date-day">Day</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                            id="lpa-questionnaire-due-date-day" name="lpa-questionnaire-due-date-day"
+                            type="text" inputmode="numeric">
+                        </div>
+                    </div>
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="lpa-questionnaire-due-date-month">Month</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                            id="lpa-questionnaire-due-date-month" name="lpa-questionnaire-due-date-month"
+                            type="text" inputmode="numeric">
+                        </div>
+                    </div>
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="lpa-questionnaire-due-date-year">Year</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-4"
+                            id="lpa-questionnaire-due-date-year" name="lpa-questionnaire-due-date-year"
+                            type="text" inputmode="numeric">
+                        </div>
+                    </div>
+                </div>
+            </fieldset>
+        </div>
+        <div class="govuk-form-group govuk-form-group--error">
+            <fieldset class="govuk-fieldset" role="group" aria-describedby="lpa-statement-due-date-hint lpa-statement-due-date-error">
+                <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">Statements due</legend>
+                <div id="lpa-statement-due-date-hint" class="govuk-hint">For example, 27 3 2007</div>
+                <p id="lpa-statement-due-date-error" class="govuk-error-message"><span class="govuk-visually-hidden">Error:</span> Statements due date must
+                    include a day
+                    <br>Statements due date must include a month
+                    <br>Statements due date must include a year</p>
+                <div class="govuk-date-input"
+                id="lpa-statement-due-date">
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="lpa-statement-due-date-day">Day</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                            id="lpa-statement-due-date-day" name="lpa-statement-due-date-day" type="text"
+                            inputmode="numeric">
+                        </div>
+                    </div>
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="lpa-statement-due-date-month">Month</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                            id="lpa-statement-due-date-month" name="lpa-statement-due-date-month" type="text"
+                            inputmode="numeric">
+                        </div>
+                    </div>
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="lpa-statement-due-date-year">Year</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-4"
+                            id="lpa-statement-due-date-year" name="lpa-statement-due-date-year" type="text"
+                            inputmode="numeric">
+                        </div>
+                    </div>
+                </div>
+            </fieldset>
+        </div>
+        <div class="govuk-form-group govuk-form-group--error">
+            <fieldset class="govuk-fieldset" role="group" aria-describedby="ip-comments-due-date-hint ip-comments-due-date-error">
+                <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">Interested party comments due</legend>
+                <div id="ip-comments-due-date-hint"
+                class="govuk-hint">For example, 27 3 2007</div>
+                <p id="ip-comments-due-date-error" class="govuk-error-message"><span class="govuk-visually-hidden">Error:</span> Interested party comments
+                    due date must include a day
+                    <br>Interested party comments due date must include a month
+                    <br>Interested party comments due date must include a year</p>
+                <div class="govuk-date-input"
+                id="ip-comments-due-date">
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="ip-comments-due-date-day">Day</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                            id="ip-comments-due-date-day" name="ip-comments-due-date-day" type="text"
+                            inputmode="numeric">
+                        </div>
+                    </div>
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="ip-comments-due-date-month">Month</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                            id="ip-comments-due-date-month" name="ip-comments-due-date-month" type="text"
+                            inputmode="numeric">
+                        </div>
+                    </div>
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="ip-comments-due-date-year">Year</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-4"
+                            id="ip-comments-due-date-year" name="ip-comments-due-date-year" type="text"
+                            inputmode="numeric">
+                        </div>
+                    </div>
+                </div>
+            </fieldset>
+        </div>
+        <div class="govuk-form-group govuk-form-group--error">
+            <fieldset class="govuk-fieldset" role="group" aria-describedby="final-comments-due-date-hint final-comments-due-date-error">
+                <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">Final comments due</legend>
+                <div id="final-comments-due-date-hint" class="govuk-hint">For example, 27 3 2007</div>
+                <p id="final-comments-due-date-error" class="govuk-error-message"><span class="govuk-visually-hidden">Error:</span> Final comments due date
+                    must include a day</p>
+                <div class="govuk-date-input" id="final-comments-due-date">
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="final-comments-due-date-day">Day</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                            id="final-comments-due-date-day" name="final-comments-due-date-day" type="text"
+                            inputmode="numeric">
+                        </div>
+                    </div>
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="final-comments-due-date-month">Month</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                            id="final-comments-due-date-month" name="final-comments-due-date-month"
+                            type="text" inputmode="numeric">
+                        </div>
+                    </div>
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="final-comments-due-date-year">Year</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-4"
+                            id="final-comments-due-date-year" name="final-comments-due-date-year" type="text"
+                            inputmode="numeric">
+                        </div>
+                    </div>
+                </div>
+            </fieldset>
+        </div>
+        <div class="govuk-button-group">
+            <button type="submit" class="govuk-button" data-module="govuk-button">Continue</button>
+        </div>
+    </form>
+</main>"
+`;
+
+exports[`Timetable POST /edit S78 Final comments should re-render edit timetable page with missing month error for Final comments 1`] = `
+"<main class="govuk-main-wrapper" id="main-content">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <div class="govuk-error-summary" data-module="govuk-error-summary">
+                <div role="alert">
+                    <h2 class="govuk-error-summary__title"> There is a problem</h2>
+                    <div class="govuk-error-summary__body">
+                        <ul class="govuk-list govuk-error-summary__list">
+                            <li><a href="#lpa-questionnaire-due-date-day">LPA questionnaire due date must include a day</a>
+                            </li>
+                            <li><a href="#lpa-questionnaire-due-date-month">LPA questionnaire due date must include a month</a>
+                            </li>
+                            <li><a href="#lpa-questionnaire-due-date-year">LPA questionnaire due date must include a year</a>
+                            </li>
+                            <li><a href="#lpa-statement-due-date-day">Statements due date must include a day</a>
+                            </li>
+                            <li><a href="#lpa-statement-due-date-month">Statements due date must include a month</a>
+                            </li>
+                            <li><a href="#lpa-statement-due-date-year">Statements due date must include a year</a>
+                            </li>
+                            <li><a href="#ip-comments-due-date-day">Interested party comments due date must include a day</a>
+                            </li>
+                            <li><a href="#ip-comments-due-date-month">Interested party comments due date must include a month</a>
+                            </li>
+                            <li><a href="#ip-comments-due-date-year">Interested party comments due date must include a year</a>
+                            </li>
+                            <li><a href="#final-comments-due-date-month">Final comments due date must include a month</a>
+                            </li>
+                        </ul>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Appeal 351062</span>
+            <h1 class="govuk-heading-l">Timetable due dates</h1>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full"></div>
+    </div>
+    <form method="post" novalidate="novalidate">
+        <div class="govuk-form-group govuk-form-group--error">
+            <fieldset class="govuk-fieldset" role="group" aria-describedby="lpa-questionnaire-due-date-hint lpa-questionnaire-due-date-error">
+                <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">LPA questionnaire due</legend>
+                <div id="lpa-questionnaire-due-date-hint"
+                class="govuk-hint">For example, 27 3 2007</div>
+                <p id="lpa-questionnaire-due-date-error" class="govuk-error-message"><span class="govuk-visually-hidden">Error:</span> LPA questionnaire due
+                    date must include a day
+                    <br>LPA questionnaire due date must include a month
+                    <br>LPA questionnaire due date must include a year</p>
+                <div class="govuk-date-input"
+                id="lpa-questionnaire-due-date">
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="lpa-questionnaire-due-date-day">Day</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                            id="lpa-questionnaire-due-date-day" name="lpa-questionnaire-due-date-day"
+                            type="text" inputmode="numeric">
+                        </div>
+                    </div>
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="lpa-questionnaire-due-date-month">Month</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                            id="lpa-questionnaire-due-date-month" name="lpa-questionnaire-due-date-month"
+                            type="text" inputmode="numeric">
+                        </div>
+                    </div>
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="lpa-questionnaire-due-date-year">Year</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-4"
+                            id="lpa-questionnaire-due-date-year" name="lpa-questionnaire-due-date-year"
+                            type="text" inputmode="numeric">
+                        </div>
+                    </div>
+                </div>
+            </fieldset>
+        </div>
+        <div class="govuk-form-group govuk-form-group--error">
+            <fieldset class="govuk-fieldset" role="group" aria-describedby="lpa-statement-due-date-hint lpa-statement-due-date-error">
+                <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">Statements due</legend>
+                <div id="lpa-statement-due-date-hint" class="govuk-hint">For example, 27 3 2007</div>
+                <p id="lpa-statement-due-date-error" class="govuk-error-message"><span class="govuk-visually-hidden">Error:</span> Statements due date must
+                    include a day
+                    <br>Statements due date must include a month
+                    <br>Statements due date must include a year</p>
+                <div class="govuk-date-input"
+                id="lpa-statement-due-date">
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="lpa-statement-due-date-day">Day</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                            id="lpa-statement-due-date-day" name="lpa-statement-due-date-day" type="text"
+                            inputmode="numeric">
+                        </div>
+                    </div>
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="lpa-statement-due-date-month">Month</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                            id="lpa-statement-due-date-month" name="lpa-statement-due-date-month" type="text"
+                            inputmode="numeric">
+                        </div>
+                    </div>
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="lpa-statement-due-date-year">Year</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-4"
+                            id="lpa-statement-due-date-year" name="lpa-statement-due-date-year" type="text"
+                            inputmode="numeric">
+                        </div>
+                    </div>
+                </div>
+            </fieldset>
+        </div>
+        <div class="govuk-form-group govuk-form-group--error">
+            <fieldset class="govuk-fieldset" role="group" aria-describedby="ip-comments-due-date-hint ip-comments-due-date-error">
+                <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">Interested party comments due</legend>
+                <div id="ip-comments-due-date-hint"
+                class="govuk-hint">For example, 27 3 2007</div>
+                <p id="ip-comments-due-date-error" class="govuk-error-message"><span class="govuk-visually-hidden">Error:</span> Interested party comments
+                    due date must include a day
+                    <br>Interested party comments due date must include a month
+                    <br>Interested party comments due date must include a year</p>
+                <div class="govuk-date-input"
+                id="ip-comments-due-date">
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="ip-comments-due-date-day">Day</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                            id="ip-comments-due-date-day" name="ip-comments-due-date-day" type="text"
+                            inputmode="numeric">
+                        </div>
+                    </div>
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="ip-comments-due-date-month">Month</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                            id="ip-comments-due-date-month" name="ip-comments-due-date-month" type="text"
+                            inputmode="numeric">
+                        </div>
+                    </div>
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="ip-comments-due-date-year">Year</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-4"
+                            id="ip-comments-due-date-year" name="ip-comments-due-date-year" type="text"
+                            inputmode="numeric">
+                        </div>
+                    </div>
+                </div>
+            </fieldset>
+        </div>
+        <div class="govuk-form-group govuk-form-group--error">
+            <fieldset class="govuk-fieldset" role="group" aria-describedby="final-comments-due-date-hint final-comments-due-date-error">
+                <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">Final comments due</legend>
+                <div id="final-comments-due-date-hint" class="govuk-hint">For example, 27 3 2007</div>
+                <p id="final-comments-due-date-error" class="govuk-error-message"><span class="govuk-visually-hidden">Error:</span> Final comments due date
+                    must include a month</p>
+                <div class="govuk-date-input" id="final-comments-due-date">
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="final-comments-due-date-day">Day</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                            id="final-comments-due-date-day" name="final-comments-due-date-day" type="text"
+                            inputmode="numeric">
+                        </div>
+                    </div>
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="final-comments-due-date-month">Month</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                            id="final-comments-due-date-month" name="final-comments-due-date-month"
+                            type="text" inputmode="numeric">
+                        </div>
+                    </div>
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="final-comments-due-date-year">Year</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-4"
+                            id="final-comments-due-date-year" name="final-comments-due-date-year" type="text"
+                            inputmode="numeric">
+                        </div>
+                    </div>
+                </div>
+            </fieldset>
+        </div>
+        <div class="govuk-button-group">
+            <button type="submit" class="govuk-button" data-module="govuk-button">Continue</button>
+        </div>
+    </form>
+</main>"
+`;
+
+exports[`Timetable POST /edit S78 Final comments should re-render edit timetable page with missing year error for Final comments 1`] = `
+"<main class="govuk-main-wrapper" id="main-content">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <div class="govuk-error-summary" data-module="govuk-error-summary">
+                <div role="alert">
+                    <h2 class="govuk-error-summary__title"> There is a problem</h2>
+                    <div class="govuk-error-summary__body">
+                        <ul class="govuk-list govuk-error-summary__list">
+                            <li><a href="#lpa-questionnaire-due-date-day">LPA questionnaire due date must include a day</a>
+                            </li>
+                            <li><a href="#lpa-questionnaire-due-date-month">LPA questionnaire due date must include a month</a>
+                            </li>
+                            <li><a href="#lpa-questionnaire-due-date-year">LPA questionnaire due date must include a year</a>
+                            </li>
+                            <li><a href="#lpa-statement-due-date-day">Statements due date must include a day</a>
+                            </li>
+                            <li><a href="#lpa-statement-due-date-month">Statements due date must include a month</a>
+                            </li>
+                            <li><a href="#lpa-statement-due-date-year">Statements due date must include a year</a>
+                            </li>
+                            <li><a href="#ip-comments-due-date-day">Interested party comments due date must include a day</a>
+                            </li>
+                            <li><a href="#ip-comments-due-date-month">Interested party comments due date must include a month</a>
+                            </li>
+                            <li><a href="#ip-comments-due-date-year">Interested party comments due date must include a year</a>
+                            </li>
+                            <li><a href="#final-comments-due-date-year">Final comments due date must include a year</a>
+                            </li>
+                        </ul>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Appeal 351062</span>
+            <h1 class="govuk-heading-l">Timetable due dates</h1>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full"></div>
+    </div>
+    <form method="post" novalidate="novalidate">
+        <div class="govuk-form-group govuk-form-group--error">
+            <fieldset class="govuk-fieldset" role="group" aria-describedby="lpa-questionnaire-due-date-hint lpa-questionnaire-due-date-error">
+                <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">LPA questionnaire due</legend>
+                <div id="lpa-questionnaire-due-date-hint"
+                class="govuk-hint">For example, 27 3 2007</div>
+                <p id="lpa-questionnaire-due-date-error" class="govuk-error-message"><span class="govuk-visually-hidden">Error:</span> LPA questionnaire due
+                    date must include a day
+                    <br>LPA questionnaire due date must include a month
+                    <br>LPA questionnaire due date must include a year</p>
+                <div class="govuk-date-input"
+                id="lpa-questionnaire-due-date">
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="lpa-questionnaire-due-date-day">Day</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                            id="lpa-questionnaire-due-date-day" name="lpa-questionnaire-due-date-day"
+                            type="text" inputmode="numeric">
+                        </div>
+                    </div>
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="lpa-questionnaire-due-date-month">Month</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                            id="lpa-questionnaire-due-date-month" name="lpa-questionnaire-due-date-month"
+                            type="text" inputmode="numeric">
+                        </div>
+                    </div>
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="lpa-questionnaire-due-date-year">Year</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-4"
+                            id="lpa-questionnaire-due-date-year" name="lpa-questionnaire-due-date-year"
+                            type="text" inputmode="numeric">
+                        </div>
+                    </div>
+                </div>
+            </fieldset>
+        </div>
+        <div class="govuk-form-group govuk-form-group--error">
+            <fieldset class="govuk-fieldset" role="group" aria-describedby="lpa-statement-due-date-hint lpa-statement-due-date-error">
+                <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">Statements due</legend>
+                <div id="lpa-statement-due-date-hint" class="govuk-hint">For example, 27 3 2007</div>
+                <p id="lpa-statement-due-date-error" class="govuk-error-message"><span class="govuk-visually-hidden">Error:</span> Statements due date must
+                    include a day
+                    <br>Statements due date must include a month
+                    <br>Statements due date must include a year</p>
+                <div class="govuk-date-input"
+                id="lpa-statement-due-date">
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="lpa-statement-due-date-day">Day</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                            id="lpa-statement-due-date-day" name="lpa-statement-due-date-day" type="text"
+                            inputmode="numeric">
+                        </div>
+                    </div>
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="lpa-statement-due-date-month">Month</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                            id="lpa-statement-due-date-month" name="lpa-statement-due-date-month" type="text"
+                            inputmode="numeric">
+                        </div>
+                    </div>
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="lpa-statement-due-date-year">Year</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-4"
+                            id="lpa-statement-due-date-year" name="lpa-statement-due-date-year" type="text"
+                            inputmode="numeric">
+                        </div>
+                    </div>
+                </div>
+            </fieldset>
+        </div>
+        <div class="govuk-form-group govuk-form-group--error">
+            <fieldset class="govuk-fieldset" role="group" aria-describedby="ip-comments-due-date-hint ip-comments-due-date-error">
+                <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">Interested party comments due</legend>
+                <div id="ip-comments-due-date-hint"
+                class="govuk-hint">For example, 27 3 2007</div>
+                <p id="ip-comments-due-date-error" class="govuk-error-message"><span class="govuk-visually-hidden">Error:</span> Interested party comments
+                    due date must include a day
+                    <br>Interested party comments due date must include a month
+                    <br>Interested party comments due date must include a year</p>
+                <div class="govuk-date-input"
+                id="ip-comments-due-date">
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="ip-comments-due-date-day">Day</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                            id="ip-comments-due-date-day" name="ip-comments-due-date-day" type="text"
+                            inputmode="numeric">
+                        </div>
+                    </div>
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="ip-comments-due-date-month">Month</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                            id="ip-comments-due-date-month" name="ip-comments-due-date-month" type="text"
+                            inputmode="numeric">
+                        </div>
+                    </div>
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="ip-comments-due-date-year">Year</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-4"
+                            id="ip-comments-due-date-year" name="ip-comments-due-date-year" type="text"
+                            inputmode="numeric">
+                        </div>
+                    </div>
+                </div>
+            </fieldset>
+        </div>
+        <div class="govuk-form-group govuk-form-group--error">
+            <fieldset class="govuk-fieldset" role="group" aria-describedby="final-comments-due-date-hint final-comments-due-date-error">
+                <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">Final comments due</legend>
+                <div id="final-comments-due-date-hint" class="govuk-hint">For example, 27 3 2007</div>
+                <p id="final-comments-due-date-error" class="govuk-error-message"><span class="govuk-visually-hidden">Error:</span> Final comments due date
+                    must include a year</p>
+                <div class="govuk-date-input" id="final-comments-due-date">
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="final-comments-due-date-day">Day</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                            id="final-comments-due-date-day" name="final-comments-due-date-day" type="text"
+                            inputmode="numeric">
+                        </div>
+                    </div>
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="final-comments-due-date-month">Month</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                            id="final-comments-due-date-month" name="final-comments-due-date-month"
+                            type="text" inputmode="numeric">
+                        </div>
+                    </div>
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="final-comments-due-date-year">Year</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-4"
+                            id="final-comments-due-date-year" name="final-comments-due-date-year" type="text"
+                            inputmode="numeric">
+                        </div>
+                    </div>
+                </div>
+            </fieldset>
+        </div>
+        <div class="govuk-button-group">
+            <button type="submit" class="govuk-button" data-module="govuk-button">Continue</button>
+        </div>
+    </form>
+</main>"
+`;
+
+exports[`Timetable POST /edit S78 Final comments should re-render edit timetable page with must be in the future error for Final comments 1`] = `
+"<main class="govuk-main-wrapper" id="main-content">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <div class="govuk-error-summary" data-module="govuk-error-summary">
+                <div role="alert">
+                    <h2 class="govuk-error-summary__title"> There is a problem</h2>
+                    <div class="govuk-error-summary__body">
+                        <ul class="govuk-list govuk-error-summary__list">
+                            <li><a href="#lpa-questionnaire-due-date-day">LPA questionnaire due date must include a day</a>
+                            </li>
+                            <li><a href="#lpa-questionnaire-due-date-month">LPA questionnaire due date must include a month</a>
+                            </li>
+                            <li><a href="#lpa-questionnaire-due-date-year">LPA questionnaire due date must include a year</a>
+                            </li>
+                            <li><a href="#lpa-statement-due-date-day">Statements due date must include a day</a>
+                            </li>
+                            <li><a href="#lpa-statement-due-date-month">Statements due date must include a month</a>
+                            </li>
+                            <li><a href="#lpa-statement-due-date-year">Statements due date must include a year</a>
+                            </li>
+                            <li><a href="#ip-comments-due-date-day">Interested party comments due date must include a day</a>
+                            </li>
+                            <li><a href="#ip-comments-due-date-month">Interested party comments due date must include a month</a>
+                            </li>
+                            <li><a href="#ip-comments-due-date-year">Interested party comments due date must include a year</a>
+                            </li>
+                            <li><a href="#">The final comments due date must be in the future</a>
+                            </li>
+                        </ul>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Appeal 351062</span>
+            <h1 class="govuk-heading-l">Timetable due dates</h1>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full"></div>
+    </div>
+    <form method="post" novalidate="novalidate">
+        <div class="govuk-form-group govuk-form-group--error">
+            <fieldset class="govuk-fieldset" role="group" aria-describedby="lpa-questionnaire-due-date-hint lpa-questionnaire-due-date-error">
+                <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">LPA questionnaire due</legend>
+                <div id="lpa-questionnaire-due-date-hint"
+                class="govuk-hint">For example, 27 3 2007</div>
+                <p id="lpa-questionnaire-due-date-error" class="govuk-error-message"><span class="govuk-visually-hidden">Error:</span> LPA questionnaire due
+                    date must include a day
+                    <br>LPA questionnaire due date must include a month
+                    <br>LPA questionnaire due date must include a year</p>
+                <div class="govuk-date-input"
+                id="lpa-questionnaire-due-date">
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="lpa-questionnaire-due-date-day">Day</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                            id="lpa-questionnaire-due-date-day" name="lpa-questionnaire-due-date-day"
+                            type="text" inputmode="numeric">
+                        </div>
+                    </div>
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="lpa-questionnaire-due-date-month">Month</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                            id="lpa-questionnaire-due-date-month" name="lpa-questionnaire-due-date-month"
+                            type="text" inputmode="numeric">
+                        </div>
+                    </div>
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="lpa-questionnaire-due-date-year">Year</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-4"
+                            id="lpa-questionnaire-due-date-year" name="lpa-questionnaire-due-date-year"
+                            type="text" inputmode="numeric">
+                        </div>
+                    </div>
+                </div>
+            </fieldset>
+        </div>
+        <div class="govuk-form-group govuk-form-group--error">
+            <fieldset class="govuk-fieldset" role="group" aria-describedby="lpa-statement-due-date-hint lpa-statement-due-date-error">
+                <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">Statements due</legend>
+                <div id="lpa-statement-due-date-hint" class="govuk-hint">For example, 27 3 2007</div>
+                <p id="lpa-statement-due-date-error" class="govuk-error-message"><span class="govuk-visually-hidden">Error:</span> Statements due date must
+                    include a day
+                    <br>Statements due date must include a month
+                    <br>Statements due date must include a year</p>
+                <div class="govuk-date-input"
+                id="lpa-statement-due-date">
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="lpa-statement-due-date-day">Day</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                            id="lpa-statement-due-date-day" name="lpa-statement-due-date-day" type="text"
+                            inputmode="numeric">
+                        </div>
+                    </div>
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="lpa-statement-due-date-month">Month</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                            id="lpa-statement-due-date-month" name="lpa-statement-due-date-month" type="text"
+                            inputmode="numeric">
+                        </div>
+                    </div>
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="lpa-statement-due-date-year">Year</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-4"
+                            id="lpa-statement-due-date-year" name="lpa-statement-due-date-year" type="text"
+                            inputmode="numeric">
+                        </div>
+                    </div>
+                </div>
+            </fieldset>
+        </div>
+        <div class="govuk-form-group govuk-form-group--error">
+            <fieldset class="govuk-fieldset" role="group" aria-describedby="ip-comments-due-date-hint ip-comments-due-date-error">
+                <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">Interested party comments due</legend>
+                <div id="ip-comments-due-date-hint"
+                class="govuk-hint">For example, 27 3 2007</div>
+                <p id="ip-comments-due-date-error" class="govuk-error-message"><span class="govuk-visually-hidden">Error:</span> Interested party comments
+                    due date must include a day
+                    <br>Interested party comments due date must include a month
+                    <br>Interested party comments due date must include a year</p>
+                <div class="govuk-date-input"
+                id="ip-comments-due-date">
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="ip-comments-due-date-day">Day</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                            id="ip-comments-due-date-day" name="ip-comments-due-date-day" type="text"
+                            inputmode="numeric">
+                        </div>
+                    </div>
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="ip-comments-due-date-month">Month</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                            id="ip-comments-due-date-month" name="ip-comments-due-date-month" type="text"
+                            inputmode="numeric">
+                        </div>
+                    </div>
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="ip-comments-due-date-year">Year</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-4"
+                            id="ip-comments-due-date-year" name="ip-comments-due-date-year" type="text"
+                            inputmode="numeric">
+                        </div>
+                    </div>
+                </div>
+            </fieldset>
+        </div>
+        <div class="govuk-form-group">
+            <fieldset class="govuk-fieldset" role="group" aria-describedby="final-comments-due-date-hint">
+                <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">Final comments due</legend>
+                <div id="final-comments-due-date-hint" class="govuk-hint">For example, 27 3 2007</div>
+                <div class="govuk-date-input" id="final-comments-due-date">
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="final-comments-due-date-day">Day</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                            id="final-comments-due-date-day" name="final-comments-due-date-day" type="text"
+                            inputmode="numeric">
+                        </div>
+                    </div>
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="final-comments-due-date-month">Month</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                            id="final-comments-due-date-month" name="final-comments-due-date-month"
+                            type="text" inputmode="numeric">
+                        </div>
+                    </div>
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="final-comments-due-date-year">Year</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-4"
+                            id="final-comments-due-date-year" name="final-comments-due-date-year" type="text"
+                            inputmode="numeric">
+                        </div>
+                    </div>
+                </div>
+            </fieldset>
+        </div>
+        <div class="govuk-button-group">
+            <button type="submit" class="govuk-button" data-module="govuk-button">Continue</button>
+        </div>
+    </form>
+</main>"
+`;
+
+exports[`Timetable POST /edit S78 Final comments should re-render edit timetable page with not a real date error for Final comments 1`] = `
+"<main class="govuk-main-wrapper" id="main-content">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <div class="govuk-error-summary" data-module="govuk-error-summary">
+                <div role="alert">
+                    <h2 class="govuk-error-summary__title"> There is a problem</h2>
+                    <div class="govuk-error-summary__body">
+                        <ul class="govuk-list govuk-error-summary__list">
+                            <li><a href="#lpa-questionnaire-due-date-day">LPA questionnaire due date must include a day</a>
+                            </li>
+                            <li><a href="#lpa-questionnaire-due-date-month">LPA questionnaire due date must include a month</a>
+                            </li>
+                            <li><a href="#lpa-questionnaire-due-date-year">LPA questionnaire due date must include a year</a>
+                            </li>
+                            <li><a href="#lpa-statement-due-date-day">Statements due date must include a day</a>
+                            </li>
+                            <li><a href="#lpa-statement-due-date-month">Statements due date must include a month</a>
+                            </li>
+                            <li><a href="#lpa-statement-due-date-year">Statements due date must include a year</a>
+                            </li>
+                            <li><a href="#ip-comments-due-date-day">Interested party comments due date must include a day</a>
+                            </li>
+                            <li><a href="#ip-comments-due-date-month">Interested party comments due date must include a month</a>
+                            </li>
+                            <li><a href="#ip-comments-due-date-year">Interested party comments due date must include a year</a>
+                            </li>
+                            <li><a href="#">Final comments due date must be a real date</a>
+                            </li>
+                        </ul>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Appeal 351062</span>
+            <h1 class="govuk-heading-l">Timetable due dates</h1>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full"></div>
+    </div>
+    <form method="post" novalidate="novalidate">
+        <div class="govuk-form-group govuk-form-group--error">
+            <fieldset class="govuk-fieldset" role="group" aria-describedby="lpa-questionnaire-due-date-hint lpa-questionnaire-due-date-error">
+                <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">LPA questionnaire due</legend>
+                <div id="lpa-questionnaire-due-date-hint"
+                class="govuk-hint">For example, 27 3 2007</div>
+                <p id="lpa-questionnaire-due-date-error" class="govuk-error-message"><span class="govuk-visually-hidden">Error:</span> LPA questionnaire due
+                    date must include a day
+                    <br>LPA questionnaire due date must include a month
+                    <br>LPA questionnaire due date must include a year</p>
+                <div class="govuk-date-input"
+                id="lpa-questionnaire-due-date">
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="lpa-questionnaire-due-date-day">Day</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                            id="lpa-questionnaire-due-date-day" name="lpa-questionnaire-due-date-day"
+                            type="text" inputmode="numeric">
+                        </div>
+                    </div>
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="lpa-questionnaire-due-date-month">Month</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                            id="lpa-questionnaire-due-date-month" name="lpa-questionnaire-due-date-month"
+                            type="text" inputmode="numeric">
+                        </div>
+                    </div>
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="lpa-questionnaire-due-date-year">Year</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-4"
+                            id="lpa-questionnaire-due-date-year" name="lpa-questionnaire-due-date-year"
+                            type="text" inputmode="numeric">
+                        </div>
+                    </div>
+                </div>
+            </fieldset>
+        </div>
+        <div class="govuk-form-group govuk-form-group--error">
+            <fieldset class="govuk-fieldset" role="group" aria-describedby="lpa-statement-due-date-hint lpa-statement-due-date-error">
+                <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">Statements due</legend>
+                <div id="lpa-statement-due-date-hint" class="govuk-hint">For example, 27 3 2007</div>
+                <p id="lpa-statement-due-date-error" class="govuk-error-message"><span class="govuk-visually-hidden">Error:</span> Statements due date must
+                    include a day
+                    <br>Statements due date must include a month
+                    <br>Statements due date must include a year</p>
+                <div class="govuk-date-input"
+                id="lpa-statement-due-date">
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="lpa-statement-due-date-day">Day</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                            id="lpa-statement-due-date-day" name="lpa-statement-due-date-day" type="text"
+                            inputmode="numeric">
+                        </div>
+                    </div>
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="lpa-statement-due-date-month">Month</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                            id="lpa-statement-due-date-month" name="lpa-statement-due-date-month" type="text"
+                            inputmode="numeric">
+                        </div>
+                    </div>
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="lpa-statement-due-date-year">Year</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-4"
+                            id="lpa-statement-due-date-year" name="lpa-statement-due-date-year" type="text"
+                            inputmode="numeric">
+                        </div>
+                    </div>
+                </div>
+            </fieldset>
+        </div>
+        <div class="govuk-form-group govuk-form-group--error">
+            <fieldset class="govuk-fieldset" role="group" aria-describedby="ip-comments-due-date-hint ip-comments-due-date-error">
+                <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">Interested party comments due</legend>
+                <div id="ip-comments-due-date-hint"
+                class="govuk-hint">For example, 27 3 2007</div>
+                <p id="ip-comments-due-date-error" class="govuk-error-message"><span class="govuk-visually-hidden">Error:</span> Interested party comments
+                    due date must include a day
+                    <br>Interested party comments due date must include a month
+                    <br>Interested party comments due date must include a year</p>
+                <div class="govuk-date-input"
+                id="ip-comments-due-date">
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="ip-comments-due-date-day">Day</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                            id="ip-comments-due-date-day" name="ip-comments-due-date-day" type="text"
+                            inputmode="numeric">
+                        </div>
+                    </div>
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="ip-comments-due-date-month">Month</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                            id="ip-comments-due-date-month" name="ip-comments-due-date-month" type="text"
+                            inputmode="numeric">
+                        </div>
+                    </div>
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="ip-comments-due-date-year">Year</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-4"
+                            id="ip-comments-due-date-year" name="ip-comments-due-date-year" type="text"
+                            inputmode="numeric">
+                        </div>
+                    </div>
+                </div>
+            </fieldset>
+        </div>
+        <div class="govuk-form-group">
+            <fieldset class="govuk-fieldset" role="group" aria-describedby="final-comments-due-date-hint">
+                <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">Final comments due</legend>
+                <div id="final-comments-due-date-hint" class="govuk-hint">For example, 27 3 2007</div>
+                <div class="govuk-date-input" id="final-comments-due-date">
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="final-comments-due-date-day">Day</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                            id="final-comments-due-date-day" name="final-comments-due-date-day" type="text"
+                            inputmode="numeric">
+                        </div>
+                    </div>
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="final-comments-due-date-month">Month</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                            id="final-comments-due-date-month" name="final-comments-due-date-month"
+                            type="text" inputmode="numeric">
+                        </div>
+                    </div>
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="final-comments-due-date-year">Year</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-4"
+                            id="final-comments-due-date-year" name="final-comments-due-date-year" type="text"
+                            inputmode="numeric">
+                        </div>
+                    </div>
+                </div>
+            </fieldset>
+        </div>
+        <div class="govuk-button-group">
+            <button type="submit" class="govuk-button" data-module="govuk-button">Continue</button>
+        </div>
+    </form>
+</main>"
+`;
+
+exports[`Timetable POST /edit S78 Interested party comments should re-render edit timetable page with missing day error for Interested party comments 1`] = `
+"<main class="govuk-main-wrapper" id="main-content">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <div class="govuk-error-summary" data-module="govuk-error-summary">
+                <div role="alert">
+                    <h2 class="govuk-error-summary__title"> There is a problem</h2>
+                    <div class="govuk-error-summary__body">
+                        <ul class="govuk-list govuk-error-summary__list">
+                            <li><a href="#lpa-questionnaire-due-date-day">LPA questionnaire due date must include a day</a>
+                            </li>
+                            <li><a href="#lpa-questionnaire-due-date-month">LPA questionnaire due date must include a month</a>
+                            </li>
+                            <li><a href="#lpa-questionnaire-due-date-year">LPA questionnaire due date must include a year</a>
+                            </li>
+                            <li><a href="#lpa-statement-due-date-day">Statements due date must include a day</a>
+                            </li>
+                            <li><a href="#lpa-statement-due-date-month">Statements due date must include a month</a>
+                            </li>
+                            <li><a href="#lpa-statement-due-date-year">Statements due date must include a year</a>
+                            </li>
+                            <li><a href="#ip-comments-due-date-day">Interested party comments due date must include a day</a>
+                            </li>
+                            <li><a href="#final-comments-due-date-day">Final comments due date must include a day</a>
+                            </li>
+                            <li><a href="#final-comments-due-date-month">Final comments due date must include a month</a>
+                            </li>
+                            <li><a href="#final-comments-due-date-year">Final comments due date must include a year</a>
+                            </li>
+                        </ul>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Appeal 351062</span>
+            <h1 class="govuk-heading-l">Timetable due dates</h1>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full"></div>
+    </div>
+    <form method="post" novalidate="novalidate">
+        <div class="govuk-form-group govuk-form-group--error">
+            <fieldset class="govuk-fieldset" role="group" aria-describedby="lpa-questionnaire-due-date-hint lpa-questionnaire-due-date-error">
+                <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">LPA questionnaire due</legend>
+                <div id="lpa-questionnaire-due-date-hint"
+                class="govuk-hint">For example, 27 3 2007</div>
+                <p id="lpa-questionnaire-due-date-error" class="govuk-error-message"><span class="govuk-visually-hidden">Error:</span> LPA questionnaire due
+                    date must include a day
+                    <br>LPA questionnaire due date must include a month
+                    <br>LPA questionnaire due date must include a year</p>
+                <div class="govuk-date-input"
+                id="lpa-questionnaire-due-date">
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="lpa-questionnaire-due-date-day">Day</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                            id="lpa-questionnaire-due-date-day" name="lpa-questionnaire-due-date-day"
+                            type="text" inputmode="numeric">
+                        </div>
+                    </div>
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="lpa-questionnaire-due-date-month">Month</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                            id="lpa-questionnaire-due-date-month" name="lpa-questionnaire-due-date-month"
+                            type="text" inputmode="numeric">
+                        </div>
+                    </div>
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="lpa-questionnaire-due-date-year">Year</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-4"
+                            id="lpa-questionnaire-due-date-year" name="lpa-questionnaire-due-date-year"
+                            type="text" inputmode="numeric">
+                        </div>
+                    </div>
+                </div>
+            </fieldset>
+        </div>
+        <div class="govuk-form-group govuk-form-group--error">
+            <fieldset class="govuk-fieldset" role="group" aria-describedby="lpa-statement-due-date-hint lpa-statement-due-date-error">
+                <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">Statements due</legend>
+                <div id="lpa-statement-due-date-hint" class="govuk-hint">For example, 27 3 2007</div>
+                <p id="lpa-statement-due-date-error" class="govuk-error-message"><span class="govuk-visually-hidden">Error:</span> Statements due date must
+                    include a day
+                    <br>Statements due date must include a month
+                    <br>Statements due date must include a year</p>
+                <div class="govuk-date-input"
+                id="lpa-statement-due-date">
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="lpa-statement-due-date-day">Day</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                            id="lpa-statement-due-date-day" name="lpa-statement-due-date-day" type="text"
+                            inputmode="numeric">
+                        </div>
+                    </div>
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="lpa-statement-due-date-month">Month</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                            id="lpa-statement-due-date-month" name="lpa-statement-due-date-month" type="text"
+                            inputmode="numeric">
+                        </div>
+                    </div>
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="lpa-statement-due-date-year">Year</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-4"
+                            id="lpa-statement-due-date-year" name="lpa-statement-due-date-year" type="text"
+                            inputmode="numeric">
+                        </div>
+                    </div>
+                </div>
+            </fieldset>
+        </div>
+        <div class="govuk-form-group govuk-form-group--error">
+            <fieldset class="govuk-fieldset" role="group" aria-describedby="ip-comments-due-date-hint ip-comments-due-date-error">
+                <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">Interested party comments due</legend>
+                <div id="ip-comments-due-date-hint"
+                class="govuk-hint">For example, 27 3 2007</div>
+                <p id="ip-comments-due-date-error" class="govuk-error-message"><span class="govuk-visually-hidden">Error:</span> Interested party comments
+                    due date must include a day</p>
+                <div class="govuk-date-input" id="ip-comments-due-date">
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="ip-comments-due-date-day">Day</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                            id="ip-comments-due-date-day" name="ip-comments-due-date-day" type="text"
+                            inputmode="numeric">
+                        </div>
+                    </div>
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="ip-comments-due-date-month">Month</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                            id="ip-comments-due-date-month" name="ip-comments-due-date-month" type="text"
+                            inputmode="numeric">
+                        </div>
+                    </div>
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="ip-comments-due-date-year">Year</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-4"
+                            id="ip-comments-due-date-year" name="ip-comments-due-date-year" type="text"
+                            inputmode="numeric">
+                        </div>
+                    </div>
+                </div>
+            </fieldset>
+        </div>
+        <div class="govuk-form-group govuk-form-group--error">
+            <fieldset class="govuk-fieldset" role="group" aria-describedby="final-comments-due-date-hint final-comments-due-date-error">
+                <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">Final comments due</legend>
+                <div id="final-comments-due-date-hint" class="govuk-hint">For example, 27 3 2007</div>
+                <p id="final-comments-due-date-error" class="govuk-error-message"><span class="govuk-visually-hidden">Error:</span> Final comments due date
+                    must include a day
+                    <br>Final comments due date must include a month
+                    <br>Final comments due date must include a year</p>
+                <div class="govuk-date-input"
+                id="final-comments-due-date">
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="final-comments-due-date-day">Day</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                            id="final-comments-due-date-day" name="final-comments-due-date-day" type="text"
+                            inputmode="numeric">
+                        </div>
+                    </div>
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="final-comments-due-date-month">Month</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                            id="final-comments-due-date-month" name="final-comments-due-date-month"
+                            type="text" inputmode="numeric">
+                        </div>
+                    </div>
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="final-comments-due-date-year">Year</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-4"
+                            id="final-comments-due-date-year" name="final-comments-due-date-year" type="text"
+                            inputmode="numeric">
+                        </div>
+                    </div>
+                </div>
+            </fieldset>
+        </div>
+        <div class="govuk-button-group">
+            <button type="submit" class="govuk-button" data-module="govuk-button">Continue</button>
+        </div>
+    </form>
+</main>"
+`;
+
+exports[`Timetable POST /edit S78 Interested party comments should re-render edit timetable page with missing month error for Interested party comments 1`] = `
+"<main class="govuk-main-wrapper" id="main-content">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <div class="govuk-error-summary" data-module="govuk-error-summary">
+                <div role="alert">
+                    <h2 class="govuk-error-summary__title"> There is a problem</h2>
+                    <div class="govuk-error-summary__body">
+                        <ul class="govuk-list govuk-error-summary__list">
+                            <li><a href="#lpa-questionnaire-due-date-day">LPA questionnaire due date must include a day</a>
+                            </li>
+                            <li><a href="#lpa-questionnaire-due-date-month">LPA questionnaire due date must include a month</a>
+                            </li>
+                            <li><a href="#lpa-questionnaire-due-date-year">LPA questionnaire due date must include a year</a>
+                            </li>
+                            <li><a href="#lpa-statement-due-date-day">Statements due date must include a day</a>
+                            </li>
+                            <li><a href="#lpa-statement-due-date-month">Statements due date must include a month</a>
+                            </li>
+                            <li><a href="#lpa-statement-due-date-year">Statements due date must include a year</a>
+                            </li>
+                            <li><a href="#ip-comments-due-date-month">Interested party comments due date must include a month</a>
+                            </li>
+                            <li><a href="#final-comments-due-date-day">Final comments due date must include a day</a>
+                            </li>
+                            <li><a href="#final-comments-due-date-month">Final comments due date must include a month</a>
+                            </li>
+                            <li><a href="#final-comments-due-date-year">Final comments due date must include a year</a>
+                            </li>
+                        </ul>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Appeal 351062</span>
+            <h1 class="govuk-heading-l">Timetable due dates</h1>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full"></div>
+    </div>
+    <form method="post" novalidate="novalidate">
+        <div class="govuk-form-group govuk-form-group--error">
+            <fieldset class="govuk-fieldset" role="group" aria-describedby="lpa-questionnaire-due-date-hint lpa-questionnaire-due-date-error">
+                <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">LPA questionnaire due</legend>
+                <div id="lpa-questionnaire-due-date-hint"
+                class="govuk-hint">For example, 27 3 2007</div>
+                <p id="lpa-questionnaire-due-date-error" class="govuk-error-message"><span class="govuk-visually-hidden">Error:</span> LPA questionnaire due
+                    date must include a day
+                    <br>LPA questionnaire due date must include a month
+                    <br>LPA questionnaire due date must include a year</p>
+                <div class="govuk-date-input"
+                id="lpa-questionnaire-due-date">
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="lpa-questionnaire-due-date-day">Day</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                            id="lpa-questionnaire-due-date-day" name="lpa-questionnaire-due-date-day"
+                            type="text" inputmode="numeric">
+                        </div>
+                    </div>
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="lpa-questionnaire-due-date-month">Month</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                            id="lpa-questionnaire-due-date-month" name="lpa-questionnaire-due-date-month"
+                            type="text" inputmode="numeric">
+                        </div>
+                    </div>
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="lpa-questionnaire-due-date-year">Year</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-4"
+                            id="lpa-questionnaire-due-date-year" name="lpa-questionnaire-due-date-year"
+                            type="text" inputmode="numeric">
+                        </div>
+                    </div>
+                </div>
+            </fieldset>
+        </div>
+        <div class="govuk-form-group govuk-form-group--error">
+            <fieldset class="govuk-fieldset" role="group" aria-describedby="lpa-statement-due-date-hint lpa-statement-due-date-error">
+                <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">Statements due</legend>
+                <div id="lpa-statement-due-date-hint" class="govuk-hint">For example, 27 3 2007</div>
+                <p id="lpa-statement-due-date-error" class="govuk-error-message"><span class="govuk-visually-hidden">Error:</span> Statements due date must
+                    include a day
+                    <br>Statements due date must include a month
+                    <br>Statements due date must include a year</p>
+                <div class="govuk-date-input"
+                id="lpa-statement-due-date">
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="lpa-statement-due-date-day">Day</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                            id="lpa-statement-due-date-day" name="lpa-statement-due-date-day" type="text"
+                            inputmode="numeric">
+                        </div>
+                    </div>
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="lpa-statement-due-date-month">Month</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                            id="lpa-statement-due-date-month" name="lpa-statement-due-date-month" type="text"
+                            inputmode="numeric">
+                        </div>
+                    </div>
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="lpa-statement-due-date-year">Year</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-4"
+                            id="lpa-statement-due-date-year" name="lpa-statement-due-date-year" type="text"
+                            inputmode="numeric">
+                        </div>
+                    </div>
+                </div>
+            </fieldset>
+        </div>
+        <div class="govuk-form-group govuk-form-group--error">
+            <fieldset class="govuk-fieldset" role="group" aria-describedby="ip-comments-due-date-hint ip-comments-due-date-error">
+                <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">Interested party comments due</legend>
+                <div id="ip-comments-due-date-hint"
+                class="govuk-hint">For example, 27 3 2007</div>
+                <p id="ip-comments-due-date-error" class="govuk-error-message"><span class="govuk-visually-hidden">Error:</span> Interested party comments
+                    due date must include a month</p>
+                <div class="govuk-date-input" id="ip-comments-due-date">
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="ip-comments-due-date-day">Day</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                            id="ip-comments-due-date-day" name="ip-comments-due-date-day" type="text"
+                            inputmode="numeric">
+                        </div>
+                    </div>
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="ip-comments-due-date-month">Month</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                            id="ip-comments-due-date-month" name="ip-comments-due-date-month" type="text"
+                            inputmode="numeric">
+                        </div>
+                    </div>
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="ip-comments-due-date-year">Year</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-4"
+                            id="ip-comments-due-date-year" name="ip-comments-due-date-year" type="text"
+                            inputmode="numeric">
+                        </div>
+                    </div>
+                </div>
+            </fieldset>
+        </div>
+        <div class="govuk-form-group govuk-form-group--error">
+            <fieldset class="govuk-fieldset" role="group" aria-describedby="final-comments-due-date-hint final-comments-due-date-error">
+                <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">Final comments due</legend>
+                <div id="final-comments-due-date-hint" class="govuk-hint">For example, 27 3 2007</div>
+                <p id="final-comments-due-date-error" class="govuk-error-message"><span class="govuk-visually-hidden">Error:</span> Final comments due date
+                    must include a day
+                    <br>Final comments due date must include a month
+                    <br>Final comments due date must include a year</p>
+                <div class="govuk-date-input"
+                id="final-comments-due-date">
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="final-comments-due-date-day">Day</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                            id="final-comments-due-date-day" name="final-comments-due-date-day" type="text"
+                            inputmode="numeric">
+                        </div>
+                    </div>
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="final-comments-due-date-month">Month</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                            id="final-comments-due-date-month" name="final-comments-due-date-month"
+                            type="text" inputmode="numeric">
+                        </div>
+                    </div>
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="final-comments-due-date-year">Year</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-4"
+                            id="final-comments-due-date-year" name="final-comments-due-date-year" type="text"
+                            inputmode="numeric">
+                        </div>
+                    </div>
+                </div>
+            </fieldset>
+        </div>
+        <div class="govuk-button-group">
+            <button type="submit" class="govuk-button" data-module="govuk-button">Continue</button>
+        </div>
+    </form>
+</main>"
+`;
+
+exports[`Timetable POST /edit S78 Interested party comments should re-render edit timetable page with missing year error for Interested party comments 1`] = `
+"<main class="govuk-main-wrapper" id="main-content">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <div class="govuk-error-summary" data-module="govuk-error-summary">
+                <div role="alert">
+                    <h2 class="govuk-error-summary__title"> There is a problem</h2>
+                    <div class="govuk-error-summary__body">
+                        <ul class="govuk-list govuk-error-summary__list">
+                            <li><a href="#lpa-questionnaire-due-date-day">LPA questionnaire due date must include a day</a>
+                            </li>
+                            <li><a href="#lpa-questionnaire-due-date-month">LPA questionnaire due date must include a month</a>
+                            </li>
+                            <li><a href="#lpa-questionnaire-due-date-year">LPA questionnaire due date must include a year</a>
+                            </li>
+                            <li><a href="#lpa-statement-due-date-day">Statements due date must include a day</a>
+                            </li>
+                            <li><a href="#lpa-statement-due-date-month">Statements due date must include a month</a>
+                            </li>
+                            <li><a href="#lpa-statement-due-date-year">Statements due date must include a year</a>
+                            </li>
+                            <li><a href="#ip-comments-due-date-year">Interested party comments due date must include a year</a>
+                            </li>
+                            <li><a href="#final-comments-due-date-day">Final comments due date must include a day</a>
+                            </li>
+                            <li><a href="#final-comments-due-date-month">Final comments due date must include a month</a>
+                            </li>
+                            <li><a href="#final-comments-due-date-year">Final comments due date must include a year</a>
+                            </li>
+                        </ul>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Appeal 351062</span>
+            <h1 class="govuk-heading-l">Timetable due dates</h1>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full"></div>
+    </div>
+    <form method="post" novalidate="novalidate">
+        <div class="govuk-form-group govuk-form-group--error">
+            <fieldset class="govuk-fieldset" role="group" aria-describedby="lpa-questionnaire-due-date-hint lpa-questionnaire-due-date-error">
+                <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">LPA questionnaire due</legend>
+                <div id="lpa-questionnaire-due-date-hint"
+                class="govuk-hint">For example, 27 3 2007</div>
+                <p id="lpa-questionnaire-due-date-error" class="govuk-error-message"><span class="govuk-visually-hidden">Error:</span> LPA questionnaire due
+                    date must include a day
+                    <br>LPA questionnaire due date must include a month
+                    <br>LPA questionnaire due date must include a year</p>
+                <div class="govuk-date-input"
+                id="lpa-questionnaire-due-date">
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="lpa-questionnaire-due-date-day">Day</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                            id="lpa-questionnaire-due-date-day" name="lpa-questionnaire-due-date-day"
+                            type="text" inputmode="numeric">
+                        </div>
+                    </div>
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="lpa-questionnaire-due-date-month">Month</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                            id="lpa-questionnaire-due-date-month" name="lpa-questionnaire-due-date-month"
+                            type="text" inputmode="numeric">
+                        </div>
+                    </div>
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="lpa-questionnaire-due-date-year">Year</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-4"
+                            id="lpa-questionnaire-due-date-year" name="lpa-questionnaire-due-date-year"
+                            type="text" inputmode="numeric">
+                        </div>
+                    </div>
+                </div>
+            </fieldset>
+        </div>
+        <div class="govuk-form-group govuk-form-group--error">
+            <fieldset class="govuk-fieldset" role="group" aria-describedby="lpa-statement-due-date-hint lpa-statement-due-date-error">
+                <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">Statements due</legend>
+                <div id="lpa-statement-due-date-hint" class="govuk-hint">For example, 27 3 2007</div>
+                <p id="lpa-statement-due-date-error" class="govuk-error-message"><span class="govuk-visually-hidden">Error:</span> Statements due date must
+                    include a day
+                    <br>Statements due date must include a month
+                    <br>Statements due date must include a year</p>
+                <div class="govuk-date-input"
+                id="lpa-statement-due-date">
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="lpa-statement-due-date-day">Day</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                            id="lpa-statement-due-date-day" name="lpa-statement-due-date-day" type="text"
+                            inputmode="numeric">
+                        </div>
+                    </div>
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="lpa-statement-due-date-month">Month</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                            id="lpa-statement-due-date-month" name="lpa-statement-due-date-month" type="text"
+                            inputmode="numeric">
+                        </div>
+                    </div>
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="lpa-statement-due-date-year">Year</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-4"
+                            id="lpa-statement-due-date-year" name="lpa-statement-due-date-year" type="text"
+                            inputmode="numeric">
+                        </div>
+                    </div>
+                </div>
+            </fieldset>
+        </div>
+        <div class="govuk-form-group govuk-form-group--error">
+            <fieldset class="govuk-fieldset" role="group" aria-describedby="ip-comments-due-date-hint ip-comments-due-date-error">
+                <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">Interested party comments due</legend>
+                <div id="ip-comments-due-date-hint"
+                class="govuk-hint">For example, 27 3 2007</div>
+                <p id="ip-comments-due-date-error" class="govuk-error-message"><span class="govuk-visually-hidden">Error:</span> Interested party comments
+                    due date must include a year</p>
+                <div class="govuk-date-input" id="ip-comments-due-date">
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="ip-comments-due-date-day">Day</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                            id="ip-comments-due-date-day" name="ip-comments-due-date-day" type="text"
+                            inputmode="numeric">
+                        </div>
+                    </div>
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="ip-comments-due-date-month">Month</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                            id="ip-comments-due-date-month" name="ip-comments-due-date-month" type="text"
+                            inputmode="numeric">
+                        </div>
+                    </div>
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="ip-comments-due-date-year">Year</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-4"
+                            id="ip-comments-due-date-year" name="ip-comments-due-date-year" type="text"
+                            inputmode="numeric">
+                        </div>
+                    </div>
+                </div>
+            </fieldset>
+        </div>
+        <div class="govuk-form-group govuk-form-group--error">
+            <fieldset class="govuk-fieldset" role="group" aria-describedby="final-comments-due-date-hint final-comments-due-date-error">
+                <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">Final comments due</legend>
+                <div id="final-comments-due-date-hint" class="govuk-hint">For example, 27 3 2007</div>
+                <p id="final-comments-due-date-error" class="govuk-error-message"><span class="govuk-visually-hidden">Error:</span> Final comments due date
+                    must include a day
+                    <br>Final comments due date must include a month
+                    <br>Final comments due date must include a year</p>
+                <div class="govuk-date-input"
+                id="final-comments-due-date">
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="final-comments-due-date-day">Day</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                            id="final-comments-due-date-day" name="final-comments-due-date-day" type="text"
+                            inputmode="numeric">
+                        </div>
+                    </div>
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="final-comments-due-date-month">Month</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                            id="final-comments-due-date-month" name="final-comments-due-date-month"
+                            type="text" inputmode="numeric">
+                        </div>
+                    </div>
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="final-comments-due-date-year">Year</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-4"
+                            id="final-comments-due-date-year" name="final-comments-due-date-year" type="text"
+                            inputmode="numeric">
+                        </div>
+                    </div>
+                </div>
+            </fieldset>
+        </div>
+        <div class="govuk-button-group">
+            <button type="submit" class="govuk-button" data-module="govuk-button">Continue</button>
+        </div>
+    </form>
+</main>"
+`;
+
+exports[`Timetable POST /edit S78 Interested party comments should re-render edit timetable page with must be in the future error for Interested party comments 1`] = `
+"<main class="govuk-main-wrapper" id="main-content">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <div class="govuk-error-summary" data-module="govuk-error-summary">
+                <div role="alert">
+                    <h2 class="govuk-error-summary__title"> There is a problem</h2>
+                    <div class="govuk-error-summary__body">
+                        <ul class="govuk-list govuk-error-summary__list">
+                            <li><a href="#lpa-questionnaire-due-date-day">LPA questionnaire due date must include a day</a>
+                            </li>
+                            <li><a href="#lpa-questionnaire-due-date-month">LPA questionnaire due date must include a month</a>
+                            </li>
+                            <li><a href="#lpa-questionnaire-due-date-year">LPA questionnaire due date must include a year</a>
+                            </li>
+                            <li><a href="#lpa-statement-due-date-day">Statements due date must include a day</a>
+                            </li>
+                            <li><a href="#lpa-statement-due-date-month">Statements due date must include a month</a>
+                            </li>
+                            <li><a href="#lpa-statement-due-date-year">Statements due date must include a year</a>
+                            </li>
+                            <li><a href="#">The interested party comments due date must be in the future</a>
+                            </li>
+                            <li><a href="#final-comments-due-date-day">Final comments due date must include a day</a>
+                            </li>
+                            <li><a href="#final-comments-due-date-month">Final comments due date must include a month</a>
+                            </li>
+                            <li><a href="#final-comments-due-date-year">Final comments due date must include a year</a>
+                            </li>
+                        </ul>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Appeal 351062</span>
+            <h1 class="govuk-heading-l">Timetable due dates</h1>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full"></div>
+    </div>
+    <form method="post" novalidate="novalidate">
+        <div class="govuk-form-group govuk-form-group--error">
+            <fieldset class="govuk-fieldset" role="group" aria-describedby="lpa-questionnaire-due-date-hint lpa-questionnaire-due-date-error">
+                <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">LPA questionnaire due</legend>
+                <div id="lpa-questionnaire-due-date-hint"
+                class="govuk-hint">For example, 27 3 2007</div>
+                <p id="lpa-questionnaire-due-date-error" class="govuk-error-message"><span class="govuk-visually-hidden">Error:</span> LPA questionnaire due
+                    date must include a day
+                    <br>LPA questionnaire due date must include a month
+                    <br>LPA questionnaire due date must include a year</p>
+                <div class="govuk-date-input"
+                id="lpa-questionnaire-due-date">
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="lpa-questionnaire-due-date-day">Day</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                            id="lpa-questionnaire-due-date-day" name="lpa-questionnaire-due-date-day"
+                            type="text" inputmode="numeric">
+                        </div>
+                    </div>
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="lpa-questionnaire-due-date-month">Month</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                            id="lpa-questionnaire-due-date-month" name="lpa-questionnaire-due-date-month"
+                            type="text" inputmode="numeric">
+                        </div>
+                    </div>
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="lpa-questionnaire-due-date-year">Year</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-4"
+                            id="lpa-questionnaire-due-date-year" name="lpa-questionnaire-due-date-year"
+                            type="text" inputmode="numeric">
+                        </div>
+                    </div>
+                </div>
+            </fieldset>
+        </div>
+        <div class="govuk-form-group govuk-form-group--error">
+            <fieldset class="govuk-fieldset" role="group" aria-describedby="lpa-statement-due-date-hint lpa-statement-due-date-error">
+                <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">Statements due</legend>
+                <div id="lpa-statement-due-date-hint" class="govuk-hint">For example, 27 3 2007</div>
+                <p id="lpa-statement-due-date-error" class="govuk-error-message"><span class="govuk-visually-hidden">Error:</span> Statements due date must
+                    include a day
+                    <br>Statements due date must include a month
+                    <br>Statements due date must include a year</p>
+                <div class="govuk-date-input"
+                id="lpa-statement-due-date">
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="lpa-statement-due-date-day">Day</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                            id="lpa-statement-due-date-day" name="lpa-statement-due-date-day" type="text"
+                            inputmode="numeric">
+                        </div>
+                    </div>
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="lpa-statement-due-date-month">Month</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                            id="lpa-statement-due-date-month" name="lpa-statement-due-date-month" type="text"
+                            inputmode="numeric">
+                        </div>
+                    </div>
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="lpa-statement-due-date-year">Year</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-4"
+                            id="lpa-statement-due-date-year" name="lpa-statement-due-date-year" type="text"
+                            inputmode="numeric">
+                        </div>
+                    </div>
+                </div>
+            </fieldset>
+        </div>
+        <div class="govuk-form-group">
+            <fieldset class="govuk-fieldset" role="group" aria-describedby="ip-comments-due-date-hint">
+                <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">Interested party comments due</legend>
+                <div id="ip-comments-due-date-hint"
+                class="govuk-hint">For example, 27 3 2007</div>
+                <div class="govuk-date-input" id="ip-comments-due-date">
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="ip-comments-due-date-day">Day</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                            id="ip-comments-due-date-day" name="ip-comments-due-date-day" type="text"
+                            inputmode="numeric">
+                        </div>
+                    </div>
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="ip-comments-due-date-month">Month</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                            id="ip-comments-due-date-month" name="ip-comments-due-date-month" type="text"
+                            inputmode="numeric">
+                        </div>
+                    </div>
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="ip-comments-due-date-year">Year</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-4"
+                            id="ip-comments-due-date-year" name="ip-comments-due-date-year" type="text"
+                            inputmode="numeric">
+                        </div>
+                    </div>
+                </div>
+            </fieldset>
+        </div>
+        <div class="govuk-form-group govuk-form-group--error">
+            <fieldset class="govuk-fieldset" role="group" aria-describedby="final-comments-due-date-hint final-comments-due-date-error">
+                <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">Final comments due</legend>
+                <div id="final-comments-due-date-hint" class="govuk-hint">For example, 27 3 2007</div>
+                <p id="final-comments-due-date-error" class="govuk-error-message"><span class="govuk-visually-hidden">Error:</span> Final comments due date
+                    must include a day
+                    <br>Final comments due date must include a month
+                    <br>Final comments due date must include a year</p>
+                <div class="govuk-date-input"
+                id="final-comments-due-date">
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="final-comments-due-date-day">Day</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                            id="final-comments-due-date-day" name="final-comments-due-date-day" type="text"
+                            inputmode="numeric">
+                        </div>
+                    </div>
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="final-comments-due-date-month">Month</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                            id="final-comments-due-date-month" name="final-comments-due-date-month"
+                            type="text" inputmode="numeric">
+                        </div>
+                    </div>
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="final-comments-due-date-year">Year</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-4"
+                            id="final-comments-due-date-year" name="final-comments-due-date-year" type="text"
+                            inputmode="numeric">
+                        </div>
+                    </div>
+                </div>
+            </fieldset>
+        </div>
+        <div class="govuk-button-group">
+            <button type="submit" class="govuk-button" data-module="govuk-button">Continue</button>
+        </div>
+    </form>
+</main>"
+`;
+
+exports[`Timetable POST /edit S78 Interested party comments should re-render edit timetable page with not a real date error for Interested party comments 1`] = `
+"<main class="govuk-main-wrapper" id="main-content">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <div class="govuk-error-summary" data-module="govuk-error-summary">
+                <div role="alert">
+                    <h2 class="govuk-error-summary__title"> There is a problem</h2>
+                    <div class="govuk-error-summary__body">
+                        <ul class="govuk-list govuk-error-summary__list">
+                            <li><a href="#lpa-questionnaire-due-date-day">LPA questionnaire due date must include a day</a>
+                            </li>
+                            <li><a href="#lpa-questionnaire-due-date-month">LPA questionnaire due date must include a month</a>
+                            </li>
+                            <li><a href="#lpa-questionnaire-due-date-year">LPA questionnaire due date must include a year</a>
+                            </li>
+                            <li><a href="#lpa-statement-due-date-day">Statements due date must include a day</a>
+                            </li>
+                            <li><a href="#lpa-statement-due-date-month">Statements due date must include a month</a>
+                            </li>
+                            <li><a href="#lpa-statement-due-date-year">Statements due date must include a year</a>
+                            </li>
+                            <li><a href="#">Interested party comments due date must be a real date</a>
+                            </li>
+                            <li><a href="#final-comments-due-date-day">Final comments due date must include a day</a>
+                            </li>
+                            <li><a href="#final-comments-due-date-month">Final comments due date must include a month</a>
+                            </li>
+                            <li><a href="#final-comments-due-date-year">Final comments due date must include a year</a>
+                            </li>
+                        </ul>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Appeal 351062</span>
+            <h1 class="govuk-heading-l">Timetable due dates</h1>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full"></div>
+    </div>
+    <form method="post" novalidate="novalidate">
+        <div class="govuk-form-group govuk-form-group--error">
+            <fieldset class="govuk-fieldset" role="group" aria-describedby="lpa-questionnaire-due-date-hint lpa-questionnaire-due-date-error">
+                <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">LPA questionnaire due</legend>
+                <div id="lpa-questionnaire-due-date-hint"
+                class="govuk-hint">For example, 27 3 2007</div>
+                <p id="lpa-questionnaire-due-date-error" class="govuk-error-message"><span class="govuk-visually-hidden">Error:</span> LPA questionnaire due
+                    date must include a day
+                    <br>LPA questionnaire due date must include a month
+                    <br>LPA questionnaire due date must include a year</p>
+                <div class="govuk-date-input"
+                id="lpa-questionnaire-due-date">
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="lpa-questionnaire-due-date-day">Day</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                            id="lpa-questionnaire-due-date-day" name="lpa-questionnaire-due-date-day"
+                            type="text" inputmode="numeric">
+                        </div>
+                    </div>
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="lpa-questionnaire-due-date-month">Month</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                            id="lpa-questionnaire-due-date-month" name="lpa-questionnaire-due-date-month"
+                            type="text" inputmode="numeric">
+                        </div>
+                    </div>
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="lpa-questionnaire-due-date-year">Year</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-4"
+                            id="lpa-questionnaire-due-date-year" name="lpa-questionnaire-due-date-year"
+                            type="text" inputmode="numeric">
+                        </div>
+                    </div>
+                </div>
+            </fieldset>
+        </div>
+        <div class="govuk-form-group govuk-form-group--error">
+            <fieldset class="govuk-fieldset" role="group" aria-describedby="lpa-statement-due-date-hint lpa-statement-due-date-error">
+                <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">Statements due</legend>
+                <div id="lpa-statement-due-date-hint" class="govuk-hint">For example, 27 3 2007</div>
+                <p id="lpa-statement-due-date-error" class="govuk-error-message"><span class="govuk-visually-hidden">Error:</span> Statements due date must
+                    include a day
+                    <br>Statements due date must include a month
+                    <br>Statements due date must include a year</p>
+                <div class="govuk-date-input"
+                id="lpa-statement-due-date">
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="lpa-statement-due-date-day">Day</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                            id="lpa-statement-due-date-day" name="lpa-statement-due-date-day" type="text"
+                            inputmode="numeric">
+                        </div>
+                    </div>
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="lpa-statement-due-date-month">Month</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                            id="lpa-statement-due-date-month" name="lpa-statement-due-date-month" type="text"
+                            inputmode="numeric">
+                        </div>
+                    </div>
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="lpa-statement-due-date-year">Year</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-4"
+                            id="lpa-statement-due-date-year" name="lpa-statement-due-date-year" type="text"
+                            inputmode="numeric">
+                        </div>
+                    </div>
+                </div>
+            </fieldset>
+        </div>
+        <div class="govuk-form-group">
+            <fieldset class="govuk-fieldset" role="group" aria-describedby="ip-comments-due-date-hint">
+                <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">Interested party comments due</legend>
+                <div id="ip-comments-due-date-hint"
+                class="govuk-hint">For example, 27 3 2007</div>
+                <div class="govuk-date-input" id="ip-comments-due-date">
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="ip-comments-due-date-day">Day</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                            id="ip-comments-due-date-day" name="ip-comments-due-date-day" type="text"
+                            inputmode="numeric">
+                        </div>
+                    </div>
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="ip-comments-due-date-month">Month</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                            id="ip-comments-due-date-month" name="ip-comments-due-date-month" type="text"
+                            inputmode="numeric">
+                        </div>
+                    </div>
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="ip-comments-due-date-year">Year</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-4"
+                            id="ip-comments-due-date-year" name="ip-comments-due-date-year" type="text"
+                            inputmode="numeric">
+                        </div>
+                    </div>
+                </div>
+            </fieldset>
+        </div>
+        <div class="govuk-form-group govuk-form-group--error">
+            <fieldset class="govuk-fieldset" role="group" aria-describedby="final-comments-due-date-hint final-comments-due-date-error">
+                <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">Final comments due</legend>
+                <div id="final-comments-due-date-hint" class="govuk-hint">For example, 27 3 2007</div>
+                <p id="final-comments-due-date-error" class="govuk-error-message"><span class="govuk-visually-hidden">Error:</span> Final comments due date
+                    must include a day
+                    <br>Final comments due date must include a month
+                    <br>Final comments due date must include a year</p>
+                <div class="govuk-date-input"
+                id="final-comments-due-date">
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="final-comments-due-date-day">Day</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                            id="final-comments-due-date-day" name="final-comments-due-date-day" type="text"
+                            inputmode="numeric">
+                        </div>
+                    </div>
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="final-comments-due-date-month">Month</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                            id="final-comments-due-date-month" name="final-comments-due-date-month"
+                            type="text" inputmode="numeric">
+                        </div>
+                    </div>
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="final-comments-due-date-year">Year</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-4"
+                            id="final-comments-due-date-year" name="final-comments-due-date-year" type="text"
+                            inputmode="numeric">
+                        </div>
+                    </div>
+                </div>
+            </fieldset>
+        </div>
+        <div class="govuk-button-group">
+            <button type="submit" class="govuk-button" data-module="govuk-button">Continue</button>
+        </div>
+    </form>
+</main>"
+`;
+
+exports[`Timetable POST /edit S78 LPA questionnaire should re-render edit timetable page with missing day error for LPA questionnaire 1`] = `
+"<main class="govuk-main-wrapper" id="main-content">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <div class="govuk-error-summary" data-module="govuk-error-summary">
+                <div role="alert">
+                    <h2 class="govuk-error-summary__title"> There is a problem</h2>
+                    <div class="govuk-error-summary__body">
+                        <ul class="govuk-list govuk-error-summary__list">
+                            <li><a href="#lpa-questionnaire-due-date-day">LPA questionnaire due date must include a day</a>
+                            </li>
+                            <li><a href="#lpa-statement-due-date-day">Statements due date must include a day</a>
+                            </li>
+                            <li><a href="#lpa-statement-due-date-month">Statements due date must include a month</a>
+                            </li>
+                            <li><a href="#lpa-statement-due-date-year">Statements due date must include a year</a>
+                            </li>
+                            <li><a href="#ip-comments-due-date-day">Interested party comments due date must include a day</a>
+                            </li>
+                            <li><a href="#ip-comments-due-date-month">Interested party comments due date must include a month</a>
+                            </li>
+                            <li><a href="#ip-comments-due-date-year">Interested party comments due date must include a year</a>
+                            </li>
+                            <li><a href="#final-comments-due-date-day">Final comments due date must include a day</a>
+                            </li>
+                            <li><a href="#final-comments-due-date-month">Final comments due date must include a month</a>
+                            </li>
+                            <li><a href="#final-comments-due-date-year">Final comments due date must include a year</a>
+                            </li>
+                        </ul>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Appeal 351062</span>
+            <h1 class="govuk-heading-l">Timetable due dates</h1>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full"></div>
+    </div>
+    <form method="post" novalidate="novalidate">
+        <div class="govuk-form-group govuk-form-group--error">
+            <fieldset class="govuk-fieldset" role="group" aria-describedby="lpa-questionnaire-due-date-hint lpa-questionnaire-due-date-error">
+                <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">LPA questionnaire due</legend>
+                <div id="lpa-questionnaire-due-date-hint"
+                class="govuk-hint">For example, 27 3 2007</div>
+                <p id="lpa-questionnaire-due-date-error" class="govuk-error-message"><span class="govuk-visually-hidden">Error:</span> LPA questionnaire due
+                    date must include a day</p>
+                <div class="govuk-date-input" id="lpa-questionnaire-due-date">
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="lpa-questionnaire-due-date-day">Day</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                            id="lpa-questionnaire-due-date-day" name="lpa-questionnaire-due-date-day"
+                            type="text" inputmode="numeric">
+                        </div>
+                    </div>
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="lpa-questionnaire-due-date-month">Month</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                            id="lpa-questionnaire-due-date-month" name="lpa-questionnaire-due-date-month"
+                            type="text" inputmode="numeric">
+                        </div>
+                    </div>
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="lpa-questionnaire-due-date-year">Year</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-4"
+                            id="lpa-questionnaire-due-date-year" name="lpa-questionnaire-due-date-year"
+                            type="text" inputmode="numeric">
+                        </div>
+                    </div>
+                </div>
+            </fieldset>
+        </div>
+        <div class="govuk-form-group govuk-form-group--error">
+            <fieldset class="govuk-fieldset" role="group" aria-describedby="lpa-statement-due-date-hint lpa-statement-due-date-error">
+                <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">Statements due</legend>
+                <div id="lpa-statement-due-date-hint" class="govuk-hint">For example, 27 3 2007</div>
+                <p id="lpa-statement-due-date-error" class="govuk-error-message"><span class="govuk-visually-hidden">Error:</span> Statements due date must
+                    include a day
+                    <br>Statements due date must include a month
+                    <br>Statements due date must include a year</p>
+                <div class="govuk-date-input"
+                id="lpa-statement-due-date">
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="lpa-statement-due-date-day">Day</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                            id="lpa-statement-due-date-day" name="lpa-statement-due-date-day" type="text"
+                            inputmode="numeric">
+                        </div>
+                    </div>
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="lpa-statement-due-date-month">Month</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                            id="lpa-statement-due-date-month" name="lpa-statement-due-date-month" type="text"
+                            inputmode="numeric">
+                        </div>
+                    </div>
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="lpa-statement-due-date-year">Year</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-4"
+                            id="lpa-statement-due-date-year" name="lpa-statement-due-date-year" type="text"
+                            inputmode="numeric">
+                        </div>
+                    </div>
+                </div>
+            </fieldset>
+        </div>
+        <div class="govuk-form-group govuk-form-group--error">
+            <fieldset class="govuk-fieldset" role="group" aria-describedby="ip-comments-due-date-hint ip-comments-due-date-error">
+                <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">Interested party comments due</legend>
+                <div id="ip-comments-due-date-hint"
+                class="govuk-hint">For example, 27 3 2007</div>
+                <p id="ip-comments-due-date-error" class="govuk-error-message"><span class="govuk-visually-hidden">Error:</span> Interested party comments
+                    due date must include a day
+                    <br>Interested party comments due date must include a month
+                    <br>Interested party comments due date must include a year</p>
+                <div class="govuk-date-input"
+                id="ip-comments-due-date">
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="ip-comments-due-date-day">Day</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                            id="ip-comments-due-date-day" name="ip-comments-due-date-day" type="text"
+                            inputmode="numeric">
+                        </div>
+                    </div>
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="ip-comments-due-date-month">Month</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                            id="ip-comments-due-date-month" name="ip-comments-due-date-month" type="text"
+                            inputmode="numeric">
+                        </div>
+                    </div>
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="ip-comments-due-date-year">Year</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-4"
+                            id="ip-comments-due-date-year" name="ip-comments-due-date-year" type="text"
+                            inputmode="numeric">
+                        </div>
+                    </div>
+                </div>
+            </fieldset>
+        </div>
+        <div class="govuk-form-group govuk-form-group--error">
+            <fieldset class="govuk-fieldset" role="group" aria-describedby="final-comments-due-date-hint final-comments-due-date-error">
+                <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">Final comments due</legend>
+                <div id="final-comments-due-date-hint" class="govuk-hint">For example, 27 3 2007</div>
+                <p id="final-comments-due-date-error" class="govuk-error-message"><span class="govuk-visually-hidden">Error:</span> Final comments due date
+                    must include a day
+                    <br>Final comments due date must include a month
+                    <br>Final comments due date must include a year</p>
+                <div class="govuk-date-input"
+                id="final-comments-due-date">
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="final-comments-due-date-day">Day</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                            id="final-comments-due-date-day" name="final-comments-due-date-day" type="text"
+                            inputmode="numeric">
+                        </div>
+                    </div>
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="final-comments-due-date-month">Month</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                            id="final-comments-due-date-month" name="final-comments-due-date-month"
+                            type="text" inputmode="numeric">
+                        </div>
+                    </div>
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="final-comments-due-date-year">Year</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-4"
+                            id="final-comments-due-date-year" name="final-comments-due-date-year" type="text"
+                            inputmode="numeric">
+                        </div>
+                    </div>
+                </div>
+            </fieldset>
+        </div>
+        <div class="govuk-button-group">
+            <button type="submit" class="govuk-button" data-module="govuk-button">Continue</button>
+        </div>
+    </form>
+</main>"
+`;
+
+exports[`Timetable POST /edit S78 LPA questionnaire should re-render edit timetable page with missing month error for LPA questionnaire 1`] = `
+"<main class="govuk-main-wrapper" id="main-content">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <div class="govuk-error-summary" data-module="govuk-error-summary">
+                <div role="alert">
+                    <h2 class="govuk-error-summary__title"> There is a problem</h2>
+                    <div class="govuk-error-summary__body">
+                        <ul class="govuk-list govuk-error-summary__list">
+                            <li><a href="#lpa-questionnaire-due-date-month">LPA questionnaire due date must include a month</a>
+                            </li>
+                            <li><a href="#lpa-statement-due-date-day">Statements due date must include a day</a>
+                            </li>
+                            <li><a href="#lpa-statement-due-date-month">Statements due date must include a month</a>
+                            </li>
+                            <li><a href="#lpa-statement-due-date-year">Statements due date must include a year</a>
+                            </li>
+                            <li><a href="#ip-comments-due-date-day">Interested party comments due date must include a day</a>
+                            </li>
+                            <li><a href="#ip-comments-due-date-month">Interested party comments due date must include a month</a>
+                            </li>
+                            <li><a href="#ip-comments-due-date-year">Interested party comments due date must include a year</a>
+                            </li>
+                            <li><a href="#final-comments-due-date-day">Final comments due date must include a day</a>
+                            </li>
+                            <li><a href="#final-comments-due-date-month">Final comments due date must include a month</a>
+                            </li>
+                            <li><a href="#final-comments-due-date-year">Final comments due date must include a year</a>
+                            </li>
+                        </ul>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Appeal 351062</span>
+            <h1 class="govuk-heading-l">Timetable due dates</h1>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full"></div>
+    </div>
+    <form method="post" novalidate="novalidate">
+        <div class="govuk-form-group govuk-form-group--error">
+            <fieldset class="govuk-fieldset" role="group" aria-describedby="lpa-questionnaire-due-date-hint lpa-questionnaire-due-date-error">
+                <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">LPA questionnaire due</legend>
+                <div id="lpa-questionnaire-due-date-hint"
+                class="govuk-hint">For example, 27 3 2007</div>
+                <p id="lpa-questionnaire-due-date-error" class="govuk-error-message"><span class="govuk-visually-hidden">Error:</span> LPA questionnaire due
+                    date must include a month</p>
+                <div class="govuk-date-input" id="lpa-questionnaire-due-date">
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="lpa-questionnaire-due-date-day">Day</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                            id="lpa-questionnaire-due-date-day" name="lpa-questionnaire-due-date-day"
+                            type="text" inputmode="numeric">
+                        </div>
+                    </div>
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="lpa-questionnaire-due-date-month">Month</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                            id="lpa-questionnaire-due-date-month" name="lpa-questionnaire-due-date-month"
+                            type="text" inputmode="numeric">
+                        </div>
+                    </div>
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="lpa-questionnaire-due-date-year">Year</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-4"
+                            id="lpa-questionnaire-due-date-year" name="lpa-questionnaire-due-date-year"
+                            type="text" inputmode="numeric">
+                        </div>
+                    </div>
+                </div>
+            </fieldset>
+        </div>
+        <div class="govuk-form-group govuk-form-group--error">
+            <fieldset class="govuk-fieldset" role="group" aria-describedby="lpa-statement-due-date-hint lpa-statement-due-date-error">
+                <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">Statements due</legend>
+                <div id="lpa-statement-due-date-hint" class="govuk-hint">For example, 27 3 2007</div>
+                <p id="lpa-statement-due-date-error" class="govuk-error-message"><span class="govuk-visually-hidden">Error:</span> Statements due date must
+                    include a day
+                    <br>Statements due date must include a month
+                    <br>Statements due date must include a year</p>
+                <div class="govuk-date-input"
+                id="lpa-statement-due-date">
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="lpa-statement-due-date-day">Day</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                            id="lpa-statement-due-date-day" name="lpa-statement-due-date-day" type="text"
+                            inputmode="numeric">
+                        </div>
+                    </div>
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="lpa-statement-due-date-month">Month</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                            id="lpa-statement-due-date-month" name="lpa-statement-due-date-month" type="text"
+                            inputmode="numeric">
+                        </div>
+                    </div>
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="lpa-statement-due-date-year">Year</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-4"
+                            id="lpa-statement-due-date-year" name="lpa-statement-due-date-year" type="text"
+                            inputmode="numeric">
+                        </div>
+                    </div>
+                </div>
+            </fieldset>
+        </div>
+        <div class="govuk-form-group govuk-form-group--error">
+            <fieldset class="govuk-fieldset" role="group" aria-describedby="ip-comments-due-date-hint ip-comments-due-date-error">
+                <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">Interested party comments due</legend>
+                <div id="ip-comments-due-date-hint"
+                class="govuk-hint">For example, 27 3 2007</div>
+                <p id="ip-comments-due-date-error" class="govuk-error-message"><span class="govuk-visually-hidden">Error:</span> Interested party comments
+                    due date must include a day
+                    <br>Interested party comments due date must include a month
+                    <br>Interested party comments due date must include a year</p>
+                <div class="govuk-date-input"
+                id="ip-comments-due-date">
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="ip-comments-due-date-day">Day</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                            id="ip-comments-due-date-day" name="ip-comments-due-date-day" type="text"
+                            inputmode="numeric">
+                        </div>
+                    </div>
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="ip-comments-due-date-month">Month</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                            id="ip-comments-due-date-month" name="ip-comments-due-date-month" type="text"
+                            inputmode="numeric">
+                        </div>
+                    </div>
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="ip-comments-due-date-year">Year</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-4"
+                            id="ip-comments-due-date-year" name="ip-comments-due-date-year" type="text"
+                            inputmode="numeric">
+                        </div>
+                    </div>
+                </div>
+            </fieldset>
+        </div>
+        <div class="govuk-form-group govuk-form-group--error">
+            <fieldset class="govuk-fieldset" role="group" aria-describedby="final-comments-due-date-hint final-comments-due-date-error">
+                <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">Final comments due</legend>
+                <div id="final-comments-due-date-hint" class="govuk-hint">For example, 27 3 2007</div>
+                <p id="final-comments-due-date-error" class="govuk-error-message"><span class="govuk-visually-hidden">Error:</span> Final comments due date
+                    must include a day
+                    <br>Final comments due date must include a month
+                    <br>Final comments due date must include a year</p>
+                <div class="govuk-date-input"
+                id="final-comments-due-date">
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="final-comments-due-date-day">Day</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                            id="final-comments-due-date-day" name="final-comments-due-date-day" type="text"
+                            inputmode="numeric">
+                        </div>
+                    </div>
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="final-comments-due-date-month">Month</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                            id="final-comments-due-date-month" name="final-comments-due-date-month"
+                            type="text" inputmode="numeric">
+                        </div>
+                    </div>
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="final-comments-due-date-year">Year</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-4"
+                            id="final-comments-due-date-year" name="final-comments-due-date-year" type="text"
+                            inputmode="numeric">
+                        </div>
+                    </div>
+                </div>
+            </fieldset>
+        </div>
+        <div class="govuk-button-group">
+            <button type="submit" class="govuk-button" data-module="govuk-button">Continue</button>
+        </div>
+    </form>
+</main>"
+`;
+
+exports[`Timetable POST /edit S78 LPA questionnaire should re-render edit timetable page with missing year error for LPA questionnaire 1`] = `
+"<main class="govuk-main-wrapper" id="main-content">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <div class="govuk-error-summary" data-module="govuk-error-summary">
+                <div role="alert">
+                    <h2 class="govuk-error-summary__title"> There is a problem</h2>
+                    <div class="govuk-error-summary__body">
+                        <ul class="govuk-list govuk-error-summary__list">
+                            <li><a href="#lpa-questionnaire-due-date-year">LPA questionnaire due date must include a year</a>
+                            </li>
+                            <li><a href="#lpa-statement-due-date-day">Statements due date must include a day</a>
+                            </li>
+                            <li><a href="#lpa-statement-due-date-month">Statements due date must include a month</a>
+                            </li>
+                            <li><a href="#lpa-statement-due-date-year">Statements due date must include a year</a>
+                            </li>
+                            <li><a href="#ip-comments-due-date-day">Interested party comments due date must include a day</a>
+                            </li>
+                            <li><a href="#ip-comments-due-date-month">Interested party comments due date must include a month</a>
+                            </li>
+                            <li><a href="#ip-comments-due-date-year">Interested party comments due date must include a year</a>
+                            </li>
+                            <li><a href="#final-comments-due-date-day">Final comments due date must include a day</a>
+                            </li>
+                            <li><a href="#final-comments-due-date-month">Final comments due date must include a month</a>
+                            </li>
+                            <li><a href="#final-comments-due-date-year">Final comments due date must include a year</a>
+                            </li>
+                        </ul>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Appeal 351062</span>
+            <h1 class="govuk-heading-l">Timetable due dates</h1>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full"></div>
+    </div>
+    <form method="post" novalidate="novalidate">
+        <div class="govuk-form-group govuk-form-group--error">
+            <fieldset class="govuk-fieldset" role="group" aria-describedby="lpa-questionnaire-due-date-hint lpa-questionnaire-due-date-error">
+                <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">LPA questionnaire due</legend>
+                <div id="lpa-questionnaire-due-date-hint"
+                class="govuk-hint">For example, 27 3 2007</div>
+                <p id="lpa-questionnaire-due-date-error" class="govuk-error-message"><span class="govuk-visually-hidden">Error:</span> LPA questionnaire due
+                    date must include a year</p>
+                <div class="govuk-date-input" id="lpa-questionnaire-due-date">
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="lpa-questionnaire-due-date-day">Day</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                            id="lpa-questionnaire-due-date-day" name="lpa-questionnaire-due-date-day"
+                            type="text" inputmode="numeric">
+                        </div>
+                    </div>
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="lpa-questionnaire-due-date-month">Month</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                            id="lpa-questionnaire-due-date-month" name="lpa-questionnaire-due-date-month"
+                            type="text" inputmode="numeric">
+                        </div>
+                    </div>
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="lpa-questionnaire-due-date-year">Year</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-4"
+                            id="lpa-questionnaire-due-date-year" name="lpa-questionnaire-due-date-year"
+                            type="text" inputmode="numeric">
+                        </div>
+                    </div>
+                </div>
+            </fieldset>
+        </div>
+        <div class="govuk-form-group govuk-form-group--error">
+            <fieldset class="govuk-fieldset" role="group" aria-describedby="lpa-statement-due-date-hint lpa-statement-due-date-error">
+                <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">Statements due</legend>
+                <div id="lpa-statement-due-date-hint" class="govuk-hint">For example, 27 3 2007</div>
+                <p id="lpa-statement-due-date-error" class="govuk-error-message"><span class="govuk-visually-hidden">Error:</span> Statements due date must
+                    include a day
+                    <br>Statements due date must include a month
+                    <br>Statements due date must include a year</p>
+                <div class="govuk-date-input"
+                id="lpa-statement-due-date">
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="lpa-statement-due-date-day">Day</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                            id="lpa-statement-due-date-day" name="lpa-statement-due-date-day" type="text"
+                            inputmode="numeric">
+                        </div>
+                    </div>
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="lpa-statement-due-date-month">Month</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                            id="lpa-statement-due-date-month" name="lpa-statement-due-date-month" type="text"
+                            inputmode="numeric">
+                        </div>
+                    </div>
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="lpa-statement-due-date-year">Year</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-4"
+                            id="lpa-statement-due-date-year" name="lpa-statement-due-date-year" type="text"
+                            inputmode="numeric">
+                        </div>
+                    </div>
+                </div>
+            </fieldset>
+        </div>
+        <div class="govuk-form-group govuk-form-group--error">
+            <fieldset class="govuk-fieldset" role="group" aria-describedby="ip-comments-due-date-hint ip-comments-due-date-error">
+                <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">Interested party comments due</legend>
+                <div id="ip-comments-due-date-hint"
+                class="govuk-hint">For example, 27 3 2007</div>
+                <p id="ip-comments-due-date-error" class="govuk-error-message"><span class="govuk-visually-hidden">Error:</span> Interested party comments
+                    due date must include a day
+                    <br>Interested party comments due date must include a month
+                    <br>Interested party comments due date must include a year</p>
+                <div class="govuk-date-input"
+                id="ip-comments-due-date">
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="ip-comments-due-date-day">Day</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                            id="ip-comments-due-date-day" name="ip-comments-due-date-day" type="text"
+                            inputmode="numeric">
+                        </div>
+                    </div>
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="ip-comments-due-date-month">Month</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                            id="ip-comments-due-date-month" name="ip-comments-due-date-month" type="text"
+                            inputmode="numeric">
+                        </div>
+                    </div>
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="ip-comments-due-date-year">Year</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-4"
+                            id="ip-comments-due-date-year" name="ip-comments-due-date-year" type="text"
+                            inputmode="numeric">
+                        </div>
+                    </div>
+                </div>
+            </fieldset>
+        </div>
+        <div class="govuk-form-group govuk-form-group--error">
+            <fieldset class="govuk-fieldset" role="group" aria-describedby="final-comments-due-date-hint final-comments-due-date-error">
+                <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">Final comments due</legend>
+                <div id="final-comments-due-date-hint" class="govuk-hint">For example, 27 3 2007</div>
+                <p id="final-comments-due-date-error" class="govuk-error-message"><span class="govuk-visually-hidden">Error:</span> Final comments due date
+                    must include a day
+                    <br>Final comments due date must include a month
+                    <br>Final comments due date must include a year</p>
+                <div class="govuk-date-input"
+                id="final-comments-due-date">
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="final-comments-due-date-day">Day</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                            id="final-comments-due-date-day" name="final-comments-due-date-day" type="text"
+                            inputmode="numeric">
+                        </div>
+                    </div>
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="final-comments-due-date-month">Month</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                            id="final-comments-due-date-month" name="final-comments-due-date-month"
+                            type="text" inputmode="numeric">
+                        </div>
+                    </div>
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="final-comments-due-date-year">Year</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-4"
+                            id="final-comments-due-date-year" name="final-comments-due-date-year" type="text"
+                            inputmode="numeric">
+                        </div>
+                    </div>
+                </div>
+            </fieldset>
+        </div>
+        <div class="govuk-button-group">
+            <button type="submit" class="govuk-button" data-module="govuk-button">Continue</button>
+        </div>
+    </form>
+</main>"
+`;
+
+exports[`Timetable POST /edit S78 LPA questionnaire should re-render edit timetable page with must be in the future error for LPA questionnaire 1`] = `
+"<main class="govuk-main-wrapper" id="main-content">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <div class="govuk-error-summary" data-module="govuk-error-summary">
+                <div role="alert">
+                    <h2 class="govuk-error-summary__title"> There is a problem</h2>
+                    <div class="govuk-error-summary__body">
+                        <ul class="govuk-list govuk-error-summary__list">
+                            <li><a href="#">The lpa questionnaire due date must be in the future</a>
+                            </li>
+                            <li><a href="#lpa-statement-due-date-day">Statements due date must include a day</a>
+                            </li>
+                            <li><a href="#lpa-statement-due-date-month">Statements due date must include a month</a>
+                            </li>
+                            <li><a href="#lpa-statement-due-date-year">Statements due date must include a year</a>
+                            </li>
+                            <li><a href="#ip-comments-due-date-day">Interested party comments due date must include a day</a>
+                            </li>
+                            <li><a href="#ip-comments-due-date-month">Interested party comments due date must include a month</a>
+                            </li>
+                            <li><a href="#ip-comments-due-date-year">Interested party comments due date must include a year</a>
+                            </li>
+                            <li><a href="#final-comments-due-date-day">Final comments due date must include a day</a>
+                            </li>
+                            <li><a href="#final-comments-due-date-month">Final comments due date must include a month</a>
+                            </li>
+                            <li><a href="#final-comments-due-date-year">Final comments due date must include a year</a>
+                            </li>
+                        </ul>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Appeal 351062</span>
+            <h1 class="govuk-heading-l">Timetable due dates</h1>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full"></div>
+    </div>
+    <form method="post" novalidate="novalidate">
+        <div class="govuk-form-group">
+            <fieldset class="govuk-fieldset" role="group" aria-describedby="lpa-questionnaire-due-date-hint">
+                <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">LPA questionnaire due</legend>
+                <div id="lpa-questionnaire-due-date-hint"
+                class="govuk-hint">For example, 27 3 2007</div>
+                <div class="govuk-date-input" id="lpa-questionnaire-due-date">
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="lpa-questionnaire-due-date-day">Day</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                            id="lpa-questionnaire-due-date-day" name="lpa-questionnaire-due-date-day"
+                            type="text" inputmode="numeric">
+                        </div>
+                    </div>
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="lpa-questionnaire-due-date-month">Month</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                            id="lpa-questionnaire-due-date-month" name="lpa-questionnaire-due-date-month"
+                            type="text" inputmode="numeric">
+                        </div>
+                    </div>
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="lpa-questionnaire-due-date-year">Year</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-4"
+                            id="lpa-questionnaire-due-date-year" name="lpa-questionnaire-due-date-year"
+                            type="text" inputmode="numeric">
+                        </div>
+                    </div>
+                </div>
+            </fieldset>
+        </div>
+        <div class="govuk-form-group govuk-form-group--error">
+            <fieldset class="govuk-fieldset" role="group" aria-describedby="lpa-statement-due-date-hint lpa-statement-due-date-error">
+                <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">Statements due</legend>
+                <div id="lpa-statement-due-date-hint" class="govuk-hint">For example, 27 3 2007</div>
+                <p id="lpa-statement-due-date-error" class="govuk-error-message"><span class="govuk-visually-hidden">Error:</span> Statements due date must
+                    include a day
+                    <br>Statements due date must include a month
+                    <br>Statements due date must include a year</p>
+                <div class="govuk-date-input"
+                id="lpa-statement-due-date">
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="lpa-statement-due-date-day">Day</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                            id="lpa-statement-due-date-day" name="lpa-statement-due-date-day" type="text"
+                            inputmode="numeric">
+                        </div>
+                    </div>
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="lpa-statement-due-date-month">Month</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                            id="lpa-statement-due-date-month" name="lpa-statement-due-date-month" type="text"
+                            inputmode="numeric">
+                        </div>
+                    </div>
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="lpa-statement-due-date-year">Year</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-4"
+                            id="lpa-statement-due-date-year" name="lpa-statement-due-date-year" type="text"
+                            inputmode="numeric">
+                        </div>
+                    </div>
+                </div>
+            </fieldset>
+        </div>
+        <div class="govuk-form-group govuk-form-group--error">
+            <fieldset class="govuk-fieldset" role="group" aria-describedby="ip-comments-due-date-hint ip-comments-due-date-error">
+                <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">Interested party comments due</legend>
+                <div id="ip-comments-due-date-hint"
+                class="govuk-hint">For example, 27 3 2007</div>
+                <p id="ip-comments-due-date-error" class="govuk-error-message"><span class="govuk-visually-hidden">Error:</span> Interested party comments
+                    due date must include a day
+                    <br>Interested party comments due date must include a month
+                    <br>Interested party comments due date must include a year</p>
+                <div class="govuk-date-input"
+                id="ip-comments-due-date">
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="ip-comments-due-date-day">Day</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                            id="ip-comments-due-date-day" name="ip-comments-due-date-day" type="text"
+                            inputmode="numeric">
+                        </div>
+                    </div>
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="ip-comments-due-date-month">Month</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                            id="ip-comments-due-date-month" name="ip-comments-due-date-month" type="text"
+                            inputmode="numeric">
+                        </div>
+                    </div>
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="ip-comments-due-date-year">Year</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-4"
+                            id="ip-comments-due-date-year" name="ip-comments-due-date-year" type="text"
+                            inputmode="numeric">
+                        </div>
+                    </div>
+                </div>
+            </fieldset>
+        </div>
+        <div class="govuk-form-group govuk-form-group--error">
+            <fieldset class="govuk-fieldset" role="group" aria-describedby="final-comments-due-date-hint final-comments-due-date-error">
+                <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">Final comments due</legend>
+                <div id="final-comments-due-date-hint" class="govuk-hint">For example, 27 3 2007</div>
+                <p id="final-comments-due-date-error" class="govuk-error-message"><span class="govuk-visually-hidden">Error:</span> Final comments due date
+                    must include a day
+                    <br>Final comments due date must include a month
+                    <br>Final comments due date must include a year</p>
+                <div class="govuk-date-input"
+                id="final-comments-due-date">
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="final-comments-due-date-day">Day</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                            id="final-comments-due-date-day" name="final-comments-due-date-day" type="text"
+                            inputmode="numeric">
+                        </div>
+                    </div>
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="final-comments-due-date-month">Month</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                            id="final-comments-due-date-month" name="final-comments-due-date-month"
+                            type="text" inputmode="numeric">
+                        </div>
+                    </div>
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="final-comments-due-date-year">Year</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-4"
+                            id="final-comments-due-date-year" name="final-comments-due-date-year" type="text"
+                            inputmode="numeric">
+                        </div>
+                    </div>
+                </div>
+            </fieldset>
+        </div>
+        <div class="govuk-button-group">
+            <button type="submit" class="govuk-button" data-module="govuk-button">Continue</button>
+        </div>
+    </form>
+</main>"
+`;
+
+exports[`Timetable POST /edit S78 LPA questionnaire should re-render edit timetable page with not a real date error for LPA questionnaire 1`] = `
+"<main class="govuk-main-wrapper" id="main-content">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <div class="govuk-error-summary" data-module="govuk-error-summary">
+                <div role="alert">
+                    <h2 class="govuk-error-summary__title"> There is a problem</h2>
+                    <div class="govuk-error-summary__body">
+                        <ul class="govuk-list govuk-error-summary__list">
+                            <li><a href="#">LPA questionnaire due date must be a real date</a>
+                            </li>
+                            <li><a href="#lpa-statement-due-date-day">Statements due date must include a day</a>
+                            </li>
+                            <li><a href="#lpa-statement-due-date-month">Statements due date must include a month</a>
+                            </li>
+                            <li><a href="#lpa-statement-due-date-year">Statements due date must include a year</a>
+                            </li>
+                            <li><a href="#ip-comments-due-date-day">Interested party comments due date must include a day</a>
+                            </li>
+                            <li><a href="#ip-comments-due-date-month">Interested party comments due date must include a month</a>
+                            </li>
+                            <li><a href="#ip-comments-due-date-year">Interested party comments due date must include a year</a>
+                            </li>
+                            <li><a href="#final-comments-due-date-day">Final comments due date must include a day</a>
+                            </li>
+                            <li><a href="#final-comments-due-date-month">Final comments due date must include a month</a>
+                            </li>
+                            <li><a href="#final-comments-due-date-year">Final comments due date must include a year</a>
+                            </li>
+                        </ul>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Appeal 351062</span>
+            <h1 class="govuk-heading-l">Timetable due dates</h1>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full"></div>
+    </div>
+    <form method="post" novalidate="novalidate">
+        <div class="govuk-form-group">
+            <fieldset class="govuk-fieldset" role="group" aria-describedby="lpa-questionnaire-due-date-hint">
+                <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">LPA questionnaire due</legend>
+                <div id="lpa-questionnaire-due-date-hint"
+                class="govuk-hint">For example, 27 3 2007</div>
+                <div class="govuk-date-input" id="lpa-questionnaire-due-date">
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="lpa-questionnaire-due-date-day">Day</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                            id="lpa-questionnaire-due-date-day" name="lpa-questionnaire-due-date-day"
+                            type="text" inputmode="numeric">
+                        </div>
+                    </div>
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="lpa-questionnaire-due-date-month">Month</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                            id="lpa-questionnaire-due-date-month" name="lpa-questionnaire-due-date-month"
+                            type="text" inputmode="numeric">
+                        </div>
+                    </div>
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="lpa-questionnaire-due-date-year">Year</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-4"
+                            id="lpa-questionnaire-due-date-year" name="lpa-questionnaire-due-date-year"
+                            type="text" inputmode="numeric">
+                        </div>
+                    </div>
+                </div>
+            </fieldset>
+        </div>
+        <div class="govuk-form-group govuk-form-group--error">
+            <fieldset class="govuk-fieldset" role="group" aria-describedby="lpa-statement-due-date-hint lpa-statement-due-date-error">
+                <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">Statements due</legend>
+                <div id="lpa-statement-due-date-hint" class="govuk-hint">For example, 27 3 2007</div>
+                <p id="lpa-statement-due-date-error" class="govuk-error-message"><span class="govuk-visually-hidden">Error:</span> Statements due date must
+                    include a day
+                    <br>Statements due date must include a month
+                    <br>Statements due date must include a year</p>
+                <div class="govuk-date-input"
+                id="lpa-statement-due-date">
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="lpa-statement-due-date-day">Day</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                            id="lpa-statement-due-date-day" name="lpa-statement-due-date-day" type="text"
+                            inputmode="numeric">
+                        </div>
+                    </div>
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="lpa-statement-due-date-month">Month</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                            id="lpa-statement-due-date-month" name="lpa-statement-due-date-month" type="text"
+                            inputmode="numeric">
+                        </div>
+                    </div>
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="lpa-statement-due-date-year">Year</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-4"
+                            id="lpa-statement-due-date-year" name="lpa-statement-due-date-year" type="text"
+                            inputmode="numeric">
+                        </div>
+                    </div>
+                </div>
+            </fieldset>
+        </div>
+        <div class="govuk-form-group govuk-form-group--error">
+            <fieldset class="govuk-fieldset" role="group" aria-describedby="ip-comments-due-date-hint ip-comments-due-date-error">
+                <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">Interested party comments due</legend>
+                <div id="ip-comments-due-date-hint"
+                class="govuk-hint">For example, 27 3 2007</div>
+                <p id="ip-comments-due-date-error" class="govuk-error-message"><span class="govuk-visually-hidden">Error:</span> Interested party comments
+                    due date must include a day
+                    <br>Interested party comments due date must include a month
+                    <br>Interested party comments due date must include a year</p>
+                <div class="govuk-date-input"
+                id="ip-comments-due-date">
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="ip-comments-due-date-day">Day</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                            id="ip-comments-due-date-day" name="ip-comments-due-date-day" type="text"
+                            inputmode="numeric">
+                        </div>
+                    </div>
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="ip-comments-due-date-month">Month</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                            id="ip-comments-due-date-month" name="ip-comments-due-date-month" type="text"
+                            inputmode="numeric">
+                        </div>
+                    </div>
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="ip-comments-due-date-year">Year</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-4"
+                            id="ip-comments-due-date-year" name="ip-comments-due-date-year" type="text"
+                            inputmode="numeric">
+                        </div>
+                    </div>
+                </div>
+            </fieldset>
+        </div>
+        <div class="govuk-form-group govuk-form-group--error">
+            <fieldset class="govuk-fieldset" role="group" aria-describedby="final-comments-due-date-hint final-comments-due-date-error">
+                <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">Final comments due</legend>
+                <div id="final-comments-due-date-hint" class="govuk-hint">For example, 27 3 2007</div>
+                <p id="final-comments-due-date-error" class="govuk-error-message"><span class="govuk-visually-hidden">Error:</span> Final comments due date
+                    must include a day
+                    <br>Final comments due date must include a month
+                    <br>Final comments due date must include a year</p>
+                <div class="govuk-date-input"
+                id="final-comments-due-date">
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="final-comments-due-date-day">Day</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                            id="final-comments-due-date-day" name="final-comments-due-date-day" type="text"
+                            inputmode="numeric">
+                        </div>
+                    </div>
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="final-comments-due-date-month">Month</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                            id="final-comments-due-date-month" name="final-comments-due-date-month"
+                            type="text" inputmode="numeric">
+                        </div>
+                    </div>
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="final-comments-due-date-year">Year</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-4"
+                            id="final-comments-due-date-year" name="final-comments-due-date-year" type="text"
+                            inputmode="numeric">
+                        </div>
+                    </div>
+                </div>
+            </fieldset>
+        </div>
+        <div class="govuk-button-group">
+            <button type="submit" class="govuk-button" data-module="govuk-button">Continue</button>
+        </div>
+    </form>
+</main>"
+`;
+
+exports[`Timetable POST /edit S78 Statements should re-render edit timetable page with missing day error for Statements 1`] = `
+"<main class="govuk-main-wrapper" id="main-content">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <div class="govuk-error-summary" data-module="govuk-error-summary">
+                <div role="alert">
+                    <h2 class="govuk-error-summary__title"> There is a problem</h2>
+                    <div class="govuk-error-summary__body">
+                        <ul class="govuk-list govuk-error-summary__list">
+                            <li><a href="#lpa-questionnaire-due-date-day">LPA questionnaire due date must include a day</a>
+                            </li>
+                            <li><a href="#lpa-questionnaire-due-date-month">LPA questionnaire due date must include a month</a>
+                            </li>
+                            <li><a href="#lpa-questionnaire-due-date-year">LPA questionnaire due date must include a year</a>
+                            </li>
+                            <li><a href="#lpa-statement-due-date-day">Statements due date must include a day</a>
+                            </li>
+                            <li><a href="#ip-comments-due-date-day">Interested party comments due date must include a day</a>
+                            </li>
+                            <li><a href="#ip-comments-due-date-month">Interested party comments due date must include a month</a>
+                            </li>
+                            <li><a href="#ip-comments-due-date-year">Interested party comments due date must include a year</a>
+                            </li>
+                            <li><a href="#final-comments-due-date-day">Final comments due date must include a day</a>
+                            </li>
+                            <li><a href="#final-comments-due-date-month">Final comments due date must include a month</a>
+                            </li>
+                            <li><a href="#final-comments-due-date-year">Final comments due date must include a year</a>
+                            </li>
+                        </ul>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Appeal 351062</span>
+            <h1 class="govuk-heading-l">Timetable due dates</h1>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full"></div>
+    </div>
+    <form method="post" novalidate="novalidate">
+        <div class="govuk-form-group govuk-form-group--error">
+            <fieldset class="govuk-fieldset" role="group" aria-describedby="lpa-questionnaire-due-date-hint lpa-questionnaire-due-date-error">
+                <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">LPA questionnaire due</legend>
+                <div id="lpa-questionnaire-due-date-hint"
+                class="govuk-hint">For example, 27 3 2007</div>
+                <p id="lpa-questionnaire-due-date-error" class="govuk-error-message"><span class="govuk-visually-hidden">Error:</span> LPA questionnaire due
+                    date must include a day
+                    <br>LPA questionnaire due date must include a month
+                    <br>LPA questionnaire due date must include a year</p>
+                <div class="govuk-date-input"
+                id="lpa-questionnaire-due-date">
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="lpa-questionnaire-due-date-day">Day</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                            id="lpa-questionnaire-due-date-day" name="lpa-questionnaire-due-date-day"
+                            type="text" inputmode="numeric">
+                        </div>
+                    </div>
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="lpa-questionnaire-due-date-month">Month</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                            id="lpa-questionnaire-due-date-month" name="lpa-questionnaire-due-date-month"
+                            type="text" inputmode="numeric">
+                        </div>
+                    </div>
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="lpa-questionnaire-due-date-year">Year</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-4"
+                            id="lpa-questionnaire-due-date-year" name="lpa-questionnaire-due-date-year"
+                            type="text" inputmode="numeric">
+                        </div>
+                    </div>
+                </div>
+            </fieldset>
+        </div>
+        <div class="govuk-form-group govuk-form-group--error">
+            <fieldset class="govuk-fieldset" role="group" aria-describedby="lpa-statement-due-date-hint lpa-statement-due-date-error">
+                <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">Statements due</legend>
+                <div id="lpa-statement-due-date-hint" class="govuk-hint">For example, 27 3 2007</div>
+                <p id="lpa-statement-due-date-error" class="govuk-error-message"><span class="govuk-visually-hidden">Error:</span> Statements due date must
+                    include a day</p>
+                <div class="govuk-date-input" id="lpa-statement-due-date">
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="lpa-statement-due-date-day">Day</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                            id="lpa-statement-due-date-day" name="lpa-statement-due-date-day" type="text"
+                            inputmode="numeric">
+                        </div>
+                    </div>
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="lpa-statement-due-date-month">Month</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                            id="lpa-statement-due-date-month" name="lpa-statement-due-date-month" type="text"
+                            inputmode="numeric">
+                        </div>
+                    </div>
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="lpa-statement-due-date-year">Year</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-4"
+                            id="lpa-statement-due-date-year" name="lpa-statement-due-date-year" type="text"
+                            inputmode="numeric">
+                        </div>
+                    </div>
+                </div>
+            </fieldset>
+        </div>
+        <div class="govuk-form-group govuk-form-group--error">
+            <fieldset class="govuk-fieldset" role="group" aria-describedby="ip-comments-due-date-hint ip-comments-due-date-error">
+                <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">Interested party comments due</legend>
+                <div id="ip-comments-due-date-hint"
+                class="govuk-hint">For example, 27 3 2007</div>
+                <p id="ip-comments-due-date-error" class="govuk-error-message"><span class="govuk-visually-hidden">Error:</span> Interested party comments
+                    due date must include a day
+                    <br>Interested party comments due date must include a month
+                    <br>Interested party comments due date must include a year</p>
+                <div class="govuk-date-input"
+                id="ip-comments-due-date">
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="ip-comments-due-date-day">Day</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                            id="ip-comments-due-date-day" name="ip-comments-due-date-day" type="text"
+                            inputmode="numeric">
+                        </div>
+                    </div>
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="ip-comments-due-date-month">Month</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                            id="ip-comments-due-date-month" name="ip-comments-due-date-month" type="text"
+                            inputmode="numeric">
+                        </div>
+                    </div>
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="ip-comments-due-date-year">Year</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-4"
+                            id="ip-comments-due-date-year" name="ip-comments-due-date-year" type="text"
+                            inputmode="numeric">
+                        </div>
+                    </div>
+                </div>
+            </fieldset>
+        </div>
+        <div class="govuk-form-group govuk-form-group--error">
+            <fieldset class="govuk-fieldset" role="group" aria-describedby="final-comments-due-date-hint final-comments-due-date-error">
+                <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">Final comments due</legend>
+                <div id="final-comments-due-date-hint" class="govuk-hint">For example, 27 3 2007</div>
+                <p id="final-comments-due-date-error" class="govuk-error-message"><span class="govuk-visually-hidden">Error:</span> Final comments due date
+                    must include a day
+                    <br>Final comments due date must include a month
+                    <br>Final comments due date must include a year</p>
+                <div class="govuk-date-input"
+                id="final-comments-due-date">
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="final-comments-due-date-day">Day</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                            id="final-comments-due-date-day" name="final-comments-due-date-day" type="text"
+                            inputmode="numeric">
+                        </div>
+                    </div>
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="final-comments-due-date-month">Month</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                            id="final-comments-due-date-month" name="final-comments-due-date-month"
+                            type="text" inputmode="numeric">
+                        </div>
+                    </div>
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="final-comments-due-date-year">Year</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-4"
+                            id="final-comments-due-date-year" name="final-comments-due-date-year" type="text"
+                            inputmode="numeric">
+                        </div>
+                    </div>
+                </div>
+            </fieldset>
+        </div>
+        <div class="govuk-button-group">
+            <button type="submit" class="govuk-button" data-module="govuk-button">Continue</button>
+        </div>
+    </form>
+</main>"
+`;
+
+exports[`Timetable POST /edit S78 Statements should re-render edit timetable page with missing month error for Statements 1`] = `
+"<main class="govuk-main-wrapper" id="main-content">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <div class="govuk-error-summary" data-module="govuk-error-summary">
+                <div role="alert">
+                    <h2 class="govuk-error-summary__title"> There is a problem</h2>
+                    <div class="govuk-error-summary__body">
+                        <ul class="govuk-list govuk-error-summary__list">
+                            <li><a href="#lpa-questionnaire-due-date-day">LPA questionnaire due date must include a day</a>
+                            </li>
+                            <li><a href="#lpa-questionnaire-due-date-month">LPA questionnaire due date must include a month</a>
+                            </li>
+                            <li><a href="#lpa-questionnaire-due-date-year">LPA questionnaire due date must include a year</a>
+                            </li>
+                            <li><a href="#lpa-statement-due-date-month">Statements due date must include a month</a>
+                            </li>
+                            <li><a href="#ip-comments-due-date-day">Interested party comments due date must include a day</a>
+                            </li>
+                            <li><a href="#ip-comments-due-date-month">Interested party comments due date must include a month</a>
+                            </li>
+                            <li><a href="#ip-comments-due-date-year">Interested party comments due date must include a year</a>
+                            </li>
+                            <li><a href="#final-comments-due-date-day">Final comments due date must include a day</a>
+                            </li>
+                            <li><a href="#final-comments-due-date-month">Final comments due date must include a month</a>
+                            </li>
+                            <li><a href="#final-comments-due-date-year">Final comments due date must include a year</a>
+                            </li>
+                        </ul>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Appeal 351062</span>
+            <h1 class="govuk-heading-l">Timetable due dates</h1>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full"></div>
+    </div>
+    <form method="post" novalidate="novalidate">
+        <div class="govuk-form-group govuk-form-group--error">
+            <fieldset class="govuk-fieldset" role="group" aria-describedby="lpa-questionnaire-due-date-hint lpa-questionnaire-due-date-error">
+                <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">LPA questionnaire due</legend>
+                <div id="lpa-questionnaire-due-date-hint"
+                class="govuk-hint">For example, 27 3 2007</div>
+                <p id="lpa-questionnaire-due-date-error" class="govuk-error-message"><span class="govuk-visually-hidden">Error:</span> LPA questionnaire due
+                    date must include a day
+                    <br>LPA questionnaire due date must include a month
+                    <br>LPA questionnaire due date must include a year</p>
+                <div class="govuk-date-input"
+                id="lpa-questionnaire-due-date">
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="lpa-questionnaire-due-date-day">Day</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                            id="lpa-questionnaire-due-date-day" name="lpa-questionnaire-due-date-day"
+                            type="text" inputmode="numeric">
+                        </div>
+                    </div>
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="lpa-questionnaire-due-date-month">Month</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                            id="lpa-questionnaire-due-date-month" name="lpa-questionnaire-due-date-month"
+                            type="text" inputmode="numeric">
+                        </div>
+                    </div>
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="lpa-questionnaire-due-date-year">Year</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-4"
+                            id="lpa-questionnaire-due-date-year" name="lpa-questionnaire-due-date-year"
+                            type="text" inputmode="numeric">
+                        </div>
+                    </div>
+                </div>
+            </fieldset>
+        </div>
+        <div class="govuk-form-group govuk-form-group--error">
+            <fieldset class="govuk-fieldset" role="group" aria-describedby="lpa-statement-due-date-hint lpa-statement-due-date-error">
+                <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">Statements due</legend>
+                <div id="lpa-statement-due-date-hint" class="govuk-hint">For example, 27 3 2007</div>
+                <p id="lpa-statement-due-date-error" class="govuk-error-message"><span class="govuk-visually-hidden">Error:</span> Statements due date must
+                    include a month</p>
+                <div class="govuk-date-input" id="lpa-statement-due-date">
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="lpa-statement-due-date-day">Day</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                            id="lpa-statement-due-date-day" name="lpa-statement-due-date-day" type="text"
+                            inputmode="numeric">
+                        </div>
+                    </div>
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="lpa-statement-due-date-month">Month</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                            id="lpa-statement-due-date-month" name="lpa-statement-due-date-month" type="text"
+                            inputmode="numeric">
+                        </div>
+                    </div>
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="lpa-statement-due-date-year">Year</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-4"
+                            id="lpa-statement-due-date-year" name="lpa-statement-due-date-year" type="text"
+                            inputmode="numeric">
+                        </div>
+                    </div>
+                </div>
+            </fieldset>
+        </div>
+        <div class="govuk-form-group govuk-form-group--error">
+            <fieldset class="govuk-fieldset" role="group" aria-describedby="ip-comments-due-date-hint ip-comments-due-date-error">
+                <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">Interested party comments due</legend>
+                <div id="ip-comments-due-date-hint"
+                class="govuk-hint">For example, 27 3 2007</div>
+                <p id="ip-comments-due-date-error" class="govuk-error-message"><span class="govuk-visually-hidden">Error:</span> Interested party comments
+                    due date must include a day
+                    <br>Interested party comments due date must include a month
+                    <br>Interested party comments due date must include a year</p>
+                <div class="govuk-date-input"
+                id="ip-comments-due-date">
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="ip-comments-due-date-day">Day</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                            id="ip-comments-due-date-day" name="ip-comments-due-date-day" type="text"
+                            inputmode="numeric">
+                        </div>
+                    </div>
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="ip-comments-due-date-month">Month</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                            id="ip-comments-due-date-month" name="ip-comments-due-date-month" type="text"
+                            inputmode="numeric">
+                        </div>
+                    </div>
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="ip-comments-due-date-year">Year</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-4"
+                            id="ip-comments-due-date-year" name="ip-comments-due-date-year" type="text"
+                            inputmode="numeric">
+                        </div>
+                    </div>
+                </div>
+            </fieldset>
+        </div>
+        <div class="govuk-form-group govuk-form-group--error">
+            <fieldset class="govuk-fieldset" role="group" aria-describedby="final-comments-due-date-hint final-comments-due-date-error">
+                <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">Final comments due</legend>
+                <div id="final-comments-due-date-hint" class="govuk-hint">For example, 27 3 2007</div>
+                <p id="final-comments-due-date-error" class="govuk-error-message"><span class="govuk-visually-hidden">Error:</span> Final comments due date
+                    must include a day
+                    <br>Final comments due date must include a month
+                    <br>Final comments due date must include a year</p>
+                <div class="govuk-date-input"
+                id="final-comments-due-date">
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="final-comments-due-date-day">Day</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                            id="final-comments-due-date-day" name="final-comments-due-date-day" type="text"
+                            inputmode="numeric">
+                        </div>
+                    </div>
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="final-comments-due-date-month">Month</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                            id="final-comments-due-date-month" name="final-comments-due-date-month"
+                            type="text" inputmode="numeric">
+                        </div>
+                    </div>
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="final-comments-due-date-year">Year</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-4"
+                            id="final-comments-due-date-year" name="final-comments-due-date-year" type="text"
+                            inputmode="numeric">
+                        </div>
+                    </div>
+                </div>
+            </fieldset>
+        </div>
+        <div class="govuk-button-group">
+            <button type="submit" class="govuk-button" data-module="govuk-button">Continue</button>
+        </div>
+    </form>
+</main>"
+`;
+
+exports[`Timetable POST /edit S78 Statements should re-render edit timetable page with missing year error for Statements 1`] = `
+"<main class="govuk-main-wrapper" id="main-content">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <div class="govuk-error-summary" data-module="govuk-error-summary">
+                <div role="alert">
+                    <h2 class="govuk-error-summary__title"> There is a problem</h2>
+                    <div class="govuk-error-summary__body">
+                        <ul class="govuk-list govuk-error-summary__list">
+                            <li><a href="#lpa-questionnaire-due-date-day">LPA questionnaire due date must include a day</a>
+                            </li>
+                            <li><a href="#lpa-questionnaire-due-date-month">LPA questionnaire due date must include a month</a>
+                            </li>
+                            <li><a href="#lpa-questionnaire-due-date-year">LPA questionnaire due date must include a year</a>
+                            </li>
+                            <li><a href="#lpa-statement-due-date-year">Statements due date must include a year</a>
+                            </li>
+                            <li><a href="#ip-comments-due-date-day">Interested party comments due date must include a day</a>
+                            </li>
+                            <li><a href="#ip-comments-due-date-month">Interested party comments due date must include a month</a>
+                            </li>
+                            <li><a href="#ip-comments-due-date-year">Interested party comments due date must include a year</a>
+                            </li>
+                            <li><a href="#final-comments-due-date-day">Final comments due date must include a day</a>
+                            </li>
+                            <li><a href="#final-comments-due-date-month">Final comments due date must include a month</a>
+                            </li>
+                            <li><a href="#final-comments-due-date-year">Final comments due date must include a year</a>
+                            </li>
+                        </ul>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Appeal 351062</span>
+            <h1 class="govuk-heading-l">Timetable due dates</h1>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full"></div>
+    </div>
+    <form method="post" novalidate="novalidate">
+        <div class="govuk-form-group govuk-form-group--error">
+            <fieldset class="govuk-fieldset" role="group" aria-describedby="lpa-questionnaire-due-date-hint lpa-questionnaire-due-date-error">
+                <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">LPA questionnaire due</legend>
+                <div id="lpa-questionnaire-due-date-hint"
+                class="govuk-hint">For example, 27 3 2007</div>
+                <p id="lpa-questionnaire-due-date-error" class="govuk-error-message"><span class="govuk-visually-hidden">Error:</span> LPA questionnaire due
+                    date must include a day
+                    <br>LPA questionnaire due date must include a month
+                    <br>LPA questionnaire due date must include a year</p>
+                <div class="govuk-date-input"
+                id="lpa-questionnaire-due-date">
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="lpa-questionnaire-due-date-day">Day</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                            id="lpa-questionnaire-due-date-day" name="lpa-questionnaire-due-date-day"
+                            type="text" inputmode="numeric">
+                        </div>
+                    </div>
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="lpa-questionnaire-due-date-month">Month</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                            id="lpa-questionnaire-due-date-month" name="lpa-questionnaire-due-date-month"
+                            type="text" inputmode="numeric">
+                        </div>
+                    </div>
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="lpa-questionnaire-due-date-year">Year</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-4"
+                            id="lpa-questionnaire-due-date-year" name="lpa-questionnaire-due-date-year"
+                            type="text" inputmode="numeric">
+                        </div>
+                    </div>
+                </div>
+            </fieldset>
+        </div>
+        <div class="govuk-form-group govuk-form-group--error">
+            <fieldset class="govuk-fieldset" role="group" aria-describedby="lpa-statement-due-date-hint lpa-statement-due-date-error">
+                <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">Statements due</legend>
+                <div id="lpa-statement-due-date-hint" class="govuk-hint">For example, 27 3 2007</div>
+                <p id="lpa-statement-due-date-error" class="govuk-error-message"><span class="govuk-visually-hidden">Error:</span> Statements due date must
+                    include a year</p>
+                <div class="govuk-date-input" id="lpa-statement-due-date">
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="lpa-statement-due-date-day">Day</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                            id="lpa-statement-due-date-day" name="lpa-statement-due-date-day" type="text"
+                            inputmode="numeric">
+                        </div>
+                    </div>
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="lpa-statement-due-date-month">Month</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                            id="lpa-statement-due-date-month" name="lpa-statement-due-date-month" type="text"
+                            inputmode="numeric">
+                        </div>
+                    </div>
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="lpa-statement-due-date-year">Year</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-4"
+                            id="lpa-statement-due-date-year" name="lpa-statement-due-date-year" type="text"
+                            inputmode="numeric">
+                        </div>
+                    </div>
+                </div>
+            </fieldset>
+        </div>
+        <div class="govuk-form-group govuk-form-group--error">
+            <fieldset class="govuk-fieldset" role="group" aria-describedby="ip-comments-due-date-hint ip-comments-due-date-error">
+                <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">Interested party comments due</legend>
+                <div id="ip-comments-due-date-hint"
+                class="govuk-hint">For example, 27 3 2007</div>
+                <p id="ip-comments-due-date-error" class="govuk-error-message"><span class="govuk-visually-hidden">Error:</span> Interested party comments
+                    due date must include a day
+                    <br>Interested party comments due date must include a month
+                    <br>Interested party comments due date must include a year</p>
+                <div class="govuk-date-input"
+                id="ip-comments-due-date">
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="ip-comments-due-date-day">Day</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                            id="ip-comments-due-date-day" name="ip-comments-due-date-day" type="text"
+                            inputmode="numeric">
+                        </div>
+                    </div>
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="ip-comments-due-date-month">Month</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                            id="ip-comments-due-date-month" name="ip-comments-due-date-month" type="text"
+                            inputmode="numeric">
+                        </div>
+                    </div>
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="ip-comments-due-date-year">Year</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-4"
+                            id="ip-comments-due-date-year" name="ip-comments-due-date-year" type="text"
+                            inputmode="numeric">
+                        </div>
+                    </div>
+                </div>
+            </fieldset>
+        </div>
+        <div class="govuk-form-group govuk-form-group--error">
+            <fieldset class="govuk-fieldset" role="group" aria-describedby="final-comments-due-date-hint final-comments-due-date-error">
+                <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">Final comments due</legend>
+                <div id="final-comments-due-date-hint" class="govuk-hint">For example, 27 3 2007</div>
+                <p id="final-comments-due-date-error" class="govuk-error-message"><span class="govuk-visually-hidden">Error:</span> Final comments due date
+                    must include a day
+                    <br>Final comments due date must include a month
+                    <br>Final comments due date must include a year</p>
+                <div class="govuk-date-input"
+                id="final-comments-due-date">
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="final-comments-due-date-day">Day</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                            id="final-comments-due-date-day" name="final-comments-due-date-day" type="text"
+                            inputmode="numeric">
+                        </div>
+                    </div>
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="final-comments-due-date-month">Month</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                            id="final-comments-due-date-month" name="final-comments-due-date-month"
+                            type="text" inputmode="numeric">
+                        </div>
+                    </div>
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="final-comments-due-date-year">Year</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-4"
+                            id="final-comments-due-date-year" name="final-comments-due-date-year" type="text"
+                            inputmode="numeric">
+                        </div>
+                    </div>
+                </div>
+            </fieldset>
+        </div>
+        <div class="govuk-button-group">
+            <button type="submit" class="govuk-button" data-module="govuk-button">Continue</button>
+        </div>
+    </form>
+</main>"
+`;
+
+exports[`Timetable POST /edit S78 Statements should re-render edit timetable page with must be in the future error for Statements 1`] = `
+"<main class="govuk-main-wrapper" id="main-content">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <div class="govuk-error-summary" data-module="govuk-error-summary">
+                <div role="alert">
+                    <h2 class="govuk-error-summary__title"> There is a problem</h2>
+                    <div class="govuk-error-summary__body">
+                        <ul class="govuk-list govuk-error-summary__list">
+                            <li><a href="#lpa-questionnaire-due-date-day">LPA questionnaire due date must include a day</a>
+                            </li>
+                            <li><a href="#lpa-questionnaire-due-date-month">LPA questionnaire due date must include a month</a>
+                            </li>
+                            <li><a href="#lpa-questionnaire-due-date-year">LPA questionnaire due date must include a year</a>
+                            </li>
+                            <li><a href="#">The statements due date must be in the future</a>
+                            </li>
+                            <li><a href="#ip-comments-due-date-day">Interested party comments due date must include a day</a>
+                            </li>
+                            <li><a href="#ip-comments-due-date-month">Interested party comments due date must include a month</a>
+                            </li>
+                            <li><a href="#ip-comments-due-date-year">Interested party comments due date must include a year</a>
+                            </li>
+                            <li><a href="#final-comments-due-date-day">Final comments due date must include a day</a>
+                            </li>
+                            <li><a href="#final-comments-due-date-month">Final comments due date must include a month</a>
+                            </li>
+                            <li><a href="#final-comments-due-date-year">Final comments due date must include a year</a>
+                            </li>
+                        </ul>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Appeal 351062</span>
+            <h1 class="govuk-heading-l">Timetable due dates</h1>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full"></div>
+    </div>
+    <form method="post" novalidate="novalidate">
+        <div class="govuk-form-group govuk-form-group--error">
+            <fieldset class="govuk-fieldset" role="group" aria-describedby="lpa-questionnaire-due-date-hint lpa-questionnaire-due-date-error">
+                <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">LPA questionnaire due</legend>
+                <div id="lpa-questionnaire-due-date-hint"
+                class="govuk-hint">For example, 27 3 2007</div>
+                <p id="lpa-questionnaire-due-date-error" class="govuk-error-message"><span class="govuk-visually-hidden">Error:</span> LPA questionnaire due
+                    date must include a day
+                    <br>LPA questionnaire due date must include a month
+                    <br>LPA questionnaire due date must include a year</p>
+                <div class="govuk-date-input"
+                id="lpa-questionnaire-due-date">
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="lpa-questionnaire-due-date-day">Day</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                            id="lpa-questionnaire-due-date-day" name="lpa-questionnaire-due-date-day"
+                            type="text" inputmode="numeric">
+                        </div>
+                    </div>
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="lpa-questionnaire-due-date-month">Month</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                            id="lpa-questionnaire-due-date-month" name="lpa-questionnaire-due-date-month"
+                            type="text" inputmode="numeric">
+                        </div>
+                    </div>
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="lpa-questionnaire-due-date-year">Year</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-4"
+                            id="lpa-questionnaire-due-date-year" name="lpa-questionnaire-due-date-year"
+                            type="text" inputmode="numeric">
+                        </div>
+                    </div>
+                </div>
+            </fieldset>
+        </div>
+        <div class="govuk-form-group">
+            <fieldset class="govuk-fieldset" role="group" aria-describedby="lpa-statement-due-date-hint">
+                <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">Statements due</legend>
+                <div id="lpa-statement-due-date-hint" class="govuk-hint">For example, 27 3 2007</div>
+                <div class="govuk-date-input" id="lpa-statement-due-date">
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="lpa-statement-due-date-day">Day</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                            id="lpa-statement-due-date-day" name="lpa-statement-due-date-day" type="text"
+                            inputmode="numeric">
+                        </div>
+                    </div>
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="lpa-statement-due-date-month">Month</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                            id="lpa-statement-due-date-month" name="lpa-statement-due-date-month" type="text"
+                            inputmode="numeric">
+                        </div>
+                    </div>
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="lpa-statement-due-date-year">Year</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-4"
+                            id="lpa-statement-due-date-year" name="lpa-statement-due-date-year" type="text"
+                            inputmode="numeric">
+                        </div>
+                    </div>
+                </div>
+            </fieldset>
+        </div>
+        <div class="govuk-form-group govuk-form-group--error">
+            <fieldset class="govuk-fieldset" role="group" aria-describedby="ip-comments-due-date-hint ip-comments-due-date-error">
+                <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">Interested party comments due</legend>
+                <div id="ip-comments-due-date-hint"
+                class="govuk-hint">For example, 27 3 2007</div>
+                <p id="ip-comments-due-date-error" class="govuk-error-message"><span class="govuk-visually-hidden">Error:</span> Interested party comments
+                    due date must include a day
+                    <br>Interested party comments due date must include a month
+                    <br>Interested party comments due date must include a year</p>
+                <div class="govuk-date-input"
+                id="ip-comments-due-date">
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="ip-comments-due-date-day">Day</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                            id="ip-comments-due-date-day" name="ip-comments-due-date-day" type="text"
+                            inputmode="numeric">
+                        </div>
+                    </div>
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="ip-comments-due-date-month">Month</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                            id="ip-comments-due-date-month" name="ip-comments-due-date-month" type="text"
+                            inputmode="numeric">
+                        </div>
+                    </div>
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="ip-comments-due-date-year">Year</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-4"
+                            id="ip-comments-due-date-year" name="ip-comments-due-date-year" type="text"
+                            inputmode="numeric">
+                        </div>
+                    </div>
+                </div>
+            </fieldset>
+        </div>
+        <div class="govuk-form-group govuk-form-group--error">
+            <fieldset class="govuk-fieldset" role="group" aria-describedby="final-comments-due-date-hint final-comments-due-date-error">
+                <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">Final comments due</legend>
+                <div id="final-comments-due-date-hint" class="govuk-hint">For example, 27 3 2007</div>
+                <p id="final-comments-due-date-error" class="govuk-error-message"><span class="govuk-visually-hidden">Error:</span> Final comments due date
+                    must include a day
+                    <br>Final comments due date must include a month
+                    <br>Final comments due date must include a year</p>
+                <div class="govuk-date-input"
+                id="final-comments-due-date">
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="final-comments-due-date-day">Day</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                            id="final-comments-due-date-day" name="final-comments-due-date-day" type="text"
+                            inputmode="numeric">
+                        </div>
+                    </div>
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="final-comments-due-date-month">Month</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                            id="final-comments-due-date-month" name="final-comments-due-date-month"
+                            type="text" inputmode="numeric">
+                        </div>
+                    </div>
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="final-comments-due-date-year">Year</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-4"
+                            id="final-comments-due-date-year" name="final-comments-due-date-year" type="text"
+                            inputmode="numeric">
+                        </div>
+                    </div>
+                </div>
+            </fieldset>
+        </div>
+        <div class="govuk-button-group">
+            <button type="submit" class="govuk-button" data-module="govuk-button">Continue</button>
+        </div>
+    </form>
+</main>"
+`;
+
+exports[`Timetable POST /edit S78 Statements should re-render edit timetable page with not a real date error for Statements 1`] = `
+"<main class="govuk-main-wrapper" id="main-content">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <div class="govuk-error-summary" data-module="govuk-error-summary">
+                <div role="alert">
+                    <h2 class="govuk-error-summary__title"> There is a problem</h2>
+                    <div class="govuk-error-summary__body">
+                        <ul class="govuk-list govuk-error-summary__list">
+                            <li><a href="#lpa-questionnaire-due-date-day">LPA questionnaire due date must include a day</a>
+                            </li>
+                            <li><a href="#lpa-questionnaire-due-date-month">LPA questionnaire due date must include a month</a>
+                            </li>
+                            <li><a href="#lpa-questionnaire-due-date-year">LPA questionnaire due date must include a year</a>
+                            </li>
+                            <li><a href="#">Statements due date must be a real date</a>
+                            </li>
+                            <li><a href="#ip-comments-due-date-day">Interested party comments due date must include a day</a>
+                            </li>
+                            <li><a href="#ip-comments-due-date-month">Interested party comments due date must include a month</a>
+                            </li>
+                            <li><a href="#ip-comments-due-date-year">Interested party comments due date must include a year</a>
+                            </li>
+                            <li><a href="#final-comments-due-date-day">Final comments due date must include a day</a>
+                            </li>
+                            <li><a href="#final-comments-due-date-month">Final comments due date must include a month</a>
+                            </li>
+                            <li><a href="#final-comments-due-date-year">Final comments due date must include a year</a>
+                            </li>
+                        </ul>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Appeal 351062</span>
+            <h1 class="govuk-heading-l">Timetable due dates</h1>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full"></div>
+    </div>
+    <form method="post" novalidate="novalidate">
+        <div class="govuk-form-group govuk-form-group--error">
+            <fieldset class="govuk-fieldset" role="group" aria-describedby="lpa-questionnaire-due-date-hint lpa-questionnaire-due-date-error">
+                <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">LPA questionnaire due</legend>
+                <div id="lpa-questionnaire-due-date-hint"
+                class="govuk-hint">For example, 27 3 2007</div>
+                <p id="lpa-questionnaire-due-date-error" class="govuk-error-message"><span class="govuk-visually-hidden">Error:</span> LPA questionnaire due
+                    date must include a day
+                    <br>LPA questionnaire due date must include a month
+                    <br>LPA questionnaire due date must include a year</p>
+                <div class="govuk-date-input"
+                id="lpa-questionnaire-due-date">
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="lpa-questionnaire-due-date-day">Day</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                            id="lpa-questionnaire-due-date-day" name="lpa-questionnaire-due-date-day"
+                            type="text" inputmode="numeric">
+                        </div>
+                    </div>
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="lpa-questionnaire-due-date-month">Month</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                            id="lpa-questionnaire-due-date-month" name="lpa-questionnaire-due-date-month"
+                            type="text" inputmode="numeric">
+                        </div>
+                    </div>
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="lpa-questionnaire-due-date-year">Year</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-4"
+                            id="lpa-questionnaire-due-date-year" name="lpa-questionnaire-due-date-year"
+                            type="text" inputmode="numeric">
+                        </div>
+                    </div>
+                </div>
+            </fieldset>
+        </div>
+        <div class="govuk-form-group">
+            <fieldset class="govuk-fieldset" role="group" aria-describedby="lpa-statement-due-date-hint">
+                <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">Statements due</legend>
+                <div id="lpa-statement-due-date-hint" class="govuk-hint">For example, 27 3 2007</div>
+                <div class="govuk-date-input" id="lpa-statement-due-date">
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="lpa-statement-due-date-day">Day</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                            id="lpa-statement-due-date-day" name="lpa-statement-due-date-day" type="text"
+                            inputmode="numeric">
+                        </div>
+                    </div>
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="lpa-statement-due-date-month">Month</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                            id="lpa-statement-due-date-month" name="lpa-statement-due-date-month" type="text"
+                            inputmode="numeric">
+                        </div>
+                    </div>
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="lpa-statement-due-date-year">Year</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-4"
+                            id="lpa-statement-due-date-year" name="lpa-statement-due-date-year" type="text"
+                            inputmode="numeric">
+                        </div>
+                    </div>
+                </div>
+            </fieldset>
+        </div>
+        <div class="govuk-form-group govuk-form-group--error">
+            <fieldset class="govuk-fieldset" role="group" aria-describedby="ip-comments-due-date-hint ip-comments-due-date-error">
+                <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">Interested party comments due</legend>
+                <div id="ip-comments-due-date-hint"
+                class="govuk-hint">For example, 27 3 2007</div>
+                <p id="ip-comments-due-date-error" class="govuk-error-message"><span class="govuk-visually-hidden">Error:</span> Interested party comments
+                    due date must include a day
+                    <br>Interested party comments due date must include a month
+                    <br>Interested party comments due date must include a year</p>
+                <div class="govuk-date-input"
+                id="ip-comments-due-date">
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="ip-comments-due-date-day">Day</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                            id="ip-comments-due-date-day" name="ip-comments-due-date-day" type="text"
+                            inputmode="numeric">
+                        </div>
+                    </div>
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="ip-comments-due-date-month">Month</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                            id="ip-comments-due-date-month" name="ip-comments-due-date-month" type="text"
+                            inputmode="numeric">
+                        </div>
+                    </div>
+                    <div class="govuk-date-input__item">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-date-input__label" for="ip-comments-due-date-year">Year</label>
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-4"
+                            id="ip-comments-due-date-year" name="ip-comments-due-date-year" type="text"
+                            inputmode="numeric">
+                        </div>
+                    </div>
+                </div>
+            </fieldset>
+        </div>
+        <div class="govuk-form-group govuk-form-group--error">
+            <fieldset class="govuk-fieldset" role="group" aria-describedby="final-comments-due-date-hint final-comments-due-date-error">
+                <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">Final comments due</legend>
+                <div id="final-comments-due-date-hint" class="govuk-hint">For example, 27 3 2007</div>
+                <p id="final-comments-due-date-error" class="govuk-error-message"><span class="govuk-visually-hidden">Error:</span> Final comments due date
+                    must include a day
+                    <br>Final comments due date must include a month
+                    <br>Final comments due date must include a year</p>
+                <div class="govuk-date-input"
+                id="final-comments-due-date">
                     <div class="govuk-date-input__item">
                         <div class="govuk-form-group">
                             <label class="govuk-label govuk-date-input__label" for="final-comments-due-date-day">Day</label>

--- a/appeals/web/src/server/appeals/appeal-details/timetable/__tests__/timetable.test.js
+++ b/appeals/web/src/server/appeals/appeal-details/timetable/__tests__/timetable.test.js
@@ -8,148 +8,616 @@ const { app, teardown } = createTestEnvironment();
 const request = supertest(app);
 const baseUrl = '/appeals-service/appeal-details/1/timetable';
 
-describe('Appeal Timetables', () => {
+describe('Timetable', () => {
 	afterEach(teardown);
 
-	it('should render "Timetable due dates" page for householder appeal type', async () => {
-		const appealData = {
-			...baseAppealData,
-			appealTimetable: {
-				appealTimetableId: 1
-			}
-		};
+	describe('GET /edit', () => {
+		it('should render "Timetable due dates" page for householder appeal type', async () => {
+			const appealData = {
+				...baseAppealData,
+				appealTimetable: {
+					appealTimetableId: 1
+				}
+			};
 
-		nock('http://test/').get('/appeals/1').reply(200, appealData);
+			nock('http://test/').get('/appeals/1').reply(200, appealData);
 
-		const response = await request.get(`${baseUrl}/edit`);
-		const element = parseHtml(response.text);
+			const response = await request.get(`${baseUrl}/edit`);
+			const element = parseHtml(response.text);
 
-		expect(element.innerHTML).toMatchSnapshot();
-		expect(element.innerHTML).toContain('LPA questionnaire due</h1>');
-		expect(element.innerHTML).toContain('name="lpa-questionnaire-due-date-day');
-		expect(element.innerHTML).toContain('name="lpa-questionnaire-due-date-month"');
-		expect(element.innerHTML).toContain('name="lpa-questionnaire-due-date-year"');
-		expect(element.innerHTML).toContain('Continue</button>');
+			expect(element.innerHTML).toMatchSnapshot();
+			expect(element.innerHTML).toContain('LPA questionnaire due</h1>');
+			expect(element.innerHTML).toContain('name="lpa-questionnaire-due-date-day');
+			expect(element.innerHTML).toContain('name="lpa-questionnaire-due-date-month"');
+			expect(element.innerHTML).toContain('name="lpa-questionnaire-due-date-year"');
+			expect(element.innerHTML).toContain('Continue</button>');
+		});
+
+		it('should render correct "Timetable due dates" page for S78 appeal type and status lpa_questionnaire', async () => {
+			const appealData = {
+				...baseAppealData,
+				appealTimetable: {
+					appealTimetableId: 1
+				}
+			};
+			appealData.appealType = 'Planning appeal';
+			appealData.appealStatus = 'lpa_questionnaire';
+
+			nock('http://test/').get('/appeals/1').reply(200, appealData);
+
+			const response = await request.get(`${baseUrl}/edit`);
+			const element = parseHtml(response.text);
+
+			expect(element.innerHTML).toMatchSnapshot();
+			expect(element.innerHTML).toContain('Timetable due dates</h1>');
+			expect(element.innerHTML).toContain('name="lpa-questionnaire-due-date-day');
+			expect(element.innerHTML).toContain('name="lpa-questionnaire-due-date-month"');
+			expect(element.innerHTML).toContain('name="lpa-questionnaire-due-date-year"');
+			expect(element.innerHTML).toContain('name="lpa-statement-due-date-day');
+			expect(element.innerHTML).toContain('name="lpa-statement-due-date-month"');
+			expect(element.innerHTML).toContain('name="lpa-statement-due-date-year"');
+			expect(element.innerHTML).toContain('name="ip-comments-due-date-day');
+			expect(element.innerHTML).toContain('name="ip-comments-due-date-month"');
+			expect(element.innerHTML).toContain('name="ip-comments-due-date-year"');
+			expect(element.innerHTML).toContain('name="final-comments-due-date-day');
+			expect(element.innerHTML).toContain('name="final-comments-due-date-month"');
+			expect(element.innerHTML).toContain('name="final-comments-due-date-year"');
+			expect(element.innerHTML).toContain('Continue</button>');
+		});
+
+		it('should render correct "Timetable due dates" page for S78 appeal type and status lpa_questionnaire and lpaq received', async () => {
+			const appealData = {
+				...baseAppealData,
+				appealTimetable: {
+					appealTimetableId: 1
+				}
+			};
+			appealData.appealType = 'Planning appeal';
+			appealData.appealStatus = 'lpa_questionnaire';
+			appealData.documentationSummary = {
+				lpaQuestionnaire: {
+					status: 'received',
+					dueDate: '2024-10-11T10:27:06.626Z',
+					receivedAt: '2024-08-02T10:27:06.626Z',
+					representationStatus: 'awaiting_review'
+				}
+			};
+
+			nock('http://test/').get('/appeals/1').reply(200, appealData);
+
+			const response = await request.get(`${baseUrl}/edit`);
+			const element = parseHtml(response.text);
+
+			expect(element.innerHTML).toMatchSnapshot();
+			expect(element.innerHTML).toContain('Timetable due dates</h1>');
+			expect(element.innerHTML).toContain('name="lpa-statement-due-date-day');
+			expect(element.innerHTML).toContain('name="lpa-statement-due-date-month"');
+			expect(element.innerHTML).toContain('name="lpa-statement-due-date-year"');
+			expect(element.innerHTML).toContain('name="ip-comments-due-date-day');
+			expect(element.innerHTML).toContain('name="ip-comments-due-date-month"');
+			expect(element.innerHTML).toContain('name="ip-comments-due-date-year"');
+			expect(element.innerHTML).toContain('name="final-comments-due-date-day');
+			expect(element.innerHTML).toContain('name="final-comments-due-date-month"');
+			expect(element.innerHTML).toContain('name="final-comments-due-date-year"');
+			expect(element.innerHTML).toContain('Continue</button>');
+		});
+
+		it('should render correct "Timetable due dates" page for S78 appeal type and status statements', async () => {
+			const appealData = {
+				...baseAppealData,
+				appealTimetable: {
+					appealTimetableId: 1
+				}
+			};
+			appealData.appealType = 'Planning appeal';
+			appealData.appealStatus = 'statements';
+
+			nock('http://test/').get('/appeals/1').reply(200, appealData);
+
+			const response = await request.get(`${baseUrl}/edit`);
+			const element = parseHtml(response.text);
+
+			expect(element.innerHTML).toMatchSnapshot();
+			expect(element.innerHTML).toContain('Timetable due dates</h1>');
+			expect(element.innerHTML).toContain('name="lpa-statement-due-date-day');
+			expect(element.innerHTML).toContain('name="lpa-statement-due-date-month"');
+			expect(element.innerHTML).toContain('name="lpa-statement-due-date-year"');
+			expect(element.innerHTML).toContain('name="ip-comments-due-date-day');
+			expect(element.innerHTML).toContain('name="ip-comments-due-date-month"');
+			expect(element.innerHTML).toContain('name="ip-comments-due-date-year"');
+			expect(element.innerHTML).toContain('name="final-comments-due-date-day');
+			expect(element.innerHTML).toContain('name="final-comments-due-date-month"');
+			expect(element.innerHTML).toContain('name="final-comments-due-date-year"');
+			expect(element.innerHTML).toContain('Continue</button>');
+		});
+
+		it('should render correct "Timetable due dates" page for S78 appeal type and status final_comments', async () => {
+			const appealData = {
+				...baseAppealData,
+				appealTimetable: {
+					appealTimetableId: 1
+				}
+			};
+			appealData.appealType = 'Planning appeal';
+			appealData.appealStatus = 'final_comments';
+
+			nock('http://test/').get('/appeals/1').reply(200, appealData);
+
+			const response = await request.get(`${baseUrl}/edit`);
+			const element = parseHtml(response.text);
+
+			expect(element.innerHTML).toMatchSnapshot();
+			expect(element.innerHTML).toContain('Final comments due</h1>');
+			expect(element.innerHTML).toContain('name="final-comments-due-date-day');
+			expect(element.innerHTML).toContain('name="final-comments-due-date-month"');
+			expect(element.innerHTML).toContain('name="final-comments-due-date-year"');
+			expect(element.innerHTML).toContain('Continue</button>');
+		});
 	});
 
-	it('should render correct "Timetable due dates" page for S78 appeal type and status lpa_questionnaire', async () => {
-		const appealData = {
-			...baseAppealData,
-			appealTimetable: {
-				appealTimetableId: 1
-			}
-		};
-		appealData.appealType = 'Planning appeal';
-		appealData.appealStatus = 'lpa_questionnaire';
+	describe('POST /edit', () => {
+		describe('Householder', () => {
+			const appealData = {
+				...baseAppealData,
+				appealTimetable: {
+					appealTimetableId: 1
+				}
+			};
 
-		nock('http://test/').get('/appeals/1').reply(200, appealData);
+			beforeEach(() => {
+				nock.cleanAll();
+				nock('http://test/').get('/appeals/1').reply(200, appealData).persist();
+				nock('http://test/').post(`/appeals/validate-business-date`).reply(200, { result: true });
+			});
+			afterEach(() => {
+				nock.cleanAll();
+			});
 
-		const response = await request.get(`${baseUrl}/edit`);
-		const element = parseHtml(response.text);
+			it.each([
+				{
+					name: 'missing day',
+					payload: {
+						'lpa-questionnaire-due-date-month': '10',
+						'lpa-questionnaire-due-date-year': '2050'
+					},
+					expectedError: 'LPA questionnaire due date must include a day</a>'
+				},
+				{
+					name: 'missing month',
+					payload: {
+						'lpa-questionnaire-due-date-day': '10',
+						'lpa-questionnaire-due-date-year': '2050'
+					},
+					expectedError: 'LPA questionnaire due date must include a month</a>'
+				},
+				{
+					name: 'missing year',
+					payload: {
+						'lpa-questionnaire-due-date-day': '10',
+						'lpa-questionnaire-due-date-month': '12'
+					},
+					expectedError: 'LPA questionnaire due date must include a year</a>'
+				},
+				{
+					name: 'not a real date',
+					payload: {
+						'lpa-questionnaire-due-date-day': '29',
+						'lpa-questionnaire-due-date-month': '2',
+						'lpa-questionnaire-due-date-year': '3000'
+					},
+					expectedError: 'LPA questionnaire due date must be a real date</a>'
+				},
+				{
+					name: 'must be in the future',
+					payload: {
+						'lpa-questionnaire-due-date-day': '25',
+						'lpa-questionnaire-due-date-month': '2',
+						'lpa-questionnaire-due-date-year': '1950'
+					},
+					expectedError: 'The lpa questionnaire due date must be in the future</a>'
+				}
+			])(
+				'should re-render edit timetable page with $name error based on payload',
+				async ({ payload, expectedError }) => {
+					const response = await request.post(`${baseUrl}/edit`).send(payload);
 
-		expect(element.innerHTML).toMatchSnapshot();
-		expect(element.innerHTML).toContain('Timetable due dates</h1>');
-		expect(element.innerHTML).toContain('name="lpa-questionnaire-due-date-day');
-		expect(element.innerHTML).toContain('name="lpa-questionnaire-due-date-month"');
-		expect(element.innerHTML).toContain('name="lpa-questionnaire-due-date-year"');
-		expect(element.innerHTML).toContain('name="lpa-statement-due-date-day');
-		expect(element.innerHTML).toContain('name="lpa-statement-due-date-month"');
-		expect(element.innerHTML).toContain('name="lpa-statement-due-date-year"');
-		expect(element.innerHTML).toContain('name="ip-comments-due-date-day');
-		expect(element.innerHTML).toContain('name="ip-comments-due-date-month"');
-		expect(element.innerHTML).toContain('name="ip-comments-due-date-year"');
-		expect(element.innerHTML).toContain('name="final-comments-due-date-day');
-		expect(element.innerHTML).toContain('name="final-comments-due-date-month"');
-		expect(element.innerHTML).toContain('name="final-comments-due-date-year"');
-		expect(element.innerHTML).toContain('Continue</button>');
+					const element = parseHtml(response.text);
+
+					expect(element.innerHTML).toMatchSnapshot();
+					expect(element.innerHTML).toContain(expectedError);
+					expect(element.innerHTML).toContain(
+						'<h2 class="govuk-error-summary__title"> There is a problem</h2>'
+					);
+					expect(element.innerHTML).toContain('LPA questionnaire due</h1>');
+					expect(element.innerHTML).toContain('name="lpa-questionnaire-due-date-day');
+					expect(element.innerHTML).toContain('name="lpa-questionnaire-due-date-month"');
+					expect(element.innerHTML).toContain('name="lpa-questionnaire-due-date-year"');
+					expect(element.innerHTML).toContain('Continue</button>');
+				}
+			);
+
+			it('should redirect to the timetable CYA page if required due dates are present in the request body and in the correct format', async () => {
+				const response = await request.post(`${baseUrl}/edit`).send({
+					'lpa-questionnaire-due-date-day': '10',
+					'lpa-questionnaire-due-date-month': '10',
+					'lpa-questionnaire-due-date-year': '2050'
+				});
+
+				expect(response.statusCode).toBe(302);
+				expect(response.text).toBe(
+					'Found. Redirecting to /appeals-service/appeal-details/1/timetable/edit/check'
+				);
+			});
+		});
+
+		describe('S78', () => {
+			const appealData = {
+				...baseAppealData,
+				appealTimetable: {
+					appealTimetableId: 1
+				},
+				appealType: 'Planning appeal',
+				appealStatus: 'lpa_questionnaire'
+			};
+
+			beforeEach(() => {
+				nock.cleanAll();
+				nock('http://test/').get('/appeals/1').reply(200, appealData).persist();
+				nock('http://test/')
+					.post(`/appeals/validate-business-date`)
+					.reply(200, { result: true })
+					.persist();
+			});
+			afterEach(() => {
+				nock.cleanAll();
+			});
+
+			const timetableTypes = [
+				{
+					id: 'lpa-questionnaire',
+					label: 'LPA questionnaire'
+				},
+				{
+					id: 'lpa-statement',
+					label: 'Statements'
+				},
+				{
+					id: 'ip-comments',
+					label: 'Interested party comments'
+				},
+				{
+					id: 'final-comments',
+					label: 'Final comments'
+				}
+			];
+
+			const testCases = [
+				{
+					name: 'missing day',
+					payload: (/** @type {string} */ id) => ({
+						[`${id}-due-date-month`]: '10',
+						[`${id}-due-date-year`]: '2050'
+					}),
+					expectedError: (/** @type {string} */ label) => `${label} due date must include a day</a>`
+				},
+				{
+					name: 'missing month',
+					payload: (/** @type {string} */ id) => ({
+						[`${id}-due-date-day`]: '10',
+						[`${id}-due-date-year`]: '2050'
+					}),
+					expectedError: (/** @type {string} */ label) =>
+						`${label} due date must include a month</a>`
+				},
+				{
+					name: 'missing year',
+					payload: (/** @type {string} */ id) => ({
+						[`${id}-due-date-day`]: '10',
+						[`${id}-due-date-month`]: '12'
+					}),
+					expectedError: (/** @type {string} */ label) =>
+						`${label} due date must include a year</a>`
+				},
+				{
+					name: 'not a real date',
+					payload: (/** @type {string} */ id) => ({
+						[`${id}-due-date-day`]: '29',
+						[`${id}-due-date-month`]: '2',
+						[`${id}-due-date-year`]: '3000'
+					}),
+					expectedError: (/** @type {string} */ label) =>
+						`${label} due date must be a real date</a>`
+				},
+				{
+					name: 'must be in the future',
+					payload: (/** @type {string} */ id) => ({
+						[`${id}-due-date-day`]: '25',
+						[`${id}-due-date-month`]: '2',
+						[`${id}-due-date-year`]: '1950'
+					}),
+					expectedError: (/** @type {string} */ label) =>
+						`The ${label.toLowerCase()} due date must be in the future</a>`
+				}
+			];
+
+			timetableTypes.forEach(({ id, label }) => {
+				describe(`${label}`, () => {
+					it.each(testCases)(
+						'should re-render edit timetable page with $name error for ' + label,
+						async (testCase) => {
+							const response = await request.post(`${baseUrl}/edit`).send(testCase.payload(id));
+
+							const element = parseHtml(response.text);
+
+							expect(element.innerHTML).toMatchSnapshot();
+							expect(element.innerHTML).toContain(
+								'<h2 class="govuk-error-summary__title"> There is a problem</h2>'
+							);
+							expect(element.innerHTML).toContain(testCase.expectedError(label));
+						}
+					);
+				});
+			});
+
+			it('should redirect to the timetable CYA page if required due dates are present in the request body', async () => {
+				const response = await request.post(`${baseUrl}/edit`).send({
+					'lpa-questionnaire-due-date-day': '10',
+					'lpa-questionnaire-due-date-month': '10',
+					'lpa-questionnaire-due-date-year': '2050',
+					'lpa-statement-due-date-day': '10',
+					'lpa-statement-due-date-month': '10',
+					'lpa-statement-due-date-year': '2050',
+					'ip-comments-due-date-day': '10',
+					'ip-comments-due-date-month': '10',
+					'ip-comments-due-date-year': '2050',
+					'final-comments-due-date-day': '10',
+					'final-comments-due-date-month': '10',
+					'final-comments-due-date-year': '2050'
+				});
+
+				expect(response.statusCode).toBe(302);
+				expect(response.text).toBe(
+					'Found. Redirecting to /appeals-service/appeal-details/1/timetable/edit/check'
+				);
+			});
+		});
 	});
 
-	it('should render correct "Timetable due dates" page for S78 appeal type and status lpa_questionnaire and lpaq received', async () => {
+	describe('GET /edit/check', () => {
 		const appealData = {
 			...baseAppealData,
 			appealTimetable: {
 				appealTimetableId: 1
 			}
 		};
-		appealData.appealType = 'Planning appeal';
-		appealData.appealStatus = 'lpa_questionnaire';
-		appealData.documentationSummary = {
-			lpaQuestionnaire: {
-				status: 'received',
-				dueDate: '2024-10-11T10:27:06.626Z',
-				receivedAt: '2024-08-02T10:27:06.626Z',
-				representationStatus: 'awaiting_review'
-			}
-		};
 
-		nock('http://test/').get('/appeals/1').reply(200, appealData);
+		beforeEach(() => {
+			nock.cleanAll();
+			nock('http://test/').get('/appeals/1').reply(200, appealData).persist();
+			nock('http://test/')
+				.post(`/appeals/validate-business-date`)
+				.reply(200, { result: true })
+				.persist();
+		});
+		afterEach(() => {
+			nock.cleanAll();
+		});
 
-		const response = await request.get(`${baseUrl}/edit`);
-		const element = parseHtml(response.text);
+		it('should render "Timetable CYA" page for householder appeal type', async () => {
+			await request.post(`${baseUrl}/edit`).send({
+				'lpa-questionnaire-due-date-day': '13',
+				'lpa-questionnaire-due-date-month': '10',
+				'lpa-questionnaire-due-date-year': '2030'
+			});
 
-		expect(element.innerHTML).toMatchSnapshot();
-		expect(element.innerHTML).toContain('Timetable due dates</h1>');
-		expect(element.innerHTML).toContain('name="lpa-statement-due-date-day');
-		expect(element.innerHTML).toContain('name="lpa-statement-due-date-month"');
-		expect(element.innerHTML).toContain('name="lpa-statement-due-date-year"');
-		expect(element.innerHTML).toContain('name="ip-comments-due-date-day');
-		expect(element.innerHTML).toContain('name="ip-comments-due-date-month"');
-		expect(element.innerHTML).toContain('name="ip-comments-due-date-year"');
-		expect(element.innerHTML).toContain('name="final-comments-due-date-day');
-		expect(element.innerHTML).toContain('name="final-comments-due-date-month"');
-		expect(element.innerHTML).toContain('name="final-comments-due-date-year"');
-		expect(element.innerHTML).toContain('Continue</button>');
-	});
+			const response = await request.get(`${baseUrl}/edit/check`);
+			const element = parseHtml(response.text);
 
-	it('should render correct "Timetable due dates" page for S78 appeal type and status statements', async () => {
-		const appealData = {
-			...baseAppealData,
-			appealTimetable: {
-				appealTimetableId: 1
-			}
-		};
-		appealData.appealType = 'Planning appeal';
-		appealData.appealStatus = 'statements';
+			expect(element.innerHTML).toMatchSnapshot();
+			expect(element.innerHTML).toContain('LPA questionnaire due</dt>');
+			expect(element.innerHTML).toContain('13 October 2030</dd>');
+			expect(element.innerHTML).toContain(
+				'<a class="govuk-link" href="/appeals-service/appeal-details/1/timetable/edit">Change '
+			);
+			expect(element.innerHTML).toContain(
+				'We’ll send an email to the appellant and LPA to tell them about the new'
+			);
+			expect(element.innerHTML).toContain('Update timetable due dates</button>');
+		});
 
-		nock('http://test/').get('/appeals/1').reply(200, appealData);
+		it('should render correct "Timetable CYA" page for S78 appeal type and status lpa_questionnaire and lpaq NOT received', async () => {
+			const appeal = {
+				...baseAppealData,
+				appealTimetable: {
+					appealTimetableId: 1
+				}
+			};
+			appeal.appealType = 'Planning appeal';
+			appeal.appealStatus = 'lpa_questionnaire';
 
-		const response = await request.get(`${baseUrl}/edit`);
-		const element = parseHtml(response.text);
+			nock.cleanAll();
+			nock('http://test/')
+				.post(`/appeals/validate-business-date`)
+				.reply(200, { result: true })
+				.persist();
+			nock('http://test/').get('/appeals/1').reply(200, appeal).persist();
 
-		expect(element.innerHTML).toMatchSnapshot();
-		expect(element.innerHTML).toContain('Timetable due dates</h1>');
-		expect(element.innerHTML).toContain('name="lpa-statement-due-date-day');
-		expect(element.innerHTML).toContain('name="lpa-statement-due-date-month"');
-		expect(element.innerHTML).toContain('name="lpa-statement-due-date-year"');
-		expect(element.innerHTML).toContain('name="ip-comments-due-date-day');
-		expect(element.innerHTML).toContain('name="ip-comments-due-date-month"');
-		expect(element.innerHTML).toContain('name="ip-comments-due-date-year"');
-		expect(element.innerHTML).toContain('name="final-comments-due-date-day');
-		expect(element.innerHTML).toContain('name="final-comments-due-date-month"');
-		expect(element.innerHTML).toContain('name="final-comments-due-date-year"');
-		expect(element.innerHTML).toContain('Continue</button>');
-	});
+			await request.post(`${baseUrl}/edit`).send({
+				'lpa-questionnaire-due-date-day': '13',
+				'lpa-questionnaire-due-date-month': '10',
+				'lpa-questionnaire-due-date-year': '2030',
+				'lpa-statement-due-date-day': '14',
+				'lpa-statement-due-date-month': '10',
+				'lpa-statement-due-date-year': '2030',
+				'ip-comments-due-date-day': '15',
+				'ip-comments-due-date-month': '10',
+				'ip-comments-due-date-year': '2030',
+				'final-comments-due-date-day': '16',
+				'final-comments-due-date-month': '10',
+				'final-comments-due-date-year': '2030'
+			});
+			const response = await request.get(`${baseUrl}/edit/check`);
+			const element = parseHtml(response.text);
 
-	it('should render correct "Timetable due dates" page for S78 appeal type and status final_comments', async () => {
-		const appealData = {
-			...baseAppealData,
-			appealTimetable: {
-				appealTimetableId: 1
-			}
-		};
-		appealData.appealType = 'Planning appeal';
-		appealData.appealStatus = 'final_comments';
+			expect(element.innerHTML).toMatchSnapshot();
+			expect(element.innerHTML).toContain('LPA questionnaire due</dt>');
+			expect(element.innerHTML).toContain('13 October 2030</dd>');
+			expect(element.innerHTML).toContain('Statements due</dt>');
+			expect(element.innerHTML).toContain('14 October 2030</dd>');
+			expect(element.innerHTML).toContain('Interested party comments due</dt>');
+			expect(element.innerHTML).toContain('15 October 2030</dd>');
+			expect(element.innerHTML).toContain('Final comments due</dt>');
+			expect(element.innerHTML).toContain('16 October 2030</dd>');
+			expect(element.innerHTML).toContain(
+				'We’ll send an email to the appellant and LPA to tell them about the new'
+			);
+			expect(element.innerHTML).toContain('Update timetable due dates</button>');
+		});
 
-		nock('http://test/').get('/appeals/1').reply(200, appealData);
+		it('should render correct "Timetable CYA" page for S78 appeal type and status lpa_questionnaire and lpaq received', async () => {
+			const appeal = {
+				...baseAppealData,
+				appealTimetable: {
+					appealTimetableId: 1
+				}
+			};
+			appeal.appealType = 'Planning appeal';
+			appeal.appealStatus = 'lpa_questionnaire';
+			appeal.documentationSummary = {
+				lpaQuestionnaire: {
+					status: 'received',
+					dueDate: '2024-10-11T10:27:06.626Z',
+					receivedAt: '2024-08-02T10:27:06.626Z',
+					representationStatus: 'awaiting_review'
+				}
+			};
 
-		const response = await request.get(`${baseUrl}/edit`);
-		const element = parseHtml(response.text);
+			nock.cleanAll();
+			nock('http://test/')
+				.post(`/appeals/validate-business-date`)
+				.reply(200, { result: true })
+				.persist();
+			nock('http://test/').get('/appeals/1').reply(200, appeal).persist();
 
-		expect(element.innerHTML).toMatchSnapshot();
-		expect(element.innerHTML).toContain('Final comments due</h1>');
-		expect(element.innerHTML).toContain('name="final-comments-due-date-day');
-		expect(element.innerHTML).toContain('name="final-comments-due-date-month"');
-		expect(element.innerHTML).toContain('name="final-comments-due-date-year"');
-		expect(element.innerHTML).toContain('Continue</button>');
+			await request.post(`${baseUrl}/edit`).send({
+				'lpa-statement-due-date-day': '14',
+				'lpa-statement-due-date-month': '10',
+				'lpa-statement-due-date-year': '2030',
+				'ip-comments-due-date-day': '15',
+				'ip-comments-due-date-month': '10',
+				'ip-comments-due-date-year': '2030',
+				'final-comments-due-date-day': '16',
+				'final-comments-due-date-month': '10',
+				'final-comments-due-date-year': '2030'
+			});
+			const response = await request.get(`${baseUrl}/edit/check`);
+			const element = parseHtml(response.text);
+
+			expect(element.innerHTML).toMatchSnapshot();
+			expect(element.innerHTML).toContain('Statements due</dt>');
+			expect(element.innerHTML).toContain('14 October 2030</dd>');
+			expect(element.innerHTML).toContain('Interested party comments due</dt>');
+			expect(element.innerHTML).toContain('15 October 2030</dd>');
+			expect(element.innerHTML).toContain('Final comments due</dt>');
+			expect(element.innerHTML).toContain('16 October 2030</dd>');
+			expect(element.innerHTML).toContain(
+				'We’ll send an email to the appellant and LPA to tell them about the new'
+			);
+			expect(element.innerHTML).toContain('Update timetable due dates</button>');
+		});
+
+		it('should render correct "Timetable CYA" page for S78 appeal type and status statements', async () => {
+			const appeal = {
+				...baseAppealData,
+				appealTimetable: {
+					appealTimetableId: 1
+				}
+			};
+			appeal.appealType = 'Planning appeal';
+			appeal.appealStatus = 'statements';
+			appeal.documentationSummary = {
+				lpaQuestionnaire: {
+					status: 'received',
+					dueDate: '2024-10-11T10:27:06.626Z',
+					receivedAt: '2024-08-02T10:27:06.626Z',
+					representationStatus: 'awaiting_review'
+				}
+			};
+
+			nock.cleanAll();
+			nock('http://test/')
+				.post(`/appeals/validate-business-date`)
+				.reply(200, { result: true })
+				.persist();
+			nock('http://test/').get('/appeals/1').reply(200, appeal).persist();
+
+			await request.post(`${baseUrl}/edit`).send({
+				'lpa-statement-due-date-day': '14',
+				'lpa-statement-due-date-month': '10',
+				'lpa-statement-due-date-year': '2030',
+				'ip-comments-due-date-day': '15',
+				'ip-comments-due-date-month': '10',
+				'ip-comments-due-date-year': '2030',
+				'final-comments-due-date-day': '16',
+				'final-comments-due-date-month': '10',
+				'final-comments-due-date-year': '2030'
+			});
+			const response = await request.get(`${baseUrl}/edit/check`);
+			const element = parseHtml(response.text);
+
+			expect(element.innerHTML).toMatchSnapshot();
+			expect(element.innerHTML).toContain('Statements due</dt>');
+			expect(element.innerHTML).toContain('14 October 2030</dd>');
+			expect(element.innerHTML).toContain('Interested party comments due</dt>');
+			expect(element.innerHTML).toContain('15 October 2030</dd>');
+			expect(element.innerHTML).toContain('Final comments due</dt>');
+			expect(element.innerHTML).toContain('16 October 2030</dd>');
+			expect(element.innerHTML).toContain(
+				'We’ll send an email to the appellant and LPA to tell them about the new'
+			);
+			expect(element.innerHTML).toContain('Update timetable due dates</button>');
+		});
+
+		it('should render correct "Timetable CYA" page for S78 appeal type and status final_comments', async () => {
+			const appeal = {
+				...baseAppealData,
+				appealTimetable: {
+					appealTimetableId: 1
+				}
+			};
+			appeal.appealType = 'Planning appeal';
+			appeal.appealStatus = 'final_comments';
+			appeal.documentationSummary = {
+				lpaQuestionnaire: {
+					status: 'received',
+					dueDate: '2024-10-11T10:27:06.626Z',
+					receivedAt: '2024-08-02T10:27:06.626Z',
+					representationStatus: 'awaiting_review'
+				}
+			};
+
+			nock.cleanAll();
+			nock('http://test/')
+				.post(`/appeals/validate-business-date`)
+				.reply(200, { result: true })
+				.persist();
+			nock('http://test/').get('/appeals/1').reply(200, appeal).persist();
+
+			await request.post(`${baseUrl}/edit`).send({
+				'final-comments-due-date-day': '16',
+				'final-comments-due-date-month': '10',
+				'final-comments-due-date-year': '2030'
+			});
+			const response = await request.get(`${baseUrl}/edit/check`);
+			const element = parseHtml(response.text);
+
+			expect(element.innerHTML).toMatchSnapshot();
+			expect(element.innerHTML).toContain('Final comments due</dt>');
+			expect(element.innerHTML).toContain('16 October 2030</dd>');
+			expect(element.innerHTML).toContain(
+				'We’ll send an email to the appellant and LPA to tell them about the new'
+			);
+			expect(element.innerHTML).toContain('Update timetable due dates</button>');
+		});
 	});
 });

--- a/appeals/web/src/server/appeals/appeal-details/timetable/timetable.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/timetable/timetable.mapper.js
@@ -106,7 +106,7 @@ export const mapEditTimetablePage = (appealTimetable, appealDetails, errors = un
  * @param {AppealTimetableType} timetableType
  * @returns {string}
  */
-const getTimetableTypeText = (timetableType) => {
+export const getTimetableTypeText = (timetableType) => {
 	switch (timetableType) {
 		case 'lpaQuestionnaireDueDate':
 			return 'LPA questionnaire';


### PR DESCRIPTION
## Describe your changes
- Added unit tests for routes timetable/edit POST and timetable/check GET/POST
- Added logic so that CYA page works for S78 where the timetable type changes depending on appeal status
<!--
    Please include a summary of the change along with any relevant context.
    List any dependencies that are required for this change.
-->

## Issue ticket number and link
[Ticket](<!--Paste your ticket link here-->)
