### PR TITLE
fix(appeals): wrong feedback link (a2-3430)

### DIFF
--- a/appeals/api/src/server/endpoints/appellant-cases/__tests__/appellant-cases.test.js
+++ b/appeals/api/src/server/endpoints/appellant-cases/__tests__/appellant-cases.test.js
@@ -960,6 +960,7 @@ describe('appellant cases routes', () => {
 					personalisation: {
 						lpa_reference: '48269/APP/2021/1482',
 						appeal_reference_number: '1345264',
+						feedback_link: 'https://forms.office.com/r/9U4Sq9rEff',
 						site_address: '96 The Avenue, Leftfield, Maidstone, Kent, MD21 5XY, United Kingdom'
 					},
 					recipientEmail: 'test@136s7.com',

--- a/appeals/api/src/server/endpoints/appellant-cases/appellant-cases.service.js
+++ b/appeals/api/src/server/endpoints/appellant-cases/appellant-cases.service.js
@@ -24,6 +24,7 @@ import { broadcasters } from '#endpoints/integrations/integrations.broadcasters.
 import { EventType } from '@pins/event-client';
 import { notifySend } from '#notify/notify-send.js';
 import { APPEAL_DEVELOPMENT_TYPES } from './appellant-cases.constants.js';
+import { APPEAL_TYPE } from '@pins/appeals/constants/common.js';
 
 /** @typedef {import('@pins/appeals.api').Appeals.UpdateAppellantCaseValidationOutcomeParams} UpdateAppellantCaseValidationOutcomeParams */
 /** @typedef {import('express').Request} Request */
@@ -97,7 +98,11 @@ export const updateAppellantCaseValidationOutcome = async (
 		const personalisation = {
 			appeal_reference_number: appeal.reference,
 			lpa_reference: appeal.applicationReference || '',
-			site_address: siteAddress
+			site_address: siteAddress,
+			feedback_link:
+				appeal.appealType.type === APPEAL_TYPE.S78
+					? 'https://forms.cloud.microsoft/Pages/ResponsePage.aspx?id=mN94WIhvq0iTIpmM5VcIjYt1ax_BPvtOqhVjfvzyJN5UQzg1SlNPQjA3V0FDNUFJTldHMlEzMDdMRS4u'
+					: 'https://forms.office.com/r/9U4Sq9rEff'
 		};
 		await notifySend({
 			templateName: 'appeal-confirmed',

--- a/appeals/api/src/server/notify/templates/__tests__/notify-appeal-confirmed.test.js
+++ b/appeals/api/src/server/notify/templates/__tests__/notify-appeal-confirmed.test.js
@@ -13,7 +13,8 @@ describe('appeal-confirmed.md', () => {
 			personalisation: {
 				lpa_reference: '48269/APP/2021/1482',
 				appeal_reference_number: '134526',
-				site_address: '96 The Avenue, Leftfield, Maidstone, Kent, MD21 5XY, United Kingdom'
+				site_address: '96 The Avenue, Leftfield, Maidstone, Kent, MD21 5XY, United Kingdom',
+				feedback_link: 'https://forms.office.com/r/9U4Sq9rEff'
 			}
 		};
 

--- a/appeals/api/src/server/notify/templates/appeal-confirmed.content.md
+++ b/appeals/api/src/server/notify/templates/appeal-confirmed.content.md
@@ -4,7 +4,7 @@ We have reviewed your appeal and you have submitted all of the information we ne
 
 # Give feedback
 
-[Give feedback on the appeals service](https://forms.office.com/r/9U4Sq9rEff) (takes 2 minutes)
+[Give feedback on the appeals service]({{feedback_link}}) (takes 2 minutes)
 
 The Planning Inspectorate
 caseofficers@planninginspectorate.gov.uk


### PR DESCRIPTION
## Describe your changes
#### Notify email should be a different link from HAS when S78 (A2-3430)

### API (Notify):
- Make link a parameter in the notify template

### TEST:
- Fixed unit tests
- Made sure all unit tests pass
- Manually tested within browser

## Issue ticket number and link:
- [(A2-3430) Clicking on "Give feedback on the appeals service" for V2 S78 -Validation notify email to Appellant navigating to the Householder | Help us improve this service](https://pins-ds.atlassian.net/browse/A2-3430)

