### PR TITLE
feat(api): add planningObligationDueDate to appeal timetable

### DIFF
--- a/appeals/api/src/database/migrations/20250603091131_add_po_due_date_to_timetable/migration.sql
+++ b/appeals/api/src/database/migrations/20250603091131_add_po_due_date_to_timetable/migration.sql
@@ -1,0 +1,19 @@
+BEGIN TRY
+
+BEGIN TRAN;
+
+-- AlterTable
+ALTER TABLE [dbo].[AppealTimetable] ADD [planningObligationDueDate] DATETIME2;
+
+COMMIT TRAN;
+
+END TRY
+BEGIN CATCH
+
+IF @@TRANCOUNT > 0
+BEGIN
+    ROLLBACK TRAN;
+END;
+THROW
+
+END CATCH

--- a/appeals/api/src/database/schema.prisma
+++ b/appeals/api/src/database/schema.prisma
@@ -120,6 +120,7 @@ model AppealTimetable {
   s106ObligationDueDate          DateTime?
   issueDeterminationDate         DateTime?
   statementOfCommonGroundDueDate DateTime?
+  planningObligationDueDate      DateTime?
 }
 
 /// AppealStatus model

--- a/appeals/api/src/server/endpoints/appeal-details/__tests__/appeals-details.test.js
+++ b/appeals/api/src/server/endpoints/appeal-details/__tests__/appeals-details.test.js
@@ -143,7 +143,9 @@ const s78AppealDto = {
 		finalCommentsDueDate: fullPlanningAppeal.appealTimetable.finalCommentsDueDate.toISOString(),
 		s106ObligationDueDate: fullPlanningAppeal.appealTimetable.s106ObligationDueDate.toISOString(),
 		statementOfCommonGroundDueDate:
-			fullPlanningAppeal.appealTimetable.statementOfCommonGroundDueDate.toISOString()
+			fullPlanningAppeal.appealTimetable.statementOfCommonGroundDueDate.toISOString(),
+		planningObligationDueDate:
+			fullPlanningAppeal.appealTimetable.planningObligationDueDate.toISOString()
 	},
 	appealType: fullPlanningAppeal.appealType.type,
 	appellantCaseId: fullPlanningAppeal.appellantCase.id,

--- a/appeals/api/src/server/endpoints/appeal-timetables/__tests__/appeal-timetables.test.js
+++ b/appeals/api/src/server/endpoints/appeal-timetables/__tests__/appeal-timetables.test.js
@@ -212,7 +212,8 @@ describe('appeal timetables routes', () => {
 				'issueDeterminationDate',
 				'lpaQuestionnaireDueDate',
 				'lpaStatementDueDate',
-				'statementOfCommonGroundDueDate'
+				'statementOfCommonGroundDueDate',
+				'planningObligationDueDate'
 			].forEach((fieldName) => {
 				test(`returns an error if ${fieldName} is not in the correct format`, async () => {
 					// @ts-ignore

--- a/appeals/api/src/server/endpoints/appeal-timetables/appeal-timetables.controller.js
+++ b/appeals/api/src/server/endpoints/appeal-timetables/appeal-timetables.controller.js
@@ -64,7 +64,8 @@ const updateAppealTimetableById = async (req, res) => {
 			finalCommentsDueDate: body.finalCommentsDueDate,
 			s106ObligationDueDate: body.s106ObligationDueDate,
 			issueDeterminationDate: body.issueDeterminationDate,
-			statementOfCommonGroundDueDate: body.statementOfCommonGroundDueDate
+			statementOfCommonGroundDueDate: body.statementOfCommonGroundDueDate,
+			planningObligationDueDate: body.planningObligationDueDate
 		};
 
 		return res.send(updatedTimetable);

--- a/appeals/api/src/server/endpoints/appeal-timetables/appeal-timetables.validators.js
+++ b/appeals/api/src/server/endpoints/appeal-timetables/appeal-timetables.validators.js
@@ -69,6 +69,11 @@ const patchAppealTimetableValidator = composeMiddleware(
 		mustBeFutureDate: true,
 		mustBeBusinessDay: true
 	}),
+	validateDateParameter({
+		parameterName: 'planningObligationDueDate',
+		mustBeFutureDate: true,
+		mustBeBusinessDay: true
+	}),
 	validationErrorHandler
 );
 

--- a/appeals/api/src/server/endpoints/appeals.d.ts
+++ b/appeals/api/src/server/endpoints/appeals.d.ts
@@ -498,6 +498,8 @@ interface AppealTimetable {
 	finalCommentsDueDate?: string | null;
 	s106ObligationDueDate?: string | null;
 	issueDeterminationDate?: string | null;
+	statementOfCommonGroundDueDate?: string | null;
+	planningObligationDueDate?: string | null;
 }
 
 interface UpdateTimetableRequest {

--- a/appeals/api/src/server/mappers/api/definitions/timetable.js
+++ b/appeals/api/src/server/mappers/api/definitions/timetable.js
@@ -40,6 +40,16 @@ const timetable = {
 			type: 'string',
 			format: 'date-time',
 			nullable: true
+		},
+		statementOfCommonGroundDueDate: {
+			type: 'string',
+			format: 'date-time',
+			nullable: true
+		},
+		planningObligationDueDate: {
+			type: 'string',
+			format: 'date-time',
+			nullable: true
 		}
 	}
 };

--- a/appeals/api/src/server/mappers/api/shared/map-appeal-timetable.js
+++ b/appeals/api/src/server/mappers/api/shared/map-appeal-timetable.js
@@ -46,6 +46,10 @@ export const mapAppealTimetable = (data) => {
 				statementOfCommonGroundDueDate:
 					(appeal.appealTimetable.statementOfCommonGroundDueDate &&
 						appeal.appealTimetable.statementOfCommonGroundDueDate.toISOString()) ||
+					null,
+				planningObligationDueDate:
+					(appeal.appealTimetable.planningObligationDueDate &&
+						appeal.appealTimetable.planningObligationDueDate.toISOString()) ||
 					null
 			})
 		};

--- a/appeals/api/src/server/openapi-types.ts
+++ b/appeals/api/src/server/openapi-types.ts
@@ -2167,6 +2167,10 @@ export interface UpdateAppealTimetableRequest {
 	lpaQuestionnaireDueDate?: string;
 	/** @example "2024-08-12" */
 	statementReviewDate?: string;
+	/** @example "2024-08-12" */
+	statementOfCommonGroundDueDate?: string;
+	/** @example "2024-08-13" */
+	planningObligationDueDate?: string;
 }
 
 export interface UpdateAppealTimetableResponse {
@@ -2178,6 +2182,10 @@ export interface UpdateAppealTimetableResponse {
 	lpaQuestionnaireDueDate?: string;
 	/** @example "2024-08-12T01:00:00.000Z" */
 	statementReviewDate?: string;
+	/** @example "2024-08-12T01:00:00.000Z" */
+	statementOfCommonGroundDueDate?: string;
+	/** @example "2024-08-13T01:00:00.000Z" */
+	planningObligationDueDate?: string;
 }
 
 export interface AllDocumentRedactionStatusesResponse {
@@ -2640,6 +2648,10 @@ export interface Timetable {
 	finalCommentsDueDate?: string | null;
 	/** @format date-time */
 	s106ObligationDueDate?: string | null;
+	/** @format date-time */
+	statementOfCommonGroundDueDate?: string | null;
+	/** @format date-time */
+	planningObligationDueDate?: string | null;
 }
 
 export interface TransferStatus {
@@ -10854,6 +10866,10 @@ export interface Appeal {
 		finalCommentsDueDate?: string | null;
 		/** @format date-time */
 		s106ObligationDueDate?: string | null;
+		/** @format date-time */
+		statementOfCommonGroundDueDate?: string | null;
+		/** @format date-time */
+		planningObligationDueDate?: string | null;
 	};
 	transferStatus?: {
 		transferredAppealType: string;

--- a/appeals/api/src/server/openapi.json
+++ b/appeals/api/src/server/openapi.json
@@ -10318,6 +10318,14 @@
 					"statementReviewDate": {
 						"type": "string",
 						"example": "2024-08-12"
+					},
+					"statementOfCommonGroundDueDate": {
+						"type": "string",
+						"example": "2024-08-12"
+					},
+					"planningObligationDueDate": {
+						"type": "string",
+						"example": "2024-08-13"
 					}
 				},
 				"xml": {
@@ -10342,6 +10350,14 @@
 					"statementReviewDate": {
 						"type": "string",
 						"example": "2024-08-12T01:00:00.000Z"
+					},
+					"statementOfCommonGroundDueDate": {
+						"type": "string",
+						"example": "2024-08-12T01:00:00.000Z"
+					},
+					"planningObligationDueDate": {
+						"type": "string",
+						"example": "2024-08-13T01:00:00.000Z"
 					}
 				},
 				"xml": {
@@ -11211,6 +11227,16 @@
 						"nullable": true
 					},
 					"s106ObligationDueDate": {
+						"type": "string",
+						"format": "date-time",
+						"nullable": true
+					},
+					"statementOfCommonGroundDueDate": {
+						"type": "string",
+						"format": "date-time",
+						"nullable": true
+					},
+					"planningObligationDueDate": {
 						"type": "string",
 						"format": "date-time",
 						"nullable": true
@@ -25953,6 +25979,16 @@
 								"nullable": true
 							},
 							"s106ObligationDueDate": {
+								"type": "string",
+								"format": "date-time",
+								"nullable": true
+							},
+							"statementOfCommonGroundDueDate": {
+								"type": "string",
+								"format": "date-time",
+								"nullable": true
+							},
+							"planningObligationDueDate": {
 								"type": "string",
 								"format": "date-time",
 								"nullable": true

--- a/appeals/api/src/server/swagger.js
+++ b/appeals/api/src/server/swagger.js
@@ -851,13 +851,17 @@ export const spec = {
 			finalCommentReviewDate: '2024-08-09',
 			issueDeterminationDate: '2024-08-10',
 			lpaQuestionnaireDueDate: '2024-08-11',
-			statementReviewDate: '2024-08-12'
+			statementReviewDate: '2024-08-12',
+			statementOfCommonGroundDueDate: '2024-08-12',
+			planningObligationDueDate: '2024-08-13'
 		},
 		UpdateAppealTimetableResponse: {
 			finalCommentReviewDate: '2024-08-09T01:00:00.000Z',
 			issueDeterminationDate: '2024-08-10T01:00:00.000Z',
 			lpaQuestionnaireDueDate: '2024-08-11T01:00:00.000Z',
-			statementReviewDate: '2024-08-12T01:00:00.000Z'
+			statementReviewDate: '2024-08-12T01:00:00.000Z',
+			statementOfCommonGroundDueDate: '2024-08-12T01:00:00.000Z',
+			planningObligationDueDate: '2024-08-13T01:00:00.000Z'
 		},
 		AllDocumentRedactionStatusesResponse: {
 			id: 1,

--- a/appeals/api/src/server/tests/appeals/s78.js
+++ b/appeals/api/src/server/tests/appeals/s78.js
@@ -198,6 +198,7 @@ export default {
 		finalCommentsDueDate: new Date('2024-12-04T23:59:00.000Z'),
 		s106ObligationDueDate: new Date('2024-12-04T23:59:00.000Z'),
 		statementOfCommonGroundDueDate: new Date('2024-12-04T23:59:00.000Z'),
+		planningObligationDueDate: new Date('2024-12-04T23:59:00.000Z'),
 		issueDeterminationDate: null
 	},
 	appealType: {


### PR DESCRIPTION
## Describe your changes

- Add planningObligationDueDate to appeal timetable
- Add statementOfCommonGroundDueDate and planningObligationDueDate to OpenAPI docs

## Issue ticket number and link

[A2-2670](https://pins-ds.atlassian.net/browse/A2-2670)


[A2-2670]: https://pins-ds.atlassian.net/browse/A2-2670?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ