### PR TITLE
feat(api): adding the logic for timetable due date notify

### DIFF
--- a/appeals/api/src/server/endpoints/appeal-timetables/__tests__/appeal-timetables.test.js
+++ b/appeals/api/src/server/endpoints/appeal-timetables/__tests__/appeal-timetables.test.js
@@ -87,6 +87,7 @@ describe('appeal timetables routes', () => {
 					id: 1,
 					azureAdUserId
 				});
+				databaseConnector.appealTimetable.update.mockResolvedValue(1);
 
 				const { appealTimetable, id } = houseAppealWithTimetable;
 				const response = await request

--- a/appeals/api/src/server/endpoints/appeal-timetables/appeal-timetables.controller.js
+++ b/appeals/api/src/server/endpoints/appeal-timetables/appeal-timetables.controller.js
@@ -49,12 +49,10 @@ const startAppeal = async (req, res) => {
  * @returns {Promise<Response>}
  */
 const updateAppealTimetableById = async (req, res) => {
-	const { body, params, appeal } = req;
-	const appealTimetableId = Number(params.appealTimetableId);
-	const appealId = Number(appeal.id);
+	const { body, appeal, notifyClient } = req;
 
 	try {
-		await updateAppealTimetable(appealId, appealTimetableId, body, req.get('azureAdUserId') || '');
+		await updateAppealTimetable(appeal, body, notifyClient, req.get('azureAdUserId') || '');
 
 		const updatedTimetable = {
 			lpaQuestionnaireDueDate: body.lpaQuestionnaireDueDate,

--- a/appeals/api/src/server/notify/templates/appeal-timetable-updated.content.md
+++ b/appeals/api/src/server/notify/templates/appeal-timetable-updated.content.md
@@ -1,0 +1,20 @@
+We have updated your timetable.
+
+{% include 'parts/appeal-details.md' %}
+
+# Timetable
+
+## Local planning authority questionnaire 
+Due by {{lpa_questionnaire_due_date}}.
+
+## Statement from the local planning authority
+Due by {{lpa_statement_due_date}}.
+
+## Interested party comments 
+Due by {{ip_comments_due_date}}.
+
+## Final comments
+Due by {{final_comments_due_date}}.
+
+The Planning Inspectorate
+caseofficers@planninginspectorate.gov.uk

--- a/appeals/api/src/server/notify/templates/appeal-timetable-updated.subject.md
+++ b/appeals/api/src/server/notify/templates/appeal-timetable-updated.subject.md
@@ -1,0 +1,1 @@
+We have updated your timetable: {{appeal_reference_number}}

--- a/appeals/api/src/server/notify/templates/has-appeal-timetable-updated.content.md
+++ b/appeals/api/src/server/notify/templates/has-appeal-timetable-updated.content.md
@@ -1,0 +1,11 @@
+We have updated your timetable.
+
+{% include 'parts/appeal-details.md' %}
+
+# Timetable
+
+## Local planning authority questionnaire 
+Due by {{lpa_questionnaire_due_date}}.
+
+The Planning Inspectorate
+caseofficers@planninginspectorate.gov.uk

--- a/appeals/api/src/server/notify/templates/has-appeal-timetable-updated.subject.md
+++ b/appeals/api/src/server/notify/templates/has-appeal-timetable-updated.subject.md
@@ -1,0 +1,1 @@
+We have updated your timetable: {{appeal_reference_number}}


### PR DESCRIPTION
## Describe your changes
API:
- Added notify templates for HAS and full planning appeals
- Only sending notifies for appeal & procedure types where new case chronology applies
- Sending notifies to LPA & appellant
<!--
    Please include a summary of the change along with any relevant context.
    List any dependencies that are required for this change.
-->

## Issue ticket number and link
[Ticket](https://pins-ds.atlassian.net.mcas.ms/browse/A2-3150)
