### PR TITLE
fix(appeals): prevent duplicate file names when uploading new version…

### DIFF
--- a/appeals/web/src/client/components/file-uploader/_client-actions.js
+++ b/appeals/web/src/client/components/file-uploader/_client-actions.js
@@ -398,7 +398,7 @@ const clientActions = (container) => {
 			return { message: 'SIZE_SINGLE_FILE' };
 		}
 
-		if (container.dataset?.documentStage === 'representation') {
+		if (container.dataset?.documentStage === 'representation' && !isNewVersionOfExistingFile()) {
 			return null;
 		}
 
@@ -505,15 +505,17 @@ const clientActions = (container) => {
 
 		const createdUploadInfoForAtLeastOneDocument = createUploadInfoForStagedDocuments();
 
+		const { formId, documentTitle } = container.dataset || {};
+
 		if (createdUploadInfoForAtLeastOneDocument) {
 			form?.submit();
 		} else {
 			showErrors(
 				{
 					message: 'NO_FILE',
-					formId: container.dataset?.formId || '',
+					formId: formId || '',
 					metadata: {
-						fileTitle: container.dataset?.documentTitle || 'file'
+						fileTitle: documentTitle ? `the ${documentTitle}` : 'a file'
 					}
 				},
 				container

--- a/appeals/web/src/client/components/file-uploader/_html.js
+++ b/appeals/web/src/client/components/file-uploader/_html.js
@@ -32,7 +32,7 @@ export const errorMessage = (type, replaceValue, additionalValues = {}) => {
 		ADDITIONAL_DOCUMENTS_CONFIRMATION_REQUIRED:
 			'Please confirm that the document does not belong anywhere else',
 		TIMEOUT: 'There was a timeout and your files could not be uploaded',
-		NO_FILE: 'Select the {fileTitle}',
+		NO_FILE: 'Select {fileTitle}',
 		SIZE_SINGLE_FILE: `The selected file must be smaller than 25MB`,
 		GENERIC_SINGLE_FILE: `{REPLACE_VALUE} could not be added`,
 		NAME_SINGLE_FILE: `{REPLACE_VALUE} could not be added because the file name is too long or contains special characters. Rename the file and try again.`,


### PR DESCRIPTION
## Describe your changes
#### Prevent duplicate file names when uploading new versions (A2-3257)

### WEB:
- Update clientside validation to only bypass duplicate check when uploading a rep file that is not a new version
- Update clientside code to default to "Select a file" when a file is not selected and an override message has not been set

See the [comments](https://pins-ds.atlassian.net/browse/A2-3257?focusedCommentId=88998) for the scenario failures these changes address.

### TEST:
- Made sure all unit tests pass
- Manually tested within browser

## Issue ticket number and link:
- [(A2-3257) Content when uploading a new document version in BO](https://pins-ds.atlassian.net/browse/A2-3257)

