### PR TITLE
fix(web): adding notification banner for lpaq complete before redirect

### DIFF
--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/lpa-questionnaire.controller.js
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/lpa-questionnaire.controller.js
@@ -113,6 +113,12 @@ export const postLpaQuestionnaire = async (request, response) => {
 				mapWebValidationOutcomeToApiValidationOutcome('complete')
 			);
 
+			addNotificationBannerToSession({
+				session: request.session,
+				bannerDefinitionKey: 'lpaqReviewComplete',
+				appealId
+			});
+
 			return response.redirect(`/appeals-service/appeal-details/${appealId}`);
 		} else if (reviewOutcome === 'incomplete') {
 			return response.redirect(


### PR DESCRIPTION
## Describe your changes
- Adding success banner before redirect to appeal-details page for lpaq complete
<!--
    Please include a summary of the change along with any relevant context.
    List any dependencies that are required for this change.
-->

## Issue ticket number and link
[Ticket](https://pins-ds.atlassian.net.mcas.ms/browse/A2-3466)
