### PR TITLE
fix(appeals): invalid appeal issuing flow part 2 notify (a2-3254)

### DIFF
--- a/appeals/api/src/server/endpoints/invalid-appeal-decision/__tests__/invalid-appeal-decision.test.js
+++ b/appeals/api/src/server/endpoints/invalid-appeal-decision/__tests__/invalid-appeal-decision.test.js
@@ -118,6 +118,7 @@ describe('invalid appeal decision routes', () => {
 				notifyClient: expect.any(Object),
 				personalisation: {
 					appeal_reference_number: correctAppealState.reference,
+					has_costs_decision: false,
 					lpa_reference: correctAppealState.applicationReference,
 					site_address: '96 The Avenue, Leftfield, Maidstone, Kent, MD21 5XY, United Kingdom',
 					reasons: ['Invalid reason']
@@ -131,6 +132,7 @@ describe('invalid appeal decision routes', () => {
 				notifyClient: expect.any(Object),
 				personalisation: {
 					appeal_reference_number: correctAppealState.reference,
+					has_costs_decision: false,
 					lpa_reference: correctAppealState.applicationReference,
 					site_address: '96 The Avenue, Leftfield, Maidstone, Kent, MD21 5XY, United Kingdom',
 					reasons: ['Invalid reason']

--- a/appeals/api/src/server/notify/templates/__tests__/notify-decision-is-invalid-appellant.test.js
+++ b/appeals/api/src/server/notify/templates/__tests__/notify-decision-is-invalid-appellant.test.js
@@ -1,9 +1,14 @@
+// @ts-nocheck
 import { notifySend } from '#notify/notify-send.js';
 import { jest } from '@jest/globals';
 
 describe('decision-is-invalid-appellant.md', () => {
-	test('should call notify sendEmail with the correct data', async () => {
-		const notifySendData = {
+	let notifySendData;
+	let expectedContentA;
+	let expectedContentB;
+
+	beforeEach(() => {
+		notifySendData = {
 			doNotMockNotifySend: true,
 			templateName: 'decision-is-invalid-appellant',
 			notifyClient: {
@@ -19,7 +24,7 @@ describe('decision-is-invalid-appellant.md', () => {
 			}
 		};
 
-		const expectedContent = [
+		expectedContentA = [
 			'# Appeal details',
 			'',
 			'^Appeal reference number: ABC45678',
@@ -28,32 +33,37 @@ describe('decision-is-invalid-appellant.md', () => {
 			'',
 			'# Appeal decision',
 			'',
-			'We have reviewed your appeal and decided that it is invalid. We have contacted the local planning authority to tell them our decision.',
+			'We have reviewed your appeal and decided that it is not valid. We have contacted the local planning authority to tell them our decision.',
 			'',
 			'Your appeal is now closed.',
 			'',
-			'# Why the appeal is invalid',
+			'# Why the appeal is not valid',
 			'',
 			'- Reason one',
 			'- Reason two',
 			'- Reason three',
-			'',
-			'# The Planning Inspectorate’s role',
-			'',
-			'We consider all of the information submitted by all parties in the appeal, but only include key points in our decision.',
-			'',
-			'We cannot change or discuss the decision.',
-			'',
-			'# If you think the appeal decision is legally incorrect',
-			'',
-			'You can challenge the decision in the [High Court](https://www.justice.gov.uk/courts/rcj-rolls-building/administrative-court) if you think the Planning Inspectorate made a legal mistake.',
-			'',
+			''
+		];
+
+		expectedContentB = [
 			'# Feedback',
 			'',
-			'We welcome your feedback on our appeals service. Tell us on this short [feedback form](https://forms.office.com/pages/responsepage.aspx?id=mN94WIhvq0iTIpmM5VcIjfMZj__F6D9LmMUUyoUrZDZUOERYMEFBN0NCOFdNU1BGWEhHUFQxWVhUUy4u).',
+			'This is a new service. Help us improve it and [give your feedback (opens in new tab)](https://forms.office.com/pages/responsepage.aspx?id=mN94WIhvq0iTIpmM5VcIjfMZj__F6D9LmMUUyoUrZDZUOERYMEFBN0NCOFdNU1BGWEhHUFQxWVhUUy4u).',
 			'',
 			'The Planning Inspectorate',
 			'allcustomerteam@planninginspectorate.gov.uk'
+		];
+	});
+
+	test('should call notify sendEmail with the correct data when there are cost decisions', async () => {
+		notifySendData.personalisation.has_costs_decision = true;
+		const expectedContent = [
+			...expectedContentA,
+			'# Costs decision',
+			'',
+			'[Sign in to our service](/mock-front-office-url/appeals/ABC45678) to view the costs decision.',
+			'',
+			...expectedContentB
 		].join('\n');
 
 		await notifySend(notifySendData);
@@ -65,7 +75,25 @@ describe('decision-is-invalid-appellant.md', () => {
 			'test@136s7.com',
 			{
 				content: expectedContent,
-				subject: 'Your appeal is invalid: ABC45678'
+				subject: 'Your appeal is not valid: ABC45678'
+			}
+		);
+	});
+
+	test('should call notify sendEmail with the correct data when there are no cost decisions', async () => {
+		notifySendData.personalisation.has_costs_decision = false;
+		const expectedContent = [...expectedContentA, ...expectedContentB].join('\n');
+
+		await notifySend(notifySendData);
+
+		expect(notifySendData.notifyClient.sendEmail).toHaveBeenCalledWith(
+			{
+				id: 'mock-appeal-generic-id'
+			},
+			'test@136s7.com',
+			{
+				content: expectedContent,
+				subject: 'Your appeal is not valid: ABC45678'
 			}
 		);
 	});

--- a/appeals/api/src/server/notify/templates/__tests__/notify-decision-is-invalid-lpa.test.js
+++ b/appeals/api/src/server/notify/templates/__tests__/notify-decision-is-invalid-lpa.test.js
@@ -1,9 +1,14 @@
+// @ts-nocheck
 import { notifySend } from '#notify/notify-send.js';
 import { jest } from '@jest/globals';
 
 describe('decision-is-invalid-lpa.md', () => {
-	test('should call notify sendEmail with the correct data', async () => {
-		const notifySendData = {
+	let notifySendData;
+	let expectedContentA;
+	let expectedContentB;
+
+	beforeEach(() => {
+		notifySendData = {
 			doNotMockNotifySend: true,
 			templateName: 'decision-is-invalid-lpa',
 			notifyClient: {
@@ -19,7 +24,7 @@ describe('decision-is-invalid-lpa.md', () => {
 			}
 		};
 
-		const expectedContent = [
+		expectedContentA = [
 			'# Appeal details',
 			'',
 			'^Appeal reference number: ABC45678',
@@ -28,27 +33,56 @@ describe('decision-is-invalid-lpa.md', () => {
 			'',
 			'# Appeal decision',
 			'',
-			"We've decided that the appeal is invalid. We've closed the appeal.",
+			'We have reviewed the appeal and decided that it is not valid. We have contacted the appellant to tell them our decision.',
 			'',
-			'# Why the appeal is invalid',
+			'The appeal is now closed.',
+			'',
+			'# Why the appeal is not valid',
 			'',
 			'- Reason one',
 			'- Reason two',
 			'- Reason three',
-			'',
-			'# The Planning Inspectorate’s role',
-			'',
-			'We consider all of the information submitted by all parties in the appeal, but only include key points in our decision.',
-			'',
-			'We cannot change or discuss the decision.',
-			'',
+			''
+		];
+
+		expectedContentB = [
 			'# Feedback',
 			'',
-			'We welcome your feedback on our appeals service. Tell us on this short [feedback form](https://forms.office.com/pages/responsepage.aspx?id=mN94WIhvq0iTIpmM5VcIjfMZj__F6D9LmMUUyoUrZDZUOERYMEFBN0NCOFdNU1BGWEhHUFQxWVhUUy4u).',
+			'This is a new service. Help us improve it and [give your feedback (opens in new tab)](https://forms.office.com/pages/responsepage.aspx?id=mN94WIhvq0iTIpmM5VcIjfMZj__F6D9LmMUUyoUrZDZUOERYMEFBN0NCOFdNU1BGWEhHUFQxWVhUUy4u).',
 			'',
 			'The Planning Inspectorate',
 			'allcustomerteam@planninginspectorate.gov.uk'
+		];
+	});
+
+	test('should call notify sendEmail with the correct data when there are cost decisions', async () => {
+		notifySendData.personalisation.has_costs_decision = true;
+		const expectedContent = [
+			...expectedContentA,
+			'# Costs decision',
+			'',
+			'[Sign in to our service](/mock-front-office-url/manage-appeals/ABC45678) to view the costs decision.',
+			'',
+			...expectedContentB
 		].join('\n');
+
+		await notifySend(notifySendData);
+
+		expect(notifySendData.notifyClient.sendEmail).toHaveBeenCalledWith(
+			{
+				id: 'mock-appeal-generic-id'
+			},
+			'test@136s7.com',
+			{
+				content: expectedContent,
+				subject: 'Appeal invalid: ABC45678'
+			}
+		);
+	});
+
+	test('should call notify sendEmail with the correct data when there are no cost decisions', async () => {
+		notifySendData.personalisation.has_costs_decision = false;
+		const expectedContent = [...expectedContentA, ...expectedContentB].join('\n');
 
 		await notifySend(notifySendData);
 

--- a/appeals/api/src/server/notify/templates/decision-is-invalid-appellant.content.md
+++ b/appeals/api/src/server/notify/templates/decision-is-invalid-appellant.content.md
@@ -2,28 +2,22 @@
 
 # Appeal decision
 
-We have reviewed your appeal and decided that it is invalid. We have contacted the local planning authority to tell them our decision.
+We have reviewed your appeal and decided that it is not valid. We have contacted the local planning authority to tell them our decision.
 
 Your appeal is now closed.
 
-# Why the appeal is invalid
+# Why the appeal is not valid
 {% for reason in reasons %}
 - {{reason}}
 {%- endfor %}
+{% if has_costs_decision %}
+# Costs decision
 
-# The Planning Inspectorate’s role
-
-We consider all of the information submitted by all parties in the appeal, but only include key points in our decision.
-
-We cannot change or discuss the decision.
-
-# If you think the appeal decision is legally incorrect
-
-You can challenge the decision in the [High Court](https://www.justice.gov.uk/courts/rcj-rolls-building/administrative-court) if you think the Planning Inspectorate made a legal mistake.
-
+[Sign in to our service]({{front_office_url}}/appeals/{{appeal_reference_number}}) to view the costs decision.
+{% endif %}
 # Feedback
 
-We welcome your feedback on our appeals service. Tell us on this short [feedback form](https://forms.office.com/pages/responsepage.aspx?id=mN94WIhvq0iTIpmM5VcIjfMZj__F6D9LmMUUyoUrZDZUOERYMEFBN0NCOFdNU1BGWEhHUFQxWVhUUy4u).
+This is a new service. Help us improve it and [give your feedback (opens in new tab)](https://forms.office.com/pages/responsepage.aspx?id=mN94WIhvq0iTIpmM5VcIjfMZj__F6D9LmMUUyoUrZDZUOERYMEFBN0NCOFdNU1BGWEhHUFQxWVhUUy4u).
 
 The Planning Inspectorate
 allcustomerteam@planninginspectorate.gov.uk

--- a/appeals/api/src/server/notify/templates/decision-is-invalid-appellant.subject.md
+++ b/appeals/api/src/server/notify/templates/decision-is-invalid-appellant.subject.md
@@ -1,1 +1,1 @@
-Your appeal is invalid: {{appeal_reference_number}}
+Your appeal is not valid: {{appeal_reference_number}}

--- a/appeals/api/src/server/notify/templates/decision-is-invalid-lpa.content.md
+++ b/appeals/api/src/server/notify/templates/decision-is-invalid-lpa.content.md
@@ -2,22 +2,22 @@
 
 # Appeal decision
 
-We've decided that the appeal is invalid. We've closed the appeal.
+We have reviewed the appeal and decided that it is not valid. We have contacted the appellant to tell them our decision.
 
-# Why the appeal is invalid
+The appeal is now closed.
+
+# Why the appeal is not valid
 {% for reason in reasons %}
 - {{reason}}
 {%- endfor %}
+{% if has_costs_decision %}
+# Costs decision
 
-# The Planning Inspectorate’s role
-
-We consider all of the information submitted by all parties in the appeal, but only include key points in our decision.
-
-We cannot change or discuss the decision.
-
+[Sign in to our service]({{front_office_url}}/manage-appeals/{{appeal_reference_number}}) to view the costs decision.
+{% endif %}
 # Feedback
 
-We welcome your feedback on our appeals service. Tell us on this short [feedback form](https://forms.office.com/pages/responsepage.aspx?id=mN94WIhvq0iTIpmM5VcIjfMZj__F6D9LmMUUyoUrZDZUOERYMEFBN0NCOFdNU1BGWEhHUFQxWVhUUy4u).
+This is a new service. Help us improve it and [give your feedback (opens in new tab)](https://forms.office.com/pages/responsepage.aspx?id=mN94WIhvq0iTIpmM5VcIjfMZj__F6D9LmMUUyoUrZDZUOERYMEFBN0NCOFdNU1BGWEhHUFQxWVhUUy4u).
 
 The Planning Inspectorate
 allcustomerteam@planninginspectorate.gov.uk


### PR DESCRIPTION
## Describe your changes
#### Invalid appeal - issuing decision flow - Part 2 - Notify (A2-3254)

### API:
- Update notify templates for invalid decision for both LPA and appellant as described within the ticket including a conditional "Costs decision" section
- Updated invalid appeal decision service to determine and pass the conditional "has_costs_decision" parameter to each notify template.

### TEST:
- Updated unit tests where required
- Made sure all unit tests pass
- Manually tested within browser
- Checked the notify emails are produced correctly using the notify emulator

## Issue ticket number and link:
- [(A2-3254) Invalid appeal - issuing decision flow - Part 2 - GOV.Notifies](https://pins-ds.atlassian.net/browse/A2-3254)

