### PR TITLE
fix(appeals): correct show more parameter (a2-3229)

### DIFF
--- a/appeals/web/src/server/appeals/appeal-details/issue-decision/issue-decision.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/issue-decision/issue-decision.mapper.js
@@ -10,7 +10,8 @@ import { getErrorByFieldname } from '#lib/error-handlers/change-screen-error-han
 import { addBackLinkQueryToUrl, getBackLinkUrlFromQuery } from '#lib/url-utilities.js';
 import {
 	DECISION_TYPE_APPELLANT_COSTS,
-	DECISION_TYPE_LPA_COSTS
+	DECISION_TYPE_LPA_COSTS,
+	LENGTH_300
 } from '@pins/appeals/constants/support.js';
 import {
 	baseUrl,
@@ -308,15 +309,14 @@ function checkAndConfirmPageRows(appealData, request) {
 		const decisionOutcome = mapDecisionOutcome(inspectorDecision.outcome);
 
 		if (decisionOutcome) {
-			let invalidReasonHtml = inspectorDecision.invalidReason
-				? `Reason: ${inspectorDecision.invalidReason}`
-				: '';
-			if (inspectorDecision.invalidReason?.length > 300) {
+			let invalidReasonHtml = inspectorDecision.invalidReason ? `Reason: ` : '';
+			if (invalidReasonHtml) {
 				invalidReasonHtml = nunjucksEnvironments.render('appeals/components/page-component.njk', {
 					component: {
 						type: 'show-more',
 						parameters: {
-							text: invalidReasonHtml,
+							text: `${invalidReasonHtml}${inspectorDecision.invalidReason}`,
+							maximumBeforeHiding: invalidReasonHtml.length + LENGTH_300, // 300 being the maximum length of the invalid reason before hiding
 							toggleTextCollapsed: 'Show more',
 							toggleTextExpanded: 'Show less'
 						}


### PR DESCRIPTION
## Describe your changes

Quick fix to the show more functionality for invalid decision reason so the "maximumBeforeHiding" parameter is used.
Ignoring the prefix "Reason :", the show more only appears when the invalid reason itself is 301 characters or more. 

## Issue ticket number and link
[Ticket: A2-3229](https://pins-ds.atlassian.net/browse/A2-3229)
