### PR TITLE
fix(web): removing appeal timetable from session before redirect

### DIFF
--- a/appeals/web/src/server/appeals/appeal-details/timetable/timetable.controller.js
+++ b/appeals/web/src/server/appeals/appeal-details/timetable/timetable.controller.js
@@ -181,6 +181,7 @@ export const postAppealTimetables = async (request, response) => {
 
 	if (Object.keys(sessionTimetable).length === 0) {
 		// no success banner since user made no changes
+		delete session.appealTimetable;
 		return response.redirect(`/appeals-service/appeal-details/${appealId}`);
 	}
 


### PR DESCRIPTION
## Describe your changes
- fixing small bug where session was not cleared when no changes were made to timetables

<!--
    Please include a summary of the change along with any relevant context.
    List any dependencies that are required for this change.
-->

## Issue ticket number and link
[Ticket](https://pins-ds.atlassian.net/browse/A2-3097)
