### PR TITLE
fix(appeals): fix completed statuses list (a2-3496)

### DIFF
--- a/appeals/api/src/server/endpoints/appeal-decision/appeal-decision.controller.js
+++ b/appeals/api/src/server/endpoints/appeal-decision/appeal-decision.controller.js
@@ -2,6 +2,7 @@ import { publishDecision } from './appeal-decision.service.js';
 import { ERROR_INVALID_APPEAL_STATE } from '@pins/appeals/constants/support.js';
 import { formatAddressSingleLine } from '#endpoints/addresses/addresses.formatter.js';
 import { APPEAL_CASE_DECISION_OUTCOME, APPEAL_CASE_STATUS } from 'pins-data-model';
+import { isCurrentStatus } from '#utils/current-status.js';
 
 /** @typedef {import('express').Request} Request */
 /** @typedef {import('express').Response} Response */
@@ -20,7 +21,7 @@ export const postInspectorDecision = async (req, res) => {
 		expectedOutcome = APPEAL_CASE_DECISION_OUTCOME.SPLIT_DECISION;
 	}
 
-	if (appeal.appealStatus[0].status !== APPEAL_CASE_STATUS.ISSUE_DETERMINATION) {
+	if (!isCurrentStatus(appeal, APPEAL_CASE_STATUS.ISSUE_DETERMINATION)) {
 		return res.status(400).send({ errors: { state: ERROR_INVALID_APPEAL_STATE } });
 	}
 

--- a/appeals/api/src/server/endpoints/appeal-details/__tests__/appeals-details.test.js
+++ b/appeals/api/src/server/endpoints/appeal-details/__tests__/appeals-details.test.js
@@ -51,6 +51,7 @@ const householdAppealDto = {
 	},
 	appealStatus: householdAppeal.appealStatus[0].status,
 	stateList: householdAppeal.stateList,
+	completedStateList: [householdAppeal.appealStatus[0].status],
 	appealType: householdAppeal.appealType.type,
 	appealTimetable: {
 		appealTimetableId: householdAppeal.appealTimetable.id,
@@ -131,6 +132,7 @@ const s78AppealDto = {
 	},
 	appealStatus: fullPlanningAppeal.appealStatus[0].status,
 	stateList: fullPlanningAppeal.stateList,
+	completedStateList: [fullPlanningAppeal.appealStatus[0].status],
 	appealTimetable: {
 		appealTimetableId: fullPlanningAppeal.appealTimetable.id,
 		caseResubmissionDueDate: null,

--- a/appeals/api/src/server/endpoints/appeals.d.ts
+++ b/appeals/api/src/server/endpoints/appeals.d.ts
@@ -41,6 +41,7 @@ interface SingleAppealDetailsResponse {
 	appealSite: AppealSite;
 	appealStatus: string;
 	stateList: StateStub[];
+	completedStateList: string[];
 	transferStatus?: {
 		transferredAppealType: string;
 		transferredAppealReference: string;

--- a/appeals/api/src/server/endpoints/appeals/appeals.formatter.js
+++ b/appeals/api/src/server/endpoints/appeals/appeals.formatter.js
@@ -14,6 +14,7 @@ import {
 	DOCUMENT_STATUS_RECEIVED
 } from '@pins/appeals/constants/support.js';
 import { calculateIssueDecisionDeadline } from '#endpoints/appeals/appeals.service.js';
+import { currentStatus } from '#utils/current-status.js';
 
 const approxStageCompletion = {
 	STATE_TARGET_READY_TO_START: 5,
@@ -48,7 +49,7 @@ const formatAppeal = (appeal, linkedAppeals) => ({
 	appealId: appeal.id,
 	appealReference: appeal.reference,
 	appealSite: formatAddress(appeal.address),
-	appealStatus: appeal.appealStatus[0].status,
+	appealStatus: currentStatus(appeal),
 	appealType: appeal.appealType?.type,
 	procedureType: appeal.procedureType?.name,
 	createdAt: appeal.caseCreatedDate,
@@ -70,7 +71,7 @@ const formatMyAppeals = async (appeal, linkedAppeals) => ({
 	appealId: appeal.id,
 	appealReference: appeal.reference,
 	appealSite: formatAddress(appeal.address),
-	appealStatus: appeal.appealStatus[0].status,
+	appealStatus: currentStatus(appeal),
 	appealType: appeal.appealType?.type,
 	procedureType: appeal.procedureType?.name,
 	createdAt: appeal.caseCreatedDate,
@@ -189,7 +190,7 @@ function formatAppealTimetable(appeal) {
  * @returns {Promise<Date | null | undefined>}
  */
 export const mapAppealToDueDate = async (appeal, appellantCaseStatus, appellantCaseDueDate) => {
-	switch (appeal.appealStatus[0].status) {
+	switch (currentStatus(appeal)) {
 		case APPEAL_CASE_STATUS.READY_TO_START:
 			if (appellantCaseStatus === 'Incomplete' && appellantCaseDueDate) {
 				return new Date(appellantCaseDueDate);

--- a/appeals/api/src/server/endpoints/change-appeal-type/change-appeal-type.middleware.js
+++ b/appeals/api/src/server/endpoints/change-appeal-type/change-appeal-type.middleware.js
@@ -1,6 +1,7 @@
 import { ERROR_NOT_FOUND, ERROR_INVALID_APPEAL_STATE } from '@pins/appeals/constants/support.js';
 import { getAllAppealTypes } from '#repositories/appeal-type.repository.js';
 import { APPEAL_CASE_STATUS } from 'pins-data-model';
+import { currentStatus, isCurrentStatus } from '#utils/current-status.js';
 
 /** @typedef {import('express').Request} Request */
 /** @typedef {import('express').Response} Response */
@@ -37,17 +38,16 @@ export const validateAppealType = async (req, res, next) => {
  * @returns {Promise<object|void>}
  */
 export const validateAppealStatus = async (req, res, next) => {
-	const isValidStatus =
-		[
-			APPEAL_CASE_STATUS.CLOSED,
-			APPEAL_CASE_STATUS.COMPLETE,
-			APPEAL_CASE_STATUS.INVALID,
-			APPEAL_CASE_STATUS.AWAITING_TRANSFER,
-			APPEAL_CASE_STATUS.TRANSFERRED,
-			APPEAL_CASE_STATUS.WITHDRAWN
-		].indexOf(req.appeal.appealStatus[0].status) === -1;
+	const isInvalidStatus = [
+		APPEAL_CASE_STATUS.CLOSED,
+		APPEAL_CASE_STATUS.COMPLETE,
+		APPEAL_CASE_STATUS.INVALID,
+		APPEAL_CASE_STATUS.AWAITING_TRANSFER,
+		APPEAL_CASE_STATUS.TRANSFERRED,
+		APPEAL_CASE_STATUS.WITHDRAWN
+	].includes(currentStatus(req.appeal));
 
-	if (!isValidStatus) {
+	if (isInvalidStatus) {
 		return res.status(400).send({ errors: { appealStatus: ERROR_INVALID_APPEAL_STATE } });
 	}
 	next();
@@ -58,7 +58,7 @@ export const validateAppealStatus = async (req, res, next) => {
  * @returns {Promise<object|void>}
  */
 export const validateAppealStatusForTransfer = async (req, res, next) => {
-	const isValidStatus = req.appeal.appealStatus[0].status === APPEAL_CASE_STATUS.AWAITING_TRANSFER;
+	const isValidStatus = isCurrentStatus(req.appeal, APPEAL_CASE_STATUS.AWAITING_TRANSFER);
 
 	if (!isValidStatus) {
 		return res.status(400).send({ errors: { appealStatus: ERROR_INVALID_APPEAL_STATE } });

--- a/appeals/api/src/server/endpoints/decision/decision.controller.js
+++ b/appeals/api/src/server/endpoints/decision/decision.controller.js
@@ -10,6 +10,7 @@ import {
 import { formatAddressSingleLine } from '#endpoints/addresses/addresses.formatter.js';
 import { APPEAL_CASE_STATUS } from 'pins-data-model';
 import { createAuditTrail } from '#endpoints/audit-trails/audit-trails.service.js';
+import { isCurrentStatus } from '#utils/current-status.js';
 
 /** @typedef {import('express').Request} Request */
 /** @typedef {import('express').Response} Response */
@@ -28,7 +29,7 @@ export const postInspectorDecision = async (req, res) => {
 		decisions.some(
 			(/** @type {Decision} */ decision) => decision?.decisionType === DECISION_TYPE_INSPECTOR
 		) &&
-		appeal.appealStatus[0].status !== APPEAL_CASE_STATUS.ISSUE_DETERMINATION
+		!isCurrentStatus(req.appeal, APPEAL_CASE_STATUS.ISSUE_DETERMINATION)
 	) {
 		return res.status(400).send({ errors: { state: ERROR_INVALID_APPEAL_STATE } });
 	}

--- a/appeals/api/src/server/endpoints/invalid-appeal-decision/invalid-appeal-decision.controller.js
+++ b/appeals/api/src/server/endpoints/invalid-appeal-decision/invalid-appeal-decision.controller.js
@@ -1,6 +1,7 @@
 import { publishInvalidDecision } from './invalid-appeal-decision.service.js';
 import { ERROR_INVALID_APPEAL_STATE } from '@pins/appeals/constants/support.js';
 import { APPEAL_CASE_STATUS } from 'pins-data-model';
+import { isCurrentStatus } from '#utils/current-status.js';
 
 /** @typedef {import('express').Request} Request */
 /** @typedef {import('express').Response} Response */
@@ -15,7 +16,7 @@ export const postInvalidDecision = async (req, res) => {
 	const { invalidDecisionReason } = req.body;
 	const notifyClient = req.notifyClient;
 
-	if (appeal.appealStatus[0].status !== APPEAL_CASE_STATUS.ISSUE_DETERMINATION) {
+	if (!isCurrentStatus(appeal, APPEAL_CASE_STATUS.ISSUE_DETERMINATION)) {
 		return res.status(400).send({ errors: { state: ERROR_INVALID_APPEAL_STATE } });
 	}
 

--- a/appeals/api/src/server/endpoints/linkable-appeals/linkable-appeal.formatter.js
+++ b/appeals/api/src/server/endpoints/linkable-appeals/linkable-appeal.formatter.js
@@ -1,5 +1,7 @@
 /** @typedef {import('@pins/appeals.api').Schema.Appeal} Appeal */
 
+import { currentStatus } from '#utils/current-status.js';
+
 /**
  * @param {Appeal} appeal
  * @returns {import('@pins/appeals.api').Appeals.LinkableAppealSummary}
@@ -9,7 +11,7 @@ export const formatLinkableAppealSummary = (appeal) => {
 		appealId: appeal.id.toString(),
 		appealReference: appeal.reference,
 		appealType: appeal.appealType?.type,
-		appealStatus: appeal.appealStatus[0].status,
+		appealStatus: currentStatus(appeal),
 		siteAddress: {
 			addressLine1: appeal.address?.addressLine1 || '',
 			addressLine2: appeal.address?.addressLine2 || '',

--- a/appeals/api/src/server/endpoints/lpa-questionnaires/lpa-questionnaires.service.js
+++ b/appeals/api/src/server/endpoints/lpa-questionnaires/lpa-questionnaires.service.js
@@ -19,6 +19,7 @@ import { notifySend } from '#notify/notify-send.js';
 import { APPEAL_TYPE } from '@pins/appeals/constants/common.js';
 import { APPEAL_CASE_STATUS } from 'pins-data-model';
 import logger from '#utils/logger.js';
+import { isCurrentStatus } from '#utils/current-status.js';
 
 /** @typedef {import('express').RequestHandler} RequestHandler */
 /** @typedef {import('@pins/appeals.api').Appeals.UpdateLPAQuestionnaireValidationOutcomeParams} UpdateLPAQuestionnaireValidationOutcomeParams */
@@ -54,10 +55,10 @@ const updateLPAQuestionnaireValidationOutcome = async (
 ) => {
 	let timetable = undefined;
 
-	const { id: appealId, applicationReference: lpaReference, appealStatus } = appeal;
+	const { id: appealId, applicationReference: lpaReference } = appeal;
 	const { lpaQuestionnaireDueDate, incompleteReasons } = data;
 
-	if (appealStatus[0].status != APPEAL_CASE_STATUS.LPA_QUESTIONNAIRE) {
+	if (!isCurrentStatus(appeal, APPEAL_CASE_STATUS.LPA_QUESTIONNAIRE)) {
 		logger.error('LPAQ already validated');
 		throw new Error('LPAQ already validated');
 	}

--- a/appeals/api/src/server/endpoints/representations/representations.controller.js
+++ b/appeals/api/src/server/endpoints/representations/representations.controller.js
@@ -23,6 +23,7 @@ import { camelToScreamingSnake } from '#utils/string-utils.js';
 import stringTokenReplacement from '#utils/string-token-replacement.js';
 import BackOfficeAppError from '#utils/app-error.js';
 import { notifyOnStatusChange } from './notify/index.js';
+import { currentStatus } from '#utils/current-status.js';
 
 /** @typedef {import('express').Request} Request */
 /** @typedef {import('express').Response} Response */
@@ -315,15 +316,15 @@ export async function publish(req, res) {
 		throw new BackOfficeAppError('azureAdUserId not provided', 401);
 	}
 
-	const currentStatus = appeal.appealStatus[0]?.status;
-	if (!currentStatus) {
+	const currentAppealStatus = currentStatus(appeal);
+	if (!currentAppealStatus) {
 		throw new BackOfficeAppError(`no status found for appeal ${appeal.id}`, 500);
 	}
 
-	const publish = handlers[currentStatus];
+	const publish = handlers[currentAppealStatus];
 	if (!publish) {
 		throw new BackOfficeAppError(
-			`cannot publish representations when appeal is in the ${currentStatus} state`,
+			`cannot publish representations when appeal is in the ${currentAppealStatus} state`,
 			409
 		);
 	}
@@ -337,7 +338,7 @@ export async function publish(req, res) {
 			[APPEAL_CASE_STATUS.FINAL_COMMENTS]: 'Final comments'
 		};
 
-		const replacement = replacements[currentStatus];
+		const replacement = replacements[currentAppealStatus];
 		if (replacement) {
 			const details = stringTokenReplacement(CONSTANTS.AUDIT_TRAIL_REP_SHARED, [replacement]);
 

--- a/appeals/api/src/server/endpoints/representations/representations.middleware.js
+++ b/appeals/api/src/server/endpoints/representations/representations.middleware.js
@@ -5,6 +5,7 @@ import {
 	APPEAL_REPRESENTATION_TYPE
 } from '@pins/appeals/constants/common.js';
 import { APPEAL_CASE_STATUS } from 'pins-data-model';
+import { currentStatus } from '#utils/current-status.js';
 
 /** @typedef {import('@pins/appeals.api').Schema.Appeal} Appeal */
 
@@ -68,7 +69,7 @@ const canPublishFinalComments = (currentAppeal) => {
 @returns {Promise<object|void>}
  */
 export const validateRepresentationsToPublish = async (req, res, next) => {
-	const { status } = req.appeal?.appealStatus[0] || {};
+	const status = currentStatus(req.appeal);
 	const { STATEMENTS, FINAL_COMMENTS } = APPEAL_CASE_STATUS;
 
 	if (

--- a/appeals/api/src/server/endpoints/representations/representations.service.js
+++ b/appeals/api/src/server/endpoints/representations/representations.service.js
@@ -20,6 +20,7 @@ import formatDate from '#utils/date-formatter.js';
 import { notifySend } from '#notify/notify-send.js';
 import { EventType } from '@pins/event-client';
 import { broadcasters } from '#endpoints/integrations/integrations.broadcasters.js';
+import { isCurrentStatus } from '#utils/current-status.js';
 
 /** @typedef {import('@pins/appeals.api').Schema.Appeal} Appeal */
 /** @typedef {import('@pins/appeals.api').Schema.Representation} Representation */
@@ -195,7 +196,7 @@ export async function updateRepresentation(repId, payload) {
  * @type {PublishFunction}
  * */
 export async function publishLpaStatements(appeal, azureAdUserId, notifyClient) {
-	if (appeal.appealStatus[0].status !== APPEAL_CASE_STATUS.STATEMENTS) {
+	if (!isCurrentStatus(appeal, APPEAL_CASE_STATUS.STATEMENTS)) {
 		throw new BackOfficeAppError('appeal in incorrect state to publish LPA statement', 409);
 	}
 
@@ -268,7 +269,7 @@ export async function publishLpaStatements(appeal, azureAdUserId, notifyClient) 
 
 /** @type {PublishFunction} */
 export async function publishFinalComments(appeal, azureAdUserId, notifyClient) {
-	if (appeal.appealStatus[0].status !== APPEAL_CASE_STATUS.FINAL_COMMENTS) {
+	if (!isCurrentStatus(appeal, APPEAL_CASE_STATUS.FINAL_COMMENTS)) {
 		throw new BackOfficeAppError('appeal in incorrect state to publish final comments', 409);
 	}
 

--- a/appeals/api/src/server/mappers/api/shared/index.js
+++ b/appeals/api/src/server/mappers/api/shared/index.js
@@ -16,6 +16,7 @@ import { mapAppellantCase } from './map-appellant-case.js';
 import { mapLpaQuestionnaire } from './map-lpa-questionnaire.js';
 import { mapHearing } from './map-hearing.js';
 import { mapHearingEstimate } from './map-hearing-estimate.js';
+import { mapCompletedStateList } from '#mappers/api/shared/map-completed-state-list.js';
 
 export const apiSharedMappers = {
 	appealSummary: mapAppealSummary,
@@ -27,6 +28,7 @@ export const apiSharedMappers = {
 	appealTimetable: mapAppealTimetable,
 	documentationSummary: mapDocumentationSummary,
 	stateList: mapStateList,
+	completedStateList: mapCompletedStateList,
 	decision: mapAppealDecision,
 	appealRelationships: mapAppealRelationships,
 	neighbouringSites: mapNeighbouringSites,

--- a/appeals/api/src/server/mappers/api/shared/map-appeal-status.js
+++ b/appeals/api/src/server/mappers/api/shared/map-appeal-status.js
@@ -1,6 +1,8 @@
 /** @typedef {import('@pins/appeals.api').Schema.Appeal} Appeal */
 /** @typedef {import('#mappers/mapper-factory.js').MappingRequest} MappingRequest */
 
+import { currentStatus } from '#utils/current-status.js';
+
 /**
  *
  * @param {MappingRequest} data
@@ -14,7 +16,7 @@ export const mapAppealStatus = (data) => {
 	}
 
 	if (appeal.appealStatus.length > 1) {
-		return appeal.appealStatus.find((status) => status.valid === true)?.status || '';
+		return currentStatus(appeal);
 	}
 
 	return appeal.appealStatus[0].status;

--- a/appeals/api/src/server/mappers/api/shared/map-completed-state-list.js
+++ b/appeals/api/src/server/mappers/api/shared/map-completed-state-list.js
@@ -1,0 +1,11 @@
+/** @typedef {import('#mappers/mapper-factory.js').MappingRequest} MappingRequest */
+/** @typedef {import('@pins/appeals.api').Appeals.StateStub} StateStub */
+
+/**
+ *
+ * @param {MappingRequest} data
+ * @returns {string[]}
+ */
+export function mapCompletedStateList(data) {
+	return data.appeal.appealStatus?.map(({ status }) => status) || [];
+}

--- a/appeals/api/src/server/mappers/api/shared/map-state-list.js
+++ b/appeals/api/src/server/mappers/api/shared/map-state-list.js
@@ -1,4 +1,5 @@
 import listStates from '#state/list-states.js';
+import { currentStatus } from '#utils/current-status.js';
 
 /** @typedef {import('#mappers/mapper-factory.js').MappingRequest} MappingRequest */
 /** @typedef {import('@pins/appeals.api').Appeals.StateStub} StateStub */
@@ -9,9 +10,9 @@ import listStates from '#state/list-states.js';
  * @returns {StateStub[]}
  */
 export function mapStateList(data) {
-	const { appealType, procedureType, appealStatus } = data.appeal;
+	const { appealType, procedureType } = data.appeal;
 
-	const status = appealStatus?.[0]?.status;
+	const status = currentStatus(data.appeal);
 	if (!appealType || !status) {
 		return [];
 	}

--- a/appeals/api/src/server/openapi-types.ts
+++ b/appeals/api/src/server/openapi-types.ts
@@ -1162,6 +1162,8 @@ export interface SingleAppealResponse {
 	};
 	/** @example [] */
 	stateList?: any[];
+	/** @example ["awaiting_event"] */
+	completedStateList?: string[];
 }
 
 export interface SingleAppellantCaseResponse {

--- a/appeals/api/src/server/openapi.json
+++ b/appeals/api/src/server/openapi.json
@@ -7990,6 +7990,13 @@
 						"type": "array",
 						"example": [],
 						"items": {}
+					},
+					"completedStateList": {
+						"type": "array",
+						"example": ["awaiting_event"],
+						"items": {
+							"type": "string"
+						}
 					}
 				},
 				"xml": {

--- a/appeals/api/src/server/repositories/appeal.repository.js
+++ b/appeals/api/src/server/repositories/appeal.repository.js
@@ -68,11 +68,7 @@ const appealDetailsInclude = {
 	appellant: true,
 	agent: true,
 	lpa: true,
-	appealStatus: {
-		where: {
-			valid: true
-		}
-	},
+	appealStatus: true,
 	appealTimetable: true,
 	appealType: true,
 	caseOfficer: true,

--- a/appeals/api/src/server/state/transition-state.js
+++ b/appeals/api/src/server/state/transition-state.js
@@ -13,6 +13,7 @@ import {
 } from '@pins/appeals/constants/support.js';
 import { APPEAL_CASE_PROCEDURE, APPEAL_CASE_STATUS } from 'pins-data-model';
 import isFPA from '#utils/is-fpa.js';
+import { currentStatus } from '#utils/current-status.js';
 
 /** @typedef {import('#db-client').AppealType} AppealType */
 /** @typedef {import('#db-client').AppealStatus} AppealStatus */
@@ -34,7 +35,7 @@ const transitionState = async (appealId, azureAdUserId, trigger) => {
 		throw new Error(`appeal with ID ${appealId} is missing fields required to transition state`);
 	}
 
-	const currentState = appealStatus[0].status;
+	const currentState = currentStatus(appeal);
 
 	if (!procedureType) {
 		logger.info(`Procedure type not set for appeal ${appealId}, defaulting to written`);
@@ -74,6 +75,7 @@ const transitionState = async (appealId, azureAdUserId, trigger) => {
 	if (
 		currentState !== APPEAL_CASE_STATUS.AWAITING_EVENT &&
 		newState === APPEAL_CASE_STATUS.EVENT &&
+		// newState === APPEAL_CASE_STATUS.ISSUE_DETERMINATION &&
 		[APPEAL_TYPE_SHORTHAND_HAS, APPEAL_TYPE_SHORTHAND_FPA].includes(appealType.key) &&
 		appeal.siteVisit
 	) {

--- a/appeals/api/src/server/swagger.js
+++ b/appeals/api/src/server/swagger.js
@@ -387,7 +387,8 @@ export const spec = {
 					status: 'not_received'
 				}
 			},
-			stateList: []
+			stateList: [],
+			completedStateList: ['awaiting_event']
 		},
 		SingleAppellantCaseResponse: {
 			agriculturalHolding: {

--- a/appeals/api/src/server/tests/appeals/has.js
+++ b/appeals/api/src/server/tests/appeals/has.js
@@ -187,6 +187,7 @@ export default {
 			key: 'complete'
 		}
 	],
+	completedStateList: ['assign_case_officer', 'validation', 'ready_to_start'],
 	appealTimetable: {
 		id: 1,
 		appealId: 1,

--- a/appeals/api/src/server/utils/current-status.js
+++ b/appeals/api/src/server/utils/current-status.js
@@ -1,0 +1,23 @@
+/** @typedef {import('@pins/appeals.api').Schema.Appeal} Appeal */
+/** @typedef {import('#repositories/appeal-lists.repository.js').DBUserAppeal} DBUserAppeal */
+/** @typedef {import('#repositories/appeal-lists.repository.js').DBAppeals} DBAppeals */
+/** @typedef {DBAppeals[0]} DBAppeal */
+
+/**
+ *
+ * @param {DBAppeal | DBUserAppeal | Appeal} appeal
+ * @returns {string}
+ */
+export const currentStatus = (appeal) => {
+	return appeal?.appealStatus?.find((item) => item?.valid)?.status ?? '';
+};
+
+/**
+ *
+ * @param {DBAppeal | DBUserAppeal | Appeal} appeal
+ * @param {string} status
+ * @returns {boolean}
+ */
+export const isCurrentStatus = (appeal, status) => {
+	return currentStatus(appeal) === status;
+};

--- a/appeals/web/src/server/appeals/appeal-details/__tests__/appeal-details.test.js
+++ b/appeals/web/src/server/appeals/appeal-details/__tests__/appeal-details.test.js
@@ -1887,7 +1887,7 @@ describe('appeal-details', () => {
 				.reply(200, {
 					...appealData,
 					appealStatus: 'complete',
-					stateList: [{ key: 'awaiting_event', completed: true }]
+					completedStateList: ['awaiting_event']
 				});
 			nock('http://test/').get(`/appeals/${appealId}/case-notes`).reply(200, caseNotes);
 			const response = await request.get(`${baseUrl}/${appealId}`);
@@ -2937,12 +2937,7 @@ describe('appeal-details', () => {
 							},
 							caseOfficer: '2cb7735e-c4cf-410b-b773-5ec4cf110b87',
 							appealId,
-							stateList: [
-								{
-									key: 'statements',
-									completed: true
-								}
-							]
+							completedStateList: ['statements']
 						});
 					const response = await request.get(`${baseUrl}/${appealId}`);
 					expect(response.statusCode).toBe(200);
@@ -3898,7 +3893,7 @@ describe('appeal-details', () => {
 						...appealData,
 						appealId,
 						appealStatus: 'issue_determination',
-						stateList: [{ key: 'awaiting_event', completed: true }],
+						completedStateList: ['awaiting_event'],
 						decision: {
 							...appealData.decision,
 							outcome: null
@@ -3965,7 +3960,7 @@ describe('appeal-details', () => {
 							.reply(200, {
 								...appealData,
 								appealId,
-								stateList: [{ key: 'awaiting_event', completed: true }],
+								completedStateList: ['awaiting_event'],
 								appealStatus: 'issue_determination',
 								costs: {
 									appellantApplicationFolder: {
@@ -4003,7 +3998,7 @@ describe('appeal-details', () => {
 							.reply(200, {
 								...appealData,
 								appealId,
-								stateList: [{ key: 'event', completed: false }],
+								completedStateList: ['event'],
 								appealStatus,
 								costs: {
 									appellantApplicationFolder: {
@@ -4032,8 +4027,8 @@ describe('appeal-details', () => {
 							.reply(200, {
 								...appealData,
 								appealId,
-								stateList: [{ key: 'awaiting_event', completed: true }],
-								appealStatus: 'issue_determination',
+								completedStateList: ['awaiting_event'],
+								appealStatus,
 								costs: {
 									lpaApplicationFolder: {
 										documents: [{ id: 1 }]
@@ -4070,7 +4065,7 @@ describe('appeal-details', () => {
 							.reply(200, {
 								...appealData,
 								appealId,
-								stateList: [{ key: 'event', completed: false }],
+								completedStateList: ['event'],
 								appealStatus,
 								costs: {
 									lpaApplicationFolder: {

--- a/appeals/web/src/server/lib/appeal-status.js
+++ b/appeals/web/src/server/lib/appeal-status.js
@@ -51,18 +51,9 @@ export function mapAppealProcedureTypeToEventName(appealProcedureType) {
  * @returns {boolean}
  * */
 export function isStatePassed(appeal, state) {
-	const { stateList } = appeal;
+	const { completedStateList = [] } = appeal;
 
-	if (!stateList) {
-		return false;
-	}
-
-	const propState = stateList.find((s) => s.key === state);
-	if (!propState) {
-		return false;
-	}
-
-	return propState.completed;
+	return completedStateList.includes(state);
 }
 
 /**

--- a/appeals/web/testing/app/fixtures/referencedata.js
+++ b/appeals/web/testing/app/fixtures/referencedata.js
@@ -171,6 +171,7 @@ export const appealData = {
 	},
 	appealStatus: 'received_appeal',
 	stateList: [],
+	completedStateList: [],
 	appealTimetable: {
 		appealTimetableId: 1053,
 		lpaQuestionnaireDueDate: '2023-10-11T01:00:00.000Z',


### PR DESCRIPTION
## Describe your changes
#### Fix completed statuses list (A2-3496)

### API:
- Return all completed statuses when retrieving appeal data within the API.
- Create a simple single function to retrieve the current status from the list of completed appeal statuses.
- Change all references to obtaining the appeal status to use the currentStatus function
- Updated the API definition for Appeal to include completedStatusList array

### WEB:
- Change the isStatusPassed function so that it just checks the existence of the status in the completed status list

### TEST:
- Fixed unit tests in both the API and WEB
- Made sure all unit tests pass
- Manually tested within browser
- Tested with the e2e tests  progressS78ToDecision.spec.js and issueDecision.spec.js to check the status progression is working correctly.

## Issue ticket number and link:
- [(A2-3496) Fix completed statuses list so it is possible to know when a status has been completed](https://pins-ds.atlassian.net/browse/A2-3496)

