### PR TITLE
chore(appeals): add notify emails sent route to test utils

### DIFF
--- a/appeals/api/src/server/endpoints/notifications/notification.controller.js
+++ b/appeals/api/src/server/endpoints/notifications/notification.controller.js
@@ -12,5 +12,5 @@ export const getNotifications = async (req, res) => {
 	const { appeal } = req;
 	const notifications = await getAppealNotifications(appeal.reference);
 
-	return res.status(201).send(notifications);
+	return res.status(200).send(notifications);
 };

--- a/appeals/api/src/server/endpoints/notifications/notifications.routes.js
+++ b/appeals/api/src/server/endpoints/notifications/notifications.routes.js
@@ -17,7 +17,7 @@ router.get(
 			example: '434bff4e-8191-4ce0-9a0a-91e5d6cdd882'
 		}
 		#swagger.responses[400] = {}
-		#swagger.responses[201] = {
+		#swagger.responses[200] = {
 			description: 'Returns the notification list',
 			schema: { $ref: '#/components/schemas/Notifications' }
 		}

--- a/appeals/api/src/server/endpoints/test-utils/test-utils.controller.js
+++ b/appeals/api/src/server/endpoints/test-utils/test-utils.controller.js
@@ -3,6 +3,7 @@ import { sub } from 'date-fns';
 import { updateCompletedEvents } from '#endpoints/appeals/appeals.service.js';
 import { AUDIT_TRAIL_SYSTEM_UUID } from '@pins/appeals/constants/support.js';
 import { APPEAL_START_RANGE } from '@pins/appeals/constants/common.js';
+import { getAppealNotifications } from '#repositories/appeal-notification.repository.js';
 
 /** @typedef {import('express').Request} Request */
 /** @typedef {import('express').Response} Response */
@@ -108,4 +109,16 @@ export const simulateFinalCommentsElapsed = async (req, res) => {
 	}
 
 	return res.send(false);
+};
+
+/**
+ * @param {Request} req
+ * @param {Response} res
+ * @returns {Promise<Response>}
+ * */
+export const retrieveNotifyEmails = async (req, res) => {
+	const { appealReference } = req.params;
+	const notifications = await getAppealNotifications(appealReference);
+
+	return res.status(200).send(notifications);
 };

--- a/appeals/api/src/server/endpoints/test-utils/test-utils.routes.js
+++ b/appeals/api/src/server/endpoints/test-utils/test-utils.routes.js
@@ -3,7 +3,8 @@ import { asyncHandler } from '@pins/express';
 import {
 	simulateSiteVisitElapsed,
 	simulateStatementsElapsed,
-	simulateFinalCommentsElapsed
+	simulateFinalCommentsElapsed,
+	retrieveNotifyEmails
 } from './test-utils.controller.js';
 
 const router = createRouter();
@@ -57,6 +58,23 @@ router.post(
 		#swagger.responses[400] = {}
 	 */
 	asyncHandler(simulateFinalCommentsElapsed)
+);
+
+router.get(
+	'/:appealReference/notify-emails-sent',
+	/*
+		#swagger.tags = ['Test Utilities']
+		#swagger.path = '/appeals/{appealReference}/notify-emails-sent'
+		#swagger.description = 'A test endpoint to retrieve an array of notify emails sent for this appeal reference'
+		#swagger.parameters['azureAdUserId'] = {
+			in: 'header',
+			required: true,
+			example: '434bff4e-8191-4ce0-9a0a-91e5d6cdd882'
+		}
+		#swagger.responses[200] = {}
+		#swagger.responses[400] = {}
+	 */
+	asyncHandler(retrieveNotifyEmails)
 );
 
 export { router as testUtilsRoutes };

--- a/appeals/api/src/server/openapi.json
+++ b/appeals/api/src/server/openapi.json
@@ -4882,7 +4882,7 @@
 					}
 				],
 				"responses": {
-					"201": {
+					"200": {
 						"description": "Returns the notification list",
 						"content": {
 							"application/json": {
@@ -5228,6 +5228,39 @@
 			"post": {
 				"tags": ["Test Utilities"],
 				"description": "A test endpoint to simulate the deadline for final comments in the past",
+				"parameters": [
+					{
+						"name": "appealReference",
+						"in": "path",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"name": "azureAdUserId",
+						"in": "header",
+						"required": true,
+						"example": "434bff4e-8191-4ce0-9a0a-91e5d6cdd882",
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK"
+					},
+					"400": {
+						"description": "Bad Request"
+					}
+				}
+			}
+		},
+		"/appeals/{appealReference}/notify-emails-sent": {
+			"get": {
+				"tags": ["Test Utilities"],
+				"description": "A test endpoint to retrieve an array of notify emails sent for this appeal reference",
 				"parameters": [
 					{
 						"name": "appealReference",


### PR DESCRIPTION
## Describe your changes

- Add test utils get route: '/appeals/{appealReference}/notify-emails-sent' so the notifications can be retrieved via the appeal reference.
- Amend the return code in the notifications route so that it returns a 200 and not a 201 as nothing is created, just retrieved.
