### PR TITLE
test(appeals): refactor checkNotifySent to accept arrays

### DIFF
--- a/appeals/e2e/cypress/e2e/back-office-appeals/issueDecision.spec.js
+++ b/appeals/e2e/cypress/e2e/back-office-appeals/issueDecision.spec.js
@@ -66,7 +66,12 @@ describe('Issue Decision', () => {
 				caseDetailsPage.viewDecisionLetter('View decision');
 
 				//Notify
-				cy.checkNotifySent(caseRef, 'decision-is-allowed-split-dismissed-lpa');
+				const expectedNotifies = [
+					'decision-is-allowed-split-dismissed-lpa',
+					'decision-is-allowed-split-dismissed-appellant'
+				];
+
+				cy.checkNotifySent(caseRef, expectedNotifies);
 			});
 		});
 	});

--- a/appeals/e2e/cypress/support/commands.js
+++ b/appeals/e2e/cypress/support/commands.js
@@ -212,11 +212,21 @@ Cypress.Commands.add('deleteHearing', (reference) => {
 	});
 });
 
-Cypress.Commands.add('checkNotifySent', (reference, templateName) => {
-	return cy.wrap(null).then(async () => {
-		const emails = await appealsApiClient.getNotifyEmails(reference);
-		const targetEmail = await emails.find((email) => email.template === templateName);
+Cypress.Commands.add('checkNotifySent', (reference, templates) => {
+	const expectedTemplates = [].concat(templates);
 
-		expect(targetEmail.template).to.eq(templateName);
+	return cy.wrap(null).then(async () => {
+		// returns an array of email objects sent for the given reference
+		const emails = await appealsApiClient.getNotifyEmails(reference);
+
+		// creates an array of unique sent email templates that match expected
+		const foundTemplateNames = [...new Set(emails.map((email) => email.template))];
+
+		// creates a list of expected templates that were not found
+		const missingTemplates = expectedTemplates.filter(
+			(expected) => !foundTemplateNames.includes(expected)
+		);
+
+		expect(missingTemplates, `Expected, but not found:${missingTemplates}`).to.be.empty;
 	});
 });


### PR DESCRIPTION
## Describe your changes

<!--
Refactored the cy.checkNotifySent function to accept arrays or strings. Previously only accepted single strings. 
-->

## Issue ticket number and link
[A2-3494](https://pins-ds.atlassian.net/browse/A2-3494)
