### PR TITLE
fix(appeals): link appeals part 4 case overview add linked appeal (a2-3339)

### DIFF
--- a/appeals/api/src/server/endpoints/link-appeals/link-appeals.service.js
+++ b/appeals/api/src/server/endpoints/link-appeals/link-appeals.service.js
@@ -2,27 +2,32 @@
 
 /**
  * Checks if an appeal is linked to other appeals as a parent.
- * @param {{ childAppeals?: unknown[] }} appeal The appeal to check for linked appeals.
+ * @param {{ childAppeals?: any[] }} appeal The appeal to check for linked appeals.
+ * @param {string} type The linkable type to check for.
  * @returns {boolean}
  */
-const isAppealLead = (appeal) => (appeal.childAppeals || []).length > 0;
+const isAppealLead = (appeal, type) =>
+	Boolean(appeal.childAppeals?.some((childAppeal) => childAppeal.type === type));
 
 /**
  * Checks if an appeal is linked to other appeals as a child.
- * @param {{ parentAppeals?: unknown[] }} appeal The appeal to check for linked appeals.
+ * @param {{ parentAppeals?: any[] }} appeal The appeal to check for linked appeals.
+ * @param {string} type The linkable type to check for.
  * @returns {boolean}
  */
-const isAppealChild = (appeal) => (appeal.parentAppeals || []).length > 0;
+const isAppealChild = (appeal, type) =>
+	Boolean(appeal.parentAppeals?.some((parentAppeal) => parentAppeal.type === type));
 
 /**
  * Checks if an appeal can be linked, with a specific relationship type (parent/child).
  * @param {{ childAppeals?: unknown[], parentAppeals?: unknown[] }} appeal The appeal to check for linked appeals.
+ * @param {string} type The linkable type to check for.
  * @param {'lead'|'child'} relationship The relationship to check for.
  * @returns {boolean}
  */
-export const canLinkAppeals = (appeal, relationship) => {
-	const isLead = isAppealLead(appeal);
-	const isChild = isAppealChild(appeal);
+export const canLinkAppeals = (appeal, type, relationship) => {
+	const isLead = isAppealLead(appeal, type);
+	const isChild = isAppealChild(appeal, type);
 
 	return relationship === 'lead' ? !isChild : !isChild && !isLead;
 };

--- a/appeals/api/src/server/endpoints/linkable-appeals/__tests__/linkable-appeal.test.js
+++ b/appeals/api/src/server/endpoints/linkable-appeals/__tests__/linkable-appeal.test.js
@@ -12,7 +12,7 @@ import {
 const { databaseConnector } = await import('#utils/database-connector.js');
 const { default: got } = await import('got');
 
-describe('/appeals/linkable-appeal/:appealReference', () => {
+describe('/appeals/linkable-appeal/:appealReference/:linkableType', () => {
 	describe('GET', () => {
 		beforeEach(() => {
 			jest.resetAllMocks();
@@ -20,7 +20,7 @@ describe('/appeals/linkable-appeal/:appealReference', () => {
 		test('gets a back office linkable appeal summary when the appeal exists in back office', async () => {
 			databaseConnector.appeal.findUnique.mockResolvedValueOnce(householdAppeal);
 			const response = await request
-				.get(`/appeals/linkable-appeal/${householdAppeal.reference}`)
+				.get(`/appeals/linkable-appeal/${householdAppeal.reference}/related`)
 				.set('azureAdUserId', azureAdUserId);
 			expect(response.status).toEqual(200);
 			expect(response.body).toEqual({
@@ -56,7 +56,7 @@ describe('/appeals/linkable-appeal/:appealReference', () => {
 					.mockResolvedValueOnce(parseHorizonGetCaseResponse(horizonGetCaseSuccessResponse))
 			});
 			const response = await request
-				.get(`/appeals/linkable-appeal/1`)
+				.get(`/appeals/linkable-appeal/1/related`)
 				.set('azureAdUserId', azureAdUserId);
 			expect(response.status).toEqual(200);
 			expect(response.body).toEqual({
@@ -85,14 +85,14 @@ describe('/appeals/linkable-appeal/:appealReference', () => {
 				})
 			});
 			const response = await request
-				.get(`/appeals/linkable-appeal/1`)
+				.get(`/appeals/linkable-appeal/1/related`)
 				.set('azureAdUserId', azureAdUserId);
 			expect(response.status).toEqual(404);
 		});
 		test('responds with a 500 if the Horizon API is down', async () => {
 			databaseConnector.appeal.findUnique.mockResolvedValueOnce(null);
 			const response = await request
-				.get(`/appeals/linkable-appeal/1`)
+				.get(`/appeals/linkable-appeal/1/related`)
 				.set('azureAdUserId', azureAdUserId);
 			expect(response.status).toEqual(500);
 		});

--- a/appeals/api/src/server/endpoints/linkable-appeals/linkable-appeal.controller.js
+++ b/appeals/api/src/server/endpoints/linkable-appeals/linkable-appeal.controller.js
@@ -10,7 +10,7 @@ import { getLinkableAppealSummaryByCaseReference } from './linkable-appeal.servi
  * @returns {Promise<Response>}
  */
 export const getLinkableAppealById = async (req, res) => {
-	const { appealReference } = req.params;
+	const { appealReference, linkableType } = req.params;
 
 	try {
 		const linkableAppeal = await getLinkableAppealSummaryByCaseReference(appealReference);
@@ -19,7 +19,7 @@ export const getLinkableAppealById = async (req, res) => {
 			return res.send(linkableAppeal);
 		}
 
-		if (!canLinkAppeals(linkableAppeal, 'child')) {
+		if (!canLinkAppeals(linkableAppeal, linkableType, 'lead')) {
 			throw 409;
 		}
 

--- a/appeals/api/src/server/endpoints/linkable-appeals/linkable-appeal.routes.js
+++ b/appeals/api/src/server/endpoints/linkable-appeals/linkable-appeal.routes.js
@@ -5,10 +5,10 @@ import { getLinkableAppealById } from './linkable-appeal.controller.js';
 const router = createRouter();
 
 router.get(
-	'/linkable-appeal/:appealReference',
+	'/linkable-appeal/:appealReference/:linkableType',
 	/*
 		#swagger.tags = ['Linkable appeals']
-		#swagger.path = '/appeals/linkable-appeal/{appealReference}'
+		#swagger.path = '/appeals/linkable-appeal/{appealReference}/{linkableType}'
 		#swagger.description = Gets a single related appeal by id from BO or Horizon. If mocking use 1000000 for valid case on horizon, 2000000 for unpublished case on horizon, any for case not found on horizon
 		#swagger.parameters['azureAdUserId'] = {
 			in: 'header',

--- a/appeals/api/src/server/openapi.json
+++ b/appeals/api/src/server/openapi.json
@@ -5290,7 +5290,7 @@
 				}
 			}
 		},
-		"/appeals/linkable-appeal/{appealReference}": {
+		"/appeals/linkable-appeal/{appealReference}/{linkableType}": {
 			"get": {
 				"tags": ["Linkable appeals"],
 				"description": "Gets a single related appeal by id from BO or Horizon. If mocking use 1000000 for valid case on horizon, 2000000 for unpublished case on horizon, any for case not found on horizon",
@@ -5303,6 +5303,14 @@
 							"type": "string"
 						},
 						"description": "Appeal Reference"
+					},
+					{
+						"name": "linkableType",
+						"in": "path",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
 					},
 					{
 						"name": "azureAdUserId",

--- a/appeals/e2e/cypress/e2e/back-office-appeals/linkAppeals.spec.js
+++ b/appeals/e2e/cypress/e2e/back-office-appeals/linkAppeals.spec.js
@@ -26,10 +26,7 @@ describe('link appeals', () => {
 				caseDetailsPage.selectRadioButtonByValue(caseRef);
 				caseDetailsPage.clickButtonByText('Continue');
 				caseDetailsPage.clickButtonByText('Add linked appeal');
-				caseDetailsPage.validateBannerMessage(
-					'Success',
-					`This appeal is now the lead for appeal ${caseRefToLink}`
-				);
+				caseDetailsPage.validateBannerMessage('Success', 'Linked appeal added');
 				caseDetailsPage.checkStatusOfCase('Child', 1);
 			});
 		});
@@ -46,10 +43,7 @@ describe('link appeals', () => {
 				caseDetailsPage.selectRadioButtonByValue(caseRef);
 				caseDetailsPage.clickButtonByText('Continue');
 				caseDetailsPage.clickButtonByText('Add linked appeal');
-				caseDetailsPage.validateBannerMessage(
-					'Success',
-					`This appeal is now the lead for appeal ${caseRefToLink}`
-				);
+				caseDetailsPage.validateBannerMessage('Success', 'Linked appeal added');
 				caseDetailsPage.checkStatusOfCase('Child', 1);
 				caseDetailsPage.clickLinkedAppeal(caseRefToLink);
 				caseDetailsPage.verifyAppealRefOnCaseDetails(caseRefToLink);

--- a/appeals/web/package.json
+++ b/appeals/web/package.json
@@ -19,7 +19,7 @@
     "rollup": "node ./scripts/rollup/bundle-js.js",
     "sass": "node ./scripts/rollup/compile-css.js",
     "start": "node ./src/server/server.js",
-    "test": "cross-env NODE_ENV=test NODE_OPTIONS=\"--experimental-vm-modules --expose-gc\" npx jest --logHeapUsage --ci",
+    "test": "cross-env NODE_ENV=test NODE_OPTIONS=\"--experimental-vm-modules --expose-gc\" npx jest --logHeapUsage --ci --updateSnapshot",
 		"test:update": "cross-env NODE_ENV=test NODE_OPTIONS=\"--experimental-vm-modules --expose-gc\" npx jest -u --logHeapUsage --ci",
     "test:watch": "npm run test -- --watch",
     "test:cov": "cross-env NODE_ENV=test NODE_OPTIONS=\"--experimental-vm-modules --expose-gc\" npx jest --logHeapUsage --ci --coverage --forceExit",

--- a/appeals/web/src/server/appeals/appeal-details/__tests__/__snapshots__/appeal-details.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/__tests__/__snapshots__/appeal-details.test.js.snap
@@ -321,7 +321,7 @@ data-index="0">
 </div>"
 `;
 
-exports[`appeal-details GET /:appealId Notification banners should render a "Horizon reference added" success notification banner, a "Transferred" status tag, and an inset text component with the appeal type and horizon link for the transferred appeal, when the appeal was successfully transferred to horizon 2`] = `"<strong class="govuk-tag govuk-tag--grey govuk-!-margin-bottom-4">Transferred</strong>"`;
+exports[`appeal-details GET /:appealId Notification banners should render a "Horizon reference added" success notification banner, a "Transferred" status tag, and an inset text component with the appeal type and horizon link for the transferred appeal, when the appeal was successfully transferred to horizon 2`] = `"<strong class="govuk-tag govuk-tag--grey pins-status-tag--full-width">Transferred</strong>"`;
 
 exports[`appeal-details GET /:appealId Notification banners should render a "Horizon reference added" success notification banner, a "Transferred" status tag, and an inset text component with the appeal type and horizon link for the transferred appeal, when the appeal was successfully transferred to horizon 3`] = `
 "<div class="govuk-inset-text govuk-!-margin-top-0">
@@ -342,6 +342,19 @@ data-index="0">
         <p><a class="govuk-notification-banner__link" data-cy="review-lpa-questionnaire-banner"
             href="/appeals-service/appeal-details/2/lpa-questionnaire/123?backUrl=%2Fappeals-service%2Fappeal-details%2F2">Review <span class="govuk-visually-hidden">LPA questionnaire</span></a>
         </p>
+    </div>
+</div>"
+`;
+
+exports[`appeal-details GET /:appealId Notification banners should render a "Linked appeal added" success notification banner when the appeal was successfully linked as the lead of a back-office appeal 1`] = `
+"<div class="govuk-notification-banner govuk-notification-banner--success govuk-!-margin-bottom-5"
+role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner"
+data-index="0">
+    <div class="govuk-notification-banner__header">
+        <h3 class="govuk-notification-banner__title" id="govuk-notification-banner-title"> Success</h3>
+    </div>
+    <div class="govuk-notification-banner__content">
+        <p class="govuk-notification-banner__heading">Linked appeal added</p>
     </div>
 </div>"
 `;
@@ -373,19 +386,6 @@ data-index="0">
         <p class="govuk-notification-banner__heading">This appeal is awaiting transfer</p>
         <p class="govuk-body">The appeal must be transferred to Horizon. When this is done, <a class="govuk-link"
             data-cy="awaiting-transfer" href="/appeals-service/appeal-details/2/change-appeal-type/add-horizon-reference?backUrl=%2Fappeals-service%2Fappeal-details%2F2">update the appeal with the new horizon reference</a>.</p>
-    </div>
-</div>"
-`;
-
-exports[`appeal-details GET /:appealId Notification banners should render a "This appeal is now the lead for appeal" success notification banner when the appeal was successfully linked as the lead of a back-office appeal 1`] = `
-"<div class="govuk-notification-banner govuk-notification-banner--success govuk-!-margin-bottom-5"
-role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner"
-data-index="0">
-    <div class="govuk-notification-banner__header">
-        <h3 class="govuk-notification-banner__title" id="govuk-notification-banner-title"> Success</h3>
-    </div>
-    <div class="govuk-notification-banner__content">
-        <p class="govuk-notification-banner__heading">This appeal is now the lead for appeal TEST-12345</p>
     </div>
 </div>"
 `;
@@ -606,7 +606,7 @@ data-index="0">
         <h3 class="govuk-notification-banner__title" id="govuk-notification-banner-title"> Success</h3>
     </div>
     <div class="govuk-notification-banner__content">
-        <p class="govuk-notification-banner__heading">This appeal is now the lead for appeal 3171066</p>
+        <p class="govuk-notification-banner__heading">Linked appeal added</p>
     </div>
 </div>"
 `;
@@ -627,43 +627,43 @@ data-index="0">
 </div>"
 `;
 
-exports[`appeal-details GET /:appealId Status tags should render a status tag with the content "Assign case officer" and a green modifier class if appeal status is assign_case_officer 1`] = `"<strong class="govuk-tag govuk-tag--green govuk-!-margin-bottom-4">Assign case officer</strong>"`;
+exports[`appeal-details GET /:appealId Status tags should render a status tag with the content "Assign case officer" and a green modifier class if appeal status is assign_case_officer 1`] = `"<strong class="govuk-tag govuk-tag--green pins-status-tag--full-width">Assign case officer</strong>"`;
 
-exports[`appeal-details GET /:appealId Status tags should render a status tag with the content "Awaiting hearing" and a yellow modifier class if appeal status is awaiting_hearing 1`] = `"<strong class="govuk-tag govuk-tag--yellow govuk-!-margin-bottom-4">Awaiting hearing</strong>"`;
+exports[`appeal-details GET /:appealId Status tags should render a status tag with the content "Awaiting hearing" and a yellow modifier class if appeal status is awaiting_hearing 1`] = `"<strong class="govuk-tag govuk-tag--yellow pins-status-tag--full-width">Awaiting hearing</strong>"`;
 
-exports[`appeal-details GET /:appealId Status tags should render a status tag with the content "Awaiting inquiry" and a yellow modifier class if appeal status is awaiting_inquiry 1`] = `"<strong class="govuk-tag govuk-tag--yellow govuk-!-margin-bottom-4">Awaiting inquiry</strong>"`;
+exports[`appeal-details GET /:appealId Status tags should render a status tag with the content "Awaiting inquiry" and a yellow modifier class if appeal status is awaiting_inquiry 1`] = `"<strong class="govuk-tag govuk-tag--yellow pins-status-tag--full-width">Awaiting inquiry</strong>"`;
 
-exports[`appeal-details GET /:appealId Status tags should render a status tag with the content "Awaiting site visit" and a yellow modifier class if appeal status is awaiting_site_visit 1`] = `"<strong class="govuk-tag govuk-tag--yellow govuk-!-margin-bottom-4">Awaiting site visit</strong>"`;
+exports[`appeal-details GET /:appealId Status tags should render a status tag with the content "Awaiting site visit" and a yellow modifier class if appeal status is awaiting_site_visit 1`] = `"<strong class="govuk-tag govuk-tag--yellow pins-status-tag--full-width">Awaiting site visit</strong>"`;
 
-exports[`appeal-details GET /:appealId Status tags should render a status tag with the content "Awaiting transfer" and a green modifier class if appeal status is awaiting_transfer 1`] = `"<strong class="govuk-tag govuk-tag--green govuk-!-margin-bottom-4">Awaiting transfer</strong>"`;
+exports[`appeal-details GET /:appealId Status tags should render a status tag with the content "Awaiting transfer" and a green modifier class if appeal status is awaiting_transfer 1`] = `"<strong class="govuk-tag govuk-tag--green pins-status-tag--full-width">Awaiting transfer</strong>"`;
 
-exports[`appeal-details GET /:appealId Status tags should render a status tag with the content "Complete" and a blue modifier class if appeal status is complete 1`] = `"<strong class="govuk-tag govuk-tag--blue govuk-!-margin-bottom-4">Complete</strong>"`;
+exports[`appeal-details GET /:appealId Status tags should render a status tag with the content "Complete" and a blue modifier class if appeal status is complete 1`] = `"<strong class="govuk-tag govuk-tag--blue pins-status-tag--full-width">Complete</strong>"`;
 
-exports[`appeal-details GET /:appealId Status tags should render a status tag with the content "Evidence" and a green modifier class if appeal status is evidence 1`] = `"<strong class="govuk-tag govuk-tag--green govuk-!-margin-bottom-4">Evidence</strong>"`;
+exports[`appeal-details GET /:appealId Status tags should render a status tag with the content "Evidence" and a green modifier class if appeal status is evidence 1`] = `"<strong class="govuk-tag govuk-tag--green pins-status-tag--full-width">Evidence</strong>"`;
 
-exports[`appeal-details GET /:appealId Status tags should render a status tag with the content "Final comments" and a green modifier class if appeal status is final_comments 1`] = `"<strong class="govuk-tag govuk-tag--green govuk-!-margin-bottom-4">Final comments</strong>"`;
+exports[`appeal-details GET /:appealId Status tags should render a status tag with the content "Final comments" and a green modifier class if appeal status is final_comments 1`] = `"<strong class="govuk-tag govuk-tag--green pins-status-tag--full-width">Final comments</strong>"`;
 
-exports[`appeal-details GET /:appealId Status tags should render a status tag with the content "Hearing ready to set up" and a green modifier class if appeal status is hearing_ready_to_set_up 1`] = `"<strong class="govuk-tag govuk-tag--green govuk-!-margin-bottom-4">Hearing ready to set up</strong>"`;
+exports[`appeal-details GET /:appealId Status tags should render a status tag with the content "Hearing ready to set up" and a green modifier class if appeal status is hearing_ready_to_set_up 1`] = `"<strong class="govuk-tag govuk-tag--green pins-status-tag--full-width">Hearing ready to set up</strong>"`;
 
-exports[`appeal-details GET /:appealId Status tags should render a status tag with the content "Inquiry ready to set up" and a green modifier class if appeal status is inquiry_ready_to_set_up 1`] = `"<strong class="govuk-tag govuk-tag--green govuk-!-margin-bottom-4">Inquiry ready to set up</strong>"`;
+exports[`appeal-details GET /:appealId Status tags should render a status tag with the content "Inquiry ready to set up" and a green modifier class if appeal status is inquiry_ready_to_set_up 1`] = `"<strong class="govuk-tag govuk-tag--green pins-status-tag--full-width">Inquiry ready to set up</strong>"`;
 
-exports[`appeal-details GET /:appealId Status tags should render a status tag with the content "Invalid" and a grey modifier class if appeal status is invalid 1`] = `"<strong class="govuk-tag govuk-tag--grey govuk-!-margin-bottom-4">Invalid</strong>"`;
+exports[`appeal-details GET /:appealId Status tags should render a status tag with the content "Invalid" and a grey modifier class if appeal status is invalid 1`] = `"<strong class="govuk-tag govuk-tag--grey pins-status-tag--full-width">Invalid</strong>"`;
 
-exports[`appeal-details GET /:appealId Status tags should render a status tag with the content "Issue decision" and a green modifier class if appeal status is issue_determination 1`] = `"<strong class="govuk-tag govuk-tag--green govuk-!-margin-bottom-4">Issue decision</strong>"`;
+exports[`appeal-details GET /:appealId Status tags should render a status tag with the content "Issue decision" and a green modifier class if appeal status is issue_determination 1`] = `"<strong class="govuk-tag govuk-tag--green pins-status-tag--full-width">Issue decision</strong>"`;
 
-exports[`appeal-details GET /:appealId Status tags should render a status tag with the content "LPA questionnaire" and a green modifier class if appeal status is lpa_questionnaire 1`] = `"<strong class="govuk-tag govuk-tag--green govuk-!-margin-bottom-4">LPA questionnaire</strong>"`;
+exports[`appeal-details GET /:appealId Status tags should render a status tag with the content "LPA questionnaire" and a green modifier class if appeal status is lpa_questionnaire 1`] = `"<strong class="govuk-tag govuk-tag--green pins-status-tag--full-width">LPA questionnaire</strong>"`;
 
-exports[`appeal-details GET /:appealId Status tags should render a status tag with the content "Ready to start" and a green modifier class if appeal status is ready_to_start 1`] = `"<strong class="govuk-tag govuk-tag--green govuk-!-margin-bottom-4">Ready to start</strong>"`;
+exports[`appeal-details GET /:appealId Status tags should render a status tag with the content "Ready to start" and a green modifier class if appeal status is ready_to_start 1`] = `"<strong class="govuk-tag govuk-tag--green pins-status-tag--full-width">Ready to start</strong>"`;
 
-exports[`appeal-details GET /:appealId Status tags should render a status tag with the content "Site visit ready to set up" and a green modifier class if appeal status is site_visit_ready_to_set_up 1`] = `"<strong class="govuk-tag govuk-tag--green govuk-!-margin-bottom-4">Site visit ready to set up</strong>"`;
+exports[`appeal-details GET /:appealId Status tags should render a status tag with the content "Site visit ready to set up" and a green modifier class if appeal status is site_visit_ready_to_set_up 1`] = `"<strong class="govuk-tag govuk-tag--green pins-status-tag--full-width">Site visit ready to set up</strong>"`;
 
-exports[`appeal-details GET /:appealId Status tags should render a status tag with the content "Statements" and a green modifier class if appeal status is statements 1`] = `"<strong class="govuk-tag govuk-tag--green govuk-!-margin-bottom-4">Statements</strong>"`;
+exports[`appeal-details GET /:appealId Status tags should render a status tag with the content "Statements" and a green modifier class if appeal status is statements 1`] = `"<strong class="govuk-tag govuk-tag--green pins-status-tag--full-width">Statements</strong>"`;
 
-exports[`appeal-details GET /:appealId Status tags should render a status tag with the content "Transferred" and a grey modifier class if appeal status is transferred 1`] = `"<strong class="govuk-tag govuk-tag--grey govuk-!-margin-bottom-4">Transferred</strong>"`;
+exports[`appeal-details GET /:appealId Status tags should render a status tag with the content "Transferred" and a grey modifier class if appeal status is transferred 1`] = `"<strong class="govuk-tag govuk-tag--grey pins-status-tag--full-width">Transferred</strong>"`;
 
-exports[`appeal-details GET /:appealId Status tags should render a status tag with the content "Validation" and a green modifier class if appeal status is validation 1`] = `"<strong class="govuk-tag govuk-tag--green govuk-!-margin-bottom-4">Validation</strong>"`;
+exports[`appeal-details GET /:appealId Status tags should render a status tag with the content "Validation" and a green modifier class if appeal status is validation 1`] = `"<strong class="govuk-tag govuk-tag--green pins-status-tag--full-width">Validation</strong>"`;
 
-exports[`appeal-details GET /:appealId Status tags should render a status tag with the content "Withdrawn" and a grey modifier class if appeal status is withdrawn 1`] = `"<strong class="govuk-tag govuk-tag--grey govuk-!-margin-bottom-4">Withdrawn</strong>"`;
+exports[`appeal-details GET /:appealId Status tags should render a status tag with the content "Withdrawn" and a grey modifier class if appeal status is withdrawn 1`] = `"<strong class="govuk-tag govuk-tag--grey pins-status-tag--full-width">Withdrawn</strong>"`;
 
 exports[`appeal-details GET /:appealId Timetable Valid date should render a "Timetable" with a Valid date row and a Start date row including no date and start action link 1`] = `
 "<dl class="govuk-summary-list appeal-case-timetable">
@@ -782,10 +782,11 @@ exports[`appeal-details GET /:appealId should not render action links to the man
         </div>
     </div>
     <div class="govuk-grid-row">
-        <div class="govuk-grid-column-full"><strong class="govuk-tag govuk-tag--grey govuk-!-margin-bottom-4">Received appeal</strong>
+        <div class="govuk-grid-column-full"><strong class="govuk-tag govuk-tag--grey pins-status-tag--full-width">Received appeal</strong>
+            <strong             class="govuk-tag govuk-tag--grey govuk-!-margin-left-1 govuk-!-margin-bottom-4"></strong>
         </div>
-    </div><strong class="govuk-tag govuk-tag--grey govuk-!-margin-left-1 govuk-!-margin-bottom-4"></strong>
-    <div     class="govuk-grid-row">
+    </div>
+    <div class="govuk-grid-row">
         <div class="govuk-grid-column-full">
             <dl class="govuk-summary-list pins-summary-list--no-border">
                 <div class="govuk-summary-list__row appeal-case-officer"><dt class="govuk-summary-list__key"> Case officer</dt>
@@ -810,415 +811,415 @@ exports[`appeal-details GET /:appealId should not render action links to the man
                 </div>
             </dl>
         </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
+            <p class="govuk-body govuk-!-margin-bottom-6" id="download-case-files"
+            data-cy="download-case-files"><a class="govuk-link" href="/documents/1/bulk-download/case-APP/Q9999/D/21/351062.zip">Download case</a>
+            </p>
         </div>
-        <div class="govuk-grid-row">
-            <div class="govuk-grid-column-full">
-                <p class="govuk-body govuk-!-margin-bottom-6" id="download-case-files"
-                data-cy="download-case-files"><a class="govuk-link" href="/documents/1/bulk-download/case-APP/Q9999/D/21/351062.zip">Download case</a>
-                </p>
-            </div>
-        </div>
-        <div class="govuk-grid-row">
-            <div class="govuk-grid-column-full">
-                <details class="govuk-details">
-                    <summary class="govuk-details__summary"><span class="govuk-details__summary-text"> 2 case notes</span>
-                    </summary>
-                    <div class="govuk-details__text">
-                        <form method="POST" novalidate="novalidate">
-                            <div class="govuk-grid-row">
-                                <div class="govuk-grid-column-two-thirds">
-                                    <div class="govuk-form-group govuk-character-count" data-module="govuk-character-count"
-                                    data-maxlength="500">
-                                        <textarea class="govuk-textarea govuk-js-character-count" id="comment"
-                                        name="comment" rows="5" aria-describedby="comment-info"></textarea>
-                                        <div id="comment-info" class="govuk-hint govuk-character-count__message">You can enter up to 500 characters</div>
-                                    </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
+            <details class="govuk-details">
+                <summary class="govuk-details__summary"><span class="govuk-details__summary-text"> 2 case notes</span>
+                </summary>
+                <div class="govuk-details__text">
+                    <form method="POST" novalidate="novalidate">
+                        <div class="govuk-grid-row">
+                            <div class="govuk-grid-column-two-thirds">
+                                <div class="govuk-form-group govuk-character-count" data-module="govuk-character-count"
+                                data-maxlength="500">
+                                    <textarea class="govuk-textarea govuk-js-character-count" id="comment"
+                                    name="comment" rows="5" aria-describedby="comment-info"></textarea>
+                                    <div id="comment-info" class="govuk-hint govuk-character-count__message">You can enter up to 500 characters</div>
                                 </div>
                             </div>
-                            <button type="submit" data-prevent-double-click="true" class="govuk-button govuk-button--secondary govuk-!-margin-bottom-1"
-                            data-module="govuk-button">Add case note</button>
-                        </form>
-                        <div>
+                        </div>
+                        <button type="submit" data-prevent-double-click="true" class="govuk-button govuk-button--secondary govuk-!-margin-bottom-1"
+                        data-module="govuk-button">Add case note</button>
+                    </form>
+                    <div>
+                        <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+                        <section>
+                            <p class="govuk-body govuk-!-margin-bottom-1">A case note you should see.</p>
+                            <p class="govuk-hint govuk-!-margin-bottom-6">11:00am on Tuesday 1 October 2024 by John.Smith</p>
                             <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
-                            <section>
-                                <p class="govuk-body govuk-!-margin-bottom-1">A case note you should see.</p>
-                                <p class="govuk-hint govuk-!-margin-bottom-6">11:00am on Tuesday 1 October 2024 by John.Smith</p>
-                                <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
-                            </section>
-                            <section>
-                                <p class="govuk-body govuk-!-margin-bottom-1">A case note you should see.</p>
-                                <p class="govuk-hint govuk-!-margin-bottom-6">11:00am on Tuesday 1 October 2024 by John.Smith</p>
-                                <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
-                            </section>
-                        </div>
+                        </section>
+                        <section>
+                            <p class="govuk-body govuk-!-margin-bottom-1">A case note you should see.</p>
+                            <p class="govuk-hint govuk-!-margin-bottom-6">11:00am on Tuesday 1 October 2024 by John.Smith</p>
+                            <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+                        </section>
                     </div>
-                </details>
-            </div>
+                </div>
+            </details>
         </div>
-        <div class="govuk-grid-row">
-            <div class="govuk-grid-column-full">
-                <div class="govuk-accordion" data-module="govuk-accordion" id="accordion-default1">
-                    <div class="govuk-accordion__section">
-                        <div class="govuk-accordion__section-header">
-                            <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-1"> Overview</span></h2>
-                        </div>
-                        <div id="accordion-default1-content-1" class="govuk-accordion__section-content">
-                            <dl class="govuk-summary-list">
-                                <div class="govuk-summary-list__row govuk-summary-list__row--no-actions appeal-lpa-reference"><dt class="govuk-summary-list__key"> Planning application reference</dt>
-                                    <dd                                     class="govuk-summary-list__value">48269/APP/2021/1482</dd>
-                                </div>
-                                <div class="govuk-summary-list__row appeal-appeal-type"><dt class="govuk-summary-list__key"> Appeal type</dt>
-                                    <dd class="govuk-summary-list__value">Householder</dd>
-                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/change-appeal-type/appeal-type"
-                                        data-cy="change-appeal-type">Change<span class="govuk-visually-hidden"> Appeal type</span></a>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
+            <div class="govuk-accordion" data-module="govuk-accordion" id="accordion-default1">
+                <div class="govuk-accordion__section">
+                    <div class="govuk-accordion__section-header">
+                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-1"> Overview</span></h2>
+                    </div>
+                    <div id="accordion-default1-content-1" class="govuk-accordion__section-content">
+                        <dl class="govuk-summary-list">
+                            <div class="govuk-summary-list__row govuk-summary-list__row--no-actions appeal-lpa-reference"><dt class="govuk-summary-list__key"> Planning application reference</dt>
+                                <dd                                 class="govuk-summary-list__value">48269/APP/2021/1482</dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-appeal-type"><dt class="govuk-summary-list__key"> Appeal type</dt>
+                                <dd class="govuk-summary-list__value">Householder</dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/change-appeal-type/appeal-type"
+                                    data-cy="change-appeal-type">Change<span class="govuk-visually-hidden"> Appeal type</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row govuk-summary-list__row--no-actions appeal-case-procedure"><dt class="govuk-summary-list__key"> Appeal procedure</dt>
+                                <dd class="govuk-summary-list__value">Written</dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-allocation-details"><dt class="govuk-summary-list__key"> Allocation level</dt>
+                                <dd class="govuk-summary-list__value">
+                                    <ul class="govuk-!-margin-0">
+                                        <li>Level: A</li>
+                                        <li>Historic heritage</li>
+                                        <li>Architecture design</li>
+                                    </ul>
+                                </dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/allocation-details/allocation-level"
+                                    data-cy="change-allocation-details">Change<span class="govuk-visually-hidden"> Allocation level</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-linked-appeals"><dt class="govuk-summary-list__key"> Linked appeals</dt>
+                                <dd class="govuk-summary-list__value">
+                                    <ul class="govuk-list govuk-list--bullet">
+                                        <li><a href="/appeals-service/appeal-details/5449" class="govuk-link" data-cy="linked-appeal-784706"
+                                            aria-label="Appeal 7 8 4 7 0 6">784706</a> (Child)</li>
+                                        <li><span class="govuk-body">87326527</span> (Child)</li>
+                                        <li><a href="/appeals-service/appeal-details/5464" class="govuk-link" data-cy="linked-appeal-140079"
+                                            aria-label="Appeal 1 4 0 0 7 9">140079</a> (Lead)</li>
+                                        <li><a href="/appeals-service/appeal-details/5451" class="govuk-link" data-cy="linked-appeal-721086"
+                                            aria-label="Appeal 7 2 1 0 8 6">721086</a> (Child)</li>
+                                        <li><span class="govuk-body">76215416</span> (Lead)</li>
+                                    </ul>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-other-appeals"><dt class="govuk-summary-list__key"> Related appeals</dt>
+                                <dd class="govuk-summary-list__value"><span>No</span>
+                                </dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/other-appeals/add"
+                                    data-cy="add-related-appeals">Add<span class="govuk-visually-hidden"> Related appeals</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-decision"><dt class="govuk-summary-list__key"> Decision</dt>
+                                <dd class="govuk-summary-list__value">Dismissed</dd>
+                            </div>
+                        </dl>
+                    </div>
+                </div>
+                <div class="govuk-accordion__section">
+                    <div class="govuk-accordion__section-header">
+                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-2"> Site</span></h2>
+                    </div>
+                    <div id="accordion-default1-content-2" class="govuk-accordion__section-content">
+                        <dl class="govuk-summary-list">
+                            <div class="govuk-summary-list__row appeal-visit-type"><dt class="govuk-summary-list__key"> Visit type</dt>
+                                <dd class="govuk-summary-list__value">Accompanied</dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/visit-booked?backUrl=%2Fappeals-service%2Fappeal-details%2F1"
+                                    data-cy="change-set-visit-type">Change<span class="govuk-visually-hidden"> Visit type</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Date</dt>
+                                <dd class="govuk-summary-list__value">9 October 2023</dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/visit-booked"
+                                    data-cy="change-site-visit-date">Change<span class="govuk-visually-hidden"> Date</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Start time</dt>
+                                <dd class="govuk-summary-list__value">9:38am</dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/visit-booked"
+                                    data-cy="change-site-visit-start-time">Change<span class="govuk-visually-hidden"> Start time</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> End time</dt>
+                                <dd class="govuk-summary-list__value">10:00am</dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/visit-booked"
+                                    data-cy="change-site-visit-end-time">Change<span class="govuk-visually-hidden"> End time</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-neighbouring-sites-inspector"><dt class="govuk-summary-list__key"> Interested party and neighbour addresses</dt>
+                                <dd                                 class="govuk-summary-list__value">
+                                    <ul class="govuk-list govuk-list--bullet">
+                                        <li>2 Grove Cottage, Shotesham Road, Woodton, Devon, NR35 2ND</li>
+                                    </ul>
                                     </dd>
-                                </div>
-                                <div class="govuk-summary-list__row govuk-summary-list__row--no-actions appeal-case-procedure"><dt class="govuk-summary-list__key"> Appeal procedure</dt>
-                                    <dd class="govuk-summary-list__value">Written</dd>
-                                </div>
-                                <div class="govuk-summary-list__row appeal-allocation-details"><dt class="govuk-summary-list__key"> Allocation level</dt>
-                                    <dd class="govuk-summary-list__value">
-                                        <ul class="govuk-!-margin-0">
-                                            <li>Level: A</li>
-                                            <li>Historic heritage</li>
-                                            <li>Architecture design</li>
+                                    <dd class="govuk-summary-list__actions">
+                                        <ul class="govuk-summary-list__actions-list">
+                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/neighbouring-sites/manage"
+                                                data-cy="manage-neighbouring-sites-inspector">Manage<span class="govuk-visually-hidden"> Interested party and neighbour addresses</span></a>
+                                            </li>
+                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/neighbouring-sites/add/back-office"
+                                                data-cy="add-neighbouring-sites-inspector">Add<span class="govuk-visually-hidden"> Interested party and neighbour addresses</span></a>
+                                            </li>
                                         </ul>
                                     </dd>
-                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/allocation-details/allocation-level"
-                                        data-cy="change-allocation-details">Change<span class="govuk-visually-hidden"> Allocation level</span></a>
-                                    </dd>
-                                </div>
-                                <div class="govuk-summary-list__row appeal-linked-appeals"><dt class="govuk-summary-list__key"> Linked appeals</dt>
-                                    <dd class="govuk-summary-list__value">
-                                        <ul class="govuk-list govuk-list--bullet">
-                                            <li><a href="/appeals-service/appeal-details/5449" class="govuk-link" data-cy="linked-appeal-784706"
-                                                aria-label="Appeal 7 8 4 7 0 6">784706</a> (Child)</li>
-                                            <li><span class="govuk-body">87326527</span> (Child)</li>
-                                            <li><a href="/appeals-service/appeal-details/5464" class="govuk-link" data-cy="linked-appeal-140079"
-                                                aria-label="Appeal 1 4 0 0 7 9">140079</a> (Lead)</li>
-                                            <li><a href="/appeals-service/appeal-details/5451" class="govuk-link" data-cy="linked-appeal-721086"
-                                                aria-label="Appeal 7 2 1 0 8 6">721086</a> (Child)</li>
-                                            <li><span class="govuk-body">76215416</span> (Lead)</li>
+                            </div>
+                        </dl>
+                    </div>
+                </div>
+                <div class="govuk-accordion__section">
+                    <div class="govuk-accordion__section-header">
+                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-3"> Timetable</span></h2>
+                    </div>
+                    <div id="accordion-default1-content-3" class="govuk-accordion__section-content">
+                        <dl class="govuk-summary-list appeal-case-timetable">
+                            <div class="govuk-summary-list__row appeal-valid-date"><dt class="govuk-summary-list__key"> Valid date</dt>
+                                <dd class="govuk-summary-list__value">23 May 2023</dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/valid/date"
+                                    data-cy="-valid-date"><span class="govuk-visually-hidden"> Valid date</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-start-date"><dt class="govuk-summary-list__key"> Start date</dt>
+                                <dd class="govuk-summary-list__value">23 May 2023</dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/start-case/change"
+                                    data-cy="change-start-case-date">Change<span class="govuk-visually-hidden"> Start date</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-lpa-questionnaire-due-date"><dt class="govuk-summary-list__key"> LPA questionnaire due</dt>
+                                <dd class="govuk-summary-list__value">11 October 2023</dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-site-visit"><dt class="govuk-summary-list__key"> Site visit</dt>
+                                <dd class="govuk-summary-list__value">
+                                    <ul class="govuk-list govuk-!-margin-top-0 govuk-!-padding-left-0">
+                                        <li>9 October 2023</li>
+                                        <li>9:38am - 10:00am</li>
+                                    </ul>
+                                </dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/manage-visit?backUrl=%2Fappeals-service%2Fappeal-details%2F1"
+                                    data-cy="change-schedule-visit">Change<span class="govuk-visually-hidden"> Site visit</span></a>
+                                </dd>
+                            </div>
+                        </dl>
+                    </div>
+                </div>
+                <div class="govuk-accordion__section">
+                    <div class="govuk-accordion__section-header">
+                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-4"> Documentation</span></h2>
+                    </div>
+                    <div id="accordion-default1-content-4" class="govuk-accordion__section-content">
+                        <table class="govuk-table">
+                            <thead class="govuk-table__head">
+                                <tr class="govuk-table__row">
+                                    <th scope="col" class="govuk-table__header">Documentation</th>
+                                    <th scope="col" class="govuk-table__header">Status</th>
+                                    <th scope="col" class="govuk-table__header">Received</th>
+                                    <th scope="col" class="govuk-table__header govuk-!-text-align-right">Action</th>
+                                </tr>
+                            </thead>
+                            <tbody class="govuk-table__body">
+                                <tr class="govuk-table__row">
+                                    <th scope="row" class="govuk-table__header">Appeal</th>
+                                    <td class="govuk-table__cell">Ready to review</td>
+                                    <td class="govuk-table__cell">2 August 2024</td>
+                                    <td class="govuk-table__cell govuk-!-text-align-right"><a href="/appeals-service/appeal-details/1/appellant-case?backUrl=%2Fappeals-service%2Fappeal-details%2F1"
+                                        data-cy="review-appellant-case" class="govuk-link">Review<span class="govuk-visually-hidden"> appellant case</span></a>
+                                    </td>
+                                </tr>
+                                <tr class="govuk-table__row">
+                                    <th scope="row" class="govuk-table__header">LPA questionnaire</th>
+                                    <td class="govuk-table__cell">Overdue</td>
+                                    <td class="govuk-table__cell">Due by 11 October 2023</td>
+                                    <td class="govuk-table__cell govuk-!-text-align-right"></td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
+                <div class="govuk-accordion__section">
+                    <div class="govuk-accordion__section-header">
+                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-5"> Costs</span></h2>
+                    </div>
+                    <div id="accordion-default1-content-5" class="govuk-accordion__section-content">
+                        <table class="govuk-table">
+                            <thead class="govuk-table__head">
+                                <tr class="govuk-table__row">
+                                    <th scope="col" class="govuk-table__header">Documentation</th>
+                                    <th scope="col" class="govuk-table__header">Status</th>
+                                    <th scope="col" class="govuk-table__header govuk-!-text-align-right">Action</th>
+                                </tr>
+                            </thead>
+                            <tbody class="govuk-table__body">
+                                <tr class="govuk-table__row">
+                                    <th scope="row" class="govuk-table__header appeal-costs-appellant-application-documentation">Appellant application</th>
+                                    <td class="govuk-table__cell appeal-costs-appellant-application-status">No documents available</td>
+                                    <td class="govuk-table__cell appeal-costs-appellant-application-actions govuk-!-text-align-right">
+                                        <ul class="govuk-summary-list__actions-list">
+                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-appellant-application" href="/appeals-service/appeal-details/1/costs/appellant/application/upload-documents/1">Add<span class="govuk-visually-hidden"> Appellant application</span></a>
+                                            </li>
                                         </ul>
-                                    </dd>
-                                </div>
-                                <div class="govuk-summary-list__row appeal-other-appeals"><dt class="govuk-summary-list__key"> Related appeals</dt>
-                                    <dd class="govuk-summary-list__value"><span>No</span>
-                                    </dd>
-                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/other-appeals/add"
-                                        data-cy="add-related-appeals">Add<span class="govuk-visually-hidden"> Related appeals</span></a>
-                                    </dd>
-                                </div>
-                                <div class="govuk-summary-list__row appeal-decision"><dt class="govuk-summary-list__key"> Decision</dt>
-                                    <dd class="govuk-summary-list__value">Dismissed</dd>
-                                </div>
-                            </dl>
-                        </div>
-                    </div>
-                    <div class="govuk-accordion__section">
-                        <div class="govuk-accordion__section-header">
-                            <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-2"> Site</span></h2>
-                        </div>
-                        <div id="accordion-default1-content-2" class="govuk-accordion__section-content">
-                            <dl class="govuk-summary-list">
-                                <div class="govuk-summary-list__row appeal-visit-type"><dt class="govuk-summary-list__key"> Visit type</dt>
-                                    <dd class="govuk-summary-list__value">Accompanied</dd>
-                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/visit-booked?backUrl=%2Fappeals-service%2Fappeal-details%2F1"
-                                        data-cy="change-set-visit-type">Change<span class="govuk-visually-hidden"> Visit type</span></a>
-                                    </dd>
-                                </div>
-                                <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Date</dt>
-                                    <dd class="govuk-summary-list__value">9 October 2023</dd>
-                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/visit-booked"
-                                        data-cy="change-site-visit-date">Change<span class="govuk-visually-hidden"> Date</span></a>
-                                    </dd>
-                                </div>
-                                <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Start time</dt>
-                                    <dd class="govuk-summary-list__value">9:38am</dd>
-                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/visit-booked"
-                                        data-cy="change-site-visit-start-time">Change<span class="govuk-visually-hidden"> Start time</span></a>
-                                    </dd>
-                                </div>
-                                <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> End time</dt>
-                                    <dd class="govuk-summary-list__value">10:00am</dd>
-                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/visit-booked"
-                                        data-cy="change-site-visit-end-time">Change<span class="govuk-visually-hidden"> End time</span></a>
-                                    </dd>
-                                </div>
-                                <div class="govuk-summary-list__row appeal-neighbouring-sites-inspector"><dt class="govuk-summary-list__key"> Interested party and neighbour addresses</dt>
-                                    <dd                                     class="govuk-summary-list__value">
-                                        <ul class="govuk-list govuk-list--bullet">
-                                            <li>2 Grove Cottage, Shotesham Road, Woodton, Devon, NR35 2ND</li>
+                                    </td>
+                                </tr>
+                                <tr class="govuk-table__row">
+                                    <th scope="row" class="govuk-table__header appeal-costs-appellant-withdrawal-documentation">Appellant withdrawal</th>
+                                    <td class="govuk-table__cell appeal-costs-appellant-withdrawal-status">No documents available</td>
+                                    <td class="govuk-table__cell appeal-costs-appellant-withdrawal-actions govuk-!-text-align-right">
+                                        <ul class="govuk-summary-list__actions-list">
+                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-appellant-withdrawal" href="/appeals-service/appeal-details/1/costs/appellant/withdrawal/upload-documents/2">Add<span class="govuk-visually-hidden"> Appellant withdrawal</span></a>
+                                            </li>
                                         </ul>
-                                        </dd>
-                                        <dd class="govuk-summary-list__actions">
-                                            <ul class="govuk-summary-list__actions-list">
-                                                <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/neighbouring-sites/manage"
-                                                    data-cy="manage-neighbouring-sites-inspector">Manage<span class="govuk-visually-hidden"> Interested party and neighbour addresses</span></a>
-                                                </li>
-                                                <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/neighbouring-sites/add/back-office"
-                                                    data-cy="add-neighbouring-sites-inspector">Add<span class="govuk-visually-hidden"> Interested party and neighbour addresses</span></a>
-                                                </li>
-                                            </ul>
-                                        </dd>
-                                </div>
-                            </dl>
-                        </div>
-                    </div>
-                    <div class="govuk-accordion__section">
-                        <div class="govuk-accordion__section-header">
-                            <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-3"> Timetable</span></h2>
-                        </div>
-                        <div id="accordion-default1-content-3" class="govuk-accordion__section-content">
-                            <dl class="govuk-summary-list appeal-case-timetable">
-                                <div class="govuk-summary-list__row appeal-valid-date"><dt class="govuk-summary-list__key"> Valid date</dt>
-                                    <dd class="govuk-summary-list__value">23 May 2023</dd>
-                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/valid/date"
-                                        data-cy="-valid-date"><span class="govuk-visually-hidden"> Valid date</span></a>
-                                    </dd>
-                                </div>
-                                <div class="govuk-summary-list__row appeal-start-date"><dt class="govuk-summary-list__key"> Start date</dt>
-                                    <dd class="govuk-summary-list__value">23 May 2023</dd>
-                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/start-case/change"
-                                        data-cy="change-start-case-date">Change<span class="govuk-visually-hidden"> Start date</span></a>
-                                    </dd>
-                                </div>
-                                <div class="govuk-summary-list__row appeal-lpa-questionnaire-due-date"><dt class="govuk-summary-list__key"> LPA questionnaire due</dt>
-                                    <dd class="govuk-summary-list__value">11 October 2023</dd>
-                                </div>
-                                <div class="govuk-summary-list__row appeal-site-visit"><dt class="govuk-summary-list__key"> Site visit</dt>
-                                    <dd class="govuk-summary-list__value">
-                                        <ul class="govuk-list govuk-!-margin-top-0 govuk-!-padding-left-0">
-                                            <li>9 October 2023</li>
-                                            <li>9:38am - 10:00am</li>
+                                    </td>
+                                </tr>
+                                <tr class="govuk-table__row">
+                                    <th scope="row" class="govuk-table__header appeal-costs-appellant-correspondence-documentation">Appellant correspondence</th>
+                                    <td class="govuk-table__cell appeal-costs-appellant-correspondence-status">No documents available</td>
+                                    <td class="govuk-table__cell appeal-costs-appellant-correspondence-actions govuk-!-text-align-right">
+                                        <ul class="govuk-summary-list__actions-list">
+                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-appellant-correspondence" href="/appeals-service/appeal-details/1/costs/appellant/correspondence/upload-documents/3">Add<span class="govuk-visually-hidden"> Appellant correspondence</span></a>
+                                            </li>
                                         </ul>
-                                    </dd>
-                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/manage-visit?backUrl=%2Fappeals-service%2Fappeal-details%2F1"
-                                        data-cy="change-schedule-visit">Change<span class="govuk-visually-hidden"> Site visit</span></a>
-                                    </dd>
-                                </div>
-                            </dl>
-                        </div>
-                    </div>
-                    <div class="govuk-accordion__section">
-                        <div class="govuk-accordion__section-header">
-                            <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-4"> Documentation</span></h2>
-                        </div>
-                        <div id="accordion-default1-content-4" class="govuk-accordion__section-content">
-                            <table class="govuk-table">
-                                <thead class="govuk-table__head">
-                                    <tr class="govuk-table__row">
-                                        <th scope="col" class="govuk-table__header">Documentation</th>
-                                        <th scope="col" class="govuk-table__header">Status</th>
-                                        <th scope="col" class="govuk-table__header">Received</th>
-                                        <th scope="col" class="govuk-table__header govuk-!-text-align-right">Action</th>
-                                    </tr>
-                                </thead>
-                                <tbody class="govuk-table__body">
-                                    <tr class="govuk-table__row">
-                                        <th scope="row" class="govuk-table__header">Appeal</th>
-                                        <td class="govuk-table__cell">Ready to review</td>
-                                        <td class="govuk-table__cell">2 August 2024</td>
-                                        <td class="govuk-table__cell govuk-!-text-align-right"><a href="/appeals-service/appeal-details/1/appellant-case?backUrl=%2Fappeals-service%2Fappeal-details%2F1"
-                                            data-cy="review-appellant-case" class="govuk-link">Review<span class="govuk-visually-hidden"> appellant case</span></a>
-                                        </td>
-                                    </tr>
-                                    <tr class="govuk-table__row">
-                                        <th scope="row" class="govuk-table__header">LPA questionnaire</th>
-                                        <td class="govuk-table__cell">Overdue</td>
-                                        <td class="govuk-table__cell">Due by 11 October 2023</td>
-                                        <td class="govuk-table__cell govuk-!-text-align-right"></td>
-                                    </tr>
-                                </tbody>
-                            </table>
-                        </div>
-                    </div>
-                    <div class="govuk-accordion__section">
-                        <div class="govuk-accordion__section-header">
-                            <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-5"> Costs</span></h2>
-                        </div>
-                        <div id="accordion-default1-content-5" class="govuk-accordion__section-content">
-                            <table class="govuk-table">
-                                <thead class="govuk-table__head">
-                                    <tr class="govuk-table__row">
-                                        <th scope="col" class="govuk-table__header">Documentation</th>
-                                        <th scope="col" class="govuk-table__header">Status</th>
-                                        <th scope="col" class="govuk-table__header govuk-!-text-align-right">Action</th>
-                                    </tr>
-                                </thead>
-                                <tbody class="govuk-table__body">
-                                    <tr class="govuk-table__row">
-                                        <th scope="row" class="govuk-table__header appeal-costs-appellant-application-documentation">Appellant application</th>
-                                        <td class="govuk-table__cell appeal-costs-appellant-application-status">No documents available</td>
-                                        <td class="govuk-table__cell appeal-costs-appellant-application-actions govuk-!-text-align-right">
-                                            <ul class="govuk-summary-list__actions-list">
-                                                <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-appellant-application" href="/appeals-service/appeal-details/1/costs/appellant/application/upload-documents/1">Add<span class="govuk-visually-hidden"> Appellant application</span></a>
-                                                </li>
-                                            </ul>
-                                        </td>
-                                    </tr>
-                                    <tr class="govuk-table__row">
-                                        <th scope="row" class="govuk-table__header appeal-costs-appellant-withdrawal-documentation">Appellant withdrawal</th>
-                                        <td class="govuk-table__cell appeal-costs-appellant-withdrawal-status">No documents available</td>
-                                        <td class="govuk-table__cell appeal-costs-appellant-withdrawal-actions govuk-!-text-align-right">
-                                            <ul class="govuk-summary-list__actions-list">
-                                                <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-appellant-withdrawal" href="/appeals-service/appeal-details/1/costs/appellant/withdrawal/upload-documents/2">Add<span class="govuk-visually-hidden"> Appellant withdrawal</span></a>
-                                                </li>
-                                            </ul>
-                                        </td>
-                                    </tr>
-                                    <tr class="govuk-table__row">
-                                        <th scope="row" class="govuk-table__header appeal-costs-appellant-correspondence-documentation">Appellant correspondence</th>
-                                        <td class="govuk-table__cell appeal-costs-appellant-correspondence-status">No documents available</td>
-                                        <td class="govuk-table__cell appeal-costs-appellant-correspondence-actions govuk-!-text-align-right">
-                                            <ul class="govuk-summary-list__actions-list">
-                                                <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-appellant-correspondence" href="/appeals-service/appeal-details/1/costs/appellant/correspondence/upload-documents/3">Add<span class="govuk-visually-hidden"> Appellant correspondence</span></a>
-                                                </li>
-                                            </ul>
-                                        </td>
-                                    </tr>
-                                    <tr class="govuk-table__row">
-                                        <th scope="row" class="govuk-table__header appeal-costs-lpa-application-documentation">LPA application</th>
-                                        <td class="govuk-table__cell appeal-costs-lpa-application-status">No documents available</td>
-                                        <td class="govuk-table__cell appeal-costs-lpa-application-actions govuk-!-text-align-right">
-                                            <ul class="govuk-summary-list__actions-list">
-                                                <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-lpa-application" href="/appeals-service/appeal-details/1/costs/lpa/application/upload-documents/4">Add<span class="govuk-visually-hidden"> LPA application</span></a>
-                                                </li>
-                                            </ul>
-                                        </td>
-                                    </tr>
-                                    <tr class="govuk-table__row">
-                                        <th scope="row" class="govuk-table__header appeal-costs-lpa-withdrawal-documentation">LPA withdrawal</th>
-                                        <td class="govuk-table__cell appeal-costs-lpa-withdrawal-status">No documents available</td>
-                                        <td class="govuk-table__cell appeal-costs-lpa-withdrawal-actions govuk-!-text-align-right">
-                                            <ul class="govuk-summary-list__actions-list">
-                                                <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-lpa-withdrawal" href="/appeals-service/appeal-details/1/costs/lpa/withdrawal/upload-documents/5">Add<span class="govuk-visually-hidden"> LPA withdrawal</span></a>
-                                                </li>
-                                            </ul>
-                                        </td>
-                                    </tr>
-                                    <tr class="govuk-table__row">
-                                        <th scope="row" class="govuk-table__header appeal-costs-lpa-correspondence-documentation">LPA correspondence</th>
-                                        <td class="govuk-table__cell appeal-costs-lpa-correspondence-status">No documents available</td>
-                                        <td class="govuk-table__cell appeal-costs-lpa-correspondence-actions govuk-!-text-align-right">
-                                            <ul class="govuk-summary-list__actions-list">
-                                                <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-lpa-correspondence" href="/appeals-service/appeal-details/1/costs/lpa/correspondence/upload-documents/6">Add<span class="govuk-visually-hidden"> LPA correspondence</span></a>
-                                                </li>
-                                            </ul>
-                                        </td>
-                                    </tr>
-                                </tbody>
-                            </table>
-                        </div>
-                    </div>
-                    <div class="govuk-accordion__section">
-                        <div class="govuk-accordion__section-header">
-                            <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-6"> Contacts</span></h2>
-                        </div>
-                        <div id="accordion-default1-content-6" class="govuk-accordion__section-content">
-                            <dl class="govuk-summary-list">
-                                <div class="govuk-summary-list__row appeal-appellant"><dt class="govuk-summary-list__key"> Appellant</dt>
-                                    <dd class="govuk-summary-list__value">
-                                        <ul class="govuk-list">
-                                            <li>Roger Simmons</li>
-                                            <li>test3@example.com</li>
+                                    </td>
+                                </tr>
+                                <tr class="govuk-table__row">
+                                    <th scope="row" class="govuk-table__header appeal-costs-lpa-application-documentation">LPA application</th>
+                                    <td class="govuk-table__cell appeal-costs-lpa-application-status">No documents available</td>
+                                    <td class="govuk-table__cell appeal-costs-lpa-application-actions govuk-!-text-align-right">
+                                        <ul class="govuk-summary-list__actions-list">
+                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-lpa-application" href="/appeals-service/appeal-details/1/costs/lpa/application/upload-documents/4">Add<span class="govuk-visually-hidden"> LPA application</span></a>
+                                            </li>
                                         </ul>
-                                    </dd>
-                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/service-user/change/appellant"
-                                        data-cy="change-appellant">Change<span class="govuk-visually-hidden"> Appellant</span></a>
-                                    </dd>
-                                </div>
-                                <div class="govuk-summary-list__row appeal-agent"><dt class="govuk-summary-list__key"> Agent</dt>
-                                    <dd class="govuk-summary-list__value">
-                                        <ul class="govuk-list">
-                                            <li>Fiona Shell</li>
-                                            <li>test2@example.com</li>
+                                    </td>
+                                </tr>
+                                <tr class="govuk-table__row">
+                                    <th scope="row" class="govuk-table__header appeal-costs-lpa-withdrawal-documentation">LPA withdrawal</th>
+                                    <td class="govuk-table__cell appeal-costs-lpa-withdrawal-status">No documents available</td>
+                                    <td class="govuk-table__cell appeal-costs-lpa-withdrawal-actions govuk-!-text-align-right">
+                                        <ul class="govuk-summary-list__actions-list">
+                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-lpa-withdrawal" href="/appeals-service/appeal-details/1/costs/lpa/withdrawal/upload-documents/5">Add<span class="govuk-visually-hidden"> LPA withdrawal</span></a>
+                                            </li>
                                         </ul>
-                                    </dd>
-                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/service-user/change/agent"
-                                        data-cy="change-agent">Change<span class="govuk-visually-hidden"> Agent</span></a>
-                                    </dd>
-                                </div>
-                                <div class="govuk-summary-list__row appeal-lpa-contact-details"><dt class="govuk-summary-list__key"> LPA</dt>
-                                    <dd class="govuk-summary-list__value">
-                                        <ul class="govuk-list">
-                                            <li>Wiltshire Council</li>
-                                            <li>wilt@lpa-email.gov.uk</li>
+                                    </td>
+                                </tr>
+                                <tr class="govuk-table__row">
+                                    <th scope="row" class="govuk-table__header appeal-costs-lpa-correspondence-documentation">LPA correspondence</th>
+                                    <td class="govuk-table__cell appeal-costs-lpa-correspondence-status">No documents available</td>
+                                    <td class="govuk-table__cell appeal-costs-lpa-correspondence-actions govuk-!-text-align-right">
+                                        <ul class="govuk-summary-list__actions-list">
+                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-lpa-correspondence" href="/appeals-service/appeal-details/1/costs/lpa/correspondence/upload-documents/6">Add<span class="govuk-visually-hidden"> LPA correspondence</span></a>
+                                            </li>
                                         </ul>
-                                    </dd>
-                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/change-appeal-details/local-planning-authority"
-                                        data-cy="change-lpa-contact-details">Change<span class="govuk-visually-hidden"> Local planning authority (LPA)</span></a>
-                                    </dd>
-                                </div>
-                            </dl>
-                        </div>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
                     </div>
-                    <div class="govuk-accordion__section">
-                        <div class="govuk-accordion__section-header">
-                            <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-7"> Team</span></h2>
-                        </div>
-                        <div id="accordion-default1-content-7" class="govuk-accordion__section-content">
-                            <dl class="govuk-summary-list">
-                                <div class="govuk-summary-list__row appeal-case-officer"><dt class="govuk-summary-list__key"> Case officer</dt>
-                                    <dd class="govuk-summary-list__value">
-                                        <p class="govuk-body">Not assigned</p>
-                                    </dd>
-                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/assign-user/case-officer"
-                                        data-cy="assign-case-officer">Assign<span class="govuk-visually-hidden"> Case officer</span></a>
-                                    </dd>
-                                </div>
-                                <div class="govuk-summary-list__row appeal-inspector"><dt class="govuk-summary-list__key"> Inspector</dt>
-                                    <dd class="govuk-summary-list__value">
-                                        <p class="govuk-body">Not assigned</p>
-                                    </dd>
-                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/assign-user/inspector"
-                                        data-cy="assign-inspector">Assign<span class="govuk-visually-hidden"> Inspector</span></a>
-                                    </dd>
-                                </div>
-                            </dl>
-                        </div>
+                </div>
+                <div class="govuk-accordion__section">
+                    <div class="govuk-accordion__section-header">
+                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-6"> Contacts</span></h2>
                     </div>
-                    <div class="govuk-accordion__section">
-                        <div class="govuk-accordion__section-header">
-                            <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-8"> Case management</span></h2>
-                        </div>
-                        <div id="accordion-default1-content-8" class="govuk-accordion__section-content">
-                            <dl class="govuk-summary-list">
-                                <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Cross-team correspondence</dt>
-                                    <dd                                     class="govuk-summary-list__value">No documents</dd>
-                                        <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/internal-correspondence/cross-team/upload-documents/10"
-                                            data-cy="add-cross-team-correspondence">Add<span class="govuk-visually-hidden"> Cross-team correspondence</span></a>
-                                        </dd>
-                                </div>
-                                <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Inspector correspondence</dt>
-                                    <dd                                     class="govuk-summary-list__value">No documents</dd>
-                                        <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/internal-correspondence/inspector/upload-documents/11"
-                                            data-cy="add-inspector-correspondence">Add<span class="govuk-visually-hidden"> Inspector correspondence</span></a>
-                                        </dd>
-                                </div>
-                                <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Main party correspondence</dt>
-                                    <dd                                     class="govuk-summary-list__value">No documents</dd>
-                                        <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/internal-correspondence/main-party/upload-documents/22"
-                                            data-cy="add-main-party-correspondence">Add<span class="govuk-visually-hidden"> Main party correspondence</span></a>
-                                        </dd>
-                                </div>
-                                <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Case history</dt>
-                                    <dd class="govuk-summary-list__value"></dd>
-                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/audit" data-cy="view-case-history">View<span class="govuk-visually-hidden"> Case history</span></a>
+                    <div id="accordion-default1-content-6" class="govuk-accordion__section-content">
+                        <dl class="govuk-summary-list">
+                            <div class="govuk-summary-list__row appeal-appellant"><dt class="govuk-summary-list__key"> Appellant</dt>
+                                <dd class="govuk-summary-list__value">
+                                    <ul class="govuk-list">
+                                        <li>Roger Simmons</li>
+                                        <li>test3@example.com</li>
+                                    </ul>
+                                </dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/service-user/change/appellant"
+                                    data-cy="change-appellant">Change<span class="govuk-visually-hidden"> Appellant</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-agent"><dt class="govuk-summary-list__key"> Agent</dt>
+                                <dd class="govuk-summary-list__value">
+                                    <ul class="govuk-list">
+                                        <li>Fiona Shell</li>
+                                        <li>test2@example.com</li>
+                                    </ul>
+                                </dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/service-user/change/agent"
+                                    data-cy="change-agent">Change<span class="govuk-visually-hidden"> Agent</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-lpa-contact-details"><dt class="govuk-summary-list__key"> LPA</dt>
+                                <dd class="govuk-summary-list__value">
+                                    <ul class="govuk-list">
+                                        <li>Wiltshire Council</li>
+                                        <li>wilt@lpa-email.gov.uk</li>
+                                    </ul>
+                                </dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/change-appeal-details/local-planning-authority"
+                                    data-cy="change-lpa-contact-details">Change<span class="govuk-visually-hidden"> Local planning authority (LPA)</span></a>
+                                </dd>
+                            </div>
+                        </dl>
+                    </div>
+                </div>
+                <div class="govuk-accordion__section">
+                    <div class="govuk-accordion__section-header">
+                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-7"> Team</span></h2>
+                    </div>
+                    <div id="accordion-default1-content-7" class="govuk-accordion__section-content">
+                        <dl class="govuk-summary-list">
+                            <div class="govuk-summary-list__row appeal-case-officer"><dt class="govuk-summary-list__key"> Case officer</dt>
+                                <dd class="govuk-summary-list__value">
+                                    <p class="govuk-body">Not assigned</p>
+                                </dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/assign-user/case-officer"
+                                    data-cy="assign-case-officer">Assign<span class="govuk-visually-hidden"> Case officer</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-inspector"><dt class="govuk-summary-list__key"> Inspector</dt>
+                                <dd class="govuk-summary-list__value">
+                                    <p class="govuk-body">Not assigned</p>
+                                </dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/assign-user/inspector"
+                                    data-cy="assign-inspector">Assign<span class="govuk-visually-hidden"> Inspector</span></a>
+                                </dd>
+                            </div>
+                        </dl>
+                    </div>
+                </div>
+                <div class="govuk-accordion__section">
+                    <div class="govuk-accordion__section-header">
+                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-8"> Case management</span></h2>
+                    </div>
+                    <div id="accordion-default1-content-8" class="govuk-accordion__section-content">
+                        <dl class="govuk-summary-list">
+                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Cross-team correspondence</dt>
+                                <dd                                 class="govuk-summary-list__value">No documents</dd>
+                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/internal-correspondence/cross-team/upload-documents/10"
+                                        data-cy="add-cross-team-correspondence">Add<span class="govuk-visually-hidden"> Cross-team correspondence</span></a>
                                     </dd>
-                                </div>
-                                <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Appeal withdrawal</dt>
-                                    <dd class="govuk-summary-list__value"></dd>
-                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/withdrawal/start"
-                                        data-cy="start-appeal-withdrawal">Start<span class="govuk-visually-hidden"> Appeal withdrawal</span></a>
+                            </div>
+                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Inspector correspondence</dt>
+                                <dd                                 class="govuk-summary-list__value">No documents</dd>
+                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/internal-correspondence/inspector/upload-documents/11"
+                                        data-cy="add-inspector-correspondence">Add<span class="govuk-visually-hidden"> Inspector correspondence</span></a>
                                     </dd>
-                                </div>
-                            </dl>
-                        </div>
+                            </div>
+                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Main party correspondence</dt>
+                                <dd                                 class="govuk-summary-list__value">No documents</dd>
+                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/internal-correspondence/main-party/upload-documents/22"
+                                        data-cy="add-main-party-correspondence">Add<span class="govuk-visually-hidden"> Main party correspondence</span></a>
+                                    </dd>
+                            </div>
+                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Case history</dt>
+                                <dd class="govuk-summary-list__value"></dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/audit" data-cy="view-case-history">View<span class="govuk-visually-hidden"> Case history</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Appeal withdrawal</dt>
+                                <dd class="govuk-summary-list__value"></dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/withdrawal/start"
+                                    data-cy="start-appeal-withdrawal">Start<span class="govuk-visually-hidden"> Appeal withdrawal</span></a>
+                                </dd>
+                            </div>
+                        </dl>
                     </div>
                 </div>
             </div>
         </div>
+    </div>
 </main>"
 `;
 
@@ -1245,7 +1246,7 @@ exports[`appeal-details GET /:appealId should render a Decision inset panel when
         </div>
     </div>
     <div class="govuk-grid-row">
-        <div class="govuk-grid-column-full"><strong class="govuk-tag govuk-tag--blue govuk-!-margin-bottom-4">Complete</strong>
+        <div class="govuk-grid-column-full"><strong class="govuk-tag govuk-tag--blue pins-status-tag--full-width">Complete</strong>
         </div>
     </div>
     <div class="govuk-inset-text">
@@ -1694,10 +1695,11 @@ exports[`appeal-details GET /:appealId should render a child tag next to the app
         </div>
     </div>
     <div class="govuk-grid-row">
-        <div class="govuk-grid-column-full"><strong class="govuk-tag govuk-tag--grey govuk-!-margin-bottom-4">Received appeal</strong>
+        <div class="govuk-grid-column-full"><strong class="govuk-tag govuk-tag--grey pins-status-tag--full-width">Received appeal</strong>
+            <strong             class="govuk-tag govuk-tag--grey govuk-!-margin-left-1 govuk-!-margin-bottom-4">Child</strong>
         </div>
-    </div><strong class="govuk-tag govuk-tag--grey govuk-!-margin-left-1 govuk-!-margin-bottom-4">Child</strong>
-    <div     class="govuk-grid-row">
+    </div>
+    <div class="govuk-grid-row">
         <div class="govuk-grid-column-full">
             <dl class="govuk-summary-list pins-summary-list--no-border">
                 <div class="govuk-summary-list__row appeal-case-officer"><dt class="govuk-summary-list__key"> Case officer</dt>
@@ -1722,412 +1724,412 @@ exports[`appeal-details GET /:appealId should render a child tag next to the app
                 </div>
             </dl>
         </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
+            <p class="govuk-body govuk-!-margin-bottom-6" id="download-case-files"
+            data-cy="download-case-files"><a class="govuk-link" href="/documents/1/bulk-download/case-APP/Q9999/D/21/351062.zip">Download case</a>
+            </p>
         </div>
-        <div class="govuk-grid-row">
-            <div class="govuk-grid-column-full">
-                <p class="govuk-body govuk-!-margin-bottom-6" id="download-case-files"
-                data-cy="download-case-files"><a class="govuk-link" href="/documents/1/bulk-download/case-APP/Q9999/D/21/351062.zip">Download case</a>
-                </p>
-            </div>
-        </div>
-        <div class="govuk-grid-row">
-            <div class="govuk-grid-column-full">
-                <details class="govuk-details">
-                    <summary class="govuk-details__summary"><span class="govuk-details__summary-text"> 2 case notes</span>
-                    </summary>
-                    <div class="govuk-details__text">
-                        <form method="POST" novalidate="novalidate">
-                            <div class="govuk-grid-row">
-                                <div class="govuk-grid-column-two-thirds">
-                                    <div class="govuk-form-group govuk-character-count" data-module="govuk-character-count"
-                                    data-maxlength="500">
-                                        <textarea class="govuk-textarea govuk-js-character-count" id="comment"
-                                        name="comment" rows="5" aria-describedby="comment-info"></textarea>
-                                        <div id="comment-info" class="govuk-hint govuk-character-count__message">You can enter up to 500 characters</div>
-                                    </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
+            <details class="govuk-details">
+                <summary class="govuk-details__summary"><span class="govuk-details__summary-text"> 2 case notes</span>
+                </summary>
+                <div class="govuk-details__text">
+                    <form method="POST" novalidate="novalidate">
+                        <div class="govuk-grid-row">
+                            <div class="govuk-grid-column-two-thirds">
+                                <div class="govuk-form-group govuk-character-count" data-module="govuk-character-count"
+                                data-maxlength="500">
+                                    <textarea class="govuk-textarea govuk-js-character-count" id="comment"
+                                    name="comment" rows="5" aria-describedby="comment-info"></textarea>
+                                    <div id="comment-info" class="govuk-hint govuk-character-count__message">You can enter up to 500 characters</div>
                                 </div>
                             </div>
-                            <button type="submit" data-prevent-double-click="true" class="govuk-button govuk-button--secondary govuk-!-margin-bottom-1"
-                            data-module="govuk-button">Add case note</button>
-                        </form>
-                        <div>
+                        </div>
+                        <button type="submit" data-prevent-double-click="true" class="govuk-button govuk-button--secondary govuk-!-margin-bottom-1"
+                        data-module="govuk-button">Add case note</button>
+                    </form>
+                    <div>
+                        <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+                        <section>
+                            <p class="govuk-body govuk-!-margin-bottom-1">A case note you should see.</p>
+                            <p class="govuk-hint govuk-!-margin-bottom-6">11:00am on Tuesday 1 October 2024 by John.Smith</p>
                             <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
-                            <section>
-                                <p class="govuk-body govuk-!-margin-bottom-1">A case note you should see.</p>
-                                <p class="govuk-hint govuk-!-margin-bottom-6">11:00am on Tuesday 1 October 2024 by John.Smith</p>
-                                <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
-                            </section>
-                            <section>
-                                <p class="govuk-body govuk-!-margin-bottom-1">A case note you should see.</p>
-                                <p class="govuk-hint govuk-!-margin-bottom-6">11:00am on Tuesday 1 October 2024 by John.Smith</p>
-                                <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
-                            </section>
-                        </div>
+                        </section>
+                        <section>
+                            <p class="govuk-body govuk-!-margin-bottom-1">A case note you should see.</p>
+                            <p class="govuk-hint govuk-!-margin-bottom-6">11:00am on Tuesday 1 October 2024 by John.Smith</p>
+                            <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+                        </section>
                     </div>
-                </details>
-            </div>
+                </div>
+            </details>
         </div>
-        <div class="govuk-grid-row">
-            <div class="govuk-grid-column-full">
-                <div class="govuk-accordion" data-module="govuk-accordion" id="accordion-default1">
-                    <div class="govuk-accordion__section">
-                        <div class="govuk-accordion__section-header">
-                            <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-1"> Overview</span></h2>
-                        </div>
-                        <div id="accordion-default1-content-1" class="govuk-accordion__section-content">
-                            <dl class="govuk-summary-list">
-                                <div class="govuk-summary-list__row govuk-summary-list__row--no-actions appeal-lpa-reference"><dt class="govuk-summary-list__key"> Planning application reference</dt>
-                                    <dd                                     class="govuk-summary-list__value">48269/APP/2021/1482</dd>
-                                </div>
-                                <div class="govuk-summary-list__row appeal-appeal-type"><dt class="govuk-summary-list__key"> Appeal type</dt>
-                                    <dd class="govuk-summary-list__value">Householder</dd>
-                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/change-appeal-type/appeal-type"
-                                        data-cy="change-appeal-type">Change<span class="govuk-visually-hidden"> Appeal type</span></a>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
+            <div class="govuk-accordion" data-module="govuk-accordion" id="accordion-default1">
+                <div class="govuk-accordion__section">
+                    <div class="govuk-accordion__section-header">
+                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-1"> Overview</span></h2>
+                    </div>
+                    <div id="accordion-default1-content-1" class="govuk-accordion__section-content">
+                        <dl class="govuk-summary-list">
+                            <div class="govuk-summary-list__row govuk-summary-list__row--no-actions appeal-lpa-reference"><dt class="govuk-summary-list__key"> Planning application reference</dt>
+                                <dd                                 class="govuk-summary-list__value">48269/APP/2021/1482</dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-appeal-type"><dt class="govuk-summary-list__key"> Appeal type</dt>
+                                <dd class="govuk-summary-list__value">Householder</dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/change-appeal-type/appeal-type"
+                                    data-cy="change-appeal-type">Change<span class="govuk-visually-hidden"> Appeal type</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row govuk-summary-list__row--no-actions appeal-case-procedure"><dt class="govuk-summary-list__key"> Appeal procedure</dt>
+                                <dd class="govuk-summary-list__value">Written</dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-allocation-details"><dt class="govuk-summary-list__key"> Allocation level</dt>
+                                <dd class="govuk-summary-list__value">
+                                    <ul class="govuk-!-margin-0">
+                                        <li>Level: A</li>
+                                        <li>Historic heritage</li>
+                                        <li>Architecture design</li>
+                                    </ul>
+                                </dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/allocation-details/allocation-level"
+                                    data-cy="change-allocation-details">Change<span class="govuk-visually-hidden"> Allocation level</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-linked-appeals"><dt class="govuk-summary-list__key"> Linked appeals</dt>
+                                <dd class="govuk-summary-list__value">
+                                    <ul class="govuk-list govuk-list--bullet">
+                                        <li><a href="/appeals-service/appeal-details/5464" class="govuk-link" data-cy="linked-appeal-140079"
+                                            aria-label="Appeal 1 4 0 0 7 9">140079</a> (Lead)</li>
+                                    </ul>
+                                </dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/linked-appeals/manage"
+                                    data-cy="manage-linked-appeals">Manage<span class="govuk-visually-hidden"> Linked appeals</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-other-appeals"><dt class="govuk-summary-list__key"> Related appeals</dt>
+                                <dd class="govuk-summary-list__value"><span>No</span>
+                                </dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/other-appeals/add"
+                                    data-cy="add-related-appeals">Add<span class="govuk-visually-hidden"> Related appeals</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-decision"><dt class="govuk-summary-list__key"> Decision</dt>
+                                <dd class="govuk-summary-list__value">Dismissed</dd>
+                            </div>
+                        </dl>
+                    </div>
+                </div>
+                <div class="govuk-accordion__section">
+                    <div class="govuk-accordion__section-header">
+                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-2"> Site</span></h2>
+                    </div>
+                    <div id="accordion-default1-content-2" class="govuk-accordion__section-content">
+                        <dl class="govuk-summary-list">
+                            <div class="govuk-summary-list__row appeal-visit-type"><dt class="govuk-summary-list__key"> Visit type</dt>
+                                <dd class="govuk-summary-list__value">Accompanied</dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/visit-booked?backUrl=%2Fappeals-service%2Fappeal-details%2F1"
+                                    data-cy="change-set-visit-type">Change<span class="govuk-visually-hidden"> Visit type</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Date</dt>
+                                <dd class="govuk-summary-list__value">9 October 2023</dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/visit-booked"
+                                    data-cy="change-site-visit-date">Change<span class="govuk-visually-hidden"> Date</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Start time</dt>
+                                <dd class="govuk-summary-list__value">9:38am</dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/visit-booked"
+                                    data-cy="change-site-visit-start-time">Change<span class="govuk-visually-hidden"> Start time</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> End time</dt>
+                                <dd class="govuk-summary-list__value">10:00am</dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/visit-booked"
+                                    data-cy="change-site-visit-end-time">Change<span class="govuk-visually-hidden"> End time</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-neighbouring-sites-inspector"><dt class="govuk-summary-list__key"> Interested party and neighbour addresses</dt>
+                                <dd                                 class="govuk-summary-list__value">
+                                    <ul class="govuk-list govuk-list--bullet">
+                                        <li>2 Grove Cottage, Shotesham Road, Woodton, Devon, NR35 2ND</li>
+                                    </ul>
                                     </dd>
-                                </div>
-                                <div class="govuk-summary-list__row govuk-summary-list__row--no-actions appeal-case-procedure"><dt class="govuk-summary-list__key"> Appeal procedure</dt>
-                                    <dd class="govuk-summary-list__value">Written</dd>
-                                </div>
-                                <div class="govuk-summary-list__row appeal-allocation-details"><dt class="govuk-summary-list__key"> Allocation level</dt>
-                                    <dd class="govuk-summary-list__value">
-                                        <ul class="govuk-!-margin-0">
-                                            <li>Level: A</li>
-                                            <li>Historic heritage</li>
-                                            <li>Architecture design</li>
+                                    <dd class="govuk-summary-list__actions">
+                                        <ul class="govuk-summary-list__actions-list">
+                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/neighbouring-sites/manage"
+                                                data-cy="manage-neighbouring-sites-inspector">Manage<span class="govuk-visually-hidden"> Interested party and neighbour addresses</span></a>
+                                            </li>
+                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/neighbouring-sites/add/back-office"
+                                                data-cy="add-neighbouring-sites-inspector">Add<span class="govuk-visually-hidden"> Interested party and neighbour addresses</span></a>
+                                            </li>
                                         </ul>
                                     </dd>
-                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/allocation-details/allocation-level"
-                                        data-cy="change-allocation-details">Change<span class="govuk-visually-hidden"> Allocation level</span></a>
-                                    </dd>
-                                </div>
-                                <div class="govuk-summary-list__row appeal-linked-appeals"><dt class="govuk-summary-list__key"> Linked appeals</dt>
-                                    <dd class="govuk-summary-list__value">
-                                        <ul class="govuk-list govuk-list--bullet">
-                                            <li><a href="/appeals-service/appeal-details/5464" class="govuk-link" data-cy="linked-appeal-140079"
-                                                aria-label="Appeal 1 4 0 0 7 9">140079</a> (Lead)</li>
+                            </div>
+                        </dl>
+                    </div>
+                </div>
+                <div class="govuk-accordion__section">
+                    <div class="govuk-accordion__section-header">
+                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-3"> Timetable</span></h2>
+                    </div>
+                    <div id="accordion-default1-content-3" class="govuk-accordion__section-content">
+                        <dl class="govuk-summary-list appeal-case-timetable">
+                            <div class="govuk-summary-list__row appeal-valid-date"><dt class="govuk-summary-list__key"> Valid date</dt>
+                                <dd class="govuk-summary-list__value">23 May 2023</dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/valid/date"
+                                    data-cy="-valid-date"><span class="govuk-visually-hidden"> Valid date</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-start-date"><dt class="govuk-summary-list__key"> Start date</dt>
+                                <dd class="govuk-summary-list__value">23 May 2023</dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/start-case/change"
+                                    data-cy="change-start-case-date">Change<span class="govuk-visually-hidden"> Start date</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-lpa-questionnaire-due-date"><dt class="govuk-summary-list__key"> LPA questionnaire due</dt>
+                                <dd class="govuk-summary-list__value">11 October 2023</dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-site-visit"><dt class="govuk-summary-list__key"> Site visit</dt>
+                                <dd class="govuk-summary-list__value">
+                                    <ul class="govuk-list govuk-!-margin-top-0 govuk-!-padding-left-0">
+                                        <li>9 October 2023</li>
+                                        <li>9:38am - 10:00am</li>
+                                    </ul>
+                                </dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/manage-visit?backUrl=%2Fappeals-service%2Fappeal-details%2F1"
+                                    data-cy="change-schedule-visit">Change<span class="govuk-visually-hidden"> Site visit</span></a>
+                                </dd>
+                            </div>
+                        </dl>
+                    </div>
+                </div>
+                <div class="govuk-accordion__section">
+                    <div class="govuk-accordion__section-header">
+                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-4"> Documentation</span></h2>
+                    </div>
+                    <div id="accordion-default1-content-4" class="govuk-accordion__section-content">
+                        <table class="govuk-table">
+                            <thead class="govuk-table__head">
+                                <tr class="govuk-table__row">
+                                    <th scope="col" class="govuk-table__header">Documentation</th>
+                                    <th scope="col" class="govuk-table__header">Status</th>
+                                    <th scope="col" class="govuk-table__header">Received</th>
+                                    <th scope="col" class="govuk-table__header govuk-!-text-align-right">Action</th>
+                                </tr>
+                            </thead>
+                            <tbody class="govuk-table__body">
+                                <tr class="govuk-table__row">
+                                    <th scope="row" class="govuk-table__header">Appeal</th>
+                                    <td class="govuk-table__cell">Ready to review</td>
+                                    <td class="govuk-table__cell">2 August 2024</td>
+                                    <td class="govuk-table__cell govuk-!-text-align-right"><a href="/appeals-service/appeal-details/1/appellant-case?backUrl=%2Fappeals-service%2Fappeal-details%2F1"
+                                        data-cy="review-appellant-case" class="govuk-link">Review<span class="govuk-visually-hidden"> appellant case</span></a>
+                                    </td>
+                                </tr>
+                                <tr class="govuk-table__row">
+                                    <th scope="row" class="govuk-table__header">LPA questionnaire</th>
+                                    <td class="govuk-table__cell">Overdue</td>
+                                    <td class="govuk-table__cell">Due by 11 October 2023</td>
+                                    <td class="govuk-table__cell govuk-!-text-align-right"></td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
+                <div class="govuk-accordion__section">
+                    <div class="govuk-accordion__section-header">
+                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-5"> Costs</span></h2>
+                    </div>
+                    <div id="accordion-default1-content-5" class="govuk-accordion__section-content">
+                        <table class="govuk-table">
+                            <thead class="govuk-table__head">
+                                <tr class="govuk-table__row">
+                                    <th scope="col" class="govuk-table__header">Documentation</th>
+                                    <th scope="col" class="govuk-table__header">Status</th>
+                                    <th scope="col" class="govuk-table__header govuk-!-text-align-right">Action</th>
+                                </tr>
+                            </thead>
+                            <tbody class="govuk-table__body">
+                                <tr class="govuk-table__row">
+                                    <th scope="row" class="govuk-table__header appeal-costs-appellant-application-documentation">Appellant application</th>
+                                    <td class="govuk-table__cell appeal-costs-appellant-application-status">No documents available</td>
+                                    <td class="govuk-table__cell appeal-costs-appellant-application-actions govuk-!-text-align-right">
+                                        <ul class="govuk-summary-list__actions-list">
+                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-appellant-application" href="/appeals-service/appeal-details/1/costs/appellant/application/upload-documents/1">Add<span class="govuk-visually-hidden"> Appellant application</span></a>
+                                            </li>
                                         </ul>
-                                    </dd>
-                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/linked-appeals/manage"
-                                        data-cy="manage-linked-appeals">Manage<span class="govuk-visually-hidden"> Linked appeals</span></a>
-                                    </dd>
-                                </div>
-                                <div class="govuk-summary-list__row appeal-other-appeals"><dt class="govuk-summary-list__key"> Related appeals</dt>
-                                    <dd class="govuk-summary-list__value"><span>No</span>
-                                    </dd>
-                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/other-appeals/add"
-                                        data-cy="add-related-appeals">Add<span class="govuk-visually-hidden"> Related appeals</span></a>
-                                    </dd>
-                                </div>
-                                <div class="govuk-summary-list__row appeal-decision"><dt class="govuk-summary-list__key"> Decision</dt>
-                                    <dd class="govuk-summary-list__value">Dismissed</dd>
-                                </div>
-                            </dl>
-                        </div>
-                    </div>
-                    <div class="govuk-accordion__section">
-                        <div class="govuk-accordion__section-header">
-                            <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-2"> Site</span></h2>
-                        </div>
-                        <div id="accordion-default1-content-2" class="govuk-accordion__section-content">
-                            <dl class="govuk-summary-list">
-                                <div class="govuk-summary-list__row appeal-visit-type"><dt class="govuk-summary-list__key"> Visit type</dt>
-                                    <dd class="govuk-summary-list__value">Accompanied</dd>
-                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/visit-booked?backUrl=%2Fappeals-service%2Fappeal-details%2F1"
-                                        data-cy="change-set-visit-type">Change<span class="govuk-visually-hidden"> Visit type</span></a>
-                                    </dd>
-                                </div>
-                                <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Date</dt>
-                                    <dd class="govuk-summary-list__value">9 October 2023</dd>
-                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/visit-booked"
-                                        data-cy="change-site-visit-date">Change<span class="govuk-visually-hidden"> Date</span></a>
-                                    </dd>
-                                </div>
-                                <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Start time</dt>
-                                    <dd class="govuk-summary-list__value">9:38am</dd>
-                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/visit-booked"
-                                        data-cy="change-site-visit-start-time">Change<span class="govuk-visually-hidden"> Start time</span></a>
-                                    </dd>
-                                </div>
-                                <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> End time</dt>
-                                    <dd class="govuk-summary-list__value">10:00am</dd>
-                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/visit-booked"
-                                        data-cy="change-site-visit-end-time">Change<span class="govuk-visually-hidden"> End time</span></a>
-                                    </dd>
-                                </div>
-                                <div class="govuk-summary-list__row appeal-neighbouring-sites-inspector"><dt class="govuk-summary-list__key"> Interested party and neighbour addresses</dt>
-                                    <dd                                     class="govuk-summary-list__value">
-                                        <ul class="govuk-list govuk-list--bullet">
-                                            <li>2 Grove Cottage, Shotesham Road, Woodton, Devon, NR35 2ND</li>
+                                    </td>
+                                </tr>
+                                <tr class="govuk-table__row">
+                                    <th scope="row" class="govuk-table__header appeal-costs-appellant-withdrawal-documentation">Appellant withdrawal</th>
+                                    <td class="govuk-table__cell appeal-costs-appellant-withdrawal-status">No documents available</td>
+                                    <td class="govuk-table__cell appeal-costs-appellant-withdrawal-actions govuk-!-text-align-right">
+                                        <ul class="govuk-summary-list__actions-list">
+                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-appellant-withdrawal" href="/appeals-service/appeal-details/1/costs/appellant/withdrawal/upload-documents/2">Add<span class="govuk-visually-hidden"> Appellant withdrawal</span></a>
+                                            </li>
                                         </ul>
-                                        </dd>
-                                        <dd class="govuk-summary-list__actions">
-                                            <ul class="govuk-summary-list__actions-list">
-                                                <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/neighbouring-sites/manage"
-                                                    data-cy="manage-neighbouring-sites-inspector">Manage<span class="govuk-visually-hidden"> Interested party and neighbour addresses</span></a>
-                                                </li>
-                                                <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/neighbouring-sites/add/back-office"
-                                                    data-cy="add-neighbouring-sites-inspector">Add<span class="govuk-visually-hidden"> Interested party and neighbour addresses</span></a>
-                                                </li>
-                                            </ul>
-                                        </dd>
-                                </div>
-                            </dl>
-                        </div>
-                    </div>
-                    <div class="govuk-accordion__section">
-                        <div class="govuk-accordion__section-header">
-                            <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-3"> Timetable</span></h2>
-                        </div>
-                        <div id="accordion-default1-content-3" class="govuk-accordion__section-content">
-                            <dl class="govuk-summary-list appeal-case-timetable">
-                                <div class="govuk-summary-list__row appeal-valid-date"><dt class="govuk-summary-list__key"> Valid date</dt>
-                                    <dd class="govuk-summary-list__value">23 May 2023</dd>
-                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/valid/date"
-                                        data-cy="-valid-date"><span class="govuk-visually-hidden"> Valid date</span></a>
-                                    </dd>
-                                </div>
-                                <div class="govuk-summary-list__row appeal-start-date"><dt class="govuk-summary-list__key"> Start date</dt>
-                                    <dd class="govuk-summary-list__value">23 May 2023</dd>
-                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/start-case/change"
-                                        data-cy="change-start-case-date">Change<span class="govuk-visually-hidden"> Start date</span></a>
-                                    </dd>
-                                </div>
-                                <div class="govuk-summary-list__row appeal-lpa-questionnaire-due-date"><dt class="govuk-summary-list__key"> LPA questionnaire due</dt>
-                                    <dd class="govuk-summary-list__value">11 October 2023</dd>
-                                </div>
-                                <div class="govuk-summary-list__row appeal-site-visit"><dt class="govuk-summary-list__key"> Site visit</dt>
-                                    <dd class="govuk-summary-list__value">
-                                        <ul class="govuk-list govuk-!-margin-top-0 govuk-!-padding-left-0">
-                                            <li>9 October 2023</li>
-                                            <li>9:38am - 10:00am</li>
+                                    </td>
+                                </tr>
+                                <tr class="govuk-table__row">
+                                    <th scope="row" class="govuk-table__header appeal-costs-appellant-correspondence-documentation">Appellant correspondence</th>
+                                    <td class="govuk-table__cell appeal-costs-appellant-correspondence-status">No documents available</td>
+                                    <td class="govuk-table__cell appeal-costs-appellant-correspondence-actions govuk-!-text-align-right">
+                                        <ul class="govuk-summary-list__actions-list">
+                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-appellant-correspondence" href="/appeals-service/appeal-details/1/costs/appellant/correspondence/upload-documents/3">Add<span class="govuk-visually-hidden"> Appellant correspondence</span></a>
+                                            </li>
                                         </ul>
-                                    </dd>
-                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/manage-visit?backUrl=%2Fappeals-service%2Fappeal-details%2F1"
-                                        data-cy="change-schedule-visit">Change<span class="govuk-visually-hidden"> Site visit</span></a>
-                                    </dd>
-                                </div>
-                            </dl>
-                        </div>
-                    </div>
-                    <div class="govuk-accordion__section">
-                        <div class="govuk-accordion__section-header">
-                            <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-4"> Documentation</span></h2>
-                        </div>
-                        <div id="accordion-default1-content-4" class="govuk-accordion__section-content">
-                            <table class="govuk-table">
-                                <thead class="govuk-table__head">
-                                    <tr class="govuk-table__row">
-                                        <th scope="col" class="govuk-table__header">Documentation</th>
-                                        <th scope="col" class="govuk-table__header">Status</th>
-                                        <th scope="col" class="govuk-table__header">Received</th>
-                                        <th scope="col" class="govuk-table__header govuk-!-text-align-right">Action</th>
-                                    </tr>
-                                </thead>
-                                <tbody class="govuk-table__body">
-                                    <tr class="govuk-table__row">
-                                        <th scope="row" class="govuk-table__header">Appeal</th>
-                                        <td class="govuk-table__cell">Ready to review</td>
-                                        <td class="govuk-table__cell">2 August 2024</td>
-                                        <td class="govuk-table__cell govuk-!-text-align-right"><a href="/appeals-service/appeal-details/1/appellant-case?backUrl=%2Fappeals-service%2Fappeal-details%2F1"
-                                            data-cy="review-appellant-case" class="govuk-link">Review<span class="govuk-visually-hidden"> appellant case</span></a>
-                                        </td>
-                                    </tr>
-                                    <tr class="govuk-table__row">
-                                        <th scope="row" class="govuk-table__header">LPA questionnaire</th>
-                                        <td class="govuk-table__cell">Overdue</td>
-                                        <td class="govuk-table__cell">Due by 11 October 2023</td>
-                                        <td class="govuk-table__cell govuk-!-text-align-right"></td>
-                                    </tr>
-                                </tbody>
-                            </table>
-                        </div>
-                    </div>
-                    <div class="govuk-accordion__section">
-                        <div class="govuk-accordion__section-header">
-                            <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-5"> Costs</span></h2>
-                        </div>
-                        <div id="accordion-default1-content-5" class="govuk-accordion__section-content">
-                            <table class="govuk-table">
-                                <thead class="govuk-table__head">
-                                    <tr class="govuk-table__row">
-                                        <th scope="col" class="govuk-table__header">Documentation</th>
-                                        <th scope="col" class="govuk-table__header">Status</th>
-                                        <th scope="col" class="govuk-table__header govuk-!-text-align-right">Action</th>
-                                    </tr>
-                                </thead>
-                                <tbody class="govuk-table__body">
-                                    <tr class="govuk-table__row">
-                                        <th scope="row" class="govuk-table__header appeal-costs-appellant-application-documentation">Appellant application</th>
-                                        <td class="govuk-table__cell appeal-costs-appellant-application-status">No documents available</td>
-                                        <td class="govuk-table__cell appeal-costs-appellant-application-actions govuk-!-text-align-right">
-                                            <ul class="govuk-summary-list__actions-list">
-                                                <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-appellant-application" href="/appeals-service/appeal-details/1/costs/appellant/application/upload-documents/1">Add<span class="govuk-visually-hidden"> Appellant application</span></a>
-                                                </li>
-                                            </ul>
-                                        </td>
-                                    </tr>
-                                    <tr class="govuk-table__row">
-                                        <th scope="row" class="govuk-table__header appeal-costs-appellant-withdrawal-documentation">Appellant withdrawal</th>
-                                        <td class="govuk-table__cell appeal-costs-appellant-withdrawal-status">No documents available</td>
-                                        <td class="govuk-table__cell appeal-costs-appellant-withdrawal-actions govuk-!-text-align-right">
-                                            <ul class="govuk-summary-list__actions-list">
-                                                <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-appellant-withdrawal" href="/appeals-service/appeal-details/1/costs/appellant/withdrawal/upload-documents/2">Add<span class="govuk-visually-hidden"> Appellant withdrawal</span></a>
-                                                </li>
-                                            </ul>
-                                        </td>
-                                    </tr>
-                                    <tr class="govuk-table__row">
-                                        <th scope="row" class="govuk-table__header appeal-costs-appellant-correspondence-documentation">Appellant correspondence</th>
-                                        <td class="govuk-table__cell appeal-costs-appellant-correspondence-status">No documents available</td>
-                                        <td class="govuk-table__cell appeal-costs-appellant-correspondence-actions govuk-!-text-align-right">
-                                            <ul class="govuk-summary-list__actions-list">
-                                                <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-appellant-correspondence" href="/appeals-service/appeal-details/1/costs/appellant/correspondence/upload-documents/3">Add<span class="govuk-visually-hidden"> Appellant correspondence</span></a>
-                                                </li>
-                                            </ul>
-                                        </td>
-                                    </tr>
-                                    <tr class="govuk-table__row">
-                                        <th scope="row" class="govuk-table__header appeal-costs-lpa-application-documentation">LPA application</th>
-                                        <td class="govuk-table__cell appeal-costs-lpa-application-status">No documents available</td>
-                                        <td class="govuk-table__cell appeal-costs-lpa-application-actions govuk-!-text-align-right">
-                                            <ul class="govuk-summary-list__actions-list">
-                                                <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-lpa-application" href="/appeals-service/appeal-details/1/costs/lpa/application/upload-documents/4">Add<span class="govuk-visually-hidden"> LPA application</span></a>
-                                                </li>
-                                            </ul>
-                                        </td>
-                                    </tr>
-                                    <tr class="govuk-table__row">
-                                        <th scope="row" class="govuk-table__header appeal-costs-lpa-withdrawal-documentation">LPA withdrawal</th>
-                                        <td class="govuk-table__cell appeal-costs-lpa-withdrawal-status">No documents available</td>
-                                        <td class="govuk-table__cell appeal-costs-lpa-withdrawal-actions govuk-!-text-align-right">
-                                            <ul class="govuk-summary-list__actions-list">
-                                                <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-lpa-withdrawal" href="/appeals-service/appeal-details/1/costs/lpa/withdrawal/upload-documents/5">Add<span class="govuk-visually-hidden"> LPA withdrawal</span></a>
-                                                </li>
-                                            </ul>
-                                        </td>
-                                    </tr>
-                                    <tr class="govuk-table__row">
-                                        <th scope="row" class="govuk-table__header appeal-costs-lpa-correspondence-documentation">LPA correspondence</th>
-                                        <td class="govuk-table__cell appeal-costs-lpa-correspondence-status">No documents available</td>
-                                        <td class="govuk-table__cell appeal-costs-lpa-correspondence-actions govuk-!-text-align-right">
-                                            <ul class="govuk-summary-list__actions-list">
-                                                <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-lpa-correspondence" href="/appeals-service/appeal-details/1/costs/lpa/correspondence/upload-documents/6">Add<span class="govuk-visually-hidden"> LPA correspondence</span></a>
-                                                </li>
-                                            </ul>
-                                        </td>
-                                    </tr>
-                                </tbody>
-                            </table>
-                        </div>
-                    </div>
-                    <div class="govuk-accordion__section">
-                        <div class="govuk-accordion__section-header">
-                            <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-6"> Contacts</span></h2>
-                        </div>
-                        <div id="accordion-default1-content-6" class="govuk-accordion__section-content">
-                            <dl class="govuk-summary-list">
-                                <div class="govuk-summary-list__row appeal-appellant"><dt class="govuk-summary-list__key"> Appellant</dt>
-                                    <dd class="govuk-summary-list__value">
-                                        <ul class="govuk-list">
-                                            <li>Roger Simmons</li>
-                                            <li>test3@example.com</li>
+                                    </td>
+                                </tr>
+                                <tr class="govuk-table__row">
+                                    <th scope="row" class="govuk-table__header appeal-costs-lpa-application-documentation">LPA application</th>
+                                    <td class="govuk-table__cell appeal-costs-lpa-application-status">No documents available</td>
+                                    <td class="govuk-table__cell appeal-costs-lpa-application-actions govuk-!-text-align-right">
+                                        <ul class="govuk-summary-list__actions-list">
+                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-lpa-application" href="/appeals-service/appeal-details/1/costs/lpa/application/upload-documents/4">Add<span class="govuk-visually-hidden"> LPA application</span></a>
+                                            </li>
                                         </ul>
-                                    </dd>
-                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/service-user/change/appellant"
-                                        data-cy="change-appellant">Change<span class="govuk-visually-hidden"> Appellant</span></a>
-                                    </dd>
-                                </div>
-                                <div class="govuk-summary-list__row appeal-agent"><dt class="govuk-summary-list__key"> Agent</dt>
-                                    <dd class="govuk-summary-list__value">
-                                        <ul class="govuk-list">
-                                            <li>Fiona Shell</li>
-                                            <li>test2@example.com</li>
+                                    </td>
+                                </tr>
+                                <tr class="govuk-table__row">
+                                    <th scope="row" class="govuk-table__header appeal-costs-lpa-withdrawal-documentation">LPA withdrawal</th>
+                                    <td class="govuk-table__cell appeal-costs-lpa-withdrawal-status">No documents available</td>
+                                    <td class="govuk-table__cell appeal-costs-lpa-withdrawal-actions govuk-!-text-align-right">
+                                        <ul class="govuk-summary-list__actions-list">
+                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-lpa-withdrawal" href="/appeals-service/appeal-details/1/costs/lpa/withdrawal/upload-documents/5">Add<span class="govuk-visually-hidden"> LPA withdrawal</span></a>
+                                            </li>
                                         </ul>
-                                    </dd>
-                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/service-user/change/agent"
-                                        data-cy="change-agent">Change<span class="govuk-visually-hidden"> Agent</span></a>
-                                    </dd>
-                                </div>
-                                <div class="govuk-summary-list__row appeal-lpa-contact-details"><dt class="govuk-summary-list__key"> LPA</dt>
-                                    <dd class="govuk-summary-list__value">
-                                        <ul class="govuk-list">
-                                            <li>Wiltshire Council</li>
-                                            <li>wilt@lpa-email.gov.uk</li>
+                                    </td>
+                                </tr>
+                                <tr class="govuk-table__row">
+                                    <th scope="row" class="govuk-table__header appeal-costs-lpa-correspondence-documentation">LPA correspondence</th>
+                                    <td class="govuk-table__cell appeal-costs-lpa-correspondence-status">No documents available</td>
+                                    <td class="govuk-table__cell appeal-costs-lpa-correspondence-actions govuk-!-text-align-right">
+                                        <ul class="govuk-summary-list__actions-list">
+                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-lpa-correspondence" href="/appeals-service/appeal-details/1/costs/lpa/correspondence/upload-documents/6">Add<span class="govuk-visually-hidden"> LPA correspondence</span></a>
+                                            </li>
                                         </ul>
-                                    </dd>
-                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/change-appeal-details/local-planning-authority"
-                                        data-cy="change-lpa-contact-details">Change<span class="govuk-visually-hidden"> Local planning authority (LPA)</span></a>
-                                    </dd>
-                                </div>
-                            </dl>
-                        </div>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
                     </div>
-                    <div class="govuk-accordion__section">
-                        <div class="govuk-accordion__section-header">
-                            <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-7"> Team</span></h2>
-                        </div>
-                        <div id="accordion-default1-content-7" class="govuk-accordion__section-content">
-                            <dl class="govuk-summary-list">
-                                <div class="govuk-summary-list__row appeal-case-officer"><dt class="govuk-summary-list__key"> Case officer</dt>
-                                    <dd class="govuk-summary-list__value">
-                                        <p class="govuk-body">Not assigned</p>
-                                    </dd>
-                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/assign-user/case-officer"
-                                        data-cy="assign-case-officer">Assign<span class="govuk-visually-hidden"> Case officer</span></a>
-                                    </dd>
-                                </div>
-                                <div class="govuk-summary-list__row appeal-inspector"><dt class="govuk-summary-list__key"> Inspector</dt>
-                                    <dd class="govuk-summary-list__value">
-                                        <p class="govuk-body">Not assigned</p>
-                                    </dd>
-                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/assign-user/inspector"
-                                        data-cy="assign-inspector">Assign<span class="govuk-visually-hidden"> Inspector</span></a>
-                                    </dd>
-                                </div>
-                            </dl>
-                        </div>
+                </div>
+                <div class="govuk-accordion__section">
+                    <div class="govuk-accordion__section-header">
+                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-6"> Contacts</span></h2>
                     </div>
-                    <div class="govuk-accordion__section">
-                        <div class="govuk-accordion__section-header">
-                            <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-8"> Case management</span></h2>
-                        </div>
-                        <div id="accordion-default1-content-8" class="govuk-accordion__section-content">
-                            <dl class="govuk-summary-list">
-                                <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Cross-team correspondence</dt>
-                                    <dd                                     class="govuk-summary-list__value">No documents</dd>
-                                        <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/internal-correspondence/cross-team/upload-documents/10"
-                                            data-cy="add-cross-team-correspondence">Add<span class="govuk-visually-hidden"> Cross-team correspondence</span></a>
-                                        </dd>
-                                </div>
-                                <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Inspector correspondence</dt>
-                                    <dd                                     class="govuk-summary-list__value">No documents</dd>
-                                        <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/internal-correspondence/inspector/upload-documents/11"
-                                            data-cy="add-inspector-correspondence">Add<span class="govuk-visually-hidden"> Inspector correspondence</span></a>
-                                        </dd>
-                                </div>
-                                <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Main party correspondence</dt>
-                                    <dd                                     class="govuk-summary-list__value">No documents</dd>
-                                        <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/internal-correspondence/main-party/upload-documents/22"
-                                            data-cy="add-main-party-correspondence">Add<span class="govuk-visually-hidden"> Main party correspondence</span></a>
-                                        </dd>
-                                </div>
-                                <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Case history</dt>
-                                    <dd class="govuk-summary-list__value"></dd>
-                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/audit" data-cy="view-case-history">View<span class="govuk-visually-hidden"> Case history</span></a>
+                    <div id="accordion-default1-content-6" class="govuk-accordion__section-content">
+                        <dl class="govuk-summary-list">
+                            <div class="govuk-summary-list__row appeal-appellant"><dt class="govuk-summary-list__key"> Appellant</dt>
+                                <dd class="govuk-summary-list__value">
+                                    <ul class="govuk-list">
+                                        <li>Roger Simmons</li>
+                                        <li>test3@example.com</li>
+                                    </ul>
+                                </dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/service-user/change/appellant"
+                                    data-cy="change-appellant">Change<span class="govuk-visually-hidden"> Appellant</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-agent"><dt class="govuk-summary-list__key"> Agent</dt>
+                                <dd class="govuk-summary-list__value">
+                                    <ul class="govuk-list">
+                                        <li>Fiona Shell</li>
+                                        <li>test2@example.com</li>
+                                    </ul>
+                                </dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/service-user/change/agent"
+                                    data-cy="change-agent">Change<span class="govuk-visually-hidden"> Agent</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-lpa-contact-details"><dt class="govuk-summary-list__key"> LPA</dt>
+                                <dd class="govuk-summary-list__value">
+                                    <ul class="govuk-list">
+                                        <li>Wiltshire Council</li>
+                                        <li>wilt@lpa-email.gov.uk</li>
+                                    </ul>
+                                </dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/change-appeal-details/local-planning-authority"
+                                    data-cy="change-lpa-contact-details">Change<span class="govuk-visually-hidden"> Local planning authority (LPA)</span></a>
+                                </dd>
+                            </div>
+                        </dl>
+                    </div>
+                </div>
+                <div class="govuk-accordion__section">
+                    <div class="govuk-accordion__section-header">
+                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-7"> Team</span></h2>
+                    </div>
+                    <div id="accordion-default1-content-7" class="govuk-accordion__section-content">
+                        <dl class="govuk-summary-list">
+                            <div class="govuk-summary-list__row appeal-case-officer"><dt class="govuk-summary-list__key"> Case officer</dt>
+                                <dd class="govuk-summary-list__value">
+                                    <p class="govuk-body">Not assigned</p>
+                                </dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/assign-user/case-officer"
+                                    data-cy="assign-case-officer">Assign<span class="govuk-visually-hidden"> Case officer</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-inspector"><dt class="govuk-summary-list__key"> Inspector</dt>
+                                <dd class="govuk-summary-list__value">
+                                    <p class="govuk-body">Not assigned</p>
+                                </dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/assign-user/inspector"
+                                    data-cy="assign-inspector">Assign<span class="govuk-visually-hidden"> Inspector</span></a>
+                                </dd>
+                            </div>
+                        </dl>
+                    </div>
+                </div>
+                <div class="govuk-accordion__section">
+                    <div class="govuk-accordion__section-header">
+                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-8"> Case management</span></h2>
+                    </div>
+                    <div id="accordion-default1-content-8" class="govuk-accordion__section-content">
+                        <dl class="govuk-summary-list">
+                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Cross-team correspondence</dt>
+                                <dd                                 class="govuk-summary-list__value">No documents</dd>
+                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/internal-correspondence/cross-team/upload-documents/10"
+                                        data-cy="add-cross-team-correspondence">Add<span class="govuk-visually-hidden"> Cross-team correspondence</span></a>
                                     </dd>
-                                </div>
-                                <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Appeal withdrawal</dt>
-                                    <dd class="govuk-summary-list__value"></dd>
-                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/withdrawal/start"
-                                        data-cy="start-appeal-withdrawal">Start<span class="govuk-visually-hidden"> Appeal withdrawal</span></a>
+                            </div>
+                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Inspector correspondence</dt>
+                                <dd                                 class="govuk-summary-list__value">No documents</dd>
+                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/internal-correspondence/inspector/upload-documents/11"
+                                        data-cy="add-inspector-correspondence">Add<span class="govuk-visually-hidden"> Inspector correspondence</span></a>
                                     </dd>
-                                </div>
-                            </dl>
-                        </div>
+                            </div>
+                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Main party correspondence</dt>
+                                <dd                                 class="govuk-summary-list__value">No documents</dd>
+                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/internal-correspondence/main-party/upload-documents/22"
+                                        data-cy="add-main-party-correspondence">Add<span class="govuk-visually-hidden"> Main party correspondence</span></a>
+                                    </dd>
+                            </div>
+                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Case history</dt>
+                                <dd class="govuk-summary-list__value"></dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/audit" data-cy="view-case-history">View<span class="govuk-visually-hidden"> Case history</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Appeal withdrawal</dt>
+                                <dd class="govuk-summary-list__value"></dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/withdrawal/start"
+                                    data-cy="start-appeal-withdrawal">Start<span class="govuk-visually-hidden"> Appeal withdrawal</span></a>
+                                </dd>
+                            </div>
+                        </dl>
                     </div>
                 </div>
             </div>
         </div>
+    </div>
 </main>"
 `;
 
@@ -2139,10 +2141,11 @@ exports[`appeal-details GET /:appealId should render a lead tag next to the appe
         </div>
     </div>
     <div class="govuk-grid-row">
-        <div class="govuk-grid-column-full"><strong class="govuk-tag govuk-tag--grey govuk-!-margin-bottom-4">Received appeal</strong>
+        <div class="govuk-grid-column-full"><strong class="govuk-tag govuk-tag--grey pins-status-tag--full-width">Received appeal</strong>
+            <strong             class="govuk-tag govuk-tag--grey govuk-!-margin-left-1 govuk-!-margin-bottom-4">Lead</strong>
         </div>
-    </div><strong class="govuk-tag govuk-tag--grey govuk-!-margin-left-1 govuk-!-margin-bottom-4">Lead</strong>
-    <div     class="govuk-grid-row">
+    </div>
+    <div class="govuk-grid-row">
         <div class="govuk-grid-column-full">
             <dl class="govuk-summary-list pins-summary-list--no-border">
                 <div class="govuk-summary-list__row appeal-case-officer"><dt class="govuk-summary-list__key"> Case officer</dt>
@@ -2167,415 +2170,415 @@ exports[`appeal-details GET /:appealId should render a lead tag next to the appe
                 </div>
             </dl>
         </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
+            <p class="govuk-body govuk-!-margin-bottom-6" id="download-case-files"
+            data-cy="download-case-files"><a class="govuk-link" href="/documents/1/bulk-download/case-APP/Q9999/D/21/351062.zip">Download case</a>
+            </p>
         </div>
-        <div class="govuk-grid-row">
-            <div class="govuk-grid-column-full">
-                <p class="govuk-body govuk-!-margin-bottom-6" id="download-case-files"
-                data-cy="download-case-files"><a class="govuk-link" href="/documents/1/bulk-download/case-APP/Q9999/D/21/351062.zip">Download case</a>
-                </p>
-            </div>
-        </div>
-        <div class="govuk-grid-row">
-            <div class="govuk-grid-column-full">
-                <details class="govuk-details">
-                    <summary class="govuk-details__summary"><span class="govuk-details__summary-text"> 2 case notes</span>
-                    </summary>
-                    <div class="govuk-details__text">
-                        <form method="POST" novalidate="novalidate">
-                            <div class="govuk-grid-row">
-                                <div class="govuk-grid-column-two-thirds">
-                                    <div class="govuk-form-group govuk-character-count" data-module="govuk-character-count"
-                                    data-maxlength="500">
-                                        <textarea class="govuk-textarea govuk-js-character-count" id="comment"
-                                        name="comment" rows="5" aria-describedby="comment-info"></textarea>
-                                        <div id="comment-info" class="govuk-hint govuk-character-count__message">You can enter up to 500 characters</div>
-                                    </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
+            <details class="govuk-details">
+                <summary class="govuk-details__summary"><span class="govuk-details__summary-text"> 2 case notes</span>
+                </summary>
+                <div class="govuk-details__text">
+                    <form method="POST" novalidate="novalidate">
+                        <div class="govuk-grid-row">
+                            <div class="govuk-grid-column-two-thirds">
+                                <div class="govuk-form-group govuk-character-count" data-module="govuk-character-count"
+                                data-maxlength="500">
+                                    <textarea class="govuk-textarea govuk-js-character-count" id="comment"
+                                    name="comment" rows="5" aria-describedby="comment-info"></textarea>
+                                    <div id="comment-info" class="govuk-hint govuk-character-count__message">You can enter up to 500 characters</div>
                                 </div>
                             </div>
-                            <button type="submit" data-prevent-double-click="true" class="govuk-button govuk-button--secondary govuk-!-margin-bottom-1"
-                            data-module="govuk-button">Add case note</button>
-                        </form>
-                        <div>
+                        </div>
+                        <button type="submit" data-prevent-double-click="true" class="govuk-button govuk-button--secondary govuk-!-margin-bottom-1"
+                        data-module="govuk-button">Add case note</button>
+                    </form>
+                    <div>
+                        <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+                        <section>
+                            <p class="govuk-body govuk-!-margin-bottom-1">A case note you should see.</p>
+                            <p class="govuk-hint govuk-!-margin-bottom-6">11:00am on Tuesday 1 October 2024 by John.Smith</p>
                             <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
-                            <section>
-                                <p class="govuk-body govuk-!-margin-bottom-1">A case note you should see.</p>
-                                <p class="govuk-hint govuk-!-margin-bottom-6">11:00am on Tuesday 1 October 2024 by John.Smith</p>
-                                <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
-                            </section>
-                            <section>
-                                <p class="govuk-body govuk-!-margin-bottom-1">A case note you should see.</p>
-                                <p class="govuk-hint govuk-!-margin-bottom-6">11:00am on Tuesday 1 October 2024 by John.Smith</p>
-                                <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
-                            </section>
-                        </div>
+                        </section>
+                        <section>
+                            <p class="govuk-body govuk-!-margin-bottom-1">A case note you should see.</p>
+                            <p class="govuk-hint govuk-!-margin-bottom-6">11:00am on Tuesday 1 October 2024 by John.Smith</p>
+                            <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+                        </section>
                     </div>
-                </details>
-            </div>
+                </div>
+            </details>
         </div>
-        <div class="govuk-grid-row">
-            <div class="govuk-grid-column-full">
-                <div class="govuk-accordion" data-module="govuk-accordion" id="accordion-default1">
-                    <div class="govuk-accordion__section">
-                        <div class="govuk-accordion__section-header">
-                            <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-1"> Overview</span></h2>
-                        </div>
-                        <div id="accordion-default1-content-1" class="govuk-accordion__section-content">
-                            <dl class="govuk-summary-list">
-                                <div class="govuk-summary-list__row govuk-summary-list__row--no-actions appeal-lpa-reference"><dt class="govuk-summary-list__key"> Planning application reference</dt>
-                                    <dd                                     class="govuk-summary-list__value">48269/APP/2021/1482</dd>
-                                </div>
-                                <div class="govuk-summary-list__row appeal-appeal-type"><dt class="govuk-summary-list__key"> Appeal type</dt>
-                                    <dd class="govuk-summary-list__value">Householder</dd>
-                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/change-appeal-type/appeal-type"
-                                        data-cy="change-appeal-type">Change<span class="govuk-visually-hidden"> Appeal type</span></a>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
+            <div class="govuk-accordion" data-module="govuk-accordion" id="accordion-default1">
+                <div class="govuk-accordion__section">
+                    <div class="govuk-accordion__section-header">
+                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-1"> Overview</span></h2>
+                    </div>
+                    <div id="accordion-default1-content-1" class="govuk-accordion__section-content">
+                        <dl class="govuk-summary-list">
+                            <div class="govuk-summary-list__row govuk-summary-list__row--no-actions appeal-lpa-reference"><dt class="govuk-summary-list__key"> Planning application reference</dt>
+                                <dd                                 class="govuk-summary-list__value">48269/APP/2021/1482</dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-appeal-type"><dt class="govuk-summary-list__key"> Appeal type</dt>
+                                <dd class="govuk-summary-list__value">Householder</dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/change-appeal-type/appeal-type"
+                                    data-cy="change-appeal-type">Change<span class="govuk-visually-hidden"> Appeal type</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row govuk-summary-list__row--no-actions appeal-case-procedure"><dt class="govuk-summary-list__key"> Appeal procedure</dt>
+                                <dd class="govuk-summary-list__value">Written</dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-allocation-details"><dt class="govuk-summary-list__key"> Allocation level</dt>
+                                <dd class="govuk-summary-list__value">
+                                    <ul class="govuk-!-margin-0">
+                                        <li>Level: A</li>
+                                        <li>Historic heritage</li>
+                                        <li>Architecture design</li>
+                                    </ul>
+                                </dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/allocation-details/allocation-level"
+                                    data-cy="change-allocation-details">Change<span class="govuk-visually-hidden"> Allocation level</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-linked-appeals"><dt class="govuk-summary-list__key"> Linked appeals</dt>
+                                <dd class="govuk-summary-list__value">
+                                    <ul class="govuk-list govuk-list--bullet">
+                                        <li><a href="/appeals-service/appeal-details/5449" class="govuk-link" data-cy="linked-appeal-784706"
+                                            aria-label="Appeal 7 8 4 7 0 6">784706</a> (Child)</li>
+                                        <li><span class="govuk-body">87326527</span> (Child)</li>
+                                        <li><a href="/appeals-service/appeal-details/5451" class="govuk-link" data-cy="linked-appeal-721086"
+                                            aria-label="Appeal 7 2 1 0 8 6">721086</a> (Child)</li>
+                                    </ul>
+                                </dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/linked-appeals/manage"
+                                    data-cy="manage-linked-appeals">Manage<span class="govuk-visually-hidden"> Linked appeals</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-other-appeals"><dt class="govuk-summary-list__key"> Related appeals</dt>
+                                <dd class="govuk-summary-list__value"><span>No</span>
+                                </dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/other-appeals/add"
+                                    data-cy="add-related-appeals">Add<span class="govuk-visually-hidden"> Related appeals</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-decision"><dt class="govuk-summary-list__key"> Decision</dt>
+                                <dd class="govuk-summary-list__value">Dismissed</dd>
+                            </div>
+                        </dl>
+                    </div>
+                </div>
+                <div class="govuk-accordion__section">
+                    <div class="govuk-accordion__section-header">
+                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-2"> Site</span></h2>
+                    </div>
+                    <div id="accordion-default1-content-2" class="govuk-accordion__section-content">
+                        <dl class="govuk-summary-list">
+                            <div class="govuk-summary-list__row appeal-visit-type"><dt class="govuk-summary-list__key"> Visit type</dt>
+                                <dd class="govuk-summary-list__value">Accompanied</dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/visit-booked?backUrl=%2Fappeals-service%2Fappeal-details%2F1"
+                                    data-cy="change-set-visit-type">Change<span class="govuk-visually-hidden"> Visit type</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Date</dt>
+                                <dd class="govuk-summary-list__value">9 October 2023</dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/visit-booked"
+                                    data-cy="change-site-visit-date">Change<span class="govuk-visually-hidden"> Date</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Start time</dt>
+                                <dd class="govuk-summary-list__value">9:38am</dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/visit-booked"
+                                    data-cy="change-site-visit-start-time">Change<span class="govuk-visually-hidden"> Start time</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> End time</dt>
+                                <dd class="govuk-summary-list__value">10:00am</dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/visit-booked"
+                                    data-cy="change-site-visit-end-time">Change<span class="govuk-visually-hidden"> End time</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-neighbouring-sites-inspector"><dt class="govuk-summary-list__key"> Interested party and neighbour addresses</dt>
+                                <dd                                 class="govuk-summary-list__value">
+                                    <ul class="govuk-list govuk-list--bullet">
+                                        <li>2 Grove Cottage, Shotesham Road, Woodton, Devon, NR35 2ND</li>
+                                    </ul>
                                     </dd>
-                                </div>
-                                <div class="govuk-summary-list__row govuk-summary-list__row--no-actions appeal-case-procedure"><dt class="govuk-summary-list__key"> Appeal procedure</dt>
-                                    <dd class="govuk-summary-list__value">Written</dd>
-                                </div>
-                                <div class="govuk-summary-list__row appeal-allocation-details"><dt class="govuk-summary-list__key"> Allocation level</dt>
-                                    <dd class="govuk-summary-list__value">
-                                        <ul class="govuk-!-margin-0">
-                                            <li>Level: A</li>
-                                            <li>Historic heritage</li>
-                                            <li>Architecture design</li>
+                                    <dd class="govuk-summary-list__actions">
+                                        <ul class="govuk-summary-list__actions-list">
+                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/neighbouring-sites/manage"
+                                                data-cy="manage-neighbouring-sites-inspector">Manage<span class="govuk-visually-hidden"> Interested party and neighbour addresses</span></a>
+                                            </li>
+                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/neighbouring-sites/add/back-office"
+                                                data-cy="add-neighbouring-sites-inspector">Add<span class="govuk-visually-hidden"> Interested party and neighbour addresses</span></a>
+                                            </li>
                                         </ul>
                                     </dd>
-                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/allocation-details/allocation-level"
-                                        data-cy="change-allocation-details">Change<span class="govuk-visually-hidden"> Allocation level</span></a>
-                                    </dd>
-                                </div>
-                                <div class="govuk-summary-list__row appeal-linked-appeals"><dt class="govuk-summary-list__key"> Linked appeals</dt>
-                                    <dd class="govuk-summary-list__value">
-                                        <ul class="govuk-list govuk-list--bullet">
-                                            <li><a href="/appeals-service/appeal-details/5449" class="govuk-link" data-cy="linked-appeal-784706"
-                                                aria-label="Appeal 7 8 4 7 0 6">784706</a> (Child)</li>
-                                            <li><span class="govuk-body">87326527</span> (Child)</li>
-                                            <li><a href="/appeals-service/appeal-details/5451" class="govuk-link" data-cy="linked-appeal-721086"
-                                                aria-label="Appeal 7 2 1 0 8 6">721086</a> (Child)</li>
+                            </div>
+                        </dl>
+                    </div>
+                </div>
+                <div class="govuk-accordion__section">
+                    <div class="govuk-accordion__section-header">
+                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-3"> Timetable</span></h2>
+                    </div>
+                    <div id="accordion-default1-content-3" class="govuk-accordion__section-content">
+                        <dl class="govuk-summary-list appeal-case-timetable">
+                            <div class="govuk-summary-list__row appeal-valid-date"><dt class="govuk-summary-list__key"> Valid date</dt>
+                                <dd class="govuk-summary-list__value">23 May 2023</dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/valid/date"
+                                    data-cy="-valid-date"><span class="govuk-visually-hidden"> Valid date</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-start-date"><dt class="govuk-summary-list__key"> Start date</dt>
+                                <dd class="govuk-summary-list__value">23 May 2023</dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/start-case/change"
+                                    data-cy="change-start-case-date">Change<span class="govuk-visually-hidden"> Start date</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-lpa-questionnaire-due-date"><dt class="govuk-summary-list__key"> LPA questionnaire due</dt>
+                                <dd class="govuk-summary-list__value">11 October 2023</dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-site-visit"><dt class="govuk-summary-list__key"> Site visit</dt>
+                                <dd class="govuk-summary-list__value">
+                                    <ul class="govuk-list govuk-!-margin-top-0 govuk-!-padding-left-0">
+                                        <li>9 October 2023</li>
+                                        <li>9:38am - 10:00am</li>
+                                    </ul>
+                                </dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/manage-visit?backUrl=%2Fappeals-service%2Fappeal-details%2F1"
+                                    data-cy="change-schedule-visit">Change<span class="govuk-visually-hidden"> Site visit</span></a>
+                                </dd>
+                            </div>
+                        </dl>
+                    </div>
+                </div>
+                <div class="govuk-accordion__section">
+                    <div class="govuk-accordion__section-header">
+                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-4"> Documentation</span></h2>
+                    </div>
+                    <div id="accordion-default1-content-4" class="govuk-accordion__section-content">
+                        <table class="govuk-table">
+                            <thead class="govuk-table__head">
+                                <tr class="govuk-table__row">
+                                    <th scope="col" class="govuk-table__header">Documentation</th>
+                                    <th scope="col" class="govuk-table__header">Status</th>
+                                    <th scope="col" class="govuk-table__header">Received</th>
+                                    <th scope="col" class="govuk-table__header govuk-!-text-align-right">Action</th>
+                                </tr>
+                            </thead>
+                            <tbody class="govuk-table__body">
+                                <tr class="govuk-table__row">
+                                    <th scope="row" class="govuk-table__header">Appeal</th>
+                                    <td class="govuk-table__cell">Ready to review</td>
+                                    <td class="govuk-table__cell">2 August 2024</td>
+                                    <td class="govuk-table__cell govuk-!-text-align-right"><a href="/appeals-service/appeal-details/1/appellant-case?backUrl=%2Fappeals-service%2Fappeal-details%2F1"
+                                        data-cy="review-appellant-case" class="govuk-link">Review<span class="govuk-visually-hidden"> appellant case</span></a>
+                                    </td>
+                                </tr>
+                                <tr class="govuk-table__row">
+                                    <th scope="row" class="govuk-table__header">LPA questionnaire</th>
+                                    <td class="govuk-table__cell">Overdue</td>
+                                    <td class="govuk-table__cell">Due by 11 October 2023</td>
+                                    <td class="govuk-table__cell govuk-!-text-align-right"></td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
+                <div class="govuk-accordion__section">
+                    <div class="govuk-accordion__section-header">
+                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-5"> Costs</span></h2>
+                    </div>
+                    <div id="accordion-default1-content-5" class="govuk-accordion__section-content">
+                        <table class="govuk-table">
+                            <thead class="govuk-table__head">
+                                <tr class="govuk-table__row">
+                                    <th scope="col" class="govuk-table__header">Documentation</th>
+                                    <th scope="col" class="govuk-table__header">Status</th>
+                                    <th scope="col" class="govuk-table__header govuk-!-text-align-right">Action</th>
+                                </tr>
+                            </thead>
+                            <tbody class="govuk-table__body">
+                                <tr class="govuk-table__row">
+                                    <th scope="row" class="govuk-table__header appeal-costs-appellant-application-documentation">Appellant application</th>
+                                    <td class="govuk-table__cell appeal-costs-appellant-application-status">No documents available</td>
+                                    <td class="govuk-table__cell appeal-costs-appellant-application-actions govuk-!-text-align-right">
+                                        <ul class="govuk-summary-list__actions-list">
+                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-appellant-application" href="/appeals-service/appeal-details/1/costs/appellant/application/upload-documents/1">Add<span class="govuk-visually-hidden"> Appellant application</span></a>
+                                            </li>
                                         </ul>
-                                    </dd>
-                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/linked-appeals/manage"
-                                        data-cy="manage-linked-appeals">Manage<span class="govuk-visually-hidden"> Linked appeals</span></a>
-                                    </dd>
-                                </div>
-                                <div class="govuk-summary-list__row appeal-other-appeals"><dt class="govuk-summary-list__key"> Related appeals</dt>
-                                    <dd class="govuk-summary-list__value"><span>No</span>
-                                    </dd>
-                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/other-appeals/add"
-                                        data-cy="add-related-appeals">Add<span class="govuk-visually-hidden"> Related appeals</span></a>
-                                    </dd>
-                                </div>
-                                <div class="govuk-summary-list__row appeal-decision"><dt class="govuk-summary-list__key"> Decision</dt>
-                                    <dd class="govuk-summary-list__value">Dismissed</dd>
-                                </div>
-                            </dl>
-                        </div>
-                    </div>
-                    <div class="govuk-accordion__section">
-                        <div class="govuk-accordion__section-header">
-                            <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-2"> Site</span></h2>
-                        </div>
-                        <div id="accordion-default1-content-2" class="govuk-accordion__section-content">
-                            <dl class="govuk-summary-list">
-                                <div class="govuk-summary-list__row appeal-visit-type"><dt class="govuk-summary-list__key"> Visit type</dt>
-                                    <dd class="govuk-summary-list__value">Accompanied</dd>
-                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/visit-booked?backUrl=%2Fappeals-service%2Fappeal-details%2F1"
-                                        data-cy="change-set-visit-type">Change<span class="govuk-visually-hidden"> Visit type</span></a>
-                                    </dd>
-                                </div>
-                                <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Date</dt>
-                                    <dd class="govuk-summary-list__value">9 October 2023</dd>
-                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/visit-booked"
-                                        data-cy="change-site-visit-date">Change<span class="govuk-visually-hidden"> Date</span></a>
-                                    </dd>
-                                </div>
-                                <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Start time</dt>
-                                    <dd class="govuk-summary-list__value">9:38am</dd>
-                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/visit-booked"
-                                        data-cy="change-site-visit-start-time">Change<span class="govuk-visually-hidden"> Start time</span></a>
-                                    </dd>
-                                </div>
-                                <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> End time</dt>
-                                    <dd class="govuk-summary-list__value">10:00am</dd>
-                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/visit-booked"
-                                        data-cy="change-site-visit-end-time">Change<span class="govuk-visually-hidden"> End time</span></a>
-                                    </dd>
-                                </div>
-                                <div class="govuk-summary-list__row appeal-neighbouring-sites-inspector"><dt class="govuk-summary-list__key"> Interested party and neighbour addresses</dt>
-                                    <dd                                     class="govuk-summary-list__value">
-                                        <ul class="govuk-list govuk-list--bullet">
-                                            <li>2 Grove Cottage, Shotesham Road, Woodton, Devon, NR35 2ND</li>
+                                    </td>
+                                </tr>
+                                <tr class="govuk-table__row">
+                                    <th scope="row" class="govuk-table__header appeal-costs-appellant-withdrawal-documentation">Appellant withdrawal</th>
+                                    <td class="govuk-table__cell appeal-costs-appellant-withdrawal-status">No documents available</td>
+                                    <td class="govuk-table__cell appeal-costs-appellant-withdrawal-actions govuk-!-text-align-right">
+                                        <ul class="govuk-summary-list__actions-list">
+                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-appellant-withdrawal" href="/appeals-service/appeal-details/1/costs/appellant/withdrawal/upload-documents/2">Add<span class="govuk-visually-hidden"> Appellant withdrawal</span></a>
+                                            </li>
                                         </ul>
-                                        </dd>
-                                        <dd class="govuk-summary-list__actions">
-                                            <ul class="govuk-summary-list__actions-list">
-                                                <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/neighbouring-sites/manage"
-                                                    data-cy="manage-neighbouring-sites-inspector">Manage<span class="govuk-visually-hidden"> Interested party and neighbour addresses</span></a>
-                                                </li>
-                                                <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/neighbouring-sites/add/back-office"
-                                                    data-cy="add-neighbouring-sites-inspector">Add<span class="govuk-visually-hidden"> Interested party and neighbour addresses</span></a>
-                                                </li>
-                                            </ul>
-                                        </dd>
-                                </div>
-                            </dl>
-                        </div>
-                    </div>
-                    <div class="govuk-accordion__section">
-                        <div class="govuk-accordion__section-header">
-                            <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-3"> Timetable</span></h2>
-                        </div>
-                        <div id="accordion-default1-content-3" class="govuk-accordion__section-content">
-                            <dl class="govuk-summary-list appeal-case-timetable">
-                                <div class="govuk-summary-list__row appeal-valid-date"><dt class="govuk-summary-list__key"> Valid date</dt>
-                                    <dd class="govuk-summary-list__value">23 May 2023</dd>
-                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/valid/date"
-                                        data-cy="-valid-date"><span class="govuk-visually-hidden"> Valid date</span></a>
-                                    </dd>
-                                </div>
-                                <div class="govuk-summary-list__row appeal-start-date"><dt class="govuk-summary-list__key"> Start date</dt>
-                                    <dd class="govuk-summary-list__value">23 May 2023</dd>
-                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/start-case/change"
-                                        data-cy="change-start-case-date">Change<span class="govuk-visually-hidden"> Start date</span></a>
-                                    </dd>
-                                </div>
-                                <div class="govuk-summary-list__row appeal-lpa-questionnaire-due-date"><dt class="govuk-summary-list__key"> LPA questionnaire due</dt>
-                                    <dd class="govuk-summary-list__value">11 October 2023</dd>
-                                </div>
-                                <div class="govuk-summary-list__row appeal-site-visit"><dt class="govuk-summary-list__key"> Site visit</dt>
-                                    <dd class="govuk-summary-list__value">
-                                        <ul class="govuk-list govuk-!-margin-top-0 govuk-!-padding-left-0">
-                                            <li>9 October 2023</li>
-                                            <li>9:38am - 10:00am</li>
+                                    </td>
+                                </tr>
+                                <tr class="govuk-table__row">
+                                    <th scope="row" class="govuk-table__header appeal-costs-appellant-correspondence-documentation">Appellant correspondence</th>
+                                    <td class="govuk-table__cell appeal-costs-appellant-correspondence-status">No documents available</td>
+                                    <td class="govuk-table__cell appeal-costs-appellant-correspondence-actions govuk-!-text-align-right">
+                                        <ul class="govuk-summary-list__actions-list">
+                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-appellant-correspondence" href="/appeals-service/appeal-details/1/costs/appellant/correspondence/upload-documents/3">Add<span class="govuk-visually-hidden"> Appellant correspondence</span></a>
+                                            </li>
                                         </ul>
-                                    </dd>
-                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/manage-visit?backUrl=%2Fappeals-service%2Fappeal-details%2F1"
-                                        data-cy="change-schedule-visit">Change<span class="govuk-visually-hidden"> Site visit</span></a>
-                                    </dd>
-                                </div>
-                            </dl>
-                        </div>
-                    </div>
-                    <div class="govuk-accordion__section">
-                        <div class="govuk-accordion__section-header">
-                            <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-4"> Documentation</span></h2>
-                        </div>
-                        <div id="accordion-default1-content-4" class="govuk-accordion__section-content">
-                            <table class="govuk-table">
-                                <thead class="govuk-table__head">
-                                    <tr class="govuk-table__row">
-                                        <th scope="col" class="govuk-table__header">Documentation</th>
-                                        <th scope="col" class="govuk-table__header">Status</th>
-                                        <th scope="col" class="govuk-table__header">Received</th>
-                                        <th scope="col" class="govuk-table__header govuk-!-text-align-right">Action</th>
-                                    </tr>
-                                </thead>
-                                <tbody class="govuk-table__body">
-                                    <tr class="govuk-table__row">
-                                        <th scope="row" class="govuk-table__header">Appeal</th>
-                                        <td class="govuk-table__cell">Ready to review</td>
-                                        <td class="govuk-table__cell">2 August 2024</td>
-                                        <td class="govuk-table__cell govuk-!-text-align-right"><a href="/appeals-service/appeal-details/1/appellant-case?backUrl=%2Fappeals-service%2Fappeal-details%2F1"
-                                            data-cy="review-appellant-case" class="govuk-link">Review<span class="govuk-visually-hidden"> appellant case</span></a>
-                                        </td>
-                                    </tr>
-                                    <tr class="govuk-table__row">
-                                        <th scope="row" class="govuk-table__header">LPA questionnaire</th>
-                                        <td class="govuk-table__cell">Overdue</td>
-                                        <td class="govuk-table__cell">Due by 11 October 2023</td>
-                                        <td class="govuk-table__cell govuk-!-text-align-right"></td>
-                                    </tr>
-                                </tbody>
-                            </table>
-                        </div>
-                    </div>
-                    <div class="govuk-accordion__section">
-                        <div class="govuk-accordion__section-header">
-                            <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-5"> Costs</span></h2>
-                        </div>
-                        <div id="accordion-default1-content-5" class="govuk-accordion__section-content">
-                            <table class="govuk-table">
-                                <thead class="govuk-table__head">
-                                    <tr class="govuk-table__row">
-                                        <th scope="col" class="govuk-table__header">Documentation</th>
-                                        <th scope="col" class="govuk-table__header">Status</th>
-                                        <th scope="col" class="govuk-table__header govuk-!-text-align-right">Action</th>
-                                    </tr>
-                                </thead>
-                                <tbody class="govuk-table__body">
-                                    <tr class="govuk-table__row">
-                                        <th scope="row" class="govuk-table__header appeal-costs-appellant-application-documentation">Appellant application</th>
-                                        <td class="govuk-table__cell appeal-costs-appellant-application-status">No documents available</td>
-                                        <td class="govuk-table__cell appeal-costs-appellant-application-actions govuk-!-text-align-right">
-                                            <ul class="govuk-summary-list__actions-list">
-                                                <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-appellant-application" href="/appeals-service/appeal-details/1/costs/appellant/application/upload-documents/1">Add<span class="govuk-visually-hidden"> Appellant application</span></a>
-                                                </li>
-                                            </ul>
-                                        </td>
-                                    </tr>
-                                    <tr class="govuk-table__row">
-                                        <th scope="row" class="govuk-table__header appeal-costs-appellant-withdrawal-documentation">Appellant withdrawal</th>
-                                        <td class="govuk-table__cell appeal-costs-appellant-withdrawal-status">No documents available</td>
-                                        <td class="govuk-table__cell appeal-costs-appellant-withdrawal-actions govuk-!-text-align-right">
-                                            <ul class="govuk-summary-list__actions-list">
-                                                <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-appellant-withdrawal" href="/appeals-service/appeal-details/1/costs/appellant/withdrawal/upload-documents/2">Add<span class="govuk-visually-hidden"> Appellant withdrawal</span></a>
-                                                </li>
-                                            </ul>
-                                        </td>
-                                    </tr>
-                                    <tr class="govuk-table__row">
-                                        <th scope="row" class="govuk-table__header appeal-costs-appellant-correspondence-documentation">Appellant correspondence</th>
-                                        <td class="govuk-table__cell appeal-costs-appellant-correspondence-status">No documents available</td>
-                                        <td class="govuk-table__cell appeal-costs-appellant-correspondence-actions govuk-!-text-align-right">
-                                            <ul class="govuk-summary-list__actions-list">
-                                                <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-appellant-correspondence" href="/appeals-service/appeal-details/1/costs/appellant/correspondence/upload-documents/3">Add<span class="govuk-visually-hidden"> Appellant correspondence</span></a>
-                                                </li>
-                                            </ul>
-                                        </td>
-                                    </tr>
-                                    <tr class="govuk-table__row">
-                                        <th scope="row" class="govuk-table__header appeal-costs-lpa-application-documentation">LPA application</th>
-                                        <td class="govuk-table__cell appeal-costs-lpa-application-status">No documents available</td>
-                                        <td class="govuk-table__cell appeal-costs-lpa-application-actions govuk-!-text-align-right">
-                                            <ul class="govuk-summary-list__actions-list">
-                                                <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-lpa-application" href="/appeals-service/appeal-details/1/costs/lpa/application/upload-documents/4">Add<span class="govuk-visually-hidden"> LPA application</span></a>
-                                                </li>
-                                            </ul>
-                                        </td>
-                                    </tr>
-                                    <tr class="govuk-table__row">
-                                        <th scope="row" class="govuk-table__header appeal-costs-lpa-withdrawal-documentation">LPA withdrawal</th>
-                                        <td class="govuk-table__cell appeal-costs-lpa-withdrawal-status">No documents available</td>
-                                        <td class="govuk-table__cell appeal-costs-lpa-withdrawal-actions govuk-!-text-align-right">
-                                            <ul class="govuk-summary-list__actions-list">
-                                                <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-lpa-withdrawal" href="/appeals-service/appeal-details/1/costs/lpa/withdrawal/upload-documents/5">Add<span class="govuk-visually-hidden"> LPA withdrawal</span></a>
-                                                </li>
-                                            </ul>
-                                        </td>
-                                    </tr>
-                                    <tr class="govuk-table__row">
-                                        <th scope="row" class="govuk-table__header appeal-costs-lpa-correspondence-documentation">LPA correspondence</th>
-                                        <td class="govuk-table__cell appeal-costs-lpa-correspondence-status">No documents available</td>
-                                        <td class="govuk-table__cell appeal-costs-lpa-correspondence-actions govuk-!-text-align-right">
-                                            <ul class="govuk-summary-list__actions-list">
-                                                <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-lpa-correspondence" href="/appeals-service/appeal-details/1/costs/lpa/correspondence/upload-documents/6">Add<span class="govuk-visually-hidden"> LPA correspondence</span></a>
-                                                </li>
-                                            </ul>
-                                        </td>
-                                    </tr>
-                                </tbody>
-                            </table>
-                        </div>
-                    </div>
-                    <div class="govuk-accordion__section">
-                        <div class="govuk-accordion__section-header">
-                            <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-6"> Contacts</span></h2>
-                        </div>
-                        <div id="accordion-default1-content-6" class="govuk-accordion__section-content">
-                            <dl class="govuk-summary-list">
-                                <div class="govuk-summary-list__row appeal-appellant"><dt class="govuk-summary-list__key"> Appellant</dt>
-                                    <dd class="govuk-summary-list__value">
-                                        <ul class="govuk-list">
-                                            <li>Roger Simmons</li>
-                                            <li>test3@example.com</li>
+                                    </td>
+                                </tr>
+                                <tr class="govuk-table__row">
+                                    <th scope="row" class="govuk-table__header appeal-costs-lpa-application-documentation">LPA application</th>
+                                    <td class="govuk-table__cell appeal-costs-lpa-application-status">No documents available</td>
+                                    <td class="govuk-table__cell appeal-costs-lpa-application-actions govuk-!-text-align-right">
+                                        <ul class="govuk-summary-list__actions-list">
+                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-lpa-application" href="/appeals-service/appeal-details/1/costs/lpa/application/upload-documents/4">Add<span class="govuk-visually-hidden"> LPA application</span></a>
+                                            </li>
                                         </ul>
-                                    </dd>
-                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/service-user/change/appellant"
-                                        data-cy="change-appellant">Change<span class="govuk-visually-hidden"> Appellant</span></a>
-                                    </dd>
-                                </div>
-                                <div class="govuk-summary-list__row appeal-agent"><dt class="govuk-summary-list__key"> Agent</dt>
-                                    <dd class="govuk-summary-list__value">
-                                        <ul class="govuk-list">
-                                            <li>Fiona Shell</li>
-                                            <li>test2@example.com</li>
+                                    </td>
+                                </tr>
+                                <tr class="govuk-table__row">
+                                    <th scope="row" class="govuk-table__header appeal-costs-lpa-withdrawal-documentation">LPA withdrawal</th>
+                                    <td class="govuk-table__cell appeal-costs-lpa-withdrawal-status">No documents available</td>
+                                    <td class="govuk-table__cell appeal-costs-lpa-withdrawal-actions govuk-!-text-align-right">
+                                        <ul class="govuk-summary-list__actions-list">
+                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-lpa-withdrawal" href="/appeals-service/appeal-details/1/costs/lpa/withdrawal/upload-documents/5">Add<span class="govuk-visually-hidden"> LPA withdrawal</span></a>
+                                            </li>
                                         </ul>
-                                    </dd>
-                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/service-user/change/agent"
-                                        data-cy="change-agent">Change<span class="govuk-visually-hidden"> Agent</span></a>
-                                    </dd>
-                                </div>
-                                <div class="govuk-summary-list__row appeal-lpa-contact-details"><dt class="govuk-summary-list__key"> LPA</dt>
-                                    <dd class="govuk-summary-list__value">
-                                        <ul class="govuk-list">
-                                            <li>Wiltshire Council</li>
-                                            <li>wilt@lpa-email.gov.uk</li>
+                                    </td>
+                                </tr>
+                                <tr class="govuk-table__row">
+                                    <th scope="row" class="govuk-table__header appeal-costs-lpa-correspondence-documentation">LPA correspondence</th>
+                                    <td class="govuk-table__cell appeal-costs-lpa-correspondence-status">No documents available</td>
+                                    <td class="govuk-table__cell appeal-costs-lpa-correspondence-actions govuk-!-text-align-right">
+                                        <ul class="govuk-summary-list__actions-list">
+                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-lpa-correspondence" href="/appeals-service/appeal-details/1/costs/lpa/correspondence/upload-documents/6">Add<span class="govuk-visually-hidden"> LPA correspondence</span></a>
+                                            </li>
                                         </ul>
-                                    </dd>
-                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/change-appeal-details/local-planning-authority"
-                                        data-cy="change-lpa-contact-details">Change<span class="govuk-visually-hidden"> Local planning authority (LPA)</span></a>
-                                    </dd>
-                                </div>
-                            </dl>
-                        </div>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
                     </div>
-                    <div class="govuk-accordion__section">
-                        <div class="govuk-accordion__section-header">
-                            <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-7"> Team</span></h2>
-                        </div>
-                        <div id="accordion-default1-content-7" class="govuk-accordion__section-content">
-                            <dl class="govuk-summary-list">
-                                <div class="govuk-summary-list__row appeal-case-officer"><dt class="govuk-summary-list__key"> Case officer</dt>
-                                    <dd class="govuk-summary-list__value">
-                                        <p class="govuk-body">Not assigned</p>
-                                    </dd>
-                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/assign-user/case-officer"
-                                        data-cy="assign-case-officer">Assign<span class="govuk-visually-hidden"> Case officer</span></a>
-                                    </dd>
-                                </div>
-                                <div class="govuk-summary-list__row appeal-inspector"><dt class="govuk-summary-list__key"> Inspector</dt>
-                                    <dd class="govuk-summary-list__value">
-                                        <p class="govuk-body">Not assigned</p>
-                                    </dd>
-                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/assign-user/inspector"
-                                        data-cy="assign-inspector">Assign<span class="govuk-visually-hidden"> Inspector</span></a>
-                                    </dd>
-                                </div>
-                            </dl>
-                        </div>
+                </div>
+                <div class="govuk-accordion__section">
+                    <div class="govuk-accordion__section-header">
+                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-6"> Contacts</span></h2>
                     </div>
-                    <div class="govuk-accordion__section">
-                        <div class="govuk-accordion__section-header">
-                            <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-8"> Case management</span></h2>
-                        </div>
-                        <div id="accordion-default1-content-8" class="govuk-accordion__section-content">
-                            <dl class="govuk-summary-list">
-                                <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Cross-team correspondence</dt>
-                                    <dd                                     class="govuk-summary-list__value">No documents</dd>
-                                        <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/internal-correspondence/cross-team/upload-documents/10"
-                                            data-cy="add-cross-team-correspondence">Add<span class="govuk-visually-hidden"> Cross-team correspondence</span></a>
-                                        </dd>
-                                </div>
-                                <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Inspector correspondence</dt>
-                                    <dd                                     class="govuk-summary-list__value">No documents</dd>
-                                        <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/internal-correspondence/inspector/upload-documents/11"
-                                            data-cy="add-inspector-correspondence">Add<span class="govuk-visually-hidden"> Inspector correspondence</span></a>
-                                        </dd>
-                                </div>
-                                <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Main party correspondence</dt>
-                                    <dd                                     class="govuk-summary-list__value">No documents</dd>
-                                        <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/internal-correspondence/main-party/upload-documents/22"
-                                            data-cy="add-main-party-correspondence">Add<span class="govuk-visually-hidden"> Main party correspondence</span></a>
-                                        </dd>
-                                </div>
-                                <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Case history</dt>
-                                    <dd class="govuk-summary-list__value"></dd>
-                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/audit" data-cy="view-case-history">View<span class="govuk-visually-hidden"> Case history</span></a>
+                    <div id="accordion-default1-content-6" class="govuk-accordion__section-content">
+                        <dl class="govuk-summary-list">
+                            <div class="govuk-summary-list__row appeal-appellant"><dt class="govuk-summary-list__key"> Appellant</dt>
+                                <dd class="govuk-summary-list__value">
+                                    <ul class="govuk-list">
+                                        <li>Roger Simmons</li>
+                                        <li>test3@example.com</li>
+                                    </ul>
+                                </dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/service-user/change/appellant"
+                                    data-cy="change-appellant">Change<span class="govuk-visually-hidden"> Appellant</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-agent"><dt class="govuk-summary-list__key"> Agent</dt>
+                                <dd class="govuk-summary-list__value">
+                                    <ul class="govuk-list">
+                                        <li>Fiona Shell</li>
+                                        <li>test2@example.com</li>
+                                    </ul>
+                                </dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/service-user/change/agent"
+                                    data-cy="change-agent">Change<span class="govuk-visually-hidden"> Agent</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-lpa-contact-details"><dt class="govuk-summary-list__key"> LPA</dt>
+                                <dd class="govuk-summary-list__value">
+                                    <ul class="govuk-list">
+                                        <li>Wiltshire Council</li>
+                                        <li>wilt@lpa-email.gov.uk</li>
+                                    </ul>
+                                </dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/change-appeal-details/local-planning-authority"
+                                    data-cy="change-lpa-contact-details">Change<span class="govuk-visually-hidden"> Local planning authority (LPA)</span></a>
+                                </dd>
+                            </div>
+                        </dl>
+                    </div>
+                </div>
+                <div class="govuk-accordion__section">
+                    <div class="govuk-accordion__section-header">
+                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-7"> Team</span></h2>
+                    </div>
+                    <div id="accordion-default1-content-7" class="govuk-accordion__section-content">
+                        <dl class="govuk-summary-list">
+                            <div class="govuk-summary-list__row appeal-case-officer"><dt class="govuk-summary-list__key"> Case officer</dt>
+                                <dd class="govuk-summary-list__value">
+                                    <p class="govuk-body">Not assigned</p>
+                                </dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/assign-user/case-officer"
+                                    data-cy="assign-case-officer">Assign<span class="govuk-visually-hidden"> Case officer</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-inspector"><dt class="govuk-summary-list__key"> Inspector</dt>
+                                <dd class="govuk-summary-list__value">
+                                    <p class="govuk-body">Not assigned</p>
+                                </dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/assign-user/inspector"
+                                    data-cy="assign-inspector">Assign<span class="govuk-visually-hidden"> Inspector</span></a>
+                                </dd>
+                            </div>
+                        </dl>
+                    </div>
+                </div>
+                <div class="govuk-accordion__section">
+                    <div class="govuk-accordion__section-header">
+                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-8"> Case management</span></h2>
+                    </div>
+                    <div id="accordion-default1-content-8" class="govuk-accordion__section-content">
+                        <dl class="govuk-summary-list">
+                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Cross-team correspondence</dt>
+                                <dd                                 class="govuk-summary-list__value">No documents</dd>
+                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/internal-correspondence/cross-team/upload-documents/10"
+                                        data-cy="add-cross-team-correspondence">Add<span class="govuk-visually-hidden"> Cross-team correspondence</span></a>
                                     </dd>
-                                </div>
-                                <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Appeal withdrawal</dt>
-                                    <dd class="govuk-summary-list__value"></dd>
-                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/withdrawal/start"
-                                        data-cy="start-appeal-withdrawal">Start<span class="govuk-visually-hidden"> Appeal withdrawal</span></a>
+                            </div>
+                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Inspector correspondence</dt>
+                                <dd                                 class="govuk-summary-list__value">No documents</dd>
+                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/internal-correspondence/inspector/upload-documents/11"
+                                        data-cy="add-inspector-correspondence">Add<span class="govuk-visually-hidden"> Inspector correspondence</span></a>
                                     </dd>
-                                </div>
-                            </dl>
-                        </div>
+                            </div>
+                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Main party correspondence</dt>
+                                <dd                                 class="govuk-summary-list__value">No documents</dd>
+                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/internal-correspondence/main-party/upload-documents/22"
+                                        data-cy="add-main-party-correspondence">Add<span class="govuk-visually-hidden"> Main party correspondence</span></a>
+                                    </dd>
+                            </div>
+                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Case history</dt>
+                                <dd class="govuk-summary-list__value"></dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/audit" data-cy="view-case-history">View<span class="govuk-visually-hidden"> Case history</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Appeal withdrawal</dt>
+                                <dd class="govuk-summary-list__value"></dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/withdrawal/start"
+                                    data-cy="start-appeal-withdrawal">Start<span class="govuk-visually-hidden"> Appeal withdrawal</span></a>
+                                </dd>
+                            </div>
+                        </dl>
                     </div>
                 </div>
             </div>
         </div>
+    </div>
 </main>"
 `;
 
@@ -2622,7 +2625,7 @@ exports[`appeal-details GET /:appealId should render an Issue a decision notific
         </div>
     </div>
     <div class="govuk-grid-row">
-        <div class="govuk-grid-column-full"><strong class="govuk-tag govuk-tag--green govuk-!-margin-bottom-4">Issue decision</strong>
+        <div class="govuk-grid-column-full"><strong class="govuk-tag govuk-tag--green pins-status-tag--full-width">Issue decision</strong>
         </div>
     </div>
     <div class="govuk-grid-row">
@@ -3060,10 +3063,11 @@ exports[`appeal-details GET /:appealId should render an action link to the add l
         </div>
     </div>
     <div class="govuk-grid-row">
-        <div class="govuk-grid-column-full"><strong class="govuk-tag govuk-tag--green govuk-!-margin-bottom-4">LPA questionnaire</strong>
+        <div class="govuk-grid-column-full"><strong class="govuk-tag govuk-tag--green pins-status-tag--full-width">LPA questionnaire</strong>
+            <strong             class="govuk-tag govuk-tag--grey govuk-!-margin-left-1 govuk-!-margin-bottom-4"></strong>
         </div>
-    </div><strong class="govuk-tag govuk-tag--grey govuk-!-margin-left-1 govuk-!-margin-bottom-4"></strong>
-    <div     class="govuk-grid-row">
+    </div>
+    <div class="govuk-grid-row">
         <div class="govuk-grid-column-full">
             <dl class="govuk-summary-list pins-summary-list--no-border">
                 <div class="govuk-summary-list__row appeal-case-officer"><dt class="govuk-summary-list__key"> Case officer</dt>
@@ -3088,427 +3092,427 @@ exports[`appeal-details GET /:appealId should render an action link to the add l
                 </div>
             </dl>
         </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
+            <p class="govuk-body govuk-!-margin-bottom-6" id="download-case-files"
+            data-cy="download-case-files"><a class="govuk-link" href="/documents/1/bulk-download/case-APP/Q9999/D/21/351062.zip">Download case</a>
+            </p>
         </div>
-        <div class="govuk-grid-row">
-            <div class="govuk-grid-column-full">
-                <p class="govuk-body govuk-!-margin-bottom-6" id="download-case-files"
-                data-cy="download-case-files"><a class="govuk-link" href="/documents/1/bulk-download/case-APP/Q9999/D/21/351062.zip">Download case</a>
-                </p>
-            </div>
-        </div>
-        <div class="govuk-grid-row">
-            <div class="govuk-grid-column-full">
-                <details class="govuk-details">
-                    <summary class="govuk-details__summary"><span class="govuk-details__summary-text"> 2 case notes</span>
-                    </summary>
-                    <div class="govuk-details__text">
-                        <form method="POST" novalidate="novalidate">
-                            <div class="govuk-grid-row">
-                                <div class="govuk-grid-column-two-thirds">
-                                    <div class="govuk-form-group govuk-character-count" data-module="govuk-character-count"
-                                    data-maxlength="500">
-                                        <textarea class="govuk-textarea govuk-js-character-count" id="comment"
-                                        name="comment" rows="5" aria-describedby="comment-info"></textarea>
-                                        <div id="comment-info" class="govuk-hint govuk-character-count__message">You can enter up to 500 characters</div>
-                                    </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
+            <details class="govuk-details">
+                <summary class="govuk-details__summary"><span class="govuk-details__summary-text"> 2 case notes</span>
+                </summary>
+                <div class="govuk-details__text">
+                    <form method="POST" novalidate="novalidate">
+                        <div class="govuk-grid-row">
+                            <div class="govuk-grid-column-two-thirds">
+                                <div class="govuk-form-group govuk-character-count" data-module="govuk-character-count"
+                                data-maxlength="500">
+                                    <textarea class="govuk-textarea govuk-js-character-count" id="comment"
+                                    name="comment" rows="5" aria-describedby="comment-info"></textarea>
+                                    <div id="comment-info" class="govuk-hint govuk-character-count__message">You can enter up to 500 characters</div>
                                 </div>
                             </div>
-                            <button type="submit" data-prevent-double-click="true" class="govuk-button govuk-button--secondary govuk-!-margin-bottom-1"
-                            data-module="govuk-button">Add case note</button>
-                        </form>
-                        <div>
+                        </div>
+                        <button type="submit" data-prevent-double-click="true" class="govuk-button govuk-button--secondary govuk-!-margin-bottom-1"
+                        data-module="govuk-button">Add case note</button>
+                    </form>
+                    <div>
+                        <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+                        <section>
+                            <p class="govuk-body govuk-!-margin-bottom-1">A case note you should see.</p>
+                            <p class="govuk-hint govuk-!-margin-bottom-6">11:00am on Tuesday 1 October 2024 by John.Smith</p>
                             <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
-                            <section>
-                                <p class="govuk-body govuk-!-margin-bottom-1">A case note you should see.</p>
-                                <p class="govuk-hint govuk-!-margin-bottom-6">11:00am on Tuesday 1 October 2024 by John.Smith</p>
-                                <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
-                            </section>
-                            <section>
-                                <p class="govuk-body govuk-!-margin-bottom-1">A case note you should see.</p>
-                                <p class="govuk-hint govuk-!-margin-bottom-6">11:00am on Tuesday 1 October 2024 by John.Smith</p>
-                                <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
-                            </section>
-                        </div>
+                        </section>
+                        <section>
+                            <p class="govuk-body govuk-!-margin-bottom-1">A case note you should see.</p>
+                            <p class="govuk-hint govuk-!-margin-bottom-6">11:00am on Tuesday 1 October 2024 by John.Smith</p>
+                            <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+                        </section>
                     </div>
-                </details>
-            </div>
+                </div>
+            </details>
         </div>
-        <div class="govuk-grid-row">
-            <div class="govuk-grid-column-full">
-                <div class="govuk-accordion" data-module="govuk-accordion" id="accordion-default1">
-                    <div class="govuk-accordion__section">
-                        <div class="govuk-accordion__section-header">
-                            <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-1"> Overview</span></h2>
-                        </div>
-                        <div id="accordion-default1-content-1" class="govuk-accordion__section-content">
-                            <dl class="govuk-summary-list">
-                                <div class="govuk-summary-list__row govuk-summary-list__row--no-actions appeal-lpa-reference"><dt class="govuk-summary-list__key"> Planning application reference</dt>
-                                    <dd                                     class="govuk-summary-list__value">48269/APP/2021/1482</dd>
-                                </div>
-                                <div class="govuk-summary-list__row appeal-appeal-type"><dt class="govuk-summary-list__key"> Appeal type</dt>
-                                    <dd class="govuk-summary-list__value">Householder</dd>
-                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/change-appeal-type/appeal-type"
-                                        data-cy="change-appeal-type">Change<span class="govuk-visually-hidden"> Appeal type</span></a>
-                                    </dd>
-                                </div>
-                                <div class="govuk-summary-list__row govuk-summary-list__row--no-actions appeal-case-procedure"><dt class="govuk-summary-list__key"> Appeal procedure</dt>
-                                    <dd class="govuk-summary-list__value">Written</dd>
-                                </div>
-                                <div class="govuk-summary-list__row appeal-allocation-details"><dt class="govuk-summary-list__key"> Allocation level</dt>
-                                    <dd class="govuk-summary-list__value">
-                                        <ul class="govuk-!-margin-0">
-                                            <li>Level: A</li>
-                                            <li>Historic heritage</li>
-                                            <li>Architecture design</li>
-                                        </ul>
-                                    </dd>
-                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/allocation-details/allocation-level"
-                                        data-cy="change-allocation-details">Change<span class="govuk-visually-hidden"> Allocation level</span></a>
-                                    </dd>
-                                </div>
-                                <div class="govuk-summary-list__row appeal-linked-appeals"><dt class="govuk-summary-list__key"> Linked appeals</dt>
-                                    <dd class="govuk-summary-list__value">
-                                        <ul class="govuk-list govuk-list--bullet">
-                                            <li><a href="/appeals-service/appeal-details/5449" class="govuk-link" data-cy="linked-appeal-784706"
-                                                aria-label="Appeal 7 8 4 7 0 6">784706</a> (Child)</li>
-                                            <li><span class="govuk-body">87326527</span> (Child)</li>
-                                            <li><a href="/appeals-service/appeal-details/5464" class="govuk-link" data-cy="linked-appeal-140079"
-                                                aria-label="Appeal 1 4 0 0 7 9">140079</a> (Lead)</li>
-                                            <li><a href="/appeals-service/appeal-details/5451" class="govuk-link" data-cy="linked-appeal-721086"
-                                                aria-label="Appeal 7 2 1 0 8 6">721086</a> (Child)</li>
-                                        </ul>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
+            <div class="govuk-accordion" data-module="govuk-accordion" id="accordion-default1">
+                <div class="govuk-accordion__section">
+                    <div class="govuk-accordion__section-header">
+                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-1"> Overview</span></h2>
+                    </div>
+                    <div id="accordion-default1-content-1" class="govuk-accordion__section-content">
+                        <dl class="govuk-summary-list">
+                            <div class="govuk-summary-list__row govuk-summary-list__row--no-actions appeal-lpa-reference"><dt class="govuk-summary-list__key"> Planning application reference</dt>
+                                <dd                                 class="govuk-summary-list__value">48269/APP/2021/1482</dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-appeal-type"><dt class="govuk-summary-list__key"> Appeal type</dt>
+                                <dd class="govuk-summary-list__value">Householder</dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/change-appeal-type/appeal-type"
+                                    data-cy="change-appeal-type">Change<span class="govuk-visually-hidden"> Appeal type</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row govuk-summary-list__row--no-actions appeal-case-procedure"><dt class="govuk-summary-list__key"> Appeal procedure</dt>
+                                <dd class="govuk-summary-list__value">Written</dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-allocation-details"><dt class="govuk-summary-list__key"> Allocation level</dt>
+                                <dd class="govuk-summary-list__value">
+                                    <ul class="govuk-!-margin-0">
+                                        <li>Level: A</li>
+                                        <li>Historic heritage</li>
+                                        <li>Architecture design</li>
+                                    </ul>
+                                </dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/allocation-details/allocation-level"
+                                    data-cy="change-allocation-details">Change<span class="govuk-visually-hidden"> Allocation level</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-linked-appeals"><dt class="govuk-summary-list__key"> Linked appeals</dt>
+                                <dd class="govuk-summary-list__value">
+                                    <ul class="govuk-list govuk-list--bullet">
+                                        <li><a href="/appeals-service/appeal-details/5449" class="govuk-link" data-cy="linked-appeal-784706"
+                                            aria-label="Appeal 7 8 4 7 0 6">784706</a> (Child)</li>
+                                        <li><span class="govuk-body">87326527</span> (Child)</li>
+                                        <li><a href="/appeals-service/appeal-details/5464" class="govuk-link" data-cy="linked-appeal-140079"
+                                            aria-label="Appeal 1 4 0 0 7 9">140079</a> (Lead)</li>
+                                        <li><a href="/appeals-service/appeal-details/5451" class="govuk-link" data-cy="linked-appeal-721086"
+                                            aria-label="Appeal 7 2 1 0 8 6">721086</a> (Child)</li>
+                                    </ul>
+                                </dd>
+                                <dd class="govuk-summary-list__actions">
+                                    <ul class="govuk-summary-list__actions-list">
+                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/linked-appeals/manage"
+                                            data-cy="manage-linked-appeals">Manage<span class="govuk-visually-hidden"> Linked appeals</span></a>
+                                        </li>
+                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/linked-appeals/add"
+                                            data-cy="add-linked-appeal">Add<span class="govuk-visually-hidden"> Linked appeals</span></a>
+                                        </li>
+                                    </ul>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-other-appeals"><dt class="govuk-summary-list__key"> Related appeals</dt>
+                                <dd class="govuk-summary-list__value"><span>No</span>
+                                </dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/other-appeals/add"
+                                    data-cy="add-related-appeals">Add<span class="govuk-visually-hidden"> Related appeals</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-decision"><dt class="govuk-summary-list__key"> Decision</dt>
+                                <dd class="govuk-summary-list__value">Dismissed</dd>
+                            </div>
+                        </dl>
+                    </div>
+                </div>
+                <div class="govuk-accordion__section">
+                    <div class="govuk-accordion__section-header">
+                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-2"> Site</span></h2>
+                    </div>
+                    <div id="accordion-default1-content-2" class="govuk-accordion__section-content">
+                        <dl class="govuk-summary-list">
+                            <div class="govuk-summary-list__row appeal-visit-type"><dt class="govuk-summary-list__key"> Visit type</dt>
+                                <dd class="govuk-summary-list__value">Accompanied</dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/visit-booked?backUrl=%2Fappeals-service%2Fappeal-details%2F1"
+                                    data-cy="change-set-visit-type">Change<span class="govuk-visually-hidden"> Visit type</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Date</dt>
+                                <dd class="govuk-summary-list__value">9 October 2023</dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/visit-booked"
+                                    data-cy="change-site-visit-date">Change<span class="govuk-visually-hidden"> Date</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Start time</dt>
+                                <dd class="govuk-summary-list__value">9:38am</dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/visit-booked"
+                                    data-cy="change-site-visit-start-time">Change<span class="govuk-visually-hidden"> Start time</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> End time</dt>
+                                <dd class="govuk-summary-list__value">10:00am</dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/visit-booked"
+                                    data-cy="change-site-visit-end-time">Change<span class="govuk-visually-hidden"> End time</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-neighbouring-sites-inspector"><dt class="govuk-summary-list__key"> Interested party and neighbour addresses</dt>
+                                <dd                                 class="govuk-summary-list__value">
+                                    <ul class="govuk-list govuk-list--bullet">
+                                        <li>2 Grove Cottage, Shotesham Road, Woodton, Devon, NR35 2ND</li>
+                                    </ul>
                                     </dd>
                                     <dd class="govuk-summary-list__actions">
                                         <ul class="govuk-summary-list__actions-list">
-                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/linked-appeals/manage"
-                                                data-cy="manage-linked-appeals">Manage<span class="govuk-visually-hidden"> Linked appeals</span></a>
+                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/neighbouring-sites/manage"
+                                                data-cy="manage-neighbouring-sites-inspector">Manage<span class="govuk-visually-hidden"> Interested party and neighbour addresses</span></a>
                                             </li>
-                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/linked-appeals/add"
-                                                data-cy="add-linked-appeal">Add<span class="govuk-visually-hidden"> Linked appeals</span></a>
+                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/neighbouring-sites/add/back-office"
+                                                data-cy="add-neighbouring-sites-inspector">Add<span class="govuk-visually-hidden"> Interested party and neighbour addresses</span></a>
                                             </li>
                                         </ul>
                                     </dd>
-                                </div>
-                                <div class="govuk-summary-list__row appeal-other-appeals"><dt class="govuk-summary-list__key"> Related appeals</dt>
-                                    <dd class="govuk-summary-list__value"><span>No</span>
-                                    </dd>
-                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/other-appeals/add"
-                                        data-cy="add-related-appeals">Add<span class="govuk-visually-hidden"> Related appeals</span></a>
-                                    </dd>
-                                </div>
-                                <div class="govuk-summary-list__row appeal-decision"><dt class="govuk-summary-list__key"> Decision</dt>
-                                    <dd class="govuk-summary-list__value">Dismissed</dd>
-                                </div>
-                            </dl>
-                        </div>
+                            </div>
+                        </dl>
                     </div>
-                    <div class="govuk-accordion__section">
-                        <div class="govuk-accordion__section-header">
-                            <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-2"> Site</span></h2>
-                        </div>
-                        <div id="accordion-default1-content-2" class="govuk-accordion__section-content">
-                            <dl class="govuk-summary-list">
-                                <div class="govuk-summary-list__row appeal-visit-type"><dt class="govuk-summary-list__key"> Visit type</dt>
-                                    <dd class="govuk-summary-list__value">Accompanied</dd>
-                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/visit-booked?backUrl=%2Fappeals-service%2Fappeal-details%2F1"
-                                        data-cy="change-set-visit-type">Change<span class="govuk-visually-hidden"> Visit type</span></a>
-                                    </dd>
-                                </div>
-                                <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Date</dt>
-                                    <dd class="govuk-summary-list__value">9 October 2023</dd>
-                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/visit-booked"
-                                        data-cy="change-site-visit-date">Change<span class="govuk-visually-hidden"> Date</span></a>
-                                    </dd>
-                                </div>
-                                <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Start time</dt>
-                                    <dd class="govuk-summary-list__value">9:38am</dd>
-                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/visit-booked"
-                                        data-cy="change-site-visit-start-time">Change<span class="govuk-visually-hidden"> Start time</span></a>
-                                    </dd>
-                                </div>
-                                <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> End time</dt>
-                                    <dd class="govuk-summary-list__value">10:00am</dd>
-                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/visit-booked"
-                                        data-cy="change-site-visit-end-time">Change<span class="govuk-visually-hidden"> End time</span></a>
-                                    </dd>
-                                </div>
-                                <div class="govuk-summary-list__row appeal-neighbouring-sites-inspector"><dt class="govuk-summary-list__key"> Interested party and neighbour addresses</dt>
-                                    <dd                                     class="govuk-summary-list__value">
-                                        <ul class="govuk-list govuk-list--bullet">
-                                            <li>2 Grove Cottage, Shotesham Road, Woodton, Devon, NR35 2ND</li>
+                </div>
+                <div class="govuk-accordion__section">
+                    <div class="govuk-accordion__section-header">
+                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-3"> Timetable</span></h2>
+                    </div>
+                    <div id="accordion-default1-content-3" class="govuk-accordion__section-content">
+                        <dl class="govuk-summary-list appeal-case-timetable">
+                            <div class="govuk-summary-list__row appeal-valid-date"><dt class="govuk-summary-list__key"> Valid date</dt>
+                                <dd class="govuk-summary-list__value">23 May 2023</dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/valid/date"
+                                    data-cy="-valid-date"><span class="govuk-visually-hidden"> Valid date</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-start-date"><dt class="govuk-summary-list__key"> Start date</dt>
+                                <dd class="govuk-summary-list__value">23 May 2023</dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/start-case/change"
+                                    data-cy="change-start-case-date">Change<span class="govuk-visually-hidden"> Start date</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-lpa-questionnaire-due-date"><dt class="govuk-summary-list__key"> LPA questionnaire due</dt>
+                                <dd class="govuk-summary-list__value">11 October 2023</dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/timetable/edit"
+                                    data-cy="change-lpa-questionnaire-due-date">Change<span class="govuk-visually-hidden"> LPA questionnaire due</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-site-visit"><dt class="govuk-summary-list__key"> Site visit</dt>
+                                <dd class="govuk-summary-list__value">
+                                    <ul class="govuk-list govuk-!-margin-top-0 govuk-!-padding-left-0">
+                                        <li>9 October 2023</li>
+                                        <li>9:38am - 10:00am</li>
+                                    </ul>
+                                </dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/manage-visit?backUrl=%2Fappeals-service%2Fappeal-details%2F1"
+                                    data-cy="change-schedule-visit">Change<span class="govuk-visually-hidden"> Site visit</span></a>
+                                </dd>
+                            </div>
+                        </dl>
+                    </div>
+                </div>
+                <div class="govuk-accordion__section">
+                    <div class="govuk-accordion__section-header">
+                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-4"> Documentation</span></h2>
+                    </div>
+                    <div id="accordion-default1-content-4" class="govuk-accordion__section-content">
+                        <table class="govuk-table">
+                            <thead class="govuk-table__head">
+                                <tr class="govuk-table__row">
+                                    <th scope="col" class="govuk-table__header">Documentation</th>
+                                    <th scope="col" class="govuk-table__header">Status</th>
+                                    <th scope="col" class="govuk-table__header">Received</th>
+                                    <th scope="col" class="govuk-table__header govuk-!-text-align-right">Action</th>
+                                </tr>
+                            </thead>
+                            <tbody class="govuk-table__body">
+                                <tr class="govuk-table__row">
+                                    <th scope="row" class="govuk-table__header">Appeal</th>
+                                    <td class="govuk-table__cell">Ready to review</td>
+                                    <td class="govuk-table__cell">2 August 2024</td>
+                                    <td class="govuk-table__cell govuk-!-text-align-right"><a href="/appeals-service/appeal-details/1/appellant-case?backUrl=%2Fappeals-service%2Fappeal-details%2F1"
+                                        data-cy="review-appellant-case" class="govuk-link">Review<span class="govuk-visually-hidden"> appellant case</span></a>
+                                    </td>
+                                </tr>
+                                <tr class="govuk-table__row">
+                                    <th scope="row" class="govuk-table__header">LPA questionnaire</th>
+                                    <td class="govuk-table__cell">Overdue</td>
+                                    <td class="govuk-table__cell">Due by 11 October 2023</td>
+                                    <td class="govuk-table__cell govuk-!-text-align-right"></td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
+                <div class="govuk-accordion__section">
+                    <div class="govuk-accordion__section-header">
+                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-5"> Costs</span></h2>
+                    </div>
+                    <div id="accordion-default1-content-5" class="govuk-accordion__section-content">
+                        <table class="govuk-table">
+                            <thead class="govuk-table__head">
+                                <tr class="govuk-table__row">
+                                    <th scope="col" class="govuk-table__header">Documentation</th>
+                                    <th scope="col" class="govuk-table__header">Status</th>
+                                    <th scope="col" class="govuk-table__header govuk-!-text-align-right">Action</th>
+                                </tr>
+                            </thead>
+                            <tbody class="govuk-table__body">
+                                <tr class="govuk-table__row">
+                                    <th scope="row" class="govuk-table__header appeal-costs-appellant-application-documentation">Appellant application</th>
+                                    <td class="govuk-table__cell appeal-costs-appellant-application-status">No documents available</td>
+                                    <td class="govuk-table__cell appeal-costs-appellant-application-actions govuk-!-text-align-right">
+                                        <ul class="govuk-summary-list__actions-list">
+                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-appellant-application" href="/appeals-service/appeal-details/1/costs/appellant/application/upload-documents/1">Add<span class="govuk-visually-hidden"> Appellant application</span></a>
+                                            </li>
                                         </ul>
-                                        </dd>
-                                        <dd class="govuk-summary-list__actions">
-                                            <ul class="govuk-summary-list__actions-list">
-                                                <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/neighbouring-sites/manage"
-                                                    data-cy="manage-neighbouring-sites-inspector">Manage<span class="govuk-visually-hidden"> Interested party and neighbour addresses</span></a>
-                                                </li>
-                                                <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/neighbouring-sites/add/back-office"
-                                                    data-cy="add-neighbouring-sites-inspector">Add<span class="govuk-visually-hidden"> Interested party and neighbour addresses</span></a>
-                                                </li>
-                                            </ul>
-                                        </dd>
-                                </div>
-                            </dl>
-                        </div>
-                    </div>
-                    <div class="govuk-accordion__section">
-                        <div class="govuk-accordion__section-header">
-                            <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-3"> Timetable</span></h2>
-                        </div>
-                        <div id="accordion-default1-content-3" class="govuk-accordion__section-content">
-                            <dl class="govuk-summary-list appeal-case-timetable">
-                                <div class="govuk-summary-list__row appeal-valid-date"><dt class="govuk-summary-list__key"> Valid date</dt>
-                                    <dd class="govuk-summary-list__value">23 May 2023</dd>
-                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/valid/date"
-                                        data-cy="-valid-date"><span class="govuk-visually-hidden"> Valid date</span></a>
-                                    </dd>
-                                </div>
-                                <div class="govuk-summary-list__row appeal-start-date"><dt class="govuk-summary-list__key"> Start date</dt>
-                                    <dd class="govuk-summary-list__value">23 May 2023</dd>
-                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/start-case/change"
-                                        data-cy="change-start-case-date">Change<span class="govuk-visually-hidden"> Start date</span></a>
-                                    </dd>
-                                </div>
-                                <div class="govuk-summary-list__row appeal-lpa-questionnaire-due-date"><dt class="govuk-summary-list__key"> LPA questionnaire due</dt>
-                                    <dd class="govuk-summary-list__value">11 October 2023</dd>
-                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/timetable/edit"
-                                        data-cy="change-lpa-questionnaire-due-date">Change<span class="govuk-visually-hidden"> LPA questionnaire due</span></a>
-                                    </dd>
-                                </div>
-                                <div class="govuk-summary-list__row appeal-site-visit"><dt class="govuk-summary-list__key"> Site visit</dt>
-                                    <dd class="govuk-summary-list__value">
-                                        <ul class="govuk-list govuk-!-margin-top-0 govuk-!-padding-left-0">
-                                            <li>9 October 2023</li>
-                                            <li>9:38am - 10:00am</li>
+                                    </td>
+                                </tr>
+                                <tr class="govuk-table__row">
+                                    <th scope="row" class="govuk-table__header appeal-costs-appellant-withdrawal-documentation">Appellant withdrawal</th>
+                                    <td class="govuk-table__cell appeal-costs-appellant-withdrawal-status">No documents available</td>
+                                    <td class="govuk-table__cell appeal-costs-appellant-withdrawal-actions govuk-!-text-align-right">
+                                        <ul class="govuk-summary-list__actions-list">
+                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-appellant-withdrawal" href="/appeals-service/appeal-details/1/costs/appellant/withdrawal/upload-documents/2">Add<span class="govuk-visually-hidden"> Appellant withdrawal</span></a>
+                                            </li>
                                         </ul>
-                                    </dd>
-                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/manage-visit?backUrl=%2Fappeals-service%2Fappeal-details%2F1"
-                                        data-cy="change-schedule-visit">Change<span class="govuk-visually-hidden"> Site visit</span></a>
-                                    </dd>
-                                </div>
-                            </dl>
-                        </div>
-                    </div>
-                    <div class="govuk-accordion__section">
-                        <div class="govuk-accordion__section-header">
-                            <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-4"> Documentation</span></h2>
-                        </div>
-                        <div id="accordion-default1-content-4" class="govuk-accordion__section-content">
-                            <table class="govuk-table">
-                                <thead class="govuk-table__head">
-                                    <tr class="govuk-table__row">
-                                        <th scope="col" class="govuk-table__header">Documentation</th>
-                                        <th scope="col" class="govuk-table__header">Status</th>
-                                        <th scope="col" class="govuk-table__header">Received</th>
-                                        <th scope="col" class="govuk-table__header govuk-!-text-align-right">Action</th>
-                                    </tr>
-                                </thead>
-                                <tbody class="govuk-table__body">
-                                    <tr class="govuk-table__row">
-                                        <th scope="row" class="govuk-table__header">Appeal</th>
-                                        <td class="govuk-table__cell">Ready to review</td>
-                                        <td class="govuk-table__cell">2 August 2024</td>
-                                        <td class="govuk-table__cell govuk-!-text-align-right"><a href="/appeals-service/appeal-details/1/appellant-case?backUrl=%2Fappeals-service%2Fappeal-details%2F1"
-                                            data-cy="review-appellant-case" class="govuk-link">Review<span class="govuk-visually-hidden"> appellant case</span></a>
-                                        </td>
-                                    </tr>
-                                    <tr class="govuk-table__row">
-                                        <th scope="row" class="govuk-table__header">LPA questionnaire</th>
-                                        <td class="govuk-table__cell">Overdue</td>
-                                        <td class="govuk-table__cell">Due by 11 October 2023</td>
-                                        <td class="govuk-table__cell govuk-!-text-align-right"></td>
-                                    </tr>
-                                </tbody>
-                            </table>
-                        </div>
-                    </div>
-                    <div class="govuk-accordion__section">
-                        <div class="govuk-accordion__section-header">
-                            <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-5"> Costs</span></h2>
-                        </div>
-                        <div id="accordion-default1-content-5" class="govuk-accordion__section-content">
-                            <table class="govuk-table">
-                                <thead class="govuk-table__head">
-                                    <tr class="govuk-table__row">
-                                        <th scope="col" class="govuk-table__header">Documentation</th>
-                                        <th scope="col" class="govuk-table__header">Status</th>
-                                        <th scope="col" class="govuk-table__header govuk-!-text-align-right">Action</th>
-                                    </tr>
-                                </thead>
-                                <tbody class="govuk-table__body">
-                                    <tr class="govuk-table__row">
-                                        <th scope="row" class="govuk-table__header appeal-costs-appellant-application-documentation">Appellant application</th>
-                                        <td class="govuk-table__cell appeal-costs-appellant-application-status">No documents available</td>
-                                        <td class="govuk-table__cell appeal-costs-appellant-application-actions govuk-!-text-align-right">
-                                            <ul class="govuk-summary-list__actions-list">
-                                                <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-appellant-application" href="/appeals-service/appeal-details/1/costs/appellant/application/upload-documents/1">Add<span class="govuk-visually-hidden"> Appellant application</span></a>
-                                                </li>
-                                            </ul>
-                                        </td>
-                                    </tr>
-                                    <tr class="govuk-table__row">
-                                        <th scope="row" class="govuk-table__header appeal-costs-appellant-withdrawal-documentation">Appellant withdrawal</th>
-                                        <td class="govuk-table__cell appeal-costs-appellant-withdrawal-status">No documents available</td>
-                                        <td class="govuk-table__cell appeal-costs-appellant-withdrawal-actions govuk-!-text-align-right">
-                                            <ul class="govuk-summary-list__actions-list">
-                                                <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-appellant-withdrawal" href="/appeals-service/appeal-details/1/costs/appellant/withdrawal/upload-documents/2">Add<span class="govuk-visually-hidden"> Appellant withdrawal</span></a>
-                                                </li>
-                                            </ul>
-                                        </td>
-                                    </tr>
-                                    <tr class="govuk-table__row">
-                                        <th scope="row" class="govuk-table__header appeal-costs-appellant-correspondence-documentation">Appellant correspondence</th>
-                                        <td class="govuk-table__cell appeal-costs-appellant-correspondence-status">No documents available</td>
-                                        <td class="govuk-table__cell appeal-costs-appellant-correspondence-actions govuk-!-text-align-right">
-                                            <ul class="govuk-summary-list__actions-list">
-                                                <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-appellant-correspondence" href="/appeals-service/appeal-details/1/costs/appellant/correspondence/upload-documents/3">Add<span class="govuk-visually-hidden"> Appellant correspondence</span></a>
-                                                </li>
-                                            </ul>
-                                        </td>
-                                    </tr>
-                                    <tr class="govuk-table__row">
-                                        <th scope="row" class="govuk-table__header appeal-costs-lpa-application-documentation">LPA application</th>
-                                        <td class="govuk-table__cell appeal-costs-lpa-application-status">No documents available</td>
-                                        <td class="govuk-table__cell appeal-costs-lpa-application-actions govuk-!-text-align-right">
-                                            <ul class="govuk-summary-list__actions-list">
-                                                <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-lpa-application" href="/appeals-service/appeal-details/1/costs/lpa/application/upload-documents/4">Add<span class="govuk-visually-hidden"> LPA application</span></a>
-                                                </li>
-                                            </ul>
-                                        </td>
-                                    </tr>
-                                    <tr class="govuk-table__row">
-                                        <th scope="row" class="govuk-table__header appeal-costs-lpa-withdrawal-documentation">LPA withdrawal</th>
-                                        <td class="govuk-table__cell appeal-costs-lpa-withdrawal-status">No documents available</td>
-                                        <td class="govuk-table__cell appeal-costs-lpa-withdrawal-actions govuk-!-text-align-right">
-                                            <ul class="govuk-summary-list__actions-list">
-                                                <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-lpa-withdrawal" href="/appeals-service/appeal-details/1/costs/lpa/withdrawal/upload-documents/5">Add<span class="govuk-visually-hidden"> LPA withdrawal</span></a>
-                                                </li>
-                                            </ul>
-                                        </td>
-                                    </tr>
-                                    <tr class="govuk-table__row">
-                                        <th scope="row" class="govuk-table__header appeal-costs-lpa-correspondence-documentation">LPA correspondence</th>
-                                        <td class="govuk-table__cell appeal-costs-lpa-correspondence-status">No documents available</td>
-                                        <td class="govuk-table__cell appeal-costs-lpa-correspondence-actions govuk-!-text-align-right">
-                                            <ul class="govuk-summary-list__actions-list">
-                                                <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-lpa-correspondence" href="/appeals-service/appeal-details/1/costs/lpa/correspondence/upload-documents/6">Add<span class="govuk-visually-hidden"> LPA correspondence</span></a>
-                                                </li>
-                                            </ul>
-                                        </td>
-                                    </tr>
-                                </tbody>
-                            </table>
-                        </div>
-                    </div>
-                    <div class="govuk-accordion__section">
-                        <div class="govuk-accordion__section-header">
-                            <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-6"> Contacts</span></h2>
-                        </div>
-                        <div id="accordion-default1-content-6" class="govuk-accordion__section-content">
-                            <dl class="govuk-summary-list">
-                                <div class="govuk-summary-list__row appeal-appellant"><dt class="govuk-summary-list__key"> Appellant</dt>
-                                    <dd class="govuk-summary-list__value">
-                                        <ul class="govuk-list">
-                                            <li>Roger Simmons</li>
-                                            <li>test3@example.com</li>
+                                    </td>
+                                </tr>
+                                <tr class="govuk-table__row">
+                                    <th scope="row" class="govuk-table__header appeal-costs-appellant-correspondence-documentation">Appellant correspondence</th>
+                                    <td class="govuk-table__cell appeal-costs-appellant-correspondence-status">No documents available</td>
+                                    <td class="govuk-table__cell appeal-costs-appellant-correspondence-actions govuk-!-text-align-right">
+                                        <ul class="govuk-summary-list__actions-list">
+                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-appellant-correspondence" href="/appeals-service/appeal-details/1/costs/appellant/correspondence/upload-documents/3">Add<span class="govuk-visually-hidden"> Appellant correspondence</span></a>
+                                            </li>
                                         </ul>
-                                    </dd>
-                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/service-user/change/appellant"
-                                        data-cy="change-appellant">Change<span class="govuk-visually-hidden"> Appellant</span></a>
-                                    </dd>
-                                </div>
-                                <div class="govuk-summary-list__row appeal-agent"><dt class="govuk-summary-list__key"> Agent</dt>
-                                    <dd class="govuk-summary-list__value">
-                                        <ul class="govuk-list">
-                                            <li>Fiona Shell</li>
-                                            <li>test2@example.com</li>
+                                    </td>
+                                </tr>
+                                <tr class="govuk-table__row">
+                                    <th scope="row" class="govuk-table__header appeal-costs-lpa-application-documentation">LPA application</th>
+                                    <td class="govuk-table__cell appeal-costs-lpa-application-status">No documents available</td>
+                                    <td class="govuk-table__cell appeal-costs-lpa-application-actions govuk-!-text-align-right">
+                                        <ul class="govuk-summary-list__actions-list">
+                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-lpa-application" href="/appeals-service/appeal-details/1/costs/lpa/application/upload-documents/4">Add<span class="govuk-visually-hidden"> LPA application</span></a>
+                                            </li>
                                         </ul>
-                                    </dd>
-                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/service-user/change/agent"
-                                        data-cy="change-agent">Change<span class="govuk-visually-hidden"> Agent</span></a>
-                                    </dd>
-                                </div>
-                                <div class="govuk-summary-list__row appeal-lpa-contact-details"><dt class="govuk-summary-list__key"> LPA</dt>
-                                    <dd class="govuk-summary-list__value">
-                                        <ul class="govuk-list">
-                                            <li>Wiltshire Council</li>
-                                            <li>wilt@lpa-email.gov.uk</li>
+                                    </td>
+                                </tr>
+                                <tr class="govuk-table__row">
+                                    <th scope="row" class="govuk-table__header appeal-costs-lpa-withdrawal-documentation">LPA withdrawal</th>
+                                    <td class="govuk-table__cell appeal-costs-lpa-withdrawal-status">No documents available</td>
+                                    <td class="govuk-table__cell appeal-costs-lpa-withdrawal-actions govuk-!-text-align-right">
+                                        <ul class="govuk-summary-list__actions-list">
+                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-lpa-withdrawal" href="/appeals-service/appeal-details/1/costs/lpa/withdrawal/upload-documents/5">Add<span class="govuk-visually-hidden"> LPA withdrawal</span></a>
+                                            </li>
                                         </ul>
-                                    </dd>
-                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/change-appeal-details/local-planning-authority"
-                                        data-cy="change-lpa-contact-details">Change<span class="govuk-visually-hidden"> Local planning authority (LPA)</span></a>
-                                    </dd>
-                                </div>
-                            </dl>
-                        </div>
+                                    </td>
+                                </tr>
+                                <tr class="govuk-table__row">
+                                    <th scope="row" class="govuk-table__header appeal-costs-lpa-correspondence-documentation">LPA correspondence</th>
+                                    <td class="govuk-table__cell appeal-costs-lpa-correspondence-status">No documents available</td>
+                                    <td class="govuk-table__cell appeal-costs-lpa-correspondence-actions govuk-!-text-align-right">
+                                        <ul class="govuk-summary-list__actions-list">
+                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-lpa-correspondence" href="/appeals-service/appeal-details/1/costs/lpa/correspondence/upload-documents/6">Add<span class="govuk-visually-hidden"> LPA correspondence</span></a>
+                                            </li>
+                                        </ul>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
                     </div>
-                    <div class="govuk-accordion__section">
-                        <div class="govuk-accordion__section-header">
-                            <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-7"> Team</span></h2>
-                        </div>
-                        <div id="accordion-default1-content-7" class="govuk-accordion__section-content">
-                            <dl class="govuk-summary-list">
-                                <div class="govuk-summary-list__row appeal-case-officer"><dt class="govuk-summary-list__key"> Case officer</dt>
-                                    <dd class="govuk-summary-list__value">
-                                        <p class="govuk-body">Not assigned</p>
-                                    </dd>
-                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/assign-user/case-officer"
-                                        data-cy="assign-case-officer">Assign<span class="govuk-visually-hidden"> Case officer</span></a>
-                                    </dd>
-                                </div>
-                                <div class="govuk-summary-list__row appeal-inspector"><dt class="govuk-summary-list__key"> Inspector</dt>
-                                    <dd class="govuk-summary-list__value">
-                                        <p class="govuk-body">Not assigned</p>
-                                    </dd>
-                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/assign-user/inspector"
-                                        data-cy="assign-inspector">Assign<span class="govuk-visually-hidden"> Inspector</span></a>
-                                    </dd>
-                                </div>
-                            </dl>
-                        </div>
+                </div>
+                <div class="govuk-accordion__section">
+                    <div class="govuk-accordion__section-header">
+                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-6"> Contacts</span></h2>
                     </div>
-                    <div class="govuk-accordion__section">
-                        <div class="govuk-accordion__section-header">
-                            <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-8"> Case management</span></h2>
-                        </div>
-                        <div id="accordion-default1-content-8" class="govuk-accordion__section-content">
-                            <dl class="govuk-summary-list">
-                                <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Cross-team correspondence</dt>
-                                    <dd                                     class="govuk-summary-list__value">No documents</dd>
-                                        <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/internal-correspondence/cross-team/upload-documents/10"
-                                            data-cy="add-cross-team-correspondence">Add<span class="govuk-visually-hidden"> Cross-team correspondence</span></a>
-                                        </dd>
-                                </div>
-                                <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Inspector correspondence</dt>
-                                    <dd                                     class="govuk-summary-list__value">No documents</dd>
-                                        <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/internal-correspondence/inspector/upload-documents/11"
-                                            data-cy="add-inspector-correspondence">Add<span class="govuk-visually-hidden"> Inspector correspondence</span></a>
-                                        </dd>
-                                </div>
-                                <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Main party correspondence</dt>
-                                    <dd                                     class="govuk-summary-list__value">No documents</dd>
-                                        <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/internal-correspondence/main-party/upload-documents/22"
-                                            data-cy="add-main-party-correspondence">Add<span class="govuk-visually-hidden"> Main party correspondence</span></a>
-                                        </dd>
-                                </div>
-                                <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Case history</dt>
-                                    <dd class="govuk-summary-list__value"></dd>
-                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/audit" data-cy="view-case-history">View<span class="govuk-visually-hidden"> Case history</span></a>
+                    <div id="accordion-default1-content-6" class="govuk-accordion__section-content">
+                        <dl class="govuk-summary-list">
+                            <div class="govuk-summary-list__row appeal-appellant"><dt class="govuk-summary-list__key"> Appellant</dt>
+                                <dd class="govuk-summary-list__value">
+                                    <ul class="govuk-list">
+                                        <li>Roger Simmons</li>
+                                        <li>test3@example.com</li>
+                                    </ul>
+                                </dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/service-user/change/appellant"
+                                    data-cy="change-appellant">Change<span class="govuk-visually-hidden"> Appellant</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-agent"><dt class="govuk-summary-list__key"> Agent</dt>
+                                <dd class="govuk-summary-list__value">
+                                    <ul class="govuk-list">
+                                        <li>Fiona Shell</li>
+                                        <li>test2@example.com</li>
+                                    </ul>
+                                </dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/service-user/change/agent"
+                                    data-cy="change-agent">Change<span class="govuk-visually-hidden"> Agent</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-lpa-contact-details"><dt class="govuk-summary-list__key"> LPA</dt>
+                                <dd class="govuk-summary-list__value">
+                                    <ul class="govuk-list">
+                                        <li>Wiltshire Council</li>
+                                        <li>wilt@lpa-email.gov.uk</li>
+                                    </ul>
+                                </dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/change-appeal-details/local-planning-authority"
+                                    data-cy="change-lpa-contact-details">Change<span class="govuk-visually-hidden"> Local planning authority (LPA)</span></a>
+                                </dd>
+                            </div>
+                        </dl>
+                    </div>
+                </div>
+                <div class="govuk-accordion__section">
+                    <div class="govuk-accordion__section-header">
+                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-7"> Team</span></h2>
+                    </div>
+                    <div id="accordion-default1-content-7" class="govuk-accordion__section-content">
+                        <dl class="govuk-summary-list">
+                            <div class="govuk-summary-list__row appeal-case-officer"><dt class="govuk-summary-list__key"> Case officer</dt>
+                                <dd class="govuk-summary-list__value">
+                                    <p class="govuk-body">Not assigned</p>
+                                </dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/assign-user/case-officer"
+                                    data-cy="assign-case-officer">Assign<span class="govuk-visually-hidden"> Case officer</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-inspector"><dt class="govuk-summary-list__key"> Inspector</dt>
+                                <dd class="govuk-summary-list__value">
+                                    <p class="govuk-body">Not assigned</p>
+                                </dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/assign-user/inspector"
+                                    data-cy="assign-inspector">Assign<span class="govuk-visually-hidden"> Inspector</span></a>
+                                </dd>
+                            </div>
+                        </dl>
+                    </div>
+                </div>
+                <div class="govuk-accordion__section">
+                    <div class="govuk-accordion__section-header">
+                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-8"> Case management</span></h2>
+                    </div>
+                    <div id="accordion-default1-content-8" class="govuk-accordion__section-content">
+                        <dl class="govuk-summary-list">
+                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Cross-team correspondence</dt>
+                                <dd                                 class="govuk-summary-list__value">No documents</dd>
+                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/internal-correspondence/cross-team/upload-documents/10"
+                                        data-cy="add-cross-team-correspondence">Add<span class="govuk-visually-hidden"> Cross-team correspondence</span></a>
                                     </dd>
-                                </div>
-                                <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Appeal withdrawal</dt>
-                                    <dd class="govuk-summary-list__value"></dd>
-                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/withdrawal/start"
-                                        data-cy="start-appeal-withdrawal">Start<span class="govuk-visually-hidden"> Appeal withdrawal</span></a>
+                            </div>
+                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Inspector correspondence</dt>
+                                <dd                                 class="govuk-summary-list__value">No documents</dd>
+                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/internal-correspondence/inspector/upload-documents/11"
+                                        data-cy="add-inspector-correspondence">Add<span class="govuk-visually-hidden"> Inspector correspondence</span></a>
                                     </dd>
-                                </div>
-                            </dl>
-                        </div>
+                            </div>
+                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Main party correspondence</dt>
+                                <dd                                 class="govuk-summary-list__value">No documents</dd>
+                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/internal-correspondence/main-party/upload-documents/22"
+                                        data-cy="add-main-party-correspondence">Add<span class="govuk-visually-hidden"> Main party correspondence</span></a>
+                                    </dd>
+                            </div>
+                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Case history</dt>
+                                <dd class="govuk-summary-list__value"></dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/audit" data-cy="view-case-history">View<span class="govuk-visually-hidden"> Case history</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Appeal withdrawal</dt>
+                                <dd class="govuk-summary-list__value"></dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/withdrawal/start"
+                                    data-cy="start-appeal-withdrawal">Start<span class="govuk-visually-hidden"> Appeal withdrawal</span></a>
+                                </dd>
+                            </div>
+                        </dl>
                     </div>
                 </div>
             </div>
         </div>
+    </div>
 </main>"
 `;
 
@@ -3520,10 +3524,11 @@ exports[`appeal-details GET /:appealId should render an action link to the manag
         </div>
     </div>
     <div class="govuk-grid-row">
-        <div class="govuk-grid-column-full"><strong class="govuk-tag govuk-tag--grey govuk-!-margin-bottom-4">Received appeal</strong>
+        <div class="govuk-grid-column-full"><strong class="govuk-tag govuk-tag--grey pins-status-tag--full-width">Received appeal</strong>
+            <strong             class="govuk-tag govuk-tag--grey govuk-!-margin-left-1 govuk-!-margin-bottom-4"></strong>
         </div>
-    </div><strong class="govuk-tag govuk-tag--grey govuk-!-margin-left-1 govuk-!-margin-bottom-4"></strong>
-    <div     class="govuk-grid-row">
+    </div>
+    <div class="govuk-grid-row">
         <div class="govuk-grid-column-full">
             <dl class="govuk-summary-list pins-summary-list--no-border">
                 <div class="govuk-summary-list__row appeal-case-officer"><dt class="govuk-summary-list__key"> Case officer</dt>
@@ -3548,417 +3553,417 @@ exports[`appeal-details GET /:appealId should render an action link to the manag
                 </div>
             </dl>
         </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
+            <p class="govuk-body govuk-!-margin-bottom-6" id="download-case-files"
+            data-cy="download-case-files"><a class="govuk-link" href="/documents/1/bulk-download/case-APP/Q9999/D/21/351062.zip">Download case</a>
+            </p>
         </div>
-        <div class="govuk-grid-row">
-            <div class="govuk-grid-column-full">
-                <p class="govuk-body govuk-!-margin-bottom-6" id="download-case-files"
-                data-cy="download-case-files"><a class="govuk-link" href="/documents/1/bulk-download/case-APP/Q9999/D/21/351062.zip">Download case</a>
-                </p>
-            </div>
-        </div>
-        <div class="govuk-grid-row">
-            <div class="govuk-grid-column-full">
-                <details class="govuk-details">
-                    <summary class="govuk-details__summary"><span class="govuk-details__summary-text"> 2 case notes</span>
-                    </summary>
-                    <div class="govuk-details__text">
-                        <form method="POST" novalidate="novalidate">
-                            <div class="govuk-grid-row">
-                                <div class="govuk-grid-column-two-thirds">
-                                    <div class="govuk-form-group govuk-character-count" data-module="govuk-character-count"
-                                    data-maxlength="500">
-                                        <textarea class="govuk-textarea govuk-js-character-count" id="comment"
-                                        name="comment" rows="5" aria-describedby="comment-info"></textarea>
-                                        <div id="comment-info" class="govuk-hint govuk-character-count__message">You can enter up to 500 characters</div>
-                                    </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
+            <details class="govuk-details">
+                <summary class="govuk-details__summary"><span class="govuk-details__summary-text"> 2 case notes</span>
+                </summary>
+                <div class="govuk-details__text">
+                    <form method="POST" novalidate="novalidate">
+                        <div class="govuk-grid-row">
+                            <div class="govuk-grid-column-two-thirds">
+                                <div class="govuk-form-group govuk-character-count" data-module="govuk-character-count"
+                                data-maxlength="500">
+                                    <textarea class="govuk-textarea govuk-js-character-count" id="comment"
+                                    name="comment" rows="5" aria-describedby="comment-info"></textarea>
+                                    <div id="comment-info" class="govuk-hint govuk-character-count__message">You can enter up to 500 characters</div>
                                 </div>
                             </div>
-                            <button type="submit" data-prevent-double-click="true" class="govuk-button govuk-button--secondary govuk-!-margin-bottom-1"
-                            data-module="govuk-button">Add case note</button>
-                        </form>
-                        <div>
+                        </div>
+                        <button type="submit" data-prevent-double-click="true" class="govuk-button govuk-button--secondary govuk-!-margin-bottom-1"
+                        data-module="govuk-button">Add case note</button>
+                    </form>
+                    <div>
+                        <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+                        <section>
+                            <p class="govuk-body govuk-!-margin-bottom-1">A case note you should see.</p>
+                            <p class="govuk-hint govuk-!-margin-bottom-6">11:00am on Tuesday 1 October 2024 by John.Smith</p>
                             <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
-                            <section>
-                                <p class="govuk-body govuk-!-margin-bottom-1">A case note you should see.</p>
-                                <p class="govuk-hint govuk-!-margin-bottom-6">11:00am on Tuesday 1 October 2024 by John.Smith</p>
-                                <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
-                            </section>
-                            <section>
-                                <p class="govuk-body govuk-!-margin-bottom-1">A case note you should see.</p>
-                                <p class="govuk-hint govuk-!-margin-bottom-6">11:00am on Tuesday 1 October 2024 by John.Smith</p>
-                                <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
-                            </section>
-                        </div>
+                        </section>
+                        <section>
+                            <p class="govuk-body govuk-!-margin-bottom-1">A case note you should see.</p>
+                            <p class="govuk-hint govuk-!-margin-bottom-6">11:00am on Tuesday 1 October 2024 by John.Smith</p>
+                            <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+                        </section>
                     </div>
-                </details>
-            </div>
+                </div>
+            </details>
         </div>
-        <div class="govuk-grid-row">
-            <div class="govuk-grid-column-full">
-                <div class="govuk-accordion" data-module="govuk-accordion" id="accordion-default1">
-                    <div class="govuk-accordion__section">
-                        <div class="govuk-accordion__section-header">
-                            <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-1"> Overview</span></h2>
-                        </div>
-                        <div id="accordion-default1-content-1" class="govuk-accordion__section-content">
-                            <dl class="govuk-summary-list">
-                                <div class="govuk-summary-list__row govuk-summary-list__row--no-actions appeal-lpa-reference"><dt class="govuk-summary-list__key"> Planning application reference</dt>
-                                    <dd                                     class="govuk-summary-list__value">48269/APP/2021/1482</dd>
-                                </div>
-                                <div class="govuk-summary-list__row appeal-appeal-type"><dt class="govuk-summary-list__key"> Appeal type</dt>
-                                    <dd class="govuk-summary-list__value">Householder</dd>
-                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/change-appeal-type/appeal-type"
-                                        data-cy="change-appeal-type">Change<span class="govuk-visually-hidden"> Appeal type</span></a>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
+            <div class="govuk-accordion" data-module="govuk-accordion" id="accordion-default1">
+                <div class="govuk-accordion__section">
+                    <div class="govuk-accordion__section-header">
+                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-1"> Overview</span></h2>
+                    </div>
+                    <div id="accordion-default1-content-1" class="govuk-accordion__section-content">
+                        <dl class="govuk-summary-list">
+                            <div class="govuk-summary-list__row govuk-summary-list__row--no-actions appeal-lpa-reference"><dt class="govuk-summary-list__key"> Planning application reference</dt>
+                                <dd                                 class="govuk-summary-list__value">48269/APP/2021/1482</dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-appeal-type"><dt class="govuk-summary-list__key"> Appeal type</dt>
+                                <dd class="govuk-summary-list__value">Householder</dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/change-appeal-type/appeal-type"
+                                    data-cy="change-appeal-type">Change<span class="govuk-visually-hidden"> Appeal type</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row govuk-summary-list__row--no-actions appeal-case-procedure"><dt class="govuk-summary-list__key"> Appeal procedure</dt>
+                                <dd class="govuk-summary-list__value">Written</dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-allocation-details"><dt class="govuk-summary-list__key"> Allocation level</dt>
+                                <dd class="govuk-summary-list__value">
+                                    <ul class="govuk-!-margin-0">
+                                        <li>Level: A</li>
+                                        <li>Historic heritage</li>
+                                        <li>Architecture design</li>
+                                    </ul>
+                                </dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/allocation-details/allocation-level"
+                                    data-cy="change-allocation-details">Change<span class="govuk-visually-hidden"> Allocation level</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-linked-appeals"><dt class="govuk-summary-list__key"> Linked appeals</dt>
+                                <dd class="govuk-summary-list__value">
+                                    <ul class="govuk-list govuk-list--bullet">
+                                        <li><a href="/appeals-service/appeal-details/5449" class="govuk-link" data-cy="linked-appeal-784706"
+                                            aria-label="Appeal 7 8 4 7 0 6">784706</a> (Child)</li>
+                                        <li><span class="govuk-body">87326527</span> (Child)</li>
+                                        <li><a href="/appeals-service/appeal-details/5464" class="govuk-link" data-cy="linked-appeal-140079"
+                                            aria-label="Appeal 1 4 0 0 7 9">140079</a> (Lead)</li>
+                                        <li><a href="/appeals-service/appeal-details/5451" class="govuk-link" data-cy="linked-appeal-721086"
+                                            aria-label="Appeal 7 2 1 0 8 6">721086</a> (Child)</li>
+                                    </ul>
+                                </dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/linked-appeals/manage"
+                                    data-cy="manage-linked-appeals">Manage<span class="govuk-visually-hidden"> Linked appeals</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-other-appeals"><dt class="govuk-summary-list__key"> Related appeals</dt>
+                                <dd class="govuk-summary-list__value"><span>No</span>
+                                </dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/other-appeals/add"
+                                    data-cy="add-related-appeals">Add<span class="govuk-visually-hidden"> Related appeals</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-decision"><dt class="govuk-summary-list__key"> Decision</dt>
+                                <dd class="govuk-summary-list__value">Dismissed</dd>
+                            </div>
+                        </dl>
+                    </div>
+                </div>
+                <div class="govuk-accordion__section">
+                    <div class="govuk-accordion__section-header">
+                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-2"> Site</span></h2>
+                    </div>
+                    <div id="accordion-default1-content-2" class="govuk-accordion__section-content">
+                        <dl class="govuk-summary-list">
+                            <div class="govuk-summary-list__row appeal-visit-type"><dt class="govuk-summary-list__key"> Visit type</dt>
+                                <dd class="govuk-summary-list__value">Accompanied</dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/visit-booked?backUrl=%2Fappeals-service%2Fappeal-details%2F1"
+                                    data-cy="change-set-visit-type">Change<span class="govuk-visually-hidden"> Visit type</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Date</dt>
+                                <dd class="govuk-summary-list__value">9 October 2023</dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/visit-booked"
+                                    data-cy="change-site-visit-date">Change<span class="govuk-visually-hidden"> Date</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Start time</dt>
+                                <dd class="govuk-summary-list__value">9:38am</dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/visit-booked"
+                                    data-cy="change-site-visit-start-time">Change<span class="govuk-visually-hidden"> Start time</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> End time</dt>
+                                <dd class="govuk-summary-list__value">10:00am</dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/visit-booked"
+                                    data-cy="change-site-visit-end-time">Change<span class="govuk-visually-hidden"> End time</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-neighbouring-sites-inspector"><dt class="govuk-summary-list__key"> Interested party and neighbour addresses</dt>
+                                <dd                                 class="govuk-summary-list__value">
+                                    <ul class="govuk-list govuk-list--bullet">
+                                        <li>2 Grove Cottage, Shotesham Road, Woodton, Devon, NR35 2ND</li>
+                                    </ul>
                                     </dd>
-                                </div>
-                                <div class="govuk-summary-list__row govuk-summary-list__row--no-actions appeal-case-procedure"><dt class="govuk-summary-list__key"> Appeal procedure</dt>
-                                    <dd class="govuk-summary-list__value">Written</dd>
-                                </div>
-                                <div class="govuk-summary-list__row appeal-allocation-details"><dt class="govuk-summary-list__key"> Allocation level</dt>
-                                    <dd class="govuk-summary-list__value">
-                                        <ul class="govuk-!-margin-0">
-                                            <li>Level: A</li>
-                                            <li>Historic heritage</li>
-                                            <li>Architecture design</li>
+                                    <dd class="govuk-summary-list__actions">
+                                        <ul class="govuk-summary-list__actions-list">
+                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/neighbouring-sites/manage"
+                                                data-cy="manage-neighbouring-sites-inspector">Manage<span class="govuk-visually-hidden"> Interested party and neighbour addresses</span></a>
+                                            </li>
+                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/neighbouring-sites/add/back-office"
+                                                data-cy="add-neighbouring-sites-inspector">Add<span class="govuk-visually-hidden"> Interested party and neighbour addresses</span></a>
+                                            </li>
                                         </ul>
                                     </dd>
-                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/allocation-details/allocation-level"
-                                        data-cy="change-allocation-details">Change<span class="govuk-visually-hidden"> Allocation level</span></a>
-                                    </dd>
-                                </div>
-                                <div class="govuk-summary-list__row appeal-linked-appeals"><dt class="govuk-summary-list__key"> Linked appeals</dt>
-                                    <dd class="govuk-summary-list__value">
-                                        <ul class="govuk-list govuk-list--bullet">
-                                            <li><a href="/appeals-service/appeal-details/5449" class="govuk-link" data-cy="linked-appeal-784706"
-                                                aria-label="Appeal 7 8 4 7 0 6">784706</a> (Child)</li>
-                                            <li><span class="govuk-body">87326527</span> (Child)</li>
-                                            <li><a href="/appeals-service/appeal-details/5464" class="govuk-link" data-cy="linked-appeal-140079"
-                                                aria-label="Appeal 1 4 0 0 7 9">140079</a> (Lead)</li>
-                                            <li><a href="/appeals-service/appeal-details/5451" class="govuk-link" data-cy="linked-appeal-721086"
-                                                aria-label="Appeal 7 2 1 0 8 6">721086</a> (Child)</li>
+                            </div>
+                        </dl>
+                    </div>
+                </div>
+                <div class="govuk-accordion__section">
+                    <div class="govuk-accordion__section-header">
+                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-3"> Timetable</span></h2>
+                    </div>
+                    <div id="accordion-default1-content-3" class="govuk-accordion__section-content">
+                        <dl class="govuk-summary-list appeal-case-timetable">
+                            <div class="govuk-summary-list__row appeal-valid-date"><dt class="govuk-summary-list__key"> Valid date</dt>
+                                <dd class="govuk-summary-list__value">23 May 2023</dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/valid/date"
+                                    data-cy="-valid-date"><span class="govuk-visually-hidden"> Valid date</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-start-date"><dt class="govuk-summary-list__key"> Start date</dt>
+                                <dd class="govuk-summary-list__value">23 May 2023</dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/start-case/change"
+                                    data-cy="change-start-case-date">Change<span class="govuk-visually-hidden"> Start date</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-lpa-questionnaire-due-date"><dt class="govuk-summary-list__key"> LPA questionnaire due</dt>
+                                <dd class="govuk-summary-list__value">11 October 2023</dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-site-visit"><dt class="govuk-summary-list__key"> Site visit</dt>
+                                <dd class="govuk-summary-list__value">
+                                    <ul class="govuk-list govuk-!-margin-top-0 govuk-!-padding-left-0">
+                                        <li>9 October 2023</li>
+                                        <li>9:38am - 10:00am</li>
+                                    </ul>
+                                </dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/manage-visit?backUrl=%2Fappeals-service%2Fappeal-details%2F1"
+                                    data-cy="change-schedule-visit">Change<span class="govuk-visually-hidden"> Site visit</span></a>
+                                </dd>
+                            </div>
+                        </dl>
+                    </div>
+                </div>
+                <div class="govuk-accordion__section">
+                    <div class="govuk-accordion__section-header">
+                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-4"> Documentation</span></h2>
+                    </div>
+                    <div id="accordion-default1-content-4" class="govuk-accordion__section-content">
+                        <table class="govuk-table">
+                            <thead class="govuk-table__head">
+                                <tr class="govuk-table__row">
+                                    <th scope="col" class="govuk-table__header">Documentation</th>
+                                    <th scope="col" class="govuk-table__header">Status</th>
+                                    <th scope="col" class="govuk-table__header">Received</th>
+                                    <th scope="col" class="govuk-table__header govuk-!-text-align-right">Action</th>
+                                </tr>
+                            </thead>
+                            <tbody class="govuk-table__body">
+                                <tr class="govuk-table__row">
+                                    <th scope="row" class="govuk-table__header">Appeal</th>
+                                    <td class="govuk-table__cell">Ready to review</td>
+                                    <td class="govuk-table__cell">2 August 2024</td>
+                                    <td class="govuk-table__cell govuk-!-text-align-right"><a href="/appeals-service/appeal-details/1/appellant-case?backUrl=%2Fappeals-service%2Fappeal-details%2F1"
+                                        data-cy="review-appellant-case" class="govuk-link">Review<span class="govuk-visually-hidden"> appellant case</span></a>
+                                    </td>
+                                </tr>
+                                <tr class="govuk-table__row">
+                                    <th scope="row" class="govuk-table__header">LPA questionnaire</th>
+                                    <td class="govuk-table__cell">Overdue</td>
+                                    <td class="govuk-table__cell">Due by 11 October 2023</td>
+                                    <td class="govuk-table__cell govuk-!-text-align-right"></td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
+                <div class="govuk-accordion__section">
+                    <div class="govuk-accordion__section-header">
+                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-5"> Costs</span></h2>
+                    </div>
+                    <div id="accordion-default1-content-5" class="govuk-accordion__section-content">
+                        <table class="govuk-table">
+                            <thead class="govuk-table__head">
+                                <tr class="govuk-table__row">
+                                    <th scope="col" class="govuk-table__header">Documentation</th>
+                                    <th scope="col" class="govuk-table__header">Status</th>
+                                    <th scope="col" class="govuk-table__header govuk-!-text-align-right">Action</th>
+                                </tr>
+                            </thead>
+                            <tbody class="govuk-table__body">
+                                <tr class="govuk-table__row">
+                                    <th scope="row" class="govuk-table__header appeal-costs-appellant-application-documentation">Appellant application</th>
+                                    <td class="govuk-table__cell appeal-costs-appellant-application-status">No documents available</td>
+                                    <td class="govuk-table__cell appeal-costs-appellant-application-actions govuk-!-text-align-right">
+                                        <ul class="govuk-summary-list__actions-list">
+                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-appellant-application" href="/appeals-service/appeal-details/1/costs/appellant/application/upload-documents/1">Add<span class="govuk-visually-hidden"> Appellant application</span></a>
+                                            </li>
                                         </ul>
-                                    </dd>
-                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/linked-appeals/manage"
-                                        data-cy="manage-linked-appeals">Manage<span class="govuk-visually-hidden"> Linked appeals</span></a>
-                                    </dd>
-                                </div>
-                                <div class="govuk-summary-list__row appeal-other-appeals"><dt class="govuk-summary-list__key"> Related appeals</dt>
-                                    <dd class="govuk-summary-list__value"><span>No</span>
-                                    </dd>
-                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/other-appeals/add"
-                                        data-cy="add-related-appeals">Add<span class="govuk-visually-hidden"> Related appeals</span></a>
-                                    </dd>
-                                </div>
-                                <div class="govuk-summary-list__row appeal-decision"><dt class="govuk-summary-list__key"> Decision</dt>
-                                    <dd class="govuk-summary-list__value">Dismissed</dd>
-                                </div>
-                            </dl>
-                        </div>
-                    </div>
-                    <div class="govuk-accordion__section">
-                        <div class="govuk-accordion__section-header">
-                            <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-2"> Site</span></h2>
-                        </div>
-                        <div id="accordion-default1-content-2" class="govuk-accordion__section-content">
-                            <dl class="govuk-summary-list">
-                                <div class="govuk-summary-list__row appeal-visit-type"><dt class="govuk-summary-list__key"> Visit type</dt>
-                                    <dd class="govuk-summary-list__value">Accompanied</dd>
-                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/visit-booked?backUrl=%2Fappeals-service%2Fappeal-details%2F1"
-                                        data-cy="change-set-visit-type">Change<span class="govuk-visually-hidden"> Visit type</span></a>
-                                    </dd>
-                                </div>
-                                <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Date</dt>
-                                    <dd class="govuk-summary-list__value">9 October 2023</dd>
-                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/visit-booked"
-                                        data-cy="change-site-visit-date">Change<span class="govuk-visually-hidden"> Date</span></a>
-                                    </dd>
-                                </div>
-                                <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Start time</dt>
-                                    <dd class="govuk-summary-list__value">9:38am</dd>
-                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/visit-booked"
-                                        data-cy="change-site-visit-start-time">Change<span class="govuk-visually-hidden"> Start time</span></a>
-                                    </dd>
-                                </div>
-                                <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> End time</dt>
-                                    <dd class="govuk-summary-list__value">10:00am</dd>
-                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/visit-booked"
-                                        data-cy="change-site-visit-end-time">Change<span class="govuk-visually-hidden"> End time</span></a>
-                                    </dd>
-                                </div>
-                                <div class="govuk-summary-list__row appeal-neighbouring-sites-inspector"><dt class="govuk-summary-list__key"> Interested party and neighbour addresses</dt>
-                                    <dd                                     class="govuk-summary-list__value">
-                                        <ul class="govuk-list govuk-list--bullet">
-                                            <li>2 Grove Cottage, Shotesham Road, Woodton, Devon, NR35 2ND</li>
+                                    </td>
+                                </tr>
+                                <tr class="govuk-table__row">
+                                    <th scope="row" class="govuk-table__header appeal-costs-appellant-withdrawal-documentation">Appellant withdrawal</th>
+                                    <td class="govuk-table__cell appeal-costs-appellant-withdrawal-status">No documents available</td>
+                                    <td class="govuk-table__cell appeal-costs-appellant-withdrawal-actions govuk-!-text-align-right">
+                                        <ul class="govuk-summary-list__actions-list">
+                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-appellant-withdrawal" href="/appeals-service/appeal-details/1/costs/appellant/withdrawal/upload-documents/2">Add<span class="govuk-visually-hidden"> Appellant withdrawal</span></a>
+                                            </li>
                                         </ul>
-                                        </dd>
-                                        <dd class="govuk-summary-list__actions">
-                                            <ul class="govuk-summary-list__actions-list">
-                                                <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/neighbouring-sites/manage"
-                                                    data-cy="manage-neighbouring-sites-inspector">Manage<span class="govuk-visually-hidden"> Interested party and neighbour addresses</span></a>
-                                                </li>
-                                                <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/neighbouring-sites/add/back-office"
-                                                    data-cy="add-neighbouring-sites-inspector">Add<span class="govuk-visually-hidden"> Interested party and neighbour addresses</span></a>
-                                                </li>
-                                            </ul>
-                                        </dd>
-                                </div>
-                            </dl>
-                        </div>
-                    </div>
-                    <div class="govuk-accordion__section">
-                        <div class="govuk-accordion__section-header">
-                            <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-3"> Timetable</span></h2>
-                        </div>
-                        <div id="accordion-default1-content-3" class="govuk-accordion__section-content">
-                            <dl class="govuk-summary-list appeal-case-timetable">
-                                <div class="govuk-summary-list__row appeal-valid-date"><dt class="govuk-summary-list__key"> Valid date</dt>
-                                    <dd class="govuk-summary-list__value">23 May 2023</dd>
-                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/valid/date"
-                                        data-cy="-valid-date"><span class="govuk-visually-hidden"> Valid date</span></a>
-                                    </dd>
-                                </div>
-                                <div class="govuk-summary-list__row appeal-start-date"><dt class="govuk-summary-list__key"> Start date</dt>
-                                    <dd class="govuk-summary-list__value">23 May 2023</dd>
-                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/start-case/change"
-                                        data-cy="change-start-case-date">Change<span class="govuk-visually-hidden"> Start date</span></a>
-                                    </dd>
-                                </div>
-                                <div class="govuk-summary-list__row appeal-lpa-questionnaire-due-date"><dt class="govuk-summary-list__key"> LPA questionnaire due</dt>
-                                    <dd class="govuk-summary-list__value">11 October 2023</dd>
-                                </div>
-                                <div class="govuk-summary-list__row appeal-site-visit"><dt class="govuk-summary-list__key"> Site visit</dt>
-                                    <dd class="govuk-summary-list__value">
-                                        <ul class="govuk-list govuk-!-margin-top-0 govuk-!-padding-left-0">
-                                            <li>9 October 2023</li>
-                                            <li>9:38am - 10:00am</li>
+                                    </td>
+                                </tr>
+                                <tr class="govuk-table__row">
+                                    <th scope="row" class="govuk-table__header appeal-costs-appellant-correspondence-documentation">Appellant correspondence</th>
+                                    <td class="govuk-table__cell appeal-costs-appellant-correspondence-status">No documents available</td>
+                                    <td class="govuk-table__cell appeal-costs-appellant-correspondence-actions govuk-!-text-align-right">
+                                        <ul class="govuk-summary-list__actions-list">
+                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-appellant-correspondence" href="/appeals-service/appeal-details/1/costs/appellant/correspondence/upload-documents/3">Add<span class="govuk-visually-hidden"> Appellant correspondence</span></a>
+                                            </li>
                                         </ul>
-                                    </dd>
-                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/manage-visit?backUrl=%2Fappeals-service%2Fappeal-details%2F1"
-                                        data-cy="change-schedule-visit">Change<span class="govuk-visually-hidden"> Site visit</span></a>
-                                    </dd>
-                                </div>
-                            </dl>
-                        </div>
-                    </div>
-                    <div class="govuk-accordion__section">
-                        <div class="govuk-accordion__section-header">
-                            <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-4"> Documentation</span></h2>
-                        </div>
-                        <div id="accordion-default1-content-4" class="govuk-accordion__section-content">
-                            <table class="govuk-table">
-                                <thead class="govuk-table__head">
-                                    <tr class="govuk-table__row">
-                                        <th scope="col" class="govuk-table__header">Documentation</th>
-                                        <th scope="col" class="govuk-table__header">Status</th>
-                                        <th scope="col" class="govuk-table__header">Received</th>
-                                        <th scope="col" class="govuk-table__header govuk-!-text-align-right">Action</th>
-                                    </tr>
-                                </thead>
-                                <tbody class="govuk-table__body">
-                                    <tr class="govuk-table__row">
-                                        <th scope="row" class="govuk-table__header">Appeal</th>
-                                        <td class="govuk-table__cell">Ready to review</td>
-                                        <td class="govuk-table__cell">2 August 2024</td>
-                                        <td class="govuk-table__cell govuk-!-text-align-right"><a href="/appeals-service/appeal-details/1/appellant-case?backUrl=%2Fappeals-service%2Fappeal-details%2F1"
-                                            data-cy="review-appellant-case" class="govuk-link">Review<span class="govuk-visually-hidden"> appellant case</span></a>
-                                        </td>
-                                    </tr>
-                                    <tr class="govuk-table__row">
-                                        <th scope="row" class="govuk-table__header">LPA questionnaire</th>
-                                        <td class="govuk-table__cell">Overdue</td>
-                                        <td class="govuk-table__cell">Due by 11 October 2023</td>
-                                        <td class="govuk-table__cell govuk-!-text-align-right"></td>
-                                    </tr>
-                                </tbody>
-                            </table>
-                        </div>
-                    </div>
-                    <div class="govuk-accordion__section">
-                        <div class="govuk-accordion__section-header">
-                            <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-5"> Costs</span></h2>
-                        </div>
-                        <div id="accordion-default1-content-5" class="govuk-accordion__section-content">
-                            <table class="govuk-table">
-                                <thead class="govuk-table__head">
-                                    <tr class="govuk-table__row">
-                                        <th scope="col" class="govuk-table__header">Documentation</th>
-                                        <th scope="col" class="govuk-table__header">Status</th>
-                                        <th scope="col" class="govuk-table__header govuk-!-text-align-right">Action</th>
-                                    </tr>
-                                </thead>
-                                <tbody class="govuk-table__body">
-                                    <tr class="govuk-table__row">
-                                        <th scope="row" class="govuk-table__header appeal-costs-appellant-application-documentation">Appellant application</th>
-                                        <td class="govuk-table__cell appeal-costs-appellant-application-status">No documents available</td>
-                                        <td class="govuk-table__cell appeal-costs-appellant-application-actions govuk-!-text-align-right">
-                                            <ul class="govuk-summary-list__actions-list">
-                                                <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-appellant-application" href="/appeals-service/appeal-details/1/costs/appellant/application/upload-documents/1">Add<span class="govuk-visually-hidden"> Appellant application</span></a>
-                                                </li>
-                                            </ul>
-                                        </td>
-                                    </tr>
-                                    <tr class="govuk-table__row">
-                                        <th scope="row" class="govuk-table__header appeal-costs-appellant-withdrawal-documentation">Appellant withdrawal</th>
-                                        <td class="govuk-table__cell appeal-costs-appellant-withdrawal-status">No documents available</td>
-                                        <td class="govuk-table__cell appeal-costs-appellant-withdrawal-actions govuk-!-text-align-right">
-                                            <ul class="govuk-summary-list__actions-list">
-                                                <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-appellant-withdrawal" href="/appeals-service/appeal-details/1/costs/appellant/withdrawal/upload-documents/2">Add<span class="govuk-visually-hidden"> Appellant withdrawal</span></a>
-                                                </li>
-                                            </ul>
-                                        </td>
-                                    </tr>
-                                    <tr class="govuk-table__row">
-                                        <th scope="row" class="govuk-table__header appeal-costs-appellant-correspondence-documentation">Appellant correspondence</th>
-                                        <td class="govuk-table__cell appeal-costs-appellant-correspondence-status">No documents available</td>
-                                        <td class="govuk-table__cell appeal-costs-appellant-correspondence-actions govuk-!-text-align-right">
-                                            <ul class="govuk-summary-list__actions-list">
-                                                <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-appellant-correspondence" href="/appeals-service/appeal-details/1/costs/appellant/correspondence/upload-documents/3">Add<span class="govuk-visually-hidden"> Appellant correspondence</span></a>
-                                                </li>
-                                            </ul>
-                                        </td>
-                                    </tr>
-                                    <tr class="govuk-table__row">
-                                        <th scope="row" class="govuk-table__header appeal-costs-lpa-application-documentation">LPA application</th>
-                                        <td class="govuk-table__cell appeal-costs-lpa-application-status">No documents available</td>
-                                        <td class="govuk-table__cell appeal-costs-lpa-application-actions govuk-!-text-align-right">
-                                            <ul class="govuk-summary-list__actions-list">
-                                                <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-lpa-application" href="/appeals-service/appeal-details/1/costs/lpa/application/upload-documents/4">Add<span class="govuk-visually-hidden"> LPA application</span></a>
-                                                </li>
-                                            </ul>
-                                        </td>
-                                    </tr>
-                                    <tr class="govuk-table__row">
-                                        <th scope="row" class="govuk-table__header appeal-costs-lpa-withdrawal-documentation">LPA withdrawal</th>
-                                        <td class="govuk-table__cell appeal-costs-lpa-withdrawal-status">No documents available</td>
-                                        <td class="govuk-table__cell appeal-costs-lpa-withdrawal-actions govuk-!-text-align-right">
-                                            <ul class="govuk-summary-list__actions-list">
-                                                <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-lpa-withdrawal" href="/appeals-service/appeal-details/1/costs/lpa/withdrawal/upload-documents/5">Add<span class="govuk-visually-hidden"> LPA withdrawal</span></a>
-                                                </li>
-                                            </ul>
-                                        </td>
-                                    </tr>
-                                    <tr class="govuk-table__row">
-                                        <th scope="row" class="govuk-table__header appeal-costs-lpa-correspondence-documentation">LPA correspondence</th>
-                                        <td class="govuk-table__cell appeal-costs-lpa-correspondence-status">No documents available</td>
-                                        <td class="govuk-table__cell appeal-costs-lpa-correspondence-actions govuk-!-text-align-right">
-                                            <ul class="govuk-summary-list__actions-list">
-                                                <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-lpa-correspondence" href="/appeals-service/appeal-details/1/costs/lpa/correspondence/upload-documents/6">Add<span class="govuk-visually-hidden"> LPA correspondence</span></a>
-                                                </li>
-                                            </ul>
-                                        </td>
-                                    </tr>
-                                </tbody>
-                            </table>
-                        </div>
-                    </div>
-                    <div class="govuk-accordion__section">
-                        <div class="govuk-accordion__section-header">
-                            <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-6"> Contacts</span></h2>
-                        </div>
-                        <div id="accordion-default1-content-6" class="govuk-accordion__section-content">
-                            <dl class="govuk-summary-list">
-                                <div class="govuk-summary-list__row appeal-appellant"><dt class="govuk-summary-list__key"> Appellant</dt>
-                                    <dd class="govuk-summary-list__value">
-                                        <ul class="govuk-list">
-                                            <li>Roger Simmons</li>
-                                            <li>test3@example.com</li>
+                                    </td>
+                                </tr>
+                                <tr class="govuk-table__row">
+                                    <th scope="row" class="govuk-table__header appeal-costs-lpa-application-documentation">LPA application</th>
+                                    <td class="govuk-table__cell appeal-costs-lpa-application-status">No documents available</td>
+                                    <td class="govuk-table__cell appeal-costs-lpa-application-actions govuk-!-text-align-right">
+                                        <ul class="govuk-summary-list__actions-list">
+                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-lpa-application" href="/appeals-service/appeal-details/1/costs/lpa/application/upload-documents/4">Add<span class="govuk-visually-hidden"> LPA application</span></a>
+                                            </li>
                                         </ul>
-                                    </dd>
-                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/service-user/change/appellant"
-                                        data-cy="change-appellant">Change<span class="govuk-visually-hidden"> Appellant</span></a>
-                                    </dd>
-                                </div>
-                                <div class="govuk-summary-list__row appeal-agent"><dt class="govuk-summary-list__key"> Agent</dt>
-                                    <dd class="govuk-summary-list__value">
-                                        <ul class="govuk-list">
-                                            <li>Fiona Shell</li>
-                                            <li>test2@example.com</li>
+                                    </td>
+                                </tr>
+                                <tr class="govuk-table__row">
+                                    <th scope="row" class="govuk-table__header appeal-costs-lpa-withdrawal-documentation">LPA withdrawal</th>
+                                    <td class="govuk-table__cell appeal-costs-lpa-withdrawal-status">No documents available</td>
+                                    <td class="govuk-table__cell appeal-costs-lpa-withdrawal-actions govuk-!-text-align-right">
+                                        <ul class="govuk-summary-list__actions-list">
+                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-lpa-withdrawal" href="/appeals-service/appeal-details/1/costs/lpa/withdrawal/upload-documents/5">Add<span class="govuk-visually-hidden"> LPA withdrawal</span></a>
+                                            </li>
                                         </ul>
-                                    </dd>
-                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/service-user/change/agent"
-                                        data-cy="change-agent">Change<span class="govuk-visually-hidden"> Agent</span></a>
-                                    </dd>
-                                </div>
-                                <div class="govuk-summary-list__row appeal-lpa-contact-details"><dt class="govuk-summary-list__key"> LPA</dt>
-                                    <dd class="govuk-summary-list__value">
-                                        <ul class="govuk-list">
-                                            <li>Wiltshire Council</li>
-                                            <li>wilt@lpa-email.gov.uk</li>
+                                    </td>
+                                </tr>
+                                <tr class="govuk-table__row">
+                                    <th scope="row" class="govuk-table__header appeal-costs-lpa-correspondence-documentation">LPA correspondence</th>
+                                    <td class="govuk-table__cell appeal-costs-lpa-correspondence-status">No documents available</td>
+                                    <td class="govuk-table__cell appeal-costs-lpa-correspondence-actions govuk-!-text-align-right">
+                                        <ul class="govuk-summary-list__actions-list">
+                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-lpa-correspondence" href="/appeals-service/appeal-details/1/costs/lpa/correspondence/upload-documents/6">Add<span class="govuk-visually-hidden"> LPA correspondence</span></a>
+                                            </li>
                                         </ul>
-                                    </dd>
-                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/change-appeal-details/local-planning-authority"
-                                        data-cy="change-lpa-contact-details">Change<span class="govuk-visually-hidden"> Local planning authority (LPA)</span></a>
-                                    </dd>
-                                </div>
-                            </dl>
-                        </div>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
                     </div>
-                    <div class="govuk-accordion__section">
-                        <div class="govuk-accordion__section-header">
-                            <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-7"> Team</span></h2>
-                        </div>
-                        <div id="accordion-default1-content-7" class="govuk-accordion__section-content">
-                            <dl class="govuk-summary-list">
-                                <div class="govuk-summary-list__row appeal-case-officer"><dt class="govuk-summary-list__key"> Case officer</dt>
-                                    <dd class="govuk-summary-list__value">
-                                        <p class="govuk-body">Not assigned</p>
-                                    </dd>
-                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/assign-user/case-officer"
-                                        data-cy="assign-case-officer">Assign<span class="govuk-visually-hidden"> Case officer</span></a>
-                                    </dd>
-                                </div>
-                                <div class="govuk-summary-list__row appeal-inspector"><dt class="govuk-summary-list__key"> Inspector</dt>
-                                    <dd class="govuk-summary-list__value">
-                                        <p class="govuk-body">Not assigned</p>
-                                    </dd>
-                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/assign-user/inspector"
-                                        data-cy="assign-inspector">Assign<span class="govuk-visually-hidden"> Inspector</span></a>
-                                    </dd>
-                                </div>
-                            </dl>
-                        </div>
+                </div>
+                <div class="govuk-accordion__section">
+                    <div class="govuk-accordion__section-header">
+                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-6"> Contacts</span></h2>
                     </div>
-                    <div class="govuk-accordion__section">
-                        <div class="govuk-accordion__section-header">
-                            <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-8"> Case management</span></h2>
-                        </div>
-                        <div id="accordion-default1-content-8" class="govuk-accordion__section-content">
-                            <dl class="govuk-summary-list">
-                                <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Cross-team correspondence</dt>
-                                    <dd                                     class="govuk-summary-list__value">No documents</dd>
-                                        <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/internal-correspondence/cross-team/upload-documents/10"
-                                            data-cy="add-cross-team-correspondence">Add<span class="govuk-visually-hidden"> Cross-team correspondence</span></a>
-                                        </dd>
-                                </div>
-                                <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Inspector correspondence</dt>
-                                    <dd                                     class="govuk-summary-list__value">No documents</dd>
-                                        <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/internal-correspondence/inspector/upload-documents/11"
-                                            data-cy="add-inspector-correspondence">Add<span class="govuk-visually-hidden"> Inspector correspondence</span></a>
-                                        </dd>
-                                </div>
-                                <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Main party correspondence</dt>
-                                    <dd                                     class="govuk-summary-list__value">No documents</dd>
-                                        <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/internal-correspondence/main-party/upload-documents/22"
-                                            data-cy="add-main-party-correspondence">Add<span class="govuk-visually-hidden"> Main party correspondence</span></a>
-                                        </dd>
-                                </div>
-                                <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Case history</dt>
-                                    <dd class="govuk-summary-list__value"></dd>
-                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/audit" data-cy="view-case-history">View<span class="govuk-visually-hidden"> Case history</span></a>
+                    <div id="accordion-default1-content-6" class="govuk-accordion__section-content">
+                        <dl class="govuk-summary-list">
+                            <div class="govuk-summary-list__row appeal-appellant"><dt class="govuk-summary-list__key"> Appellant</dt>
+                                <dd class="govuk-summary-list__value">
+                                    <ul class="govuk-list">
+                                        <li>Roger Simmons</li>
+                                        <li>test3@example.com</li>
+                                    </ul>
+                                </dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/service-user/change/appellant"
+                                    data-cy="change-appellant">Change<span class="govuk-visually-hidden"> Appellant</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-agent"><dt class="govuk-summary-list__key"> Agent</dt>
+                                <dd class="govuk-summary-list__value">
+                                    <ul class="govuk-list">
+                                        <li>Fiona Shell</li>
+                                        <li>test2@example.com</li>
+                                    </ul>
+                                </dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/service-user/change/agent"
+                                    data-cy="change-agent">Change<span class="govuk-visually-hidden"> Agent</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-lpa-contact-details"><dt class="govuk-summary-list__key"> LPA</dt>
+                                <dd class="govuk-summary-list__value">
+                                    <ul class="govuk-list">
+                                        <li>Wiltshire Council</li>
+                                        <li>wilt@lpa-email.gov.uk</li>
+                                    </ul>
+                                </dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/change-appeal-details/local-planning-authority"
+                                    data-cy="change-lpa-contact-details">Change<span class="govuk-visually-hidden"> Local planning authority (LPA)</span></a>
+                                </dd>
+                            </div>
+                        </dl>
+                    </div>
+                </div>
+                <div class="govuk-accordion__section">
+                    <div class="govuk-accordion__section-header">
+                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-7"> Team</span></h2>
+                    </div>
+                    <div id="accordion-default1-content-7" class="govuk-accordion__section-content">
+                        <dl class="govuk-summary-list">
+                            <div class="govuk-summary-list__row appeal-case-officer"><dt class="govuk-summary-list__key"> Case officer</dt>
+                                <dd class="govuk-summary-list__value">
+                                    <p class="govuk-body">Not assigned</p>
+                                </dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/assign-user/case-officer"
+                                    data-cy="assign-case-officer">Assign<span class="govuk-visually-hidden"> Case officer</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-inspector"><dt class="govuk-summary-list__key"> Inspector</dt>
+                                <dd class="govuk-summary-list__value">
+                                    <p class="govuk-body">Not assigned</p>
+                                </dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/assign-user/inspector"
+                                    data-cy="assign-inspector">Assign<span class="govuk-visually-hidden"> Inspector</span></a>
+                                </dd>
+                            </div>
+                        </dl>
+                    </div>
+                </div>
+                <div class="govuk-accordion__section">
+                    <div class="govuk-accordion__section-header">
+                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-8"> Case management</span></h2>
+                    </div>
+                    <div id="accordion-default1-content-8" class="govuk-accordion__section-content">
+                        <dl class="govuk-summary-list">
+                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Cross-team correspondence</dt>
+                                <dd                                 class="govuk-summary-list__value">No documents</dd>
+                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/internal-correspondence/cross-team/upload-documents/10"
+                                        data-cy="add-cross-team-correspondence">Add<span class="govuk-visually-hidden"> Cross-team correspondence</span></a>
                                     </dd>
-                                </div>
-                                <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Appeal withdrawal</dt>
-                                    <dd class="govuk-summary-list__value"></dd>
-                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/withdrawal/start"
-                                        data-cy="start-appeal-withdrawal">Start<span class="govuk-visually-hidden"> Appeal withdrawal</span></a>
+                            </div>
+                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Inspector correspondence</dt>
+                                <dd                                 class="govuk-summary-list__value">No documents</dd>
+                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/internal-correspondence/inspector/upload-documents/11"
+                                        data-cy="add-inspector-correspondence">Add<span class="govuk-visually-hidden"> Inspector correspondence</span></a>
                                     </dd>
-                                </div>
-                            </dl>
-                        </div>
+                            </div>
+                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Main party correspondence</dt>
+                                <dd                                 class="govuk-summary-list__value">No documents</dd>
+                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/internal-correspondence/main-party/upload-documents/22"
+                                        data-cy="add-main-party-correspondence">Add<span class="govuk-visually-hidden"> Main party correspondence</span></a>
+                                    </dd>
+                            </div>
+                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Case history</dt>
+                                <dd class="govuk-summary-list__value"></dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/audit" data-cy="view-case-history">View<span class="govuk-visually-hidden"> Case history</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Appeal withdrawal</dt>
+                                <dd class="govuk-summary-list__value"></dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/withdrawal/start"
+                                    data-cy="start-appeal-withdrawal">Start<span class="govuk-visually-hidden"> Appeal withdrawal</span></a>
+                                </dd>
+                            </div>
+                        </dl>
                     </div>
                 </div>
             </div>
         </div>
+    </div>
 </main>"
 `;
 
@@ -3970,7 +3975,7 @@ exports[`appeal-details GET /:appealId should render the appellant case status a
         </div>
     </div>
     <div class="govuk-grid-row">
-        <div class="govuk-grid-column-full"><strong class="govuk-tag govuk-tag--green govuk-!-margin-bottom-4">Validation</strong>
+        <div class="govuk-grid-column-full"><strong class="govuk-tag govuk-tag--green pins-status-tag--full-width">Validation</strong>
         </div>
     </div>
     <div class="govuk-grid-row">
@@ -4411,7 +4416,7 @@ exports[`appeal-details GET /:appealId should render the appellant case status a
         </div>
     </div>
     <div class="govuk-grid-row">
-        <div class="govuk-grid-column-full"><strong class="govuk-tag govuk-tag--green govuk-!-margin-bottom-4">Validation</strong>
+        <div class="govuk-grid-column-full"><strong class="govuk-tag govuk-tag--green pins-status-tag--full-width">Validation</strong>
         </div>
     </div>
     <div class="govuk-grid-row">
@@ -4852,10 +4857,11 @@ exports[`appeal-details GET /:appealId should render the case reference for each
         </div>
     </div>
     <div class="govuk-grid-row">
-        <div class="govuk-grid-column-full"><strong class="govuk-tag govuk-tag--grey govuk-!-margin-bottom-4">Received appeal</strong>
+        <div class="govuk-grid-column-full"><strong class="govuk-tag govuk-tag--grey pins-status-tag--full-width">Received appeal</strong>
+            <strong             class="govuk-tag govuk-tag--grey govuk-!-margin-left-1 govuk-!-margin-bottom-4"></strong>
         </div>
-    </div><strong class="govuk-tag govuk-tag--grey govuk-!-margin-left-1 govuk-!-margin-bottom-4"></strong>
-    <div     class="govuk-grid-row">
+    </div>
+    <div class="govuk-grid-row">
         <div class="govuk-grid-column-full">
             <dl class="govuk-summary-list pins-summary-list--no-border">
                 <div class="govuk-summary-list__row appeal-case-officer"><dt class="govuk-summary-list__key"> Case officer</dt>
@@ -4880,417 +4886,417 @@ exports[`appeal-details GET /:appealId should render the case reference for each
                 </div>
             </dl>
         </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
+            <p class="govuk-body govuk-!-margin-bottom-6" id="download-case-files"
+            data-cy="download-case-files"><a class="govuk-link" href="/documents/1/bulk-download/case-APP/Q9999/D/21/351062.zip">Download case</a>
+            </p>
         </div>
-        <div class="govuk-grid-row">
-            <div class="govuk-grid-column-full">
-                <p class="govuk-body govuk-!-margin-bottom-6" id="download-case-files"
-                data-cy="download-case-files"><a class="govuk-link" href="/documents/1/bulk-download/case-APP/Q9999/D/21/351062.zip">Download case</a>
-                </p>
-            </div>
-        </div>
-        <div class="govuk-grid-row">
-            <div class="govuk-grid-column-full">
-                <details class="govuk-details">
-                    <summary class="govuk-details__summary"><span class="govuk-details__summary-text"> 2 case notes</span>
-                    </summary>
-                    <div class="govuk-details__text">
-                        <form method="POST" novalidate="novalidate">
-                            <div class="govuk-grid-row">
-                                <div class="govuk-grid-column-two-thirds">
-                                    <div class="govuk-form-group govuk-character-count" data-module="govuk-character-count"
-                                    data-maxlength="500">
-                                        <textarea class="govuk-textarea govuk-js-character-count" id="comment"
-                                        name="comment" rows="5" aria-describedby="comment-info"></textarea>
-                                        <div id="comment-info" class="govuk-hint govuk-character-count__message">You can enter up to 500 characters</div>
-                                    </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
+            <details class="govuk-details">
+                <summary class="govuk-details__summary"><span class="govuk-details__summary-text"> 2 case notes</span>
+                </summary>
+                <div class="govuk-details__text">
+                    <form method="POST" novalidate="novalidate">
+                        <div class="govuk-grid-row">
+                            <div class="govuk-grid-column-two-thirds">
+                                <div class="govuk-form-group govuk-character-count" data-module="govuk-character-count"
+                                data-maxlength="500">
+                                    <textarea class="govuk-textarea govuk-js-character-count" id="comment"
+                                    name="comment" rows="5" aria-describedby="comment-info"></textarea>
+                                    <div id="comment-info" class="govuk-hint govuk-character-count__message">You can enter up to 500 characters</div>
                                 </div>
                             </div>
-                            <button type="submit" data-prevent-double-click="true" class="govuk-button govuk-button--secondary govuk-!-margin-bottom-1"
-                            data-module="govuk-button">Add case note</button>
-                        </form>
-                        <div>
+                        </div>
+                        <button type="submit" data-prevent-double-click="true" class="govuk-button govuk-button--secondary govuk-!-margin-bottom-1"
+                        data-module="govuk-button">Add case note</button>
+                    </form>
+                    <div>
+                        <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+                        <section>
+                            <p class="govuk-body govuk-!-margin-bottom-1">A case note you should see.</p>
+                            <p class="govuk-hint govuk-!-margin-bottom-6">11:00am on Tuesday 1 October 2024 by John.Smith</p>
                             <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
-                            <section>
-                                <p class="govuk-body govuk-!-margin-bottom-1">A case note you should see.</p>
-                                <p class="govuk-hint govuk-!-margin-bottom-6">11:00am on Tuesday 1 October 2024 by John.Smith</p>
-                                <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
-                            </section>
-                            <section>
-                                <p class="govuk-body govuk-!-margin-bottom-1">A case note you should see.</p>
-                                <p class="govuk-hint govuk-!-margin-bottom-6">11:00am on Tuesday 1 October 2024 by John.Smith</p>
-                                <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
-                            </section>
-                        </div>
+                        </section>
+                        <section>
+                            <p class="govuk-body govuk-!-margin-bottom-1">A case note you should see.</p>
+                            <p class="govuk-hint govuk-!-margin-bottom-6">11:00am on Tuesday 1 October 2024 by John.Smith</p>
+                            <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+                        </section>
                     </div>
-                </details>
-            </div>
+                </div>
+            </details>
         </div>
-        <div class="govuk-grid-row">
-            <div class="govuk-grid-column-full">
-                <div class="govuk-accordion" data-module="govuk-accordion" id="accordion-default1">
-                    <div class="govuk-accordion__section">
-                        <div class="govuk-accordion__section-header">
-                            <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-1"> Overview</span></h2>
-                        </div>
-                        <div id="accordion-default1-content-1" class="govuk-accordion__section-content">
-                            <dl class="govuk-summary-list">
-                                <div class="govuk-summary-list__row govuk-summary-list__row--no-actions appeal-lpa-reference"><dt class="govuk-summary-list__key"> Planning application reference</dt>
-                                    <dd                                     class="govuk-summary-list__value">48269/APP/2021/1482</dd>
-                                </div>
-                                <div class="govuk-summary-list__row appeal-appeal-type"><dt class="govuk-summary-list__key"> Appeal type</dt>
-                                    <dd class="govuk-summary-list__value">Householder</dd>
-                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/change-appeal-type/appeal-type"
-                                        data-cy="change-appeal-type">Change<span class="govuk-visually-hidden"> Appeal type</span></a>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
+            <div class="govuk-accordion" data-module="govuk-accordion" id="accordion-default1">
+                <div class="govuk-accordion__section">
+                    <div class="govuk-accordion__section-header">
+                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-1"> Overview</span></h2>
+                    </div>
+                    <div id="accordion-default1-content-1" class="govuk-accordion__section-content">
+                        <dl class="govuk-summary-list">
+                            <div class="govuk-summary-list__row govuk-summary-list__row--no-actions appeal-lpa-reference"><dt class="govuk-summary-list__key"> Planning application reference</dt>
+                                <dd                                 class="govuk-summary-list__value">48269/APP/2021/1482</dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-appeal-type"><dt class="govuk-summary-list__key"> Appeal type</dt>
+                                <dd class="govuk-summary-list__value">Householder</dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/change-appeal-type/appeal-type"
+                                    data-cy="change-appeal-type">Change<span class="govuk-visually-hidden"> Appeal type</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row govuk-summary-list__row--no-actions appeal-case-procedure"><dt class="govuk-summary-list__key"> Appeal procedure</dt>
+                                <dd class="govuk-summary-list__value">Written</dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-allocation-details"><dt class="govuk-summary-list__key"> Allocation level</dt>
+                                <dd class="govuk-summary-list__value">
+                                    <ul class="govuk-!-margin-0">
+                                        <li>Level: A</li>
+                                        <li>Historic heritage</li>
+                                        <li>Architecture design</li>
+                                    </ul>
+                                </dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/allocation-details/allocation-level"
+                                    data-cy="change-allocation-details">Change<span class="govuk-visually-hidden"> Allocation level</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-linked-appeals"><dt class="govuk-summary-list__key"> Linked appeals</dt>
+                                <dd class="govuk-summary-list__value">
+                                    <ul class="govuk-list govuk-list--bullet">
+                                        <li><a href="/appeals-service/appeal-details/5449" class="govuk-link" data-cy="linked-appeal-784706"
+                                            aria-label="Appeal 7 8 4 7 0 6">784706</a> (Child)</li>
+                                        <li><span class="govuk-body">87326527</span> (Child)</li>
+                                        <li><a href="/appeals-service/appeal-details/5464" class="govuk-link" data-cy="linked-appeal-140079"
+                                            aria-label="Appeal 1 4 0 0 7 9">140079</a> (Lead)</li>
+                                        <li><a href="/appeals-service/appeal-details/5451" class="govuk-link" data-cy="linked-appeal-721086"
+                                            aria-label="Appeal 7 2 1 0 8 6">721086</a> (Child)</li>
+                                    </ul>
+                                </dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/linked-appeals/manage"
+                                    data-cy="manage-linked-appeals">Manage<span class="govuk-visually-hidden"> Linked appeals</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-other-appeals"><dt class="govuk-summary-list__key"> Related appeals</dt>
+                                <dd class="govuk-summary-list__value"><span>No</span>
+                                </dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/other-appeals/add"
+                                    data-cy="add-related-appeals">Add<span class="govuk-visually-hidden"> Related appeals</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-decision"><dt class="govuk-summary-list__key"> Decision</dt>
+                                <dd class="govuk-summary-list__value">Dismissed</dd>
+                            </div>
+                        </dl>
+                    </div>
+                </div>
+                <div class="govuk-accordion__section">
+                    <div class="govuk-accordion__section-header">
+                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-2"> Site</span></h2>
+                    </div>
+                    <div id="accordion-default1-content-2" class="govuk-accordion__section-content">
+                        <dl class="govuk-summary-list">
+                            <div class="govuk-summary-list__row appeal-visit-type"><dt class="govuk-summary-list__key"> Visit type</dt>
+                                <dd class="govuk-summary-list__value">Accompanied</dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/visit-booked?backUrl=%2Fappeals-service%2Fappeal-details%2F1"
+                                    data-cy="change-set-visit-type">Change<span class="govuk-visually-hidden"> Visit type</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Date</dt>
+                                <dd class="govuk-summary-list__value">9 October 2023</dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/visit-booked"
+                                    data-cy="change-site-visit-date">Change<span class="govuk-visually-hidden"> Date</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Start time</dt>
+                                <dd class="govuk-summary-list__value">9:38am</dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/visit-booked"
+                                    data-cy="change-site-visit-start-time">Change<span class="govuk-visually-hidden"> Start time</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> End time</dt>
+                                <dd class="govuk-summary-list__value">10:00am</dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/visit-booked"
+                                    data-cy="change-site-visit-end-time">Change<span class="govuk-visually-hidden"> End time</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-neighbouring-sites-inspector"><dt class="govuk-summary-list__key"> Interested party and neighbour addresses</dt>
+                                <dd                                 class="govuk-summary-list__value">
+                                    <ul class="govuk-list govuk-list--bullet">
+                                        <li>2 Grove Cottage, Shotesham Road, Woodton, Devon, NR35 2ND</li>
+                                    </ul>
                                     </dd>
-                                </div>
-                                <div class="govuk-summary-list__row govuk-summary-list__row--no-actions appeal-case-procedure"><dt class="govuk-summary-list__key"> Appeal procedure</dt>
-                                    <dd class="govuk-summary-list__value">Written</dd>
-                                </div>
-                                <div class="govuk-summary-list__row appeal-allocation-details"><dt class="govuk-summary-list__key"> Allocation level</dt>
-                                    <dd class="govuk-summary-list__value">
-                                        <ul class="govuk-!-margin-0">
-                                            <li>Level: A</li>
-                                            <li>Historic heritage</li>
-                                            <li>Architecture design</li>
+                                    <dd class="govuk-summary-list__actions">
+                                        <ul class="govuk-summary-list__actions-list">
+                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/neighbouring-sites/manage"
+                                                data-cy="manage-neighbouring-sites-inspector">Manage<span class="govuk-visually-hidden"> Interested party and neighbour addresses</span></a>
+                                            </li>
+                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/neighbouring-sites/add/back-office"
+                                                data-cy="add-neighbouring-sites-inspector">Add<span class="govuk-visually-hidden"> Interested party and neighbour addresses</span></a>
+                                            </li>
                                         </ul>
                                     </dd>
-                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/allocation-details/allocation-level"
-                                        data-cy="change-allocation-details">Change<span class="govuk-visually-hidden"> Allocation level</span></a>
-                                    </dd>
-                                </div>
-                                <div class="govuk-summary-list__row appeal-linked-appeals"><dt class="govuk-summary-list__key"> Linked appeals</dt>
-                                    <dd class="govuk-summary-list__value">
-                                        <ul class="govuk-list govuk-list--bullet">
-                                            <li><a href="/appeals-service/appeal-details/5449" class="govuk-link" data-cy="linked-appeal-784706"
-                                                aria-label="Appeal 7 8 4 7 0 6">784706</a> (Child)</li>
-                                            <li><span class="govuk-body">87326527</span> (Child)</li>
-                                            <li><a href="/appeals-service/appeal-details/5464" class="govuk-link" data-cy="linked-appeal-140079"
-                                                aria-label="Appeal 1 4 0 0 7 9">140079</a> (Lead)</li>
-                                            <li><a href="/appeals-service/appeal-details/5451" class="govuk-link" data-cy="linked-appeal-721086"
-                                                aria-label="Appeal 7 2 1 0 8 6">721086</a> (Child)</li>
+                            </div>
+                        </dl>
+                    </div>
+                </div>
+                <div class="govuk-accordion__section">
+                    <div class="govuk-accordion__section-header">
+                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-3"> Timetable</span></h2>
+                    </div>
+                    <div id="accordion-default1-content-3" class="govuk-accordion__section-content">
+                        <dl class="govuk-summary-list appeal-case-timetable">
+                            <div class="govuk-summary-list__row appeal-valid-date"><dt class="govuk-summary-list__key"> Valid date</dt>
+                                <dd class="govuk-summary-list__value">23 May 2023</dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/valid/date"
+                                    data-cy="-valid-date"><span class="govuk-visually-hidden"> Valid date</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-start-date"><dt class="govuk-summary-list__key"> Start date</dt>
+                                <dd class="govuk-summary-list__value">23 May 2023</dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/start-case/change"
+                                    data-cy="change-start-case-date">Change<span class="govuk-visually-hidden"> Start date</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-lpa-questionnaire-due-date"><dt class="govuk-summary-list__key"> LPA questionnaire due</dt>
+                                <dd class="govuk-summary-list__value">11 October 2023</dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-site-visit"><dt class="govuk-summary-list__key"> Site visit</dt>
+                                <dd class="govuk-summary-list__value">
+                                    <ul class="govuk-list govuk-!-margin-top-0 govuk-!-padding-left-0">
+                                        <li>9 October 2023</li>
+                                        <li>9:38am - 10:00am</li>
+                                    </ul>
+                                </dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/manage-visit?backUrl=%2Fappeals-service%2Fappeal-details%2F1"
+                                    data-cy="change-schedule-visit">Change<span class="govuk-visually-hidden"> Site visit</span></a>
+                                </dd>
+                            </div>
+                        </dl>
+                    </div>
+                </div>
+                <div class="govuk-accordion__section">
+                    <div class="govuk-accordion__section-header">
+                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-4"> Documentation</span></h2>
+                    </div>
+                    <div id="accordion-default1-content-4" class="govuk-accordion__section-content">
+                        <table class="govuk-table">
+                            <thead class="govuk-table__head">
+                                <tr class="govuk-table__row">
+                                    <th scope="col" class="govuk-table__header">Documentation</th>
+                                    <th scope="col" class="govuk-table__header">Status</th>
+                                    <th scope="col" class="govuk-table__header">Received</th>
+                                    <th scope="col" class="govuk-table__header govuk-!-text-align-right">Action</th>
+                                </tr>
+                            </thead>
+                            <tbody class="govuk-table__body">
+                                <tr class="govuk-table__row">
+                                    <th scope="row" class="govuk-table__header">Appeal</th>
+                                    <td class="govuk-table__cell">Ready to review</td>
+                                    <td class="govuk-table__cell">2 August 2024</td>
+                                    <td class="govuk-table__cell govuk-!-text-align-right"><a href="/appeals-service/appeal-details/1/appellant-case?backUrl=%2Fappeals-service%2Fappeal-details%2F1"
+                                        data-cy="review-appellant-case" class="govuk-link">Review<span class="govuk-visually-hidden"> appellant case</span></a>
+                                    </td>
+                                </tr>
+                                <tr class="govuk-table__row">
+                                    <th scope="row" class="govuk-table__header">LPA questionnaire</th>
+                                    <td class="govuk-table__cell">Overdue</td>
+                                    <td class="govuk-table__cell">Due by 11 October 2023</td>
+                                    <td class="govuk-table__cell govuk-!-text-align-right"></td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
+                <div class="govuk-accordion__section">
+                    <div class="govuk-accordion__section-header">
+                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-5"> Costs</span></h2>
+                    </div>
+                    <div id="accordion-default1-content-5" class="govuk-accordion__section-content">
+                        <table class="govuk-table">
+                            <thead class="govuk-table__head">
+                                <tr class="govuk-table__row">
+                                    <th scope="col" class="govuk-table__header">Documentation</th>
+                                    <th scope="col" class="govuk-table__header">Status</th>
+                                    <th scope="col" class="govuk-table__header govuk-!-text-align-right">Action</th>
+                                </tr>
+                            </thead>
+                            <tbody class="govuk-table__body">
+                                <tr class="govuk-table__row">
+                                    <th scope="row" class="govuk-table__header appeal-costs-appellant-application-documentation">Appellant application</th>
+                                    <td class="govuk-table__cell appeal-costs-appellant-application-status">No documents available</td>
+                                    <td class="govuk-table__cell appeal-costs-appellant-application-actions govuk-!-text-align-right">
+                                        <ul class="govuk-summary-list__actions-list">
+                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-appellant-application" href="/appeals-service/appeal-details/1/costs/appellant/application/upload-documents/1">Add<span class="govuk-visually-hidden"> Appellant application</span></a>
+                                            </li>
                                         </ul>
-                                    </dd>
-                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/linked-appeals/manage"
-                                        data-cy="manage-linked-appeals">Manage<span class="govuk-visually-hidden"> Linked appeals</span></a>
-                                    </dd>
-                                </div>
-                                <div class="govuk-summary-list__row appeal-other-appeals"><dt class="govuk-summary-list__key"> Related appeals</dt>
-                                    <dd class="govuk-summary-list__value"><span>No</span>
-                                    </dd>
-                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/other-appeals/add"
-                                        data-cy="add-related-appeals">Add<span class="govuk-visually-hidden"> Related appeals</span></a>
-                                    </dd>
-                                </div>
-                                <div class="govuk-summary-list__row appeal-decision"><dt class="govuk-summary-list__key"> Decision</dt>
-                                    <dd class="govuk-summary-list__value">Dismissed</dd>
-                                </div>
-                            </dl>
-                        </div>
-                    </div>
-                    <div class="govuk-accordion__section">
-                        <div class="govuk-accordion__section-header">
-                            <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-2"> Site</span></h2>
-                        </div>
-                        <div id="accordion-default1-content-2" class="govuk-accordion__section-content">
-                            <dl class="govuk-summary-list">
-                                <div class="govuk-summary-list__row appeal-visit-type"><dt class="govuk-summary-list__key"> Visit type</dt>
-                                    <dd class="govuk-summary-list__value">Accompanied</dd>
-                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/visit-booked?backUrl=%2Fappeals-service%2Fappeal-details%2F1"
-                                        data-cy="change-set-visit-type">Change<span class="govuk-visually-hidden"> Visit type</span></a>
-                                    </dd>
-                                </div>
-                                <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Date</dt>
-                                    <dd class="govuk-summary-list__value">9 October 2023</dd>
-                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/visit-booked"
-                                        data-cy="change-site-visit-date">Change<span class="govuk-visually-hidden"> Date</span></a>
-                                    </dd>
-                                </div>
-                                <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Start time</dt>
-                                    <dd class="govuk-summary-list__value">9:38am</dd>
-                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/visit-booked"
-                                        data-cy="change-site-visit-start-time">Change<span class="govuk-visually-hidden"> Start time</span></a>
-                                    </dd>
-                                </div>
-                                <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> End time</dt>
-                                    <dd class="govuk-summary-list__value">10:00am</dd>
-                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/visit-booked"
-                                        data-cy="change-site-visit-end-time">Change<span class="govuk-visually-hidden"> End time</span></a>
-                                    </dd>
-                                </div>
-                                <div class="govuk-summary-list__row appeal-neighbouring-sites-inspector"><dt class="govuk-summary-list__key"> Interested party and neighbour addresses</dt>
-                                    <dd                                     class="govuk-summary-list__value">
-                                        <ul class="govuk-list govuk-list--bullet">
-                                            <li>2 Grove Cottage, Shotesham Road, Woodton, Devon, NR35 2ND</li>
+                                    </td>
+                                </tr>
+                                <tr class="govuk-table__row">
+                                    <th scope="row" class="govuk-table__header appeal-costs-appellant-withdrawal-documentation">Appellant withdrawal</th>
+                                    <td class="govuk-table__cell appeal-costs-appellant-withdrawal-status">No documents available</td>
+                                    <td class="govuk-table__cell appeal-costs-appellant-withdrawal-actions govuk-!-text-align-right">
+                                        <ul class="govuk-summary-list__actions-list">
+                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-appellant-withdrawal" href="/appeals-service/appeal-details/1/costs/appellant/withdrawal/upload-documents/2">Add<span class="govuk-visually-hidden"> Appellant withdrawal</span></a>
+                                            </li>
                                         </ul>
-                                        </dd>
-                                        <dd class="govuk-summary-list__actions">
-                                            <ul class="govuk-summary-list__actions-list">
-                                                <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/neighbouring-sites/manage"
-                                                    data-cy="manage-neighbouring-sites-inspector">Manage<span class="govuk-visually-hidden"> Interested party and neighbour addresses</span></a>
-                                                </li>
-                                                <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/neighbouring-sites/add/back-office"
-                                                    data-cy="add-neighbouring-sites-inspector">Add<span class="govuk-visually-hidden"> Interested party and neighbour addresses</span></a>
-                                                </li>
-                                            </ul>
-                                        </dd>
-                                </div>
-                            </dl>
-                        </div>
-                    </div>
-                    <div class="govuk-accordion__section">
-                        <div class="govuk-accordion__section-header">
-                            <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-3"> Timetable</span></h2>
-                        </div>
-                        <div id="accordion-default1-content-3" class="govuk-accordion__section-content">
-                            <dl class="govuk-summary-list appeal-case-timetable">
-                                <div class="govuk-summary-list__row appeal-valid-date"><dt class="govuk-summary-list__key"> Valid date</dt>
-                                    <dd class="govuk-summary-list__value">23 May 2023</dd>
-                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/valid/date"
-                                        data-cy="-valid-date"><span class="govuk-visually-hidden"> Valid date</span></a>
-                                    </dd>
-                                </div>
-                                <div class="govuk-summary-list__row appeal-start-date"><dt class="govuk-summary-list__key"> Start date</dt>
-                                    <dd class="govuk-summary-list__value">23 May 2023</dd>
-                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/start-case/change"
-                                        data-cy="change-start-case-date">Change<span class="govuk-visually-hidden"> Start date</span></a>
-                                    </dd>
-                                </div>
-                                <div class="govuk-summary-list__row appeal-lpa-questionnaire-due-date"><dt class="govuk-summary-list__key"> LPA questionnaire due</dt>
-                                    <dd class="govuk-summary-list__value">11 October 2023</dd>
-                                </div>
-                                <div class="govuk-summary-list__row appeal-site-visit"><dt class="govuk-summary-list__key"> Site visit</dt>
-                                    <dd class="govuk-summary-list__value">
-                                        <ul class="govuk-list govuk-!-margin-top-0 govuk-!-padding-left-0">
-                                            <li>9 October 2023</li>
-                                            <li>9:38am - 10:00am</li>
+                                    </td>
+                                </tr>
+                                <tr class="govuk-table__row">
+                                    <th scope="row" class="govuk-table__header appeal-costs-appellant-correspondence-documentation">Appellant correspondence</th>
+                                    <td class="govuk-table__cell appeal-costs-appellant-correspondence-status">No documents available</td>
+                                    <td class="govuk-table__cell appeal-costs-appellant-correspondence-actions govuk-!-text-align-right">
+                                        <ul class="govuk-summary-list__actions-list">
+                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-appellant-correspondence" href="/appeals-service/appeal-details/1/costs/appellant/correspondence/upload-documents/3">Add<span class="govuk-visually-hidden"> Appellant correspondence</span></a>
+                                            </li>
                                         </ul>
-                                    </dd>
-                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/manage-visit?backUrl=%2Fappeals-service%2Fappeal-details%2F1"
-                                        data-cy="change-schedule-visit">Change<span class="govuk-visually-hidden"> Site visit</span></a>
-                                    </dd>
-                                </div>
-                            </dl>
-                        </div>
-                    </div>
-                    <div class="govuk-accordion__section">
-                        <div class="govuk-accordion__section-header">
-                            <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-4"> Documentation</span></h2>
-                        </div>
-                        <div id="accordion-default1-content-4" class="govuk-accordion__section-content">
-                            <table class="govuk-table">
-                                <thead class="govuk-table__head">
-                                    <tr class="govuk-table__row">
-                                        <th scope="col" class="govuk-table__header">Documentation</th>
-                                        <th scope="col" class="govuk-table__header">Status</th>
-                                        <th scope="col" class="govuk-table__header">Received</th>
-                                        <th scope="col" class="govuk-table__header govuk-!-text-align-right">Action</th>
-                                    </tr>
-                                </thead>
-                                <tbody class="govuk-table__body">
-                                    <tr class="govuk-table__row">
-                                        <th scope="row" class="govuk-table__header">Appeal</th>
-                                        <td class="govuk-table__cell">Ready to review</td>
-                                        <td class="govuk-table__cell">2 August 2024</td>
-                                        <td class="govuk-table__cell govuk-!-text-align-right"><a href="/appeals-service/appeal-details/1/appellant-case?backUrl=%2Fappeals-service%2Fappeal-details%2F1"
-                                            data-cy="review-appellant-case" class="govuk-link">Review<span class="govuk-visually-hidden"> appellant case</span></a>
-                                        </td>
-                                    </tr>
-                                    <tr class="govuk-table__row">
-                                        <th scope="row" class="govuk-table__header">LPA questionnaire</th>
-                                        <td class="govuk-table__cell">Overdue</td>
-                                        <td class="govuk-table__cell">Due by 11 October 2023</td>
-                                        <td class="govuk-table__cell govuk-!-text-align-right"></td>
-                                    </tr>
-                                </tbody>
-                            </table>
-                        </div>
-                    </div>
-                    <div class="govuk-accordion__section">
-                        <div class="govuk-accordion__section-header">
-                            <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-5"> Costs</span></h2>
-                        </div>
-                        <div id="accordion-default1-content-5" class="govuk-accordion__section-content">
-                            <table class="govuk-table">
-                                <thead class="govuk-table__head">
-                                    <tr class="govuk-table__row">
-                                        <th scope="col" class="govuk-table__header">Documentation</th>
-                                        <th scope="col" class="govuk-table__header">Status</th>
-                                        <th scope="col" class="govuk-table__header govuk-!-text-align-right">Action</th>
-                                    </tr>
-                                </thead>
-                                <tbody class="govuk-table__body">
-                                    <tr class="govuk-table__row">
-                                        <th scope="row" class="govuk-table__header appeal-costs-appellant-application-documentation">Appellant application</th>
-                                        <td class="govuk-table__cell appeal-costs-appellant-application-status">No documents available</td>
-                                        <td class="govuk-table__cell appeal-costs-appellant-application-actions govuk-!-text-align-right">
-                                            <ul class="govuk-summary-list__actions-list">
-                                                <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-appellant-application" href="/appeals-service/appeal-details/1/costs/appellant/application/upload-documents/1">Add<span class="govuk-visually-hidden"> Appellant application</span></a>
-                                                </li>
-                                            </ul>
-                                        </td>
-                                    </tr>
-                                    <tr class="govuk-table__row">
-                                        <th scope="row" class="govuk-table__header appeal-costs-appellant-withdrawal-documentation">Appellant withdrawal</th>
-                                        <td class="govuk-table__cell appeal-costs-appellant-withdrawal-status">No documents available</td>
-                                        <td class="govuk-table__cell appeal-costs-appellant-withdrawal-actions govuk-!-text-align-right">
-                                            <ul class="govuk-summary-list__actions-list">
-                                                <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-appellant-withdrawal" href="/appeals-service/appeal-details/1/costs/appellant/withdrawal/upload-documents/2">Add<span class="govuk-visually-hidden"> Appellant withdrawal</span></a>
-                                                </li>
-                                            </ul>
-                                        </td>
-                                    </tr>
-                                    <tr class="govuk-table__row">
-                                        <th scope="row" class="govuk-table__header appeal-costs-appellant-correspondence-documentation">Appellant correspondence</th>
-                                        <td class="govuk-table__cell appeal-costs-appellant-correspondence-status">No documents available</td>
-                                        <td class="govuk-table__cell appeal-costs-appellant-correspondence-actions govuk-!-text-align-right">
-                                            <ul class="govuk-summary-list__actions-list">
-                                                <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-appellant-correspondence" href="/appeals-service/appeal-details/1/costs/appellant/correspondence/upload-documents/3">Add<span class="govuk-visually-hidden"> Appellant correspondence</span></a>
-                                                </li>
-                                            </ul>
-                                        </td>
-                                    </tr>
-                                    <tr class="govuk-table__row">
-                                        <th scope="row" class="govuk-table__header appeal-costs-lpa-application-documentation">LPA application</th>
-                                        <td class="govuk-table__cell appeal-costs-lpa-application-status">No documents available</td>
-                                        <td class="govuk-table__cell appeal-costs-lpa-application-actions govuk-!-text-align-right">
-                                            <ul class="govuk-summary-list__actions-list">
-                                                <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-lpa-application" href="/appeals-service/appeal-details/1/costs/lpa/application/upload-documents/4">Add<span class="govuk-visually-hidden"> LPA application</span></a>
-                                                </li>
-                                            </ul>
-                                        </td>
-                                    </tr>
-                                    <tr class="govuk-table__row">
-                                        <th scope="row" class="govuk-table__header appeal-costs-lpa-withdrawal-documentation">LPA withdrawal</th>
-                                        <td class="govuk-table__cell appeal-costs-lpa-withdrawal-status">No documents available</td>
-                                        <td class="govuk-table__cell appeal-costs-lpa-withdrawal-actions govuk-!-text-align-right">
-                                            <ul class="govuk-summary-list__actions-list">
-                                                <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-lpa-withdrawal" href="/appeals-service/appeal-details/1/costs/lpa/withdrawal/upload-documents/5">Add<span class="govuk-visually-hidden"> LPA withdrawal</span></a>
-                                                </li>
-                                            </ul>
-                                        </td>
-                                    </tr>
-                                    <tr class="govuk-table__row">
-                                        <th scope="row" class="govuk-table__header appeal-costs-lpa-correspondence-documentation">LPA correspondence</th>
-                                        <td class="govuk-table__cell appeal-costs-lpa-correspondence-status">No documents available</td>
-                                        <td class="govuk-table__cell appeal-costs-lpa-correspondence-actions govuk-!-text-align-right">
-                                            <ul class="govuk-summary-list__actions-list">
-                                                <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-lpa-correspondence" href="/appeals-service/appeal-details/1/costs/lpa/correspondence/upload-documents/6">Add<span class="govuk-visually-hidden"> LPA correspondence</span></a>
-                                                </li>
-                                            </ul>
-                                        </td>
-                                    </tr>
-                                </tbody>
-                            </table>
-                        </div>
-                    </div>
-                    <div class="govuk-accordion__section">
-                        <div class="govuk-accordion__section-header">
-                            <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-6"> Contacts</span></h2>
-                        </div>
-                        <div id="accordion-default1-content-6" class="govuk-accordion__section-content">
-                            <dl class="govuk-summary-list">
-                                <div class="govuk-summary-list__row appeal-appellant"><dt class="govuk-summary-list__key"> Appellant</dt>
-                                    <dd class="govuk-summary-list__value">
-                                        <ul class="govuk-list">
-                                            <li>Roger Simmons</li>
-                                            <li>test3@example.com</li>
+                                    </td>
+                                </tr>
+                                <tr class="govuk-table__row">
+                                    <th scope="row" class="govuk-table__header appeal-costs-lpa-application-documentation">LPA application</th>
+                                    <td class="govuk-table__cell appeal-costs-lpa-application-status">No documents available</td>
+                                    <td class="govuk-table__cell appeal-costs-lpa-application-actions govuk-!-text-align-right">
+                                        <ul class="govuk-summary-list__actions-list">
+                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-lpa-application" href="/appeals-service/appeal-details/1/costs/lpa/application/upload-documents/4">Add<span class="govuk-visually-hidden"> LPA application</span></a>
+                                            </li>
                                         </ul>
-                                    </dd>
-                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/service-user/change/appellant"
-                                        data-cy="change-appellant">Change<span class="govuk-visually-hidden"> Appellant</span></a>
-                                    </dd>
-                                </div>
-                                <div class="govuk-summary-list__row appeal-agent"><dt class="govuk-summary-list__key"> Agent</dt>
-                                    <dd class="govuk-summary-list__value">
-                                        <ul class="govuk-list">
-                                            <li>Fiona Shell</li>
-                                            <li>test2@example.com</li>
+                                    </td>
+                                </tr>
+                                <tr class="govuk-table__row">
+                                    <th scope="row" class="govuk-table__header appeal-costs-lpa-withdrawal-documentation">LPA withdrawal</th>
+                                    <td class="govuk-table__cell appeal-costs-lpa-withdrawal-status">No documents available</td>
+                                    <td class="govuk-table__cell appeal-costs-lpa-withdrawal-actions govuk-!-text-align-right">
+                                        <ul class="govuk-summary-list__actions-list">
+                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-lpa-withdrawal" href="/appeals-service/appeal-details/1/costs/lpa/withdrawal/upload-documents/5">Add<span class="govuk-visually-hidden"> LPA withdrawal</span></a>
+                                            </li>
                                         </ul>
-                                    </dd>
-                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/service-user/change/agent"
-                                        data-cy="change-agent">Change<span class="govuk-visually-hidden"> Agent</span></a>
-                                    </dd>
-                                </div>
-                                <div class="govuk-summary-list__row appeal-lpa-contact-details"><dt class="govuk-summary-list__key"> LPA</dt>
-                                    <dd class="govuk-summary-list__value">
-                                        <ul class="govuk-list">
-                                            <li>Wiltshire Council</li>
-                                            <li>wilt@lpa-email.gov.uk</li>
+                                    </td>
+                                </tr>
+                                <tr class="govuk-table__row">
+                                    <th scope="row" class="govuk-table__header appeal-costs-lpa-correspondence-documentation">LPA correspondence</th>
+                                    <td class="govuk-table__cell appeal-costs-lpa-correspondence-status">No documents available</td>
+                                    <td class="govuk-table__cell appeal-costs-lpa-correspondence-actions govuk-!-text-align-right">
+                                        <ul class="govuk-summary-list__actions-list">
+                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-lpa-correspondence" href="/appeals-service/appeal-details/1/costs/lpa/correspondence/upload-documents/6">Add<span class="govuk-visually-hidden"> LPA correspondence</span></a>
+                                            </li>
                                         </ul>
-                                    </dd>
-                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/change-appeal-details/local-planning-authority"
-                                        data-cy="change-lpa-contact-details">Change<span class="govuk-visually-hidden"> Local planning authority (LPA)</span></a>
-                                    </dd>
-                                </div>
-                            </dl>
-                        </div>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
                     </div>
-                    <div class="govuk-accordion__section">
-                        <div class="govuk-accordion__section-header">
-                            <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-7"> Team</span></h2>
-                        </div>
-                        <div id="accordion-default1-content-7" class="govuk-accordion__section-content">
-                            <dl class="govuk-summary-list">
-                                <div class="govuk-summary-list__row appeal-case-officer"><dt class="govuk-summary-list__key"> Case officer</dt>
-                                    <dd class="govuk-summary-list__value">
-                                        <p class="govuk-body">Not assigned</p>
-                                    </dd>
-                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/assign-user/case-officer"
-                                        data-cy="assign-case-officer">Assign<span class="govuk-visually-hidden"> Case officer</span></a>
-                                    </dd>
-                                </div>
-                                <div class="govuk-summary-list__row appeal-inspector"><dt class="govuk-summary-list__key"> Inspector</dt>
-                                    <dd class="govuk-summary-list__value">
-                                        <p class="govuk-body">Not assigned</p>
-                                    </dd>
-                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/assign-user/inspector"
-                                        data-cy="assign-inspector">Assign<span class="govuk-visually-hidden"> Inspector</span></a>
-                                    </dd>
-                                </div>
-                            </dl>
-                        </div>
+                </div>
+                <div class="govuk-accordion__section">
+                    <div class="govuk-accordion__section-header">
+                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-6"> Contacts</span></h2>
                     </div>
-                    <div class="govuk-accordion__section">
-                        <div class="govuk-accordion__section-header">
-                            <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-8"> Case management</span></h2>
-                        </div>
-                        <div id="accordion-default1-content-8" class="govuk-accordion__section-content">
-                            <dl class="govuk-summary-list">
-                                <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Cross-team correspondence</dt>
-                                    <dd                                     class="govuk-summary-list__value">No documents</dd>
-                                        <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/internal-correspondence/cross-team/upload-documents/10"
-                                            data-cy="add-cross-team-correspondence">Add<span class="govuk-visually-hidden"> Cross-team correspondence</span></a>
-                                        </dd>
-                                </div>
-                                <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Inspector correspondence</dt>
-                                    <dd                                     class="govuk-summary-list__value">No documents</dd>
-                                        <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/internal-correspondence/inspector/upload-documents/11"
-                                            data-cy="add-inspector-correspondence">Add<span class="govuk-visually-hidden"> Inspector correspondence</span></a>
-                                        </dd>
-                                </div>
-                                <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Main party correspondence</dt>
-                                    <dd                                     class="govuk-summary-list__value">No documents</dd>
-                                        <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/internal-correspondence/main-party/upload-documents/22"
-                                            data-cy="add-main-party-correspondence">Add<span class="govuk-visually-hidden"> Main party correspondence</span></a>
-                                        </dd>
-                                </div>
-                                <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Case history</dt>
-                                    <dd class="govuk-summary-list__value"></dd>
-                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/audit" data-cy="view-case-history">View<span class="govuk-visually-hidden"> Case history</span></a>
+                    <div id="accordion-default1-content-6" class="govuk-accordion__section-content">
+                        <dl class="govuk-summary-list">
+                            <div class="govuk-summary-list__row appeal-appellant"><dt class="govuk-summary-list__key"> Appellant</dt>
+                                <dd class="govuk-summary-list__value">
+                                    <ul class="govuk-list">
+                                        <li>Roger Simmons</li>
+                                        <li>test3@example.com</li>
+                                    </ul>
+                                </dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/service-user/change/appellant"
+                                    data-cy="change-appellant">Change<span class="govuk-visually-hidden"> Appellant</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-agent"><dt class="govuk-summary-list__key"> Agent</dt>
+                                <dd class="govuk-summary-list__value">
+                                    <ul class="govuk-list">
+                                        <li>Fiona Shell</li>
+                                        <li>test2@example.com</li>
+                                    </ul>
+                                </dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/service-user/change/agent"
+                                    data-cy="change-agent">Change<span class="govuk-visually-hidden"> Agent</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-lpa-contact-details"><dt class="govuk-summary-list__key"> LPA</dt>
+                                <dd class="govuk-summary-list__value">
+                                    <ul class="govuk-list">
+                                        <li>Wiltshire Council</li>
+                                        <li>wilt@lpa-email.gov.uk</li>
+                                    </ul>
+                                </dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/change-appeal-details/local-planning-authority"
+                                    data-cy="change-lpa-contact-details">Change<span class="govuk-visually-hidden"> Local planning authority (LPA)</span></a>
+                                </dd>
+                            </div>
+                        </dl>
+                    </div>
+                </div>
+                <div class="govuk-accordion__section">
+                    <div class="govuk-accordion__section-header">
+                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-7"> Team</span></h2>
+                    </div>
+                    <div id="accordion-default1-content-7" class="govuk-accordion__section-content">
+                        <dl class="govuk-summary-list">
+                            <div class="govuk-summary-list__row appeal-case-officer"><dt class="govuk-summary-list__key"> Case officer</dt>
+                                <dd class="govuk-summary-list__value">
+                                    <p class="govuk-body">Not assigned</p>
+                                </dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/assign-user/case-officer"
+                                    data-cy="assign-case-officer">Assign<span class="govuk-visually-hidden"> Case officer</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-inspector"><dt class="govuk-summary-list__key"> Inspector</dt>
+                                <dd class="govuk-summary-list__value">
+                                    <p class="govuk-body">Not assigned</p>
+                                </dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/assign-user/inspector"
+                                    data-cy="assign-inspector">Assign<span class="govuk-visually-hidden"> Inspector</span></a>
+                                </dd>
+                            </div>
+                        </dl>
+                    </div>
+                </div>
+                <div class="govuk-accordion__section">
+                    <div class="govuk-accordion__section-header">
+                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-8"> Case management</span></h2>
+                    </div>
+                    <div id="accordion-default1-content-8" class="govuk-accordion__section-content">
+                        <dl class="govuk-summary-list">
+                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Cross-team correspondence</dt>
+                                <dd                                 class="govuk-summary-list__value">No documents</dd>
+                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/internal-correspondence/cross-team/upload-documents/10"
+                                        data-cy="add-cross-team-correspondence">Add<span class="govuk-visually-hidden"> Cross-team correspondence</span></a>
                                     </dd>
-                                </div>
-                                <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Appeal withdrawal</dt>
-                                    <dd class="govuk-summary-list__value"></dd>
-                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/withdrawal/start"
-                                        data-cy="start-appeal-withdrawal">Start<span class="govuk-visually-hidden"> Appeal withdrawal</span></a>
+                            </div>
+                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Inspector correspondence</dt>
+                                <dd                                 class="govuk-summary-list__value">No documents</dd>
+                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/internal-correspondence/inspector/upload-documents/11"
+                                        data-cy="add-inspector-correspondence">Add<span class="govuk-visually-hidden"> Inspector correspondence</span></a>
                                     </dd>
-                                </div>
-                            </dl>
-                        </div>
+                            </div>
+                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Main party correspondence</dt>
+                                <dd                                 class="govuk-summary-list__value">No documents</dd>
+                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/internal-correspondence/main-party/upload-documents/22"
+                                        data-cy="add-main-party-correspondence">Add<span class="govuk-visually-hidden"> Main party correspondence</span></a>
+                                    </dd>
+                            </div>
+                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Case history</dt>
+                                <dd class="govuk-summary-list__value"></dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/audit" data-cy="view-case-history">View<span class="govuk-visually-hidden"> Case history</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Appeal withdrawal</dt>
+                                <dd class="govuk-summary-list__value"></dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/withdrawal/start"
+                                    data-cy="start-appeal-withdrawal">Start<span class="govuk-visually-hidden"> Appeal withdrawal</span></a>
+                                </dd>
+                            </div>
+                        </dl>
                     </div>
                 </div>
             </div>
         </div>
+    </div>
 </main>"
 `;
 
@@ -5330,10 +5336,11 @@ exports[`appeal-details GET /:appealId should render the lead or child status af
         </div>
     </div>
     <div class="govuk-grid-row">
-        <div class="govuk-grid-column-full"><strong class="govuk-tag govuk-tag--grey govuk-!-margin-bottom-4">Received appeal</strong>
+        <div class="govuk-grid-column-full"><strong class="govuk-tag govuk-tag--grey pins-status-tag--full-width">Received appeal</strong>
+            <strong             class="govuk-tag govuk-tag--grey govuk-!-margin-left-1 govuk-!-margin-bottom-4"></strong>
         </div>
-    </div><strong class="govuk-tag govuk-tag--grey govuk-!-margin-left-1 govuk-!-margin-bottom-4"></strong>
-    <div     class="govuk-grid-row">
+    </div>
+    <div class="govuk-grid-row">
         <div class="govuk-grid-column-full">
             <dl class="govuk-summary-list pins-summary-list--no-border">
                 <div class="govuk-summary-list__row appeal-case-officer"><dt class="govuk-summary-list__key"> Case officer</dt>
@@ -5358,417 +5365,417 @@ exports[`appeal-details GET /:appealId should render the lead or child status af
                 </div>
             </dl>
         </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
+            <p class="govuk-body govuk-!-margin-bottom-6" id="download-case-files"
+            data-cy="download-case-files"><a class="govuk-link" href="/documents/1/bulk-download/case-APP/Q9999/D/21/351062.zip">Download case</a>
+            </p>
         </div>
-        <div class="govuk-grid-row">
-            <div class="govuk-grid-column-full">
-                <p class="govuk-body govuk-!-margin-bottom-6" id="download-case-files"
-                data-cy="download-case-files"><a class="govuk-link" href="/documents/1/bulk-download/case-APP/Q9999/D/21/351062.zip">Download case</a>
-                </p>
-            </div>
-        </div>
-        <div class="govuk-grid-row">
-            <div class="govuk-grid-column-full">
-                <details class="govuk-details">
-                    <summary class="govuk-details__summary"><span class="govuk-details__summary-text"> 2 case notes</span>
-                    </summary>
-                    <div class="govuk-details__text">
-                        <form method="POST" novalidate="novalidate">
-                            <div class="govuk-grid-row">
-                                <div class="govuk-grid-column-two-thirds">
-                                    <div class="govuk-form-group govuk-character-count" data-module="govuk-character-count"
-                                    data-maxlength="500">
-                                        <textarea class="govuk-textarea govuk-js-character-count" id="comment"
-                                        name="comment" rows="5" aria-describedby="comment-info"></textarea>
-                                        <div id="comment-info" class="govuk-hint govuk-character-count__message">You can enter up to 500 characters</div>
-                                    </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
+            <details class="govuk-details">
+                <summary class="govuk-details__summary"><span class="govuk-details__summary-text"> 2 case notes</span>
+                </summary>
+                <div class="govuk-details__text">
+                    <form method="POST" novalidate="novalidate">
+                        <div class="govuk-grid-row">
+                            <div class="govuk-grid-column-two-thirds">
+                                <div class="govuk-form-group govuk-character-count" data-module="govuk-character-count"
+                                data-maxlength="500">
+                                    <textarea class="govuk-textarea govuk-js-character-count" id="comment"
+                                    name="comment" rows="5" aria-describedby="comment-info"></textarea>
+                                    <div id="comment-info" class="govuk-hint govuk-character-count__message">You can enter up to 500 characters</div>
                                 </div>
                             </div>
-                            <button type="submit" data-prevent-double-click="true" class="govuk-button govuk-button--secondary govuk-!-margin-bottom-1"
-                            data-module="govuk-button">Add case note</button>
-                        </form>
-                        <div>
+                        </div>
+                        <button type="submit" data-prevent-double-click="true" class="govuk-button govuk-button--secondary govuk-!-margin-bottom-1"
+                        data-module="govuk-button">Add case note</button>
+                    </form>
+                    <div>
+                        <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+                        <section>
+                            <p class="govuk-body govuk-!-margin-bottom-1">A case note you should see.</p>
+                            <p class="govuk-hint govuk-!-margin-bottom-6">11:00am on Tuesday 1 October 2024 by John.Smith</p>
                             <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
-                            <section>
-                                <p class="govuk-body govuk-!-margin-bottom-1">A case note you should see.</p>
-                                <p class="govuk-hint govuk-!-margin-bottom-6">11:00am on Tuesday 1 October 2024 by John.Smith</p>
-                                <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
-                            </section>
-                            <section>
-                                <p class="govuk-body govuk-!-margin-bottom-1">A case note you should see.</p>
-                                <p class="govuk-hint govuk-!-margin-bottom-6">11:00am on Tuesday 1 October 2024 by John.Smith</p>
-                                <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
-                            </section>
-                        </div>
+                        </section>
+                        <section>
+                            <p class="govuk-body govuk-!-margin-bottom-1">A case note you should see.</p>
+                            <p class="govuk-hint govuk-!-margin-bottom-6">11:00am on Tuesday 1 October 2024 by John.Smith</p>
+                            <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+                        </section>
                     </div>
-                </details>
-            </div>
+                </div>
+            </details>
         </div>
-        <div class="govuk-grid-row">
-            <div class="govuk-grid-column-full">
-                <div class="govuk-accordion" data-module="govuk-accordion" id="accordion-default1">
-                    <div class="govuk-accordion__section">
-                        <div class="govuk-accordion__section-header">
-                            <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-1"> Overview</span></h2>
-                        </div>
-                        <div id="accordion-default1-content-1" class="govuk-accordion__section-content">
-                            <dl class="govuk-summary-list">
-                                <div class="govuk-summary-list__row govuk-summary-list__row--no-actions appeal-lpa-reference"><dt class="govuk-summary-list__key"> Planning application reference</dt>
-                                    <dd                                     class="govuk-summary-list__value">48269/APP/2021/1482</dd>
-                                </div>
-                                <div class="govuk-summary-list__row appeal-appeal-type"><dt class="govuk-summary-list__key"> Appeal type</dt>
-                                    <dd class="govuk-summary-list__value">Householder</dd>
-                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/change-appeal-type/appeal-type"
-                                        data-cy="change-appeal-type">Change<span class="govuk-visually-hidden"> Appeal type</span></a>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
+            <div class="govuk-accordion" data-module="govuk-accordion" id="accordion-default1">
+                <div class="govuk-accordion__section">
+                    <div class="govuk-accordion__section-header">
+                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-1"> Overview</span></h2>
+                    </div>
+                    <div id="accordion-default1-content-1" class="govuk-accordion__section-content">
+                        <dl class="govuk-summary-list">
+                            <div class="govuk-summary-list__row govuk-summary-list__row--no-actions appeal-lpa-reference"><dt class="govuk-summary-list__key"> Planning application reference</dt>
+                                <dd                                 class="govuk-summary-list__value">48269/APP/2021/1482</dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-appeal-type"><dt class="govuk-summary-list__key"> Appeal type</dt>
+                                <dd class="govuk-summary-list__value">Householder</dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/change-appeal-type/appeal-type"
+                                    data-cy="change-appeal-type">Change<span class="govuk-visually-hidden"> Appeal type</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row govuk-summary-list__row--no-actions appeal-case-procedure"><dt class="govuk-summary-list__key"> Appeal procedure</dt>
+                                <dd class="govuk-summary-list__value">Written</dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-allocation-details"><dt class="govuk-summary-list__key"> Allocation level</dt>
+                                <dd class="govuk-summary-list__value">
+                                    <ul class="govuk-!-margin-0">
+                                        <li>Level: A</li>
+                                        <li>Historic heritage</li>
+                                        <li>Architecture design</li>
+                                    </ul>
+                                </dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/allocation-details/allocation-level"
+                                    data-cy="change-allocation-details">Change<span class="govuk-visually-hidden"> Allocation level</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-linked-appeals"><dt class="govuk-summary-list__key"> Linked appeals</dt>
+                                <dd class="govuk-summary-list__value">
+                                    <ul class="govuk-list govuk-list--bullet">
+                                        <li><a href="/appeals-service/appeal-details/5449" class="govuk-link" data-cy="linked-appeal-784706"
+                                            aria-label="Appeal 7 8 4 7 0 6">784706</a> (Child)</li>
+                                        <li><span class="govuk-body">87326527</span> (Child)</li>
+                                        <li><a href="/appeals-service/appeal-details/5464" class="govuk-link" data-cy="linked-appeal-140079"
+                                            aria-label="Appeal 1 4 0 0 7 9">140079</a> (Lead)</li>
+                                        <li><a href="/appeals-service/appeal-details/5451" class="govuk-link" data-cy="linked-appeal-721086"
+                                            aria-label="Appeal 7 2 1 0 8 6">721086</a> (Child)</li>
+                                    </ul>
+                                </dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/linked-appeals/manage"
+                                    data-cy="manage-linked-appeals">Manage<span class="govuk-visually-hidden"> Linked appeals</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-other-appeals"><dt class="govuk-summary-list__key"> Related appeals</dt>
+                                <dd class="govuk-summary-list__value"><span>No</span>
+                                </dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/other-appeals/add"
+                                    data-cy="add-related-appeals">Add<span class="govuk-visually-hidden"> Related appeals</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-decision"><dt class="govuk-summary-list__key"> Decision</dt>
+                                <dd class="govuk-summary-list__value">Dismissed</dd>
+                            </div>
+                        </dl>
+                    </div>
+                </div>
+                <div class="govuk-accordion__section">
+                    <div class="govuk-accordion__section-header">
+                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-2"> Site</span></h2>
+                    </div>
+                    <div id="accordion-default1-content-2" class="govuk-accordion__section-content">
+                        <dl class="govuk-summary-list">
+                            <div class="govuk-summary-list__row appeal-visit-type"><dt class="govuk-summary-list__key"> Visit type</dt>
+                                <dd class="govuk-summary-list__value">Accompanied</dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/visit-booked?backUrl=%2Fappeals-service%2Fappeal-details%2F1"
+                                    data-cy="change-set-visit-type">Change<span class="govuk-visually-hidden"> Visit type</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Date</dt>
+                                <dd class="govuk-summary-list__value">9 October 2023</dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/visit-booked"
+                                    data-cy="change-site-visit-date">Change<span class="govuk-visually-hidden"> Date</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Start time</dt>
+                                <dd class="govuk-summary-list__value">9:38am</dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/visit-booked"
+                                    data-cy="change-site-visit-start-time">Change<span class="govuk-visually-hidden"> Start time</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> End time</dt>
+                                <dd class="govuk-summary-list__value">10:00am</dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/visit-booked"
+                                    data-cy="change-site-visit-end-time">Change<span class="govuk-visually-hidden"> End time</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-neighbouring-sites-inspector"><dt class="govuk-summary-list__key"> Interested party and neighbour addresses</dt>
+                                <dd                                 class="govuk-summary-list__value">
+                                    <ul class="govuk-list govuk-list--bullet">
+                                        <li>2 Grove Cottage, Shotesham Road, Woodton, Devon, NR35 2ND</li>
+                                    </ul>
                                     </dd>
-                                </div>
-                                <div class="govuk-summary-list__row govuk-summary-list__row--no-actions appeal-case-procedure"><dt class="govuk-summary-list__key"> Appeal procedure</dt>
-                                    <dd class="govuk-summary-list__value">Written</dd>
-                                </div>
-                                <div class="govuk-summary-list__row appeal-allocation-details"><dt class="govuk-summary-list__key"> Allocation level</dt>
-                                    <dd class="govuk-summary-list__value">
-                                        <ul class="govuk-!-margin-0">
-                                            <li>Level: A</li>
-                                            <li>Historic heritage</li>
-                                            <li>Architecture design</li>
+                                    <dd class="govuk-summary-list__actions">
+                                        <ul class="govuk-summary-list__actions-list">
+                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/neighbouring-sites/manage"
+                                                data-cy="manage-neighbouring-sites-inspector">Manage<span class="govuk-visually-hidden"> Interested party and neighbour addresses</span></a>
+                                            </li>
+                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/neighbouring-sites/add/back-office"
+                                                data-cy="add-neighbouring-sites-inspector">Add<span class="govuk-visually-hidden"> Interested party and neighbour addresses</span></a>
+                                            </li>
                                         </ul>
                                     </dd>
-                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/allocation-details/allocation-level"
-                                        data-cy="change-allocation-details">Change<span class="govuk-visually-hidden"> Allocation level</span></a>
-                                    </dd>
-                                </div>
-                                <div class="govuk-summary-list__row appeal-linked-appeals"><dt class="govuk-summary-list__key"> Linked appeals</dt>
-                                    <dd class="govuk-summary-list__value">
-                                        <ul class="govuk-list govuk-list--bullet">
-                                            <li><a href="/appeals-service/appeal-details/5449" class="govuk-link" data-cy="linked-appeal-784706"
-                                                aria-label="Appeal 7 8 4 7 0 6">784706</a> (Child)</li>
-                                            <li><span class="govuk-body">87326527</span> (Child)</li>
-                                            <li><a href="/appeals-service/appeal-details/5464" class="govuk-link" data-cy="linked-appeal-140079"
-                                                aria-label="Appeal 1 4 0 0 7 9">140079</a> (Lead)</li>
-                                            <li><a href="/appeals-service/appeal-details/5451" class="govuk-link" data-cy="linked-appeal-721086"
-                                                aria-label="Appeal 7 2 1 0 8 6">721086</a> (Child)</li>
+                            </div>
+                        </dl>
+                    </div>
+                </div>
+                <div class="govuk-accordion__section">
+                    <div class="govuk-accordion__section-header">
+                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-3"> Timetable</span></h2>
+                    </div>
+                    <div id="accordion-default1-content-3" class="govuk-accordion__section-content">
+                        <dl class="govuk-summary-list appeal-case-timetable">
+                            <div class="govuk-summary-list__row appeal-valid-date"><dt class="govuk-summary-list__key"> Valid date</dt>
+                                <dd class="govuk-summary-list__value">23 May 2023</dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/valid/date"
+                                    data-cy="-valid-date"><span class="govuk-visually-hidden"> Valid date</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-start-date"><dt class="govuk-summary-list__key"> Start date</dt>
+                                <dd class="govuk-summary-list__value">23 May 2023</dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/start-case/change"
+                                    data-cy="change-start-case-date">Change<span class="govuk-visually-hidden"> Start date</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-lpa-questionnaire-due-date"><dt class="govuk-summary-list__key"> LPA questionnaire due</dt>
+                                <dd class="govuk-summary-list__value">11 October 2023</dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-site-visit"><dt class="govuk-summary-list__key"> Site visit</dt>
+                                <dd class="govuk-summary-list__value">
+                                    <ul class="govuk-list govuk-!-margin-top-0 govuk-!-padding-left-0">
+                                        <li>9 October 2023</li>
+                                        <li>9:38am - 10:00am</li>
+                                    </ul>
+                                </dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/manage-visit?backUrl=%2Fappeals-service%2Fappeal-details%2F1"
+                                    data-cy="change-schedule-visit">Change<span class="govuk-visually-hidden"> Site visit</span></a>
+                                </dd>
+                            </div>
+                        </dl>
+                    </div>
+                </div>
+                <div class="govuk-accordion__section">
+                    <div class="govuk-accordion__section-header">
+                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-4"> Documentation</span></h2>
+                    </div>
+                    <div id="accordion-default1-content-4" class="govuk-accordion__section-content">
+                        <table class="govuk-table">
+                            <thead class="govuk-table__head">
+                                <tr class="govuk-table__row">
+                                    <th scope="col" class="govuk-table__header">Documentation</th>
+                                    <th scope="col" class="govuk-table__header">Status</th>
+                                    <th scope="col" class="govuk-table__header">Received</th>
+                                    <th scope="col" class="govuk-table__header govuk-!-text-align-right">Action</th>
+                                </tr>
+                            </thead>
+                            <tbody class="govuk-table__body">
+                                <tr class="govuk-table__row">
+                                    <th scope="row" class="govuk-table__header">Appeal</th>
+                                    <td class="govuk-table__cell">Ready to review</td>
+                                    <td class="govuk-table__cell">2 August 2024</td>
+                                    <td class="govuk-table__cell govuk-!-text-align-right"><a href="/appeals-service/appeal-details/1/appellant-case?backUrl=%2Fappeals-service%2Fappeal-details%2F1"
+                                        data-cy="review-appellant-case" class="govuk-link">Review<span class="govuk-visually-hidden"> appellant case</span></a>
+                                    </td>
+                                </tr>
+                                <tr class="govuk-table__row">
+                                    <th scope="row" class="govuk-table__header">LPA questionnaire</th>
+                                    <td class="govuk-table__cell">Overdue</td>
+                                    <td class="govuk-table__cell">Due by 11 October 2023</td>
+                                    <td class="govuk-table__cell govuk-!-text-align-right"></td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
+                <div class="govuk-accordion__section">
+                    <div class="govuk-accordion__section-header">
+                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-5"> Costs</span></h2>
+                    </div>
+                    <div id="accordion-default1-content-5" class="govuk-accordion__section-content">
+                        <table class="govuk-table">
+                            <thead class="govuk-table__head">
+                                <tr class="govuk-table__row">
+                                    <th scope="col" class="govuk-table__header">Documentation</th>
+                                    <th scope="col" class="govuk-table__header">Status</th>
+                                    <th scope="col" class="govuk-table__header govuk-!-text-align-right">Action</th>
+                                </tr>
+                            </thead>
+                            <tbody class="govuk-table__body">
+                                <tr class="govuk-table__row">
+                                    <th scope="row" class="govuk-table__header appeal-costs-appellant-application-documentation">Appellant application</th>
+                                    <td class="govuk-table__cell appeal-costs-appellant-application-status">No documents available</td>
+                                    <td class="govuk-table__cell appeal-costs-appellant-application-actions govuk-!-text-align-right">
+                                        <ul class="govuk-summary-list__actions-list">
+                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-appellant-application" href="/appeals-service/appeal-details/1/costs/appellant/application/upload-documents/1">Add<span class="govuk-visually-hidden"> Appellant application</span></a>
+                                            </li>
                                         </ul>
-                                    </dd>
-                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/linked-appeals/manage"
-                                        data-cy="manage-linked-appeals">Manage<span class="govuk-visually-hidden"> Linked appeals</span></a>
-                                    </dd>
-                                </div>
-                                <div class="govuk-summary-list__row appeal-other-appeals"><dt class="govuk-summary-list__key"> Related appeals</dt>
-                                    <dd class="govuk-summary-list__value"><span>No</span>
-                                    </dd>
-                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/other-appeals/add"
-                                        data-cy="add-related-appeals">Add<span class="govuk-visually-hidden"> Related appeals</span></a>
-                                    </dd>
-                                </div>
-                                <div class="govuk-summary-list__row appeal-decision"><dt class="govuk-summary-list__key"> Decision</dt>
-                                    <dd class="govuk-summary-list__value">Dismissed</dd>
-                                </div>
-                            </dl>
-                        </div>
-                    </div>
-                    <div class="govuk-accordion__section">
-                        <div class="govuk-accordion__section-header">
-                            <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-2"> Site</span></h2>
-                        </div>
-                        <div id="accordion-default1-content-2" class="govuk-accordion__section-content">
-                            <dl class="govuk-summary-list">
-                                <div class="govuk-summary-list__row appeal-visit-type"><dt class="govuk-summary-list__key"> Visit type</dt>
-                                    <dd class="govuk-summary-list__value">Accompanied</dd>
-                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/visit-booked?backUrl=%2Fappeals-service%2Fappeal-details%2F1"
-                                        data-cy="change-set-visit-type">Change<span class="govuk-visually-hidden"> Visit type</span></a>
-                                    </dd>
-                                </div>
-                                <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Date</dt>
-                                    <dd class="govuk-summary-list__value">9 October 2023</dd>
-                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/visit-booked"
-                                        data-cy="change-site-visit-date">Change<span class="govuk-visually-hidden"> Date</span></a>
-                                    </dd>
-                                </div>
-                                <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Start time</dt>
-                                    <dd class="govuk-summary-list__value">9:38am</dd>
-                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/visit-booked"
-                                        data-cy="change-site-visit-start-time">Change<span class="govuk-visually-hidden"> Start time</span></a>
-                                    </dd>
-                                </div>
-                                <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> End time</dt>
-                                    <dd class="govuk-summary-list__value">10:00am</dd>
-                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/visit-booked"
-                                        data-cy="change-site-visit-end-time">Change<span class="govuk-visually-hidden"> End time</span></a>
-                                    </dd>
-                                </div>
-                                <div class="govuk-summary-list__row appeal-neighbouring-sites-inspector"><dt class="govuk-summary-list__key"> Interested party and neighbour addresses</dt>
-                                    <dd                                     class="govuk-summary-list__value">
-                                        <ul class="govuk-list govuk-list--bullet">
-                                            <li>2 Grove Cottage, Shotesham Road, Woodton, Devon, NR35 2ND</li>
+                                    </td>
+                                </tr>
+                                <tr class="govuk-table__row">
+                                    <th scope="row" class="govuk-table__header appeal-costs-appellant-withdrawal-documentation">Appellant withdrawal</th>
+                                    <td class="govuk-table__cell appeal-costs-appellant-withdrawal-status">No documents available</td>
+                                    <td class="govuk-table__cell appeal-costs-appellant-withdrawal-actions govuk-!-text-align-right">
+                                        <ul class="govuk-summary-list__actions-list">
+                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-appellant-withdrawal" href="/appeals-service/appeal-details/1/costs/appellant/withdrawal/upload-documents/2">Add<span class="govuk-visually-hidden"> Appellant withdrawal</span></a>
+                                            </li>
                                         </ul>
-                                        </dd>
-                                        <dd class="govuk-summary-list__actions">
-                                            <ul class="govuk-summary-list__actions-list">
-                                                <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/neighbouring-sites/manage"
-                                                    data-cy="manage-neighbouring-sites-inspector">Manage<span class="govuk-visually-hidden"> Interested party and neighbour addresses</span></a>
-                                                </li>
-                                                <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/neighbouring-sites/add/back-office"
-                                                    data-cy="add-neighbouring-sites-inspector">Add<span class="govuk-visually-hidden"> Interested party and neighbour addresses</span></a>
-                                                </li>
-                                            </ul>
-                                        </dd>
-                                </div>
-                            </dl>
-                        </div>
-                    </div>
-                    <div class="govuk-accordion__section">
-                        <div class="govuk-accordion__section-header">
-                            <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-3"> Timetable</span></h2>
-                        </div>
-                        <div id="accordion-default1-content-3" class="govuk-accordion__section-content">
-                            <dl class="govuk-summary-list appeal-case-timetable">
-                                <div class="govuk-summary-list__row appeal-valid-date"><dt class="govuk-summary-list__key"> Valid date</dt>
-                                    <dd class="govuk-summary-list__value">23 May 2023</dd>
-                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/valid/date"
-                                        data-cy="-valid-date"><span class="govuk-visually-hidden"> Valid date</span></a>
-                                    </dd>
-                                </div>
-                                <div class="govuk-summary-list__row appeal-start-date"><dt class="govuk-summary-list__key"> Start date</dt>
-                                    <dd class="govuk-summary-list__value">23 May 2023</dd>
-                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/start-case/change"
-                                        data-cy="change-start-case-date">Change<span class="govuk-visually-hidden"> Start date</span></a>
-                                    </dd>
-                                </div>
-                                <div class="govuk-summary-list__row appeal-lpa-questionnaire-due-date"><dt class="govuk-summary-list__key"> LPA questionnaire due</dt>
-                                    <dd class="govuk-summary-list__value">11 October 2023</dd>
-                                </div>
-                                <div class="govuk-summary-list__row appeal-site-visit"><dt class="govuk-summary-list__key"> Site visit</dt>
-                                    <dd class="govuk-summary-list__value">
-                                        <ul class="govuk-list govuk-!-margin-top-0 govuk-!-padding-left-0">
-                                            <li>9 October 2023</li>
-                                            <li>9:38am - 10:00am</li>
+                                    </td>
+                                </tr>
+                                <tr class="govuk-table__row">
+                                    <th scope="row" class="govuk-table__header appeal-costs-appellant-correspondence-documentation">Appellant correspondence</th>
+                                    <td class="govuk-table__cell appeal-costs-appellant-correspondence-status">No documents available</td>
+                                    <td class="govuk-table__cell appeal-costs-appellant-correspondence-actions govuk-!-text-align-right">
+                                        <ul class="govuk-summary-list__actions-list">
+                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-appellant-correspondence" href="/appeals-service/appeal-details/1/costs/appellant/correspondence/upload-documents/3">Add<span class="govuk-visually-hidden"> Appellant correspondence</span></a>
+                                            </li>
                                         </ul>
-                                    </dd>
-                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/manage-visit?backUrl=%2Fappeals-service%2Fappeal-details%2F1"
-                                        data-cy="change-schedule-visit">Change<span class="govuk-visually-hidden"> Site visit</span></a>
-                                    </dd>
-                                </div>
-                            </dl>
-                        </div>
-                    </div>
-                    <div class="govuk-accordion__section">
-                        <div class="govuk-accordion__section-header">
-                            <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-4"> Documentation</span></h2>
-                        </div>
-                        <div id="accordion-default1-content-4" class="govuk-accordion__section-content">
-                            <table class="govuk-table">
-                                <thead class="govuk-table__head">
-                                    <tr class="govuk-table__row">
-                                        <th scope="col" class="govuk-table__header">Documentation</th>
-                                        <th scope="col" class="govuk-table__header">Status</th>
-                                        <th scope="col" class="govuk-table__header">Received</th>
-                                        <th scope="col" class="govuk-table__header govuk-!-text-align-right">Action</th>
-                                    </tr>
-                                </thead>
-                                <tbody class="govuk-table__body">
-                                    <tr class="govuk-table__row">
-                                        <th scope="row" class="govuk-table__header">Appeal</th>
-                                        <td class="govuk-table__cell">Ready to review</td>
-                                        <td class="govuk-table__cell">2 August 2024</td>
-                                        <td class="govuk-table__cell govuk-!-text-align-right"><a href="/appeals-service/appeal-details/1/appellant-case?backUrl=%2Fappeals-service%2Fappeal-details%2F1"
-                                            data-cy="review-appellant-case" class="govuk-link">Review<span class="govuk-visually-hidden"> appellant case</span></a>
-                                        </td>
-                                    </tr>
-                                    <tr class="govuk-table__row">
-                                        <th scope="row" class="govuk-table__header">LPA questionnaire</th>
-                                        <td class="govuk-table__cell">Overdue</td>
-                                        <td class="govuk-table__cell">Due by 11 October 2023</td>
-                                        <td class="govuk-table__cell govuk-!-text-align-right"></td>
-                                    </tr>
-                                </tbody>
-                            </table>
-                        </div>
-                    </div>
-                    <div class="govuk-accordion__section">
-                        <div class="govuk-accordion__section-header">
-                            <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-5"> Costs</span></h2>
-                        </div>
-                        <div id="accordion-default1-content-5" class="govuk-accordion__section-content">
-                            <table class="govuk-table">
-                                <thead class="govuk-table__head">
-                                    <tr class="govuk-table__row">
-                                        <th scope="col" class="govuk-table__header">Documentation</th>
-                                        <th scope="col" class="govuk-table__header">Status</th>
-                                        <th scope="col" class="govuk-table__header govuk-!-text-align-right">Action</th>
-                                    </tr>
-                                </thead>
-                                <tbody class="govuk-table__body">
-                                    <tr class="govuk-table__row">
-                                        <th scope="row" class="govuk-table__header appeal-costs-appellant-application-documentation">Appellant application</th>
-                                        <td class="govuk-table__cell appeal-costs-appellant-application-status">No documents available</td>
-                                        <td class="govuk-table__cell appeal-costs-appellant-application-actions govuk-!-text-align-right">
-                                            <ul class="govuk-summary-list__actions-list">
-                                                <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-appellant-application" href="/appeals-service/appeal-details/1/costs/appellant/application/upload-documents/1">Add<span class="govuk-visually-hidden"> Appellant application</span></a>
-                                                </li>
-                                            </ul>
-                                        </td>
-                                    </tr>
-                                    <tr class="govuk-table__row">
-                                        <th scope="row" class="govuk-table__header appeal-costs-appellant-withdrawal-documentation">Appellant withdrawal</th>
-                                        <td class="govuk-table__cell appeal-costs-appellant-withdrawal-status">No documents available</td>
-                                        <td class="govuk-table__cell appeal-costs-appellant-withdrawal-actions govuk-!-text-align-right">
-                                            <ul class="govuk-summary-list__actions-list">
-                                                <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-appellant-withdrawal" href="/appeals-service/appeal-details/1/costs/appellant/withdrawal/upload-documents/2">Add<span class="govuk-visually-hidden"> Appellant withdrawal</span></a>
-                                                </li>
-                                            </ul>
-                                        </td>
-                                    </tr>
-                                    <tr class="govuk-table__row">
-                                        <th scope="row" class="govuk-table__header appeal-costs-appellant-correspondence-documentation">Appellant correspondence</th>
-                                        <td class="govuk-table__cell appeal-costs-appellant-correspondence-status">No documents available</td>
-                                        <td class="govuk-table__cell appeal-costs-appellant-correspondence-actions govuk-!-text-align-right">
-                                            <ul class="govuk-summary-list__actions-list">
-                                                <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-appellant-correspondence" href="/appeals-service/appeal-details/1/costs/appellant/correspondence/upload-documents/3">Add<span class="govuk-visually-hidden"> Appellant correspondence</span></a>
-                                                </li>
-                                            </ul>
-                                        </td>
-                                    </tr>
-                                    <tr class="govuk-table__row">
-                                        <th scope="row" class="govuk-table__header appeal-costs-lpa-application-documentation">LPA application</th>
-                                        <td class="govuk-table__cell appeal-costs-lpa-application-status">No documents available</td>
-                                        <td class="govuk-table__cell appeal-costs-lpa-application-actions govuk-!-text-align-right">
-                                            <ul class="govuk-summary-list__actions-list">
-                                                <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-lpa-application" href="/appeals-service/appeal-details/1/costs/lpa/application/upload-documents/4">Add<span class="govuk-visually-hidden"> LPA application</span></a>
-                                                </li>
-                                            </ul>
-                                        </td>
-                                    </tr>
-                                    <tr class="govuk-table__row">
-                                        <th scope="row" class="govuk-table__header appeal-costs-lpa-withdrawal-documentation">LPA withdrawal</th>
-                                        <td class="govuk-table__cell appeal-costs-lpa-withdrawal-status">No documents available</td>
-                                        <td class="govuk-table__cell appeal-costs-lpa-withdrawal-actions govuk-!-text-align-right">
-                                            <ul class="govuk-summary-list__actions-list">
-                                                <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-lpa-withdrawal" href="/appeals-service/appeal-details/1/costs/lpa/withdrawal/upload-documents/5">Add<span class="govuk-visually-hidden"> LPA withdrawal</span></a>
-                                                </li>
-                                            </ul>
-                                        </td>
-                                    </tr>
-                                    <tr class="govuk-table__row">
-                                        <th scope="row" class="govuk-table__header appeal-costs-lpa-correspondence-documentation">LPA correspondence</th>
-                                        <td class="govuk-table__cell appeal-costs-lpa-correspondence-status">No documents available</td>
-                                        <td class="govuk-table__cell appeal-costs-lpa-correspondence-actions govuk-!-text-align-right">
-                                            <ul class="govuk-summary-list__actions-list">
-                                                <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-lpa-correspondence" href="/appeals-service/appeal-details/1/costs/lpa/correspondence/upload-documents/6">Add<span class="govuk-visually-hidden"> LPA correspondence</span></a>
-                                                </li>
-                                            </ul>
-                                        </td>
-                                    </tr>
-                                </tbody>
-                            </table>
-                        </div>
-                    </div>
-                    <div class="govuk-accordion__section">
-                        <div class="govuk-accordion__section-header">
-                            <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-6"> Contacts</span></h2>
-                        </div>
-                        <div id="accordion-default1-content-6" class="govuk-accordion__section-content">
-                            <dl class="govuk-summary-list">
-                                <div class="govuk-summary-list__row appeal-appellant"><dt class="govuk-summary-list__key"> Appellant</dt>
-                                    <dd class="govuk-summary-list__value">
-                                        <ul class="govuk-list">
-                                            <li>Roger Simmons</li>
-                                            <li>test3@example.com</li>
+                                    </td>
+                                </tr>
+                                <tr class="govuk-table__row">
+                                    <th scope="row" class="govuk-table__header appeal-costs-lpa-application-documentation">LPA application</th>
+                                    <td class="govuk-table__cell appeal-costs-lpa-application-status">No documents available</td>
+                                    <td class="govuk-table__cell appeal-costs-lpa-application-actions govuk-!-text-align-right">
+                                        <ul class="govuk-summary-list__actions-list">
+                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-lpa-application" href="/appeals-service/appeal-details/1/costs/lpa/application/upload-documents/4">Add<span class="govuk-visually-hidden"> LPA application</span></a>
+                                            </li>
                                         </ul>
-                                    </dd>
-                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/service-user/change/appellant"
-                                        data-cy="change-appellant">Change<span class="govuk-visually-hidden"> Appellant</span></a>
-                                    </dd>
-                                </div>
-                                <div class="govuk-summary-list__row appeal-agent"><dt class="govuk-summary-list__key"> Agent</dt>
-                                    <dd class="govuk-summary-list__value">
-                                        <ul class="govuk-list">
-                                            <li>Fiona Shell</li>
-                                            <li>test2@example.com</li>
+                                    </td>
+                                </tr>
+                                <tr class="govuk-table__row">
+                                    <th scope="row" class="govuk-table__header appeal-costs-lpa-withdrawal-documentation">LPA withdrawal</th>
+                                    <td class="govuk-table__cell appeal-costs-lpa-withdrawal-status">No documents available</td>
+                                    <td class="govuk-table__cell appeal-costs-lpa-withdrawal-actions govuk-!-text-align-right">
+                                        <ul class="govuk-summary-list__actions-list">
+                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-lpa-withdrawal" href="/appeals-service/appeal-details/1/costs/lpa/withdrawal/upload-documents/5">Add<span class="govuk-visually-hidden"> LPA withdrawal</span></a>
+                                            </li>
                                         </ul>
-                                    </dd>
-                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/service-user/change/agent"
-                                        data-cy="change-agent">Change<span class="govuk-visually-hidden"> Agent</span></a>
-                                    </dd>
-                                </div>
-                                <div class="govuk-summary-list__row appeal-lpa-contact-details"><dt class="govuk-summary-list__key"> LPA</dt>
-                                    <dd class="govuk-summary-list__value">
-                                        <ul class="govuk-list">
-                                            <li>Wiltshire Council</li>
-                                            <li>wilt@lpa-email.gov.uk</li>
+                                    </td>
+                                </tr>
+                                <tr class="govuk-table__row">
+                                    <th scope="row" class="govuk-table__header appeal-costs-lpa-correspondence-documentation">LPA correspondence</th>
+                                    <td class="govuk-table__cell appeal-costs-lpa-correspondence-status">No documents available</td>
+                                    <td class="govuk-table__cell appeal-costs-lpa-correspondence-actions govuk-!-text-align-right">
+                                        <ul class="govuk-summary-list__actions-list">
+                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-lpa-correspondence" href="/appeals-service/appeal-details/1/costs/lpa/correspondence/upload-documents/6">Add<span class="govuk-visually-hidden"> LPA correspondence</span></a>
+                                            </li>
                                         </ul>
-                                    </dd>
-                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/change-appeal-details/local-planning-authority"
-                                        data-cy="change-lpa-contact-details">Change<span class="govuk-visually-hidden"> Local planning authority (LPA)</span></a>
-                                    </dd>
-                                </div>
-                            </dl>
-                        </div>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
                     </div>
-                    <div class="govuk-accordion__section">
-                        <div class="govuk-accordion__section-header">
-                            <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-7"> Team</span></h2>
-                        </div>
-                        <div id="accordion-default1-content-7" class="govuk-accordion__section-content">
-                            <dl class="govuk-summary-list">
-                                <div class="govuk-summary-list__row appeal-case-officer"><dt class="govuk-summary-list__key"> Case officer</dt>
-                                    <dd class="govuk-summary-list__value">
-                                        <p class="govuk-body">Not assigned</p>
-                                    </dd>
-                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/assign-user/case-officer"
-                                        data-cy="assign-case-officer">Assign<span class="govuk-visually-hidden"> Case officer</span></a>
-                                    </dd>
-                                </div>
-                                <div class="govuk-summary-list__row appeal-inspector"><dt class="govuk-summary-list__key"> Inspector</dt>
-                                    <dd class="govuk-summary-list__value">
-                                        <p class="govuk-body">Not assigned</p>
-                                    </dd>
-                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/assign-user/inspector"
-                                        data-cy="assign-inspector">Assign<span class="govuk-visually-hidden"> Inspector</span></a>
-                                    </dd>
-                                </div>
-                            </dl>
-                        </div>
+                </div>
+                <div class="govuk-accordion__section">
+                    <div class="govuk-accordion__section-header">
+                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-6"> Contacts</span></h2>
                     </div>
-                    <div class="govuk-accordion__section">
-                        <div class="govuk-accordion__section-header">
-                            <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-8"> Case management</span></h2>
-                        </div>
-                        <div id="accordion-default1-content-8" class="govuk-accordion__section-content">
-                            <dl class="govuk-summary-list">
-                                <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Cross-team correspondence</dt>
-                                    <dd                                     class="govuk-summary-list__value">No documents</dd>
-                                        <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/internal-correspondence/cross-team/upload-documents/10"
-                                            data-cy="add-cross-team-correspondence">Add<span class="govuk-visually-hidden"> Cross-team correspondence</span></a>
-                                        </dd>
-                                </div>
-                                <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Inspector correspondence</dt>
-                                    <dd                                     class="govuk-summary-list__value">No documents</dd>
-                                        <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/internal-correspondence/inspector/upload-documents/11"
-                                            data-cy="add-inspector-correspondence">Add<span class="govuk-visually-hidden"> Inspector correspondence</span></a>
-                                        </dd>
-                                </div>
-                                <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Main party correspondence</dt>
-                                    <dd                                     class="govuk-summary-list__value">No documents</dd>
-                                        <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/internal-correspondence/main-party/upload-documents/22"
-                                            data-cy="add-main-party-correspondence">Add<span class="govuk-visually-hidden"> Main party correspondence</span></a>
-                                        </dd>
-                                </div>
-                                <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Case history</dt>
-                                    <dd class="govuk-summary-list__value"></dd>
-                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/audit" data-cy="view-case-history">View<span class="govuk-visually-hidden"> Case history</span></a>
+                    <div id="accordion-default1-content-6" class="govuk-accordion__section-content">
+                        <dl class="govuk-summary-list">
+                            <div class="govuk-summary-list__row appeal-appellant"><dt class="govuk-summary-list__key"> Appellant</dt>
+                                <dd class="govuk-summary-list__value">
+                                    <ul class="govuk-list">
+                                        <li>Roger Simmons</li>
+                                        <li>test3@example.com</li>
+                                    </ul>
+                                </dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/service-user/change/appellant"
+                                    data-cy="change-appellant">Change<span class="govuk-visually-hidden"> Appellant</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-agent"><dt class="govuk-summary-list__key"> Agent</dt>
+                                <dd class="govuk-summary-list__value">
+                                    <ul class="govuk-list">
+                                        <li>Fiona Shell</li>
+                                        <li>test2@example.com</li>
+                                    </ul>
+                                </dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/service-user/change/agent"
+                                    data-cy="change-agent">Change<span class="govuk-visually-hidden"> Agent</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-lpa-contact-details"><dt class="govuk-summary-list__key"> LPA</dt>
+                                <dd class="govuk-summary-list__value">
+                                    <ul class="govuk-list">
+                                        <li>Wiltshire Council</li>
+                                        <li>wilt@lpa-email.gov.uk</li>
+                                    </ul>
+                                </dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/change-appeal-details/local-planning-authority"
+                                    data-cy="change-lpa-contact-details">Change<span class="govuk-visually-hidden"> Local planning authority (LPA)</span></a>
+                                </dd>
+                            </div>
+                        </dl>
+                    </div>
+                </div>
+                <div class="govuk-accordion__section">
+                    <div class="govuk-accordion__section-header">
+                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-7"> Team</span></h2>
+                    </div>
+                    <div id="accordion-default1-content-7" class="govuk-accordion__section-content">
+                        <dl class="govuk-summary-list">
+                            <div class="govuk-summary-list__row appeal-case-officer"><dt class="govuk-summary-list__key"> Case officer</dt>
+                                <dd class="govuk-summary-list__value">
+                                    <p class="govuk-body">Not assigned</p>
+                                </dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/assign-user/case-officer"
+                                    data-cy="assign-case-officer">Assign<span class="govuk-visually-hidden"> Case officer</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-inspector"><dt class="govuk-summary-list__key"> Inspector</dt>
+                                <dd class="govuk-summary-list__value">
+                                    <p class="govuk-body">Not assigned</p>
+                                </dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/assign-user/inspector"
+                                    data-cy="assign-inspector">Assign<span class="govuk-visually-hidden"> Inspector</span></a>
+                                </dd>
+                            </div>
+                        </dl>
+                    </div>
+                </div>
+                <div class="govuk-accordion__section">
+                    <div class="govuk-accordion__section-header">
+                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-8"> Case management</span></h2>
+                    </div>
+                    <div id="accordion-default1-content-8" class="govuk-accordion__section-content">
+                        <dl class="govuk-summary-list">
+                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Cross-team correspondence</dt>
+                                <dd                                 class="govuk-summary-list__value">No documents</dd>
+                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/internal-correspondence/cross-team/upload-documents/10"
+                                        data-cy="add-cross-team-correspondence">Add<span class="govuk-visually-hidden"> Cross-team correspondence</span></a>
                                     </dd>
-                                </div>
-                                <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Appeal withdrawal</dt>
-                                    <dd class="govuk-summary-list__value"></dd>
-                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/withdrawal/start"
-                                        data-cy="start-appeal-withdrawal">Start<span class="govuk-visually-hidden"> Appeal withdrawal</span></a>
+                            </div>
+                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Inspector correspondence</dt>
+                                <dd                                 class="govuk-summary-list__value">No documents</dd>
+                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/internal-correspondence/inspector/upload-documents/11"
+                                        data-cy="add-inspector-correspondence">Add<span class="govuk-visually-hidden"> Inspector correspondence</span></a>
                                     </dd>
-                                </div>
-                            </dl>
-                        </div>
+                            </div>
+                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Main party correspondence</dt>
+                                <dd                                 class="govuk-summary-list__value">No documents</dd>
+                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/internal-correspondence/main-party/upload-documents/22"
+                                        data-cy="add-main-party-correspondence">Add<span class="govuk-visually-hidden"> Main party correspondence</span></a>
+                                    </dd>
+                            </div>
+                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Case history</dt>
+                                <dd class="govuk-summary-list__value"></dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/audit" data-cy="view-case-history">View<span class="govuk-visually-hidden"> Case history</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Appeal withdrawal</dt>
+                                <dd class="govuk-summary-list__value"></dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/withdrawal/start"
+                                    data-cy="start-appeal-withdrawal">Start<span class="govuk-visually-hidden"> Appeal withdrawal</span></a>
+                                </dd>
+                            </div>
+                        </dl>
                     </div>
                 </div>
             </div>
         </div>
+    </div>
 </main>"
 `;
 
@@ -5780,10 +5787,11 @@ exports[`appeal-details GET /:appealId should render the received appeal details
         </div>
     </div>
     <div class="govuk-grid-row">
-        <div class="govuk-grid-column-full"><strong class="govuk-tag govuk-tag--grey govuk-!-margin-bottom-4">Received appeal</strong>
+        <div class="govuk-grid-column-full"><strong class="govuk-tag govuk-tag--grey pins-status-tag--full-width">Received appeal</strong>
+            <strong             class="govuk-tag govuk-tag--grey govuk-!-margin-left-1 govuk-!-margin-bottom-4"></strong>
         </div>
-    </div><strong class="govuk-tag govuk-tag--grey govuk-!-margin-left-1 govuk-!-margin-bottom-4"></strong>
-    <div     class="govuk-grid-row">
+    </div>
+    <div class="govuk-grid-row">
         <div class="govuk-grid-column-full">
             <dl class="govuk-summary-list pins-summary-list--no-border">
                 <div class="govuk-summary-list__row appeal-case-officer"><dt class="govuk-summary-list__key"> Case officer</dt>
@@ -5808,429 +5816,429 @@ exports[`appeal-details GET /:appealId should render the received appeal details
                 </div>
             </dl>
         </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
+            <p class="govuk-body govuk-!-margin-bottom-6" id="download-case-files"
+            data-cy="download-case-files"><a class="govuk-link" href="/documents/3/bulk-download/case-APP/Q9999/D/21/351062.zip">Download case</a>
+            </p>
         </div>
-        <div class="govuk-grid-row">
-            <div class="govuk-grid-column-full">
-                <p class="govuk-body govuk-!-margin-bottom-6" id="download-case-files"
-                data-cy="download-case-files"><a class="govuk-link" href="/documents/3/bulk-download/case-APP/Q9999/D/21/351062.zip">Download case</a>
-                </p>
-            </div>
-        </div>
-        <div class="govuk-grid-row">
-            <div class="govuk-grid-column-full">
-                <details class="govuk-details">
-                    <summary class="govuk-details__summary"><span class="govuk-details__summary-text"> 2 case notes</span>
-                    </summary>
-                    <div class="govuk-details__text">
-                        <form method="POST" novalidate="novalidate">
-                            <div class="govuk-grid-row">
-                                <div class="govuk-grid-column-two-thirds">
-                                    <div class="govuk-form-group govuk-character-count" data-module="govuk-character-count"
-                                    data-maxlength="500">
-                                        <textarea class="govuk-textarea govuk-js-character-count" id="comment"
-                                        name="comment" rows="5" aria-describedby="comment-info"></textarea>
-                                        <div id="comment-info" class="govuk-hint govuk-character-count__message">You can enter up to 500 characters</div>
-                                    </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
+            <details class="govuk-details">
+                <summary class="govuk-details__summary"><span class="govuk-details__summary-text"> 2 case notes</span>
+                </summary>
+                <div class="govuk-details__text">
+                    <form method="POST" novalidate="novalidate">
+                        <div class="govuk-grid-row">
+                            <div class="govuk-grid-column-two-thirds">
+                                <div class="govuk-form-group govuk-character-count" data-module="govuk-character-count"
+                                data-maxlength="500">
+                                    <textarea class="govuk-textarea govuk-js-character-count" id="comment"
+                                    name="comment" rows="5" aria-describedby="comment-info"></textarea>
+                                    <div id="comment-info" class="govuk-hint govuk-character-count__message">You can enter up to 500 characters</div>
                                 </div>
                             </div>
-                            <button type="submit" data-prevent-double-click="true" class="govuk-button govuk-button--secondary govuk-!-margin-bottom-1"
-                            data-module="govuk-button">Add case note</button>
-                        </form>
-                        <div>
+                        </div>
+                        <button type="submit" data-prevent-double-click="true" class="govuk-button govuk-button--secondary govuk-!-margin-bottom-1"
+                        data-module="govuk-button">Add case note</button>
+                    </form>
+                    <div>
+                        <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+                        <section>
+                            <p class="govuk-body govuk-!-margin-bottom-1">A case note you should see.</p>
+                            <p class="govuk-hint govuk-!-margin-bottom-6">11:00am on Tuesday 1 October 2024 by John.Smith</p>
                             <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
-                            <section>
-                                <p class="govuk-body govuk-!-margin-bottom-1">A case note you should see.</p>
-                                <p class="govuk-hint govuk-!-margin-bottom-6">11:00am on Tuesday 1 October 2024 by John.Smith</p>
-                                <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
-                            </section>
-                            <section>
-                                <p class="govuk-body govuk-!-margin-bottom-1">A case note you should see.</p>
-                                <p class="govuk-hint govuk-!-margin-bottom-6">11:00am on Tuesday 1 October 2024 by John.Smith</p>
-                                <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
-                            </section>
-                        </div>
+                        </section>
+                        <section>
+                            <p class="govuk-body govuk-!-margin-bottom-1">A case note you should see.</p>
+                            <p class="govuk-hint govuk-!-margin-bottom-6">11:00am on Tuesday 1 October 2024 by John.Smith</p>
+                            <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+                        </section>
                     </div>
-                </details>
-            </div>
+                </div>
+            </details>
         </div>
-        <div class="govuk-grid-row">
-            <div class="govuk-grid-column-full">
-                <div class="govuk-accordion" data-module="govuk-accordion" id="accordion-default3">
-                    <div class="govuk-accordion__section">
-                        <div class="govuk-accordion__section-header">
-                            <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default3-heading-1"> Overview</span></h2>
-                        </div>
-                        <div id="accordion-default3-content-1" class="govuk-accordion__section-content">
-                            <dl class="govuk-summary-list">
-                                <div class="govuk-summary-list__row govuk-summary-list__row--no-actions appeal-lpa-reference"><dt class="govuk-summary-list__key"> Planning application reference</dt>
-                                    <dd                                     class="govuk-summary-list__value">48269/APP/2021/1482</dd>
-                                </div>
-                                <div class="govuk-summary-list__row appeal-appeal-type"><dt class="govuk-summary-list__key"> Appeal type</dt>
-                                    <dd class="govuk-summary-list__value">Householder</dd>
-                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/3/change-appeal-type/appeal-type"
-                                        data-cy="change-appeal-type">Change<span class="govuk-visually-hidden"> Appeal type</span></a>
-                                    </dd>
-                                </div>
-                                <div class="govuk-summary-list__row govuk-summary-list__row--no-actions appeal-case-procedure"><dt class="govuk-summary-list__key"> Appeal procedure</dt>
-                                    <dd class="govuk-summary-list__value">Written</dd>
-                                </div>
-                                <div class="govuk-summary-list__row appeal-allocation-details"><dt class="govuk-summary-list__key"> Allocation level</dt>
-                                    <dd class="govuk-summary-list__value">
-                                        <ul class="govuk-!-margin-0">
-                                            <li>Level: A</li>
-                                            <li>Historic heritage</li>
-                                            <li>Architecture design</li>
-                                        </ul>
-                                    </dd>
-                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/3/allocation-details/allocation-level"
-                                        data-cy="change-allocation-details">Change<span class="govuk-visually-hidden"> Allocation level</span></a>
-                                    </dd>
-                                </div>
-                                <div class="govuk-summary-list__row appeal-linked-appeals"><dt class="govuk-summary-list__key"> Linked appeals</dt>
-                                    <dd class="govuk-summary-list__value">
-                                        <ul class="govuk-list govuk-list--bullet">
-                                            <li><a href="/appeals-service/appeal-details/4" class="govuk-link" data-cy="linked-appeal-725284"
-                                                aria-label="Appeal 7 2 5 2 8 4">725284</a> (Child)</li>
-                                            <li><a href="/appeals-service/appeal-details/5" class="govuk-link" data-cy="linked-appeal-725285"
-                                                aria-label="Appeal 7 2 5 2 8 5">725285</a> (Child)</li>
-                                        </ul>
-                                    </dd>
-                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/3/linked-appeals/manage"
-                                        data-cy="manage-linked-appeals">Manage<span class="govuk-visually-hidden"> Linked appeals</span></a>
-                                    </dd>
-                                </div>
-                                <div class="govuk-summary-list__row appeal-other-appeals"><dt class="govuk-summary-list__key"> Related appeals</dt>
-                                    <dd class="govuk-summary-list__value">
-                                        <ul class="govuk-list govuk-list--bullet">
-                                            <li><a href="/appeals-service/appeal-details/6" class="govuk-link" data-cy="related-appeal-765413"
-                                                aria-label="Appeal 7 6 5 4 1 3">765413</a>
-                                            </li>
-                                            <li><a href="/appeals-service/appeal-details/7" class="govuk-link" data-cy="related-appeal-765414"
-                                                aria-label="Appeal 7 6 5 4 1 4">765414</a>
-                                            </li>
-                                        </ul>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
+            <div class="govuk-accordion" data-module="govuk-accordion" id="accordion-default3">
+                <div class="govuk-accordion__section">
+                    <div class="govuk-accordion__section-header">
+                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default3-heading-1"> Overview</span></h2>
+                    </div>
+                    <div id="accordion-default3-content-1" class="govuk-accordion__section-content">
+                        <dl class="govuk-summary-list">
+                            <div class="govuk-summary-list__row govuk-summary-list__row--no-actions appeal-lpa-reference"><dt class="govuk-summary-list__key"> Planning application reference</dt>
+                                <dd                                 class="govuk-summary-list__value">48269/APP/2021/1482</dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-appeal-type"><dt class="govuk-summary-list__key"> Appeal type</dt>
+                                <dd class="govuk-summary-list__value">Householder</dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/3/change-appeal-type/appeal-type"
+                                    data-cy="change-appeal-type">Change<span class="govuk-visually-hidden"> Appeal type</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row govuk-summary-list__row--no-actions appeal-case-procedure"><dt class="govuk-summary-list__key"> Appeal procedure</dt>
+                                <dd class="govuk-summary-list__value">Written</dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-allocation-details"><dt class="govuk-summary-list__key"> Allocation level</dt>
+                                <dd class="govuk-summary-list__value">
+                                    <ul class="govuk-!-margin-0">
+                                        <li>Level: A</li>
+                                        <li>Historic heritage</li>
+                                        <li>Architecture design</li>
+                                    </ul>
+                                </dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/3/allocation-details/allocation-level"
+                                    data-cy="change-allocation-details">Change<span class="govuk-visually-hidden"> Allocation level</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-linked-appeals"><dt class="govuk-summary-list__key"> Linked appeals</dt>
+                                <dd class="govuk-summary-list__value">
+                                    <ul class="govuk-list govuk-list--bullet">
+                                        <li><a href="/appeals-service/appeal-details/4" class="govuk-link" data-cy="linked-appeal-725284"
+                                            aria-label="Appeal 7 2 5 2 8 4">725284</a> (Child)</li>
+                                        <li><a href="/appeals-service/appeal-details/5" class="govuk-link" data-cy="linked-appeal-725285"
+                                            aria-label="Appeal 7 2 5 2 8 5">725285</a> (Child)</li>
+                                    </ul>
+                                </dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/3/linked-appeals/manage"
+                                    data-cy="manage-linked-appeals">Manage<span class="govuk-visually-hidden"> Linked appeals</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-other-appeals"><dt class="govuk-summary-list__key"> Related appeals</dt>
+                                <dd class="govuk-summary-list__value">
+                                    <ul class="govuk-list govuk-list--bullet">
+                                        <li><a href="/appeals-service/appeal-details/6" class="govuk-link" data-cy="related-appeal-765413"
+                                            aria-label="Appeal 7 6 5 4 1 3">765413</a>
+                                        </li>
+                                        <li><a href="/appeals-service/appeal-details/7" class="govuk-link" data-cy="related-appeal-765414"
+                                            aria-label="Appeal 7 6 5 4 1 4">765414</a>
+                                        </li>
+                                    </ul>
+                                </dd>
+                                <dd class="govuk-summary-list__actions">
+                                    <ul class="govuk-summary-list__actions-list">
+                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/3/other-appeals/manage"
+                                            data-cy="manage-related-appeals">Manage<span class="govuk-visually-hidden"> Related appeals</span></a>
+                                        </li>
+                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/3/other-appeals/add"
+                                            data-cy="add-related-appeals">Add<span class="govuk-visually-hidden"> Related appeals</span></a>
+                                        </li>
+                                    </ul>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-decision"><dt class="govuk-summary-list__key"> Decision</dt>
+                                <dd class="govuk-summary-list__value">Dismissed</dd>
+                            </div>
+                        </dl>
+                    </div>
+                </div>
+                <div class="govuk-accordion__section">
+                    <div class="govuk-accordion__section-header">
+                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default3-heading-2"> Site</span></h2>
+                    </div>
+                    <div id="accordion-default3-content-2" class="govuk-accordion__section-content">
+                        <dl class="govuk-summary-list">
+                            <div class="govuk-summary-list__row appeal-visit-type"><dt class="govuk-summary-list__key"> Visit type</dt>
+                                <dd class="govuk-summary-list__value">Accompanied</dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/3/site-visit/visit-booked?backUrl=%2Fappeals-service%2Fappeal-details%2F3"
+                                    data-cy="change-set-visit-type">Change<span class="govuk-visually-hidden"> Visit type</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Date</dt>
+                                <dd class="govuk-summary-list__value">9 October 2023</dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/3/site-visit/visit-booked"
+                                    data-cy="change-site-visit-date">Change<span class="govuk-visually-hidden"> Date</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Start time</dt>
+                                <dd class="govuk-summary-list__value">9:38am</dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/3/site-visit/visit-booked"
+                                    data-cy="change-site-visit-start-time">Change<span class="govuk-visually-hidden"> Start time</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> End time</dt>
+                                <dd class="govuk-summary-list__value">10:00am</dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/3/site-visit/visit-booked"
+                                    data-cy="change-site-visit-end-time">Change<span class="govuk-visually-hidden"> End time</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-neighbouring-sites-inspector"><dt class="govuk-summary-list__key"> Interested party and neighbour addresses</dt>
+                                <dd                                 class="govuk-summary-list__value">
+                                    <ul class="govuk-list govuk-list--bullet">
+                                        <li>2 Grove Cottage, Shotesham Road, Woodton, Devon, NR35 2ND</li>
+                                    </ul>
                                     </dd>
                                     <dd class="govuk-summary-list__actions">
                                         <ul class="govuk-summary-list__actions-list">
-                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/3/other-appeals/manage"
-                                                data-cy="manage-related-appeals">Manage<span class="govuk-visually-hidden"> Related appeals</span></a>
+                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/3/neighbouring-sites/manage"
+                                                data-cy="manage-neighbouring-sites-inspector">Manage<span class="govuk-visually-hidden"> Interested party and neighbour addresses</span></a>
                                             </li>
-                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/3/other-appeals/add"
-                                                data-cy="add-related-appeals">Add<span class="govuk-visually-hidden"> Related appeals</span></a>
+                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/3/neighbouring-sites/add/back-office"
+                                                data-cy="add-neighbouring-sites-inspector">Add<span class="govuk-visually-hidden"> Interested party and neighbour addresses</span></a>
                                             </li>
                                         </ul>
                                     </dd>
-                                </div>
-                                <div class="govuk-summary-list__row appeal-decision"><dt class="govuk-summary-list__key"> Decision</dt>
-                                    <dd class="govuk-summary-list__value">Dismissed</dd>
-                                </div>
-                            </dl>
-                        </div>
+                            </div>
+                        </dl>
                     </div>
-                    <div class="govuk-accordion__section">
-                        <div class="govuk-accordion__section-header">
-                            <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default3-heading-2"> Site</span></h2>
-                        </div>
-                        <div id="accordion-default3-content-2" class="govuk-accordion__section-content">
-                            <dl class="govuk-summary-list">
-                                <div class="govuk-summary-list__row appeal-visit-type"><dt class="govuk-summary-list__key"> Visit type</dt>
-                                    <dd class="govuk-summary-list__value">Accompanied</dd>
-                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/3/site-visit/visit-booked?backUrl=%2Fappeals-service%2Fappeal-details%2F3"
-                                        data-cy="change-set-visit-type">Change<span class="govuk-visually-hidden"> Visit type</span></a>
-                                    </dd>
-                                </div>
-                                <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Date</dt>
-                                    <dd class="govuk-summary-list__value">9 October 2023</dd>
-                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/3/site-visit/visit-booked"
-                                        data-cy="change-site-visit-date">Change<span class="govuk-visually-hidden"> Date</span></a>
-                                    </dd>
-                                </div>
-                                <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Start time</dt>
-                                    <dd class="govuk-summary-list__value">9:38am</dd>
-                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/3/site-visit/visit-booked"
-                                        data-cy="change-site-visit-start-time">Change<span class="govuk-visually-hidden"> Start time</span></a>
-                                    </dd>
-                                </div>
-                                <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> End time</dt>
-                                    <dd class="govuk-summary-list__value">10:00am</dd>
-                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/3/site-visit/visit-booked"
-                                        data-cy="change-site-visit-end-time">Change<span class="govuk-visually-hidden"> End time</span></a>
-                                    </dd>
-                                </div>
-                                <div class="govuk-summary-list__row appeal-neighbouring-sites-inspector"><dt class="govuk-summary-list__key"> Interested party and neighbour addresses</dt>
-                                    <dd                                     class="govuk-summary-list__value">
-                                        <ul class="govuk-list govuk-list--bullet">
-                                            <li>2 Grove Cottage, Shotesham Road, Woodton, Devon, NR35 2ND</li>
+                </div>
+                <div class="govuk-accordion__section">
+                    <div class="govuk-accordion__section-header">
+                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default3-heading-3"> Timetable</span></h2>
+                    </div>
+                    <div id="accordion-default3-content-3" class="govuk-accordion__section-content">
+                        <dl class="govuk-summary-list appeal-case-timetable">
+                            <div class="govuk-summary-list__row appeal-valid-date"><dt class="govuk-summary-list__key"> Valid date</dt>
+                                <dd class="govuk-summary-list__value">23 May 2023</dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/3/appellant-case/valid/date"
+                                    data-cy="-valid-date"><span class="govuk-visually-hidden"> Valid date</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-start-date"><dt class="govuk-summary-list__key"> Start date</dt>
+                                <dd class="govuk-summary-list__value">23 May 2023</dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/3/start-case/change"
+                                    data-cy="change-start-case-date">Change<span class="govuk-visually-hidden"> Start date</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-lpa-questionnaire-due-date"><dt class="govuk-summary-list__key"> LPA questionnaire due</dt>
+                                <dd class="govuk-summary-list__value">11 October 2023</dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-site-visit"><dt class="govuk-summary-list__key"> Site visit</dt>
+                                <dd class="govuk-summary-list__value">
+                                    <ul class="govuk-list govuk-!-margin-top-0 govuk-!-padding-left-0">
+                                        <li>9 October 2023</li>
+                                        <li>9:38am - 10:00am</li>
+                                    </ul>
+                                </dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/3/site-visit/manage-visit?backUrl=%2Fappeals-service%2Fappeal-details%2F3"
+                                    data-cy="change-schedule-visit">Change<span class="govuk-visually-hidden"> Site visit</span></a>
+                                </dd>
+                            </div>
+                        </dl>
+                    </div>
+                </div>
+                <div class="govuk-accordion__section">
+                    <div class="govuk-accordion__section-header">
+                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default3-heading-4"> Documentation</span></h2>
+                    </div>
+                    <div id="accordion-default3-content-4" class="govuk-accordion__section-content">
+                        <table class="govuk-table">
+                            <thead class="govuk-table__head">
+                                <tr class="govuk-table__row">
+                                    <th scope="col" class="govuk-table__header">Documentation</th>
+                                    <th scope="col" class="govuk-table__header">Status</th>
+                                    <th scope="col" class="govuk-table__header">Received</th>
+                                    <th scope="col" class="govuk-table__header govuk-!-text-align-right">Action</th>
+                                </tr>
+                            </thead>
+                            <tbody class="govuk-table__body">
+                                <tr class="govuk-table__row">
+                                    <th scope="row" class="govuk-table__header">Appeal</th>
+                                    <td class="govuk-table__cell">Ready to review</td>
+                                    <td class="govuk-table__cell">2 August 2024</td>
+                                    <td class="govuk-table__cell govuk-!-text-align-right"><a href="/appeals-service/appeal-details/3/appellant-case?backUrl=%2Fappeals-service%2Fappeal-details%2F3"
+                                        data-cy="review-appellant-case" class="govuk-link">Review<span class="govuk-visually-hidden"> appellant case</span></a>
+                                    </td>
+                                </tr>
+                                <tr class="govuk-table__row">
+                                    <th scope="row" class="govuk-table__header">LPA questionnaire</th>
+                                    <td class="govuk-table__cell">Overdue</td>
+                                    <td class="govuk-table__cell">Due by 11 October 2023</td>
+                                    <td class="govuk-table__cell govuk-!-text-align-right"></td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
+                <div class="govuk-accordion__section">
+                    <div class="govuk-accordion__section-header">
+                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default3-heading-5"> Costs</span></h2>
+                    </div>
+                    <div id="accordion-default3-content-5" class="govuk-accordion__section-content">
+                        <table class="govuk-table">
+                            <thead class="govuk-table__head">
+                                <tr class="govuk-table__row">
+                                    <th scope="col" class="govuk-table__header">Documentation</th>
+                                    <th scope="col" class="govuk-table__header">Status</th>
+                                    <th scope="col" class="govuk-table__header govuk-!-text-align-right">Action</th>
+                                </tr>
+                            </thead>
+                            <tbody class="govuk-table__body">
+                                <tr class="govuk-table__row">
+                                    <th scope="row" class="govuk-table__header appeal-costs-appellant-application-documentation">Appellant application</th>
+                                    <td class="govuk-table__cell appeal-costs-appellant-application-status">No documents available</td>
+                                    <td class="govuk-table__cell appeal-costs-appellant-application-actions govuk-!-text-align-right">
+                                        <ul class="govuk-summary-list__actions-list">
+                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-appellant-application" href="/appeals-service/appeal-details/3/costs/appellant/application/upload-documents/1">Add<span class="govuk-visually-hidden"> Appellant application</span></a>
+                                            </li>
                                         </ul>
-                                        </dd>
-                                        <dd class="govuk-summary-list__actions">
-                                            <ul class="govuk-summary-list__actions-list">
-                                                <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/3/neighbouring-sites/manage"
-                                                    data-cy="manage-neighbouring-sites-inspector">Manage<span class="govuk-visually-hidden"> Interested party and neighbour addresses</span></a>
-                                                </li>
-                                                <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/3/neighbouring-sites/add/back-office"
-                                                    data-cy="add-neighbouring-sites-inspector">Add<span class="govuk-visually-hidden"> Interested party and neighbour addresses</span></a>
-                                                </li>
-                                            </ul>
-                                        </dd>
-                                </div>
-                            </dl>
-                        </div>
-                    </div>
-                    <div class="govuk-accordion__section">
-                        <div class="govuk-accordion__section-header">
-                            <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default3-heading-3"> Timetable</span></h2>
-                        </div>
-                        <div id="accordion-default3-content-3" class="govuk-accordion__section-content">
-                            <dl class="govuk-summary-list appeal-case-timetable">
-                                <div class="govuk-summary-list__row appeal-valid-date"><dt class="govuk-summary-list__key"> Valid date</dt>
-                                    <dd class="govuk-summary-list__value">23 May 2023</dd>
-                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/3/appellant-case/valid/date"
-                                        data-cy="-valid-date"><span class="govuk-visually-hidden"> Valid date</span></a>
-                                    </dd>
-                                </div>
-                                <div class="govuk-summary-list__row appeal-start-date"><dt class="govuk-summary-list__key"> Start date</dt>
-                                    <dd class="govuk-summary-list__value">23 May 2023</dd>
-                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/3/start-case/change"
-                                        data-cy="change-start-case-date">Change<span class="govuk-visually-hidden"> Start date</span></a>
-                                    </dd>
-                                </div>
-                                <div class="govuk-summary-list__row appeal-lpa-questionnaire-due-date"><dt class="govuk-summary-list__key"> LPA questionnaire due</dt>
-                                    <dd class="govuk-summary-list__value">11 October 2023</dd>
-                                </div>
-                                <div class="govuk-summary-list__row appeal-site-visit"><dt class="govuk-summary-list__key"> Site visit</dt>
-                                    <dd class="govuk-summary-list__value">
-                                        <ul class="govuk-list govuk-!-margin-top-0 govuk-!-padding-left-0">
-                                            <li>9 October 2023</li>
-                                            <li>9:38am - 10:00am</li>
+                                    </td>
+                                </tr>
+                                <tr class="govuk-table__row">
+                                    <th scope="row" class="govuk-table__header appeal-costs-appellant-withdrawal-documentation">Appellant withdrawal</th>
+                                    <td class="govuk-table__cell appeal-costs-appellant-withdrawal-status">No documents available</td>
+                                    <td class="govuk-table__cell appeal-costs-appellant-withdrawal-actions govuk-!-text-align-right">
+                                        <ul class="govuk-summary-list__actions-list">
+                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-appellant-withdrawal" href="/appeals-service/appeal-details/3/costs/appellant/withdrawal/upload-documents/2">Add<span class="govuk-visually-hidden"> Appellant withdrawal</span></a>
+                                            </li>
                                         </ul>
-                                    </dd>
-                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/3/site-visit/manage-visit?backUrl=%2Fappeals-service%2Fappeal-details%2F3"
-                                        data-cy="change-schedule-visit">Change<span class="govuk-visually-hidden"> Site visit</span></a>
-                                    </dd>
-                                </div>
-                            </dl>
-                        </div>
-                    </div>
-                    <div class="govuk-accordion__section">
-                        <div class="govuk-accordion__section-header">
-                            <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default3-heading-4"> Documentation</span></h2>
-                        </div>
-                        <div id="accordion-default3-content-4" class="govuk-accordion__section-content">
-                            <table class="govuk-table">
-                                <thead class="govuk-table__head">
-                                    <tr class="govuk-table__row">
-                                        <th scope="col" class="govuk-table__header">Documentation</th>
-                                        <th scope="col" class="govuk-table__header">Status</th>
-                                        <th scope="col" class="govuk-table__header">Received</th>
-                                        <th scope="col" class="govuk-table__header govuk-!-text-align-right">Action</th>
-                                    </tr>
-                                </thead>
-                                <tbody class="govuk-table__body">
-                                    <tr class="govuk-table__row">
-                                        <th scope="row" class="govuk-table__header">Appeal</th>
-                                        <td class="govuk-table__cell">Ready to review</td>
-                                        <td class="govuk-table__cell">2 August 2024</td>
-                                        <td class="govuk-table__cell govuk-!-text-align-right"><a href="/appeals-service/appeal-details/3/appellant-case?backUrl=%2Fappeals-service%2Fappeal-details%2F3"
-                                            data-cy="review-appellant-case" class="govuk-link">Review<span class="govuk-visually-hidden"> appellant case</span></a>
-                                        </td>
-                                    </tr>
-                                    <tr class="govuk-table__row">
-                                        <th scope="row" class="govuk-table__header">LPA questionnaire</th>
-                                        <td class="govuk-table__cell">Overdue</td>
-                                        <td class="govuk-table__cell">Due by 11 October 2023</td>
-                                        <td class="govuk-table__cell govuk-!-text-align-right"></td>
-                                    </tr>
-                                </tbody>
-                            </table>
-                        </div>
-                    </div>
-                    <div class="govuk-accordion__section">
-                        <div class="govuk-accordion__section-header">
-                            <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default3-heading-5"> Costs</span></h2>
-                        </div>
-                        <div id="accordion-default3-content-5" class="govuk-accordion__section-content">
-                            <table class="govuk-table">
-                                <thead class="govuk-table__head">
-                                    <tr class="govuk-table__row">
-                                        <th scope="col" class="govuk-table__header">Documentation</th>
-                                        <th scope="col" class="govuk-table__header">Status</th>
-                                        <th scope="col" class="govuk-table__header govuk-!-text-align-right">Action</th>
-                                    </tr>
-                                </thead>
-                                <tbody class="govuk-table__body">
-                                    <tr class="govuk-table__row">
-                                        <th scope="row" class="govuk-table__header appeal-costs-appellant-application-documentation">Appellant application</th>
-                                        <td class="govuk-table__cell appeal-costs-appellant-application-status">No documents available</td>
-                                        <td class="govuk-table__cell appeal-costs-appellant-application-actions govuk-!-text-align-right">
-                                            <ul class="govuk-summary-list__actions-list">
-                                                <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-appellant-application" href="/appeals-service/appeal-details/3/costs/appellant/application/upload-documents/1">Add<span class="govuk-visually-hidden"> Appellant application</span></a>
-                                                </li>
-                                            </ul>
-                                        </td>
-                                    </tr>
-                                    <tr class="govuk-table__row">
-                                        <th scope="row" class="govuk-table__header appeal-costs-appellant-withdrawal-documentation">Appellant withdrawal</th>
-                                        <td class="govuk-table__cell appeal-costs-appellant-withdrawal-status">No documents available</td>
-                                        <td class="govuk-table__cell appeal-costs-appellant-withdrawal-actions govuk-!-text-align-right">
-                                            <ul class="govuk-summary-list__actions-list">
-                                                <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-appellant-withdrawal" href="/appeals-service/appeal-details/3/costs/appellant/withdrawal/upload-documents/2">Add<span class="govuk-visually-hidden"> Appellant withdrawal</span></a>
-                                                </li>
-                                            </ul>
-                                        </td>
-                                    </tr>
-                                    <tr class="govuk-table__row">
-                                        <th scope="row" class="govuk-table__header appeal-costs-appellant-correspondence-documentation">Appellant correspondence</th>
-                                        <td class="govuk-table__cell appeal-costs-appellant-correspondence-status">No documents available</td>
-                                        <td class="govuk-table__cell appeal-costs-appellant-correspondence-actions govuk-!-text-align-right">
-                                            <ul class="govuk-summary-list__actions-list">
-                                                <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-appellant-correspondence" href="/appeals-service/appeal-details/3/costs/appellant/correspondence/upload-documents/3">Add<span class="govuk-visually-hidden"> Appellant correspondence</span></a>
-                                                </li>
-                                            </ul>
-                                        </td>
-                                    </tr>
-                                    <tr class="govuk-table__row">
-                                        <th scope="row" class="govuk-table__header appeal-costs-lpa-application-documentation">LPA application</th>
-                                        <td class="govuk-table__cell appeal-costs-lpa-application-status">No documents available</td>
-                                        <td class="govuk-table__cell appeal-costs-lpa-application-actions govuk-!-text-align-right">
-                                            <ul class="govuk-summary-list__actions-list">
-                                                <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-lpa-application" href="/appeals-service/appeal-details/3/costs/lpa/application/upload-documents/4">Add<span class="govuk-visually-hidden"> LPA application</span></a>
-                                                </li>
-                                            </ul>
-                                        </td>
-                                    </tr>
-                                    <tr class="govuk-table__row">
-                                        <th scope="row" class="govuk-table__header appeal-costs-lpa-withdrawal-documentation">LPA withdrawal</th>
-                                        <td class="govuk-table__cell appeal-costs-lpa-withdrawal-status">No documents available</td>
-                                        <td class="govuk-table__cell appeal-costs-lpa-withdrawal-actions govuk-!-text-align-right">
-                                            <ul class="govuk-summary-list__actions-list">
-                                                <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-lpa-withdrawal" href="/appeals-service/appeal-details/3/costs/lpa/withdrawal/upload-documents/5">Add<span class="govuk-visually-hidden"> LPA withdrawal</span></a>
-                                                </li>
-                                            </ul>
-                                        </td>
-                                    </tr>
-                                    <tr class="govuk-table__row">
-                                        <th scope="row" class="govuk-table__header appeal-costs-lpa-correspondence-documentation">LPA correspondence</th>
-                                        <td class="govuk-table__cell appeal-costs-lpa-correspondence-status">No documents available</td>
-                                        <td class="govuk-table__cell appeal-costs-lpa-correspondence-actions govuk-!-text-align-right">
-                                            <ul class="govuk-summary-list__actions-list">
-                                                <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-lpa-correspondence" href="/appeals-service/appeal-details/3/costs/lpa/correspondence/upload-documents/6">Add<span class="govuk-visually-hidden"> LPA correspondence</span></a>
-                                                </li>
-                                            </ul>
-                                        </td>
-                                    </tr>
-                                </tbody>
-                            </table>
-                        </div>
-                    </div>
-                    <div class="govuk-accordion__section">
-                        <div class="govuk-accordion__section-header">
-                            <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default3-heading-6"> Contacts</span></h2>
-                        </div>
-                        <div id="accordion-default3-content-6" class="govuk-accordion__section-content">
-                            <dl class="govuk-summary-list">
-                                <div class="govuk-summary-list__row appeal-appellant"><dt class="govuk-summary-list__key"> Appellant</dt>
-                                    <dd class="govuk-summary-list__value">
-                                        <ul class="govuk-list">
-                                            <li>Roger Simmons</li>
-                                            <li>test3@example.com</li>
+                                    </td>
+                                </tr>
+                                <tr class="govuk-table__row">
+                                    <th scope="row" class="govuk-table__header appeal-costs-appellant-correspondence-documentation">Appellant correspondence</th>
+                                    <td class="govuk-table__cell appeal-costs-appellant-correspondence-status">No documents available</td>
+                                    <td class="govuk-table__cell appeal-costs-appellant-correspondence-actions govuk-!-text-align-right">
+                                        <ul class="govuk-summary-list__actions-list">
+                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-appellant-correspondence" href="/appeals-service/appeal-details/3/costs/appellant/correspondence/upload-documents/3">Add<span class="govuk-visually-hidden"> Appellant correspondence</span></a>
+                                            </li>
                                         </ul>
-                                    </dd>
-                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/3/service-user/change/appellant"
-                                        data-cy="change-appellant">Change<span class="govuk-visually-hidden"> Appellant</span></a>
-                                    </dd>
-                                </div>
-                                <div class="govuk-summary-list__row appeal-agent"><dt class="govuk-summary-list__key"> Agent</dt>
-                                    <dd class="govuk-summary-list__value">
-                                        <ul class="govuk-list">
-                                            <li>Fiona Shell</li>
-                                            <li>test2@example.com</li>
+                                    </td>
+                                </tr>
+                                <tr class="govuk-table__row">
+                                    <th scope="row" class="govuk-table__header appeal-costs-lpa-application-documentation">LPA application</th>
+                                    <td class="govuk-table__cell appeal-costs-lpa-application-status">No documents available</td>
+                                    <td class="govuk-table__cell appeal-costs-lpa-application-actions govuk-!-text-align-right">
+                                        <ul class="govuk-summary-list__actions-list">
+                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-lpa-application" href="/appeals-service/appeal-details/3/costs/lpa/application/upload-documents/4">Add<span class="govuk-visually-hidden"> LPA application</span></a>
+                                            </li>
                                         </ul>
-                                    </dd>
-                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/3/service-user/change/agent"
-                                        data-cy="change-agent">Change<span class="govuk-visually-hidden"> Agent</span></a>
-                                    </dd>
-                                </div>
-                                <div class="govuk-summary-list__row appeal-lpa-contact-details"><dt class="govuk-summary-list__key"> LPA</dt>
-                                    <dd class="govuk-summary-list__value">
-                                        <ul class="govuk-list">
-                                            <li>Wiltshire Council</li>
-                                            <li>wilt@lpa-email.gov.uk</li>
+                                    </td>
+                                </tr>
+                                <tr class="govuk-table__row">
+                                    <th scope="row" class="govuk-table__header appeal-costs-lpa-withdrawal-documentation">LPA withdrawal</th>
+                                    <td class="govuk-table__cell appeal-costs-lpa-withdrawal-status">No documents available</td>
+                                    <td class="govuk-table__cell appeal-costs-lpa-withdrawal-actions govuk-!-text-align-right">
+                                        <ul class="govuk-summary-list__actions-list">
+                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-lpa-withdrawal" href="/appeals-service/appeal-details/3/costs/lpa/withdrawal/upload-documents/5">Add<span class="govuk-visually-hidden"> LPA withdrawal</span></a>
+                                            </li>
                                         </ul>
-                                    </dd>
-                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/3/change-appeal-details/local-planning-authority"
-                                        data-cy="change-lpa-contact-details">Change<span class="govuk-visually-hidden"> Local planning authority (LPA)</span></a>
-                                    </dd>
-                                </div>
-                            </dl>
-                        </div>
+                                    </td>
+                                </tr>
+                                <tr class="govuk-table__row">
+                                    <th scope="row" class="govuk-table__header appeal-costs-lpa-correspondence-documentation">LPA correspondence</th>
+                                    <td class="govuk-table__cell appeal-costs-lpa-correspondence-status">No documents available</td>
+                                    <td class="govuk-table__cell appeal-costs-lpa-correspondence-actions govuk-!-text-align-right">
+                                        <ul class="govuk-summary-list__actions-list">
+                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-lpa-correspondence" href="/appeals-service/appeal-details/3/costs/lpa/correspondence/upload-documents/6">Add<span class="govuk-visually-hidden"> LPA correspondence</span></a>
+                                            </li>
+                                        </ul>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
                     </div>
-                    <div class="govuk-accordion__section">
-                        <div class="govuk-accordion__section-header">
-                            <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default3-heading-7"> Team</span></h2>
-                        </div>
-                        <div id="accordion-default3-content-7" class="govuk-accordion__section-content">
-                            <dl class="govuk-summary-list">
-                                <div class="govuk-summary-list__row appeal-case-officer"><dt class="govuk-summary-list__key"> Case officer</dt>
-                                    <dd class="govuk-summary-list__value">
-                                        <p class="govuk-body">Not assigned</p>
-                                    </dd>
-                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/3/assign-user/case-officer"
-                                        data-cy="assign-case-officer">Assign<span class="govuk-visually-hidden"> Case officer</span></a>
-                                    </dd>
-                                </div>
-                                <div class="govuk-summary-list__row appeal-inspector"><dt class="govuk-summary-list__key"> Inspector</dt>
-                                    <dd class="govuk-summary-list__value">
-                                        <p class="govuk-body">Not assigned</p>
-                                    </dd>
-                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/3/assign-user/inspector"
-                                        data-cy="assign-inspector">Assign<span class="govuk-visually-hidden"> Inspector</span></a>
-                                    </dd>
-                                </div>
-                            </dl>
-                        </div>
+                </div>
+                <div class="govuk-accordion__section">
+                    <div class="govuk-accordion__section-header">
+                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default3-heading-6"> Contacts</span></h2>
                     </div>
-                    <div class="govuk-accordion__section">
-                        <div class="govuk-accordion__section-header">
-                            <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default3-heading-8"> Case management</span></h2>
-                        </div>
-                        <div id="accordion-default3-content-8" class="govuk-accordion__section-content">
-                            <dl class="govuk-summary-list">
-                                <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Cross-team correspondence</dt>
-                                    <dd                                     class="govuk-summary-list__value">No documents</dd>
-                                        <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/3/internal-correspondence/cross-team/upload-documents/10"
-                                            data-cy="add-cross-team-correspondence">Add<span class="govuk-visually-hidden"> Cross-team correspondence</span></a>
-                                        </dd>
-                                </div>
-                                <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Inspector correspondence</dt>
-                                    <dd                                     class="govuk-summary-list__value">No documents</dd>
-                                        <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/3/internal-correspondence/inspector/upload-documents/11"
-                                            data-cy="add-inspector-correspondence">Add<span class="govuk-visually-hidden"> Inspector correspondence</span></a>
-                                        </dd>
-                                </div>
-                                <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Main party correspondence</dt>
-                                    <dd                                     class="govuk-summary-list__value">No documents</dd>
-                                        <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/3/internal-correspondence/main-party/upload-documents/22"
-                                            data-cy="add-main-party-correspondence">Add<span class="govuk-visually-hidden"> Main party correspondence</span></a>
-                                        </dd>
-                                </div>
-                                <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Case history</dt>
-                                    <dd class="govuk-summary-list__value"></dd>
-                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/3/audit" data-cy="view-case-history">View<span class="govuk-visually-hidden"> Case history</span></a>
+                    <div id="accordion-default3-content-6" class="govuk-accordion__section-content">
+                        <dl class="govuk-summary-list">
+                            <div class="govuk-summary-list__row appeal-appellant"><dt class="govuk-summary-list__key"> Appellant</dt>
+                                <dd class="govuk-summary-list__value">
+                                    <ul class="govuk-list">
+                                        <li>Roger Simmons</li>
+                                        <li>test3@example.com</li>
+                                    </ul>
+                                </dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/3/service-user/change/appellant"
+                                    data-cy="change-appellant">Change<span class="govuk-visually-hidden"> Appellant</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-agent"><dt class="govuk-summary-list__key"> Agent</dt>
+                                <dd class="govuk-summary-list__value">
+                                    <ul class="govuk-list">
+                                        <li>Fiona Shell</li>
+                                        <li>test2@example.com</li>
+                                    </ul>
+                                </dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/3/service-user/change/agent"
+                                    data-cy="change-agent">Change<span class="govuk-visually-hidden"> Agent</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-lpa-contact-details"><dt class="govuk-summary-list__key"> LPA</dt>
+                                <dd class="govuk-summary-list__value">
+                                    <ul class="govuk-list">
+                                        <li>Wiltshire Council</li>
+                                        <li>wilt@lpa-email.gov.uk</li>
+                                    </ul>
+                                </dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/3/change-appeal-details/local-planning-authority"
+                                    data-cy="change-lpa-contact-details">Change<span class="govuk-visually-hidden"> Local planning authority (LPA)</span></a>
+                                </dd>
+                            </div>
+                        </dl>
+                    </div>
+                </div>
+                <div class="govuk-accordion__section">
+                    <div class="govuk-accordion__section-header">
+                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default3-heading-7"> Team</span></h2>
+                    </div>
+                    <div id="accordion-default3-content-7" class="govuk-accordion__section-content">
+                        <dl class="govuk-summary-list">
+                            <div class="govuk-summary-list__row appeal-case-officer"><dt class="govuk-summary-list__key"> Case officer</dt>
+                                <dd class="govuk-summary-list__value">
+                                    <p class="govuk-body">Not assigned</p>
+                                </dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/3/assign-user/case-officer"
+                                    data-cy="assign-case-officer">Assign<span class="govuk-visually-hidden"> Case officer</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-inspector"><dt class="govuk-summary-list__key"> Inspector</dt>
+                                <dd class="govuk-summary-list__value">
+                                    <p class="govuk-body">Not assigned</p>
+                                </dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/3/assign-user/inspector"
+                                    data-cy="assign-inspector">Assign<span class="govuk-visually-hidden"> Inspector</span></a>
+                                </dd>
+                            </div>
+                        </dl>
+                    </div>
+                </div>
+                <div class="govuk-accordion__section">
+                    <div class="govuk-accordion__section-header">
+                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default3-heading-8"> Case management</span></h2>
+                    </div>
+                    <div id="accordion-default3-content-8" class="govuk-accordion__section-content">
+                        <dl class="govuk-summary-list">
+                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Cross-team correspondence</dt>
+                                <dd                                 class="govuk-summary-list__value">No documents</dd>
+                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/3/internal-correspondence/cross-team/upload-documents/10"
+                                        data-cy="add-cross-team-correspondence">Add<span class="govuk-visually-hidden"> Cross-team correspondence</span></a>
                                     </dd>
-                                </div>
-                                <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Appeal withdrawal</dt>
-                                    <dd class="govuk-summary-list__value"></dd>
-                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/3/withdrawal/start"
-                                        data-cy="start-appeal-withdrawal">Start<span class="govuk-visually-hidden"> Appeal withdrawal</span></a>
+                            </div>
+                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Inspector correspondence</dt>
+                                <dd                                 class="govuk-summary-list__value">No documents</dd>
+                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/3/internal-correspondence/inspector/upload-documents/11"
+                                        data-cy="add-inspector-correspondence">Add<span class="govuk-visually-hidden"> Inspector correspondence</span></a>
                                     </dd>
-                                </div>
-                            </dl>
-                        </div>
+                            </div>
+                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Main party correspondence</dt>
+                                <dd                                 class="govuk-summary-list__value">No documents</dd>
+                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/3/internal-correspondence/main-party/upload-documents/22"
+                                        data-cy="add-main-party-correspondence">Add<span class="govuk-visually-hidden"> Main party correspondence</span></a>
+                                    </dd>
+                            </div>
+                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Case history</dt>
+                                <dd class="govuk-summary-list__value"></dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/3/audit" data-cy="view-case-history">View<span class="govuk-visually-hidden"> Case history</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Appeal withdrawal</dt>
+                                <dd class="govuk-summary-list__value"></dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/3/withdrawal/start"
+                                    data-cy="start-appeal-withdrawal">Start<span class="govuk-visually-hidden"> Appeal withdrawal</span></a>
+                                </dd>
+                            </div>
+                        </dl>
                     </div>
                 </div>
             </div>
         </div>
+    </div>
 </main>"
 `;
 
@@ -6242,7 +6250,7 @@ exports[`appeal-details GET /:appealId should render the received appeal details
         </div>
     </div>
     <div class="govuk-grid-row">
-        <div class="govuk-grid-column-full"><strong class="govuk-tag govuk-tag--grey govuk-!-margin-bottom-4">Received appeal</strong>
+        <div class="govuk-grid-column-full"><strong class="govuk-tag govuk-tag--grey pins-status-tag--full-width">Received appeal</strong>
         </div>
     </div>
     <div class="govuk-grid-row">
@@ -6680,10 +6688,11 @@ exports[`appeal-details GET /:appealId should render the received appeal details
         </div>
     </div>
     <div class="govuk-grid-row">
-        <div class="govuk-grid-column-full"><strong class="govuk-tag govuk-tag--grey govuk-!-margin-bottom-4">Received appeal</strong>
+        <div class="govuk-grid-column-full"><strong class="govuk-tag govuk-tag--grey pins-status-tag--full-width">Received appeal</strong>
+            <strong             class="govuk-tag govuk-tag--grey govuk-!-margin-left-1 govuk-!-margin-bottom-4"></strong>
         </div>
-    </div><strong class="govuk-tag govuk-tag--grey govuk-!-margin-left-1 govuk-!-margin-bottom-4"></strong>
-    <div     class="govuk-grid-row">
+    </div>
+    <div class="govuk-grid-row">
         <div class="govuk-grid-column-full">
             <dl class="govuk-summary-list pins-summary-list--no-border">
                 <div class="govuk-summary-list__row appeal-case-officer"><dt class="govuk-summary-list__key"> Case officer</dt>
@@ -6708,424 +6717,424 @@ exports[`appeal-details GET /:appealId should render the received appeal details
                 </div>
             </dl>
         </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
+            <p class="govuk-body govuk-!-margin-bottom-6" id="download-case-files"
+            data-cy="download-case-files"><a class="govuk-link" href="/documents/2/bulk-download/case-APP/Q9999/D/21/351062.zip">Download case</a>
+            </p>
         </div>
-        <div class="govuk-grid-row">
-            <div class="govuk-grid-column-full">
-                <p class="govuk-body govuk-!-margin-bottom-6" id="download-case-files"
-                data-cy="download-case-files"><a class="govuk-link" href="/documents/2/bulk-download/case-APP/Q9999/D/21/351062.zip">Download case</a>
-                </p>
-            </div>
-        </div>
-        <div class="govuk-grid-row">
-            <div class="govuk-grid-column-full">
-                <details class="govuk-details">
-                    <summary class="govuk-details__summary"><span class="govuk-details__summary-text"> 2 case notes</span>
-                    </summary>
-                    <div class="govuk-details__text">
-                        <form method="POST" novalidate="novalidate">
-                            <div class="govuk-grid-row">
-                                <div class="govuk-grid-column-two-thirds">
-                                    <div class="govuk-form-group govuk-character-count" data-module="govuk-character-count"
-                                    data-maxlength="500">
-                                        <textarea class="govuk-textarea govuk-js-character-count" id="comment"
-                                        name="comment" rows="5" aria-describedby="comment-info"></textarea>
-                                        <div id="comment-info" class="govuk-hint govuk-character-count__message">You can enter up to 500 characters</div>
-                                    </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
+            <details class="govuk-details">
+                <summary class="govuk-details__summary"><span class="govuk-details__summary-text"> 2 case notes</span>
+                </summary>
+                <div class="govuk-details__text">
+                    <form method="POST" novalidate="novalidate">
+                        <div class="govuk-grid-row">
+                            <div class="govuk-grid-column-two-thirds">
+                                <div class="govuk-form-group govuk-character-count" data-module="govuk-character-count"
+                                data-maxlength="500">
+                                    <textarea class="govuk-textarea govuk-js-character-count" id="comment"
+                                    name="comment" rows="5" aria-describedby="comment-info"></textarea>
+                                    <div id="comment-info" class="govuk-hint govuk-character-count__message">You can enter up to 500 characters</div>
                                 </div>
                             </div>
-                            <button type="submit" data-prevent-double-click="true" class="govuk-button govuk-button--secondary govuk-!-margin-bottom-1"
-                            data-module="govuk-button">Add case note</button>
-                        </form>
-                        <div>
+                        </div>
+                        <button type="submit" data-prevent-double-click="true" class="govuk-button govuk-button--secondary govuk-!-margin-bottom-1"
+                        data-module="govuk-button">Add case note</button>
+                    </form>
+                    <div>
+                        <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+                        <section>
+                            <p class="govuk-body govuk-!-margin-bottom-1">A case note you should see.</p>
+                            <p class="govuk-hint govuk-!-margin-bottom-6">11:00am on Tuesday 1 October 2024 by John.Smith</p>
                             <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
-                            <section>
-                                <p class="govuk-body govuk-!-margin-bottom-1">A case note you should see.</p>
-                                <p class="govuk-hint govuk-!-margin-bottom-6">11:00am on Tuesday 1 October 2024 by John.Smith</p>
-                                <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
-                            </section>
-                            <section>
-                                <p class="govuk-body govuk-!-margin-bottom-1">A case note you should see.</p>
-                                <p class="govuk-hint govuk-!-margin-bottom-6">11:00am on Tuesday 1 October 2024 by John.Smith</p>
-                                <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
-                            </section>
-                        </div>
+                        </section>
+                        <section>
+                            <p class="govuk-body govuk-!-margin-bottom-1">A case note you should see.</p>
+                            <p class="govuk-hint govuk-!-margin-bottom-6">11:00am on Tuesday 1 October 2024 by John.Smith</p>
+                            <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+                        </section>
                     </div>
-                </details>
-            </div>
+                </div>
+            </details>
         </div>
-        <div class="govuk-grid-row">
-            <div class="govuk-grid-column-full">
-                <div class="govuk-accordion" data-module="govuk-accordion" id="accordion-default2">
-                    <div class="govuk-accordion__section">
-                        <div class="govuk-accordion__section-header">
-                            <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default2-heading-1"> Overview</span></h2>
-                        </div>
-                        <div id="accordion-default2-content-1" class="govuk-accordion__section-content">
-                            <dl class="govuk-summary-list">
-                                <div class="govuk-summary-list__row govuk-summary-list__row--no-actions appeal-lpa-reference"><dt class="govuk-summary-list__key"> Planning application reference</dt>
-                                    <dd                                     class="govuk-summary-list__value">48269/APP/2021/1482</dd>
-                                </div>
-                                <div class="govuk-summary-list__row appeal-appeal-type"><dt class="govuk-summary-list__key"> Appeal type</dt>
-                                    <dd class="govuk-summary-list__value">Householder</dd>
-                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/change-appeal-type/appeal-type"
-                                        data-cy="change-appeal-type">Change<span class="govuk-visually-hidden"> Appeal type</span></a>
-                                    </dd>
-                                </div>
-                                <div class="govuk-summary-list__row govuk-summary-list__row--no-actions appeal-case-procedure"><dt class="govuk-summary-list__key"> Appeal procedure</dt>
-                                    <dd class="govuk-summary-list__value">Written</dd>
-                                </div>
-                                <div class="govuk-summary-list__row appeal-allocation-details"><dt class="govuk-summary-list__key"> Allocation level</dt>
-                                    <dd class="govuk-summary-list__value">
-                                        <ul class="govuk-!-margin-0">
-                                            <li>Level: A</li>
-                                            <li>Historic heritage</li>
-                                            <li>Architecture design</li>
-                                        </ul>
-                                    </dd>
-                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/allocation-details/allocation-level"
-                                        data-cy="change-allocation-details">Change<span class="govuk-visually-hidden"> Allocation level</span></a>
-                                    </dd>
-                                </div>
-                                <div class="govuk-summary-list__row appeal-linked-appeals"><dt class="govuk-summary-list__key"> Linked appeals</dt>
-                                    <dd class="govuk-summary-list__value">
-                                        <ul class="govuk-list govuk-list--bullet">
-                                            <li><a href="/appeals-service/appeal-details/1" class="govuk-link" data-cy="linked-appeal-725284"
-                                                aria-label="Appeal 7 2 5 2 8 4">725284</a> (Child)</li>
-                                        </ul>
-                                    </dd>
-                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/linked-appeals/manage"
-                                        data-cy="manage-linked-appeals">Manage<span class="govuk-visually-hidden"> Linked appeals</span></a>
-                                    </dd>
-                                </div>
-                                <div class="govuk-summary-list__row appeal-other-appeals"><dt class="govuk-summary-list__key"> Related appeals</dt>
-                                    <dd class="govuk-summary-list__value">
-                                        <ul class="govuk-list govuk-list--bullet">
-                                            <li><a href="/appeals-service/appeal-details/3" class="govuk-link" data-cy="related-appeal-765413"
-                                                aria-label="Appeal 7 6 5 4 1 3">765413</a>
-                                            </li>
-                                        </ul>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
+            <div class="govuk-accordion" data-module="govuk-accordion" id="accordion-default2">
+                <div class="govuk-accordion__section">
+                    <div class="govuk-accordion__section-header">
+                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default2-heading-1"> Overview</span></h2>
+                    </div>
+                    <div id="accordion-default2-content-1" class="govuk-accordion__section-content">
+                        <dl class="govuk-summary-list">
+                            <div class="govuk-summary-list__row govuk-summary-list__row--no-actions appeal-lpa-reference"><dt class="govuk-summary-list__key"> Planning application reference</dt>
+                                <dd                                 class="govuk-summary-list__value">48269/APP/2021/1482</dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-appeal-type"><dt class="govuk-summary-list__key"> Appeal type</dt>
+                                <dd class="govuk-summary-list__value">Householder</dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/change-appeal-type/appeal-type"
+                                    data-cy="change-appeal-type">Change<span class="govuk-visually-hidden"> Appeal type</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row govuk-summary-list__row--no-actions appeal-case-procedure"><dt class="govuk-summary-list__key"> Appeal procedure</dt>
+                                <dd class="govuk-summary-list__value">Written</dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-allocation-details"><dt class="govuk-summary-list__key"> Allocation level</dt>
+                                <dd class="govuk-summary-list__value">
+                                    <ul class="govuk-!-margin-0">
+                                        <li>Level: A</li>
+                                        <li>Historic heritage</li>
+                                        <li>Architecture design</li>
+                                    </ul>
+                                </dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/allocation-details/allocation-level"
+                                    data-cy="change-allocation-details">Change<span class="govuk-visually-hidden"> Allocation level</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-linked-appeals"><dt class="govuk-summary-list__key"> Linked appeals</dt>
+                                <dd class="govuk-summary-list__value">
+                                    <ul class="govuk-list govuk-list--bullet">
+                                        <li><a href="/appeals-service/appeal-details/1" class="govuk-link" data-cy="linked-appeal-725284"
+                                            aria-label="Appeal 7 2 5 2 8 4">725284</a> (Child)</li>
+                                    </ul>
+                                </dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/linked-appeals/manage"
+                                    data-cy="manage-linked-appeals">Manage<span class="govuk-visually-hidden"> Linked appeals</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-other-appeals"><dt class="govuk-summary-list__key"> Related appeals</dt>
+                                <dd class="govuk-summary-list__value">
+                                    <ul class="govuk-list govuk-list--bullet">
+                                        <li><a href="/appeals-service/appeal-details/3" class="govuk-link" data-cy="related-appeal-765413"
+                                            aria-label="Appeal 7 6 5 4 1 3">765413</a>
+                                        </li>
+                                    </ul>
+                                </dd>
+                                <dd class="govuk-summary-list__actions">
+                                    <ul class="govuk-summary-list__actions-list">
+                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/2/other-appeals/manage"
+                                            data-cy="manage-related-appeals">Manage<span class="govuk-visually-hidden"> Related appeals</span></a>
+                                        </li>
+                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/2/other-appeals/add"
+                                            data-cy="add-related-appeals">Add<span class="govuk-visually-hidden"> Related appeals</span></a>
+                                        </li>
+                                    </ul>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-decision"><dt class="govuk-summary-list__key"> Decision</dt>
+                                <dd class="govuk-summary-list__value">Dismissed</dd>
+                            </div>
+                        </dl>
+                    </div>
+                </div>
+                <div class="govuk-accordion__section">
+                    <div class="govuk-accordion__section-header">
+                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default2-heading-2"> Site</span></h2>
+                    </div>
+                    <div id="accordion-default2-content-2" class="govuk-accordion__section-content">
+                        <dl class="govuk-summary-list">
+                            <div class="govuk-summary-list__row appeal-visit-type"><dt class="govuk-summary-list__key"> Visit type</dt>
+                                <dd class="govuk-summary-list__value">Accompanied</dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/site-visit/visit-booked?backUrl=%2Fappeals-service%2Fappeal-details%2F2"
+                                    data-cy="change-set-visit-type">Change<span class="govuk-visually-hidden"> Visit type</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Date</dt>
+                                <dd class="govuk-summary-list__value">9 October 2023</dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/site-visit/visit-booked"
+                                    data-cy="change-site-visit-date">Change<span class="govuk-visually-hidden"> Date</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Start time</dt>
+                                <dd class="govuk-summary-list__value">9:38am</dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/site-visit/visit-booked"
+                                    data-cy="change-site-visit-start-time">Change<span class="govuk-visually-hidden"> Start time</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> End time</dt>
+                                <dd class="govuk-summary-list__value">10:00am</dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/site-visit/visit-booked"
+                                    data-cy="change-site-visit-end-time">Change<span class="govuk-visually-hidden"> End time</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-neighbouring-sites-inspector"><dt class="govuk-summary-list__key"> Interested party and neighbour addresses</dt>
+                                <dd                                 class="govuk-summary-list__value">
+                                    <ul class="govuk-list govuk-list--bullet">
+                                        <li>2 Grove Cottage, Shotesham Road, Woodton, Devon, NR35 2ND</li>
+                                    </ul>
                                     </dd>
                                     <dd class="govuk-summary-list__actions">
                                         <ul class="govuk-summary-list__actions-list">
-                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/2/other-appeals/manage"
-                                                data-cy="manage-related-appeals">Manage<span class="govuk-visually-hidden"> Related appeals</span></a>
+                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/2/neighbouring-sites/manage"
+                                                data-cy="manage-neighbouring-sites-inspector">Manage<span class="govuk-visually-hidden"> Interested party and neighbour addresses</span></a>
                                             </li>
-                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/2/other-appeals/add"
-                                                data-cy="add-related-appeals">Add<span class="govuk-visually-hidden"> Related appeals</span></a>
+                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/2/neighbouring-sites/add/back-office"
+                                                data-cy="add-neighbouring-sites-inspector">Add<span class="govuk-visually-hidden"> Interested party and neighbour addresses</span></a>
                                             </li>
                                         </ul>
                                     </dd>
-                                </div>
-                                <div class="govuk-summary-list__row appeal-decision"><dt class="govuk-summary-list__key"> Decision</dt>
-                                    <dd class="govuk-summary-list__value">Dismissed</dd>
-                                </div>
-                            </dl>
-                        </div>
+                            </div>
+                        </dl>
                     </div>
-                    <div class="govuk-accordion__section">
-                        <div class="govuk-accordion__section-header">
-                            <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default2-heading-2"> Site</span></h2>
-                        </div>
-                        <div id="accordion-default2-content-2" class="govuk-accordion__section-content">
-                            <dl class="govuk-summary-list">
-                                <div class="govuk-summary-list__row appeal-visit-type"><dt class="govuk-summary-list__key"> Visit type</dt>
-                                    <dd class="govuk-summary-list__value">Accompanied</dd>
-                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/site-visit/visit-booked?backUrl=%2Fappeals-service%2Fappeal-details%2F2"
-                                        data-cy="change-set-visit-type">Change<span class="govuk-visually-hidden"> Visit type</span></a>
-                                    </dd>
-                                </div>
-                                <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Date</dt>
-                                    <dd class="govuk-summary-list__value">9 October 2023</dd>
-                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/site-visit/visit-booked"
-                                        data-cy="change-site-visit-date">Change<span class="govuk-visually-hidden"> Date</span></a>
-                                    </dd>
-                                </div>
-                                <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Start time</dt>
-                                    <dd class="govuk-summary-list__value">9:38am</dd>
-                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/site-visit/visit-booked"
-                                        data-cy="change-site-visit-start-time">Change<span class="govuk-visually-hidden"> Start time</span></a>
-                                    </dd>
-                                </div>
-                                <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> End time</dt>
-                                    <dd class="govuk-summary-list__value">10:00am</dd>
-                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/site-visit/visit-booked"
-                                        data-cy="change-site-visit-end-time">Change<span class="govuk-visually-hidden"> End time</span></a>
-                                    </dd>
-                                </div>
-                                <div class="govuk-summary-list__row appeal-neighbouring-sites-inspector"><dt class="govuk-summary-list__key"> Interested party and neighbour addresses</dt>
-                                    <dd                                     class="govuk-summary-list__value">
-                                        <ul class="govuk-list govuk-list--bullet">
-                                            <li>2 Grove Cottage, Shotesham Road, Woodton, Devon, NR35 2ND</li>
+                </div>
+                <div class="govuk-accordion__section">
+                    <div class="govuk-accordion__section-header">
+                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default2-heading-3"> Timetable</span></h2>
+                    </div>
+                    <div id="accordion-default2-content-3" class="govuk-accordion__section-content">
+                        <dl class="govuk-summary-list appeal-case-timetable">
+                            <div class="govuk-summary-list__row appeal-valid-date"><dt class="govuk-summary-list__key"> Valid date</dt>
+                                <dd class="govuk-summary-list__value">23 May 2023</dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/appellant-case/valid/date"
+                                    data-cy="-valid-date"><span class="govuk-visually-hidden"> Valid date</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-start-date"><dt class="govuk-summary-list__key"> Start date</dt>
+                                <dd class="govuk-summary-list__value">23 May 2023</dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/start-case/change"
+                                    data-cy="change-start-case-date">Change<span class="govuk-visually-hidden"> Start date</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-lpa-questionnaire-due-date"><dt class="govuk-summary-list__key"> LPA questionnaire due</dt>
+                                <dd class="govuk-summary-list__value">11 October 2023</dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-site-visit"><dt class="govuk-summary-list__key"> Site visit</dt>
+                                <dd class="govuk-summary-list__value">
+                                    <ul class="govuk-list govuk-!-margin-top-0 govuk-!-padding-left-0">
+                                        <li>9 October 2023</li>
+                                        <li>9:38am - 10:00am</li>
+                                    </ul>
+                                </dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/site-visit/manage-visit?backUrl=%2Fappeals-service%2Fappeal-details%2F2"
+                                    data-cy="change-schedule-visit">Change<span class="govuk-visually-hidden"> Site visit</span></a>
+                                </dd>
+                            </div>
+                        </dl>
+                    </div>
+                </div>
+                <div class="govuk-accordion__section">
+                    <div class="govuk-accordion__section-header">
+                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default2-heading-4"> Documentation</span></h2>
+                    </div>
+                    <div id="accordion-default2-content-4" class="govuk-accordion__section-content">
+                        <table class="govuk-table">
+                            <thead class="govuk-table__head">
+                                <tr class="govuk-table__row">
+                                    <th scope="col" class="govuk-table__header">Documentation</th>
+                                    <th scope="col" class="govuk-table__header">Status</th>
+                                    <th scope="col" class="govuk-table__header">Received</th>
+                                    <th scope="col" class="govuk-table__header govuk-!-text-align-right">Action</th>
+                                </tr>
+                            </thead>
+                            <tbody class="govuk-table__body">
+                                <tr class="govuk-table__row">
+                                    <th scope="row" class="govuk-table__header">Appeal</th>
+                                    <td class="govuk-table__cell">Ready to review</td>
+                                    <td class="govuk-table__cell">2 August 2024</td>
+                                    <td class="govuk-table__cell govuk-!-text-align-right"><a href="/appeals-service/appeal-details/2/appellant-case?backUrl=%2Fappeals-service%2Fappeal-details%2F2"
+                                        data-cy="review-appellant-case" class="govuk-link">Review<span class="govuk-visually-hidden"> appellant case</span></a>
+                                    </td>
+                                </tr>
+                                <tr class="govuk-table__row">
+                                    <th scope="row" class="govuk-table__header">LPA questionnaire</th>
+                                    <td class="govuk-table__cell">Overdue</td>
+                                    <td class="govuk-table__cell">Due by 11 October 2023</td>
+                                    <td class="govuk-table__cell govuk-!-text-align-right"></td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
+                <div class="govuk-accordion__section">
+                    <div class="govuk-accordion__section-header">
+                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default2-heading-5"> Costs</span></h2>
+                    </div>
+                    <div id="accordion-default2-content-5" class="govuk-accordion__section-content">
+                        <table class="govuk-table">
+                            <thead class="govuk-table__head">
+                                <tr class="govuk-table__row">
+                                    <th scope="col" class="govuk-table__header">Documentation</th>
+                                    <th scope="col" class="govuk-table__header">Status</th>
+                                    <th scope="col" class="govuk-table__header govuk-!-text-align-right">Action</th>
+                                </tr>
+                            </thead>
+                            <tbody class="govuk-table__body">
+                                <tr class="govuk-table__row">
+                                    <th scope="row" class="govuk-table__header appeal-costs-appellant-application-documentation">Appellant application</th>
+                                    <td class="govuk-table__cell appeal-costs-appellant-application-status">No documents available</td>
+                                    <td class="govuk-table__cell appeal-costs-appellant-application-actions govuk-!-text-align-right">
+                                        <ul class="govuk-summary-list__actions-list">
+                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-appellant-application" href="/appeals-service/appeal-details/2/costs/appellant/application/upload-documents/1">Add<span class="govuk-visually-hidden"> Appellant application</span></a>
+                                            </li>
                                         </ul>
-                                        </dd>
-                                        <dd class="govuk-summary-list__actions">
-                                            <ul class="govuk-summary-list__actions-list">
-                                                <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/2/neighbouring-sites/manage"
-                                                    data-cy="manage-neighbouring-sites-inspector">Manage<span class="govuk-visually-hidden"> Interested party and neighbour addresses</span></a>
-                                                </li>
-                                                <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/2/neighbouring-sites/add/back-office"
-                                                    data-cy="add-neighbouring-sites-inspector">Add<span class="govuk-visually-hidden"> Interested party and neighbour addresses</span></a>
-                                                </li>
-                                            </ul>
-                                        </dd>
-                                </div>
-                            </dl>
-                        </div>
-                    </div>
-                    <div class="govuk-accordion__section">
-                        <div class="govuk-accordion__section-header">
-                            <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default2-heading-3"> Timetable</span></h2>
-                        </div>
-                        <div id="accordion-default2-content-3" class="govuk-accordion__section-content">
-                            <dl class="govuk-summary-list appeal-case-timetable">
-                                <div class="govuk-summary-list__row appeal-valid-date"><dt class="govuk-summary-list__key"> Valid date</dt>
-                                    <dd class="govuk-summary-list__value">23 May 2023</dd>
-                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/appellant-case/valid/date"
-                                        data-cy="-valid-date"><span class="govuk-visually-hidden"> Valid date</span></a>
-                                    </dd>
-                                </div>
-                                <div class="govuk-summary-list__row appeal-start-date"><dt class="govuk-summary-list__key"> Start date</dt>
-                                    <dd class="govuk-summary-list__value">23 May 2023</dd>
-                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/start-case/change"
-                                        data-cy="change-start-case-date">Change<span class="govuk-visually-hidden"> Start date</span></a>
-                                    </dd>
-                                </div>
-                                <div class="govuk-summary-list__row appeal-lpa-questionnaire-due-date"><dt class="govuk-summary-list__key"> LPA questionnaire due</dt>
-                                    <dd class="govuk-summary-list__value">11 October 2023</dd>
-                                </div>
-                                <div class="govuk-summary-list__row appeal-site-visit"><dt class="govuk-summary-list__key"> Site visit</dt>
-                                    <dd class="govuk-summary-list__value">
-                                        <ul class="govuk-list govuk-!-margin-top-0 govuk-!-padding-left-0">
-                                            <li>9 October 2023</li>
-                                            <li>9:38am - 10:00am</li>
+                                    </td>
+                                </tr>
+                                <tr class="govuk-table__row">
+                                    <th scope="row" class="govuk-table__header appeal-costs-appellant-withdrawal-documentation">Appellant withdrawal</th>
+                                    <td class="govuk-table__cell appeal-costs-appellant-withdrawal-status">No documents available</td>
+                                    <td class="govuk-table__cell appeal-costs-appellant-withdrawal-actions govuk-!-text-align-right">
+                                        <ul class="govuk-summary-list__actions-list">
+                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-appellant-withdrawal" href="/appeals-service/appeal-details/2/costs/appellant/withdrawal/upload-documents/2">Add<span class="govuk-visually-hidden"> Appellant withdrawal</span></a>
+                                            </li>
                                         </ul>
-                                    </dd>
-                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/site-visit/manage-visit?backUrl=%2Fappeals-service%2Fappeal-details%2F2"
-                                        data-cy="change-schedule-visit">Change<span class="govuk-visually-hidden"> Site visit</span></a>
-                                    </dd>
-                                </div>
-                            </dl>
-                        </div>
-                    </div>
-                    <div class="govuk-accordion__section">
-                        <div class="govuk-accordion__section-header">
-                            <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default2-heading-4"> Documentation</span></h2>
-                        </div>
-                        <div id="accordion-default2-content-4" class="govuk-accordion__section-content">
-                            <table class="govuk-table">
-                                <thead class="govuk-table__head">
-                                    <tr class="govuk-table__row">
-                                        <th scope="col" class="govuk-table__header">Documentation</th>
-                                        <th scope="col" class="govuk-table__header">Status</th>
-                                        <th scope="col" class="govuk-table__header">Received</th>
-                                        <th scope="col" class="govuk-table__header govuk-!-text-align-right">Action</th>
-                                    </tr>
-                                </thead>
-                                <tbody class="govuk-table__body">
-                                    <tr class="govuk-table__row">
-                                        <th scope="row" class="govuk-table__header">Appeal</th>
-                                        <td class="govuk-table__cell">Ready to review</td>
-                                        <td class="govuk-table__cell">2 August 2024</td>
-                                        <td class="govuk-table__cell govuk-!-text-align-right"><a href="/appeals-service/appeal-details/2/appellant-case?backUrl=%2Fappeals-service%2Fappeal-details%2F2"
-                                            data-cy="review-appellant-case" class="govuk-link">Review<span class="govuk-visually-hidden"> appellant case</span></a>
-                                        </td>
-                                    </tr>
-                                    <tr class="govuk-table__row">
-                                        <th scope="row" class="govuk-table__header">LPA questionnaire</th>
-                                        <td class="govuk-table__cell">Overdue</td>
-                                        <td class="govuk-table__cell">Due by 11 October 2023</td>
-                                        <td class="govuk-table__cell govuk-!-text-align-right"></td>
-                                    </tr>
-                                </tbody>
-                            </table>
-                        </div>
-                    </div>
-                    <div class="govuk-accordion__section">
-                        <div class="govuk-accordion__section-header">
-                            <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default2-heading-5"> Costs</span></h2>
-                        </div>
-                        <div id="accordion-default2-content-5" class="govuk-accordion__section-content">
-                            <table class="govuk-table">
-                                <thead class="govuk-table__head">
-                                    <tr class="govuk-table__row">
-                                        <th scope="col" class="govuk-table__header">Documentation</th>
-                                        <th scope="col" class="govuk-table__header">Status</th>
-                                        <th scope="col" class="govuk-table__header govuk-!-text-align-right">Action</th>
-                                    </tr>
-                                </thead>
-                                <tbody class="govuk-table__body">
-                                    <tr class="govuk-table__row">
-                                        <th scope="row" class="govuk-table__header appeal-costs-appellant-application-documentation">Appellant application</th>
-                                        <td class="govuk-table__cell appeal-costs-appellant-application-status">No documents available</td>
-                                        <td class="govuk-table__cell appeal-costs-appellant-application-actions govuk-!-text-align-right">
-                                            <ul class="govuk-summary-list__actions-list">
-                                                <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-appellant-application" href="/appeals-service/appeal-details/2/costs/appellant/application/upload-documents/1">Add<span class="govuk-visually-hidden"> Appellant application</span></a>
-                                                </li>
-                                            </ul>
-                                        </td>
-                                    </tr>
-                                    <tr class="govuk-table__row">
-                                        <th scope="row" class="govuk-table__header appeal-costs-appellant-withdrawal-documentation">Appellant withdrawal</th>
-                                        <td class="govuk-table__cell appeal-costs-appellant-withdrawal-status">No documents available</td>
-                                        <td class="govuk-table__cell appeal-costs-appellant-withdrawal-actions govuk-!-text-align-right">
-                                            <ul class="govuk-summary-list__actions-list">
-                                                <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-appellant-withdrawal" href="/appeals-service/appeal-details/2/costs/appellant/withdrawal/upload-documents/2">Add<span class="govuk-visually-hidden"> Appellant withdrawal</span></a>
-                                                </li>
-                                            </ul>
-                                        </td>
-                                    </tr>
-                                    <tr class="govuk-table__row">
-                                        <th scope="row" class="govuk-table__header appeal-costs-appellant-correspondence-documentation">Appellant correspondence</th>
-                                        <td class="govuk-table__cell appeal-costs-appellant-correspondence-status">No documents available</td>
-                                        <td class="govuk-table__cell appeal-costs-appellant-correspondence-actions govuk-!-text-align-right">
-                                            <ul class="govuk-summary-list__actions-list">
-                                                <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-appellant-correspondence" href="/appeals-service/appeal-details/2/costs/appellant/correspondence/upload-documents/3">Add<span class="govuk-visually-hidden"> Appellant correspondence</span></a>
-                                                </li>
-                                            </ul>
-                                        </td>
-                                    </tr>
-                                    <tr class="govuk-table__row">
-                                        <th scope="row" class="govuk-table__header appeal-costs-lpa-application-documentation">LPA application</th>
-                                        <td class="govuk-table__cell appeal-costs-lpa-application-status">No documents available</td>
-                                        <td class="govuk-table__cell appeal-costs-lpa-application-actions govuk-!-text-align-right">
-                                            <ul class="govuk-summary-list__actions-list">
-                                                <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-lpa-application" href="/appeals-service/appeal-details/2/costs/lpa/application/upload-documents/4">Add<span class="govuk-visually-hidden"> LPA application</span></a>
-                                                </li>
-                                            </ul>
-                                        </td>
-                                    </tr>
-                                    <tr class="govuk-table__row">
-                                        <th scope="row" class="govuk-table__header appeal-costs-lpa-withdrawal-documentation">LPA withdrawal</th>
-                                        <td class="govuk-table__cell appeal-costs-lpa-withdrawal-status">No documents available</td>
-                                        <td class="govuk-table__cell appeal-costs-lpa-withdrawal-actions govuk-!-text-align-right">
-                                            <ul class="govuk-summary-list__actions-list">
-                                                <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-lpa-withdrawal" href="/appeals-service/appeal-details/2/costs/lpa/withdrawal/upload-documents/5">Add<span class="govuk-visually-hidden"> LPA withdrawal</span></a>
-                                                </li>
-                                            </ul>
-                                        </td>
-                                    </tr>
-                                    <tr class="govuk-table__row">
-                                        <th scope="row" class="govuk-table__header appeal-costs-lpa-correspondence-documentation">LPA correspondence</th>
-                                        <td class="govuk-table__cell appeal-costs-lpa-correspondence-status">No documents available</td>
-                                        <td class="govuk-table__cell appeal-costs-lpa-correspondence-actions govuk-!-text-align-right">
-                                            <ul class="govuk-summary-list__actions-list">
-                                                <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-lpa-correspondence" href="/appeals-service/appeal-details/2/costs/lpa/correspondence/upload-documents/6">Add<span class="govuk-visually-hidden"> LPA correspondence</span></a>
-                                                </li>
-                                            </ul>
-                                        </td>
-                                    </tr>
-                                </tbody>
-                            </table>
-                        </div>
-                    </div>
-                    <div class="govuk-accordion__section">
-                        <div class="govuk-accordion__section-header">
-                            <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default2-heading-6"> Contacts</span></h2>
-                        </div>
-                        <div id="accordion-default2-content-6" class="govuk-accordion__section-content">
-                            <dl class="govuk-summary-list">
-                                <div class="govuk-summary-list__row appeal-appellant"><dt class="govuk-summary-list__key"> Appellant</dt>
-                                    <dd class="govuk-summary-list__value">
-                                        <ul class="govuk-list">
-                                            <li>Roger Simmons</li>
-                                            <li>test3@example.com</li>
+                                    </td>
+                                </tr>
+                                <tr class="govuk-table__row">
+                                    <th scope="row" class="govuk-table__header appeal-costs-appellant-correspondence-documentation">Appellant correspondence</th>
+                                    <td class="govuk-table__cell appeal-costs-appellant-correspondence-status">No documents available</td>
+                                    <td class="govuk-table__cell appeal-costs-appellant-correspondence-actions govuk-!-text-align-right">
+                                        <ul class="govuk-summary-list__actions-list">
+                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-appellant-correspondence" href="/appeals-service/appeal-details/2/costs/appellant/correspondence/upload-documents/3">Add<span class="govuk-visually-hidden"> Appellant correspondence</span></a>
+                                            </li>
                                         </ul>
-                                    </dd>
-                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/service-user/change/appellant"
-                                        data-cy="change-appellant">Change<span class="govuk-visually-hidden"> Appellant</span></a>
-                                    </dd>
-                                </div>
-                                <div class="govuk-summary-list__row appeal-agent"><dt class="govuk-summary-list__key"> Agent</dt>
-                                    <dd class="govuk-summary-list__value">
-                                        <ul class="govuk-list">
-                                            <li>Fiona Shell</li>
-                                            <li>test2@example.com</li>
+                                    </td>
+                                </tr>
+                                <tr class="govuk-table__row">
+                                    <th scope="row" class="govuk-table__header appeal-costs-lpa-application-documentation">LPA application</th>
+                                    <td class="govuk-table__cell appeal-costs-lpa-application-status">No documents available</td>
+                                    <td class="govuk-table__cell appeal-costs-lpa-application-actions govuk-!-text-align-right">
+                                        <ul class="govuk-summary-list__actions-list">
+                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-lpa-application" href="/appeals-service/appeal-details/2/costs/lpa/application/upload-documents/4">Add<span class="govuk-visually-hidden"> LPA application</span></a>
+                                            </li>
                                         </ul>
-                                    </dd>
-                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/service-user/change/agent"
-                                        data-cy="change-agent">Change<span class="govuk-visually-hidden"> Agent</span></a>
-                                    </dd>
-                                </div>
-                                <div class="govuk-summary-list__row appeal-lpa-contact-details"><dt class="govuk-summary-list__key"> LPA</dt>
-                                    <dd class="govuk-summary-list__value">
-                                        <ul class="govuk-list">
-                                            <li>Wiltshire Council</li>
-                                            <li>wilt@lpa-email.gov.uk</li>
+                                    </td>
+                                </tr>
+                                <tr class="govuk-table__row">
+                                    <th scope="row" class="govuk-table__header appeal-costs-lpa-withdrawal-documentation">LPA withdrawal</th>
+                                    <td class="govuk-table__cell appeal-costs-lpa-withdrawal-status">No documents available</td>
+                                    <td class="govuk-table__cell appeal-costs-lpa-withdrawal-actions govuk-!-text-align-right">
+                                        <ul class="govuk-summary-list__actions-list">
+                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-lpa-withdrawal" href="/appeals-service/appeal-details/2/costs/lpa/withdrawal/upload-documents/5">Add<span class="govuk-visually-hidden"> LPA withdrawal</span></a>
+                                            </li>
                                         </ul>
-                                    </dd>
-                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/change-appeal-details/local-planning-authority"
-                                        data-cy="change-lpa-contact-details">Change<span class="govuk-visually-hidden"> Local planning authority (LPA)</span></a>
-                                    </dd>
-                                </div>
-                            </dl>
-                        </div>
+                                    </td>
+                                </tr>
+                                <tr class="govuk-table__row">
+                                    <th scope="row" class="govuk-table__header appeal-costs-lpa-correspondence-documentation">LPA correspondence</th>
+                                    <td class="govuk-table__cell appeal-costs-lpa-correspondence-status">No documents available</td>
+                                    <td class="govuk-table__cell appeal-costs-lpa-correspondence-actions govuk-!-text-align-right">
+                                        <ul class="govuk-summary-list__actions-list">
+                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-lpa-correspondence" href="/appeals-service/appeal-details/2/costs/lpa/correspondence/upload-documents/6">Add<span class="govuk-visually-hidden"> LPA correspondence</span></a>
+                                            </li>
+                                        </ul>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
                     </div>
-                    <div class="govuk-accordion__section">
-                        <div class="govuk-accordion__section-header">
-                            <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default2-heading-7"> Team</span></h2>
-                        </div>
-                        <div id="accordion-default2-content-7" class="govuk-accordion__section-content">
-                            <dl class="govuk-summary-list">
-                                <div class="govuk-summary-list__row appeal-case-officer"><dt class="govuk-summary-list__key"> Case officer</dt>
-                                    <dd class="govuk-summary-list__value">
-                                        <p class="govuk-body">Not assigned</p>
-                                    </dd>
-                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/assign-user/case-officer"
-                                        data-cy="assign-case-officer">Assign<span class="govuk-visually-hidden"> Case officer</span></a>
-                                    </dd>
-                                </div>
-                                <div class="govuk-summary-list__row appeal-inspector"><dt class="govuk-summary-list__key"> Inspector</dt>
-                                    <dd class="govuk-summary-list__value">
-                                        <p class="govuk-body">Not assigned</p>
-                                    </dd>
-                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/assign-user/inspector"
-                                        data-cy="assign-inspector">Assign<span class="govuk-visually-hidden"> Inspector</span></a>
-                                    </dd>
-                                </div>
-                            </dl>
-                        </div>
+                </div>
+                <div class="govuk-accordion__section">
+                    <div class="govuk-accordion__section-header">
+                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default2-heading-6"> Contacts</span></h2>
                     </div>
-                    <div class="govuk-accordion__section">
-                        <div class="govuk-accordion__section-header">
-                            <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default2-heading-8"> Case management</span></h2>
-                        </div>
-                        <div id="accordion-default2-content-8" class="govuk-accordion__section-content">
-                            <dl class="govuk-summary-list">
-                                <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Cross-team correspondence</dt>
-                                    <dd                                     class="govuk-summary-list__value">No documents</dd>
-                                        <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/internal-correspondence/cross-team/upload-documents/10"
-                                            data-cy="add-cross-team-correspondence">Add<span class="govuk-visually-hidden"> Cross-team correspondence</span></a>
-                                        </dd>
-                                </div>
-                                <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Inspector correspondence</dt>
-                                    <dd                                     class="govuk-summary-list__value">No documents</dd>
-                                        <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/internal-correspondence/inspector/upload-documents/11"
-                                            data-cy="add-inspector-correspondence">Add<span class="govuk-visually-hidden"> Inspector correspondence</span></a>
-                                        </dd>
-                                </div>
-                                <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Main party correspondence</dt>
-                                    <dd                                     class="govuk-summary-list__value">No documents</dd>
-                                        <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/internal-correspondence/main-party/upload-documents/22"
-                                            data-cy="add-main-party-correspondence">Add<span class="govuk-visually-hidden"> Main party correspondence</span></a>
-                                        </dd>
-                                </div>
-                                <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Case history</dt>
-                                    <dd class="govuk-summary-list__value"></dd>
-                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/audit" data-cy="view-case-history">View<span class="govuk-visually-hidden"> Case history</span></a>
+                    <div id="accordion-default2-content-6" class="govuk-accordion__section-content">
+                        <dl class="govuk-summary-list">
+                            <div class="govuk-summary-list__row appeal-appellant"><dt class="govuk-summary-list__key"> Appellant</dt>
+                                <dd class="govuk-summary-list__value">
+                                    <ul class="govuk-list">
+                                        <li>Roger Simmons</li>
+                                        <li>test3@example.com</li>
+                                    </ul>
+                                </dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/service-user/change/appellant"
+                                    data-cy="change-appellant">Change<span class="govuk-visually-hidden"> Appellant</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-agent"><dt class="govuk-summary-list__key"> Agent</dt>
+                                <dd class="govuk-summary-list__value">
+                                    <ul class="govuk-list">
+                                        <li>Fiona Shell</li>
+                                        <li>test2@example.com</li>
+                                    </ul>
+                                </dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/service-user/change/agent"
+                                    data-cy="change-agent">Change<span class="govuk-visually-hidden"> Agent</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-lpa-contact-details"><dt class="govuk-summary-list__key"> LPA</dt>
+                                <dd class="govuk-summary-list__value">
+                                    <ul class="govuk-list">
+                                        <li>Wiltshire Council</li>
+                                        <li>wilt@lpa-email.gov.uk</li>
+                                    </ul>
+                                </dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/change-appeal-details/local-planning-authority"
+                                    data-cy="change-lpa-contact-details">Change<span class="govuk-visually-hidden"> Local planning authority (LPA)</span></a>
+                                </dd>
+                            </div>
+                        </dl>
+                    </div>
+                </div>
+                <div class="govuk-accordion__section">
+                    <div class="govuk-accordion__section-header">
+                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default2-heading-7"> Team</span></h2>
+                    </div>
+                    <div id="accordion-default2-content-7" class="govuk-accordion__section-content">
+                        <dl class="govuk-summary-list">
+                            <div class="govuk-summary-list__row appeal-case-officer"><dt class="govuk-summary-list__key"> Case officer</dt>
+                                <dd class="govuk-summary-list__value">
+                                    <p class="govuk-body">Not assigned</p>
+                                </dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/assign-user/case-officer"
+                                    data-cy="assign-case-officer">Assign<span class="govuk-visually-hidden"> Case officer</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-inspector"><dt class="govuk-summary-list__key"> Inspector</dt>
+                                <dd class="govuk-summary-list__value">
+                                    <p class="govuk-body">Not assigned</p>
+                                </dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/assign-user/inspector"
+                                    data-cy="assign-inspector">Assign<span class="govuk-visually-hidden"> Inspector</span></a>
+                                </dd>
+                            </div>
+                        </dl>
+                    </div>
+                </div>
+                <div class="govuk-accordion__section">
+                    <div class="govuk-accordion__section-header">
+                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default2-heading-8"> Case management</span></h2>
+                    </div>
+                    <div id="accordion-default2-content-8" class="govuk-accordion__section-content">
+                        <dl class="govuk-summary-list">
+                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Cross-team correspondence</dt>
+                                <dd                                 class="govuk-summary-list__value">No documents</dd>
+                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/internal-correspondence/cross-team/upload-documents/10"
+                                        data-cy="add-cross-team-correspondence">Add<span class="govuk-visually-hidden"> Cross-team correspondence</span></a>
                                     </dd>
-                                </div>
-                                <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Appeal withdrawal</dt>
-                                    <dd class="govuk-summary-list__value"></dd>
-                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/withdrawal/start"
-                                        data-cy="start-appeal-withdrawal">Start<span class="govuk-visually-hidden"> Appeal withdrawal</span></a>
+                            </div>
+                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Inspector correspondence</dt>
+                                <dd                                 class="govuk-summary-list__value">No documents</dd>
+                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/internal-correspondence/inspector/upload-documents/11"
+                                        data-cy="add-inspector-correspondence">Add<span class="govuk-visually-hidden"> Inspector correspondence</span></a>
                                     </dd>
-                                </div>
-                            </dl>
-                        </div>
+                            </div>
+                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Main party correspondence</dt>
+                                <dd                                 class="govuk-summary-list__value">No documents</dd>
+                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/internal-correspondence/main-party/upload-documents/22"
+                                        data-cy="add-main-party-correspondence">Add<span class="govuk-visually-hidden"> Main party correspondence</span></a>
+                                    </dd>
+                            </div>
+                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Case history</dt>
+                                <dd class="govuk-summary-list__value"></dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/audit" data-cy="view-case-history">View<span class="govuk-visually-hidden"> Case history</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Appeal withdrawal</dt>
+                                <dd class="govuk-summary-list__value"></dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/withdrawal/start"
+                                    data-cy="start-appeal-withdrawal">Start<span class="govuk-visually-hidden"> Appeal withdrawal</span></a>
+                                </dd>
+                            </div>
+                        </dl>
                     </div>
                 </div>
             </div>
         </div>
+    </div>
 </main>"
 `;
 
@@ -7137,7 +7146,7 @@ exports[`appeal-details GET /:appealId should render the received appeal details
         </div>
     </div>
     <div class="govuk-grid-row">
-        <div class="govuk-grid-column-full"><strong class="govuk-tag govuk-tag--grey govuk-!-margin-bottom-4">Received appeal</strong>
+        <div class="govuk-grid-column-full"><strong class="govuk-tag govuk-tag--grey pins-status-tag--full-width">Received appeal</strong>
         </div>
     </div>
     <div class="govuk-grid-row">
@@ -7597,7 +7606,7 @@ exports[`appeal-details should not render a back button 1`] = `
                     </div>
                 </div>
                 <div class="govuk-grid-row">
-                    <div class="govuk-grid-column-full"><strong class="govuk-tag govuk-tag--grey govuk-!-margin-bottom-4">Received appeal</strong>
+                    <div class="govuk-grid-column-full"><strong class="govuk-tag govuk-tag--grey pins-status-tag--full-width">Received appeal</strong>
                     </div>
                 </div>
                 <div class="govuk-grid-row">

--- a/appeals/web/src/server/appeals/appeal-details/__tests__/appeal-details.test.js
+++ b/appeals/web/src/server/appeals/appeal-details/__tests__/appeal-details.test.js
@@ -339,12 +339,12 @@ describe('appeal-details', () => {
 				expect(notificationBannerElementHTML).toContain('Address removed</p>');
 			});
 
-			it('should render a "This appeal is now the lead for appeal" success notification banner when the appeal was successfully linked as the lead of a back-office appeal', async () => {
+			it('should render a "Linked appeal added" success notification banner when the appeal was successfully linked as the lead of a back-office appeal', async () => {
 				const appealReference = '1234567';
 
 				nock.cleanAll();
 				nock('http://test/')
-					.get(`/appeals/linkable-appeal/${appealReference}`)
+					.get(`/appeals/linkable-appeal/${appealReference}/linked`)
 					.reply(200, linkableAppealSummaryBackOffice);
 				nock('http://test/')
 					.get(`/appeals/${appealData.appealId}`)
@@ -385,7 +385,7 @@ describe('appeal-details', () => {
 				const element = parseHtml(response.text, { rootElement: notificationBannerElement });
 				expect(element.innerHTML).toMatchSnapshot();
 				expect(element.innerHTML).toContain('Success</h3>');
-				expect(element.innerHTML).toContain('This appeal is now the lead for appeal');
+				expect(element.innerHTML).toContain('Linked appeal added');
 			});
 
 			it('should render a success notification banner with appropriate content if the appeal was just linked as the lead of a legacy (Horizon) appeal', async () => {
@@ -393,7 +393,7 @@ describe('appeal-details', () => {
 
 				nock.cleanAll();
 				nock('http://test/')
-					.get(`/appeals/linkable-appeal/${appealReference}`)
+					.get(`/appeals/linkable-appeal/${appealReference}/linked`)
 					.reply(200, linkableAppealSummaryHorizon);
 				nock('http://test/')
 					.get(`/appeals/${appealData.appealId}`)
@@ -437,7 +437,7 @@ describe('appeal-details', () => {
 				}).innerHTML;
 				expect(notificationBannerElementHTML).toMatchSnapshot();
 				expect(notificationBannerElementHTML).toContain('Success</h3>');
-				expect(notificationBannerElementHTML).toContain('This appeal is now the lead for appeal');
+				expect(notificationBannerElementHTML).toContain('Linked appeal added');
 			});
 
 			it('should render a success notification banner when a user was successfully unassigned as inspector', async () => {

--- a/appeals/web/src/server/appeals/appeal-details/linked-appeals/__tests__/linked-appeals.test.js
+++ b/appeals/web/src/server/appeals/appeal-details/linked-appeals/__tests__/linked-appeals.test.js
@@ -112,7 +112,7 @@ describe('linked-appeals', () => {
 			nock.cleanAll();
 			nock('http://test/').get('/appeals/1').reply(200, appealData);
 			nock('http://test/')
-				.get(`/appeals/linkable-appeal/${testValidLinkableAppealReference}`)
+				.get(`/appeals/linkable-appeal/${testValidLinkableAppealReference}/linked`)
 				.reply(200, linkableAppealSummaryBackOffice);
 
 			const response = await request.post(`${baseUrl}/1${linkedAppealsPath}/add`).send({
@@ -136,7 +136,7 @@ describe('linked-appeals', () => {
 			nock.cleanAll();
 			nock('http://test/').get('/appeals/1').reply(200, appealData);
 			nock('http://test/')
-				.get(`/appeals/linkable-appeal/${testValidLinkableAppealReference}`)
+				.get(`/appeals/linkable-appeal/${testValidLinkableAppealReference}/linked`)
 				.reply(200, linkableAppealSummaryBackOffice);
 
 			const response = await request.post(`${baseUrl}/1${linkedAppealsPath}/add`).send({
@@ -160,7 +160,7 @@ describe('linked-appeals', () => {
 			nock.cleanAll();
 			nock('http://test/').get('/appeals/1').reply(200, appealData);
 			nock('http://test/')
-				.get(`/appeals/linkable-appeal/${testValidLinkableAppealReference}`)
+				.get(`/appeals/linkable-appeal/${testValidLinkableAppealReference}/linked`)
 				.reply(200, linkableAppealSummaryBackOffice);
 
 			const response = await request.post(`${baseUrl}/1${linkedAppealsPath}/add`).send({
@@ -184,7 +184,7 @@ describe('linked-appeals', () => {
 			nock.cleanAll();
 			nock('http://test/').get('/appeals/1').reply(200, appealData);
 			nock('http://test/')
-				.get(`/appeals/linkable-appeal/${testInvalidLinkableAppealReference}`)
+				.get(`/appeals/linkable-appeal/${testInvalidLinkableAppealReference}/linked`)
 				.reply(404);
 
 			const response = await request.post(`${baseUrl}/1${linkedAppealsPath}/add`).send({
@@ -209,7 +209,7 @@ describe('linked-appeals', () => {
 			nock.cleanAll();
 			nock('http://test/').get('/appeals/1').reply(200, appealData);
 			nock('http://test/')
-				.get(`/appeals/linkable-appeal/${testValidLinkableAppealReference}`)
+				.get(`/appeals/linkable-appeal/${testValidLinkableAppealReference}/linked`)
 				.reply(200, linkableAppealSummaryBackOffice);
 
 			const response = await request.post(`${baseUrl}/1${linkedAppealsPath}/add`).send({
@@ -226,7 +226,7 @@ describe('linked-appeals', () => {
 			nock.cleanAll();
 			nock('http://test/').get('/appeals/1').reply(200, appealData);
 			nock('http://test/')
-				.get(`/appeals/linkable-appeal/${testValidLinkableAppealReference}`)
+				.get(`/appeals/linkable-appeal/${testValidLinkableAppealReference}/linked`)
 				.reply(409);
 
 			const response = await request.post(`${baseUrl}/1${linkedAppealsPath}/add`).send({
@@ -252,7 +252,7 @@ describe('linked-appeals', () => {
 					appealReference: linkableAppealSummaryBackOffice.appealReference
 				});
 			nock('http://test/')
-				.get(`/appeals/linkable-appeal/${testValidLinkableAppealReference}`)
+				.get(`/appeals/linkable-appeal/${testValidLinkableAppealReference}/linked`)
 				.reply(200, linkableAppealSummaryBackOffice);
 
 			const addLinkedAppealReferenceResponse = await request
@@ -296,7 +296,7 @@ describe('linked-appeals', () => {
 					appealReference: linkableAppealSummaryBackOffice.appealReference
 				});
 			nock('http://test/')
-				.get(`/appeals/linkable-appeal/${testValidLinkableAppealReference}`)
+				.get(`/appeals/linkable-appeal/${testValidLinkableAppealReference}/linked`)
 				.reply(200, linkableAppealSummaryBackOffice);
 
 			const addLinkedAppealReferenceResponse = await request
@@ -327,7 +327,7 @@ describe('linked-appeals', () => {
 			nock.cleanAll();
 			nock('http://test/').get('/appeals/1').reply(200, appealData).persist();
 			nock('http://test/')
-				.get(`/appeals/linkable-appeal/${testValidLinkableAppealReference}`)
+				.get(`/appeals/linkable-appeal/${testValidLinkableAppealReference}/linked`)
 				.reply(200, {
 					...linkableAppealSummaryBackOffice,
 					appealReference: testValidLinkableAppealReference
@@ -366,7 +366,7 @@ describe('linked-appeals', () => {
 			nock.cleanAll();
 			nock('http://test/').get('/appeals/1').reply(200, appealData).persist();
 			nock('http://test/')
-				.get(`/appeals/linkable-appeal/${testValidLinkableAppealReference}`)
+				.get(`/appeals/linkable-appeal/${testValidLinkableAppealReference}/linked`)
 				.reply(200, {
 					...linkableAppealSummaryBackOffice,
 					appealReference: testValidLinkableAppealReference
@@ -414,7 +414,7 @@ describe('linked-appeals', () => {
 				})
 				.persist();
 			nock('http://test/')
-				.get(`/appeals/linkable-appeal/${testValidLinkableAppealReference}`)
+				.get(`/appeals/linkable-appeal/${testValidLinkableAppealReference}/linked`)
 				.reply(200, {
 					...linkableAppealSummaryBackOffice,
 					appealReference: testValidLinkableAppealReference
@@ -483,7 +483,7 @@ describe('linked-appeals', () => {
 				})
 				.persist();
 			nock('http://test/')
-				.get(`/appeals/linkable-appeal/${testValidLinkableAppealReference}`)
+				.get(`/appeals/linkable-appeal/${testValidLinkableAppealReference}/linked`)
 				.reply(200, linkableAppealSummaryBackOffice);
 			nock('http://test/').post('/appeals/1/link-appeal').reply(200, {});
 
@@ -527,7 +527,7 @@ describe('linked-appeals', () => {
 				})
 				.persist();
 			nock('http://test/')
-				.get(`/appeals/linkable-appeal/${testValidLinkableAppealReference}`)
+				.get(`/appeals/linkable-appeal/${testValidLinkableAppealReference}/linked`)
 				.reply(200, linkableAppealSummaryBackOffice);
 			nock('http://test/').post('/appeals/1/link-appeal').reply(200, {});
 
@@ -571,7 +571,7 @@ describe('linked-appeals', () => {
 				})
 				.persist();
 			nock('http://test/')
-				.get(`/appeals/linkable-appeal/${testValidLinkableAppealReference}`)
+				.get(`/appeals/linkable-appeal/${testValidLinkableAppealReference}/linked`)
 				.reply(200, linkableAppealSummaryHorizon);
 			nock('http://test/').post('/appeals/1/link-legacy-appeal').reply(200, {});
 
@@ -615,7 +615,7 @@ describe('linked-appeals', () => {
 				})
 				.persist();
 			nock('http://test/')
-				.get(`/appeals/linkable-appeal/${testValidLinkableAppealReference}`)
+				.get(`/appeals/linkable-appeal/${testValidLinkableAppealReference}/linked`)
 				.reply(200, linkableAppealSummaryHorizon);
 			nock('http://test/').post('/appeals/1/link-legacy-appeal').reply(200, {});
 

--- a/appeals/web/src/server/appeals/appeal-details/linked-appeals/add/add.controller.js
+++ b/appeals/web/src/server/appeals/appeal-details/linked-appeals/add/add.controller.js
@@ -184,7 +184,8 @@ export const postAddLinkedAppealCheckAndConfirm = async (request, response) => {
 			session.linkableAppeal?.linkableAppealSummary ?? {};
 
 		const targetIsLead =
-			session.linkableAppeal.leadAppeal === session.linkableAppeal.linkableAppealSummary.appealId;
+			session.linkableAppeal.leadAppeal ===
+			session.linkableAppeal.linkableAppealSummary.appealReference;
 
 		switch (source) {
 			case 'back-office':
@@ -209,11 +210,8 @@ export const postAddLinkedAppealCheckAndConfirm = async (request, response) => {
 
 		addNotificationBannerToSession({
 			session,
-			bannerDefinitionKey: 'appealLinked',
-			appealId,
-			text: targetIsLead
-				? `Appeal ${session.linkableAppeal?.linkableAppealSummary.appealReference} is now the lead for this appeal`
-				: `This appeal is now the lead for appeal ${session.linkableAppeal?.linkableAppealSummary.appealReference}`
+			bannerDefinitionKey: 'linkedAppealAdded',
+			appealId
 		});
 
 		delete session.linkableAppeal;

--- a/appeals/web/src/server/appeals/appeal-details/linked-appeals/add/add.service.js
+++ b/appeals/web/src/server/appeals/appeal-details/linked-appeals/add/add.service.js
@@ -4,7 +4,7 @@
  * @returns {Promise<import('@pins/appeals.api').Appeals.LinkableAppealSummary>}
  */
 export async function getLinkableAppealByReference(apiClient, appealReference) {
-	return apiClient.get(`appeals/linkable-appeal/${appealReference}`).json();
+	return apiClient.get(`appeals/linkable-appeal/${appealReference}/linked`).json();
 }
 
 /**
@@ -24,7 +24,7 @@ export async function linkAppealToBackOfficeAppeal(
 		.post(`appeals/${appealId}/link-appeal`, {
 			json: {
 				linkedAppealId,
-				isCurrentAppealParent: targetAppealIsParent
+				isCurrentAppealParent: !targetAppealIsParent
 			}
 		})
 		.json();

--- a/appeals/web/src/server/appeals/appeal-details/other-appeals/__tests__/other-appeals.test.js
+++ b/appeals/web/src/server/appeals/appeal-details/other-appeals/__tests__/other-appeals.test.js
@@ -105,7 +105,7 @@ describe('other-appeals', () => {
 
 		it('should re-render the "Enter the appeal reference number" page with error "Enter a valid appeal reference", if the provided appeal reference was invalid', async () => {
 			nock('http://test/')
-				.get(`/appeals/linkable-appeal/${testInvalidLinkableAppealReference}`)
+				.get(`/appeals/linkable-appeal/${testInvalidLinkableAppealReference}/related`)
 				.reply(404);
 			const response = await request
 				.post(`${baseUrl}/1/other-appeals/add`)
@@ -126,7 +126,7 @@ describe('other-appeals', () => {
 
 		it('should redirect to the "Related appeal details" page if related appeal reference is valid', async () => {
 			nock('http://test/')
-				.get(`/appeals/linkable-appeal/${testValidLinkableAppealReference}`)
+				.get(`/appeals/linkable-appeal/${testValidLinkableAppealReference}/related`)
 				.reply(200, linkableAppeal);
 			const response = await request
 				.post(`${baseUrl}/1/other-appeals/add`)
@@ -138,7 +138,7 @@ describe('other-appeals', () => {
 	describe('GET /other-appeals/confirm', () => {
 		it('should render the "Related appeal details" page', async () => {
 			nock('http://test/')
-				.get(`/appeals/linkable-appeal/${testValidLinkableAppealReference}`)
+				.get(`/appeals/linkable-appeal/${testValidLinkableAppealReference}/related`)
 				.reply(200, linkableAppeal);
 			const addPageResponse = await request
 				.post(`${baseUrl}/1/other-appeals/add`)
@@ -147,7 +147,7 @@ describe('other-appeals', () => {
 
 			nock('http://test/').get('/appeals/1').reply(200, appealDataWithOtherAppeals);
 			nock('http://test/')
-				.get(`/appeals/linkable-appeal/${testValidLinkableAppealReference}`)
+				.get(`/appeals/linkable-appeal/${testValidLinkableAppealReference}/related`)
 				.reply(200, linkableAppeal);
 
 			const response = await request.get(`${baseUrl}/1/other-appeals/confirm`);
@@ -181,7 +181,7 @@ describe('other-appeals', () => {
 		it('should re-render the "Related appeal details" page with the error if the answer was not provided', async () => {
 			nock('http://test/').get('/appeals/1').reply(200, appealDataWithOtherAppeals).persist();
 			nock('http://test/')
-				.get(`/appeals/linkable-appeal/${testValidLinkableAppealReference}`)
+				.get(`/appeals/linkable-appeal/${testValidLinkableAppealReference}/related`)
 				.reply(200, linkableAppeal)
 				.persist();
 
@@ -210,7 +210,7 @@ describe('other-appeals', () => {
 		it('should redirect back to appeal details page if the answer was provided (answer no)', async () => {
 			nock('http://test/').get('/appeals/1').reply(200, appealDataWithOtherAppeals).persist();
 			nock('http://test/')
-				.get(`/appeals/linkable-appeal/${testValidLinkableAppealReference}`)
+				.get(`/appeals/linkable-appeal/${testValidLinkableAppealReference}/related`)
 				.reply(200, linkableAppeal);
 
 			const addPageResponse = await request
@@ -229,7 +229,7 @@ describe('other-appeals', () => {
 		it('should redirect back to appeal details page if the answer was provided (answer yes)', async () => {
 			nock('http://test/').get('/appeals/1').reply(200, appealDataWithOtherAppeals).persist();
 			nock('http://test/')
-				.get(`/appeals/linkable-appeal/${testValidLinkableAppealReference}`)
+				.get(`/appeals/linkable-appeal/${testValidLinkableAppealReference}/related`)
 				.reply(200, linkableAppeal)
 				.persist();
 			nock('http://test/').post('/appeals/1/associate-appeal').reply(200);

--- a/appeals/web/src/server/appeals/appeal-details/other-appeals/other-appeals.service.js
+++ b/appeals/web/src/server/appeals/appeal-details/other-appeals/other-appeals.service.js
@@ -5,7 +5,7 @@
  * @returns {Promise<import('@pins/appeals.api').Appeals.LinkableAppealSummary>}
  */
 export function getLinkableAppealSummaryFromReference(apiClient, appealReference) {
-	return apiClient.get(`appeals/linkable-appeal/${appealReference}`).json();
+	return apiClient.get(`appeals/linkable-appeal/${appealReference}/related`).json();
 }
 
 /**

--- a/appeals/web/src/server/lib/mappers/components/page-components/notification-banners.mapper.js
+++ b/appeals/web/src/server/lib/mappers/components/page-components/notification-banners.mapper.js
@@ -2,7 +2,7 @@
  * @typedef {import('#appeals/appeal.constants.js').ServicePageName} ServicePageName
  */
 
-/** @typedef {'allocationDetailsUpdated'|'allocationDetailsAdded'|'appealAwaitingTransfer'|'appealLinked'|'appealTypeChanged'|'appealTypeUpdated'|'appealUnlinked'|'appealValidAndReadyToStart'|'appealWithdrawn'|'appellantCaseInvalidOrIncomplete'|'appellantCaseNotValid'|'appellantFinalCommentsAcceptSuccess'|'appellantFinalCommentsAwaitingReview'|'assignCaseOfficer'|'caseOfficerAdded'|'caseOfficerRemoved'|'caseProgressed'|'caseStarted'|'changePage'|'commentsAndLpaStatementShared'|'costsDocumentAdded'|'documentAdded'|'documentDeleted'|'documentDetailsUpdated'|'documentFilenameUpdated'|'documentVersionAdded'|'finalCommentsAppellantRejectionSuccess'|'finalCommentsDocumentAddedSuccess'|'finalCommentsLPARejectionSuccess'|'finalCommentsRedactionSuccess'|'finalCommentsShared'|'horizonReferenceAdded'|'inspectorAdded'|'inspectorRemoved'|'interestedPartyCommentAdded'|'interestedPartyCommentsAddressAddedSuccess'|'interestedPartyCommentsAddressUpdatedSuccess'|'interestedPartyCommentsAwaitingReview'|'interestedPartyCommentsDocumentAddedSuccess'|'interestedPartyCommentsRedactionSuccess'|'interestedPartyCommentsRejectedSuccess'|'interestedPartyCommentsValidSuccess'|'internalCorrespondenceDocumentAdded'|'issuedDecisionInvalid'|'issuedDecisionValid'|'lpaCostsDecisionIssued'|'appellantCostsDecisionIssued'|'lpaFinalCommentsAcceptSuccess'|'lpaFinalCommentsAwaitingReview'|'lpaqReviewComplete'|'lpaqReviewIncomplete'|'lpaQuestionnaireNotValid'|'lpaStatementAccepted'|'lpaStatementAwaitingReview'|'lpaStatementDocumentAddedSuccess'|'lpaStatementIncomplete'|'lpaStatementRedactedAndAccepted'|'neighbouringSiteAdded'|'neighbouringSiteAffected'|'neighbouringSiteRemoved'|'neighbouringSiteUpdated'|'notCheckedDocument'|'progressedToFinalComments'|'progressFromFinalComments'|'progressFromStatements'|'readyForDecision'|'readyForLpaQuestionnaireReview'|'readyForSetUpSiteVisit'|'readyForValidation'|'relatedAppeal'|'shareCommentsAndLpaStatement'|'shareFinalComments'|'siteAddressUpdated'|'siteVisitChangedDefault'|'siteVisitNoChanges'|'siteVisitRescheduled'|'siteVisitScheduled'|'siteVisitTypeChanged'|'startDateChanged'|'timetableDueDateUpdated'|'updateLpaStatement'|'lpaChanged'|'hearingEstimatesAdded'|'hearingEstimatesChanged'|'hearingSetUp'|'hearingUpdated'|'hearingCancelled'|'timetableStarted'|'addHearingAddress'|'setupHearing'} NotificationBannerDefinitionKey */
+/** @typedef {'allocationDetailsUpdated'|'allocationDetailsAdded'|'appealAwaitingTransfer'|'appealLinked'|'appealTypeChanged'|'appealTypeUpdated'|'appealUnlinked'|'appealValidAndReadyToStart'|'appealWithdrawn'|'appellantCaseInvalidOrIncomplete'|'appellantCaseNotValid'|'appellantFinalCommentsAcceptSuccess'|'appellantFinalCommentsAwaitingReview'|'assignCaseOfficer'|'caseOfficerAdded'|'caseOfficerRemoved'|'caseProgressed'|'caseStarted'|'changePage'|'commentsAndLpaStatementShared'|'costsDocumentAdded'|'documentAdded'|'documentDeleted'|'documentDetailsUpdated'|'documentFilenameUpdated'|'documentVersionAdded'|'finalCommentsAppellantRejectionSuccess'|'finalCommentsDocumentAddedSuccess'|'finalCommentsLPARejectionSuccess'|'finalCommentsRedactionSuccess'|'finalCommentsShared'|'horizonReferenceAdded'|'inspectorAdded'|'inspectorRemoved'|'interestedPartyCommentAdded'|'interestedPartyCommentsAddressAddedSuccess'|'interestedPartyCommentsAddressUpdatedSuccess'|'interestedPartyCommentsAwaitingReview'|'interestedPartyCommentsDocumentAddedSuccess'|'interestedPartyCommentsRedactionSuccess'|'interestedPartyCommentsRejectedSuccess'|'interestedPartyCommentsValidSuccess'|'internalCorrespondenceDocumentAdded'|'issuedDecisionInvalid'|'issuedDecisionValid'|'lpaCostsDecisionIssued'|'appellantCostsDecisionIssued'|'lpaFinalCommentsAcceptSuccess'|'lpaFinalCommentsAwaitingReview'|'lpaqReviewComplete'|'lpaqReviewIncomplete'|'lpaQuestionnaireNotValid'|'lpaStatementAccepted'|'lpaStatementAwaitingReview'|'lpaStatementDocumentAddedSuccess'|'lpaStatementIncomplete'|'lpaStatementRedactedAndAccepted'|'neighbouringSiteAdded'|'neighbouringSiteAffected'|'neighbouringSiteRemoved'|'neighbouringSiteUpdated'|'notCheckedDocument'|'progressedToFinalComments'|'progressFromFinalComments'|'progressFromStatements'|'readyForDecision'|'readyForLpaQuestionnaireReview'|'readyForSetUpSiteVisit'|'readyForValidation'|'relatedAppeal'|'shareCommentsAndLpaStatement'|'shareFinalComments'|'siteAddressUpdated'|'siteVisitChangedDefault'|'siteVisitNoChanges'|'siteVisitRescheduled'|'siteVisitScheduled'|'siteVisitTypeChanged'|'startDateChanged'|'timetableDueDateUpdated'|'updateLpaStatement'|'lpaChanged'|'hearingEstimatesAdded'|'hearingEstimatesChanged'|'hearingSetUp'|'hearingUpdated'|'hearingCancelled'|'timetableStarted'|'addHearingAddress'|'setupHearing'|'linkedAppealAdded'} NotificationBannerDefinitionKey */
 /**
  * @typedef {Object} NotificationBannerDefinition
  * @property {'success'|'important'} type
@@ -452,6 +452,11 @@ export const notificationBannerDefinitions = {
 	setupHearing: {
 		type: 'important',
 		pages: ['appealDetails']
+	},
+	linkedAppealAdded: {
+		type: 'success',
+		pages: ['appealDetails'],
+		text: 'Linked appeal added'
 	}
 };
 
@@ -476,7 +481,8 @@ const appealActionRequiredToNotificationBannerMapping = {
 	startAppeal: 'appealValidAndReadyToStart',
 	updateLpaStatement: 'updateLpaStatement',
 	addHearingAddress: 'addHearingAddress',
-	setupHearing: 'setupHearing'
+	setupHearing: 'setupHearing',
+	linkedAppealAdded: 'linkedAppealAdded'
 };
 
 /**

--- a/appeals/web/src/styles/7-components/_status-tag.scss
+++ b/appeals/web/src/styles/7-components/_status-tag.scss
@@ -1,0 +1,5 @@
+.govuk-tag.pins-status-tag {
+	&--full-width {
+			max-width: fit-content;
+	}
+}

--- a/appeals/web/src/styles/main.scss
+++ b/appeals/web/src/styles/main.scss
@@ -36,6 +36,7 @@
 @use "7-components/button-group";
 @use "7-components/header";
 @use "7-components/related";
+@use "7-components/status-tag";
 @use "7-components/summary-list";
 @use "7-components/table";
 @use "7-components/sort-table";

--- a/packages/appeals/constants/support.js
+++ b/packages/appeals/constants/support.js
@@ -82,8 +82,8 @@ export const AUDIT_TRAIL_REMOVED_INSPECTOR =
 	'The inspector {replacement0} was removed from the case';
 export const AUDIT_TRAIL_SITE_VISIT_ARRANGED = 'The site visit was arranged for {replacement0}';
 export const AUDIT_TRAIL_SITE_VISIT_TYPE_SELECTED = 'The site visit type was selected';
-export const AUDIT_TRAIL_APPEAL_LINK_ADDED = 'A linked appeal was added';
-export const AUDIT_TRAIL_APPEAL_LINK_REMOVED = 'A linked appeal was removed';
+export const AUDIT_TRAIL_APPEAL_LINK_ADDED = 'Linked appeal {replacement0} added';
+export const AUDIT_TRAIL_APPEAL_LINK_REMOVED = 'Linked appeal {replacement0} removed';
 export const AUDIT_TRAIL_APPEAL_RELATION_ADDED = 'A related appeal was added';
 export const AUDIT_TRAIL_APPEAL_RELATION_REMOVED = 'A related appeal was removed';
 export const AUDIT_TRAIL_APPLICATION_REFERENCE_UPDATED = 'Planning application reference updated';


### PR DESCRIPTION
## Describe your changes
#### Updated Add link appeal to match ticket description and scenarios (A2-3339)

### WEB:
- Make sure the success banner is as described in the ticket
- Made sure the status and linked relationship (lead or child) if there is one are next to each other in the case details page as shown in the ticket
- Checked that the linked relationship is displayed correctly in the personal list

### API:
- Appended "/linked" on to API endpoint /appeals/linkable-appeal/${appealReference} to differentiate linked and related appeals
- Check for linked appeals only when determining existing parent and child relationships within the API
- Add the audit trail for both the current and linked appeals when linking an appeal to the current appeal

### TEST:
- Fixed unit tests the API
- Made sure all unit tests pass
- Updated the e2e tests for add linked appeal to handle the new success banner

## Issue ticket number and link:
- [(A2-3339) Link appeals - Part 4 - Case Overview - Add linked appeal](https://pins-ds.atlassian.net/browse/A2-3339)

