### PR TITLE
a2-3415/removed-manage-button-from-cya-when-no-supporting-docs-are-present

### DIFF
--- a/appeals/web/src/server/appeals/appeal-details/representations/interested-party-comments/view-and-review/__tests__/__snapshots__/view-and-review.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/representations/interested-party-comments/view-and-review/__tests__/__snapshots__/view-and-review.test.js.snap
@@ -204,13 +204,7 @@ exports[`interested-party-comments GET /reject/check-your-answers should render 
         </div>
         <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Supporting documents</dt>
             <dd class="govuk-summary-list__value">No documents</dd>
-            <dd class="govuk-summary-list__actions">
-                <ul class="govuk-summary-list__actions-list">
-                    <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/2/interested-party-comments/3670/manage-documents/1234/?backUrl=/interested-party-comments/3670/reject/check-your-answers">Manage<span class="govuk-visually-hidden"> supporting documents</span></a>
-                    </li>
-                    <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/2/interested-party-comments/3670/add-document/?backUrl=/interested-party-comments/3670/reject/check-your-answers">Add<span class="govuk-visually-hidden"> supporting documents</span></a>
-                    </li>
-                </ul>
+            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/interested-party-comments/3670/add-document/?backUrl=/interested-party-comments/3670/reject/check-your-answers">Add<span class="govuk-visually-hidden"> supporting documents</span></a>
             </dd>
         </div>
         <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Review decision</dt>

--- a/appeals/web/src/server/appeals/appeal-details/representations/interested-party-comments/view-and-review/page-components/reject.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/representations/interested-party-comments/view-and-review/page-components/reject.mapper.js
@@ -131,11 +131,15 @@ export function rejectCheckYourAnswersPage(
 					value: { html: attachmentsList || 'No documents' },
 					actions: {
 						items: [
-							{
-								text: 'Manage',
-								href: `/appeals-service/appeal-details/${appealDetails.appealId}/interested-party-comments/${comment.id}/manage-documents/${folderId}/?backUrl=/interested-party-comments/${comment.id}/reject/check-your-answers`,
-								visuallyHiddenText: 'supporting documents'
-							},
+							...(attachmentsList && attachmentsList.length > 0
+								? [
+										{
+											text: 'Manage',
+											href: `/appeals-service/appeal-details/${appealDetails.appealId}/interested-party-comments/${comment.id}/manage-documents/${folderId}/?backUrl=/interested-party-comments/${comment.id}/reject/check-your-answers`,
+											visuallyHiddenText: 'supporting documents'
+										}
+								  ]
+								: []),
 							{
 								text: 'Add',
 								href: `/appeals-service/appeal-details/${appealDetails.appealId}/interested-party-comments/${comment.id}/add-document/?backUrl=/interested-party-comments/${comment.id}/reject/check-your-answers`,


### PR DESCRIPTION
- Added condition to remove manage button  when no supporting docs are present
- Updated snapshot

https://pins-ds.atlassian.net/browse/A2-3415