### PR TITLE
fix(api): hearing data needs to be deleted when test data is cleared

### DIFF
--- a/appeals/api/src/database/seed/seed-clear-test-data.js
+++ b/appeals/api/src/database/seed/seed-clear-test-data.js
@@ -55,6 +55,22 @@ const deleteAppealData = async (
 	documentIDs,
 	representationIDs
 ) => {
+	const deleteHearing = databaseConnector.hearing.deleteMany({
+		where: {
+			appealId: {
+				in: appealIDs
+			}
+		}
+	});
+
+	const deleteHearingEstimate = databaseConnector.hearingEstimate.deleteMany({
+		where: {
+			appealId: {
+				in: appealIDs
+			}
+		}
+	});
+
 	const deleteAppeals = databaseConnector.appeal.deleteMany({
 		where: {
 			id: {
@@ -394,6 +410,8 @@ const deleteAppealData = async (
 		deleteSiteVisits,
 		deleteReps,
 		deleteRepsAttachments,
+		deleteHearingEstimate,
+		deleteHearing,
 		deleteAppeals
 	]);
 };


### PR DESCRIPTION
## Describe your changes

Currently when the test data is cleared an error is generated about breaking a foreign key constraint on the hearing tables.

This PR fixes this issue.
