### PR TITLE
Add new happy path helper functions to e2e suite

### DIFF
--- a/appeals/e2e/cypress/page_objects/caseDetailsPage.js
+++ b/appeals/e2e/cypress/page_objects/caseDetailsPage.js
@@ -39,8 +39,6 @@ export class CaseDetailsPage extends Page {
 		manageNotifyingParties: 'manage-notifying-parties',
 		manageAgreementToChangeDescriptionEvidence: 'manage-agreement-to-change-description-evidence',
 		addCostsDecision: 'add-costs-decision',
-		issueAppellantCostsDecision: 'issue-appellant-costs-decision',
-		issueLpaCostsDecision: 'issue-lpa-costs-decision',
 		changeSiteOwnership: 'change-site-ownership',
 		changeLpaqDueDate: 'change-lpa-questionnaire-due-date',
 		changeStartDate: 'change-start-case-date',

--- a/appeals/e2e/cypress/page_objects/caseDetailsPage.js
+++ b/appeals/e2e/cypress/page_objects/caseDetailsPage.js
@@ -39,6 +39,8 @@ export class CaseDetailsPage extends Page {
 		manageNotifyingParties: 'manage-notifying-parties',
 		manageAgreementToChangeDescriptionEvidence: 'manage-agreement-to-change-description-evidence',
 		addCostsDecision: 'add-costs-decision',
+		issueAppellantCostsDecision: 'issue-appellant-costs-decision',
+		issueLpaCostsDecision: 'issue-lpa-costs-decision',
 		changeSiteOwnership: 'change-site-ownership',
 		changeLpaqDueDate: 'change-lpa-questionnaire-due-date',
 		changeStartDate: 'change-start-case-date',
@@ -79,6 +81,9 @@ export class CaseDetailsPage extends Page {
 		arrangeScheduleVisit: () => cy.getByData(this._cyDataSelectors.arrangeScheduleVisit),
 		readyToStart: () => cy.getByData(this._cyDataSelectors.readyToStart),
 		issueDecision: () => cy.getByData(this._cyDataSelectors.issueDetermination),
+		issueAppellantCostsDecision: () =>
+			cy.getByData(this._cyDataSelectors.issueAppellantCostsDecision),
+		issueLpaCostsDecision: () => cy.getByData(this._cyDataSelectors.issueLpaCostsDecision),
 		addLinkedAppeal: () => cy.getByData(this._cyDataSelectors.addLinkedAppeal),
 		addRelatedAppeals: () => cy.getByData(this._cyDataSelectors.addRelatedAppeals),
 		addCrossTeamCorrespondence: () =>
@@ -445,6 +450,14 @@ export class CaseDetailsPage extends Page {
 
 	clickHearingBannerLink() {
 		this.elements.hearingBannerLink().click();
+	}
+
+	clickIssueAppellantCostsDecision() {
+		this.elements.issueAppellantCostsDecision().click({ force: true });
+	}
+
+	clickIssueLpaCostsDecision() {
+		this.elements.issueLpaCostsDecision().click({ force: true });
 	}
 
 	/***************************************************************

--- a/appeals/e2e/cypress/support/happyPathHelper.js
+++ b/appeals/e2e/cypress/support/happyPathHelper.js
@@ -202,5 +202,67 @@ export const happyPathHelper = {
 		dateTimeSection.enterVisitEndTime('12', '00');
 		caseDetailsPage.clickButtonByText('Confirm');
 		caseDetailsPage.validateBannerMessage('Success', 'Site visit scheduled');
+	},
+
+	issueDecision(caseRef, decision) {
+		caseDetailsPage.clickIssueDecision();
+		caseDetailsPage.selectRadioButtonByValue(caseDetailsPage.exactMatch(decision));
+		caseDetailsPage.clickButtonByText('Continue');
+		caseDetailsPage.uploadSampleFile(sampleFiles.pdf);
+		caseDetailsPage.clickButtonByText('Continue');
+
+		//Appellant costs
+		caseDetailsPage.selectRadioButtonByValue('Yes');
+		caseDetailsPage.clickButtonByText('Continue');
+		caseDetailsPage.uploadSampleFile(sampleFiles.pdf);
+		caseDetailsPage.clickButtonByText('Continue');
+
+		//LPA costs
+		caseDetailsPage.selectRadioButtonByValue('Yes');
+		caseDetailsPage.clickButtonByText('Continue');
+		caseDetailsPage.uploadSampleFile(sampleFiles.pdf);
+		caseDetailsPage.clickButtonByText('Continue');
+
+		//CYA
+		caseDetailsPage.clickButtonByText('Issue decision');
+
+		//Banner & inset text
+		caseDetailsPage.validateBannerMessage('Success', 'Decision issued');
+		caseDetailsPage.checkDecisionOutcome(decision);
+	},
+
+	issueDecisionWithoutCosts(caseRef, decision) {
+		caseDetailsPage.clickIssueDecision();
+		caseDetailsPage.selectRadioButtonByValue(caseDetailsPage.exactMatch(decision));
+		caseDetailsPage.clickButtonByText('Continue');
+		caseDetailsPage.uploadSampleFile(sampleFiles.pdf);
+		caseDetailsPage.clickButtonByText('Continue');
+
+		//Dont issue appellant & LPA costs
+		caseDetailsPage.selectRadioButtonByValue('No');
+		caseDetailsPage.clickButtonByText('Continue');
+		caseDetailsPage.selectRadioButtonByValue('No');
+		caseDetailsPage.clickButtonByText('Continue');
+
+		//CYA
+		caseDetailsPage.clickButtonByText('Issue decision');
+
+		//Banner & inset text
+		caseDetailsPage.validateBannerMessage('Success', 'Decision issued');
+		caseDetailsPage.checkDecisionOutcome(decision);
+	},
+
+	issueAppellantCostsDecision(caseRef) {
+		caseDetailsPage.clickIssueAppellantCostsDecision();
+		caseDetailsPage.uploadSampleFile(sampleFiles.pdf);
+		caseDetailsPage.clickButtonByText('Continue');
+		caseDetailsPage.clickButtonByText('Issue appellant costs decision');
+	},
+
+	issueLpaCostsDecision(caseRef) {
+		caseDetailsPage.clickIssueLpaCostsDecision();
+		caseDetailsPage.uploadSampleFile(sampleFiles.pdf);
+		caseDetailsPage.clickButtonByText('Continue');
+		caseDetailsPage.clickButtonByText('Issue lpa costs decision');
 	}
 };


### PR DESCRIPTION
## Describe your changes

new case details page properties and methods. 4 new happy path helpers to aid in the writing of test cases that require a decision to be issued with or without costs.

2 helpers to also issue costs independently of the main decision.

## Issue ticket number and link
[A2-3684](https://pins-ds.atlassian.net/browse/A2-3684)


[A2-3684]: https://pins-ds.atlassian.net/browse/A2-3684?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ