### PR TITLE
fix(api): use correct mapper when importing the appeal from FO

### DIFF
--- a/appeals/api/src/server/endpoints/integrations/__tests__/integrations.test.js
+++ b/appeals/api/src/server/endpoints/integrations/__tests__/integrations.test.js
@@ -6,11 +6,13 @@ import {
 } from '@pins/appeals/constants/support.js';
 import {
 	validAppellantCase,
+	validAppellantCaseS78,
 	validLpaQuestionnaire,
 	validRepresentationIp,
 	validRepresentationAppellantFinalComment,
 	validRepresentationLpaStatement,
 	appealIngestionInput,
+	appealIngestionInputS78,
 	docIngestionInput
 } from '#tests/integrations/mocks.js';
 import { APPEAL_CASE_STATUS, APPEAL_CASE_TYPE, APPEAL_REDACTED_STATUS } from 'pins-data-model';
@@ -97,6 +99,40 @@ describe('/appeals/case-submission', () => {
 					reference: expect.any(String),
 					submissionId: expect.any(String),
 					...appealIngestionInput
+				}
+			});
+			expect(databaseConnector.appeal.update).toHaveBeenCalledWith({
+				where: { id: 100 },
+				data: {
+					reference: expect.any(String),
+					appealStatus: {
+						create: {
+							status: APPEAL_CASE_STATUS.ASSIGN_CASE_OFFICER,
+							createdAt: expect.any(String)
+						}
+					}
+				}
+			});
+
+			expect(databaseConnector.document.createMany).toHaveBeenCalled();
+			expect(databaseConnector.documentVersion.createMany).toHaveBeenCalled();
+			expect(databaseConnector.documentVersion.findMany).toHaveBeenCalled();
+
+			expect(databaseConnector.appeal.findUnique).toHaveBeenCalled();
+			expect(response.status).toEqual(201);
+			expect(response.body).toEqual(result);
+		});
+
+		test('POST valid s78 appellant case payload and create appeal', async () => {
+			const result = createIntegrationMocks(appealIngestionInputS78);
+			const payload = validAppellantCaseS78;
+			const response = await request.post('/appeals/case-submission').send(payload);
+
+			expect(databaseConnector.appeal.create).toHaveBeenCalledWith({
+				data: {
+					reference: expect.any(String),
+					submissionId: expect.any(String),
+					...appealIngestionInputS78
 				}
 			});
 			expect(databaseConnector.appeal.update).toHaveBeenCalledWith({

--- a/appeals/api/src/server/mappers/integration/commands/appellant-case.mapper.js
+++ b/appeals/api/src/server/mappers/integration/commands/appellant-case.mapper.js
@@ -2,7 +2,7 @@
 /** @typedef {import('@pins/appeals.api').Schema.AppellantCase} AppellantCase */
 
 import { APPEAL_CASE_TYPE } from 'pins-data-model';
-import { createSharedS20S78Fields } from '#mappers/integration/shared/s20s78/questionnaire-fields.js';
+import { createSharedS20S78Fields } from '#mappers/integration/shared/s20s78/appellant-case-fields.js';
 
 /**
  *

--- a/appeals/api/src/server/tests/integrations/mocks.js
+++ b/appeals/api/src/server/tests/integrations/mocks.js
@@ -61,6 +61,25 @@ export const validAppellantCase = {
 	]
 };
 
+export const validAppellantCaseS78 = {
+	...validAppellantCase,
+	casedata: {
+		...validAppellantCase.casedata,
+		caseType: 'W',
+		appellantProcedurePreference: 'inquiry',
+		appellantProcedurePreferenceDetails: 'Reason for preference',
+		appellantProcedurePreferenceDuration: 3,
+		appellantProcedurePreferenceWitnessCount: 2,
+		agriculturalHolding: false,
+		tenantAgriculturalHolding: null,
+		otherTenantsAgriculturalHolding: null,
+		informedTenantsAgriculturalHolding: null,
+		planningObligation: false,
+		statusPlanningObligation: null,
+		developmentType: 'minor-dwellings'
+	}
+};
+
 export const validLpaQuestionnaire = {
 	casedata: {
 		caseReference: '6000000',
@@ -250,11 +269,7 @@ export const appealIngestionInput = {
 					key: 'Some'
 				}
 			},
-			isGreenBelt: false,
-			appellantProcedurePreference: undefined,
-			appellantProcedurePreferenceDetails: undefined,
-			appellantProcedurePreferenceDuration: undefined,
-			appellantProcedurePreferenceWitnessCount: undefined
+			isGreenBelt: false
 		}
 	},
 	neighbouringSites: {
@@ -264,6 +279,37 @@ export const appealIngestionInput = {
 		create: FOLDERS.map((/** @type {{ path: string; }} */ f) => {
 			return { path: f };
 		})
+	}
+};
+
+export const appealIngestionInputS78 = {
+	...appealIngestionInput,
+	appealType: {
+		connect: {
+			key: 'W'
+		}
+	},
+	appellantCase: {
+		create: {
+			...appealIngestionInput.appellantCase.create,
+			appellantProcedurePreference: 'inquiry',
+			appellantProcedurePreferenceDetails: 'Reason for preference',
+			appellantProcedurePreferenceDuration: 3,
+			appellantProcedurePreferenceWitnessCount: 2,
+			agriculturalHolding: false,
+			caseworkReason: undefined,
+			developmentType: 'minor-dwellings',
+			informedTenantsAgriculturalHolding: null,
+			planningObligation: false,
+			statusPlanningObligation: null,
+			siteViewableFromRoad: undefined,
+			siteGridReferenceEasting: undefined,
+			siteGridReferenceNorthing: undefined,
+			numberOfResidencesNetChange: undefined,
+			otherTenantsAgriculturalHolding: null,
+			tenantAgriculturalHolding: null,
+			typeOfPlanningApplication: undefined
+		}
 	}
 };
 


### PR DESCRIPTION
## Describe your changes

A recent refactor led to the wrong mapper being used when importing cases from FO. This was causing some fields to be missing, e.g. procedure type preference was showing as not answered.

## Issue ticket number and link

[A2-3669](https://pins-ds.atlassian.net/browse/A2-3669)


[A2-3669]: https://pins-ds.atlassian.net/browse/A2-3669?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ