### PR TITLE
chore(web): don't update snapshots every time we run tests

### DIFF
--- a/appeals/web/package.json
+++ b/appeals/web/package.json
@@ -19,7 +19,7 @@
     "rollup": "node ./scripts/rollup/bundle-js.js",
     "sass": "node ./scripts/rollup/compile-css.js",
     "start": "node ./src/server/server.js",
-    "test": "cross-env NODE_ENV=test NODE_OPTIONS=\"--experimental-vm-modules --expose-gc\" npx jest --logHeapUsage --ci --updateSnapshot",
+    "test": "cross-env NODE_ENV=test NODE_OPTIONS=\"--experimental-vm-modules --expose-gc\" npx jest --logHeapUsage --ci",
 		"test:update": "cross-env NODE_ENV=test NODE_OPTIONS=\"--experimental-vm-modules --expose-gc\" npx jest -u --logHeapUsage --ci",
     "test:watch": "npm run test -- --watch",
     "test:cov": "cross-env NODE_ENV=test NODE_OPTIONS=\"--experimental-vm-modules --expose-gc\" npx jest --logHeapUsage --ci --coverage --forceExit",


### PR DESCRIPTION
Don't update snapshots every time we run tests. That's what test:update is for.

This was modified last week, I assume accidentally, because updating the snapshots every time you run the tests defeats the object of having a snapshot. If the snapshot has been modified then we should at least think about if we were expecting that to happen or not.

