### PR TITLE
fix(appeals): updated backurls to use whole path as they return page …

### DIFF
--- a/appeals/web/src/server/appeals/appeal-details/representations/final-comments/accept/__tests__/__snapshots__/accept-final-comments.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/representations/final-comments/accept/__tests__/__snapshots__/accept-final-comments.test.js.snap
@@ -27,16 +27,16 @@ exports[`final-comments GET / should render the accept appellant final comments 
                     </dd>
                     <dd class="govuk-summary-list__actions">
                         <ul class="govuk-summary-list__actions-list">
-                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/2/final-comments/appellant/manage-documents/135568/?backUrl=/final-comments/appellant/accept">Manage<span class="govuk-visually-hidden"> supporting documents</span></a>
+                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/2/final-comments/appellant/manage-documents/135568/?backUrl=/appeals-service/appeal-details/2/final-comments/appellant/accept">Manage<span class="govuk-visually-hidden"> supporting documents</span></a>
                             </li>
-                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/2/final-comments/appellant/add-document/?backUrl=/final-comments/appellant/accept">Add<span class="govuk-visually-hidden"> supporting documents</span></a>
+                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/2/final-comments/appellant/add-document/?backUrl=/appeals-service/appeal-details/2/final-comments/appellant/accept">Add<span class="govuk-visually-hidden"> supporting documents</span></a>
                             </li>
                         </ul>
                     </dd>
                 </div>
                 <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Review decisions</dt>
                     <dd class="govuk-summary-list__value">Accept final comments</dd>
-                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/final-comments/appellant?backUrl=/final-comments/appellant/accept">Change</a>
+                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/final-comments/appellant?backUrl=/appeals-service/appeal-details/2/final-comments/appellant/accept">Change</a>
                     </dd>
                 </div>
             </dl>
@@ -79,16 +79,16 @@ exports[`final-comments GET / should render the accept lpa final comments page w
                     </dd>
                     <dd class="govuk-summary-list__actions">
                         <ul class="govuk-summary-list__actions-list">
-                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/2/final-comments/lpa/manage-documents/135568/?backUrl=/final-comments/lpa/accept">Manage<span class="govuk-visually-hidden"> supporting documents</span></a>
+                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/2/final-comments/lpa/manage-documents/135568/?backUrl=/appeals-service/appeal-details/2/final-comments/lpa/accept">Manage<span class="govuk-visually-hidden"> supporting documents</span></a>
                             </li>
-                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/2/final-comments/lpa/add-document/?backUrl=/final-comments/lpa/accept">Add<span class="govuk-visually-hidden"> supporting documents</span></a>
+                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/2/final-comments/lpa/add-document/?backUrl=/appeals-service/appeal-details/2/final-comments/lpa/accept">Add<span class="govuk-visually-hidden"> supporting documents</span></a>
                             </li>
                         </ul>
                     </dd>
                 </div>
                 <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Review decisions</dt>
                     <dd class="govuk-summary-list__value">Accept final comments</dd>
-                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/final-comments/lpa?backUrl=/final-comments/lpa/accept">Change</a>
+                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/final-comments/lpa?backUrl=/appeals-service/appeal-details/2/final-comments/lpa/accept">Change</a>
                     </dd>
                 </div>
             </dl>

--- a/appeals/web/src/server/appeals/appeal-details/representations/final-comments/accept/components/summary-list.js
+++ b/appeals/web/src/server/appeals/appeal-details/representations/final-comments/accept/components/summary-list.js
@@ -49,14 +49,14 @@ export const summaryList = (appealDetails, comment, finalCommentsType, attachmen
 							? [
 									{
 										text: 'Manage',
-										href: `/appeals-service/appeal-details/${appealDetails.appealId}/final-comments/${finalCommentsType}/manage-documents/${comment.attachments?.[0]?.documentVersion?.document?.folderId}/?backUrl=/final-comments/${finalCommentsType}/accept`,
+										href: `/appeals-service/appeal-details/${appealDetails.appealId}/final-comments/${finalCommentsType}/manage-documents/${comment.attachments?.[0]?.documentVersion?.document?.folderId}/?backUrl=/appeals-service/appeal-details/${appealDetails.appealId}/final-comments/${finalCommentsType}/accept`,
 										visuallyHiddenText: 'supporting documents'
 									}
 							  ]
 							: []),
 						{
 							text: 'Add',
-							href: `/appeals-service/appeal-details/${appealDetails.appealId}/final-comments/${finalCommentsType}/add-document/?backUrl=/final-comments/${finalCommentsType}/accept`,
+							href: `/appeals-service/appeal-details/${appealDetails.appealId}/final-comments/${finalCommentsType}/add-document/?backUrl=/appeals-service/appeal-details/${appealDetails.appealId}/final-comments/${finalCommentsType}/accept`,
 							visuallyHiddenText: 'supporting documents'
 						}
 					]
@@ -69,7 +69,7 @@ export const summaryList = (appealDetails, comment, finalCommentsType, attachmen
 					items: [
 						{
 							text: 'Change',
-							href: `/appeals-service/appeal-details/${appealDetails.appealId}/final-comments/${finalCommentsType}?backUrl=/final-comments/${finalCommentsType}/accept`
+							href: `/appeals-service/appeal-details/${appealDetails.appealId}/final-comments/${finalCommentsType}?backUrl=/appeals-service/appeal-details/${appealDetails.appealId}/final-comments/${finalCommentsType}/accept`
 						}
 					]
 				}

--- a/appeals/web/src/server/appeals/appeal-details/representations/final-comments/redact/__tests__/redact-final-comments.test.js
+++ b/appeals/web/src/server/appeals/appeal-details/representations/final-comments/redact/__tests__/redact-final-comments.test.js
@@ -158,14 +158,14 @@ describe('final-comments', () => {
 					`class="pins-show-more" data-label="Read more" data-mode="text">${redactedRepresentation}</div>`
 				);
 				expect(unprettifiedHTML).toContain(
-					`href="/appeals-service/appeal-details/2/final-comments/${finalCommentsType.type}/redact?backUrl=/final-comments/${finalCommentsType.type}/redact/confirm">Change<span class="govuk-visually-hidden"> redacted final comments</span></a></dd>`
+					`href="/appeals-service/appeal-details/2/final-comments/${finalCommentsType.type}/redact?backUrl=/appeals-service/appeal-details/2/final-comments/${finalCommentsType.type}/redact/confirm">Change<span class="govuk-visually-hidden"> redacted final comments</span></a></dd>`
 				);
 				expect(unprettifiedHTML).toContain('Supporting documents</dt>');
 				expect(unprettifiedHTML).toContain(`No documents</dd>`);
 				expect(unprettifiedHTML).toContain('Review decision</dt>');
 				expect(unprettifiedHTML).toContain('Redact and accept final comments</dd>');
 				expect(unprettifiedHTML).toContain(
-					`href="/appeals-service/appeal-details/2/final-comments/${finalCommentsType.type}?backUrl=/final-comments/${finalCommentsType.type}/redact/confirm">Change<span class="govuk-visually-hidden"> review decision</span></a></dd>`
+					`href="/appeals-service/appeal-details/2/final-comments/${finalCommentsType.type}?backUrl=/appeals-service/appeal-details/2/final-comments/${finalCommentsType.type}/redact/confirm">Change<span class="govuk-visually-hidden"> review decision</span></a></dd>`
 				);
 				expect(unprettifiedHTML).toContain(
 					`Accept ${finalCommentsType.label} final comments</button></form>`

--- a/appeals/web/src/server/appeals/appeal-details/representations/final-comments/redact/components/summary-list.js
+++ b/appeals/web/src/server/appeals/appeal-details/representations/final-comments/redact/components/summary-list.js
@@ -75,7 +75,7 @@ export const summaryList = (
 								actions: {
 									items: [
 										{
-											href: `/appeals-service/appeal-details/${appealDetails.appealId}/final-comments/${finalCommentsType}/redact?backUrl=/final-comments/${finalCommentsType}/redact/confirm`,
+											href: `/appeals-service/appeal-details/${appealDetails.appealId}/final-comments/${finalCommentsType}/redact?backUrl=/appeals-service/appeal-details/${appealDetails.appealId}/final-comments/${finalCommentsType}/redact/confirm`,
 											text: 'Change',
 											visuallyHiddenText: 'redacted final comments'
 										}
@@ -93,14 +93,14 @@ export const summaryList = (
 								? [
 										{
 											text: 'Manage',
-											href: `/appeals-service/appeal-details/${appealDetails.appealId}/final-comments/${finalCommentsType}/manage-documents/${comment.attachments?.[0]?.documentVersion?.document?.folderId}/?backUrl=/final-comments/${finalCommentsType}/redact/confirm`,
+											href: `/appeals-service/appeal-details/${appealDetails.appealId}/final-comments/${finalCommentsType}/manage-documents/${comment.attachments?.[0]?.documentVersion?.document?.folderId}/?backUrl=/appeals-service/appeal-details/${appealDetails.appealId}/final-comments/${finalCommentsType}/redact/confirm`,
 											visuallyHiddenText: 'supporting documents'
 										}
 								  ]
 								: []),
 							{
 								text: 'Add',
-								href: `/appeals-service/appeal-details/${appealDetails.appealId}/final-comments/${finalCommentsType}/add-document/?backUrl=/final-comments/${finalCommentsType}/redact/confirm`,
+								href: `/appeals-service/appeal-details/${appealDetails.appealId}/final-comments/${finalCommentsType}/add-document/?backUrl=/appeals-service/appeal-details/${appealDetails.appealId}/final-comments/${finalCommentsType}/redact/confirm`,
 								visuallyHiddenText: 'supporting documents'
 							}
 						]
@@ -112,7 +112,7 @@ export const summaryList = (
 					actions: {
 						items: [
 							{
-								href: `/appeals-service/appeal-details/${appealDetails.appealId}/final-comments/${finalCommentsType}?backUrl=/final-comments/${finalCommentsType}/redact/confirm`,
+								href: `/appeals-service/appeal-details/${appealDetails.appealId}/final-comments/${finalCommentsType}?backUrl=/appeals-service/appeal-details/${appealDetails.appealId}/final-comments/${finalCommentsType}/redact/confirm`,
 								text: 'Change',
 								visuallyHiddenText: 'review decision'
 							}

--- a/appeals/web/src/server/appeals/appeal-details/representations/final-comments/reject/__tests__/reject-final-comments.test.js
+++ b/appeals/web/src/server/appeals/appeal-details/representations/final-comments/reject/__tests__/reject-final-comments.test.js
@@ -146,7 +146,7 @@ describe('final-comments', () => {
 					`Why are you rejecting the ${finalCommentsType.label}&#39;s final comments?`
 				);
 				expect(unprettifiedHTML).toContain(
-					`href="/appeals-service/appeal-details/2/final-comments/${finalCommentsType.type}?backUrl=/final-comments/${finalCommentsType.type}/reject/confirm">Change<span class="govuk-visually-hidden"> review decision</span></a></dd>`
+					`href="/appeals-service/appeal-details/2/final-comments/${finalCommentsType.type}?backUrl=/appeals-service/appeal-details/2/final-comments/${finalCommentsType.type}/reject/confirm">Change<span class="govuk-visually-hidden"> review decision</span></a></dd>`
 				);
 				expect(unprettifiedHTML).toContain(
 					`Reject ${finalCommentsType.label} final comments</button></form>`

--- a/appeals/web/src/server/appeals/appeal-details/representations/final-comments/reject/reject.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/representations/final-comments/reject/reject.mapper.js
@@ -92,14 +92,14 @@ export const confirmRejectFinalCommentPage = (
 									? [
 											{
 												text: 'Manage',
-												href: `/appeals-service/appeal-details/${appealDetails.appealId}/final-comments/${finalCommentsType}/manage-documents/${comment.attachments?.[0]?.documentVersion?.document?.folderId}/?backUrl=/final-comments/${finalCommentsType}/reject/confirm`,
+												href: `/appeals-service/appeal-details/${appealDetails.appealId}/final-comments/${finalCommentsType}/manage-documents/${comment.attachments?.[0]?.documentVersion?.document?.folderId}/?backUrl=/appeals-service/appeal-details/${appealDetails.appealId}/final-comments/${finalCommentsType}/reject/confirm`,
 												visuallyHiddenText: 'supporting documents'
 											}
 									  ]
 									: []),
 								{
 									text: 'Add',
-									href: `/appeals-service/appeal-details/${appealDetails.appealId}/final-comments/${finalCommentsType}/add-document/?backUrl=/final-comments/${finalCommentsType}/reject/confirm`,
+									href: `/appeals-service/appeal-details/${appealDetails.appealId}/final-comments/${finalCommentsType}/add-document/?backUrl=/appeals-service/appeal-details/${appealDetails.appealId}/final-comments/${finalCommentsType}/reject/confirm`,
 									visuallyHiddenText: 'supporting documents'
 								}
 							]
@@ -111,7 +111,7 @@ export const confirmRejectFinalCommentPage = (
 						actions: {
 							items: [
 								{
-									href: `/appeals-service/appeal-details/${appealDetails.appealId}/final-comments/${finalCommentsType}?backUrl=/final-comments/${finalCommentsType}/reject/confirm`,
+									href: `/appeals-service/appeal-details/${appealDetails.appealId}/final-comments/${finalCommentsType}?backUrl=/appeals-service/appeal-details/${appealDetails.appealId}/final-comments/${finalCommentsType}/reject/confirm`,
 									text: 'Change',
 									visuallyHiddenText: 'review decision'
 								}
@@ -139,7 +139,7 @@ export const confirmRejectFinalCommentPage = (
 						actions: {
 							items: [
 								{
-									href: `/appeals-service/appeal-details/${appealDetails.appealId}/final-comments/${finalCommentsType}/reject?backUrl=/final-comments/${finalCommentsType}/reject/confirm`,
+									href: `/appeals-service/appeal-details/${appealDetails.appealId}/final-comments/${finalCommentsType}/reject?backUrl=/appeals-service/appeal-details/${appealDetails.appealId}/final-comments/${finalCommentsType}/reject/confirm`,
 									text: 'Change',
 									visuallyHiddenText: 'rejections reasons'
 								}


### PR DESCRIPTION
…not found

## Describe your changes

updated backurls to use whole path as they return page not found

## Issue ticket number and link
[A2-3054](https://pins-ds.atlassian.net/browse/A2-3054)


[A2-3054]: https://pins-ds.atlassian.net/browse/A2-3054?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ