### PR TITLE
fix(appeals): prevent uploading any duplicate named documents including versions (a2-3257)

### DIFF
--- a/appeals/web/src/client/components/file-uploader/_client-actions.js
+++ b/appeals/web/src/client/components/file-uploader/_client-actions.js
@@ -398,10 +398,6 @@ const clientActions = (container) => {
 			return { message: 'SIZE_SINGLE_FILE' };
 		}
 
-		if (container.dataset?.documentStage === 'representation' && !isNewVersionOfExistingFile()) {
-			return null;
-		}
-
 		if ([...filenamesInStagedFiles, ...filenamesInFolder].includes(selectedFile.name)) {
 			return { message: 'DUPLICATE_NAME_SINGLE_FILE' };
 		}


### PR DESCRIPTION
## Describe your changes
#### Prevent uploading any duplicate named documents including versions (a2-3257)

### WEB (Client side):
- Remove code that allows duplicates when document stage is 'representation' so that all files no matter what stage will be tested for duplicates.

### TEST:
- Made sure all unit tests pass
- Manually tested within browser

## Issue ticket number and link:
- [(A2-3257) Content when uploading a new document version in BO](https://pins-ds.atlassian.net/browse/A2-3257)

