### PR TITLE
feat(appeals): create notify to inform lpas there is no statement or interested parties comments (a2-3643)

### DIFF
--- a/appeals/api/src/server/endpoints/representations/__tests__/representations.test.js
+++ b/appeals/api/src/server/endpoints/representations/__tests__/representations.test.js
@@ -742,6 +742,8 @@ describe('/appeals/:id/reps/publish', () => {
 			const expectedEmailPayload = {
 				lpa_reference: mockAppeal.applicationReference,
 				appeal_reference_number: mockAppeal.reference,
+				has_ip_comments: false,
+				has_statement: false,
 				final_comments_deadline: '4 December 2024',
 				site_address: expectedSiteAddress
 			};
@@ -750,7 +752,8 @@ describe('/appeals/:id/reps/publish', () => {
 			databaseConnector.appealStatus.create.mockResolvedValue({});
 			databaseConnector.appealStatus.updateMany.mockResolvedValue([]);
 			databaseConnector.representation.findMany.mockResolvedValue([
-				{ representationType: 'lpa_statement' }
+				{ representationType: 'lpa_statement' },
+				{ representationType: 'appellant_final_comment' }
 			]);
 			databaseConnector.representation.updateMany.mockResolvedValue([]);
 			databaseConnector.documentRedactionStatus.findMany.mockResolvedValue([
@@ -773,6 +776,8 @@ describe('/appeals/:id/reps/publish', () => {
 				notifyClient: expect.anything(),
 				personalisation: {
 					...expectedEmailPayload,
+					has_ip_comments: true,
+					has_statement: true,
 					what_happens_next:
 						'You need to [submit your final comments](/mock-front-office-url/manage-appeals/6000002) by 4 December 2024.'
 				},
@@ -808,6 +813,8 @@ describe('/appeals/:id/reps/publish', () => {
 
 			const expectedEmailPayload = {
 				lpa_reference: mockAppeal.applicationReference,
+				has_ip_comments: false,
+				has_statement: false,
 				appeal_reference_number: mockAppeal.reference,
 				final_comments_deadline: '4 December 2024',
 				site_address: expectedSiteAddress
@@ -822,7 +829,8 @@ describe('/appeals/:id/reps/publish', () => {
 			databaseConnector.appealStatus.create.mockResolvedValue({});
 			databaseConnector.appealStatus.updateMany.mockResolvedValue([]);
 			databaseConnector.representation.findMany.mockResolvedValue([
-				{ representationType: 'lpa_statement' }
+				{ representationType: 'lpa_statement' },
+				{ representationType: 'appellant_final_comment' }
 			]);
 			databaseConnector.representation.updateMany.mockResolvedValue([]);
 			databaseConnector.documentRedactionStatus.findMany.mockResolvedValue([
@@ -845,8 +853,9 @@ describe('/appeals/:id/reps/publish', () => {
 				notifyClient: expect.anything(),
 				personalisation: {
 					...expectedEmailPayload,
-					what_happens_next:
-						'We will contact you when the hearing has been set up.'
+					has_ip_comments: true,
+					has_statement: true,
+					what_happens_next: 'We will contact you when the hearing has been set up.'
 				},
 				recipientEmail: appealS78.lpa.email,
 				templateName: 'received-statement-and-ip-comments-lpa'
@@ -857,8 +866,7 @@ describe('/appeals/:id/reps/publish', () => {
 				notifyClient: expect.anything(),
 				personalisation: {
 					...expectedEmailPayload,
-					what_happens_next:
-						'We will contact you if we need any more information.'
+					what_happens_next: 'We will contact you if we need any more information.'
 				},
 				recipientEmail: appealS78.appellant.email,
 				templateName: 'received-statement-and-ip-comments-appellant'
@@ -880,6 +888,8 @@ describe('/appeals/:id/reps/publish', () => {
 
 			const expectedEmailPayload = {
 				lpa_reference: mockAppeal.applicationReference,
+				has_ip_comments: false,
+				has_statement: false,
 				appeal_reference_number: mockAppeal.reference,
 				final_comments_deadline: '4 December 2024',
 				site_address: expectedSiteAddress
@@ -897,7 +907,8 @@ describe('/appeals/:id/reps/publish', () => {
 			databaseConnector.appealStatus.create.mockResolvedValue({});
 			databaseConnector.appealStatus.updateMany.mockResolvedValue([]);
 			databaseConnector.representation.findMany.mockResolvedValue([
-				{ representationType: 'lpa_statement' }
+				{ representationType: 'lpa_statement' },
+				{ representationType: 'appellant_final_comment' }
 			]);
 			databaseConnector.representation.updateMany.mockResolvedValue([]);
 			databaseConnector.documentRedactionStatus.findMany.mockResolvedValue([
@@ -920,6 +931,8 @@ describe('/appeals/:id/reps/publish', () => {
 				notifyClient: expect.anything(),
 				personalisation: {
 					...expectedEmailPayload,
+					has_ip_comments: true,
+					has_statement: true,
 					what_happens_next: 'The hearing is on 31 January 2025.'
 				},
 				recipientEmail: appealS78.lpa.email,
@@ -1002,6 +1015,8 @@ describe('/appeals/:id/reps/publish', () => {
 
 			const expectedEmailPayload = {
 				lpa_reference: mockAppeal.applicationReference,
+				has_ip_comments: false,
+				has_statement: false,
 				appeal_reference_number: mockAppeal.reference,
 				final_comments_deadline: '',
 				site_address: expectedSiteAddress

--- a/appeals/api/src/server/notify/templates/received-statement-and-ip-comments-appellant.content.md
+++ b/appeals/api/src/server/notify/templates/received-statement-and-ip-comments-appellant.content.md
@@ -1,6 +1,21 @@
-We have received the local planning authority’s questionnaire, all statements and comments from interested parties.
+
+
+{% if has_statement and has_ip_comments -%}
+   We have received the local planning authority’s questionnaire, all statements and comments from interested parties.
+{% elif has_statement -%}
+   We have received a statement from the local planning authority.
+{% elif has_ip_comments -%}
+   We have received comments from interested parties.
+{% endif -%}
 
 You can [view this information in the appeals service]({{front_office_url}}/appeals/{{appeal_reference_number}}).
+
+{% if not has_statement -%}
+   The local planning authority did not submit a statement.
+{% endif -%}
+{% if not has_ip_comments -%}
+   We did not receive any comments from interested parties.
+{% endif -%}
 
 {% include 'parts/appeal-details.md' %}
 


### PR DESCRIPTION
## Describe your changes
#### Update Notify to inform the LPA that there is no statement or interested parties comments (a2-3643)

### API:
- Add parameters to the notify template for LPA to tailor whether there are statements and/or ip comments

### TEST:
- Added notify tests to handle no statement or interested parties comments within the template
- Made sure all unit tests pass
- Manually tested within browser

## Issue ticket number and link:
- [(A2-3643) Create Notify to inform LPAs there are no Statement/Interested Parties](https://pins-ds.atlassian.net/browse/A2-3643)

