### PR TITLE
feat(appeals): error check affected or changed listed building numbers (A2-3525)

### DIFF
--- a/appeals/api/src/server/endpoints/historic-england/historic-england.controller.js
+++ b/appeals/api/src/server/endpoints/historic-england/historic-england.controller.js
@@ -15,7 +15,7 @@ export const findListedBuilding = async (req, res) => {
 	if (!result) {
 		return res.status(404).send();
 	}
-	return res.status(201).send(result);
+	return res.status(200).send(result);
 };
 
 /**

--- a/appeals/api/src/server/endpoints/historic-england/historic-england.routes.js
+++ b/appeals/api/src/server/endpoints/historic-england/historic-england.routes.js
@@ -21,7 +21,7 @@ router.get(
 			example: '434bff4e-8191-4ce0-9a0a-91e5d6cdd882'
 		}
 		#swagger.responses[400] = {}
-		#swagger.responses[201] = {
+		#swagger.responses[200] = {
 			description: 'Returns the listedBuilding data',
 			schema: { $ref: '#/components/schemas/ListedBuilding' }
 		}

--- a/appeals/api/src/server/openapi-types.ts
+++ b/appeals/api/src/server/openapi-types.ts
@@ -3657,6 +3657,8 @@ export type AppellantCase = {
 	typeOfPlanningApplication?:
 		| 'full-appeal'
 		| 'householder-planning'
+		| 'listed-building'
+		| 'minor-commercial-development'
 		| 'outline-planning'
 		| 'prior-approval'
 		| 'removal-or-variation-of-conditions'
@@ -11726,6 +11728,8 @@ export interface AppellantCaseUpdateRequest {
 	typeOfPlanningApplication?:
 		| 'full-appeal'
 		| 'householder-planning'
+		| 'listed-building'
+		| 'minor-commercial-development'
 		| 'outline-planning'
 		| 'prior-approval'
 		| 'removal-or-variation-of-conditions'

--- a/appeals/api/src/server/openapi.json
+++ b/appeals/api/src/server/openapi.json
@@ -769,7 +769,7 @@
 					}
 				],
 				"responses": {
-					"201": {
+					"200": {
 						"description": "Returns the listedBuilding data",
 						"content": {
 							"application/json": {
@@ -13262,6 +13262,8 @@
 						"enum": [
 							"full-appeal",
 							"householder-planning",
+							"listed-building",
+							"minor-commercial-development",
 							"outline-planning",
 							"prior-approval",
 							"removal-or-variation-of-conditions",
@@ -32053,6 +32055,8 @@
 						"enum": [
 							"full-appeal",
 							"householder-planning",
+							"listed-building",
+							"minor-commercial-development",
 							"outline-planning",
 							"prior-approval",
 							"removal-or-variation-of-conditions",

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/affected-listed-buildings/__tests__/__snapshots__/affected-listed-buildings.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/affected-listed-buildings/__tests__/__snapshots__/affected-listed-buildings.test.js.snap
@@ -39,8 +39,8 @@ exports[`affected-listed-buildings GET /add/check-and-confirm should render the 
         <div class="govuk-grid-column-two-thirds">
             <dl class="govuk-summary-list govuk-!-margin-bottom-9">
                 <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Affected listed building</dt>
-                    <dd                     class="govuk-summary-list__value"><a href="https://historicengland.org.uk/listing/the-list/list-entry/12345"
-                        class="govuk-link" target="_blank">12345</a>
+                    <dd                     class="govuk-summary-list__value"><a href="https://historicengland.org.uk/listing/the-list/list-entry/1234567"
+                        class="govuk-link" target="_blank">1234567</a>
                         </dd>
                         <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/1/affected-listed-buildings/add">Change<span class="govuk-visually-hidden"> listed building number</span></a>
                         </dd>
@@ -73,7 +73,7 @@ exports[`affected-listed-buildings GET /change/:listedBuildingId should render t
                         <div class="govuk-form-group">
                             <div id="affectedListedBuilding-hint" class="govuk-hint">This is a 7 digit number from Historic England</div>
                             <input class="govuk-input"
-                            id="affectedListedBuilding" name="affectedListedBuilding" type="text" value="123456"
+                            id="affectedListedBuilding" name="affectedListedBuilding" type="text" value="1234567"
                             aria-describedby="affectedListedBuilding-hint">
                         </div>
                         <button type="submit" data-prevent-double-click="true" class="govuk-button"
@@ -97,8 +97,8 @@ exports[`affected-listed-buildings GET /change/:listedBuildingId/check-and-confi
         <div class="govuk-grid-column-two-thirds">
             <dl class="govuk-summary-list govuk-!-margin-bottom-9">
                 <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Affected listed building</dt>
-                    <dd                     class="govuk-summary-list__value"><a href="https://historicengland.org.uk/listing/the-list/list-entry/12345"
-                        class="govuk-link" target="_blank">12345</a>
+                    <dd                     class="govuk-summary-list__value"><a href="https://historicengland.org.uk/listing/the-list/list-entry/1234567"
+                        class="govuk-link" target="_blank">1234567</a>
                         </dd>
                         <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/1/affected-listed-buildings/change/1">Change<span class="govuk-visually-hidden"> affected listed building</span></a>
                         </dd>
@@ -128,8 +128,8 @@ exports[`affected-listed-buildings GET /remove/:listedBuildingId should render t
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full">
                     <form method="POST" novalidate="novalidate">
-                        <p class="govuk-body"><a href="https://historicengland.org.uk/listing/the-list/list-entry/123456"
-                            class="govuk-link" target="_blank">123456</a>
+                        <p class="govuk-body"><a href="https://historicengland.org.uk/listing/the-list/list-entry/1234567"
+                            class="govuk-link" target="_blank">1234567</a>
                         </p>
                         <button type="submit" data-prevent-double-click="true" class="govuk-button"
                         data-module="govuk-button">Remove affected listed building</button>
@@ -141,6 +141,92 @@ exports[`affected-listed-buildings GET /remove/:listedBuildingId should render t
                     <p class="govuk-body"><a href="/appeals-service/appeal-details/1/lpa-questionnaire/1/affected-listed-buildings/manage"
                         class="govuk-link" target="_blank">Cancel</a>
                     </p>
+                </div>
+            </div>
+        </div>
+    </div>
+</main>"
+`;
+
+exports[`affected-listed-buildings POST /add should re-render the add affected listed building page with an error when listed building contains a letter 1`] = `
+"<main class="govuk-main-wrapper" id="main-content">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <div class="govuk-error-summary" data-module="govuk-error-summary">
+                <div role="alert">
+                    <h2 class="govuk-error-summary__title"> There is a problem</h2>
+                    <div class="govuk-error-summary__body">
+                        <ul class="govuk-list govuk-error-summary__list">
+                            <li><a href="#affected-listed-building">Listed building entry number must be 7 digits</a>
+                            </li>
+                        </ul>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Appeal 351062 - add affected listed building</span>
+            <h1             class="govuk-heading-l">Affected listed building entry number</h1>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <div class="govuk-grid-row">
+                <div class="govuk-grid-column-full">
+                    <form method="POST" novalidate="novalidate">
+                        <div class="govuk-form-group">
+                            <div id="affectedListedBuilding-hint" class="govuk-hint">This is a 7 digit number from Historic England</div>
+                            <input class="govuk-input"
+                            id="affectedListedBuilding" name="affectedListedBuilding" type="text" value="A123456"
+                            aria-describedby="affectedListedBuilding-hint">
+                        </div>
+                        <button type="submit" data-prevent-double-click="true" class="govuk-button"
+                        data-module="govuk-button">Continue</button>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </div>
+</main>"
+`;
+
+exports[`affected-listed-buildings POST /add should re-render the add affected listed building page with an error when listed building contains a special character 1`] = `
+"<main class="govuk-main-wrapper" id="main-content">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <div class="govuk-error-summary" data-module="govuk-error-summary">
+                <div role="alert">
+                    <h2 class="govuk-error-summary__title"> There is a problem</h2>
+                    <div class="govuk-error-summary__body">
+                        <ul class="govuk-list govuk-error-summary__list">
+                            <li><a href="#affected-listed-building">Listed building entry number must be 7 digits</a>
+                            </li>
+                        </ul>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Appeal 351062 - add affected listed building</span>
+            <h1             class="govuk-heading-l">Affected listed building entry number</h1>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <div class="govuk-grid-row">
+                <div class="govuk-grid-column-full">
+                    <form method="POST" novalidate="novalidate">
+                        <div class="govuk-form-group">
+                            <div id="affectedListedBuilding-hint" class="govuk-hint">This is a 7 digit number from Historic England</div>
+                            <input class="govuk-input"
+                            id="affectedListedBuilding" name="affectedListedBuilding" type="text" value="*123456"
+                            aria-describedby="affectedListedBuilding-hint">
+                        </div>
+                        <button type="submit" data-prevent-double-click="true" class="govuk-button"
+                        data-module="govuk-button">Continue</button>
+                    </form>
                 </div>
             </div>
         </div>
@@ -191,7 +277,265 @@ exports[`affected-listed-buildings POST /add should re-render the add affected l
 </main>"
 `;
 
-exports[`affected-listed-buildings POST /change/:listedBuildingId should re-render the change listed building page when the data is invalid 1`] = `
+exports[`affected-listed-buildings POST /add should re-render the add affected listed building page with an error when listed building is less than seven digits 1`] = `
+"<main class="govuk-main-wrapper" id="main-content">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <div class="govuk-error-summary" data-module="govuk-error-summary">
+                <div role="alert">
+                    <h2 class="govuk-error-summary__title"> There is a problem</h2>
+                    <div class="govuk-error-summary__body">
+                        <ul class="govuk-list govuk-error-summary__list">
+                            <li><a href="#affected-listed-building">Listed building entry number must be 7 digits</a>
+                            </li>
+                        </ul>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Appeal 351062 - add affected listed building</span>
+            <h1             class="govuk-heading-l">Affected listed building entry number</h1>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <div class="govuk-grid-row">
+                <div class="govuk-grid-column-full">
+                    <form method="POST" novalidate="novalidate">
+                        <div class="govuk-form-group">
+                            <div id="affectedListedBuilding-hint" class="govuk-hint">This is a 7 digit number from Historic England</div>
+                            <input class="govuk-input"
+                            id="affectedListedBuilding" name="affectedListedBuilding" type="text" value="12345"
+                            aria-describedby="affectedListedBuilding-hint">
+                        </div>
+                        <button type="submit" data-prevent-double-click="true" class="govuk-button"
+                        data-module="govuk-button">Continue</button>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </div>
+</main>"
+`;
+
+exports[`affected-listed-buildings POST /add should re-render the add affected listed building page with an error when listed building is more than seven digits 1`] = `
+"<main class="govuk-main-wrapper" id="main-content">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <div class="govuk-error-summary" data-module="govuk-error-summary">
+                <div role="alert">
+                    <h2 class="govuk-error-summary__title"> There is a problem</h2>
+                    <div class="govuk-error-summary__body">
+                        <ul class="govuk-list govuk-error-summary__list">
+                            <li><a href="#affected-listed-building">Listed building entry number must be 7 digits</a>
+                            </li>
+                        </ul>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Appeal 351062 - add affected listed building</span>
+            <h1             class="govuk-heading-l">Affected listed building entry number</h1>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <div class="govuk-grid-row">
+                <div class="govuk-grid-column-full">
+                    <form method="POST" novalidate="novalidate">
+                        <div class="govuk-form-group">
+                            <div id="affectedListedBuilding-hint" class="govuk-hint">This is a 7 digit number from Historic England</div>
+                            <input class="govuk-input"
+                            id="affectedListedBuilding" name="affectedListedBuilding" type="text" value="12345678"
+                            aria-describedby="affectedListedBuilding-hint">
+                        </div>
+                        <button type="submit" data-prevent-double-click="true" class="govuk-button"
+                        data-module="govuk-button">Continue</button>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </div>
+</main>"
+`;
+
+exports[`affected-listed-buildings POST /change/:listedBuildingId should re-render the change affected listed building page with an error when listed building contains a letter 1`] = `
+"<main class="govuk-main-wrapper" id="main-content">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <div class="govuk-error-summary" data-module="govuk-error-summary">
+                <div role="alert">
+                    <h2 class="govuk-error-summary__title"> There is a problem</h2>
+                    <div class="govuk-error-summary__body">
+                        <ul class="govuk-list govuk-error-summary__list">
+                            <li><a href="#affected-listed-building">Listed building entry number must be 7 digits</a>
+                            </li>
+                        </ul>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Appeal 351062 - update affected listed building</span>
+            <h1             class="govuk-heading-l">Affected listed building entry number</h1>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <div class="govuk-grid-row">
+                <div class="govuk-grid-column-full">
+                    <form method="POST" novalidate="novalidate">
+                        <div class="govuk-form-group">
+                            <div id="affectedListedBuilding-hint" class="govuk-hint">This is a 7 digit number from Historic England</div>
+                            <input class="govuk-input"
+                            id="affectedListedBuilding" name="affectedListedBuilding" type="text" value="A123456"
+                            aria-describedby="affectedListedBuilding-hint">
+                        </div>
+                        <button type="submit" data-prevent-double-click="true" class="govuk-button"
+                        data-module="govuk-button">Continue</button>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </div>
+</main>"
+`;
+
+exports[`affected-listed-buildings POST /change/:listedBuildingId should re-render the change affected listed building page with an error when listed building contains a special character 1`] = `
+"<main class="govuk-main-wrapper" id="main-content">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <div class="govuk-error-summary" data-module="govuk-error-summary">
+                <div role="alert">
+                    <h2 class="govuk-error-summary__title"> There is a problem</h2>
+                    <div class="govuk-error-summary__body">
+                        <ul class="govuk-list govuk-error-summary__list">
+                            <li><a href="#affected-listed-building">Listed building entry number must be 7 digits</a>
+                            </li>
+                        </ul>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Appeal 351062 - update affected listed building</span>
+            <h1             class="govuk-heading-l">Affected listed building entry number</h1>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <div class="govuk-grid-row">
+                <div class="govuk-grid-column-full">
+                    <form method="POST" novalidate="novalidate">
+                        <div class="govuk-form-group">
+                            <div id="affectedListedBuilding-hint" class="govuk-hint">This is a 7 digit number from Historic England</div>
+                            <input class="govuk-input"
+                            id="affectedListedBuilding" name="affectedListedBuilding" type="text" value="*123456"
+                            aria-describedby="affectedListedBuilding-hint">
+                        </div>
+                        <button type="submit" data-prevent-double-click="true" class="govuk-button"
+                        data-module="govuk-button">Continue</button>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </div>
+</main>"
+`;
+
+exports[`affected-listed-buildings POST /change/:listedBuildingId should re-render the change affected listed building page with an error when listed building is less than seven digits 1`] = `
+"<main class="govuk-main-wrapper" id="main-content">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <div class="govuk-error-summary" data-module="govuk-error-summary">
+                <div role="alert">
+                    <h2 class="govuk-error-summary__title"> There is a problem</h2>
+                    <div class="govuk-error-summary__body">
+                        <ul class="govuk-list govuk-error-summary__list">
+                            <li><a href="#affected-listed-building">Listed building entry number must be 7 digits</a>
+                            </li>
+                        </ul>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Appeal 351062 - update affected listed building</span>
+            <h1             class="govuk-heading-l">Affected listed building entry number</h1>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <div class="govuk-grid-row">
+                <div class="govuk-grid-column-full">
+                    <form method="POST" novalidate="novalidate">
+                        <div class="govuk-form-group">
+                            <div id="affectedListedBuilding-hint" class="govuk-hint">This is a 7 digit number from Historic England</div>
+                            <input class="govuk-input"
+                            id="affectedListedBuilding" name="affectedListedBuilding" type="text" value="12345"
+                            aria-describedby="affectedListedBuilding-hint">
+                        </div>
+                        <button type="submit" data-prevent-double-click="true" class="govuk-button"
+                        data-module="govuk-button">Continue</button>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </div>
+</main>"
+`;
+
+exports[`affected-listed-buildings POST /change/:listedBuildingId should re-render the change affected listed building page with an error when listed building is more than seven digits 1`] = `
+"<main class="govuk-main-wrapper" id="main-content">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <div class="govuk-error-summary" data-module="govuk-error-summary">
+                <div role="alert">
+                    <h2 class="govuk-error-summary__title"> There is a problem</h2>
+                    <div class="govuk-error-summary__body">
+                        <ul class="govuk-list govuk-error-summary__list">
+                            <li><a href="#affected-listed-building">Listed building entry number must be 7 digits</a>
+                            </li>
+                        </ul>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Appeal 351062 - update affected listed building</span>
+            <h1             class="govuk-heading-l">Affected listed building entry number</h1>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <div class="govuk-grid-row">
+                <div class="govuk-grid-column-full">
+                    <form method="POST" novalidate="novalidate">
+                        <div class="govuk-form-group">
+                            <div id="affectedListedBuilding-hint" class="govuk-hint">This is a 7 digit number from Historic England</div>
+                            <input class="govuk-input"
+                            id="affectedListedBuilding" name="affectedListedBuilding" type="text" value="12345678"
+                            aria-describedby="affectedListedBuilding-hint">
+                        </div>
+                        <button type="submit" data-prevent-double-click="true" class="govuk-button"
+                        data-module="govuk-button">Continue</button>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </div>
+</main>"
+`;
+
+exports[`affected-listed-buildings POST /change/:listedBuildingId should re-render the change listed building page when the listed building is empty 1`] = `
 "<main class="govuk-main-wrapper" id="main-content">
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">
@@ -221,7 +565,7 @@ exports[`affected-listed-buildings POST /change/:listedBuildingId should re-rend
                         <div class="govuk-form-group">
                             <div id="affectedListedBuilding-hint" class="govuk-hint">This is a 7 digit number from Historic England</div>
                             <input class="govuk-input"
-                            id="affectedListedBuilding" name="affectedListedBuilding" type="text" value="123456"
+                            id="affectedListedBuilding" name="affectedListedBuilding" type="text" value="1234567"
                             aria-describedby="affectedListedBuilding-hint">
                         </div>
                         <button type="submit" data-prevent-double-click="true" class="govuk-button"

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/affected-listed-buildings/__tests__/__snapshots__/affected-listed-buildings.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/affected-listed-buildings/__tests__/__snapshots__/affected-listed-buildings.test.js.snap
@@ -363,6 +363,49 @@ exports[`affected-listed-buildings POST /add should re-render the add affected l
 </main>"
 `;
 
+exports[`affected-listed-buildings POST /add should re-render the add affected listed building page with an error when listed building is seven digits but not in historic england 1`] = `
+"<main class="govuk-main-wrapper" id="main-content">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <div class="govuk-error-summary" data-module="govuk-error-summary">
+                <div role="alert">
+                    <h2 class="govuk-error-summary__title"> There is a problem</h2>
+                    <div class="govuk-error-summary__body">
+                        <ul class="govuk-list govuk-error-summary__list">
+                            <li><a href="#affected-listed-building">Enter a real listed building entry number</a>
+                            </li>
+                        </ul>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Appeal 351062 - add affected listed building</span>
+            <h1             class="govuk-heading-l">Affected listed building entry number</h1>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <div class="govuk-grid-row">
+                <div class="govuk-grid-column-full">
+                    <form method="POST" novalidate="novalidate">
+                        <div class="govuk-form-group">
+                            <div id="affectedListedBuilding-hint" class="govuk-hint">This is a 7 digit number from Historic England</div>
+                            <input class="govuk-input"
+                            id="affectedListedBuilding" name="affectedListedBuilding" type="text" value="9999999"
+                            aria-describedby="affectedListedBuilding-hint">
+                        </div>
+                        <button type="submit" data-prevent-double-click="true" class="govuk-button"
+                        data-module="govuk-button">Continue</button>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </div>
+</main>"
+`;
+
 exports[`affected-listed-buildings POST /change/:listedBuildingId should re-render the change affected listed building page with an error when listed building contains a letter 1`] = `
 "<main class="govuk-main-wrapper" id="main-content">
     <div class="govuk-grid-row">
@@ -523,6 +566,49 @@ exports[`affected-listed-buildings POST /change/:listedBuildingId should re-rend
                             <div id="affectedListedBuilding-hint" class="govuk-hint">This is a 7 digit number from Historic England</div>
                             <input class="govuk-input"
                             id="affectedListedBuilding" name="affectedListedBuilding" type="text" value="12345678"
+                            aria-describedby="affectedListedBuilding-hint">
+                        </div>
+                        <button type="submit" data-prevent-double-click="true" class="govuk-button"
+                        data-module="govuk-button">Continue</button>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </div>
+</main>"
+`;
+
+exports[`affected-listed-buildings POST /change/:listedBuildingId should re-render the change affected listed building page with an error when listed building is seven digits but not in historic england 1`] = `
+"<main class="govuk-main-wrapper" id="main-content">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <div class="govuk-error-summary" data-module="govuk-error-summary">
+                <div role="alert">
+                    <h2 class="govuk-error-summary__title"> There is a problem</h2>
+                    <div class="govuk-error-summary__body">
+                        <ul class="govuk-list govuk-error-summary__list">
+                            <li><a href="#affected-listed-building">Enter a real listed building entry number</a>
+                            </li>
+                        </ul>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Appeal 351062 - update affected listed building</span>
+            <h1             class="govuk-heading-l">Affected listed building entry number</h1>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <div class="govuk-grid-row">
+                <div class="govuk-grid-column-full">
+                    <form method="POST" novalidate="novalidate">
+                        <div class="govuk-form-group">
+                            <div id="affectedListedBuilding-hint" class="govuk-hint">This is a 7 digit number from Historic England</div>
+                            <input class="govuk-input"
+                            id="affectedListedBuilding" name="affectedListedBuilding" type="text" value="9999999"
                             aria-describedby="affectedListedBuilding-hint">
                         </div>
                         <button type="submit" data-prevent-double-click="true" class="govuk-button"

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/affected-listed-buildings/__tests__/affected-listed-buildings.test.js
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/affected-listed-buildings/__tests__/affected-listed-buildings.test.js
@@ -9,6 +9,8 @@ const request = supertest(app);
 const baseUrl = '/appeals-service/appeal-details';
 const appealId = appealData.appealId;
 const lpaQuestionnaireId = appealData.lpaQuestionnaireId;
+const validListedBuilding = '1234567';
+const invalidListedBuilding = '9999999';
 
 describe('affected-listed-buildings', () => {
 	beforeEach(() => {
@@ -18,6 +20,8 @@ describe('affected-listed-buildings', () => {
 			.reply(200, {
 				...lpaQuestionnaireData
 			});
+		nock('http://test/').get(`/appeals/listed-buildings/${validListedBuilding}`).reply(200, {});
+		nock('http://test/').get(`/appeals/listed-buildings/${invalidListedBuilding}`).reply(404, {});
 	});
 	afterEach(teardown);
 
@@ -169,9 +173,36 @@ describe('affected-listed-buildings', () => {
 			expect(errorSummaryHtml).toContain('Listed building entry number must be 7 digits</a>');
 		});
 
+		it('should re-render the add affected listed building page with an error when listed building is seven digits but not in historic england', async () => {
+			const invalidData = {
+				affectedListedBuilding: invalidListedBuilding
+			};
+
+			const response = await request
+				.post(
+					`${baseUrl}/${appealId}/lpa-questionnaire/${lpaQuestionnaireId}/affected-listed-buildings/add`
+				)
+				.send(invalidData);
+			expect(response.statusCode).toBe(200);
+			const elementInnerHtml = parseHtml(response.text).innerHTML;
+
+			expect(elementInnerHtml).toMatchSnapshot();
+			expect(elementInnerHtml).toContain('- add affected listed building</span>');
+			expect(elementInnerHtml).toContain('Affected listed building entry number</h1>');
+			expect(elementInnerHtml).toContain('This is a 7 digit number from Historic England</div>');
+
+			const errorSummaryHtml = parseHtml(response.text, {
+				rootElement: '.govuk-error-summary',
+				skipPrettyPrint: true
+			}).innerHTML;
+
+			expect(errorSummaryHtml).toContain('There is a problem</h2>');
+			expect(errorSummaryHtml).toContain('Enter a real listed building entry number</a>');
+		});
+
 		it('should redirect to the check-and-confirm page when data is valid', async () => {
 			const validData = {
-				affectedListedBuilding: '1234567'
+				affectedListedBuilding: validListedBuilding
 			};
 
 			const response = await request
@@ -190,7 +221,7 @@ describe('affected-listed-buildings', () => {
 	describe('GET /add/check-and-confirm', () => {
 		it('should render the add affected listed building check and confirm page', async () => {
 			const validData = {
-				affectedListedBuilding: '1234567'
+				affectedListedBuilding: validListedBuilding
 			};
 
 			await request
@@ -223,7 +254,7 @@ describe('affected-listed-buildings', () => {
 	describe('POST /add/check-and-confirm', () => {
 		it('should redirect to the lpa questionnaire page', async () => {
 			const validData = {
-				affectedListedBuilding: '1234567'
+				affectedListedBuilding: validListedBuilding
 			};
 			nock('http://test/').post(`/appeals/${appealId}/listed-buildings`).reply(200, {});
 
@@ -408,9 +439,36 @@ describe('affected-listed-buildings', () => {
 			expect(errorSummaryHtml).toContain('Listed building entry number must be 7 digits</a>');
 		});
 
+		it('should re-render the change affected listed building page with an error when listed building is seven digits but not in historic england', async () => {
+			const invalidData = {
+				affectedListedBuilding: invalidListedBuilding
+			};
+
+			const response = await request
+				.post(
+					`${baseUrl}/${appealId}/lpa-questionnaire/${lpaQuestionnaireId}/affected-listed-buildings/change/1`
+				)
+				.send(invalidData);
+			expect(response.statusCode).toBe(200);
+			const elementInnerHtml = parseHtml(response.text).innerHTML;
+
+			expect(elementInnerHtml).toMatchSnapshot();
+			expect(elementInnerHtml).toContain('- update affected listed building</span>');
+			expect(elementInnerHtml).toContain('Affected listed building entry number</h1>');
+			expect(elementInnerHtml).toContain('This is a 7 digit number from Historic England</div>');
+
+			const errorSummaryHtml = parseHtml(response.text, {
+				rootElement: '.govuk-error-summary',
+				skipPrettyPrint: true
+			}).innerHTML;
+
+			expect(errorSummaryHtml).toContain('There is a problem</h2>');
+			expect(errorSummaryHtml).toContain('Enter a real listed building entry number</a>');
+		});
+
 		it('should redirect to to the check and confirm page if the data is valid', async () => {
 			const validData = {
-				affectedListedBuilding: '1234567'
+				affectedListedBuilding: validListedBuilding
 			};
 
 			const response = await request
@@ -429,7 +487,7 @@ describe('affected-listed-buildings', () => {
 	describe('GET /change/:listedBuildingId/check-and-confirm', () => {
 		it('should render the check and confirm page', async () => {
 			const validData = {
-				affectedListedBuilding: '1234567'
+				affectedListedBuilding: validListedBuilding
 			};
 			await request
 				.post(
@@ -449,7 +507,7 @@ describe('affected-listed-buildings', () => {
 			const unprettifiedElement = parseHtml(response.text, { skipPrettyPrint: true }).innerHTML;
 			expect(unprettifiedElement).toContain('Affected listed building</dt>');
 			expect(unprettifiedElement).toContain(
-				'<a href="https://historicengland.org.uk/listing/the-list/list-entry/1234567" class="govuk-link" target="_blank">1234567</a>'
+				`<a href="https://historicengland.org.uk/listing/the-list/list-entry/${validListedBuilding}" class="govuk-link" target="_blank">${validListedBuilding}</a>`
 			);
 			expect(elementInnerHtml).toContain('Update affected listed building</button>');
 		});
@@ -458,7 +516,7 @@ describe('affected-listed-buildings', () => {
 	describe('POST /change/:listedBuildingId/check-and-confirm', () => {
 		it('should redirect to lpa questionnaire', async () => {
 			const validData = {
-				affectedListedBuilding: '1234567'
+				affectedListedBuilding: validListedBuilding
 			};
 
 			nock('http://test/').patch(`/appeals/${appealId}/listed-buildings/1`).reply(200, {});

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/affected-listed-buildings/__tests__/affected-listed-buildings.test.js
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/affected-listed-buildings/__tests__/affected-listed-buildings.test.js
@@ -60,9 +60,118 @@ describe('affected-listed-buildings', () => {
 			expect(errorSummaryHtml).toContain('Provide a listed building entry list number</a>');
 		});
 
+		it('should re-render the add affected listed building page with an error when listed building is less than seven digits', async () => {
+			const invalidData = {
+				affectedListedBuilding: '12345'
+			};
+
+			const response = await request
+				.post(
+					`${baseUrl}/${appealId}/lpa-questionnaire/${lpaQuestionnaireId}/affected-listed-buildings/add`
+				)
+				.send(invalidData);
+			expect(response.statusCode).toBe(200);
+			const elementInnerHtml = parseHtml(response.text).innerHTML;
+
+			expect(elementInnerHtml).toMatchSnapshot();
+			expect(elementInnerHtml).toContain('- add affected listed building</span>');
+			expect(elementInnerHtml).toContain('Affected listed building entry number</h1>');
+			expect(elementInnerHtml).toContain('This is a 7 digit number from Historic England</div>');
+
+			const errorSummaryHtml = parseHtml(response.text, {
+				rootElement: '.govuk-error-summary',
+				skipPrettyPrint: true
+			}).innerHTML;
+
+			expect(errorSummaryHtml).toContain('There is a problem</h2>');
+			expect(errorSummaryHtml).toContain('Listed building entry number must be 7 digits</a>');
+		});
+
+		it('should re-render the add affected listed building page with an error when listed building is more than seven digits', async () => {
+			const invalidData = {
+				affectedListedBuilding: '12345678'
+			};
+
+			const response = await request
+				.post(
+					`${baseUrl}/${appealId}/lpa-questionnaire/${lpaQuestionnaireId}/affected-listed-buildings/add`
+				)
+				.send(invalidData);
+			expect(response.statusCode).toBe(200);
+			const elementInnerHtml = parseHtml(response.text).innerHTML;
+
+			expect(elementInnerHtml).toMatchSnapshot();
+			expect(elementInnerHtml).toContain('- add affected listed building</span>');
+			expect(elementInnerHtml).toContain('Affected listed building entry number</h1>');
+			expect(elementInnerHtml).toContain('This is a 7 digit number from Historic England</div>');
+
+			const errorSummaryHtml = parseHtml(response.text, {
+				rootElement: '.govuk-error-summary',
+				skipPrettyPrint: true
+			}).innerHTML;
+
+			expect(errorSummaryHtml).toContain('There is a problem</h2>');
+			expect(errorSummaryHtml).toContain('Listed building entry number must be 7 digits</a>');
+		});
+
+		it('should re-render the add affected listed building page with an error when listed building contains a special character', async () => {
+			const invalidData = {
+				affectedListedBuilding: '*123456'
+			};
+
+			const response = await request
+				.post(
+					`${baseUrl}/${appealId}/lpa-questionnaire/${lpaQuestionnaireId}/affected-listed-buildings/add`
+				)
+				.send(invalidData);
+			expect(response.statusCode).toBe(200);
+			const elementInnerHtml = parseHtml(response.text).innerHTML;
+
+			expect(elementInnerHtml).toMatchSnapshot();
+			expect(elementInnerHtml).toContain('- add affected listed building</span>');
+			expect(elementInnerHtml).toContain('Affected listed building entry number</h1>');
+			expect(elementInnerHtml).toContain('This is a 7 digit number from Historic England</div>');
+
+			const errorSummaryHtml = parseHtml(response.text, {
+				rootElement: '.govuk-error-summary',
+				skipPrettyPrint: true
+			}).innerHTML;
+
+			expect(errorSummaryHtml).toContain('There is a problem</h2>');
+			expect(errorSummaryHtml).toContain('Listed building entry number must be 7 digits</a>');
+		});
+
+		it('should re-render the add affected listed building page with an error when listed building contains a letter', async () => {
+			const invalidData = {
+				affectedListedBuilding: 'A123456'
+			};
+
+			const response = await request
+				.post(
+					`${baseUrl}/${appealId}/lpa-questionnaire/${lpaQuestionnaireId}/affected-listed-buildings/add`
+				)
+				.send(invalidData);
+
+			expect(response.statusCode).toBe(200);
+			const elementInnerHtml = parseHtml(response.text).innerHTML;
+
+			expect(elementInnerHtml).toMatchSnapshot();
+			expect(elementInnerHtml).toContain('- add affected listed building</span>');
+			expect(elementInnerHtml).toContain('Affected listed building entry number</h1>');
+			expect(elementInnerHtml).toContain('This is a 7 digit number from Historic England</div>');
+
+			const errorSummaryHtml = parseHtml(response.text, {
+				rootElement: '.govuk-error-summary',
+				skipPrettyPrint: true
+			}).innerHTML;
+
+			expect(errorSummaryHtml).toContain('There is a problem</h2>');
+			expect(errorSummaryHtml).toContain('Listed building entry number must be 7 digits</a>');
+		});
+
 		it('should redirect to the check-and-confirm page when data is valid', async () => {
 			const validData = {
-				affectedListedBuilding: '12345'
+				affectedListedBuilding: '1234567'
 			};
 
 			const response = await request
@@ -81,7 +190,7 @@ describe('affected-listed-buildings', () => {
 	describe('GET /add/check-and-confirm', () => {
 		it('should render the add affected listed building check and confirm page', async () => {
 			const validData = {
-				affectedListedBuilding: '12345'
+				affectedListedBuilding: '1234567'
 			};
 
 			await request
@@ -105,7 +214,7 @@ describe('affected-listed-buildings', () => {
 			}).innerHTML;
 			expect(summaryListHtml).toContain('Affected listed building</dt>');
 			expect(summaryListHtml).toContain(
-				'<a href="https://historicengland.org.uk/listing/the-list/list-entry/12345" class="govuk-link" target="_blank">12345</a>'
+				'<a href="https://historicengland.org.uk/listing/the-list/list-entry/1234567" class="govuk-link" target="_blank">1234567</a>'
 			);
 			expect(elementInnerHtml).toContain('Add affected listed building</button>');
 		});
@@ -114,7 +223,7 @@ describe('affected-listed-buildings', () => {
 	describe('POST /add/check-and-confirm', () => {
 		it('should redirect to the lpa questionnaire page', async () => {
 			const validData = {
-				affectedListedBuilding: '12345'
+				affectedListedBuilding: '1234567'
 			};
 			nock('http://test/').post(`/appeals/${appealId}/listed-buildings`).reply(200, {});
 
@@ -148,10 +257,10 @@ describe('affected-listed-buildings', () => {
 			expect(unprettifiedElement).toContain('Listed building number</th>');
 			expect(unprettifiedElement).toContain('Action</th>');
 			expect(unprettifiedElement).toContain(
-				'Change<span class="govuk-visually-hidden"> listed building 123456</span></a>'
+				'Change<span class="govuk-visually-hidden"> listed building 1234567</span></a>'
 			);
 			expect(unprettifiedElement).toContain(
-				'Remove<span class="govuk-visually-hidden"> listed building 123456</span></a>'
+				'Remove<span class="govuk-visually-hidden"> listed building 1234567</span></a>'
 			);
 		});
 	});
@@ -171,7 +280,7 @@ describe('affected-listed-buildings', () => {
 	});
 
 	describe('POST /change/:listedBuildingId', () => {
-		it('should re-render the change listed building page when the data is invalid', async () => {
+		it('should re-render the change listed building page when the listed building is empty', async () => {
 			const invalidData = {
 				affectedListedBuilding: null
 			};
@@ -190,9 +299,118 @@ describe('affected-listed-buildings', () => {
 			expect(elementInnerHtml).toContain('This is a 7 digit number from Historic England</div>');
 		});
 
+		it('should re-render the change affected listed building page with an error when listed building is less than seven digits', async () => {
+			const invalidData = {
+				affectedListedBuilding: '12345'
+			};
+
+			const response = await request
+				.post(
+					`${baseUrl}/${appealId}/lpa-questionnaire/${lpaQuestionnaireId}/affected-listed-buildings/change/1`
+				)
+				.send(invalidData);
+			expect(response.statusCode).toBe(200);
+			const elementInnerHtml = parseHtml(response.text).innerHTML;
+
+			expect(elementInnerHtml).toMatchSnapshot();
+			expect(elementInnerHtml).toContain('- update affected listed building</span>');
+			expect(elementInnerHtml).toContain('Affected listed building entry number</h1>');
+			expect(elementInnerHtml).toContain('This is a 7 digit number from Historic England</div>');
+
+			const errorSummaryHtml = parseHtml(response.text, {
+				rootElement: '.govuk-error-summary',
+				skipPrettyPrint: true
+			}).innerHTML;
+
+			expect(errorSummaryHtml).toContain('There is a problem</h2>');
+			expect(errorSummaryHtml).toContain('Listed building entry number must be 7 digits</a>');
+		});
+
+		it('should re-render the change affected listed building page with an error when listed building is more than seven digits', async () => {
+			const invalidData = {
+				affectedListedBuilding: '12345678'
+			};
+
+			const response = await request
+				.post(
+					`${baseUrl}/${appealId}/lpa-questionnaire/${lpaQuestionnaireId}/affected-listed-buildings/change/1`
+				)
+				.send(invalidData);
+			expect(response.statusCode).toBe(200);
+			const elementInnerHtml = parseHtml(response.text).innerHTML;
+
+			expect(elementInnerHtml).toMatchSnapshot();
+			expect(elementInnerHtml).toContain('- update affected listed building</span>');
+			expect(elementInnerHtml).toContain('Affected listed building entry number</h1>');
+			expect(elementInnerHtml).toContain('This is a 7 digit number from Historic England</div>');
+
+			const errorSummaryHtml = parseHtml(response.text, {
+				rootElement: '.govuk-error-summary',
+				skipPrettyPrint: true
+			}).innerHTML;
+
+			expect(errorSummaryHtml).toContain('There is a problem</h2>');
+			expect(errorSummaryHtml).toContain('Listed building entry number must be 7 digits</a>');
+		});
+
+		it('should re-render the change affected listed building page with an error when listed building contains a special character', async () => {
+			const invalidData = {
+				affectedListedBuilding: '*123456'
+			};
+
+			const response = await request
+				.post(
+					`${baseUrl}/${appealId}/lpa-questionnaire/${lpaQuestionnaireId}/affected-listed-buildings/change/1`
+				)
+				.send(invalidData);
+			expect(response.statusCode).toBe(200);
+			const elementInnerHtml = parseHtml(response.text).innerHTML;
+
+			expect(elementInnerHtml).toMatchSnapshot();
+			expect(elementInnerHtml).toContain('- update affected listed building</span>');
+			expect(elementInnerHtml).toContain('Affected listed building entry number</h1>');
+			expect(elementInnerHtml).toContain('This is a 7 digit number from Historic England</div>');
+
+			const errorSummaryHtml = parseHtml(response.text, {
+				rootElement: '.govuk-error-summary',
+				skipPrettyPrint: true
+			}).innerHTML;
+
+			expect(errorSummaryHtml).toContain('There is a problem</h2>');
+			expect(errorSummaryHtml).toContain('Listed building entry number must be 7 digits</a>');
+		});
+
+		it('should re-render the change affected listed building page with an error when listed building contains a letter', async () => {
+			const invalidData = {
+				affectedListedBuilding: 'A123456'
+			};
+
+			const response = await request
+				.post(
+					`${baseUrl}/${appealId}/lpa-questionnaire/${lpaQuestionnaireId}/affected-listed-buildings/change/1`
+				)
+				.send(invalidData);
+
+			expect(response.statusCode).toBe(200);
+			const elementInnerHtml = parseHtml(response.text).innerHTML;
+
+			expect(elementInnerHtml).toMatchSnapshot();
+			expect(elementInnerHtml).toContain('- update affected listed building</span>');
+			expect(elementInnerHtml).toContain('Affected listed building entry number</h1>');
+			expect(elementInnerHtml).toContain('This is a 7 digit number from Historic England</div>');
+
+			const errorSummaryHtml = parseHtml(response.text, {
+				rootElement: '.govuk-error-summary',
+				skipPrettyPrint: true
+			}).innerHTML;
+
+			expect(errorSummaryHtml).toContain('There is a problem</h2>');
+			expect(errorSummaryHtml).toContain('Listed building entry number must be 7 digits</a>');
+		});
+
 		it('should redirect to to the check and confirm page if the data is valid', async () => {
 			const validData = {
-				affectedListedBuilding: '12345'
+				affectedListedBuilding: '1234567'
 			};
 
 			const response = await request
@@ -211,7 +429,7 @@ describe('affected-listed-buildings', () => {
 	describe('GET /change/:listedBuildingId/check-and-confirm', () => {
 		it('should render the check and confirm page', async () => {
 			const validData = {
-				affectedListedBuilding: '12345'
+				affectedListedBuilding: '1234567'
 			};
 			await request
 				.post(
@@ -231,7 +449,7 @@ describe('affected-listed-buildings', () => {
 			const unprettifiedElement = parseHtml(response.text, { skipPrettyPrint: true }).innerHTML;
 			expect(unprettifiedElement).toContain('Affected listed building</dt>');
 			expect(unprettifiedElement).toContain(
-				'<a href="https://historicengland.org.uk/listing/the-list/list-entry/12345" class="govuk-link" target="_blank">12345</a>'
+				'<a href="https://historicengland.org.uk/listing/the-list/list-entry/1234567" class="govuk-link" target="_blank">1234567</a>'
 			);
 			expect(elementInnerHtml).toContain('Update affected listed building</button>');
 		});
@@ -240,7 +458,7 @@ describe('affected-listed-buildings', () => {
 	describe('POST /change/:listedBuildingId/check-and-confirm', () => {
 		it('should redirect to lpa questionnaire', async () => {
 			const validData = {
-				affectedListedBuilding: '12345'
+				affectedListedBuilding: '1234567'
 			};
 
 			nock('http://test/').patch(`/appeals/${appealId}/listed-buildings/1`).reply(200, {});

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/affected-listed-buildings/affected-listed-buildings.service.js
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/affected-listed-buildings/affected-listed-buildings.service.js
@@ -60,3 +60,13 @@ export function removeAffectedListedBuilding(apiClient, appealId, listedBuilding
 		}
 	});
 }
+
+/**
+ *
+ * @param {import('got').Got} apiClient
+ * @param {string} listedBuildingId
+ * @returns {Promise<{}>}
+ */
+export function getAffectedListedBuilding(apiClient, listedBuildingId) {
+	return apiClient.get(`appeals/listed-buildings/${listedBuildingId}`);
+}

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/affected-listed-buildings/affected-listed-buildings.validator.js
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/affected-listed-buildings/affected-listed-buildings.validator.js
@@ -5,4 +5,8 @@ export const validateAffectedListedBuilding = createValidator(
 	body('affectedListedBuilding')
 		.notEmpty()
 		.withMessage('Provide a listed building entry list number')
+		.isNumeric()
+		.withMessage('Listed building entry number must be 7 digits')
+		.isLength({ min: 7, max: 7 })
+		.withMessage('Listed building entry number must be 7 digits')
 );

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/affected-listed-buildings/affected-listed-buildings.validator.js
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/affected-listed-buildings/affected-listed-buildings.validator.js
@@ -1,5 +1,6 @@
 import { createValidator } from '@pins/express';
 import { body } from 'express-validator';
+import { getAffectedListedBuilding } from '#appeals/appeal-details/lpa-questionnaire/affected-listed-buildings/affected-listed-buildings.service.js';
 
 export const validateAffectedListedBuilding = createValidator(
 	body('affectedListedBuilding')
@@ -9,4 +10,16 @@ export const validateAffectedListedBuilding = createValidator(
 		.withMessage('Listed building entry number must be 7 digits')
 		.isLength({ min: 7, max: 7 })
 		.withMessage('Listed building entry number must be 7 digits')
+		.custom(async (reference, { req }) => {
+			try {
+				const result = await getAffectedListedBuilding(req.apiClient, reference);
+
+				if (!result) {
+					throw new Error('Listed building entry number is not valid');
+				}
+			} catch (error) {
+				throw new Error('Listed building entry number is not valid');
+			}
+		})
+		.withMessage('Enter a real listed building entry number')
 );

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/changed-listed-buildings/__tests__/__snapshots__/changed-listed-buildings.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/changed-listed-buildings/__tests__/__snapshots__/changed-listed-buildings.test.js.snap
@@ -364,6 +364,49 @@ exports[`changed-listed-buildings POST /add should re-render the add changed lis
 </main>"
 `;
 
+exports[`changed-listed-buildings POST /add should re-render the add changed listed building page with an error when listed building is seven digits but not in historic england 1`] = `
+"<main class="govuk-main-wrapper" id="main-content">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <div class="govuk-error-summary" data-module="govuk-error-summary">
+                <div role="alert">
+                    <h2 class="govuk-error-summary__title"> There is a problem</h2>
+                    <div class="govuk-error-summary__body">
+                        <ul class="govuk-list govuk-error-summary__list">
+                            <li><a href="#changed-listed-building">Enter a real listed building entry number</a>
+                            </li>
+                        </ul>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Appeal 351062 - add changed listed building</span>
+            <h1             class="govuk-heading-l">Changed listed building entry number</h1>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <div class="govuk-grid-row">
+                <div class="govuk-grid-column-full">
+                    <form method="POST" novalidate="novalidate">
+                        <div class="govuk-form-group">
+                            <div id="changedListedBuilding-hint" class="govuk-hint">This is a 7 digit number from Historic England</div>
+                            <input class="govuk-input"
+                            id="changedListedBuilding" name="changedListedBuilding" type="text" value="9999999"
+                            aria-describedby="changedListedBuilding-hint">
+                        </div>
+                        <button type="submit" data-prevent-double-click="true" class="govuk-button"
+                        data-module="govuk-button">Continue</button>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </div>
+</main>"
+`;
+
 exports[`changed-listed-buildings POST /change/:listedBuildingId should re-render the change changed listed building page with an error when listed building contains a letter 1`] = `
 "<main class="govuk-main-wrapper" id="main-content">
     <div class="govuk-grid-row">
@@ -524,6 +567,49 @@ exports[`changed-listed-buildings POST /change/:listedBuildingId should re-rende
                             <div id="changedListedBuilding-hint" class="govuk-hint">This is a 7 digit number from Historic England</div>
                             <input class="govuk-input"
                             id="changedListedBuilding" name="changedListedBuilding" type="text" value="12345678"
+                            aria-describedby="changedListedBuilding-hint">
+                        </div>
+                        <button type="submit" data-prevent-double-click="true" class="govuk-button"
+                        data-module="govuk-button">Continue</button>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </div>
+</main>"
+`;
+
+exports[`changed-listed-buildings POST /change/:listedBuildingId should re-render the change changed listed building page with an error when listed building is seven digits but not in historic england 1`] = `
+"<main class="govuk-main-wrapper" id="main-content">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <div class="govuk-error-summary" data-module="govuk-error-summary">
+                <div role="alert">
+                    <h2 class="govuk-error-summary__title"> There is a problem</h2>
+                    <div class="govuk-error-summary__body">
+                        <ul class="govuk-list govuk-error-summary__list">
+                            <li><a href="#changed-listed-building">Enter a real listed building entry number</a>
+                            </li>
+                        </ul>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Appeal 351062 - update changed listed building</span>
+            <h1             class="govuk-heading-l">Changed listed building entry number</h1>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <div class="govuk-grid-row">
+                <div class="govuk-grid-column-full">
+                    <form method="POST" novalidate="novalidate">
+                        <div class="govuk-form-group">
+                            <div id="changedListedBuilding-hint" class="govuk-hint">This is a 7 digit number from Historic England</div>
+                            <input class="govuk-input"
+                            id="changedListedBuilding" name="changedListedBuilding" type="text" value="9999999"
                             aria-describedby="changedListedBuilding-hint">
                         </div>
                         <button type="submit" data-prevent-double-click="true" class="govuk-button"

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/changed-listed-buildings/__tests__/__snapshots__/changed-listed-buildings.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/changed-listed-buildings/__tests__/__snapshots__/changed-listed-buildings.test.js.snap
@@ -39,8 +39,8 @@ exports[`changed-listed-buildings GET /add/check-and-confirm should render the a
         <div class="govuk-grid-column-two-thirds">
             <dl class="govuk-summary-list govuk-!-margin-bottom-9">
                 <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Changed listed building</dt>
-                    <dd class="govuk-summary-list__value"><a href="https://historicengland.org.uk/listing/the-list/list-entry/12345"
-                        class="govuk-link" target="_blank">12345</a>
+                    <dd class="govuk-summary-list__value"><a href="https://historicengland.org.uk/listing/the-list/list-entry/1234567"
+                        class="govuk-link" target="_blank">1234567</a>
                     </dd>
                     <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/1/changed-listed-buildings/add">Change<span class="govuk-visually-hidden"> listed building number</span></a>
                     </dd>
@@ -73,7 +73,7 @@ exports[`changed-listed-buildings GET /change/:listedBuildingId should render th
                         <div class="govuk-form-group">
                             <div id="changedListedBuilding-hint" class="govuk-hint">This is a 7 digit number from Historic England</div>
                             <input class="govuk-input"
-                            id="changedListedBuilding" name="changedListedBuilding" type="text" value="123456"
+                            id="changedListedBuilding" name="changedListedBuilding" type="text" value="1234567"
                             aria-describedby="changedListedBuilding-hint">
                         </div>
                         <button type="submit" data-prevent-double-click="true" class="govuk-button"
@@ -97,8 +97,8 @@ exports[`changed-listed-buildings GET /change/:listedBuildingId/check-and-confir
         <div class="govuk-grid-column-two-thirds">
             <dl class="govuk-summary-list govuk-!-margin-bottom-9">
                 <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Changed listed building</dt>
-                    <dd class="govuk-summary-list__value"><a href="https://historicengland.org.uk/listing/the-list/list-entry/12345"
-                        class="govuk-link" target="_blank">12345</a>
+                    <dd class="govuk-summary-list__value"><a href="https://historicengland.org.uk/listing/the-list/list-entry/1234567"
+                        class="govuk-link" target="_blank">1234567</a>
                     </dd>
                     <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/1/changed-listed-buildings/change/1">Change<span class="govuk-visually-hidden"> changed listed building</span></a>
                     </dd>
@@ -129,8 +129,8 @@ exports[`changed-listed-buildings GET /remove/:listedBuildingId should render th
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full">
                     <form method="POST" novalidate="novalidate">
-                        <p class="govuk-body"><a href="https://historicengland.org.uk/listing/the-list/list-entry/123456"
-                            class="govuk-link" target="_blank">123456</a>
+                        <p class="govuk-body"><a href="https://historicengland.org.uk/listing/the-list/list-entry/1234567"
+                            class="govuk-link" target="_blank">1234567</a>
                         </p>
                         <button type="submit" data-prevent-double-click="true" class="govuk-button"
                         data-module="govuk-button">Remove changed listed building</button>
@@ -142,6 +142,92 @@ exports[`changed-listed-buildings GET /remove/:listedBuildingId should render th
                     <p class="govuk-body"><a href="/appeals-service/appeal-details/1/lpa-questionnaire/1/changed-listed-buildings/manage"
                         class="govuk-link" target="_blank">Cancel</a>
                     </p>
+                </div>
+            </div>
+        </div>
+    </div>
+</main>"
+`;
+
+exports[`changed-listed-buildings POST /add should re-render the add changed listed building page with an error when listed building contains a letter 1`] = `
+"<main class="govuk-main-wrapper" id="main-content">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <div class="govuk-error-summary" data-module="govuk-error-summary">
+                <div role="alert">
+                    <h2 class="govuk-error-summary__title"> There is a problem</h2>
+                    <div class="govuk-error-summary__body">
+                        <ul class="govuk-list govuk-error-summary__list">
+                            <li><a href="#changed-listed-building">Listed building entry number must be 7 digits</a>
+                            </li>
+                        </ul>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Appeal 351062 - add changed listed building</span>
+            <h1             class="govuk-heading-l">Changed listed building entry number</h1>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <div class="govuk-grid-row">
+                <div class="govuk-grid-column-full">
+                    <form method="POST" novalidate="novalidate">
+                        <div class="govuk-form-group">
+                            <div id="changedListedBuilding-hint" class="govuk-hint">This is a 7 digit number from Historic England</div>
+                            <input class="govuk-input"
+                            id="changedListedBuilding" name="changedListedBuilding" type="text" value="A123456"
+                            aria-describedby="changedListedBuilding-hint">
+                        </div>
+                        <button type="submit" data-prevent-double-click="true" class="govuk-button"
+                        data-module="govuk-button">Continue</button>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </div>
+</main>"
+`;
+
+exports[`changed-listed-buildings POST /add should re-render the add changed listed building page with an error when listed building contains a special character 1`] = `
+"<main class="govuk-main-wrapper" id="main-content">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <div class="govuk-error-summary" data-module="govuk-error-summary">
+                <div role="alert">
+                    <h2 class="govuk-error-summary__title"> There is a problem</h2>
+                    <div class="govuk-error-summary__body">
+                        <ul class="govuk-list govuk-error-summary__list">
+                            <li><a href="#changed-listed-building">Listed building entry number must be 7 digits</a>
+                            </li>
+                        </ul>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Appeal 351062 - add changed listed building</span>
+            <h1             class="govuk-heading-l">Changed listed building entry number</h1>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <div class="govuk-grid-row">
+                <div class="govuk-grid-column-full">
+                    <form method="POST" novalidate="novalidate">
+                        <div class="govuk-form-group">
+                            <div id="changedListedBuilding-hint" class="govuk-hint">This is a 7 digit number from Historic England</div>
+                            <input class="govuk-input"
+                            id="changedListedBuilding" name="changedListedBuilding" type="text" value="*123456"
+                            aria-describedby="changedListedBuilding-hint">
+                        </div>
+                        <button type="submit" data-prevent-double-click="true" class="govuk-button"
+                        data-module="govuk-button">Continue</button>
+                    </form>
                 </div>
             </div>
         </div>
@@ -192,7 +278,265 @@ exports[`changed-listed-buildings POST /add should re-render the add changed lis
 </main>"
 `;
 
-exports[`changed-listed-buildings POST /change/:listedBuildingId should re-render the change listed building page when the data is invalid 1`] = `
+exports[`changed-listed-buildings POST /add should re-render the add changed listed building page with an error when listed building is less than seven digits 1`] = `
+"<main class="govuk-main-wrapper" id="main-content">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <div class="govuk-error-summary" data-module="govuk-error-summary">
+                <div role="alert">
+                    <h2 class="govuk-error-summary__title"> There is a problem</h2>
+                    <div class="govuk-error-summary__body">
+                        <ul class="govuk-list govuk-error-summary__list">
+                            <li><a href="#changed-listed-building">Listed building entry number must be 7 digits</a>
+                            </li>
+                        </ul>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Appeal 351062 - add changed listed building</span>
+            <h1             class="govuk-heading-l">Changed listed building entry number</h1>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <div class="govuk-grid-row">
+                <div class="govuk-grid-column-full">
+                    <form method="POST" novalidate="novalidate">
+                        <div class="govuk-form-group">
+                            <div id="changedListedBuilding-hint" class="govuk-hint">This is a 7 digit number from Historic England</div>
+                            <input class="govuk-input"
+                            id="changedListedBuilding" name="changedListedBuilding" type="text" value="12345"
+                            aria-describedby="changedListedBuilding-hint">
+                        </div>
+                        <button type="submit" data-prevent-double-click="true" class="govuk-button"
+                        data-module="govuk-button">Continue</button>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </div>
+</main>"
+`;
+
+exports[`changed-listed-buildings POST /add should re-render the add changed listed building page with an error when listed building is more than seven digits 1`] = `
+"<main class="govuk-main-wrapper" id="main-content">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <div class="govuk-error-summary" data-module="govuk-error-summary">
+                <div role="alert">
+                    <h2 class="govuk-error-summary__title"> There is a problem</h2>
+                    <div class="govuk-error-summary__body">
+                        <ul class="govuk-list govuk-error-summary__list">
+                            <li><a href="#changed-listed-building">Listed building entry number must be 7 digits</a>
+                            </li>
+                        </ul>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Appeal 351062 - add changed listed building</span>
+            <h1             class="govuk-heading-l">Changed listed building entry number</h1>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <div class="govuk-grid-row">
+                <div class="govuk-grid-column-full">
+                    <form method="POST" novalidate="novalidate">
+                        <div class="govuk-form-group">
+                            <div id="changedListedBuilding-hint" class="govuk-hint">This is a 7 digit number from Historic England</div>
+                            <input class="govuk-input"
+                            id="changedListedBuilding" name="changedListedBuilding" type="text" value="12345678"
+                            aria-describedby="changedListedBuilding-hint">
+                        </div>
+                        <button type="submit" data-prevent-double-click="true" class="govuk-button"
+                        data-module="govuk-button">Continue</button>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </div>
+</main>"
+`;
+
+exports[`changed-listed-buildings POST /change/:listedBuildingId should re-render the change changed listed building page with an error when listed building contains a letter 1`] = `
+"<main class="govuk-main-wrapper" id="main-content">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <div class="govuk-error-summary" data-module="govuk-error-summary">
+                <div role="alert">
+                    <h2 class="govuk-error-summary__title"> There is a problem</h2>
+                    <div class="govuk-error-summary__body">
+                        <ul class="govuk-list govuk-error-summary__list">
+                            <li><a href="#changed-listed-building">Listed building entry number must be 7 digits</a>
+                            </li>
+                        </ul>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Appeal 351062 - update changed listed building</span>
+            <h1             class="govuk-heading-l">Changed listed building entry number</h1>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <div class="govuk-grid-row">
+                <div class="govuk-grid-column-full">
+                    <form method="POST" novalidate="novalidate">
+                        <div class="govuk-form-group">
+                            <div id="changedListedBuilding-hint" class="govuk-hint">This is a 7 digit number from Historic England</div>
+                            <input class="govuk-input"
+                            id="changedListedBuilding" name="changedListedBuilding" type="text" value="A123456"
+                            aria-describedby="changedListedBuilding-hint">
+                        </div>
+                        <button type="submit" data-prevent-double-click="true" class="govuk-button"
+                        data-module="govuk-button">Continue</button>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </div>
+</main>"
+`;
+
+exports[`changed-listed-buildings POST /change/:listedBuildingId should re-render the change changed listed building page with an error when listed building contains a special character 1`] = `
+"<main class="govuk-main-wrapper" id="main-content">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <div class="govuk-error-summary" data-module="govuk-error-summary">
+                <div role="alert">
+                    <h2 class="govuk-error-summary__title"> There is a problem</h2>
+                    <div class="govuk-error-summary__body">
+                        <ul class="govuk-list govuk-error-summary__list">
+                            <li><a href="#changed-listed-building">Listed building entry number must be 7 digits</a>
+                            </li>
+                        </ul>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Appeal 351062 - update changed listed building</span>
+            <h1             class="govuk-heading-l">Changed listed building entry number</h1>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <div class="govuk-grid-row">
+                <div class="govuk-grid-column-full">
+                    <form method="POST" novalidate="novalidate">
+                        <div class="govuk-form-group">
+                            <div id="changedListedBuilding-hint" class="govuk-hint">This is a 7 digit number from Historic England</div>
+                            <input class="govuk-input"
+                            id="changedListedBuilding" name="changedListedBuilding" type="text" value="*123456"
+                            aria-describedby="changedListedBuilding-hint">
+                        </div>
+                        <button type="submit" data-prevent-double-click="true" class="govuk-button"
+                        data-module="govuk-button">Continue</button>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </div>
+</main>"
+`;
+
+exports[`changed-listed-buildings POST /change/:listedBuildingId should re-render the change changed listed building page with an error when listed building is less than seven digits 1`] = `
+"<main class="govuk-main-wrapper" id="main-content">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <div class="govuk-error-summary" data-module="govuk-error-summary">
+                <div role="alert">
+                    <h2 class="govuk-error-summary__title"> There is a problem</h2>
+                    <div class="govuk-error-summary__body">
+                        <ul class="govuk-list govuk-error-summary__list">
+                            <li><a href="#changed-listed-building">Listed building entry number must be 7 digits</a>
+                            </li>
+                        </ul>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Appeal 351062 - update changed listed building</span>
+            <h1             class="govuk-heading-l">Changed listed building entry number</h1>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <div class="govuk-grid-row">
+                <div class="govuk-grid-column-full">
+                    <form method="POST" novalidate="novalidate">
+                        <div class="govuk-form-group">
+                            <div id="changedListedBuilding-hint" class="govuk-hint">This is a 7 digit number from Historic England</div>
+                            <input class="govuk-input"
+                            id="changedListedBuilding" name="changedListedBuilding" type="text" value="12345"
+                            aria-describedby="changedListedBuilding-hint">
+                        </div>
+                        <button type="submit" data-prevent-double-click="true" class="govuk-button"
+                        data-module="govuk-button">Continue</button>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </div>
+</main>"
+`;
+
+exports[`changed-listed-buildings POST /change/:listedBuildingId should re-render the change changed listed building page with an error when listed building is more than seven digits 1`] = `
+"<main class="govuk-main-wrapper" id="main-content">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <div class="govuk-error-summary" data-module="govuk-error-summary">
+                <div role="alert">
+                    <h2 class="govuk-error-summary__title"> There is a problem</h2>
+                    <div class="govuk-error-summary__body">
+                        <ul class="govuk-list govuk-error-summary__list">
+                            <li><a href="#changed-listed-building">Listed building entry number must be 7 digits</a>
+                            </li>
+                        </ul>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Appeal 351062 - update changed listed building</span>
+            <h1             class="govuk-heading-l">Changed listed building entry number</h1>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <div class="govuk-grid-row">
+                <div class="govuk-grid-column-full">
+                    <form method="POST" novalidate="novalidate">
+                        <div class="govuk-form-group">
+                            <div id="changedListedBuilding-hint" class="govuk-hint">This is a 7 digit number from Historic England</div>
+                            <input class="govuk-input"
+                            id="changedListedBuilding" name="changedListedBuilding" type="text" value="12345678"
+                            aria-describedby="changedListedBuilding-hint">
+                        </div>
+                        <button type="submit" data-prevent-double-click="true" class="govuk-button"
+                        data-module="govuk-button">Continue</button>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </div>
+</main>"
+`;
+
+exports[`changed-listed-buildings POST /change/:listedBuildingId should re-render the change listed building page when the listed building is empty 1`] = `
 "<main class="govuk-main-wrapper" id="main-content">
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">
@@ -222,7 +566,7 @@ exports[`changed-listed-buildings POST /change/:listedBuildingId should re-rende
                         <div class="govuk-form-group">
                             <div id="changedListedBuilding-hint" class="govuk-hint">This is a 7 digit number from Historic England</div>
                             <input class="govuk-input"
-                            id="changedListedBuilding" name="changedListedBuilding" type="text" value="123456"
+                            id="changedListedBuilding" name="changedListedBuilding" type="text" value="1234567"
                             aria-describedby="changedListedBuilding-hint">
                         </div>
                         <button type="submit" data-prevent-double-click="true" class="govuk-button"

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/changed-listed-buildings/__tests__/changed-listed-buildings.test.js
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/changed-listed-buildings/__tests__/changed-listed-buildings.test.js
@@ -60,9 +60,118 @@ describe('changed-listed-buildings', () => {
 			expect(errorSummaryHtml).toContain('Provide a listed building entry list number</a>');
 		});
 
+		it('should re-render the add changed listed building page with an error when listed building is less than seven digits', async () => {
+			const invalidData = {
+				changedListedBuilding: '12345'
+			};
+
+			const response = await request
+				.post(
+					`${baseUrl}/${appealId}/lpa-questionnaire/${lpaQuestionnaireId}/changed-listed-buildings/add`
+				)
+				.send(invalidData);
+			expect(response.statusCode).toBe(200);
+			const elementInnerHtml = parseHtml(response.text).innerHTML;
+
+			expect(elementInnerHtml).toMatchSnapshot();
+			expect(elementInnerHtml).toContain('- add changed listed building</span>');
+			expect(elementInnerHtml).toContain('Changed listed building entry number</h1>');
+			expect(elementInnerHtml).toContain('This is a 7 digit number from Historic England</div>');
+
+			const errorSummaryHtml = parseHtml(response.text, {
+				rootElement: '.govuk-error-summary',
+				skipPrettyPrint: true
+			}).innerHTML;
+
+			expect(errorSummaryHtml).toContain('There is a problem</h2>');
+			expect(errorSummaryHtml).toContain('Listed building entry number must be 7 digits</a>');
+		});
+
+		it('should re-render the add changed listed building page with an error when listed building is more than seven digits', async () => {
+			const invalidData = {
+				changedListedBuilding: '12345678'
+			};
+
+			const response = await request
+				.post(
+					`${baseUrl}/${appealId}/lpa-questionnaire/${lpaQuestionnaireId}/changed-listed-buildings/add`
+				)
+				.send(invalidData);
+			expect(response.statusCode).toBe(200);
+			const elementInnerHtml = parseHtml(response.text).innerHTML;
+
+			expect(elementInnerHtml).toMatchSnapshot();
+			expect(elementInnerHtml).toContain('- add changed listed building</span>');
+			expect(elementInnerHtml).toContain('Changed listed building entry number</h1>');
+			expect(elementInnerHtml).toContain('This is a 7 digit number from Historic England</div>');
+
+			const errorSummaryHtml = parseHtml(response.text, {
+				rootElement: '.govuk-error-summary',
+				skipPrettyPrint: true
+			}).innerHTML;
+
+			expect(errorSummaryHtml).toContain('There is a problem</h2>');
+			expect(errorSummaryHtml).toContain('Listed building entry number must be 7 digits</a>');
+		});
+
+		it('should re-render the add changed listed building page with an error when listed building contains a special character', async () => {
+			const invalidData = {
+				changedListedBuilding: '*123456'
+			};
+
+			const response = await request
+				.post(
+					`${baseUrl}/${appealId}/lpa-questionnaire/${lpaQuestionnaireId}/changed-listed-buildings/add`
+				)
+				.send(invalidData);
+			expect(response.statusCode).toBe(200);
+			const elementInnerHtml = parseHtml(response.text).innerHTML;
+
+			expect(elementInnerHtml).toMatchSnapshot();
+			expect(elementInnerHtml).toContain('- add changed listed building</span>');
+			expect(elementInnerHtml).toContain('Changed listed building entry number</h1>');
+			expect(elementInnerHtml).toContain('This is a 7 digit number from Historic England</div>');
+
+			const errorSummaryHtml = parseHtml(response.text, {
+				rootElement: '.govuk-error-summary',
+				skipPrettyPrint: true
+			}).innerHTML;
+
+			expect(errorSummaryHtml).toContain('There is a problem</h2>');
+			expect(errorSummaryHtml).toContain('Listed building entry number must be 7 digits</a>');
+		});
+
+		it('should re-render the add changed listed building page with an error when listed building contains a letter', async () => {
+			const invalidData = {
+				changedListedBuilding: 'A123456'
+			};
+
+			const response = await request
+				.post(
+					`${baseUrl}/${appealId}/lpa-questionnaire/${lpaQuestionnaireId}/changed-listed-buildings/add`
+				)
+				.send(invalidData);
+
+			expect(response.statusCode).toBe(200);
+			const elementInnerHtml = parseHtml(response.text).innerHTML;
+
+			expect(elementInnerHtml).toMatchSnapshot();
+			expect(elementInnerHtml).toContain('- add changed listed building</span>');
+			expect(elementInnerHtml).toContain('Changed listed building entry number</h1>');
+			expect(elementInnerHtml).toContain('This is a 7 digit number from Historic England</div>');
+
+			const errorSummaryHtml = parseHtml(response.text, {
+				rootElement: '.govuk-error-summary',
+				skipPrettyPrint: true
+			}).innerHTML;
+
+			expect(errorSummaryHtml).toContain('There is a problem</h2>');
+			expect(errorSummaryHtml).toContain('Listed building entry number must be 7 digits</a>');
+		});
+
 		it('should redirect to the check-and-confirm page when data is valid', async () => {
 			const validData = {
-				changedListedBuilding: '12345'
+				changedListedBuilding: '1234567'
 			};
 
 			const response = await request
@@ -81,7 +190,7 @@ describe('changed-listed-buildings', () => {
 	describe('GET /add/check-and-confirm', () => {
 		it('should render the add changed listed building check and confirm page', async () => {
 			const validData = {
-				changedListedBuilding: '12345'
+				changedListedBuilding: '1234567'
 			};
 
 			await request
@@ -105,7 +214,7 @@ describe('changed-listed-buildings', () => {
 			}).innerHTML;
 			expect(summaryListHtml).toContain('Changed listed building</dt>');
 			expect(summaryListHtml).toContain(
-				'<a href="https://historicengland.org.uk/listing/the-list/list-entry/12345" class="govuk-link" target="_blank">12345</a>'
+				'<a href="https://historicengland.org.uk/listing/the-list/list-entry/1234567" class="govuk-link" target="_blank">1234567</a>'
 			);
 			expect(elementInnerHtml).toContain('Add changed listed building</button>');
 		});
@@ -114,7 +223,7 @@ describe('changed-listed-buildings', () => {
 	describe('POST /add/check-and-confirm', () => {
 		it('should redirect to the lpa questionnaire page', async () => {
 			const validData = {
-				changedListedBuilding: '12345'
+				changedListedBuilding: '1234567'
 			};
 			nock('http://test/').post(`/appeals/${appealId}/listed-buildings`).reply(200, {});
 
@@ -148,10 +257,10 @@ describe('changed-listed-buildings', () => {
 			expect(unprettifiedElement).toContain('Listed building number</th>');
 			expect(unprettifiedElement).toContain('Action</th>');
 			expect(unprettifiedElement).toContain(
-				'Change<span class="govuk-visually-hidden"> listed building 123458</span></a>'
+				'Change<span class="govuk-visually-hidden"> listed building 1234569</span></a>'
 			);
 			expect(unprettifiedElement).toContain(
-				'Remove<span class="govuk-visually-hidden"> listed building 123458</span></a>'
+				'Remove<span class="govuk-visually-hidden"> listed building 1234569</span></a>'
 			);
 		});
 	});
@@ -171,7 +280,7 @@ describe('changed-listed-buildings', () => {
 	});
 
 	describe('POST /change/:listedBuildingId', () => {
-		it('should re-render the change listed building page when the data is invalid', async () => {
+		it('should re-render the change listed building page when the listed building is empty', async () => {
 			const invalidData = {
 				changedListedBuilding: null
 			};
@@ -190,9 +299,118 @@ describe('changed-listed-buildings', () => {
 			expect(elementInnerHtml).toContain('This is a 7 digit number from Historic England</div>');
 		});
 
+		it('should re-render the change changed listed building page with an error when listed building is less than seven digits', async () => {
+			const invalidData = {
+				changedListedBuilding: '12345'
+			};
+
+			const response = await request
+				.post(
+					`${baseUrl}/${appealId}/lpa-questionnaire/${lpaQuestionnaireId}/changed-listed-buildings/change/1`
+				)
+				.send(invalidData);
+			expect(response.statusCode).toBe(200);
+			const elementInnerHtml = parseHtml(response.text).innerHTML;
+
+			expect(elementInnerHtml).toMatchSnapshot();
+			expect(elementInnerHtml).toContain('- update changed listed building</span>');
+			expect(elementInnerHtml).toContain('Changed listed building entry number</h1>');
+			expect(elementInnerHtml).toContain('This is a 7 digit number from Historic England</div>');
+
+			const errorSummaryHtml = parseHtml(response.text, {
+				rootElement: '.govuk-error-summary',
+				skipPrettyPrint: true
+			}).innerHTML;
+
+			expect(errorSummaryHtml).toContain('There is a problem</h2>');
+			expect(errorSummaryHtml).toContain('Listed building entry number must be 7 digits</a>');
+		});
+
+		it('should re-render the change changed listed building page with an error when listed building is more than seven digits', async () => {
+			const invalidData = {
+				changedListedBuilding: '12345678'
+			};
+
+			const response = await request
+				.post(
+					`${baseUrl}/${appealId}/lpa-questionnaire/${lpaQuestionnaireId}/changed-listed-buildings/change/1`
+				)
+				.send(invalidData);
+			expect(response.statusCode).toBe(200);
+			const elementInnerHtml = parseHtml(response.text).innerHTML;
+
+			expect(elementInnerHtml).toMatchSnapshot();
+			expect(elementInnerHtml).toContain('- update changed listed building</span>');
+			expect(elementInnerHtml).toContain('Changed listed building entry number</h1>');
+			expect(elementInnerHtml).toContain('This is a 7 digit number from Historic England</div>');
+
+			const errorSummaryHtml = parseHtml(response.text, {
+				rootElement: '.govuk-error-summary',
+				skipPrettyPrint: true
+			}).innerHTML;
+
+			expect(errorSummaryHtml).toContain('There is a problem</h2>');
+			expect(errorSummaryHtml).toContain('Listed building entry number must be 7 digits</a>');
+		});
+
+		it('should re-render the change changed listed building page with an error when listed building contains a special character', async () => {
+			const invalidData = {
+				changedListedBuilding: '*123456'
+			};
+
+			const response = await request
+				.post(
+					`${baseUrl}/${appealId}/lpa-questionnaire/${lpaQuestionnaireId}/changed-listed-buildings/change/1`
+				)
+				.send(invalidData);
+			expect(response.statusCode).toBe(200);
+			const elementInnerHtml = parseHtml(response.text).innerHTML;
+
+			expect(elementInnerHtml).toMatchSnapshot();
+			expect(elementInnerHtml).toContain('- update changed listed building</span>');
+			expect(elementInnerHtml).toContain('Changed listed building entry number</h1>');
+			expect(elementInnerHtml).toContain('This is a 7 digit number from Historic England</div>');
+
+			const errorSummaryHtml = parseHtml(response.text, {
+				rootElement: '.govuk-error-summary',
+				skipPrettyPrint: true
+			}).innerHTML;
+
+			expect(errorSummaryHtml).toContain('There is a problem</h2>');
+			expect(errorSummaryHtml).toContain('Listed building entry number must be 7 digits</a>');
+		});
+
+		it('should re-render the change changed listed building page with an error when listed building contains a letter', async () => {
+			const invalidData = {
+				changedListedBuilding: 'A123456'
+			};
+
+			const response = await request
+				.post(
+					`${baseUrl}/${appealId}/lpa-questionnaire/${lpaQuestionnaireId}/changed-listed-buildings/change/1`
+				)
+				.send(invalidData);
+
+			expect(response.statusCode).toBe(200);
+			const elementInnerHtml = parseHtml(response.text).innerHTML;
+
+			expect(elementInnerHtml).toMatchSnapshot();
+			expect(elementInnerHtml).toContain('- update changed listed building</span>');
+			expect(elementInnerHtml).toContain('Changed listed building entry number</h1>');
+			expect(elementInnerHtml).toContain('This is a 7 digit number from Historic England</div>');
+
+			const errorSummaryHtml = parseHtml(response.text, {
+				rootElement: '.govuk-error-summary',
+				skipPrettyPrint: true
+			}).innerHTML;
+
+			expect(errorSummaryHtml).toContain('There is a problem</h2>');
+			expect(errorSummaryHtml).toContain('Listed building entry number must be 7 digits</a>');
+		});
+
 		it('should redirect to to the check and confirm page if the data is valid', async () => {
 			const validData = {
-				changedListedBuilding: '12345'
+				changedListedBuilding: '1234567'
 			};
 
 			const response = await request
@@ -211,7 +429,7 @@ describe('changed-listed-buildings', () => {
 	describe('GET /change/:listedBuildingId/check-and-confirm', () => {
 		it('should render the check and confirm page', async () => {
 			const validData = {
-				changedListedBuilding: '12345'
+				changedListedBuilding: '1234567'
 			};
 			await request
 				.post(
@@ -231,7 +449,7 @@ describe('changed-listed-buildings', () => {
 			const unprettifiedElement = parseHtml(response.text, { skipPrettyPrint: true }).innerHTML;
 			expect(unprettifiedElement).toContain('Changed listed building</dt>');
 			expect(unprettifiedElement).toContain(
-				'<a href="https://historicengland.org.uk/listing/the-list/list-entry/12345" class="govuk-link" target="_blank">12345</a>'
+				'<a href="https://historicengland.org.uk/listing/the-list/list-entry/1234567" class="govuk-link" target="_blank">1234567</a>'
 			);
 			expect(elementInnerHtml).toContain('Update changed listed building</button>');
 		});
@@ -240,7 +458,7 @@ describe('changed-listed-buildings', () => {
 	describe('POST /change/:listedBuildingId/check-and-confirm', () => {
 		it('should redirect to lpa questionnaire', async () => {
 			const validData = {
-				changedListedBuilding: '12345'
+				changedListedBuilding: '1234567'
 			};
 
 			nock('http://test/').patch(`/appeals/${appealId}/listed-buildings/1`).reply(200, {});

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/changed-listed-buildings/__tests__/changed-listed-buildings.test.js
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/changed-listed-buildings/__tests__/changed-listed-buildings.test.js
@@ -9,6 +9,8 @@ const request = supertest(app);
 const baseUrl = '/appeals-service/appeal-details';
 const appealId = appealData.appealId;
 const lpaQuestionnaireId = appealData.lpaQuestionnaireId;
+const validListedBuilding = '1234567';
+const invalidListedBuilding = '9999999';
 
 describe('changed-listed-buildings', () => {
 	beforeEach(() => {
@@ -18,6 +20,8 @@ describe('changed-listed-buildings', () => {
 			.reply(200, {
 				...lpaQuestionnaireData
 			});
+		nock('http://test/').get(`/appeals/listed-buildings/${validListedBuilding}`).reply(200, {});
+		nock('http://test/').get(`/appeals/listed-buildings/${invalidListedBuilding}`).reply(404, {});
 	});
 	afterEach(teardown);
 
@@ -169,9 +173,36 @@ describe('changed-listed-buildings', () => {
 			expect(errorSummaryHtml).toContain('Listed building entry number must be 7 digits</a>');
 		});
 
+		it('should re-render the add changed listed building page with an error when listed building is seven digits but not in historic england', async () => {
+			const invalidData = {
+				changedListedBuilding: invalidListedBuilding
+			};
+
+			const response = await request
+				.post(
+					`${baseUrl}/${appealId}/lpa-questionnaire/${lpaQuestionnaireId}/changed-listed-buildings/add`
+				)
+				.send(invalidData);
+			expect(response.statusCode).toBe(200);
+			const elementInnerHtml = parseHtml(response.text).innerHTML;
+
+			expect(elementInnerHtml).toMatchSnapshot();
+			expect(elementInnerHtml).toContain('- add changed listed building</span>');
+			expect(elementInnerHtml).toContain('Changed listed building entry number</h1>');
+			expect(elementInnerHtml).toContain('This is a 7 digit number from Historic England</div>');
+
+			const errorSummaryHtml = parseHtml(response.text, {
+				rootElement: '.govuk-error-summary',
+				skipPrettyPrint: true
+			}).innerHTML;
+
+			expect(errorSummaryHtml).toContain('There is a problem</h2>');
+			expect(errorSummaryHtml).toContain('Enter a real listed building entry number</a>');
+		});
+
 		it('should redirect to the check-and-confirm page when data is valid', async () => {
 			const validData = {
-				changedListedBuilding: '1234567'
+				changedListedBuilding: validListedBuilding
 			};
 
 			const response = await request
@@ -190,7 +221,7 @@ describe('changed-listed-buildings', () => {
 	describe('GET /add/check-and-confirm', () => {
 		it('should render the add changed listed building check and confirm page', async () => {
 			const validData = {
-				changedListedBuilding: '1234567'
+				changedListedBuilding: validListedBuilding
 			};
 
 			await request
@@ -214,7 +245,7 @@ describe('changed-listed-buildings', () => {
 			}).innerHTML;
 			expect(summaryListHtml).toContain('Changed listed building</dt>');
 			expect(summaryListHtml).toContain(
-				'<a href="https://historicengland.org.uk/listing/the-list/list-entry/1234567" class="govuk-link" target="_blank">1234567</a>'
+				`<a href="https://historicengland.org.uk/listing/the-list/list-entry/${validListedBuilding}" class="govuk-link" target="_blank">${validListedBuilding}</a>`
 			);
 			expect(elementInnerHtml).toContain('Add changed listed building</button>');
 		});
@@ -223,7 +254,7 @@ describe('changed-listed-buildings', () => {
 	describe('POST /add/check-and-confirm', () => {
 		it('should redirect to the lpa questionnaire page', async () => {
 			const validData = {
-				changedListedBuilding: '1234567'
+				changedListedBuilding: validListedBuilding
 			};
 			nock('http://test/').post(`/appeals/${appealId}/listed-buildings`).reply(200, {});
 
@@ -408,9 +439,36 @@ describe('changed-listed-buildings', () => {
 			expect(errorSummaryHtml).toContain('Listed building entry number must be 7 digits</a>');
 		});
 
+		it('should re-render the change changed listed building page with an error when listed building is seven digits but not in historic england', async () => {
+			const invalidData = {
+				changedListedBuilding: invalidListedBuilding
+			};
+
+			const response = await request
+				.post(
+					`${baseUrl}/${appealId}/lpa-questionnaire/${lpaQuestionnaireId}/changed-listed-buildings/change/1`
+				)
+				.send(invalidData);
+			expect(response.statusCode).toBe(200);
+			const elementInnerHtml = parseHtml(response.text).innerHTML;
+
+			expect(elementInnerHtml).toMatchSnapshot();
+			expect(elementInnerHtml).toContain('- update changed listed building</span>');
+			expect(elementInnerHtml).toContain('Changed listed building entry number</h1>');
+			expect(elementInnerHtml).toContain('This is a 7 digit number from Historic England</div>');
+
+			const errorSummaryHtml = parseHtml(response.text, {
+				rootElement: '.govuk-error-summary',
+				skipPrettyPrint: true
+			}).innerHTML;
+
+			expect(errorSummaryHtml).toContain('There is a problem</h2>');
+			expect(errorSummaryHtml).toContain('Enter a real listed building entry number</a>');
+		});
+
 		it('should redirect to to the check and confirm page if the data is valid', async () => {
 			const validData = {
-				changedListedBuilding: '1234567'
+				changedListedBuilding: validListedBuilding
 			};
 
 			const response = await request
@@ -429,7 +487,7 @@ describe('changed-listed-buildings', () => {
 	describe('GET /change/:listedBuildingId/check-and-confirm', () => {
 		it('should render the check and confirm page', async () => {
 			const validData = {
-				changedListedBuilding: '1234567'
+				changedListedBuilding: validListedBuilding
 			};
 			await request
 				.post(
@@ -449,7 +507,7 @@ describe('changed-listed-buildings', () => {
 			const unprettifiedElement = parseHtml(response.text, { skipPrettyPrint: true }).innerHTML;
 			expect(unprettifiedElement).toContain('Changed listed building</dt>');
 			expect(unprettifiedElement).toContain(
-				'<a href="https://historicengland.org.uk/listing/the-list/list-entry/1234567" class="govuk-link" target="_blank">1234567</a>'
+				`<a href="https://historicengland.org.uk/listing/the-list/list-entry/${validListedBuilding}" class="govuk-link" target="_blank">${validListedBuilding}</a>`
 			);
 			expect(elementInnerHtml).toContain('Update changed listed building</button>');
 		});
@@ -458,7 +516,7 @@ describe('changed-listed-buildings', () => {
 	describe('POST /change/:listedBuildingId/check-and-confirm', () => {
 		it('should redirect to lpa questionnaire', async () => {
 			const validData = {
-				changedListedBuilding: '1234567'
+				changedListedBuilding: validListedBuilding
 			};
 
 			nock('http://test/').patch(`/appeals/${appealId}/listed-buildings/1`).reply(200, {});

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/changed-listed-buildings/changed-listed-buildings.service.js
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/changed-listed-buildings/changed-listed-buildings.service.js
@@ -60,3 +60,13 @@ export function removeChangedListedBuilding(apiClient, appealId, listedBuildingI
 		}
 	});
 }
+
+/**
+ *
+ * @param {import('got').Got} apiClient
+ * @param {string} listedBuildingId
+ * @returns {Promise<{}>}
+ */
+export function getChangedListedBuilding(apiClient, listedBuildingId) {
+	return apiClient.get(`appeals/listed-buildings/${listedBuildingId}`);
+}

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/changed-listed-buildings/changed-listed-buildings.validator.js
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/changed-listed-buildings/changed-listed-buildings.validator.js
@@ -5,4 +5,8 @@ export const validateChangedListedBuilding = createValidator(
 	body('changedListedBuilding')
 		.notEmpty()
 		.withMessage('Provide a listed building entry list number')
+		.isNumeric()
+		.withMessage('Listed building entry number must be 7 digits')
+		.isLength({ min: 7, max: 7 })
+		.withMessage('Listed building entry number must be 7 digits')
 );

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/changed-listed-buildings/changed-listed-buildings.validator.js
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/changed-listed-buildings/changed-listed-buildings.validator.js
@@ -1,5 +1,6 @@
 import { createValidator } from '@pins/express';
 import { body } from 'express-validator';
+import { getChangedListedBuilding } from '#appeals/appeal-details/lpa-questionnaire/changed-listed-buildings/changed-listed-buildings.service.js';
 
 export const validateChangedListedBuilding = createValidator(
 	body('changedListedBuilding')
@@ -9,4 +10,16 @@ export const validateChangedListedBuilding = createValidator(
 		.withMessage('Listed building entry number must be 7 digits')
 		.isLength({ min: 7, max: 7 })
 		.withMessage('Listed building entry number must be 7 digits')
+		.custom(async (reference, { req }) => {
+			try {
+				const result = await getChangedListedBuilding(req.apiClient, reference);
+
+				if (!result) {
+					throw new Error('Listed building entry number is not valid');
+				}
+			} catch (error) {
+				throw new Error('Listed building entry number is not valid');
+			}
+		})
+		.withMessage('Enter a real listed building entry number')
 );

--- a/appeals/web/testing/app/fixtures/referencedata.js
+++ b/appeals/web/testing/app/fixtures/referencedata.js
@@ -876,17 +876,17 @@ export const lpaQuestionnaireData = {
 	listedBuildingDetails: [
 		{
 			id: 1,
-			listEntry: '123456',
+			listEntry: '1234567',
 			affectsListedBuilding: true
 		},
 		{
 			id: 2,
-			listEntry: '123457',
+			listEntry: '1234568',
 			affectsListedBuilding: true
 		},
 		{
 			id: 3,
-			listEntry: '123458',
+			listEntry: '1234569',
 			affectsListedBuilding: false
 		}
 	],


### PR DESCRIPTION
Adding validation for listed building numbers being 7 digits and being a valid historic england number.

## Issue ticket number and link
[Ticket](https://pins-ds.atlassian.net/browse/A2-3525)
