### PR TITLE
feat(A2-3663,A2-3661): appellant and lpa notifies

### DIFF
--- a/appeals/api/src/server/endpoints/invalid-appeal-decision/invalid-appeal-decision.service.js
+++ b/appeals/api/src/server/endpoints/invalid-appeal-decision/invalid-appeal-decision.service.js
@@ -53,6 +53,7 @@ export const publishInvalidDecision = async (
 
 	if (result) {
 		const recipientEmail = appeal.agent?.email || appeal.appellant?.email;
+		const lpaEmail = appeal.lpa?.email || '';
 		const siteAddress = appeal.address
 			? formatAddressSingleLine(appeal.address)
 			: 'Address not available';
@@ -87,7 +88,7 @@ export const publishInvalidDecision = async (
 			await notifySend({
 				templateName: 'decision-is-invalid-lpa',
 				notifyClient,
-				recipientEmail,
+				recipientEmail: lpaEmail,
 				personalisation: { ...personalisation, has_costs_decision: hasLpaCostsDecision }
 			})
 		]);


### PR DESCRIPTION
- Add S20 notify tests (and full planning) for site visit and appeal decisions, both for lpas and appellants
- Bug fix where lpa email for invalid decision was being sent to the appellant/agent email

## Issue ticket number and link
[LPA Ticket](https://pins-ds.atlassian.net/browse/A2-3661)
[Appellant Ticket](https://pins-ds.atlassian.net/browse/A2-3663)
