### PR TITLE
feat(appeals): notify preview functionality (A2-3447)

### DIFF
--- a/appeals/api/src/server/endpoints/appeals.routes.js
+++ b/appeals/api/src/server/endpoints/appeals.routes.js
@@ -47,6 +47,7 @@ import { hearingRoutes } from './hearings/hearing.routes.js';
 import { historicEnglandRoutes } from './historic-england/historic-england.routes.js';
 import { hearingEstimatesRoutes } from './hearing-estimates/hearing-estimates.routes.js';
 import { default as appealDetailsRoutes } from './appeal-details/appeal-details.routes.js';
+import { notifyPreviewRouter } from './notify-preview/notify-preview.routes.js';
 
 const router = createRouter();
 router.use(integrationsRoutes);
@@ -95,6 +96,7 @@ router.use(listedBuildingRoutes);
 router.use(caseNotesRoutes);
 router.use(appealNotificationRouter);
 router.use(hearingRoutes);
+router.use(notifyPreviewRouter);
 
 if (config.enableTestEndpoints) {
 	router.use(testUtilsRoutes);

--- a/appeals/api/src/server/endpoints/decision/__tests__/decision.test.js
+++ b/appeals/api/src/server/endpoints/decision/__tests__/decision.test.js
@@ -378,6 +378,7 @@ describe('decision routes', () => {
 						appeal_reference_number: correctAppealState.reference,
 						lpa_reference: correctAppealState.applicationReference,
 						site_address: '96 The Avenue, Leftfield, Maidstone, Kent, MD21 5XY, United Kingdom',
+						front_office_url: 'https://appeal-planning-decision.service.gov.uk/appeals/1345264',
 						correction_notice_reason: correctionNotice,
 						decision_date: formatDate(decisionDate, false)
 					}
@@ -434,6 +435,7 @@ describe('decision routes', () => {
 					appeal_reference_number: appealWithMissingEmails.reference,
 					lpa_reference: appealWithMissingEmails.applicationReference,
 					site_address: '96 The Avenue, Leftfield, Maidstone, Kent, MD21 5XY, United Kingdom',
+					front_office_url: 'https://appeal-planning-decision.service.gov.uk/appeals/1345264',
 					correction_notice_reason: correctionNotice,
 					decision_date: formatDate(decisionDate, false)
 				}

--- a/appeals/api/src/server/endpoints/decision/decision.service.js
+++ b/appeals/api/src/server/endpoints/decision/decision.service.js
@@ -125,7 +125,8 @@ export const sendNewDecisionLetter = async (
 			? formatAddressSingleLine(appeal.address)
 			: 'Address not available',
 		correction_notice_reason: correctionNotice,
-		decision_date: formatDate(decisionDate, false)
+		decision_date: formatDate(decisionDate, false),
+		front_office_url: environment.FRONT_OFFICE_URL || ''
 	};
 
 	await Promise.all(

--- a/appeals/api/src/server/endpoints/notify-preview/__tests__/__snapshots__/notify-preview.test.js.snap
+++ b/appeals/api/src/server/endpoints/notify-preview/__tests__/__snapshots__/notify-preview.test.js.snap
@@ -1,0 +1,31 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`notify preview tests /appeals/notify-preview/correction-notice-decision.content.md POST get notify preview for correction-notice-decision.content.md 1`] = `
+{
+  "renderedHtml": "<div class="pins-notify-preview-border"> We have corrected the appeal decision letter.<br><br>
+
+<h2>Appeal details</h2>
+
+<div class="govuk-inset-text">
+Appeal reference number: 12345 <br>
+Address: 2222<br>
+Planning application reference: planningApplicationReference<br>
+</div>
+<h2>Why we corrected the appeal decision letter</h2>
+
+correctionNotice<br><br>
+
+<a href="/manage-appeals/12345" class="govuk-link">Sign in to our service</a> to view the decision letter dated dateISOStringToDisplayDate(file.receivedDate).<br><br>
+
+<h2>The Planning Inspectorate’s role</h2>
+
+The Planning Inspectorate cannot change or revoke the decision. Only the High Court can change this decision.<br><br>
+
+<h2>Feedback</h2>
+
+We welcome your feedback on our appeals service. Tell us on this short <a href="https://forms.office.com/pages/responsepage.aspx?id=mN94WIhvq0iTIpmM5VcIjfMZj__F6D9LmMUUyoUrZDZUOERYMEFBN0NCOFdNU1BGWEhHUFQxWVhUUy4u" class="govuk-link">feedback form</a>.<br><br>
+
+The Planning Inspectorate<br><br>
+caseofficers@planninginspectorate.gov.uk<br><br> <div>",
+}
+`;

--- a/appeals/api/src/server/endpoints/notify-preview/__tests__/notify-preview.test.js
+++ b/appeals/api/src/server/endpoints/notify-preview/__tests__/notify-preview.test.js
@@ -1,0 +1,30 @@
+// @ts-nocheck
+import { jest } from '@jest/globals';
+import { request } from '../../../app-test.js';
+import { azureAdUserId } from '#tests/shared/mocks.js';
+describe('notify preview tests', () => {
+	afterEach(() => {
+		jest.clearAllMocks();
+	});
+
+	describe('/appeals/notify-preview/correction-notice-decision.content.md', () => {
+		describe('POST', () => {
+			test('get notify preview for correction-notice-decision.content.md', async () => {
+				const personalisation = {
+					appeal_reference_number: `12345`,
+					site_address: `2222`,
+					lpa_reference: `planningApplicationReference`,
+					correction_notice_reason: `correctionNotice`,
+					decision_date: `dateISOStringToDisplayDate(file.receivedDate)`
+				};
+				const response = await request
+					.post(`/appeals/notify-preview/correction-notice-decision.content.md`)
+					.set('azureAdUserId', azureAdUserId)
+					.send(personalisation);
+
+				expect(response.status).toEqual(200);
+				expect(response.body).toMatchSnapshot();
+			});
+		});
+	});
+});

--- a/appeals/api/src/server/endpoints/notify-preview/notify-preview.controller.js
+++ b/appeals/api/src/server/endpoints/notify-preview/notify-preview.controller.js
@@ -1,0 +1,21 @@
+/** @typedef {import('express').Request} Request */
+/** @typedef {import('express').Response} Response */
+
+import { generateNotifyPreview } from '#notify/emulate-notify.js';
+import { renderTemplate } from '#notify/notify-send.js';
+import { loadEnvironment } from '@pins/platform';
+const environment = loadEnvironment(process.env.NODE_ENV);
+/**
+ * @param {Request} req
+ * @param {Response} res
+ * @returns {Promise<Response>}
+ */
+const generateNotifyTemplate = async (req, res) => {
+	const personalisation = { ...req.body, front_office_url: environment.FRONT_OFFICE_URL || '' };
+	const template = renderTemplate(req.params.templateName, personalisation);
+	const renderedHtml = generateNotifyPreview(template);
+	const reply = { renderedHtml: renderedHtml };
+	return res.send(reply);
+};
+
+export { generateNotifyTemplate };

--- a/appeals/api/src/server/endpoints/notify-preview/notify-preview.routes.js
+++ b/appeals/api/src/server/endpoints/notify-preview/notify-preview.routes.js
@@ -1,0 +1,32 @@
+import { Router as createRouter } from 'express';
+import { asyncHandler } from '@pins/express';
+
+import * as controller from './notify-preview.controller.js';
+const router = createRouter();
+router.post(
+	'/notify-preview/:templateName',
+	/*
+		#swagger.tags = ['Documents']
+		#swagger.path = '/appeals/{appealId}/document-folders/{folderId}'
+		#swagger.description = Returns the contents of a single appeal folder, by id
+		#swagger.parameters['azureAdUserId'] = {
+			in: 'header',
+			required: true,
+			example: '434bff4e-8191-4ce0-9a0a-91e5d6cdd882'
+		}
+		#swagger.parameters['repId'] = {
+			in: 'query',
+			description: 'The ID of a representation to filter attachments to',
+			example: 1,
+		}
+		#swagger.responses[200] = {
+			description: 'Returns the contents of a single appeal folder, by id',
+			schema: { $ref: '#/components/schemas/Folder' }
+		}
+		#swagger.responses[400] = {}
+		#swagger.responses[404] = {}
+	 */
+	asyncHandler(controller.generateNotifyTemplate)
+);
+
+export { router as notifyPreviewRouter };

--- a/appeals/api/src/server/notify/emulate-notify.js
+++ b/appeals/api/src/server/notify/emulate-notify.js
@@ -86,3 +86,59 @@ export function initNotifyEmulator() {
 		fs.rmdirSync(outputDir, { recursive: true });
 	}
 }
+
+/**
+ * @param {string} content
+ * @returns {string}
+ */
+export const generateNotifyPreview = (content) => {
+	let blockEnd = 0;
+	const contentLines = content.split('\n').map((line, index, lines) => {
+		line = line.trim();
+		// Handle headers
+		if (line.startsWith('#')) {
+			// @ts-ignore
+			let headerLevel = line.match(/^#+/)[0].length;
+			headerLevel = +2;
+			return `<h${headerLevel}>${line.slice(headerLevel)}</h${headerLevel}>`;
+		}
+		// Handle bullet lists
+		if (line.startsWith('-')) {
+			const isListStart = index === 0 || !lines[index - 1].startsWith('-');
+			const isListEnd = index === lines.length - 1 || !lines[index + 1].startsWith('-');
+			const listItem = `<li>${line.slice(1)}</li>`;
+			return `${
+				isListStart ? '<ul style="margin-left: 1.2rem; padding-left: 0;">' : ''
+			}${listItem}${isListEnd ? '</ul>' : ''}`;
+		}
+		// Handle blockquotes
+		if (line.startsWith('^')) {
+			const blockStart = '<div class="govuk-inset-text">\n';
+			blockEnd = index;
+			while (blockEnd < lines.length && lines[blockEnd] !== '') blockEnd++;
+			return `${blockStart}${line.slice(1)} <br>`;
+		}
+		if (blockEnd && blockEnd <= index) {
+			blockEnd = 0;
+
+			return line ? `</div>\n${line}<br>` : '</div>';
+		}
+		return line && line !== '' ? (blockEnd == 0 ? `${line}<br><br>` : `${line}<br>`) : '';
+	});
+	// close blockquotes if require
+	if (blockEnd) {
+		contentLines.push('</div>');
+	}
+
+	const emailHtml =
+		'<div class="pins-notify-preview-border"> ' + contentLines.join('\n') + ' <div>';
+	const processedHtml = processLinks(emailHtml);
+
+	return processedHtml;
+};
+const processLinks = (/** @type {string} */ line) => {
+	const linkPattern = /\[([^\]]+)\]\(([^)]+)\)/g;
+	return line.replace(linkPattern, (match, linkText, url) => {
+		return `<a href="${url}" class="govuk-link">${linkText}</a>`;
+	});
+};

--- a/appeals/api/src/server/notify/notify-send.js
+++ b/appeals/api/src/server/notify/notify-send.js
@@ -91,7 +91,7 @@ export const notifySend = async (options) => {
  * @param {Personalisation} personalisation
  * @returns {string}
  */
-function renderTemplate(name, personalisation) {
+export const renderTemplate = (name, personalisation) => {
 	try {
 		// note that nunjucks returns a string with EOL characters specific to the os; we want to replace them with \n to make them the same in the logs and tests.
 		return nunjucksEnv.render(name, personalisation).trim().split(EOL).join('\n');
@@ -132,10 +132,11 @@ function renderTemplate(name, personalisation) {
 			])
 		);
 	}
-}
+};
 
 export default {
 	templatesDir,
 	nunjucksEnv,
-	notifySend
+	notifySend,
+	renderTemplate
 };

--- a/appeals/api/src/server/notify/templates/__tests__/correction-notice-decision.test.js
+++ b/appeals/api/src/server/notify/templates/__tests__/correction-notice-decision.test.js
@@ -39,7 +39,7 @@ describe('correction-notice-decision.md', () => {
 			'',
 			'There has been a mistake - but we fixed it thanks',
 			'',
-			'[Sign in to our service](https://appeals-service-test.planninginspectorate.gov.uk/manage-appeals/134526) to view the decision letter dated 01 January 2025.',
+			'[Sign in to our service](/mock-front-office-url/manage-appeals/134526) to view the decision letter dated 01 January 2025.',
 			'',
 			'# The Planning Inspectorate’s role',
 			'',

--- a/appeals/api/src/server/notify/templates/correction-notice-decision.content.md
+++ b/appeals/api/src/server/notify/templates/correction-notice-decision.content.md
@@ -10,7 +10,7 @@ Planning application reference: {{lpa_reference}}
 
 {{correction_notice_reason}}
 
-[Sign in to our service](https://appeals-service-test.planninginspectorate.gov.uk/manage-appeals/{{appeal_reference_number}}) to view the decision letter dated {{decision_date}}.
+[Sign in to our service]({{front_office_url}}/manage-appeals/{{appeal_reference_number}}) to view the decision letter dated {{decision_date}}.
 
 # The Planning Inspectorate’s role
 

--- a/appeals/web/src/server/appeals/appeal-details/update-decision-letter/__tests__/__snapshots__/update-decision-letter.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/update-decision-letter/__tests__/__snapshots__/update-decision-letter.test.js.snap
@@ -78,17 +78,54 @@ exports[`update-decision-letter GET /issue-decision/check-your-decision should r
                 </div>
             </dl>
             <p class="govuk-body">We will send the updated decision letter to the relevant parties.</p>
-            <p             class="govuk-body"><a href="/appeals-service/appeal-details/1/update-decision-letter/preview-email"
-                class="govuk-link">Preview email</a>
-                </p>
-                <div class="govuk-grid-row">
-                    <div class="govuk-grid-column-full">
-                        <form method="post" novalidate="novalidate">
-                            <button type="submit" class="govuk-button" data-module="govuk-button">Update decision letter</button>
-                        </form>
-                    </div>
+            <div             class="govuk-grid-row">
+                <div class="govuk-grid-column-full">
+                    <details class="govuk-details">
+                        <summary class="govuk-details__summary"><span class="govuk-details__summary-text"> Preview</span>
+                        </summary>
+                        <div class="govuk-details__text">
+                            <div class="pins-notify-preview-border">We have corrected the appeal decision letter.
+                                <br>
+                                <br>
+                                <h2>Appeal details</h2>
+                                <div class="govuk-inset-text">Appeal reference number: 12345
+                                    <br>Address: 2222
+                                    <br>Planning application reference: planningApplicationReference
+                                    <br>
+                                </div>
+                                <h2>Why we corrected the appeal decision letter</h2>correctionNotice
+                                <br>
+                                <br><a href="https://appeals-service-test.planninginspectorate.gov.uk/manage-appeals/12345"
+                                class="govuk-link">Sign in to our service</a> to view the decision letter
+                                dated dateISOStringToDisplayDate(file.receivedDate).
+                                <br>
+                                <br>
+                                <h2>The Planning Inspectorate's role</h2>The Planning Inspectorate cannot change or revoke the decision. Only the
+                                High Court can change this decision.
+                                <br>
+                                <br>
+                                <h2>Feedback</h2>We welcome your feedback on our appeals service. Tell us on this short
+                                <a                                 href="https://forms.office.com/pages/responsepage.aspx?id=mN94WIhvq0iTIpmM5VcIjfMZj__F6D9LmMUUyoUrZDZUOERYMEFBN0NCOFdNU1BGWEhHUFQxWVhUUy4u"
+                                class="govuk-link">feedback form</a>.
+                                    <br>
+                                    <br>The Planning Inspectorate
+                                    <br>
+                                    <br>caseofficers@planninginspectorate.gov.uk
+                                    <br>
+                                    <br>
+                            </div>
+                        </div>
+                    </details>
                 </div>
         </div>
+        <div class="govuk-grid-row">
+            <div class="govuk-grid-column-full">
+                <form method="post" novalidate="novalidate">
+                    <button type="submit" class="govuk-button" data-module="govuk-button">Update decision letter</button>
+                </form>
+            </div>
+        </div>
+    </div>
     </div>
 </main>"
 `;

--- a/appeals/web/src/server/appeals/appeal-details/update-decision-letter/__tests__/update-decision-letter.test.js
+++ b/appeals/web/src/server/appeals/appeal-details/update-decision-letter/__tests__/update-decision-letter.test.js
@@ -13,7 +13,8 @@ import {
 	documentRedactionStatuses,
 	fileUploadInfo,
 	documentFileInfo,
-	fileUploadInfo2
+	fileUploadInfo2,
+	template
 } from '../../../../../../../web/testing/app/fixtures/referencedata.js';
 
 describe('update-decision-letter', () => {
@@ -25,8 +26,8 @@ describe('update-decision-letter', () => {
 	 * @type {import("superagent").Response}
 	 */
 	let correctionNoticeResponse;
-	beforeEach(installMockApi);
 	beforeEach(() => {
+		installMockApi();
 		nock.cleanAll();
 		nock('http://test/').get('/appeals/1').reply(200, appealDataIssuedDecision).persist();
 	});
@@ -195,6 +196,9 @@ describe('update-decision-letter', () => {
 			nock('http://test/').get('/appeals/1/documents/1').reply(200, documentFileInfo);
 			nock('http://test/').post(`/appeals/validate-business-date`).reply(200, { result: true });
 			nock('http://test/')
+				.post(`/appeals/notify-preview/correction-notice-decision.content.md`)
+				.reply(200, template);
+			nock('http://test/')
 				.get('/appeals/document-redaction-statuses')
 				.reply(200, documentRedactionStatuses)
 				.persist();
@@ -227,7 +231,7 @@ describe('update-decision-letter', () => {
 			expect(unprettifiedElement.innerHTML).toContain('Check details and update decision letter');
 			expect(unprettifiedElement.innerHTML).toContain('Decision letter');
 			expect(unprettifiedElement.innerHTML).toContain('Correction notice');
-			expect(unprettifiedElement.innerHTML).toContain('Preview email');
+			expect(unprettifiedElement.innerHTML).toContain('Preview');
 			expect(unprettifiedElement.innerHTML).toContain('Update decision letter');
 		});
 		it('should render the check your view-decision page after submit', async () => {

--- a/appeals/web/src/server/lib/api/notify-preview.api.js
+++ b/appeals/web/src/server/lib/api/notify-preview.api.js
@@ -1,0 +1,9 @@
+/**
+ *
+ * @param {import('got').Got} apiClient
+ * @param {string} templateName
+ * @param {{}} [personalisation]
+ * @returns {Promise<{renderedHtml:string}>}
+ */
+export const generateNotifyPreview = (apiClient, templateName, personalisation) =>
+	apiClient.post(`appeals/notify-preview/${templateName}`, { json: personalisation }).json();

--- a/appeals/web/src/styles/8-utilities/_border.scss
+++ b/appeals/web/src/styles/8-utilities/_border.scss
@@ -1,3 +1,13 @@
+@use "../../../node_modules/govuk-frontend/dist/govuk/settings/_colours-applied" as colors;
+@import "../../../node_modules/govuk-frontend/dist/govuk/settings/_spacing";
+@import "../../../node_modules/govuk-frontend/dist/govuk/helpers/_spacing";
+
 .pins-border-bottom {
 	border-bottom: 1px solid #b1b4b6;
+}
+
+.pins-notify-preview-border {
+    border: 5px solid colors.$govuk-border-colour;
+    padding: govuk-spacing(4);
+    margin-bottom: govuk-spacing(6);
 }

--- a/appeals/web/testing/app/fixtures/referencedata.js
+++ b/appeals/web/testing/app/fixtures/referencedata.js
@@ -4006,3 +4006,26 @@ export const caseAuditLog = [
 		loggedDate: '2025-05-27T09:52:23.597Z'
 	}
 ];
+
+export const template = {
+	renderedHtml: [
+		`<div class="pins-notify-preview-border">`,
+		`We have corrected the appeal decision letter.<br><br>`,
+		`<h2>Appeal details</h2>`,
+		`<div class="govuk-inset-text">`,
+		`  Appeal reference number: 12345 <br>`,
+		`  Address: 2222<br>`,
+		`  Planning application reference: planningApplicationReference<br>`,
+		`</div>`,
+		`<h2>Why we corrected the appeal decision letter</h2>`,
+		`correctionNotice<br><br>`,
+		`<a href="https://appeals-service-test.planninginspectorate.gov.uk/manage-appeals/12345" class="govuk-link">Sign in to our service</a> to view the decision letter dated dateISOStringToDisplayDate(file.receivedDate).<br><br>`,
+		`<h2>The Planning Inspectorate's role</h2>`,
+		`The Planning Inspectorate cannot change or revoke the decision. Only the High Court can change this decision.<br><br>`,
+		`<h2>Feedback</h2>`,
+		`We welcome your feedback on our appeals service. Tell us on this short <a href="https://forms.office.com/pages/responsepage.aspx?id=mN94WIhvq0iTIpmM5VcIjfMZj__F6D9LmMUUyoUrZDZUOERYMEFBN0NCOFdNU1BGWEhHUFQxWVhUUy4u" class="govuk-link">feedback form</a>.<br><br>`,
+		`The Planning Inspectorate<br><br>`,
+		`caseofficers@planninginspectorate.gov.uk<br><br>`,
+		`</div>`
+	].join('\n')
+};


### PR DESCRIPTION
## Describe your changes

- Created a new endpoint that will return the HTML for a Notify Email when called with personalisation object and the template name as a parameter
- Added tests for this
- Updated content of notify template to have the correct front office URL in different environments
- new service to call the api endpoint for notify HTML
- added api call for notify preview to the decision letter CYA controller function
- additional CSS classes to accommodate preview box
- updated snapshots and tests for the updates to CYA page

## Issue ticket number and link
[Ticket](https://pins-ds.atlassian.net.mcas.ms/browse/A2-3447)
