### PR TITLE
feat(appeals): cta updates on lead and child appeals after linking where none have started (a2-3475)

### DIFF
--- a/appeals/web/src/server/appeals/appeal-details/__tests__/__snapshots__/appeal-details.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/__tests__/__snapshots__/appeal-details.test.js.snap
@@ -774,6 +774,444 @@ exports[`appeal-details GET /:appealId Timetable Valid date should render a "Tim
 </dl>"
 `;
 
+exports[`appeal-details GET /:appealId should not render a "Appeal valid" notification banner when status is "READY_TO_START" and appeal is a linked child appeal 1`] = `
+"<main class="govuk-main-wrapper" id="main-content">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Appeal 351062</span>
+            <h1 class="govuk-heading-xl govuk-!-margin-bottom-3">Case details</h1>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full"><strong class="govuk-tag govuk-tag--green pins-status-tag--full-width">Ready to start</strong>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
+            <dl class="govuk-summary-list pins-summary-list--no-border">
+                <div class="govuk-summary-list__row appeal-case-officer"><dt class="govuk-summary-list__key"> Case officer</dt>
+                    <dd class="govuk-summary-list__value">
+                        <p class="govuk-body">Not assigned</p>
+                    </dd>
+                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/assign-case-officer/search-case-officer"
+                        data-cy="assign-case-officer-name">Assign<span class="govuk-visually-hidden"> Case officer</span></a>
+                    </dd>
+                </div>
+                <div class="govuk-summary-list__row appeal-site-address"><dt class="govuk-summary-list__key"> Site address</dt>
+                    <dd class="govuk-summary-list__value">21 The Pavement, Wandsworth, SW4 0HY</dd>
+                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/site-address/change/1?backUrl=%2Fappeals-service%2Fappeal-details%2F2"
+                        data-cy="change-site-address">Change<span class="govuk-visually-hidden"> Site address</span></a>
+                    </dd>
+                </div>
+                <div class="govuk-summary-list__row appeal-local-planning-authority"><dt class="govuk-summary-list__key"> LPA</dt>
+                    <dd class="govuk-summary-list__value">Wiltshire Council</dd>
+                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/change-appeal-details/local-planning-authority"
+                        data-cy="change-local-planning-authority">Change<span class="govuk-visually-hidden"> LPA</span></a>
+                    </dd>
+                </div>
+            </dl>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
+            <p class="govuk-body govuk-!-margin-bottom-6" id="download-case-files"
+            data-cy="download-case-files"><a class="govuk-link" href="/documents/2/bulk-download/case-APP/Q9999/D/21/351062.zip">Download case</a>
+            </p>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
+            <details class="govuk-details">
+                <summary class="govuk-details__summary"><span class="govuk-details__summary-text"> 2 case notes</span>
+                </summary>
+                <div class="govuk-details__text">
+                    <form method="POST" novalidate="novalidate">
+                        <div class="govuk-grid-row">
+                            <div class="govuk-grid-column-two-thirds">
+                                <div class="govuk-form-group govuk-character-count" data-module="govuk-character-count"
+                                data-maxlength="500">
+                                    <textarea class="govuk-textarea govuk-js-character-count" id="comment"
+                                    name="comment" rows="5" aria-describedby="comment-info"></textarea>
+                                    <div id="comment-info" class="govuk-hint govuk-character-count__message">You can enter up to 500 characters</div>
+                                </div>
+                            </div>
+                        </div>
+                        <button type="submit" data-prevent-double-click="true" class="govuk-button govuk-button--secondary govuk-!-margin-bottom-1"
+                        data-module="govuk-button">Add case note</button>
+                    </form>
+                    <div>
+                        <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+                        <section>
+                            <p class="govuk-body govuk-!-margin-bottom-1">A case note you should see.</p>
+                            <p class="govuk-hint govuk-!-margin-bottom-6">11:00am on Tuesday 1 October 2024 by John.Smith</p>
+                            <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+                        </section>
+                        <section>
+                            <p class="govuk-body govuk-!-margin-bottom-1">A case note you should see.</p>
+                            <p class="govuk-hint govuk-!-margin-bottom-6">11:00am on Tuesday 1 October 2024 by John.Smith</p>
+                            <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+                        </section>
+                    </div>
+                </div>
+            </details>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
+            <div class="govuk-accordion" data-module="govuk-accordion" id="accordion-default2">
+                <div class="govuk-accordion__section">
+                    <div class="govuk-accordion__section-header">
+                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default2-heading-1"> Overview</span></h2>
+                    </div>
+                    <div id="accordion-default2-content-1" class="govuk-accordion__section-content">
+                        <dl class="govuk-summary-list">
+                            <div class="govuk-summary-list__row govuk-summary-list__row--no-actions appeal-lpa-reference"><dt class="govuk-summary-list__key"> Planning application reference</dt>
+                                <dd                                 class="govuk-summary-list__value">48269/APP/2021/1482</dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-appeal-type"><dt class="govuk-summary-list__key"> Appeal type</dt>
+                                <dd class="govuk-summary-list__value">Householder</dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/change-appeal-type/appeal-type"
+                                    data-cy="change-appeal-type">Change<span class="govuk-visually-hidden"> Appeal type</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row govuk-summary-list__row--no-actions appeal-case-procedure"><dt class="govuk-summary-list__key"> Appeal procedure</dt>
+                                <dd class="govuk-summary-list__value">Written</dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-allocation-details"><dt class="govuk-summary-list__key"> Allocation level</dt>
+                                <dd class="govuk-summary-list__value">
+                                    <ul class="govuk-!-margin-0">
+                                        <li>Level: A</li>
+                                        <li>Historic heritage</li>
+                                        <li>Architecture design</li>
+                                    </ul>
+                                </dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/allocation-details/allocation-level"
+                                    data-cy="change-allocation-details">Change<span class="govuk-visually-hidden"> Allocation level</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-linked-appeals"><dt class="govuk-summary-list__key"> Linked appeals</dt>
+                                <dd class="govuk-summary-list__value"><span>No linked appeals</span>
+                                </dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/linked-appeals/add"
+                                    data-cy="add-linked-appeal">Add<span class="govuk-visually-hidden"> Linked appeals</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-other-appeals"><dt class="govuk-summary-list__key"> Related appeals</dt>
+                                <dd class="govuk-summary-list__value"><span>No</span>
+                                </dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/other-appeals/add"
+                                    data-cy="add-related-appeals">Add<span class="govuk-visually-hidden"> Related appeals</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-decision"><dt class="govuk-summary-list__key"> Decision</dt>
+                                <dd class="govuk-summary-list__value">Dismissed</dd>
+                            </div>
+                        </dl>
+                    </div>
+                </div>
+                <div class="govuk-accordion__section">
+                    <div class="govuk-accordion__section-header">
+                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default2-heading-2"> Site</span></h2>
+                    </div>
+                    <div id="accordion-default2-content-2" class="govuk-accordion__section-content">
+                        <dl class="govuk-summary-list">
+                            <div class="govuk-summary-list__row appeal-visit-type"><dt class="govuk-summary-list__key"> Visit type</dt>
+                                <dd class="govuk-summary-list__value">Accompanied</dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/site-visit/visit-booked?backUrl=%2Fappeals-service%2Fappeal-details%2F2"
+                                    data-cy="change-set-visit-type">Change<span class="govuk-visually-hidden"> Visit type</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Date</dt>
+                                <dd class="govuk-summary-list__value">9 October 2023</dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/site-visit/visit-booked"
+                                    data-cy="change-site-visit-date">Change<span class="govuk-visually-hidden"> Date</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Start time</dt>
+                                <dd class="govuk-summary-list__value">9:38am</dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/site-visit/visit-booked"
+                                    data-cy="change-site-visit-start-time">Change<span class="govuk-visually-hidden"> Start time</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> End time</dt>
+                                <dd class="govuk-summary-list__value">10:00am</dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/site-visit/visit-booked"
+                                    data-cy="change-site-visit-end-time">Change<span class="govuk-visually-hidden"> End time</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-neighbouring-sites-inspector"><dt class="govuk-summary-list__key"> Interested party and neighbour addresses</dt>
+                                <dd                                 class="govuk-summary-list__value">
+                                    <ul class="govuk-list govuk-list--bullet">
+                                        <li>2 Grove Cottage, Shotesham Road, Woodton, Devon, NR35 2ND</li>
+                                    </ul>
+                                    </dd>
+                                    <dd class="govuk-summary-list__actions">
+                                        <ul class="govuk-summary-list__actions-list">
+                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/2/neighbouring-sites/manage"
+                                                data-cy="manage-neighbouring-sites-inspector">Manage<span class="govuk-visually-hidden"> Interested party and neighbour addresses</span></a>
+                                            </li>
+                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/2/neighbouring-sites/add/back-office"
+                                                data-cy="add-neighbouring-sites-inspector">Add<span class="govuk-visually-hidden"> Interested party and neighbour addresses</span></a>
+                                            </li>
+                                        </ul>
+                                    </dd>
+                            </div>
+                        </dl>
+                    </div>
+                </div>
+                <div class="govuk-accordion__section">
+                    <div class="govuk-accordion__section-header">
+                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default2-heading-3"> Timetable</span></h2>
+                    </div>
+                    <div id="accordion-default2-content-3" class="govuk-accordion__section-content">
+                        <dl class="govuk-summary-list appeal-case-timetable">
+                            <div class="govuk-summary-list__row appeal-valid-date"><dt class="govuk-summary-list__key"> Valid date</dt>
+                                <dd class="govuk-summary-list__value">23 May 2023</dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/appellant-case/valid/date"
+                                    data-cy="-valid-date"><span class="govuk-visually-hidden"> Valid date</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-start-date"><dt class="govuk-summary-list__key"> Start date</dt>
+                                <dd class="govuk-summary-list__value">23 May 2023</dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-lpa-questionnaire-due-date"><dt class="govuk-summary-list__key"> LPA questionnaire due</dt>
+                                <dd class="govuk-summary-list__value">11 October 2023</dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-site-visit"><dt class="govuk-summary-list__key"> Site visit</dt>
+                                <dd class="govuk-summary-list__value">
+                                    <ul class="govuk-list govuk-!-margin-top-0 govuk-!-padding-left-0">
+                                        <li>9 October 2023</li>
+                                        <li>9:38am - 10:00am</li>
+                                    </ul>
+                                </dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/site-visit/manage-visit?backUrl=%2Fappeals-service%2Fappeal-details%2F2"
+                                    data-cy="change-schedule-visit">Change<span class="govuk-visually-hidden"> Site visit</span></a>
+                                </dd>
+                            </div>
+                        </dl>
+                    </div>
+                </div>
+                <div class="govuk-accordion__section">
+                    <div class="govuk-accordion__section-header">
+                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default2-heading-4"> Documentation</span></h2>
+                    </div>
+                    <div id="accordion-default2-content-4" class="govuk-accordion__section-content">
+                        <table class="govuk-table">
+                            <thead class="govuk-table__head">
+                                <tr class="govuk-table__row">
+                                    <th scope="col" class="govuk-table__header">Documentation</th>
+                                    <th scope="col" class="govuk-table__header">Status</th>
+                                    <th scope="col" class="govuk-table__header">Received</th>
+                                    <th scope="col" class="govuk-table__header govuk-!-text-align-right">Action</th>
+                                </tr>
+                            </thead>
+                            <tbody class="govuk-table__body">
+                                <tr class="govuk-table__row">
+                                    <th scope="row" class="govuk-table__header">Appeal</th>
+                                    <td class="govuk-table__cell">Ready to review</td>
+                                    <td class="govuk-table__cell">2 August 2024</td>
+                                    <td class="govuk-table__cell govuk-!-text-align-right"><a href="/appeals-service/appeal-details/2/appellant-case?backUrl=%2Fappeals-service%2Fappeal-details%2F2"
+                                        data-cy="review-appellant-case" class="govuk-link">Review<span class="govuk-visually-hidden"> appellant case</span></a>
+                                    </td>
+                                </tr>
+                                <tr class="govuk-table__row">
+                                    <th scope="row" class="govuk-table__header">LPA questionnaire</th>
+                                    <td class="govuk-table__cell">Overdue</td>
+                                    <td class="govuk-table__cell">Due by 11 October 2023</td>
+                                    <td class="govuk-table__cell govuk-!-text-align-right"></td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
+                <div class="govuk-accordion__section">
+                    <div class="govuk-accordion__section-header">
+                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default2-heading-5"> Costs</span></h2>
+                    </div>
+                    <div id="accordion-default2-content-5" class="govuk-accordion__section-content">
+                        <table class="govuk-table">
+                            <thead class="govuk-table__head">
+                                <tr class="govuk-table__row">
+                                    <th scope="col" class="govuk-table__header">Documentation</th>
+                                    <th scope="col" class="govuk-table__header">Status</th>
+                                    <th scope="col" class="govuk-table__header govuk-!-text-align-right">Action</th>
+                                </tr>
+                            </thead>
+                            <tbody class="govuk-table__body">
+                                <tr class="govuk-table__row">
+                                    <th scope="row" class="govuk-table__header appeal-costs-appellant-application-documentation">Appellant application</th>
+                                    <td class="govuk-table__cell appeal-costs-appellant-application-status">No documents available</td>
+                                    <td class="govuk-table__cell appeal-costs-appellant-application-actions govuk-!-text-align-right">
+                                        <ul class="govuk-summary-list__actions-list">
+                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-appellant-application" href="/appeals-service/appeal-details/2/costs/appellant/application/upload-documents/1">Add<span class="govuk-visually-hidden"> Appellant application</span></a>
+                                            </li>
+                                        </ul>
+                                    </td>
+                                </tr>
+                                <tr class="govuk-table__row">
+                                    <th scope="row" class="govuk-table__header appeal-costs-appellant-withdrawal-documentation">Appellant withdrawal</th>
+                                    <td class="govuk-table__cell appeal-costs-appellant-withdrawal-status">No documents available</td>
+                                    <td class="govuk-table__cell appeal-costs-appellant-withdrawal-actions govuk-!-text-align-right">
+                                        <ul class="govuk-summary-list__actions-list">
+                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-appellant-withdrawal" href="/appeals-service/appeal-details/2/costs/appellant/withdrawal/upload-documents/2">Add<span class="govuk-visually-hidden"> Appellant withdrawal</span></a>
+                                            </li>
+                                        </ul>
+                                    </td>
+                                </tr>
+                                <tr class="govuk-table__row">
+                                    <th scope="row" class="govuk-table__header appeal-costs-appellant-correspondence-documentation">Appellant correspondence</th>
+                                    <td class="govuk-table__cell appeal-costs-appellant-correspondence-status">No documents available</td>
+                                    <td class="govuk-table__cell appeal-costs-appellant-correspondence-actions govuk-!-text-align-right">
+                                        <ul class="govuk-summary-list__actions-list">
+                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-appellant-correspondence" href="/appeals-service/appeal-details/2/costs/appellant/correspondence/upload-documents/3">Add<span class="govuk-visually-hidden"> Appellant correspondence</span></a>
+                                            </li>
+                                        </ul>
+                                    </td>
+                                </tr>
+                                <tr class="govuk-table__row">
+                                    <th scope="row" class="govuk-table__header appeal-costs-lpa-application-documentation">LPA application</th>
+                                    <td class="govuk-table__cell appeal-costs-lpa-application-status">No documents available</td>
+                                    <td class="govuk-table__cell appeal-costs-lpa-application-actions govuk-!-text-align-right">
+                                        <ul class="govuk-summary-list__actions-list">
+                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-lpa-application" href="/appeals-service/appeal-details/2/costs/lpa/application/upload-documents/4">Add<span class="govuk-visually-hidden"> LPA application</span></a>
+                                            </li>
+                                        </ul>
+                                    </td>
+                                </tr>
+                                <tr class="govuk-table__row">
+                                    <th scope="row" class="govuk-table__header appeal-costs-lpa-withdrawal-documentation">LPA withdrawal</th>
+                                    <td class="govuk-table__cell appeal-costs-lpa-withdrawal-status">No documents available</td>
+                                    <td class="govuk-table__cell appeal-costs-lpa-withdrawal-actions govuk-!-text-align-right">
+                                        <ul class="govuk-summary-list__actions-list">
+                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-lpa-withdrawal" href="/appeals-service/appeal-details/2/costs/lpa/withdrawal/upload-documents/5">Add<span class="govuk-visually-hidden"> LPA withdrawal</span></a>
+                                            </li>
+                                        </ul>
+                                    </td>
+                                </tr>
+                                <tr class="govuk-table__row">
+                                    <th scope="row" class="govuk-table__header appeal-costs-lpa-correspondence-documentation">LPA correspondence</th>
+                                    <td class="govuk-table__cell appeal-costs-lpa-correspondence-status">No documents available</td>
+                                    <td class="govuk-table__cell appeal-costs-lpa-correspondence-actions govuk-!-text-align-right">
+                                        <ul class="govuk-summary-list__actions-list">
+                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-lpa-correspondence" href="/appeals-service/appeal-details/2/costs/lpa/correspondence/upload-documents/6">Add<span class="govuk-visually-hidden"> LPA correspondence</span></a>
+                                            </li>
+                                        </ul>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
+                <div class="govuk-accordion__section">
+                    <div class="govuk-accordion__section-header">
+                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default2-heading-6"> Contacts</span></h2>
+                    </div>
+                    <div id="accordion-default2-content-6" class="govuk-accordion__section-content">
+                        <dl class="govuk-summary-list">
+                            <div class="govuk-summary-list__row appeal-appellant"><dt class="govuk-summary-list__key"> Appellant</dt>
+                                <dd class="govuk-summary-list__value">
+                                    <ul class="govuk-list">
+                                        <li>Roger Simmons</li>
+                                        <li>test3@example.com</li>
+                                    </ul>
+                                </dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/service-user/change/appellant"
+                                    data-cy="change-appellant">Change<span class="govuk-visually-hidden"> Appellant</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-agent"><dt class="govuk-summary-list__key"> Agent</dt>
+                                <dd class="govuk-summary-list__value">
+                                    <ul class="govuk-list">
+                                        <li>Fiona Shell</li>
+                                        <li>test2@example.com</li>
+                                    </ul>
+                                </dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/service-user/change/agent"
+                                    data-cy="change-agent">Change<span class="govuk-visually-hidden"> Agent</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-lpa-contact-details"><dt class="govuk-summary-list__key"> LPA</dt>
+                                <dd class="govuk-summary-list__value">
+                                    <ul class="govuk-list">
+                                        <li>Wiltshire Council</li>
+                                        <li>wilt@lpa-email.gov.uk</li>
+                                    </ul>
+                                </dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/change-appeal-details/local-planning-authority"
+                                    data-cy="change-lpa-contact-details">Change<span class="govuk-visually-hidden"> Local planning authority (LPA)</span></a>
+                                </dd>
+                            </div>
+                        </dl>
+                    </div>
+                </div>
+                <div class="govuk-accordion__section">
+                    <div class="govuk-accordion__section-header">
+                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default2-heading-7"> Team</span></h2>
+                    </div>
+                    <div id="accordion-default2-content-7" class="govuk-accordion__section-content">
+                        <dl class="govuk-summary-list">
+                            <div class="govuk-summary-list__row appeal-case-officer"><dt class="govuk-summary-list__key"> Case officer</dt>
+                                <dd class="govuk-summary-list__value">
+                                    <p class="govuk-body">Not assigned</p>
+                                </dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/assign-case-officer/search-case-officer"
+                                    data-cy="assign-case-officer">Assign<span class="govuk-visually-hidden"> Case officer</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-inspector"><dt class="govuk-summary-list__key"> Inspector</dt>
+                                <dd class="govuk-summary-list__value">
+                                    <p class="govuk-body">Not assigned</p>
+                                </dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/assign-inspector/search-inspector"
+                                    data-cy="assign-inspector">Assign<span class="govuk-visually-hidden"> Inspector</span></a>
+                                </dd>
+                            </div>
+                        </dl>
+                    </div>
+                </div>
+                <div class="govuk-accordion__section">
+                    <div class="govuk-accordion__section-header">
+                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default2-heading-8"> Case management</span></h2>
+                    </div>
+                    <div id="accordion-default2-content-8" class="govuk-accordion__section-content">
+                        <dl class="govuk-summary-list">
+                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Cross-team correspondence</dt>
+                                <dd                                 class="govuk-summary-list__value">No documents</dd>
+                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/internal-correspondence/cross-team/upload-documents/10"
+                                        data-cy="add-cross-team-correspondence">Add<span class="govuk-visually-hidden"> Cross-team correspondence</span></a>
+                                    </dd>
+                            </div>
+                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Inspector correspondence</dt>
+                                <dd                                 class="govuk-summary-list__value">No documents</dd>
+                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/internal-correspondence/inspector/upload-documents/11"
+                                        data-cy="add-inspector-correspondence">Add<span class="govuk-visually-hidden"> Inspector correspondence</span></a>
+                                    </dd>
+                            </div>
+                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Main party correspondence</dt>
+                                <dd                                 class="govuk-summary-list__value">No documents</dd>
+                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/internal-correspondence/main-party/upload-documents/22"
+                                        data-cy="add-main-party-correspondence">Add<span class="govuk-visually-hidden"> Main party correspondence</span></a>
+                                    </dd>
+                            </div>
+                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Case history</dt>
+                                <dd class="govuk-summary-list__value"></dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/audit" data-cy="view-case-history">View<span class="govuk-visually-hidden"> Case history</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Appeal withdrawal</dt>
+                                <dd class="govuk-summary-list__value"></dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/withdrawal/start"
+                                    data-cy="start-appeal-withdrawal">Start<span class="govuk-visually-hidden"> Appeal withdrawal</span></a>
+                                </dd>
+                            </div>
+                        </dl>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</main>"
+`;
+
 exports[`appeal-details GET /:appealId should not render action links to the manage linked appeals page or the add linked appeal page in the linked appeals row, if the appeal is linked as a child of an external lead appeal 1`] = `
 "<main class="govuk-main-wrapper" id="main-content">
     <div class="govuk-grid-row">
@@ -1889,9 +2327,6 @@ exports[`appeal-details GET /:appealId should render a child tag next to the app
                             </div>
                             <div class="govuk-summary-list__row appeal-start-date"><dt class="govuk-summary-list__key"> Start date</dt>
                                 <dd class="govuk-summary-list__value">23 May 2023</dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/start-case/change"
-                                    data-cy="change-start-case-date">Change<span class="govuk-visually-hidden"> Start date</span></a>
-                                </dd>
                             </div>
                             <div class="govuk-summary-list__row appeal-lpa-questionnaire-due-date"><dt class="govuk-summary-list__key"> LPA questionnaire due</dt>
                                 <dd class="govuk-summary-list__value">11 October 2023</dd>

--- a/appeals/web/src/server/appeals/appeal-details/__tests__/appeal-details.test.js
+++ b/appeals/web/src/server/appeals/appeal-details/__tests__/appeal-details.test.js
@@ -2242,6 +2242,26 @@ describe('appeal-details', () => {
 			);
 		});
 
+		it('should not render a "Appeal valid" notification banner when status is "READY_TO_START" and appeal is a linked child appeal', async () => {
+			const appealId = 2;
+			nock('http://test/')
+				.get(`/appeals/${appealId}`)
+				.reply(200, {
+					...appealData,
+					appealId,
+					appealStatus: 'ready_to_start',
+					isChildAppeal: true
+				});
+			nock('http://test/').get(`/appeals/${appealId}/case-notes`).reply(200, caseNotes);
+			const response = await request.get(`${baseUrl}/${appealId}`);
+
+			expect(response.statusCode).toBe(200);
+			const element = parseHtml(response.text, { rootElement: '.govuk-main-wrapper' });
+
+			expect(element.innerHTML).toMatchSnapshot();
+			expect(element.innerHTML).not.toContain('govuk-notification-banner');
+		});
+
 		describe('"Progress case" important banners', () => {
 			const appealId = 1;
 			const appealStatus = 'final_comments';

--- a/appeals/web/src/server/appeals/personal-list/__tests__/personal-list.test.js
+++ b/appeals/web/src/server/appeals/personal-list/__tests__/personal-list.test.js
@@ -381,7 +381,8 @@ describe('personal-list', () => {
 				requiredAction: 'startAppeal',
 				expectedHtml: {
 					caseOfficer: `<a class="govuk-link" href="/appeals-service/appeal-details/${appealId}/start-case/add?backUrl=%2Fappeals-service%2Fpersonal-list">Start case<span class="govuk-visually-hidden"> for appeal ${appealId}</span></a>`,
-					nonCaseOfficer: 'Start case'
+					nonCaseOfficer: 'Start case',
+					childAppeal: ''
 				}
 			},
 			{
@@ -413,6 +414,18 @@ describe('personal-list', () => {
 					);
 
 					expect(result).toBe(testCase.expectedHtml.nonCaseOfficer);
+				});
+			}
+
+			if ('childAppeal' in testCase.expectedHtml) {
+				it(`should not return an action link HTML when getRequiredActionsForAppeal returns "${testCase.requiredAction}" and "isChildAppeal" is true`, async () => {
+					const result = mapActionLinksForAppeal(
+						{ ...appealDataToGetRequiredActions[testCase.requiredAction], isChildAppeal: true },
+						true,
+						{ originalUrl: baseUrl }
+					);
+
+					expect(result).toBe(testCase.expectedHtml.childAppeal);
 				});
 			}
 		}

--- a/appeals/web/src/server/appeals/personal-list/personal-list.mapper.js
+++ b/appeals/web/src/server/appeals/personal-list/personal-list.mapper.js
@@ -238,14 +238,16 @@ export function personalListPage(
 /**
  * @param {import('#lib/mappers/index.js').AppealRequiredAction} action
  * @param {boolean} isCaseOfficer
+ * @param {boolean} isChildAppeal
  * @param {number} appealId
  * @param {number|null|undefined} lpaQuestionnaireId
  * @param {import('@pins/express/types/express.js').Request} request
- * @returns {string}
+ * @returns {string|undefined}
  */
 function mapRequiredActionToPersonalListActionHtml(
 	action,
 	isCaseOfficer,
+	isChildAppeal,
 	appealId,
 	lpaQuestionnaireId,
 	request
@@ -364,6 +366,9 @@ function mapRequiredActionToPersonalListActionHtml(
 			)}">Share IP comments and LPA statement<span class="govuk-visually-hidden"> for appeal ${appealId}</span></a>`;
 		}
 		case 'startAppeal': {
+			if (isChildAppeal) {
+				return;
+			}
 			return isCaseOfficer
 				? `<a class="govuk-link" href="${addBackLinkQueryToUrl(
 						request,
@@ -401,7 +406,7 @@ export function mapActionLinksForAppeal(appeal, isCaseOfficer, request) {
 		appealTimetable: appeal.appealTimetable || {}
 	});
 
-	const { appealId, lpaQuestionnaireId } = appeal;
+	const { appealId, lpaQuestionnaireId, isChildAppeal = false } = appeal;
 
 	if (appealId === undefined) {
 		return '';
@@ -412,10 +417,12 @@ export function mapActionLinksForAppeal(appeal, isCaseOfficer, request) {
 			return mapRequiredActionToPersonalListActionHtml(
 				action,
 				isCaseOfficer,
+				isChildAppeal,
 				appealId,
 				lpaQuestionnaireId,
 				request
 			);
 		})
+		.filter((action) => action !== undefined)
 		.join('<br>');
 }

--- a/appeals/web/src/server/lib/mappers/data/appeal/submappers/started-at.mapper.js
+++ b/appeals/web/src/server/lib/mappers/data/appeal/submappers/started-at.mapper.js
@@ -15,7 +15,7 @@ export const mapStartedAt = ({ appealDetails, currentRoute, userHasUpdateCasePer
 		link: appealDetails.startedAt
 			? `${currentRoute}/start-case/change`
 			: `${currentRoute}/start-case/add?backUrl=${currentRoute}`,
-		editable: Boolean(userHasUpdateCasePermission),
+		editable: !appealDetails.isChildAppeal && Boolean(userHasUpdateCasePermission),
 		classes: 'appeal-start-date',
 		actionText:
 			appealDetails.documentationSummary.lpaQuestionnaire?.status !== 'not_received'

--- a/appeals/web/src/server/lib/mappers/utils/map-status-dependent-notifications.js
+++ b/appeals/web/src/server/lib/mappers/utils/map-status-dependent-notifications.js
@@ -151,6 +151,9 @@ function mapBannerKeysToNotificationBanners(bannerDefinitionKey, appealDetails, 
 				)}" class="govuk-heading-s govuk-notification-banner__link">Share IP comments and LPA statement</a>`
 			});
 		case 'appealValidAndReadyToStart':
+			if (appealDetails.isChildAppeal) {
+				return;
+			}
 			return createNotificationBanner({
 				bannerDefinitionKey,
 				html: `<p class="govuk-notification-banner__heading">Appeal valid</p><p><a class="govuk-notification-banner__link" data-cy="ready-to-start" href="${addBackLinkQueryToUrl(


### PR DESCRIPTION
## Describe your changes
#### Hide start appeal CTA for linked child cases (a2-3475)

### WEB:
- Hide the start appeal link in personal cases page on child cases
- Hide the important information banner for starting an appeal on the case details page for a child case

### TEST:
- Update tests and snapshots for above
- Made sure all unit tests pass
- Manually tested within browser

## Issue ticket number and link:
- [(A2-3475) CTA updates on lead and child appeals after linking written rep S78 planning appeals (where none have been started) - part 1](https://pins-ds.atlassian.net/browse/A2-3475)

