### PR TITLE
chore(appeals): remove unnecessary eslint-disable-next-line comment

### DIFF
--- a/appeals/api/src/server/endpoints/appeal-decision/__tests__/appeal-decision.test.js
+++ b/appeals/api/src/server/endpoints/appeal-decision/__tests__/appeal-decision.test.js
@@ -175,10 +175,8 @@ describe('appeal decision routes', () => {
 				})
 				.set('azureAdUserId', azureAdUserId);
 
-			// eslint-disable-next-line no-undef
 			expect(mockNotifySend).toHaveBeenCalledTimes(2);
 
-			// eslint-disable-next-line no-undef
 			expect(mockNotifySend).toHaveBeenCalledWith({
 				notifyClient: expect.any(Object),
 				templateName: 'decision-is-allowed-split-dismissed-appellant',
@@ -192,7 +190,6 @@ describe('appeal decision routes', () => {
 				recipientEmail: 'test@136s7.com'
 			});
 
-			// eslint-disable-next-line no-undef
 			expect(mockNotifySend).toHaveBeenCalledWith({
 				notifyClient: expect.any(Object),
 				personalisation: {

--- a/appeals/api/src/server/endpoints/appeal-timetables/__tests__/appeal-timetables.test.js
+++ b/appeals/api/src/server/endpoints/appeal-timetables/__tests__/appeal-timetables.test.js
@@ -166,7 +166,6 @@ describe('appeal timetables routes', () => {
 						}
 					});
 
-					// eslint-disable-next-line no-undef
 					expect(mockNotifySend).toHaveBeenNthCalledWith(1, {
 						notifyClient: expect.any(Object),
 						personalisation: {
@@ -497,9 +496,8 @@ describe('appeal timetables routes', () => {
 				expect(response.status).toEqual(201);
 				expect(response.body).toEqual({ lpaQuestionnaireDueDate: '2024-06-12T22:59:00.000Z' });
 
-				// eslint-disable-next-line no-undef
 				expect(mockNotifySend).toHaveBeenCalledTimes(2);
-				// eslint-disable-next-line no-undef
+
 				expect(mockNotifySend).toHaveBeenNthCalledWith(1, {
 					notifyClient: expect.anything(),
 					personalisation: {
@@ -525,7 +523,7 @@ describe('appeal timetables routes', () => {
 					recipientEmail: householdAppeal.appellant.email,
 					templateName: 'appeal-start-date-change-appellant'
 				});
-				// eslint-disable-next-line no-undef
+
 				expect(mockNotifySend).toHaveBeenNthCalledWith(2, {
 					notifyClient: expect.anything(),
 					personalisation: {
@@ -567,9 +565,8 @@ describe('appeal timetables routes', () => {
 				expect(response.status).toEqual(201);
 				expect(response.body).toEqual({ lpaQuestionnaireDueDate: '2024-06-12T22:59:00.000Z' });
 
-				// eslint-disable-next-line no-undef
 				expect(mockNotifySend).toHaveBeenCalledTimes(2);
-				// eslint-disable-next-line no-undef
+
 				expect(mockNotifySend).toHaveBeenNthCalledWith(1, {
 					notifyClient: expect.anything(),
 					personalisation: {
@@ -595,7 +592,7 @@ describe('appeal timetables routes', () => {
 					recipientEmail: householdAppeal.appellant.email,
 					templateName: 'appeal-valid-start-case-appellant'
 				});
-				// eslint-disable-next-line no-undef
+
 				expect(mockNotifySend).toHaveBeenNthCalledWith(2, {
 					notifyClient: expect.anything(),
 					personalisation: {
@@ -682,9 +679,8 @@ describe('appeal timetables routes', () => {
 						});
 					});
 
-					// eslint-disable-next-line no-undef
 					expect(mockNotifySend).toHaveBeenCalledTimes(2);
-					// eslint-disable-next-line no-undef
+
 					expect(mockNotifySend).toHaveBeenNthCalledWith(1, {
 						notifyClient: expect.anything(),
 						personalisation: {
@@ -712,7 +708,7 @@ describe('appeal timetables routes', () => {
 						recipientEmail: appeal.appellant.email,
 						templateName: 'appeal-valid-start-case-s78-appellant'
 					});
-					// eslint-disable-next-line no-undef
+
 					expect(mockNotifySend).toHaveBeenNthCalledWith(2, {
 						notifyClient: expect.anything(),
 						personalisation: {

--- a/appeals/api/src/server/endpoints/appellant-cases/__tests__/appellant-cases.test.js
+++ b/appeals/api/src/server/endpoints/appellant-cases/__tests__/appellant-cases.test.js
@@ -289,7 +289,6 @@ describe('appellant cases routes', () => {
 					}
 				});
 
-				// eslint-disable-next-line no-undef
 				expect(mockNotifySend).toHaveBeenCalledTimes(1);
 
 				expect(response.status).toEqual(200);
@@ -373,7 +372,6 @@ describe('appellant cases routes', () => {
 					}
 				);
 
-				// eslint-disable-next-line no-undef
 				expect(mockNotifySend).toHaveBeenCalledTimes(1);
 
 				expect(response.status).toEqual(200);
@@ -465,7 +463,6 @@ describe('appellant cases routes', () => {
 					}
 				});
 
-				// eslint-disable-next-line no-undef
 				expect(mockNotifySend).toHaveBeenCalledTimes(1);
 
 				expect(response.status).toEqual(200);
@@ -536,7 +533,6 @@ describe('appellant cases routes', () => {
 					}
 				});
 
-				// eslint-disable-next-line no-undef
 				expect(mockNotifySend).toHaveBeenCalledTimes(1);
 
 				expect(response.status).toEqual(200);
@@ -572,9 +568,8 @@ describe('appellant cases routes', () => {
 					.send(body)
 					.set('azureAdUserId', azureAdUserId);
 
-				// eslint-disable-next-line no-undef
 				expect(mockNotifySend).toHaveBeenCalledTimes(1);
-				// eslint-disable-next-line no-undef
+
 				expect(mockNotifySend).toHaveBeenNthCalledWith(1, {
 					notifyClient: expect.anything(),
 					personalisation: {
@@ -666,7 +661,6 @@ describe('appellant cases routes', () => {
 					]
 				});
 
-				// eslint-disable-next-line no-undef
 				expect(mockNotifySend).toHaveBeenCalledTimes(1);
 
 				expect(response.status).toEqual(200);
@@ -744,7 +738,6 @@ describe('appellant cases routes', () => {
 					]
 				});
 
-				// eslint-disable-next-line no-undef
 				expect(mockNotifySend).toHaveBeenCalledTimes(1);
 
 				expect(response.status).toEqual(200);
@@ -802,7 +795,6 @@ describe('appellant cases routes', () => {
 					})
 				});
 
-				// eslint-disable-next-line no-undef
 				expect(mockNotifySend).toHaveBeenCalledTimes(1);
 
 				expect(response.status).toEqual(200);
@@ -840,9 +832,8 @@ describe('appellant cases routes', () => {
 					.send(body)
 					.set('azureAdUserId', azureAdUserId);
 
-				// eslint-disable-next-line no-undef
 				expect(mockNotifySend).toHaveBeenCalledTimes(1);
-				// eslint-disable-next-line no-undef
+
 				expect(mockNotifySend).toHaveBeenNthCalledWith(1, {
 					notifyClient: expect.anything(),
 					personalisation: {
@@ -918,9 +909,8 @@ describe('appellant cases routes', () => {
 					}
 				});
 
-				// eslint-disable-next-line no-undef
 				expect(mockNotifySend).toHaveBeenCalledTimes(1);
-				// eslint-disable-next-line no-undef
+
 				expect(mockNotifySend).toHaveBeenNthCalledWith(1, {
 					notifyClient: expect.anything(),
 					personalisation: {

--- a/appeals/api/src/server/endpoints/change-appeal-type/__tests__/change-appeal-type.test.js
+++ b/appeals/api/src/server/endpoints/change-appeal-type/__tests__/change-appeal-type.test.js
@@ -249,10 +249,8 @@ describe('appeal change type resubmit routes', () => {
 				}
 			});
 
-			// eslint-disable-next-line no-undef
 			expect(mockNotifySend).toHaveBeenCalledTimes(1);
 
-			// eslint-disable-next-line no-undef
 			expect(mockNotifySend).toHaveBeenNthCalledWith(1, {
 				notifyClient: expect.anything(),
 				personalisation: {

--- a/appeals/api/src/server/endpoints/decision/__tests__/decision.test.js
+++ b/appeals/api/src/server/endpoints/decision/__tests__/decision.test.js
@@ -233,10 +233,8 @@ describe('decision routes', () => {
 				})
 				.set('azureAdUserId', azureAdUserId);
 
-			// eslint-disable-next-line no-undef
 			expect(mockNotifySend).toHaveBeenCalledTimes(2);
 
-			// eslint-disable-next-line no-undef
 			expect(mockNotifySend).toHaveBeenNthCalledWith(1, {
 				notifyClient: expect.any(Object),
 				templateName: 'decision-is-allowed-split-dismissed-appellant',
@@ -250,7 +248,6 @@ describe('decision routes', () => {
 				recipientEmail: appeal.agent.email
 			});
 
-			// eslint-disable-next-line no-undef
 			expect(mockNotifySend).toHaveBeenNthCalledWith(2, {
 				notifyClient: expect.any(Object),
 				personalisation: {
@@ -359,7 +356,6 @@ describe('decision routes', () => {
 				decisionDate
 			);
 
-			// eslint-disable-next-line no-undef
 			expect(mockNotifySend).toHaveBeenCalledTimes(5);
 
 			const expectedRecipients = [
@@ -371,7 +367,6 @@ describe('decision routes', () => {
 			];
 
 			expectedRecipients.forEach((recipient) => {
-				// eslint-disable-next-line no-undef
 				expect(mockNotifySend).toHaveBeenCalledWith({
 					notifyClient: expect.any(Object),
 					templateName: 'correction-notice-decision',
@@ -425,10 +420,8 @@ describe('decision routes', () => {
 				decisionDate
 			);
 
-			// eslint-disable-next-line no-undef
 			expect(mockNotifySend).toHaveBeenCalledTimes(1);
 
-			// eslint-disable-next-line no-undef
 			expect(mockNotifySend).toHaveBeenCalledWith({
 				notifyClient: expect.any(Object),
 				templateName: 'correction-notice-decision',

--- a/appeals/api/src/server/endpoints/hearings/__tests__/hearing.test.js
+++ b/appeals/api/src/server/endpoints/hearings/__tests__/hearing.test.js
@@ -206,16 +206,16 @@ describe('hearing routes', () => {
 					hearing_address:
 						'Court 2, 24 Court Street, Test Town, Test County, AB12 3CD, United Kingdom'
 				};
-				// eslint-disable-next-line no-undef
+
 				expect(mockNotifySend).toHaveBeenCalledTimes(2);
-				// eslint-disable-next-line no-undef
+
 				expect(mockNotifySend).toHaveBeenNthCalledWith(1, {
 					notifyClient: expect.anything(),
 					personalisation,
 					recipientEmail: fullPlanningAppeal.appellant.email,
 					templateName: 'hearing-updated'
 				});
-				// eslint-disable-next-line no-undef
+
 				expect(mockNotifySend).toHaveBeenNthCalledWith(2, {
 					notifyClient: expect.anything(),
 					personalisation,
@@ -308,16 +308,16 @@ describe('hearing routes', () => {
 					hearing_address:
 						'Court 2, 24 Court Street, Test Town, Test County, AB12 3CD, United Kingdom'
 				};
-				// eslint-disable-next-line no-undef
+
 				expect(mockNotifySend).toHaveBeenCalledTimes(2);
-				// eslint-disable-next-line no-undef
+
 				expect(mockNotifySend).toHaveBeenNthCalledWith(1, {
 					notifyClient: expect.anything(),
 					personalisation,
 					recipientEmail: fullPlanningAppeal.appellant.email,
 					templateName: 'hearing-updated'
 				});
-				// eslint-disable-next-line no-undef
+
 				expect(mockNotifySend).toHaveBeenNthCalledWith(2, {
 					notifyClient: expect.anything(),
 					personalisation,
@@ -360,7 +360,7 @@ describe('hearing routes', () => {
 						address: true
 					}
 				});
-				// eslint-disable-next-line no-undef
+
 				expect(mockNotifySend).not.toHaveBeenCalled();
 
 				expect(response.status).toEqual(201);
@@ -1064,16 +1064,16 @@ describe('hearing routes', () => {
 					hearing_address:
 						'Court 2, 24 Court Street, Test Town, Test County, AB12 3CD, United Kingdom'
 				};
-				// eslint-disable-next-line no-undef
+
 				expect(mockNotifySend).toHaveBeenCalledTimes(2);
-				// eslint-disable-next-line no-undef
+
 				expect(mockNotifySend).toHaveBeenNthCalledWith(1, {
 					notifyClient: expect.anything(),
 					personalisation,
 					recipientEmail: fullPlanningAppeal.appellant.email,
 					templateName: 'hearing-set-up'
 				});
-				// eslint-disable-next-line no-undef
+
 				expect(mockNotifySend).toHaveBeenNthCalledWith(2, {
 					notifyClient: expect.anything(),
 					personalisation,
@@ -1113,7 +1113,6 @@ describe('hearing routes', () => {
 					}
 				});
 
-				// eslint-disable-next-line no-undef
 				expect(mockNotifySend).not.toHaveBeenCalled();
 
 				expect(response.status).toEqual(201);
@@ -1734,16 +1733,16 @@ describe('hearing routes', () => {
 					site_address: '96 The Avenue, Leftfield, Maidstone, Kent, MD21 5XY, United Kingdom',
 					lpa_reference: '48269/APP/2021/1482'
 				};
-				// eslint-disable-next-line no-undef
+
 				expect(mockNotifySend).toHaveBeenCalledTimes(2);
-				// eslint-disable-next-line no-undef
+
 				expect(mockNotifySend).toHaveBeenNthCalledWith(1, {
 					notifyClient: expect.anything(),
 					personalisation,
 					recipientEmail: fullPlanningAppeal.appellant.email,
 					templateName: 'hearing-cancelled'
 				});
-				// eslint-disable-next-line no-undef
+
 				expect(mockNotifySend).toHaveBeenNthCalledWith(2, {
 					notifyClient: expect.anything(),
 					personalisation,

--- a/appeals/api/src/server/endpoints/invalid-appeal-decision/__tests__/invalid-appeal-decision.test.js
+++ b/appeals/api/src/server/endpoints/invalid-appeal-decision/__tests__/invalid-appeal-decision.test.js
@@ -115,10 +115,8 @@ describe('invalid appeal decision routes', () => {
 				})
 				.set('azureAdUserId', azureAdUserId);
 
-			// eslint-disable-next-line no-undef
 			expect(mockNotifySend).toHaveBeenCalledTimes(2);
 
-			// eslint-disable-next-line no-undef
 			expect(mockNotifySend).toHaveBeenNthCalledWith(1, {
 				notifyClient: expect.any(Object),
 				personalisation: {
@@ -132,7 +130,6 @@ describe('invalid appeal decision routes', () => {
 				templateName: 'decision-is-invalid-appellant'
 			});
 
-			// eslint-disable-next-line no-undef
 			expect(mockNotifySend).toHaveBeenNthCalledWith(2, {
 				notifyClient: expect.any(Object),
 				personalisation: {

--- a/appeals/api/src/server/endpoints/lpa-questionnaires/__tests__/lpa-questionnaires.test.js
+++ b/appeals/api/src/server/endpoints/lpa-questionnaires/__tests__/lpa-questionnaires.test.js
@@ -236,7 +236,6 @@ describe('lpa questionnaires routes', () => {
 					databaseConnector.lPAQuestionnaireIncompleteReasonsSelected.update
 				).not.toHaveBeenCalled();
 
-				// eslint-disable-next-line no-undef
 				expect(mockNotifySend).toHaveBeenCalledTimes(2);
 
 				expect(response.status).toEqual(200);
@@ -321,9 +320,8 @@ describe('lpa questionnaires routes', () => {
 						.send(body)
 						.set('azureAdUserId', azureAdUserId);
 
-					// eslint-disable-next-line no-undef
 					expect(mockNotifySend).toHaveBeenCalledTimes(2);
-					// eslint-disable-next-line no-undef
+
 					expect(mockNotifySend).toHaveBeenNthCalledWith(1, {
 						notifyClient: expect.anything(),
 						personalisation: {
@@ -335,7 +333,6 @@ describe('lpa questionnaires routes', () => {
 						templateName: 'lpaq-complete-lpa'
 					});
 
-					// eslint-disable-next-line no-undef
 					expect(mockNotifySend).toHaveBeenNthCalledWith(2, {
 						notifyClient: expect.anything(),
 						personalisation: test.personalisation,
@@ -982,9 +979,8 @@ describe('lpa questionnaires routes', () => {
 					.send(body)
 					.set('azureAdUserId', azureAdUserId);
 
-				// eslint-disable-next-line no-undef
 				expect(mockNotifySend).toHaveBeenCalledTimes(1);
-				// eslint-disable-next-line no-undef
+
 				expect(mockNotifySend).toHaveBeenCalledWith({
 					notifyClient: expect.anything(),
 					personalisation: {

--- a/appeals/api/src/server/endpoints/representations/__tests__/representations.test.js
+++ b/appeals/api/src/server/endpoints/representations/__tests__/representations.test.js
@@ -236,10 +236,8 @@ describe('/appeals/:id/reps', () => {
 
 			expect(response.status).toEqual(200);
 
-			// eslint-disable-next-line no-undef
 			expect(mockNotifySend).toHaveBeenCalledTimes(1);
 
-			// eslint-disable-next-line no-undef
 			expect(mockNotifySend).toHaveBeenCalledWith({
 				notifyClient: expect.anything(),
 				personalisation: expectedEmailPayload,
@@ -329,10 +327,8 @@ describe('/appeals/:id/reps', () => {
 
 			expect(response.status).toEqual(200);
 
-			// eslint-disable-next-line no-undef
 			expect(mockNotifySend).toHaveBeenCalledTimes(1);
 
-			// eslint-disable-next-line no-undef
 			expect(mockNotifySend).toHaveBeenCalledWith({
 				notifyClient: expect.anything(),
 				personalisation: expectedEmailPayload,
@@ -768,10 +764,8 @@ describe('/appeals/:id/reps/publish', () => {
 
 			expect(response.status).toEqual(200);
 
-			// eslint-disable-next-line no-undef
 			expect(mockNotifySend).toHaveBeenCalledTimes(2);
 
-			// eslint-disable-next-line no-undef
 			expect(mockNotifySend).toHaveBeenNthCalledWith(1, {
 				notifyClient: expect.anything(),
 				personalisation: {
@@ -785,7 +779,6 @@ describe('/appeals/:id/reps/publish', () => {
 				templateName: 'received-statement-and-ip-comments-lpa'
 			});
 
-			// eslint-disable-next-line no-undef
 			expect(mockNotifySend).toHaveBeenNthCalledWith(2, {
 				notifyClient: expect.anything(),
 				personalisation: {
@@ -845,10 +838,8 @@ describe('/appeals/:id/reps/publish', () => {
 
 			expect(response.status).toEqual(200);
 
-			// eslint-disable-next-line no-undef
 			expect(mockNotifySend).toHaveBeenCalledTimes(2);
 
-			// eslint-disable-next-line no-undef
 			expect(mockNotifySend).toHaveBeenNthCalledWith(1, {
 				notifyClient: expect.anything(),
 				personalisation: {
@@ -861,7 +852,6 @@ describe('/appeals/:id/reps/publish', () => {
 				templateName: 'received-statement-and-ip-comments-lpa'
 			});
 
-			// eslint-disable-next-line no-undef
 			expect(mockNotifySend).toHaveBeenNthCalledWith(2, {
 				notifyClient: expect.anything(),
 				personalisation: {
@@ -923,10 +913,8 @@ describe('/appeals/:id/reps/publish', () => {
 
 			expect(response.status).toEqual(200);
 
-			// eslint-disable-next-line no-undef
 			expect(mockNotifySend).toHaveBeenCalledTimes(2);
 
-			// eslint-disable-next-line no-undef
 			expect(mockNotifySend).toHaveBeenNthCalledWith(1, {
 				notifyClient: expect.anything(),
 				personalisation: {
@@ -939,7 +927,6 @@ describe('/appeals/:id/reps/publish', () => {
 				templateName: 'received-statement-and-ip-comments-lpa'
 			});
 
-			// eslint-disable-next-line no-undef
 			expect(mockNotifySend).toHaveBeenNthCalledWith(2, {
 				notifyClient: expect.anything(),
 				personalisation: {
@@ -1040,10 +1027,8 @@ describe('/appeals/:id/reps/publish', () => {
 
 			expect(response.status).toEqual(200);
 
-			// eslint-disable-next-line no-undef
 			expect(mockNotifySend).toHaveBeenCalledTimes(2);
 
-			// eslint-disable-next-line no-undef
 			expect(mockNotifySend).toHaveBeenNthCalledWith(1, {
 				notifyClient: expect.anything(),
 				personalisation: {
@@ -1054,7 +1039,6 @@ describe('/appeals/:id/reps/publish', () => {
 				templateName: 'final-comments-done-lpa'
 			});
 
-			// eslint-disable-next-line no-undef
 			expect(mockNotifySend).toHaveBeenNthCalledWith(2, {
 				notifyClient: expect.anything(),
 				personalisation: {

--- a/appeals/api/src/server/endpoints/site-visits/__tests__/site-visits.test.js
+++ b/appeals/api/src/server/endpoints/site-visits/__tests__/site-visits.test.js
@@ -328,10 +328,8 @@ describe('site visit routes', () => {
 						visitType: siteVisit.siteVisitType.name
 					});
 
-					// eslint-disable-next-line no-undef
 					expect(mockNotifySend).toHaveBeenCalledTimes(1);
 
-					// eslint-disable-next-line no-undef
 					expect(mockNotifySend).toHaveBeenCalledWith({
 						notifyClient: expect.any(Object),
 						templateName: 'site-visit-schedule-unaccompanied-appellant',
@@ -384,10 +382,8 @@ describe('site visit routes', () => {
 						visitType: siteVisit.siteVisitType.name
 					});
 
-					// eslint-disable-next-line no-undef
 					expect(mockNotifySend).toHaveBeenCalledTimes(2);
 
-					// eslint-disable-next-line no-undef
 					expect(mockNotifySend).toHaveBeenCalledWith({
 						notifyClient: expect.any(Object),
 						templateName: 'site-visit-schedule-accompanied-appellant',
@@ -403,7 +399,6 @@ describe('site visit routes', () => {
 						recipientEmail: appeal.agent.email
 					});
 
-					// eslint-disable-next-line no-undef
 					expect(mockNotifySend).toHaveBeenCalledWith({
 						notifyClient: expect.any(Object),
 						templateName: 'site-visit-schedule-accompanied-lpa',
@@ -459,10 +454,8 @@ describe('site visit routes', () => {
 						...visitData
 					});
 
-					// eslint-disable-next-line no-undef
 					expect(mockNotifySend).toHaveBeenCalledTimes(1);
 
-					// eslint-disable-next-line no-undef
 					expect(mockNotifySend).toHaveBeenCalledWith({
 						notifyClient: expect.any(Object),
 						templateName: 'site-visit-schedule-access-required-appellant',
@@ -922,7 +915,6 @@ describe('site visit routes', () => {
 					visitType: siteVisit.siteVisitType.name
 				});
 
-				// eslint-disable-next-line no-undef
 				expect(mockNotifySend).not.toHaveBeenCalled();
 			});
 
@@ -1153,7 +1145,6 @@ describe('site visit routes', () => {
 					previousVisitType: 'Accompanied'
 				});
 
-				// eslint-disable-next-line no-undef
 				expect(mockNotifySend).toHaveBeenCalledTimes(0);
 				expect(response.status).toEqual(200);
 			});
@@ -1210,7 +1201,6 @@ describe('site visit routes', () => {
 					previousVisitType: SITE_VISIT_TYPE_ACCOMPANIED
 				});
 
-				// eslint-disable-next-line no-undef
 				expect(mockNotifySend).not.toHaveBeenCalled();
 			});
 
@@ -1268,10 +1258,8 @@ describe('site visit routes', () => {
 					siteVisitChangeType: 'visit-type'
 				});
 
-				// eslint-disable-next-line no-undef
 				expect(mockNotifySend).toHaveBeenCalledTimes(1);
 
-				// eslint-disable-next-line no-undef
 				expect(mockNotifySend).toHaveBeenCalledWith({
 					notifyClient: expect.any(Object),
 					templateName: 'site-visit-change-unaccompanied-to-access-required-appellant',
@@ -1347,10 +1335,8 @@ describe('site visit routes', () => {
 						siteVisitChangeType: 'all'
 					});
 
-					// eslint-disable-next-line no-undef
 					expect(mockNotifySend).toHaveBeenCalledTimes(2);
 
-					// eslint-disable-next-line no-undef
 					expect(mockNotifySend).toHaveBeenCalledWith({
 						notifyClient: expect.any(Object),
 						templateName: 'site-visit-change-accompanied-to-unaccompanied-appellant',
@@ -1366,7 +1352,6 @@ describe('site visit routes', () => {
 						recipientEmail: appeal.agent.email
 					});
 
-					// eslint-disable-next-line no-undef
 					expect(mockNotifySend).toHaveBeenCalledWith({
 						notifyClient: expect.any(Object),
 						templateName: 'site-visit-change-accompanied-to-unaccompanied-lpa',
@@ -1444,10 +1429,8 @@ describe('site visit routes', () => {
 						siteVisitChangeType: 'date-time'
 					});
 
-					// eslint-disable-next-line no-undef
 					expect(mockNotifySend).toHaveBeenCalledTimes(1);
 
-					// eslint-disable-next-line no-undef
 					expect(mockNotifySend).toHaveBeenCalledWith({
 						notifyClient: expect.any(Object),
 						templateName: 'site-visit-change-access-required-date-change-appellant',
@@ -1524,10 +1507,8 @@ describe('site visit routes', () => {
 						siteVisitChangeType: 'date-time'
 					});
 
-					// eslint-disable-next-line no-undef
 					expect(mockNotifySend).toHaveBeenCalledTimes(2);
 
-					// eslint-disable-next-line no-undef
 					expect(mockNotifySend).toHaveBeenCalledWith({
 						notifyClient: expect.any(Object),
 						templateName: 'site-visit-change-accompanied-date-change-appellant',
@@ -1543,7 +1524,6 @@ describe('site visit routes', () => {
 						recipientEmail: appeal.agent.email
 					});
 
-					// eslint-disable-next-line no-undef
 					expect(mockNotifySend).toHaveBeenCalledWith({
 						notifyClient: expect.any(Object),
 						templateName: 'site-visit-change-accompanied-date-change-lpa',
@@ -1620,10 +1600,8 @@ describe('site visit routes', () => {
 						siteVisitChangeType: 'visit-type'
 					});
 
-					// eslint-disable-next-line no-undef
 					expect(mockNotifySend).toHaveBeenCalledTimes(2);
 
-					// eslint-disable-next-line no-undef
 					expect(mockNotifySend).toHaveBeenCalledWith({
 						notifyClient: expect.any(Object),
 						templateName: 'site-visit-change-accompanied-to-unaccompanied-appellant',
@@ -1639,7 +1617,6 @@ describe('site visit routes', () => {
 						recipientEmail: appeal.agent.email
 					});
 
-					// eslint-disable-next-line no-undef
 					expect(mockNotifySend).toHaveBeenCalledWith({
 						notifyClient: expect.any(Object),
 						templateName: 'site-visit-change-accompanied-to-unaccompanied-lpa',
@@ -1716,10 +1693,8 @@ describe('site visit routes', () => {
 						siteVisitChangeType: 'visit-type'
 					});
 
-					// eslint-disable-next-line no-undef
 					expect(mockNotifySend).toHaveBeenCalledTimes(2);
 
-					// eslint-disable-next-line no-undef
 					expect(mockNotifySend).toHaveBeenCalledWith({
 						notifyClient: expect.any(Object),
 						templateName: 'site-visit-change-unaccompanied-to-accompanied-appellant',
@@ -1735,7 +1710,6 @@ describe('site visit routes', () => {
 						recipientEmail: appeal.agent.email
 					});
 
-					// eslint-disable-next-line no-undef
 					expect(mockNotifySend).toHaveBeenCalledWith({
 						notifyClient: expect.any(Object),
 						templateName: 'site-visit-change-unaccompanied-to-accompanied-lpa',
@@ -1813,10 +1787,8 @@ describe('site visit routes', () => {
 						siteVisitChangeType: 'visit-type'
 					});
 
-					// eslint-disable-next-line no-undef
 					expect(mockNotifySend).toHaveBeenCalledTimes(2);
 
-					// eslint-disable-next-line no-undef
 					expect(mockNotifySend).toHaveBeenCalledWith({
 						notifyClient: expect.any(Object),
 						templateName: 'site-visit-change-access-required-to-accompanied-appellant',
@@ -1832,7 +1804,6 @@ describe('site visit routes', () => {
 						recipientEmail: appeal.agent.email
 					});
 
-					// eslint-disable-next-line no-undef
 					expect(mockNotifySend).toHaveBeenCalledWith({
 						notifyClient: expect.any(Object),
 						templateName: 'site-visit-change-access-required-to-accompanied-lpa',
@@ -1909,10 +1880,8 @@ describe('site visit routes', () => {
 						siteVisitChangeType: 'visit-type'
 					});
 
-					// eslint-disable-next-line no-undef
 					expect(mockNotifySend).toHaveBeenCalledTimes(2);
 
-					// eslint-disable-next-line no-undef
 					expect(mockNotifySend).toHaveBeenCalledWith({
 						notifyClient: expect.any(Object),
 						templateName: 'site-visit-change-accompanied-to-access-required-appellant',
@@ -1928,7 +1897,6 @@ describe('site visit routes', () => {
 						recipientEmail: appeal.agent.email
 					});
 
-					// eslint-disable-next-line no-undef
 					expect(mockNotifySend).toHaveBeenCalledWith({
 						notifyClient: expect.any(Object),
 						templateName: 'site-visit-change-accompanied-to-access-required-lpa',
@@ -2005,10 +1973,8 @@ describe('site visit routes', () => {
 						siteVisitChangeType: 'visit-type'
 					});
 
-					// eslint-disable-next-line no-undef
 					expect(mockNotifySend).toHaveBeenCalledTimes(1);
 
-					// eslint-disable-next-line no-undef
 					expect(mockNotifySend).toHaveBeenCalledWith({
 						notifyClient: expect.any(Object),
 						templateName: 'site-visit-change-access-required-to-unaccompanied-appellant',
@@ -2086,10 +2052,8 @@ describe('site visit routes', () => {
 						siteVisitChangeType: 'visit-type'
 					});
 
-					// eslint-disable-next-line no-undef
 					expect(mockNotifySend).toHaveBeenCalledTimes(1);
 
-					// eslint-disable-next-line no-undef
 					expect(mockNotifySend).toHaveBeenCalledWith({
 						notifyClient: expect.any(Object),
 						templateName: 'site-visit-change-unaccompanied-to-access-required-appellant',
@@ -2141,7 +2105,6 @@ describe('site visit routes', () => {
 					}
 				});
 
-				// eslint-disable-next-line no-undef
 				expect(mockNotifySend).not.toHaveBeenCalled();
 			});
 
@@ -2163,7 +2126,6 @@ describe('site visit routes', () => {
 					}
 				});
 
-				// eslint-disable-next-line no-undef
 				expect(mockNotifySend).not.toHaveBeenCalled();
 			});
 
@@ -2185,7 +2147,6 @@ describe('site visit routes', () => {
 					}
 				});
 
-				// eslint-disable-next-line no-undef
 				expect(mockNotifySend).not.toHaveBeenCalled();
 			});
 
@@ -2207,7 +2168,6 @@ describe('site visit routes', () => {
 					}
 				});
 
-				// eslint-disable-next-line no-undef
 				expect(mockNotifySend).not.toHaveBeenCalled();
 			});
 
@@ -2231,7 +2191,6 @@ describe('site visit routes', () => {
 					}
 				});
 
-				// eslint-disable-next-line no-undef
 				expect(mockNotifySend).not.toHaveBeenCalled();
 			});
 
@@ -2257,7 +2216,6 @@ describe('site visit routes', () => {
 					}
 				});
 
-				// eslint-disable-next-line no-undef
 				expect(mockNotifySend).not.toHaveBeenCalled();
 			});
 
@@ -2283,7 +2241,6 @@ describe('site visit routes', () => {
 					}
 				});
 
-				// eslint-disable-next-line no-undef
 				expect(mockNotifySend).not.toHaveBeenCalled();
 			});
 
@@ -2309,7 +2266,6 @@ describe('site visit routes', () => {
 					}
 				});
 
-				// eslint-disable-next-line no-undef
 				expect(mockNotifySend).not.toHaveBeenCalled();
 			});
 
@@ -2364,7 +2320,6 @@ describe('site visit routes', () => {
 					siteVisitChangeType: 'unchanged'
 				});
 
-				// eslint-disable-next-line no-undef
 				expect(mockNotifySend).not.toHaveBeenCalled();
 			});
 
@@ -2391,7 +2346,6 @@ describe('site visit routes', () => {
 					}
 				});
 
-				// eslint-disable-next-line no-undef
 				expect(mockNotifySend).not.toHaveBeenCalled();
 			});
 
@@ -2418,7 +2372,6 @@ describe('site visit routes', () => {
 					}
 				});
 
-				// eslint-disable-next-line no-undef
 				expect(mockNotifySend).not.toHaveBeenCalled();
 			});
 
@@ -2443,7 +2396,6 @@ describe('site visit routes', () => {
 					}
 				});
 
-				// eslint-disable-next-line no-undef
 				expect(mockNotifySend).not.toHaveBeenCalled();
 			});
 
@@ -2468,7 +2420,6 @@ describe('site visit routes', () => {
 					}
 				});
 
-				// eslint-disable-next-line no-undef
 				expect(mockNotifySend).not.toHaveBeenCalled();
 			});
 
@@ -2495,7 +2446,6 @@ describe('site visit routes', () => {
 					}
 				});
 
-				// eslint-disable-next-line no-undef
 				expect(mockNotifySend).not.toHaveBeenCalled();
 			});
 		});

--- a/appeals/api/src/server/endpoints/withdrawal/__tests__/withdrawal.test.js
+++ b/appeals/api/src/server/endpoints/withdrawal/__tests__/withdrawal.test.js
@@ -86,10 +86,8 @@ describe('appeal withdrawal routes', () => {
 				})
 				.set('azureAdUserId', azureAdUserId);
 
-			// eslint-disable-next-line no-undef
 			expect(mockNotifySend).toHaveBeenCalledTimes(2);
 
-			// eslint-disable-next-line no-undef
 			expect(mockNotifySend).toHaveBeenCalledWith({
 				notifyClient: expect.anything(),
 				personalisation: {
@@ -104,7 +102,6 @@ describe('appeal withdrawal routes', () => {
 				templateName: 'appeal-withdrawn-appellant'
 			});
 
-			// eslint-disable-next-line no-undef
 			expect(mockNotifySend).toHaveBeenCalledWith({
 				notifyClient: expect.anything(),
 				personalisation: {


### PR DESCRIPTION
## Describe your changes

Due to the function "mockNotifySend" now being included as a global in .eslintrc.cjs for our jest tests, the eslint-disable-next-line comment can be removed everywhere the function is used.

Unit tests have been successfully run and tscheck also passes.
