### PR TITLE
feat(web): field highlighting and messages for date errors

### DIFF
--- a/appeals/web/src/server/appeals/appeal-details/appeal-timetables/__tests__/__snapshots__/appeal-timetables.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/appeal-timetables/__tests__/__snapshots__/appeal-timetables.test.js.snap
@@ -190,7 +190,7 @@ exports[`Appeal Timetables should render "Change final comments due date" with e
                 <div class="govuk-date-input__item">
                     <div class="govuk-form-group">
                         <label class="govuk-label govuk-date-input__label" for="due-date-day">Day</label>
-                        <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input govuk-input--error govuk-input--error"
+                        <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input govuk-input--error"
                         id="due-date-day" name="due-date-day" type="text" value="9" inputmode="numeric">
                     </div>
                 </div>

--- a/appeals/web/src/server/appeals/appeal-details/appellant-case/__tests__/__snapshots__/appellant-case.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/appellant-case/__tests__/__snapshots__/appellant-case.test.js.snap
@@ -6538,7 +6538,7 @@ exports[`appellant-case POST /appellant-case/incomplete/date should re-render th
                 <div class="govuk-date-input__item">
                     <div class="govuk-form-group">
                         <label class="govuk-label govuk-date-input__label" for="due-date-day">Day</label>
-                        <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input govuk-input--error govuk-input--error"
+                        <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input govuk-input--error"
                         id="due-date-day" name="due-date-day" type="text" value="29" inputmode="numeric">
                     </div>
                 </div>
@@ -7083,7 +7083,7 @@ exports[`appellant-case POST /appellant-case/incomplete/date should re-render th
                 <div class="govuk-date-input__item">
                     <div class="govuk-form-group">
                         <label class="govuk-label govuk-date-input__label" for="due-date-day">Day</label>
-                        <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input govuk-input--error govuk-input--error"
+                        <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input govuk-input--error"
                         id="due-date-day" name="due-date-day" type="text" value="" inputmode="numeric">
                     </div>
                 </div>
@@ -7144,7 +7144,7 @@ exports[`appellant-case POST /appellant-case/incomplete/date should re-render th
                 <div class="govuk-date-input__item">
                     <div class="govuk-form-group">
                         <label class="govuk-label govuk-date-input__label" for="due-date-day">Day</label>
-                        <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input govuk-input--error govuk-input--error"
+                        <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input govuk-input--error"
                         id="due-date-day" name="due-date-day" type="text" value="1" inputmode="numeric">
                     </div>
                 </div>
@@ -8146,7 +8146,7 @@ exports[`appellant-case POST /appellant-case/valid/date should re-render the val
                                 <div class="govuk-date-input__item">
                                     <div class="govuk-form-group">
                                         <label class="govuk-label govuk-date-input__label" for="valid-date-day">Day</label>
-                                        <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input govuk-input--error govuk-input--error"
+                                        <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input govuk-input--error"
                                         id="valid-date-day" name="valid-date-day" type="text" value="29" inputmode="numeric">
                                     </div>
                                 </div>
@@ -8570,7 +8570,7 @@ exports[`appellant-case POST /appellant-case/valid/date should re-render the val
                                 <div class="govuk-date-input__item">
                                     <div class="govuk-form-group">
                                         <label class="govuk-label govuk-date-input__label" for="valid-date-day">Day</label>
-                                        <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input govuk-input--error govuk-input--error"
+                                        <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input govuk-input--error"
                                         id="valid-date-day" name="valid-date-day" type="text" value="1" inputmode="numeric">
                                     </div>
                                 </div>
@@ -8640,7 +8640,7 @@ exports[`appellant-case POST /appellant-case/valid/date should re-render the val
                                 <div class="govuk-date-input__item">
                                     <div class="govuk-form-group">
                                         <label class="govuk-label govuk-date-input__label" for="valid-date-day">Day</label>
-                                        <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input govuk-input--error govuk-input--error"
+                                        <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input govuk-input--error"
                                         id="valid-date-day" name="valid-date-day" type="text" value="21" inputmode="numeric">
                                     </div>
                                 </div>
@@ -8711,7 +8711,7 @@ exports[`appellant-case POST /appellant-case/valid/date should re-render the val
                                 <div class="govuk-date-input__item">
                                     <div class="govuk-form-group">
                                         <label class="govuk-label govuk-date-input__label" for="valid-date-day">Day</label>
-                                        <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input govuk-input--error govuk-input--error"
+                                        <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input govuk-input--error"
                                         id="valid-date-day" name="valid-date-day" type="text" value="1" inputmode="numeric">
                                     </div>
                                 </div>

--- a/appeals/web/src/server/appeals/appeal-details/appellant-case/application-submission-date/__tests__/__snapshots__/application-submission-date.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/appellant-case/application-submission-date/__tests__/__snapshots__/application-submission-date.test.js.snap
@@ -891,7 +891,7 @@ exports[`application-submission-date POST /change should re-render the Date page
                                     <div class="govuk-date-input__item">
                                         <div class="govuk-form-group">
                                             <label class="govuk-label govuk-date-input__label" for="application-submission-date-day">Day</label>
-                                            <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input govuk-input--error govuk-input--error"
+                                            <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input govuk-input--error"
                                             id="application-submission-date-day" name="application-submission-date-day"
                                             type="text" value="" inputmode="numeric">
                                         </div>

--- a/appeals/web/src/server/appeals/appeal-details/change-appeal-type/__tests__/__snapshots__/change-appeal-type.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/change-appeal-type/__tests__/__snapshots__/change-appeal-type.test.js.snap
@@ -570,7 +570,7 @@ exports[`change-appeal-type should re-render the final date page with an error m
                                     <div class="govuk-date-input__item">
                                         <div class="govuk-form-group">
                                             <label class="govuk-label govuk-date-input__label" for="change-appeal-final-date-day">Day</label>
-                                            <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input govuk-input--error govuk-input--error"
+                                            <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input govuk-input--error"
                                             id="change-appeal-final-date-day" name="change-appeal-final-date-day" type="text"
                                             value="29" inputmode="numeric">
                                         </div>
@@ -643,7 +643,7 @@ exports[`change-appeal-type should re-render the final date page with an error m
                                     <div class="govuk-date-input__item">
                                         <div class="govuk-form-group">
                                             <label class="govuk-label govuk-date-input__label" for="change-appeal-final-date-day">Day</label>
-                                            <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input govuk-input--error govuk-input--error"
+                                            <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input govuk-input--error"
                                             id="change-appeal-final-date-day" name="change-appeal-final-date-day" type="text"
                                             value="" inputmode="numeric">
                                         </div>
@@ -790,7 +790,7 @@ exports[`change-appeal-type should re-render the final date page with an error m
                                     <div class="govuk-date-input__item">
                                         <div class="govuk-form-group">
                                             <label class="govuk-label govuk-date-input__label" for="change-appeal-final-date-day">Day</label>
-                                            <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input govuk-input--error govuk-input--error"
+                                            <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input govuk-input--error"
                                             id="change-appeal-final-date-day" name="change-appeal-final-date-day" type="text"
                                             value="4" inputmode="numeric">
                                         </div>

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/__tests__/__snapshots__/lpa-questionnaire.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/__tests__/__snapshots__/lpa-questionnaire.test.js.snap
@@ -5662,7 +5662,7 @@ exports[`LPA Questionnaire review POST /appeals-service/appeal-details/1/lpa-que
                 <div class="govuk-date-input__item">
                     <div class="govuk-form-group">
                         <label class="govuk-label govuk-date-input__label" for="due-date-day">Day</label>
-                        <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input govuk-input--error govuk-input--error"
+                        <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input govuk-input--error"
                         id="due-date-day" name="due-date-day" type="text" value="29" inputmode="numeric">
                     </div>
                 </div>
@@ -6225,7 +6225,7 @@ exports[`LPA Questionnaire review POST /appeals-service/appeal-details/1/lpa-que
                 <div class="govuk-date-input__item">
                     <div class="govuk-form-group">
                         <label class="govuk-label govuk-date-input__label" for="due-date-day">Day</label>
-                        <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input govuk-input--error govuk-input--error"
+                        <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input govuk-input--error"
                         id="due-date-day" name="due-date-day" type="text" value="" inputmode="numeric">
                     </div>
                 </div>
@@ -6288,7 +6288,7 @@ exports[`LPA Questionnaire review POST /appeals-service/appeal-details/1/lpa-que
                 <div class="govuk-date-input__item">
                     <div class="govuk-form-group">
                         <label class="govuk-label govuk-date-input__label" for="due-date-day">Day</label>
-                        <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input govuk-input--error govuk-input--error"
+                        <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input govuk-input--error"
                         id="due-date-day" name="due-date-day" type="text" value="1" inputmode="numeric">
                     </div>
                 </div>

--- a/appeals/web/src/server/appeals/appeal-details/site-visit/__tests__/__snapshots__/site-visit.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/site-visit/__tests__/__snapshots__/site-visit.test.js.snap
@@ -441,7 +441,7 @@ exports[`site-visit POST /site-visit/manage-visit should re-render the manage vi
                                     <div class="govuk-date-input__item">
                                         <div class="govuk-form-group">
                                             <label class="govuk-label govuk-date-input__label" for="visit-date-day">Day</label>
-                                            <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input govuk-input--error govuk-input--error"
+                                            <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input govuk-input--error"
                                             id="visit-date-day" name="visit-date-day" type="text" value="29" inputmode="numeric">
                                         </div>
                                     </div>
@@ -590,7 +590,7 @@ exports[`site-visit POST /site-visit/manage-visit should re-render the manage vi
                                     <div class="govuk-date-input__item">
                                         <div class="govuk-form-group">
                                             <label class="govuk-label govuk-date-input__label" for="visit-date-day">Day</label>
-                                            <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input govuk-input--error govuk-input--error"
+                                            <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input govuk-input--error"
                                             id="visit-date-day" name="visit-date-day" type="text" value="29" inputmode="numeric">
                                         </div>
                                     </div>
@@ -2373,7 +2373,7 @@ exports[`site-visit POST /site-visit/manage-visit should re-render the manage vi
                                     <div class="govuk-date-input__item">
                                         <div class="govuk-form-group">
                                             <label class="govuk-label govuk-date-input__label" for="visit-date-day">Day</label>
-                                            <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input govuk-input--error govuk-input--error"
+                                            <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input govuk-input--error"
                                             id="visit-date-day" name="visit-date-day" type="text" value="" inputmode="numeric">
                                         </div>
                                     </div>
@@ -2522,7 +2522,7 @@ exports[`site-visit POST /site-visit/schedule-visit should re-render the schedul
                                     <div class="govuk-date-input__item">
                                         <div class="govuk-form-group">
                                             <label class="govuk-label govuk-date-input__label" for="visit-date-day">Day</label>
-                                            <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input govuk-input--error govuk-input--error"
+                                            <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input govuk-input--error"
                                             id="visit-date-day" name="visit-date-day" type="text" value="29" inputmode="numeric">
                                         </div>
                                     </div>
@@ -2671,7 +2671,7 @@ exports[`site-visit POST /site-visit/schedule-visit should re-render the schedul
                                     <div class="govuk-date-input__item">
                                         <div class="govuk-form-group">
                                             <label class="govuk-label govuk-date-input__label" for="visit-date-day">Day</label>
-                                            <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input govuk-input--error govuk-input--error"
+                                            <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input govuk-input--error"
                                             id="visit-date-day" name="visit-date-day" type="text" value="29" inputmode="numeric">
                                         </div>
                                     </div>
@@ -4903,7 +4903,7 @@ exports[`site-visit POST /site-visit/schedule-visit should re-render the schedul
                                     <div class="govuk-date-input__item">
                                         <div class="govuk-form-group">
                                             <label class="govuk-label govuk-date-input__label" for="visit-date-day">Day</label>
-                                            <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input govuk-input--error govuk-input--error"
+                                            <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input govuk-input--error"
                                             id="visit-date-day" name="visit-date-day" type="text" value="" inputmode="numeric">
                                         </div>
                                     </div>

--- a/appeals/web/src/server/appeals/appeal-details/timetable/__tests__/__snapshots__/timetable.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/timetable/__tests__/__snapshots__/timetable.test.js.snap
@@ -1249,7 +1249,7 @@ exports[`Timetable POST /edit Householder should re-render edit timetable page w
                     <div class="govuk-date-input__item">
                         <div class="govuk-form-group">
                             <label class="govuk-label govuk-date-input__label" for="lpa-questionnaire-due-date-day">Day</label>
-                            <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input govuk-input--error govuk-input--error"
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input govuk-input--error"
                             id="lpa-questionnaire-due-date-day" name="lpa-questionnaire-due-date-day"
                             type="text" inputmode="numeric">
                         </div>
@@ -1316,7 +1316,7 @@ exports[`Timetable POST /edit Householder should re-render edit timetable page w
                     <div class="govuk-date-input__item">
                         <div class="govuk-form-group">
                             <label class="govuk-label govuk-date-input__label" for="lpa-questionnaire-due-date-day">Day</label>
-                            <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input govuk-input--error govuk-input--error"
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input govuk-input--error"
                             id="lpa-questionnaire-due-date-day" name="lpa-questionnaire-due-date-day"
                             type="text" inputmode="numeric">
                         </div>
@@ -2047,7 +2047,7 @@ exports[`Timetable POST /edit S78 hearing Interested party comments should re-re
                     <div class="govuk-date-input__item">
                         <div class="govuk-form-group">
                             <label class="govuk-label govuk-date-input__label" for="ip-comments-due-date-day">Day</label>
-                            <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input govuk-input--error govuk-input--error"
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input govuk-input--error"
                             id="ip-comments-due-date-day" name="ip-comments-due-date-day" type="text"
                             inputmode="numeric">
                         </div>
@@ -2246,7 +2246,7 @@ exports[`Timetable POST /edit S78 hearing Interested party comments should re-re
                     <div class="govuk-date-input__item">
                         <div class="govuk-form-group">
                             <label class="govuk-label govuk-date-input__label" for="ip-comments-due-date-day">Day</label>
-                            <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input govuk-input--error govuk-input--error"
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input govuk-input--error"
                             id="ip-comments-due-date-day" name="ip-comments-due-date-day" type="text"
                             inputmode="numeric">
                         </div>
@@ -2977,7 +2977,7 @@ exports[`Timetable POST /edit S78 hearing LPA questionnaire should re-render edi
                     <div class="govuk-date-input__item">
                         <div class="govuk-form-group">
                             <label class="govuk-label govuk-date-input__label" for="lpa-questionnaire-due-date-day">Day</label>
-                            <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input govuk-input--error govuk-input--error"
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input govuk-input--error"
                             id="lpa-questionnaire-due-date-day" name="lpa-questionnaire-due-date-day"
                             type="text" inputmode="numeric">
                         </div>
@@ -3176,7 +3176,7 @@ exports[`Timetable POST /edit S78 hearing LPA questionnaire should re-render edi
                     <div class="govuk-date-input__item">
                         <div class="govuk-form-group">
                             <label class="govuk-label govuk-date-input__label" for="lpa-questionnaire-due-date-day">Day</label>
-                            <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input govuk-input--error govuk-input--error"
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input govuk-input--error"
                             id="lpa-questionnaire-due-date-day" name="lpa-questionnaire-due-date-day"
                             type="text" inputmode="numeric">
                         </div>
@@ -3347,9 +3347,7 @@ exports[`Timetable POST /edit S78 hearing Planning obligation should re-render e
                     <h2 class="govuk-error-summary__title"> There is a problem</h2>
                     <div class="govuk-error-summary__body">
                         <ul class="govuk-list govuk-error-summary__list">
-                            <li><a href="#planning-obligation-due-date">Invalid value</a>
-                            </li>
-                            <li><a href="#planning-obligation-due-date-day">Planning obligation due date must include a day</a>
+                            <li><a href="#planning-obligation-due-date">day::Planning obligation due date must include a day</a>
                             </li>
                         </ul>
                     </div>
@@ -3497,19 +3495,16 @@ exports[`Timetable POST /edit S78 hearing Planning obligation should re-render e
                 </div>
             </fieldset>
         </div>
-        <div class="govuk-form-group govuk-form-group--error">
-            <fieldset class="govuk-fieldset" role="group" aria-describedby="planning-obligation-due-date-hint planning-obligation-due-date-error">
+        <div class="govuk-form-group">
+            <fieldset class="govuk-fieldset" role="group" aria-describedby="planning-obligation-due-date-hint">
                 <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">Planning obligation due</legend>
                 <div id="planning-obligation-due-date-hint"
                 class="govuk-hint">For example, 27 3 2007</div>
-                <p id="planning-obligation-due-date-error"
-                class="govuk-error-message"><span class="govuk-visually-hidden">Error:</span> Planning obligation due
-                    date must include a day</p>
                 <div class="govuk-date-input" id="planning-obligation-due-date">
                     <div class="govuk-date-input__item">
                         <div class="govuk-form-group">
                             <label class="govuk-label govuk-date-input__label" for="planning-obligation-due-date-day">Day</label>
-                            <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input govuk-input--error"
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="planning-obligation-due-date-day" name="planning-obligation-due-date-day"
                             type="text" inputmode="numeric">
                         </div>
@@ -3549,9 +3544,7 @@ exports[`Timetable POST /edit S78 hearing Planning obligation should re-render e
                     <h2 class="govuk-error-summary__title"> There is a problem</h2>
                     <div class="govuk-error-summary__body">
                         <ul class="govuk-list govuk-error-summary__list">
-                            <li><a href="#planning-obligation-due-date">Invalid value</a>
-                            </li>
-                            <li><a href="#planning-obligation-due-date-month">Planning obligation due date must include a month</a>
+                            <li><a href="#planning-obligation-due-date">month::Planning obligation due date must include a month</a>
                             </li>
                         </ul>
                     </div>
@@ -3699,14 +3692,11 @@ exports[`Timetable POST /edit S78 hearing Planning obligation should re-render e
                 </div>
             </fieldset>
         </div>
-        <div class="govuk-form-group govuk-form-group--error">
-            <fieldset class="govuk-fieldset" role="group" aria-describedby="planning-obligation-due-date-hint planning-obligation-due-date-error">
+        <div class="govuk-form-group">
+            <fieldset class="govuk-fieldset" role="group" aria-describedby="planning-obligation-due-date-hint">
                 <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">Planning obligation due</legend>
                 <div id="planning-obligation-due-date-hint"
                 class="govuk-hint">For example, 27 3 2007</div>
-                <p id="planning-obligation-due-date-error"
-                class="govuk-error-message"><span class="govuk-visually-hidden">Error:</span> Planning obligation due
-                    date must include a month</p>
                 <div class="govuk-date-input" id="planning-obligation-due-date">
                     <div class="govuk-date-input__item">
                         <div class="govuk-form-group">
@@ -3719,7 +3709,7 @@ exports[`Timetable POST /edit S78 hearing Planning obligation should re-render e
                     <div class="govuk-date-input__item">
                         <div class="govuk-form-group">
                             <label class="govuk-label govuk-date-input__label" for="planning-obligation-due-date-month">Month</label>
-                            <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input govuk-input--error"
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="planning-obligation-due-date-month" name="planning-obligation-due-date-month"
                             type="text" inputmode="numeric">
                         </div>
@@ -3751,9 +3741,7 @@ exports[`Timetable POST /edit S78 hearing Planning obligation should re-render e
                     <h2 class="govuk-error-summary__title"> There is a problem</h2>
                     <div class="govuk-error-summary__body">
                         <ul class="govuk-list govuk-error-summary__list">
-                            <li><a href="#planning-obligation-due-date">Invalid value</a>
-                            </li>
-                            <li><a href="#planning-obligation-due-date-year">Planning obligation due date must include a year</a>
+                            <li><a href="#planning-obligation-due-date">year::Planning obligation due date must include a year</a>
                             </li>
                         </ul>
                     </div>
@@ -3901,14 +3889,11 @@ exports[`Timetable POST /edit S78 hearing Planning obligation should re-render e
                 </div>
             </fieldset>
         </div>
-        <div class="govuk-form-group govuk-form-group--error">
-            <fieldset class="govuk-fieldset" role="group" aria-describedby="planning-obligation-due-date-hint planning-obligation-due-date-error">
+        <div class="govuk-form-group">
+            <fieldset class="govuk-fieldset" role="group" aria-describedby="planning-obligation-due-date-hint">
                 <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">Planning obligation due</legend>
                 <div id="planning-obligation-due-date-hint"
                 class="govuk-hint">For example, 27 3 2007</div>
-                <p id="planning-obligation-due-date-error"
-                class="govuk-error-message"><span class="govuk-visually-hidden">Error:</span> Planning obligation due
-                    date must include a year</p>
                 <div class="govuk-date-input" id="planning-obligation-due-date">
                     <div class="govuk-date-input__item">
                         <div class="govuk-form-group">
@@ -3929,7 +3914,7 @@ exports[`Timetable POST /edit S78 hearing Planning obligation should re-render e
                     <div class="govuk-date-input__item">
                         <div class="govuk-form-group">
                             <label class="govuk-label govuk-date-input__label" for="planning-obligation-due-date-year">Year</label>
-                            <input class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input govuk-date-input__input govuk-input--error"
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input govuk-date-input__input"
                             id="planning-obligation-due-date-year" name="planning-obligation-due-date-year"
                             type="text" inputmode="numeric">
                         </div>
@@ -3953,7 +3938,7 @@ exports[`Timetable POST /edit S78 hearing Planning obligation should re-render e
                     <h2 class="govuk-error-summary__title"> There is a problem</h2>
                     <div class="govuk-error-summary__body">
                         <ul class="govuk-list govuk-error-summary__list">
-                            <li><a href="#planning-obligation-due-date">The planning obligation due date must be in the future</a>
+                            <li><a href="#planning-obligation-due-date">all-fields::The planning obligation due date must be in the future</a>
                             </li>
                         </ul>
                     </div>
@@ -4150,7 +4135,7 @@ exports[`Timetable POST /edit S78 hearing Planning obligation should re-render e
                     <h2 class="govuk-error-summary__title"> There is a problem</h2>
                     <div class="govuk-error-summary__body">
                         <ul class="govuk-list govuk-error-summary__list">
-                            <li><a href="#planning-obligation-due-date">Planning obligation due date must be a real date</a>
+                            <li><a href="#planning-obligation-due-date">all-fields::Planning obligation due date must be a real date</a>
                             </li>
                         </ul>
                     </div>
@@ -4347,9 +4332,7 @@ exports[`Timetable POST /edit S78 hearing Statement of common ground should re-r
                     <h2 class="govuk-error-summary__title"> There is a problem</h2>
                     <div class="govuk-error-summary__body">
                         <ul class="govuk-list govuk-error-summary__list">
-                            <li><a href="#statement-of-common-ground-due-date">Invalid value</a>
-                            </li>
-                            <li><a href="#statement-of-common-ground-due-date-day">Statement of common ground due date must include a day</a>
+                            <li><a href="#statement-of-common-ground-due-date">day::Statement of common ground due date must include a day</a>
                             </li>
                         </ul>
                     </div>
@@ -4464,19 +4447,16 @@ exports[`Timetable POST /edit S78 hearing Statement of common ground should re-r
                 </div>
             </fieldset>
         </div>
-        <div class="govuk-form-group govuk-form-group--error">
-            <fieldset class="govuk-fieldset" role="group" aria-describedby="statement-of-common-ground-due-date-hint statement-of-common-ground-due-date-error">
+        <div class="govuk-form-group">
+            <fieldset class="govuk-fieldset" role="group" aria-describedby="statement-of-common-ground-due-date-hint">
                 <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">Statement of common ground due</legend>
                 <div id="statement-of-common-ground-due-date-hint"
                 class="govuk-hint">For example, 27 3 2007</div>
-                <p id="statement-of-common-ground-due-date-error"
-                class="govuk-error-message"><span class="govuk-visually-hidden">Error:</span> Statement of common ground
-                    due date must include a day</p>
                 <div class="govuk-date-input" id="statement-of-common-ground-due-date">
                     <div class="govuk-date-input__item">
                         <div class="govuk-form-group">
                             <label class="govuk-label govuk-date-input__label" for="statement-of-common-ground-due-date-day">Day</label>
-                            <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input govuk-input--error"
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="statement-of-common-ground-due-date-day" name="statement-of-common-ground-due-date-day"
                             type="text" inputmode="numeric">
                         </div>
@@ -4549,9 +4529,7 @@ exports[`Timetable POST /edit S78 hearing Statement of common ground should re-r
                     <h2 class="govuk-error-summary__title"> There is a problem</h2>
                     <div class="govuk-error-summary__body">
                         <ul class="govuk-list govuk-error-summary__list">
-                            <li><a href="#statement-of-common-ground-due-date">Invalid value</a>
-                            </li>
-                            <li><a href="#statement-of-common-ground-due-date-month">Statement of common ground due date must include a month</a>
+                            <li><a href="#statement-of-common-ground-due-date">month::Statement of common ground due date must include a month</a>
                             </li>
                         </ul>
                     </div>
@@ -4666,14 +4644,11 @@ exports[`Timetable POST /edit S78 hearing Statement of common ground should re-r
                 </div>
             </fieldset>
         </div>
-        <div class="govuk-form-group govuk-form-group--error">
-            <fieldset class="govuk-fieldset" role="group" aria-describedby="statement-of-common-ground-due-date-hint statement-of-common-ground-due-date-error">
+        <div class="govuk-form-group">
+            <fieldset class="govuk-fieldset" role="group" aria-describedby="statement-of-common-ground-due-date-hint">
                 <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">Statement of common ground due</legend>
                 <div id="statement-of-common-ground-due-date-hint"
                 class="govuk-hint">For example, 27 3 2007</div>
-                <p id="statement-of-common-ground-due-date-error"
-                class="govuk-error-message"><span class="govuk-visually-hidden">Error:</span> Statement of common ground
-                    due date must include a month</p>
                 <div class="govuk-date-input" id="statement-of-common-ground-due-date">
                     <div class="govuk-date-input__item">
                         <div class="govuk-form-group">
@@ -4686,7 +4661,7 @@ exports[`Timetable POST /edit S78 hearing Statement of common ground should re-r
                     <div class="govuk-date-input__item">
                         <div class="govuk-form-group">
                             <label class="govuk-label govuk-date-input__label" for="statement-of-common-ground-due-date-month">Month</label>
-                            <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input govuk-input--error"
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="statement-of-common-ground-due-date-month" name="statement-of-common-ground-due-date-month"
                             type="text" inputmode="numeric">
                         </div>
@@ -4751,9 +4726,7 @@ exports[`Timetable POST /edit S78 hearing Statement of common ground should re-r
                     <h2 class="govuk-error-summary__title"> There is a problem</h2>
                     <div class="govuk-error-summary__body">
                         <ul class="govuk-list govuk-error-summary__list">
-                            <li><a href="#statement-of-common-ground-due-date">Invalid value</a>
-                            </li>
-                            <li><a href="#statement-of-common-ground-due-date-year">Statement of common ground due date must include a year</a>
+                            <li><a href="#statement-of-common-ground-due-date">year::Statement of common ground due date must include a year</a>
                             </li>
                         </ul>
                     </div>
@@ -4868,14 +4841,11 @@ exports[`Timetable POST /edit S78 hearing Statement of common ground should re-r
                 </div>
             </fieldset>
         </div>
-        <div class="govuk-form-group govuk-form-group--error">
-            <fieldset class="govuk-fieldset" role="group" aria-describedby="statement-of-common-ground-due-date-hint statement-of-common-ground-due-date-error">
+        <div class="govuk-form-group">
+            <fieldset class="govuk-fieldset" role="group" aria-describedby="statement-of-common-ground-due-date-hint">
                 <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">Statement of common ground due</legend>
                 <div id="statement-of-common-ground-due-date-hint"
                 class="govuk-hint">For example, 27 3 2007</div>
-                <p id="statement-of-common-ground-due-date-error"
-                class="govuk-error-message"><span class="govuk-visually-hidden">Error:</span> Statement of common ground
-                    due date must include a year</p>
                 <div class="govuk-date-input" id="statement-of-common-ground-due-date">
                     <div class="govuk-date-input__item">
                         <div class="govuk-form-group">
@@ -4896,7 +4866,7 @@ exports[`Timetable POST /edit S78 hearing Statement of common ground should re-r
                     <div class="govuk-date-input__item">
                         <div class="govuk-form-group">
                             <label class="govuk-label govuk-date-input__label" for="statement-of-common-ground-due-date-year">Year</label>
-                            <input class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input govuk-date-input__input govuk-input--error"
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input govuk-date-input__input"
                             id="statement-of-common-ground-due-date-year" name="statement-of-common-ground-due-date-year"
                             type="text" inputmode="numeric">
                         </div>
@@ -4953,7 +4923,7 @@ exports[`Timetable POST /edit S78 hearing Statement of common ground should re-r
                     <h2 class="govuk-error-summary__title"> There is a problem</h2>
                     <div class="govuk-error-summary__body">
                         <ul class="govuk-list govuk-error-summary__list">
-                            <li><a href="#statement-of-common-ground-due-date">The statement of common ground due date must be in the future</a>
+                            <li><a href="#statement-of-common-ground-due-date">all-fields::The statement of common ground due date must be in the future</a>
                             </li>
                         </ul>
                     </div>
@@ -5150,7 +5120,7 @@ exports[`Timetable POST /edit S78 hearing Statement of common ground should re-r
                     <h2 class="govuk-error-summary__title"> There is a problem</h2>
                     <div class="govuk-error-summary__body">
                         <ul class="govuk-list govuk-error-summary__list">
-                            <li><a href="#statement-of-common-ground-due-date">Statement of common ground due date must be a real date</a>
+                            <li><a href="#statement-of-common-ground-due-date">all-fields::Statement of common ground due date must be a real date</a>
                             </li>
                         </ul>
                     </div>
@@ -6004,7 +5974,7 @@ exports[`Timetable POST /edit S78 hearing Statements should re-render edit timet
                     <div class="govuk-date-input__item">
                         <div class="govuk-form-group">
                             <label class="govuk-label govuk-date-input__label" for="lpa-statement-due-date-day">Day</label>
-                            <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input govuk-input--error govuk-input--error"
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input govuk-input--error"
                             id="lpa-statement-due-date-day" name="lpa-statement-due-date-day" type="text"
                             inputmode="numeric">
                         </div>
@@ -6203,7 +6173,7 @@ exports[`Timetable POST /edit S78 hearing Statements should re-render edit timet
                     <div class="govuk-date-input__item">
                         <div class="govuk-form-group">
                             <label class="govuk-label govuk-date-input__label" for="lpa-statement-due-date-day">Day</label>
-                            <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input govuk-input--error govuk-input--error"
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input govuk-input--error"
                             id="lpa-statement-due-date-day" name="lpa-statement-due-date-day" type="text"
                             inputmode="numeric">
                         </div>
@@ -6962,7 +6932,7 @@ exports[`Timetable POST /edit S78 written Final comments should re-render edit t
                     <div class="govuk-date-input__item">
                         <div class="govuk-form-group">
                             <label class="govuk-label govuk-date-input__label" for="final-comments-due-date-day">Day</label>
-                            <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input govuk-input--error govuk-input--error"
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input govuk-input--error"
                             id="final-comments-due-date-day" name="final-comments-due-date-day" type="text"
                             inputmode="numeric">
                         </div>
@@ -7127,7 +7097,7 @@ exports[`Timetable POST /edit S78 written Final comments should re-render edit t
                     <div class="govuk-date-input__item">
                         <div class="govuk-form-group">
                             <label class="govuk-label govuk-date-input__label" for="final-comments-due-date-day">Day</label>
-                            <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input govuk-input--error govuk-input--error"
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input govuk-input--error"
                             id="final-comments-due-date-day" name="final-comments-due-date-day" type="text"
                             inputmode="numeric">
                         </div>
@@ -7756,7 +7726,7 @@ exports[`Timetable POST /edit S78 written Interested party comments should re-re
                     <div class="govuk-date-input__item">
                         <div class="govuk-form-group">
                             <label class="govuk-label govuk-date-input__label" for="ip-comments-due-date-day">Day</label>
-                            <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input govuk-input--error govuk-input--error"
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input govuk-input--error"
                             id="ip-comments-due-date-day" name="ip-comments-due-date-day" type="text"
                             inputmode="numeric">
                         </div>
@@ -7921,7 +7891,7 @@ exports[`Timetable POST /edit S78 written Interested party comments should re-re
                     <div class="govuk-date-input__item">
                         <div class="govuk-form-group">
                             <label class="govuk-label govuk-date-input__label" for="ip-comments-due-date-day">Day</label>
-                            <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input govuk-input--error govuk-input--error"
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input govuk-input--error"
                             id="ip-comments-due-date-day" name="ip-comments-due-date-day" type="text"
                             inputmode="numeric">
                         </div>
@@ -8516,7 +8486,7 @@ exports[`Timetable POST /edit S78 written LPA questionnaire should re-render edi
                     <div class="govuk-date-input__item">
                         <div class="govuk-form-group">
                             <label class="govuk-label govuk-date-input__label" for="lpa-questionnaire-due-date-day">Day</label>
-                            <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input govuk-input--error govuk-input--error"
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input govuk-input--error"
                             id="lpa-questionnaire-due-date-day" name="lpa-questionnaire-due-date-day"
                             type="text" inputmode="numeric">
                         </div>
@@ -8681,7 +8651,7 @@ exports[`Timetable POST /edit S78 written LPA questionnaire should re-render edi
                     <div class="govuk-date-input__item">
                         <div class="govuk-form-group">
                             <label class="govuk-label govuk-date-input__label" for="lpa-questionnaire-due-date-day">Day</label>
-                            <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input govuk-input--error govuk-input--error"
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input govuk-input--error"
                             id="lpa-questionnaire-due-date-day" name="lpa-questionnaire-due-date-day"
                             type="text" inputmode="numeric">
                         </div>
@@ -9373,7 +9343,7 @@ exports[`Timetable POST /edit S78 written Statements should re-render edit timet
                     <div class="govuk-date-input__item">
                         <div class="govuk-form-group">
                             <label class="govuk-label govuk-date-input__label" for="lpa-statement-due-date-day">Day</label>
-                            <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input govuk-input--error govuk-input--error"
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input govuk-input--error"
                             id="lpa-statement-due-date-day" name="lpa-statement-due-date-day" type="text"
                             inputmode="numeric">
                         </div>
@@ -9538,7 +9508,7 @@ exports[`Timetable POST /edit S78 written Statements should re-render edit timet
                     <div class="govuk-date-input__item">
                         <div class="govuk-form-group">
                             <label class="govuk-label govuk-date-input__label" for="lpa-statement-due-date-day">Day</label>
-                            <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input govuk-input--error govuk-input--error"
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input govuk-input--error"
                             id="lpa-statement-due-date-day" name="lpa-statement-due-date-day" type="text"
                             inputmode="numeric">
                         </div>
@@ -9707,7 +9677,7 @@ exports[`Timetable POST /edit S78 written should re-render edit timetable page a
                     <div class="govuk-date-input__item">
                         <div class="govuk-form-group">
                             <label class="govuk-label govuk-date-input__label" for="lpa-statement-due-date-day">Day</label>
-                            <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input govuk-input--error govuk-input--error"
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input govuk-input--error"
                             id="lpa-statement-due-date-day" name="lpa-statement-due-date-day" type="text"
                             value="25" inputmode="numeric">
                         </div>
@@ -9742,7 +9712,7 @@ exports[`Timetable POST /edit S78 written should re-render edit timetable page a
                     <div class="govuk-date-input__item">
                         <div class="govuk-form-group">
                             <label class="govuk-label govuk-date-input__label" for="ip-comments-due-date-day">Day</label>
-                            <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input govuk-input--error govuk-input--error"
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input govuk-input--error"
                             id="ip-comments-due-date-day" name="ip-comments-due-date-day" type="text"
                             value="26" inputmode="numeric">
                         </div>
@@ -9776,7 +9746,7 @@ exports[`Timetable POST /edit S78 written should re-render edit timetable page a
                     <div class="govuk-date-input__item">
                         <div class="govuk-form-group">
                             <label class="govuk-label govuk-date-input__label" for="final-comments-due-date-day">Day</label>
-                            <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input govuk-input--error govuk-input--error"
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input govuk-input--error"
                             id="final-comments-due-date-day" name="final-comments-due-date-day" type="text"
                             value="7" inputmode="numeric">
                         </div>
@@ -9881,7 +9851,7 @@ exports[`Timetable POST /edit S78 written should re-render edit timetable page w
                     <div class="govuk-date-input__item">
                         <div class="govuk-form-group">
                             <label class="govuk-label govuk-date-input__label" for="lpa-statement-due-date-day">Day</label>
-                            <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input govuk-input--error govuk-input--error"
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input govuk-input--error"
                             id="lpa-statement-due-date-day" name="lpa-statement-due-date-day" type="text"
                             value="4" inputmode="numeric">
                         </div>
@@ -9916,7 +9886,7 @@ exports[`Timetable POST /edit S78 written should re-render edit timetable page w
                     <div class="govuk-date-input__item">
                         <div class="govuk-form-group">
                             <label class="govuk-label govuk-date-input__label" for="ip-comments-due-date-day">Day</label>
-                            <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input govuk-input--error govuk-input--error"
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input govuk-input--error"
                             id="ip-comments-due-date-day" name="ip-comments-due-date-day" type="text"
                             value="4" inputmode="numeric">
                         </div>
@@ -9951,7 +9921,7 @@ exports[`Timetable POST /edit S78 written should re-render edit timetable page w
                     <div class="govuk-date-input__item">
                         <div class="govuk-form-group">
                             <label class="govuk-label govuk-date-input__label" for="final-comments-due-date-day">Day</label>
-                            <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input govuk-input--error govuk-input--error"
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input govuk-input--error"
                             id="final-comments-due-date-day" name="final-comments-due-date-day" type="text"
                             value="3" inputmode="numeric">
                         </div>

--- a/appeals/web/src/server/appeals/appeal-documents/appeal-documents.validators.js
+++ b/appeals/web/src/server/appeals/appeal-documents/appeal-documents.validators.js
@@ -75,15 +75,15 @@ export const validateDocumentDetailsReceivedDatesFields = createValidator(
 		}
 
 		if (!day && !month) {
-			throw new Error('all-fields-day::Received date must include a day and a month');
+			throw new Error('day-month::Received date must include a day and a month');
 		}
 
 		if (!day && !year) {
-			throw new Error('all-fields-day::Received date must include a day and a year');
+			throw new Error('day-year::Received date must include a day and a year');
 		}
 
 		if (!month && !year) {
-			throw new Error('all-fields-month::Received date must include a month and a year');
+			throw new Error('month-year::Received date must include a month and a year');
 		}
 
 		if (!day) {

--- a/appeals/web/src/server/lib/mappers/utils/create-class-for-date-errors.js
+++ b/appeals/web/src/server/lib/mappers/utils/create-class-for-date-errors.js
@@ -1,69 +1,111 @@
 /**
- *
+ * @typedef {'day' | 'month' | 'year'} DateField
+ */
+
+/**
+ * @typedef {Object} DateClasses
+ * @property {string} day - CSS classes for the day input.
+ * @property {string} month - CSS classes for the month input.
+ * @property {string} year - CSS classes for the year input.
+ */
+
+/**
  * @param {import("@pins/express").ValidationErrors | undefined} errors
  * @param {String} fieldName
- * @returns
+ * @returns {DateClasses} Classes object for day, month, and year inputs.
  */
 export const assembleClassesFromErrors = (errors, fieldName = 'date') => {
-	let classes = {
-		day: 'govuk-input govuk-date-input__input',
-		month: 'govuk-input govuk-date-input__input',
-		year: 'govuk-input govuk-date-input__input'
+	const baseClass = 'govuk-input govuk-date-input__input';
+	const errorClass = ' govuk-input--error';
+
+	const classes = {
+		day: baseClass,
+		month: baseClass,
+		year: baseClass
 	};
-	if (errors) {
-		if (
-			errors[fieldName + 'day']?.param === 'all-fields' ||
-			errors[fieldName + 'month']?.param === 'all-fields' ||
-			errors[fieldName + 'year']?.param === 'all-fields'
-		) {
-			classes['day'] += ' govuk-input--error';
-			classes['month'] += ' govuk-input--error';
-			classes['year'] += ' govuk-input--error';
-		}
-		if (errors[fieldName + 'day']) {
-			classes['day'] += ' govuk-input--error';
-		}
-		if (errors[fieldName + 'month']) {
-			classes['month'] += ' govuk-input--error';
-		}
-		if (errors[fieldName + 'year']) {
-			classes['year'] += ' govuk-input--error';
-		}
+
+	if (!errors) return classes;
+
+	/** @type {DateField[]} */
+	const fields = ['day', 'month', 'year'];
+	/** @type {[DateField, DateField][]} */
+	const pairs = [
+		['day', 'month'],
+		['day', 'year'],
+		['month', 'year']
+	];
+
+	const hasAllFieldsError = fields.some(
+		(field) => errors[fieldName + field]?.param === 'all-fields'
+	);
+
+	if (hasAllFieldsError) {
+		fields.forEach((field) => (classes[field] += errorClass));
+		return classes;
 	}
+
+	fields.forEach((field) => {
+		if (errors[fieldName + field]) {
+			classes[field] += errorClass;
+
+			const param = errors[fieldName + field].param;
+			pairs.forEach(([field1, field2]) => {
+				if (param === `${field1}-${field2}`) {
+					classes[field1] += errorClass;
+					classes[field2] += errorClass;
+				}
+			});
+		}
+	});
+
 	return classes;
 };
 /**
- *
  * @param {import("@pins/express").ValidationErrors | undefined} errors
  * @param {String} fieldName
- * @returns
+ * @returns {DateClasses} Classes object for day, month, and year inputs.
  */
 export const assembleDocumentDateClassesFromErrors = (errors, fieldName = 'date') => {
-	let classes = {
-		day: 'govuk-input govuk-date-input__input',
-		month: 'govuk-input govuk-date-input__input',
-		year: 'govuk-input govuk-date-input__input'
+	const baseClass = 'govuk-input govuk-date-input__input';
+	const errorClass = ' govuk-input--error';
+
+	const classes = {
+		day: baseClass,
+		month: baseClass,
+		year: baseClass
 	};
-	if (errors && errors[fieldName]) {
-		if (
-			errors[fieldName]?.param === 'all-fields' ||
-			errors[fieldName]?.param === 'all-fields-day' ||
-			errors[fieldName]?.param === 'all-fields-month' ||
-			errors[fieldName]?.param === 'all-fields-year'
-		) {
-			classes['day'] += ' govuk-input--error';
-			classes['month'] += ' govuk-input--error';
-			classes['year'] += ' govuk-input--error';
-		}
-		if (errors[fieldName].param === 'day') {
-			classes['day'] += ' govuk-input--error';
-		}
-		if (errors[fieldName].param === 'month') {
-			classes['month'] += ' govuk-input--error';
-		}
-		if (errors[fieldName].param === 'year') {
-			classes['year'] += ' govuk-input--error';
-		}
+
+	if (!errors || !errors[fieldName]) return classes;
+
+	const { param } = errors[fieldName];
+
+	if (param?.startsWith('all-fields')) {
+		/** @type {DateField[]} */ (Object.keys(classes)).forEach((field) => {
+			classes[field] += errorClass;
+		});
+		return classes;
 	}
+
+	/** @type {DateField[]} */
+	const fields = ['day', 'month', 'year'];
+	fields.forEach((field) => {
+		if (param === field) {
+			classes[field] += errorClass;
+		}
+	});
+
+	/** @type {[DateField, DateField][]} */
+	const pairs = [
+		['day', 'month'],
+		['day', 'year'],
+		['month', 'year']
+	];
+	pairs.forEach(([field1, field2]) => {
+		if (param === `${field1}-${field2}`) {
+			classes[field1] += errorClass;
+			classes[field2] += errorClass;
+		}
+	});
+
 	return classes;
 };


### PR DESCRIPTION
## Describe your changes
### WEB
1. Updated date fields to highlight only the correct empty fields for standard dates and document dates
2. Refactored both validators so that the checks follow the same format
3. Updated css class mappers to accommodate new setup and be more easily adapted if more changes come in the future

### TESTS

1. Updated Unit tests to accomodate for new setup
2. Updated snapshots
3. Manually checked date fields

## Issue ticket number and link

[Ticket](https://pins-ds.atlassian.net.mcas.ms/browse/A2-1741)
