### PR TITLE
Fix(A2-3295): fixing back button and redirect regressions for reissue decision

### DIFF
--- a/appeals/web/src/server/appeals/appeal-details/issue-decision/issue-decision.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/issue-decision/issue-decision.mapper.js
@@ -23,6 +23,7 @@ import {
 } from '#appeals/appeal-details/issue-decision/issue-decision.utils.js';
 import { dateISOStringToDisplayDate } from '#lib/dates.js';
 import config from '#environment/config.js';
+import { mapNotificationBannersFromSession } from '#lib/mappers/index.js';
 
 /**
  * @typedef {import('../appeal-details.types.js').WebAppeal} Appeal
@@ -506,9 +507,10 @@ export function checkAndConfirmPage(appealData, request) {
 
 /**
  * @param {Appeal} appealData
+ * @param {Request} request
  * @returns {PageRow}[]
  */
-export function viewDecisionPageRows(appealData) {
+export function viewDecisionPageRows(appealData, request) {
 	const { appealId, decision, costs } = appealData || {};
 	const appellantCostsDecision = costs.appellantDecisionFolder?.documents[0];
 	const lpaCostsDecision = costs.lpaDecisionFolder?.documents[0];
@@ -547,7 +549,10 @@ export function viewDecisionPageRows(appealData) {
 					? [
 							{
 								text: 'Change',
-								href: `${baseUrl(appealData)}/decision-letter-upload`,
+								href: `${addBackLinkQueryToUrl(
+									request,
+									`/appeals-service/appeal-details/${appealId}/update-decision-letter/upload-decision-letter`
+								)}`,
 								visuallyHiddenText: 'decision letter'
 							}
 					  ]
@@ -616,9 +621,15 @@ export function viewDecisionPage(appealData, request) {
 	const summaryListComponent = {
 		type: 'summary-list',
 		parameters: {
-			rows: viewDecisionPageRows(appealData)
+			rows: viewDecisionPageRows(appealData, request)
 		}
 	};
+
+	const notificationBanners = mapNotificationBannersFromSession(
+		request.session,
+		'appealDecision',
+		appealData.appealId
+	);
 
 	const title = `Decision`;
 	const pageContent = {
@@ -627,7 +638,7 @@ export function viewDecisionPage(appealData, request) {
 			getBackLinkUrlFromQuery(request) || `/appeals-service/appeal-details/${appealData.appealId}`,
 		preHeading: `Appeal ${appealShortReference(appealData.appealReference)}`,
 		heading: title,
-		pageComponents: [summaryListComponent]
+		pageComponents: [...notificationBanners, summaryListComponent]
 	};
 
 	return pageContent;

--- a/appeals/web/src/server/appeals/appeal-details/update-decision-letter/__tests__/__snapshots__/update-decision-letter.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/update-decision-letter/__tests__/__snapshots__/update-decision-letter.test.js.snap
@@ -66,7 +66,7 @@ exports[`update-decision-letter GET /issue-decision/check-your-decision should r
                     <dd class="govuk-summary-list__value"><a href="/documents/APP/Q9999/D/21/351062/download-uncommitted/100/test-document2.txt"
                         class="govuk-link">test-document2.txt</a>
                     </dd>
-                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/update-decision-letter/upload-decision-letter">Change <span class="govuk-visually-hidden">decision letter</span></a>
+                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/update-decision-letter/upload-decision-letter?backUrl=%2Fappeals-service%2Fappeal-details%2F1%2Fupdate-decision-letter%2Fcheck-details">Change <span class="govuk-visually-hidden">decision letter</span></a>
                     </dd>
                 </div>
                 <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Correction notice</dt>

--- a/appeals/web/src/server/appeals/appeal-details/update-decision-letter/__tests__/update-decision-letter.test.js
+++ b/appeals/web/src/server/appeals/appeal-details/update-decision-letter/__tests__/update-decision-letter.test.js
@@ -234,7 +234,7 @@ describe('update-decision-letter', () => {
 			expect(unprettifiedElement.innerHTML).toContain('Preview');
 			expect(unprettifiedElement.innerHTML).toContain('Update decision letter');
 		});
-		it('should render the check your view-decision page after submit', async () => {
+		it('should render the view-decision page after submit', async () => {
 			expect(uploadDecisionLetterResponse.statusCode).toBe(302);
 			expect(correctionNoticeResponse.statusCode).toBe(302);
 
@@ -248,7 +248,7 @@ describe('update-decision-letter', () => {
 
 			expect(response.statusCode).toBe(302);
 			expect(response.text).toBe(
-				'Found. Redirecting to /appeals-service/appeal-details/1/appeal-decision'
+				'Found. Redirecting to /appeals-service/appeal-details/1/issue-decision/view-decision'
 			);
 		});
 	});

--- a/appeals/web/src/server/appeals/appeal-details/update-decision-letter/update-decision-letter.controller.js
+++ b/appeals/web/src/server/appeals/appeal-details/update-decision-letter/update-decision-letter.controller.js
@@ -10,6 +10,7 @@ import { addNotificationBannerToSession } from '#lib/session-utilities.js';
 import { generateNotifyPreview } from '#lib/api/notify-preview.api.js';
 import { appealSiteToAddressString } from '#lib/address-formatter.js';
 import { dateISOStringToDisplayDate } from '#lib/dates.js';
+import { addBackLinkQueryToUrl } from '#lib/url-utilities.js';
 
 /** @type {import('@pins/express').RequestHandler<Response>}  */
 export const getCorrectionNotice = async (request, response) => {
@@ -80,7 +81,7 @@ export const renderUpdateDocumentCheckDetails = async (request, response) => {
 					)}" class="govuk-link">${file.name}</a>`,
 					actions: {
 						Change: {
-							href: `${baseUrl}/upload-decision-letter`,
+							href: `${addBackLinkQueryToUrl(request, `${baseUrl}/upload-decision-letter`)}`,
 							visuallyHiddenText: 'decision letter'
 						}
 					}
@@ -187,7 +188,9 @@ export const postUpdateDocumentCheckDetails = async (request, response) => {
 			text: 'Decision letter updated'
 		});
 
-		return response.redirect(`/appeals-service/appeal-details/${appealId}/appeal-decision`);
+		return response.redirect(
+			`/appeals-service/appeal-details/${appealId}/issue-decision/view-decision`
+		);
 	} catch (error) {
 		logger.error(error);
 		return response.status(500).render('app/500.njk');

--- a/appeals/web/src/server/appeals/appeal-details/update-decision-letter/update-decision-letter.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/update-decision-letter/update-decision-letter.mapper.js
@@ -15,7 +15,8 @@ import { textareaInput } from '#lib/mappers/index.js';
  * @returns {PageContent}
  */
 export const correctionNoticePage = (appealId, appealReference, correctionNotice, errors) => {
-	const backLinkUrl = `/appeals-service/appeal-details/${appealId}/update-decision-letter/upload-decision-letter?backUrl=/appeals-service/appeal-details/${appealId}/appeal-decision`;
+	const baseUrl = `/appeals-service/appeal-details/${appealId}`;
+	const backLinkUrl = `${baseUrl}/update-decision-letter/upload-decision-letter?backUrl=${baseUrl}/issue-decision/view-decision`;
 
 	/** @type {PageContent} */
 	const pageContent = {

--- a/appeals/web/src/server/views/appeals/appeal/issue-decision.njk
+++ b/appeals/web/src/server/views/appeals/appeal/issue-decision.njk
@@ -1,5 +1,6 @@
 {%- extends "app/layouts/app-two-column.layout.njk" -%}
 {%- from "govuk/components/button/macro.njk" import govukButton -%}
+{%- from "govuk/components/notification-banner/macro.njk" import govukNotificationBanner -%}
 {%- from "../../app/components/page-heading.njk" import pageHeading -%}
 
 {%- set backLinkUrl = pageContent.backLinkUrl -%}
@@ -7,13 +8,30 @@
 {%- set pageTitle = pageContent.title if pageContent.title else 'Change' -%}
 
 {%- block pageHeading -%}
+	{%- set notificationBanners = [] -%}
+	{%- for component in pageContent.pageComponents -%}
+		{%- if component.type === 'notification-banner' -%}
+			{%- set _ = notificationBanners.push(component) -%}
+		{%- endif -%}
+	{%- endfor -%}
+	{%- if notificationBanners | length -%}
+	<div class="govuk-grid-row">
+		<div class="govuk-grid-column-two-thirds govuk-!-margin-bottom-5">
+			{%- for component in notificationBanners -%}
+				{{ govukNotificationBanner(component.parameters | assign({ classes: "govuk-!-margin-bottom-5" })) }}
+			{%- endfor -%}
+		</div>
+	</div>
+	{%- endif -%}
 	{{ pageHeading(pageContent) }}
 {%- endblock -%}
 
 {%- block pageContent -%}
 	<form method="POST" novalidate="novalidate">
 		{%- for component in pageContent.pageComponents -%}
-			{%- include "../components/page-component.njk" -%}
+			{%- if component.type !== 'notification-banner' -%}
+				{%- include "../components/page-component.njk" -%}
+			{%- endif -%}
 		{%- endfor -%}
 		{%- if not viewOnly -%}
 		<p class="govuk-body">We'll send an email to the appellant and LPA to tell them about the decision.</p>


### PR DESCRIPTION
## Describe your changes
- Ensuring issue decision change link navigates to correct page (with back button query string)
- Added notification banner to view-decision page - this is shown after updating the decision letter (i.e. reissuing decision)
- Updated the view-decison nunjunks template to account for possible display of notification banner
- Updated redirects after continue button on check-details page to view-decision
<!--
    Please include a summary of the change along with any relevant context.
    List any dependencies that are required for this change.
-->

## Issue ticket number and link

[Ticket](<!--Paste your ticket link here-->)
