### PR TITLE
fix(appeals): change lpa to uppercase in issue lpa costs decision (a2-3207)

### DIFF
--- a/appeals/web/src/server/appeals/appeal-details/issue-decision/__tests__/__snapshots__/issue-decision.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/issue-decision/__tests__/__snapshots__/issue-decision.test.js.snap
@@ -354,7 +354,7 @@ exports[`issue-decision GET /issue-decision/check-your-lpa-costs-decision should
 "<main class="govuk-main-wrapper" id="main-content">
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Appeal 351062</span>
-            <h1 class="govuk-heading-l">Check details and issue lpa costs decision</h1>
+            <h1 class="govuk-heading-l">Check details and issue LPA costs decision</h1>
         </div>
     </div>
     <div class="govuk-grid-row">
@@ -370,7 +370,7 @@ exports[`issue-decision GET /issue-decision/check-your-lpa-costs-decision should
                     </div>
                 </dl>
                 <p class="govuk-body">We'll send an email to the appellant and LPA to tell them about the decision.</p>
-                <button                 type="submit" class="govuk-button" data-module="govuk-button">Issue lpa costs decision</button>
+                <button                 type="submit" class="govuk-button" data-module="govuk-button">Issue LPA costs decision</button>
             </form>
         </div>
     </div>

--- a/appeals/web/src/server/appeals/appeal-details/issue-decision/__tests__/issue-decision.test.js
+++ b/appeals/web/src/server/appeals/appeal-details/issue-decision/__tests__/issue-decision.test.js
@@ -1063,7 +1063,7 @@ describe('issue-decision', () => {
 			expect(unprettifiedElement.innerHTML).toContain('Appeal 351062</span>');
 
 			expect(unprettifiedElement.innerHTML).toContain(
-				'Check details and issue lpa costs decision</h1>'
+				'Check details and issue LPA costs decision</h1>'
 			);
 
 			expect(unprettifiedElement.innerHTML).not.toContain('Decision</dt>');
@@ -1085,7 +1085,7 @@ describe('issue-decision', () => {
 
 			expect(unprettifiedElement.innerHTML).not.toContain('Appellant costs decision letter</dt>');
 
-			expect(unprettifiedElement.innerHTML).toContain('Issue lpa costs decision</button>');
+			expect(unprettifiedElement.innerHTML).toContain('Issue LPA costs decision</button>');
 		});
 	});
 

--- a/appeals/web/src/server/appeals/appeal-details/issue-decision/issue-decision.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/issue-decision/issue-decision.mapper.js
@@ -474,7 +474,7 @@ export function checkAndConfirmPage(appealData, request) {
 	};
 
 	const decisionTypeText = specificDecisionType
-		? specificDecisionType.replaceAll('-', ' ')
+		? specificDecisionType.replaceAll('-', ' ').replace('lpa', 'LPA')
 		: 'decision';
 
 	const baseRoute = baseUrl(currentAppeal);


### PR DESCRIPTION
## Describe your changes
#### Change lpa to uppercase in issue LPA costs decision page (a2-3207)

### WEB:
- Make sure lpa is LPA within the page.

### TEST:
- Update tests and snapshots for above
- Made sure all unit tests pass
- Manually tested within browser

## Issue ticket number and link:
- [(A2-3207) [Issue LPA Costs Decision](https://pins-ds.atlassian.net/browse/A2-3324)](https://pins-ds.atlassian.net/browse/A2-3207)


