### PR TITLE
Feat/a2-3798 transition state for alternate appeal types

### DIFF
--- a/appeals/api/src/server/state/__tests__/state-machine.test.js
+++ b/appeals/api/src/server/state/__tests__/state-machine.test.js
@@ -1,0 +1,646 @@
+import {
+	APPEAL_TYPE_SHORTHAND_FPA,
+	APPEAL_TYPE_SHORTHAND_HAS,
+	VALIDATION_OUTCOME_CANCEL,
+	VALIDATION_OUTCOME_COMPLETE,
+	VALIDATION_OUTCOME_INCOMPLETE,
+	VALIDATION_OUTCOME_INVALID,
+	VALIDATION_OUTCOME_VALID
+} from '@pins/appeals/constants/support.js';
+import { APPEAL_CASE_PROCEDURE, APPEAL_CASE_STATUS } from 'pins-data-model';
+import { interpret } from 'xstate';
+import createStateMachine from '../create-state-machine';
+
+/**
+ * Function to get the next state for HAS appeals based on the initial state and event.
+ * @param {string} initial - The initial state of the appeal.
+ * @param {string} event - The event that triggers the state transition.
+ * @return {import('xstate').StateValue} - The next state of the appeal.
+ **/
+const nextStateHAS = (initial, event) => {
+	const machine = createStateMachine(
+		APPEAL_TYPE_SHORTHAND_HAS,
+		APPEAL_CASE_PROCEDURE.WRITTEN,
+		initial
+	);
+	const service = interpret(machine).start();
+
+	service.send(event);
+	return service.state.value;
+};
+
+/**
+ * Function to get the next state for FPA appeals based on the initial state and event.
+ * @param {string} initial - The initial state of the appeal.
+ * @param {string} event - The event that triggers the state transition.
+ * @param {string} procedureType - The event that triggers the state transition.
+ * @return {import('xstate').StateValue} - The next state of the appeal.
+ **/
+const nextStateFPA = (initial, event, procedureType) => {
+	const machine = createStateMachine(APPEAL_TYPE_SHORTHAND_FPA, procedureType, initial);
+	const service = interpret(machine).start();
+
+	service.send(event);
+	return service.state.value;
+};
+
+describe('State Machine Transitions', () => {
+	describe('Assign case office transitions', () => {
+		test.each([
+			[
+				APPEAL_CASE_STATUS.ASSIGN_CASE_OFFICER,
+				APPEAL_CASE_STATUS.VALIDATION,
+				APPEAL_CASE_STATUS.VALIDATION,
+				APPEAL_CASE_STATUS.VALIDATION,
+				APPEAL_CASE_STATUS.VALIDATION,
+				APPEAL_CASE_STATUS.VALIDATION
+			],
+			[
+				APPEAL_CASE_STATUS.ASSIGN_CASE_OFFICER,
+				APPEAL_CASE_STATUS.CLOSED,
+				APPEAL_CASE_STATUS.CLOSED,
+				APPEAL_CASE_STATUS.CLOSED,
+				APPEAL_CASE_STATUS.CLOSED,
+				APPEAL_CASE_STATUS.CLOSED
+			],
+			[
+				APPEAL_CASE_STATUS.ASSIGN_CASE_OFFICER,
+				APPEAL_CASE_STATUS.AWAITING_TRANSFER,
+				APPEAL_CASE_STATUS.AWAITING_TRANSFER,
+				APPEAL_CASE_STATUS.AWAITING_TRANSFER,
+				APPEAL_CASE_STATUS.AWAITING_TRANSFER,
+				APPEAL_CASE_STATUS.AWAITING_TRANSFER
+			],
+			[
+				APPEAL_CASE_STATUS.ASSIGN_CASE_OFFICER,
+				APPEAL_CASE_STATUS.WITHDRAWN,
+				APPEAL_CASE_STATUS.WITHDRAWN,
+				APPEAL_CASE_STATUS.WITHDRAWN,
+				APPEAL_CASE_STATUS.WITHDRAWN,
+				APPEAL_CASE_STATUS.WITHDRAWN
+			]
+		])(
+			'correctly transitions from %s state on %s event to %s state',
+			(initial, event, expectedHAS, expectedFPAWritten, expectedFPAHearing, expectedFPAInquiry) => {
+				expect(nextStateHAS(initial, event)).toBe(expectedHAS);
+				expect(nextStateFPA(initial, event, APPEAL_CASE_PROCEDURE.WRITTEN)).toBe(
+					expectedFPAWritten
+				);
+				expect(nextStateFPA(initial, event, APPEAL_CASE_PROCEDURE.HEARING)).toBe(
+					expectedFPAHearing
+				);
+				expect(nextStateFPA(initial, event, APPEAL_CASE_PROCEDURE.INQUIRY)).toBe(
+					expectedFPAInquiry
+				);
+			}
+		);
+	});
+
+	describe('Validation transitions', () => {
+		test.each([
+			[
+				APPEAL_CASE_STATUS.VALIDATION,
+				VALIDATION_OUTCOME_VALID,
+				APPEAL_CASE_STATUS.READY_TO_START,
+				APPEAL_CASE_STATUS.READY_TO_START,
+				APPEAL_CASE_STATUS.READY_TO_START,
+				APPEAL_CASE_STATUS.READY_TO_START
+			],
+			[
+				APPEAL_CASE_STATUS.VALIDATION,
+				VALIDATION_OUTCOME_INVALID,
+				APPEAL_CASE_STATUS.INVALID,
+				APPEAL_CASE_STATUS.INVALID,
+				APPEAL_CASE_STATUS.INVALID,
+				APPEAL_CASE_STATUS.INVALID
+			],
+			[
+				APPEAL_CASE_STATUS.VALIDATION,
+				VALIDATION_OUTCOME_INCOMPLETE,
+				APPEAL_CASE_STATUS.VALIDATION,
+				APPEAL_CASE_STATUS.VALIDATION,
+				APPEAL_CASE_STATUS.VALIDATION,
+				APPEAL_CASE_STATUS.VALIDATION
+			],
+			[
+				APPEAL_CASE_STATUS.VALIDATION,
+				APPEAL_CASE_STATUS.CLOSED,
+				APPEAL_CASE_STATUS.CLOSED,
+				APPEAL_CASE_STATUS.CLOSED,
+				APPEAL_CASE_STATUS.CLOSED,
+				APPEAL_CASE_STATUS.CLOSED
+			],
+			[
+				APPEAL_CASE_STATUS.VALIDATION,
+				APPEAL_CASE_STATUS.AWAITING_TRANSFER,
+				APPEAL_CASE_STATUS.AWAITING_TRANSFER,
+				APPEAL_CASE_STATUS.AWAITING_TRANSFER,
+				APPEAL_CASE_STATUS.AWAITING_TRANSFER,
+				APPEAL_CASE_STATUS.AWAITING_TRANSFER
+			],
+			[
+				APPEAL_CASE_STATUS.VALIDATION,
+				APPEAL_CASE_STATUS.WITHDRAWN,
+				APPEAL_CASE_STATUS.WITHDRAWN,
+				APPEAL_CASE_STATUS.WITHDRAWN,
+				APPEAL_CASE_STATUS.WITHDRAWN,
+				APPEAL_CASE_STATUS.WITHDRAWN
+			]
+		])(
+			'correctly transitions from %s state on %s event to %s state',
+			(initial, event, expectedHAS, expectedFPAWritten, expectedFPAHearing, expectedFPAInquiry) => {
+				expect(nextStateHAS(initial, event)).toBe(expectedHAS);
+				expect(nextStateFPA(initial, event, APPEAL_CASE_PROCEDURE.WRITTEN)).toBe(
+					expectedFPAWritten
+				);
+				expect(nextStateFPA(initial, event, APPEAL_CASE_PROCEDURE.HEARING)).toBe(
+					expectedFPAHearing
+				);
+				expect(nextStateFPA(initial, event, APPEAL_CASE_PROCEDURE.INQUIRY)).toBe(
+					expectedFPAInquiry
+				);
+			}
+		);
+	});
+
+	describe('Ready to start transitions', () => {
+		test.each([
+			[
+				APPEAL_CASE_STATUS.READY_TO_START,
+				APPEAL_CASE_STATUS.LPA_QUESTIONNAIRE,
+				APPEAL_CASE_STATUS.LPA_QUESTIONNAIRE,
+				APPEAL_CASE_STATUS.LPA_QUESTIONNAIRE,
+				APPEAL_CASE_STATUS.LPA_QUESTIONNAIRE,
+				APPEAL_CASE_STATUS.LPA_QUESTIONNAIRE
+			],
+			[
+				APPEAL_CASE_STATUS.READY_TO_START,
+				APPEAL_CASE_STATUS.CLOSED,
+				APPEAL_CASE_STATUS.CLOSED,
+				APPEAL_CASE_STATUS.CLOSED,
+				APPEAL_CASE_STATUS.CLOSED,
+				APPEAL_CASE_STATUS.CLOSED
+			],
+			[
+				APPEAL_CASE_STATUS.READY_TO_START,
+				APPEAL_CASE_STATUS.AWAITING_TRANSFER,
+				APPEAL_CASE_STATUS.AWAITING_TRANSFER,
+				APPEAL_CASE_STATUS.AWAITING_TRANSFER,
+				APPEAL_CASE_STATUS.AWAITING_TRANSFER,
+				APPEAL_CASE_STATUS.AWAITING_TRANSFER
+			],
+			[
+				APPEAL_CASE_STATUS.READY_TO_START,
+				APPEAL_CASE_STATUS.WITHDRAWN,
+				APPEAL_CASE_STATUS.WITHDRAWN,
+				APPEAL_CASE_STATUS.WITHDRAWN,
+				APPEAL_CASE_STATUS.WITHDRAWN,
+				APPEAL_CASE_STATUS.WITHDRAWN
+			]
+		])(
+			'correctly transitions from %s state on %s event to %s state',
+			(initial, event, expectedHAS, expectedFPAWritten, expectedFPAHearing, expectedFPAInquiry) => {
+				expect(nextStateHAS(initial, event)).toBe(expectedHAS);
+				expect(nextStateFPA(initial, event, APPEAL_CASE_PROCEDURE.WRITTEN)).toBe(
+					expectedFPAWritten
+				);
+				expect(nextStateFPA(initial, event, APPEAL_CASE_PROCEDURE.HEARING)).toBe(
+					expectedFPAHearing
+				);
+				expect(nextStateFPA(initial, event, APPEAL_CASE_PROCEDURE.INQUIRY)).toBe(
+					expectedFPAInquiry
+				);
+			}
+		);
+	});
+
+	describe('LPA questionnaire transitions', () => {
+		test.each([
+			[
+				APPEAL_CASE_STATUS.LPA_QUESTIONNAIRE,
+				VALIDATION_OUTCOME_COMPLETE,
+				APPEAL_CASE_STATUS.EVENT,
+				APPEAL_CASE_STATUS.STATEMENTS,
+				APPEAL_CASE_STATUS.STATEMENTS,
+				APPEAL_CASE_STATUS.STATEMENTS
+			],
+			[
+				APPEAL_CASE_STATUS.LPA_QUESTIONNAIRE,
+				APPEAL_CASE_STATUS.CLOSED,
+				APPEAL_CASE_STATUS.CLOSED,
+				APPEAL_CASE_STATUS.CLOSED,
+				APPEAL_CASE_STATUS.CLOSED,
+				APPEAL_CASE_STATUS.CLOSED
+			],
+			[
+				APPEAL_CASE_STATUS.LPA_QUESTIONNAIRE,
+				APPEAL_CASE_STATUS.AWAITING_TRANSFER,
+				APPEAL_CASE_STATUS.AWAITING_TRANSFER,
+				APPEAL_CASE_STATUS.AWAITING_TRANSFER,
+				APPEAL_CASE_STATUS.AWAITING_TRANSFER,
+				APPEAL_CASE_STATUS.AWAITING_TRANSFER
+			],
+			[
+				APPEAL_CASE_STATUS.LPA_QUESTIONNAIRE,
+				APPEAL_CASE_STATUS.WITHDRAWN,
+				APPEAL_CASE_STATUS.WITHDRAWN,
+				APPEAL_CASE_STATUS.WITHDRAWN,
+				APPEAL_CASE_STATUS.WITHDRAWN,
+				APPEAL_CASE_STATUS.WITHDRAWN
+			]
+		])(
+			'correctly transitions from %s state on %s event to %s state',
+			(initial, event, expectedHAS, expectedFPAWritten, expectedFPAHearing, expectedFPAInquiry) => {
+				expect(nextStateHAS(initial, event)).toBe(expectedHAS);
+				expect(nextStateFPA(initial, event, APPEAL_CASE_PROCEDURE.WRITTEN)).toBe(
+					expectedFPAWritten
+				);
+				expect(nextStateFPA(initial, event, APPEAL_CASE_PROCEDURE.HEARING)).toBe(
+					expectedFPAHearing
+				);
+				expect(nextStateFPA(initial, event, APPEAL_CASE_PROCEDURE.INQUIRY)).toBe(
+					expectedFPAInquiry
+				);
+			}
+		);
+	});
+
+	describe('Statements transitions', () => {
+		test.each([
+			[
+				APPEAL_CASE_STATUS.STATEMENTS,
+				VALIDATION_OUTCOME_COMPLETE,
+				APPEAL_CASE_STATUS.FINAL_COMMENTS,
+				APPEAL_CASE_STATUS.EVENT,
+				APPEAL_CASE_STATUS.EVIDENCE
+			],
+			[
+				APPEAL_CASE_STATUS.STATEMENTS,
+				APPEAL_CASE_STATUS.CLOSED,
+				APPEAL_CASE_STATUS.CLOSED,
+				APPEAL_CASE_STATUS.CLOSED,
+				APPEAL_CASE_STATUS.CLOSED
+			],
+			[
+				APPEAL_CASE_STATUS.STATEMENTS,
+				APPEAL_CASE_STATUS.AWAITING_TRANSFER,
+				APPEAL_CASE_STATUS.AWAITING_TRANSFER,
+				APPEAL_CASE_STATUS.AWAITING_TRANSFER,
+				APPEAL_CASE_STATUS.AWAITING_TRANSFER
+			],
+			[
+				APPEAL_CASE_STATUS.STATEMENTS,
+				APPEAL_CASE_STATUS.WITHDRAWN,
+				APPEAL_CASE_STATUS.WITHDRAWN,
+				APPEAL_CASE_STATUS.WITHDRAWN,
+				APPEAL_CASE_STATUS.WITHDRAWN
+			]
+		])(
+			'correctly transitions from %s state on %s event to %s state for FPA',
+			(initial, event, expectedFPAWritten, expectedFPAHearing, expectedFPAInquiry) => {
+				expect(nextStateFPA(initial, event, APPEAL_CASE_PROCEDURE.WRITTEN)).toBe(
+					expectedFPAWritten
+				);
+				expect(nextStateFPA(initial, event, APPEAL_CASE_PROCEDURE.HEARING)).toBe(
+					expectedFPAHearing
+				);
+				expect(nextStateFPA(initial, event, APPEAL_CASE_PROCEDURE.INQUIRY)).toBe(
+					expectedFPAInquiry
+				);
+			}
+		);
+		test.each([
+			[APPEAL_CASE_STATUS.STATEMENTS, VALIDATION_OUTCOME_COMPLETE, APPEAL_CASE_STATUS.STATEMENTS],
+			[APPEAL_CASE_STATUS.STATEMENTS, APPEAL_CASE_STATUS.CLOSED, APPEAL_CASE_STATUS.STATEMENTS],
+			[
+				APPEAL_CASE_STATUS.STATEMENTS,
+				APPEAL_CASE_STATUS.AWAITING_TRANSFER,
+				APPEAL_CASE_STATUS.STATEMENTS
+			],
+			[APPEAL_CASE_STATUS.STATEMENTS, APPEAL_CASE_STATUS.WITHDRAWN, APPEAL_CASE_STATUS.STATEMENTS]
+		])('correctly remains at %s state for HAS', (initial, event, expectedHAS) => {
+			expect(nextStateHAS(initial, event)).toBe(expectedHAS);
+		});
+	});
+
+	describe('Final comments transitions', () => {
+		test.each([
+			[APPEAL_CASE_STATUS.FINAL_COMMENTS, VALIDATION_OUTCOME_COMPLETE, APPEAL_CASE_STATUS.EVENT],
+			[APPEAL_CASE_STATUS.FINAL_COMMENTS, APPEAL_CASE_STATUS.CLOSED, APPEAL_CASE_STATUS.CLOSED],
+			[
+				APPEAL_CASE_STATUS.FINAL_COMMENTS,
+				APPEAL_CASE_STATUS.AWAITING_TRANSFER,
+				APPEAL_CASE_STATUS.AWAITING_TRANSFER
+			],
+			[
+				APPEAL_CASE_STATUS.FINAL_COMMENTS,
+				APPEAL_CASE_STATUS.WITHDRAWN,
+				APPEAL_CASE_STATUS.WITHDRAWN
+			]
+		])(
+			'correctly transitions from %s state on %s event to %s state for FPA - written',
+			(initial, event, expectedFPAWritten) => {
+				expect(nextStateFPA(initial, event, APPEAL_CASE_PROCEDURE.WRITTEN)).toBe(
+					expectedFPAWritten
+				);
+			}
+		);
+		test.each([
+			[
+				APPEAL_CASE_STATUS.FINAL_COMMENTS,
+				VALIDATION_OUTCOME_COMPLETE,
+				APPEAL_CASE_STATUS.FINAL_COMMENTS,
+				APPEAL_CASE_STATUS.FINAL_COMMENTS,
+				APPEAL_CASE_STATUS.FINAL_COMMENTS
+			],
+			[
+				APPEAL_CASE_STATUS.FINAL_COMMENTS,
+				APPEAL_CASE_STATUS.CLOSED,
+				APPEAL_CASE_STATUS.FINAL_COMMENTS,
+				APPEAL_CASE_STATUS.FINAL_COMMENTS,
+				APPEAL_CASE_STATUS.FINAL_COMMENTS
+			],
+			[
+				APPEAL_CASE_STATUS.FINAL_COMMENTS,
+				APPEAL_CASE_STATUS.AWAITING_TRANSFER,
+				APPEAL_CASE_STATUS.FINAL_COMMENTS,
+				APPEAL_CASE_STATUS.FINAL_COMMENTS,
+				APPEAL_CASE_STATUS.FINAL_COMMENTS
+			],
+			[
+				APPEAL_CASE_STATUS.FINAL_COMMENTS,
+				APPEAL_CASE_STATUS.WITHDRAWN,
+				APPEAL_CASE_STATUS.FINAL_COMMENTS,
+				APPEAL_CASE_STATUS.FINAL_COMMENTS,
+				APPEAL_CASE_STATUS.FINAL_COMMENTS
+			]
+		])(
+			'correctly remains at %s state for HAS and FPA - hearing and inquiry',
+			(initial, event, expectedHAS, expectedFPAHearing, expectedFPAInquiry) => {
+				expect(nextStateHAS(initial, event)).toBe(expectedHAS);
+				expect(nextStateFPA(initial, event, APPEAL_CASE_PROCEDURE.HEARING)).toBe(
+					expectedFPAHearing
+				);
+				expect(nextStateFPA(initial, event, APPEAL_CASE_PROCEDURE.INQUIRY)).toBe(
+					expectedFPAInquiry
+				);
+			}
+		);
+	});
+	describe('Event transitions', () => {
+		test.each([
+			[
+				APPEAL_CASE_STATUS.EVENT,
+				VALIDATION_OUTCOME_COMPLETE,
+				APPEAL_CASE_STATUS.AWAITING_EVENT,
+				APPEAL_CASE_STATUS.AWAITING_EVENT,
+				APPEAL_CASE_STATUS.AWAITING_EVENT,
+				APPEAL_CASE_STATUS.AWAITING_EVENT
+			],
+			[
+				APPEAL_CASE_STATUS.EVENT,
+				VALIDATION_OUTCOME_INCOMPLETE,
+				APPEAL_CASE_STATUS.EVENT,
+				APPEAL_CASE_STATUS.EVENT,
+				APPEAL_CASE_STATUS.EVENT,
+				APPEAL_CASE_STATUS.EVENT
+			],
+			[
+				APPEAL_CASE_STATUS.EVENT,
+				APPEAL_CASE_STATUS.CLOSED,
+				APPEAL_CASE_STATUS.CLOSED,
+				APPEAL_CASE_STATUS.CLOSED,
+				APPEAL_CASE_STATUS.CLOSED,
+				APPEAL_CASE_STATUS.CLOSED
+			],
+			[
+				APPEAL_CASE_STATUS.EVENT,
+				APPEAL_CASE_STATUS.WITHDRAWN,
+				APPEAL_CASE_STATUS.WITHDRAWN,
+				APPEAL_CASE_STATUS.WITHDRAWN,
+				APPEAL_CASE_STATUS.WITHDRAWN,
+				APPEAL_CASE_STATUS.WITHDRAWN
+			]
+		])(
+			'correctly transitions from %s state on %s event to %s state',
+			(initial, event, expectedHAS, expectedFPAWritten, expectedFPAHearing, expectedFPAInquiry) => {
+				expect(nextStateHAS(initial, event)).toBe(expectedHAS);
+				expect(nextStateFPA(initial, event, APPEAL_CASE_PROCEDURE.WRITTEN)).toBe(
+					expectedFPAWritten
+				);
+				expect(nextStateFPA(initial, event, APPEAL_CASE_PROCEDURE.HEARING)).toBe(
+					expectedFPAHearing
+				);
+				expect(nextStateFPA(initial, event, APPEAL_CASE_PROCEDURE.INQUIRY)).toBe(
+					expectedFPAInquiry
+				);
+			}
+		);
+	});
+
+	describe('Evidence transitions', () => {
+		test.each([
+			[
+				APPEAL_CASE_STATUS.EVIDENCE,
+				VALIDATION_OUTCOME_COMPLETE,
+				APPEAL_CASE_STATUS.EVIDENCE,
+				APPEAL_CASE_STATUS.EVIDENCE,
+				APPEAL_CASE_STATUS.EVIDENCE,
+				APPEAL_CASE_STATUS.EVENT
+			],
+			[
+				APPEAL_CASE_STATUS.EVIDENCE,
+				VALIDATION_OUTCOME_INCOMPLETE,
+				APPEAL_CASE_STATUS.EVIDENCE,
+				APPEAL_CASE_STATUS.EVIDENCE,
+				APPEAL_CASE_STATUS.EVIDENCE,
+				APPEAL_CASE_STATUS.EVIDENCE
+			],
+			[
+				APPEAL_CASE_STATUS.EVIDENCE,
+				APPEAL_CASE_STATUS.CLOSED,
+				APPEAL_CASE_STATUS.EVIDENCE,
+				APPEAL_CASE_STATUS.EVIDENCE,
+				APPEAL_CASE_STATUS.EVIDENCE,
+				APPEAL_CASE_STATUS.CLOSED
+			],
+			[
+				APPEAL_CASE_STATUS.EVIDENCE,
+				APPEAL_CASE_STATUS.AWAITING_TRANSFER,
+				APPEAL_CASE_STATUS.EVIDENCE,
+				APPEAL_CASE_STATUS.EVIDENCE,
+				APPEAL_CASE_STATUS.EVIDENCE,
+				APPEAL_CASE_STATUS.AWAITING_TRANSFER
+			],
+			[
+				APPEAL_CASE_STATUS.EVIDENCE,
+				APPEAL_CASE_STATUS.WITHDRAWN,
+				APPEAL_CASE_STATUS.EVIDENCE,
+				APPEAL_CASE_STATUS.EVIDENCE,
+				APPEAL_CASE_STATUS.EVIDENCE,
+				APPEAL_CASE_STATUS.WITHDRAWN
+			]
+		])(
+			'transitions from %s on %s to %s',
+			(initial, event, expectedHAS, expectedFPAWritten, expectedFPAHearing, expectedFPAInquiry) => {
+				expect(nextStateHAS(initial, event)).toBe(expectedHAS);
+				expect(nextStateFPA(initial, event, APPEAL_CASE_PROCEDURE.WRITTEN)).toBe(
+					expectedFPAWritten
+				);
+				expect(nextStateFPA(initial, event, APPEAL_CASE_PROCEDURE.HEARING)).toBe(
+					expectedFPAHearing
+				);
+				expect(nextStateFPA(initial, event, APPEAL_CASE_PROCEDURE.INQUIRY)).toBe(
+					expectedFPAInquiry
+				);
+			}
+		);
+	});
+
+	describe('Awaiting event transitions', () => {
+		test.each([
+			[
+				APPEAL_CASE_STATUS.AWAITING_EVENT,
+				VALIDATION_OUTCOME_COMPLETE,
+				APPEAL_CASE_STATUS.ISSUE_DETERMINATION,
+				APPEAL_CASE_STATUS.ISSUE_DETERMINATION,
+				APPEAL_CASE_STATUS.ISSUE_DETERMINATION,
+				APPEAL_CASE_STATUS.ISSUE_DETERMINATION
+			],
+			[
+				APPEAL_CASE_STATUS.AWAITING_EVENT,
+				VALIDATION_OUTCOME_INCOMPLETE,
+				APPEAL_CASE_STATUS.AWAITING_EVENT,
+				APPEAL_CASE_STATUS.AWAITING_EVENT,
+				APPEAL_CASE_STATUS.AWAITING_EVENT,
+				APPEAL_CASE_STATUS.AWAITING_EVENT
+			],
+			[
+				APPEAL_CASE_STATUS.AWAITING_EVENT,
+				VALIDATION_OUTCOME_CANCEL,
+				APPEAL_CASE_STATUS.FINAL_COMMENTS,
+				APPEAL_CASE_STATUS.FINAL_COMMENTS,
+				APPEAL_CASE_STATUS.EVENT,
+				APPEAL_CASE_STATUS.EVIDENCE
+			],
+			[
+				APPEAL_CASE_STATUS.AWAITING_EVENT,
+				APPEAL_CASE_STATUS.AWAITING_TRANSFER,
+				APPEAL_CASE_STATUS.AWAITING_TRANSFER,
+				APPEAL_CASE_STATUS.AWAITING_TRANSFER,
+				APPEAL_CASE_STATUS.AWAITING_TRANSFER,
+				APPEAL_CASE_STATUS.AWAITING_TRANSFER
+			],
+			[
+				APPEAL_CASE_STATUS.AWAITING_EVENT,
+				APPEAL_CASE_STATUS.WITHDRAWN,
+				APPEAL_CASE_STATUS.WITHDRAWN,
+				APPEAL_CASE_STATUS.WITHDRAWN,
+				APPEAL_CASE_STATUS.WITHDRAWN,
+				APPEAL_CASE_STATUS.WITHDRAWN
+			]
+		])(
+			'transitions from %s on %s to %s',
+			(initial, event, expectedHAS, expectedFPAWritten, expectedFPAHearing, expectedFPAInquiry) => {
+				expect(nextStateHAS(initial, event)).toBe(expectedHAS);
+				expect(nextStateFPA(initial, event, APPEAL_CASE_PROCEDURE.WRITTEN)).toBe(
+					expectedFPAWritten
+				);
+				expect(nextStateFPA(initial, event, APPEAL_CASE_PROCEDURE.HEARING)).toBe(
+					expectedFPAHearing
+				);
+				expect(nextStateFPA(initial, event, APPEAL_CASE_PROCEDURE.INQUIRY)).toBe(
+					expectedFPAInquiry
+				);
+			}
+		);
+	});
+
+	describe('Issue determination transitions', () => {
+		test.each([
+			[
+				APPEAL_CASE_STATUS.ISSUE_DETERMINATION,
+				APPEAL_CASE_STATUS.COMPLETE,
+				APPEAL_CASE_STATUS.COMPLETE,
+				APPEAL_CASE_STATUS.COMPLETE,
+				APPEAL_CASE_STATUS.COMPLETE,
+				APPEAL_CASE_STATUS.COMPLETE
+			],
+			[
+				APPEAL_CASE_STATUS.ISSUE_DETERMINATION,
+				APPEAL_CASE_STATUS.CLOSED,
+				APPEAL_CASE_STATUS.CLOSED,
+				APPEAL_CASE_STATUS.CLOSED,
+				APPEAL_CASE_STATUS.CLOSED,
+				APPEAL_CASE_STATUS.CLOSED
+			],
+			[
+				APPEAL_CASE_STATUS.ISSUE_DETERMINATION,
+				APPEAL_CASE_STATUS.AWAITING_TRANSFER,
+				APPEAL_CASE_STATUS.AWAITING_TRANSFER,
+				APPEAL_CASE_STATUS.AWAITING_TRANSFER,
+				APPEAL_CASE_STATUS.AWAITING_TRANSFER,
+				APPEAL_CASE_STATUS.AWAITING_TRANSFER
+			],
+			[
+				APPEAL_CASE_STATUS.ISSUE_DETERMINATION,
+				APPEAL_CASE_STATUS.WITHDRAWN,
+				APPEAL_CASE_STATUS.WITHDRAWN,
+				APPEAL_CASE_STATUS.WITHDRAWN,
+				APPEAL_CASE_STATUS.WITHDRAWN,
+				APPEAL_CASE_STATUS.WITHDRAWN
+			],
+			[
+				APPEAL_CASE_STATUS.ISSUE_DETERMINATION,
+				APPEAL_CASE_STATUS.INVALID,
+				APPEAL_CASE_STATUS.INVALID,
+				APPEAL_CASE_STATUS.INVALID,
+				APPEAL_CASE_STATUS.INVALID,
+				APPEAL_CASE_STATUS.INVALID
+			]
+		])(
+			'transitions from %s on %s to %s',
+			(initial, event, expectedHAS, expectedFPAWritten, expectedFPAHearing, expectedFPAInquiry) => {
+				expect(nextStateHAS(initial, event)).toBe(expectedHAS);
+				expect(nextStateFPA(initial, event, APPEAL_CASE_PROCEDURE.WRITTEN)).toBe(
+					expectedFPAWritten
+				);
+				expect(nextStateFPA(initial, event, APPEAL_CASE_PROCEDURE.HEARING)).toBe(
+					expectedFPAHearing
+				);
+				expect(nextStateFPA(initial, event, APPEAL_CASE_PROCEDURE.INQUIRY)).toBe(
+					expectedFPAInquiry
+				);
+			}
+		);
+	});
+
+	describe('Awaiting transfer transitions', () => {
+		test('transitions from awaiting_transfer on transferred to transferred', () => {
+			expect(
+				nextStateHAS(APPEAL_CASE_STATUS.AWAITING_TRANSFER, APPEAL_CASE_STATUS.TRANSFERRED)
+			).toBe(APPEAL_CASE_STATUS.TRANSFERRED);
+			expect(
+				nextStateFPA(
+					APPEAL_CASE_STATUS.AWAITING_TRANSFER,
+					APPEAL_CASE_STATUS.TRANSFERRED,
+					APPEAL_CASE_PROCEDURE.WRITTEN
+				)
+			).toBe(APPEAL_CASE_STATUS.TRANSFERRED);
+			expect(
+				nextStateFPA(
+					APPEAL_CASE_STATUS.AWAITING_TRANSFER,
+					APPEAL_CASE_STATUS.TRANSFERRED,
+					APPEAL_CASE_PROCEDURE.HEARING
+				)
+			).toBe(APPEAL_CASE_STATUS.TRANSFERRED);
+			expect(
+				nextStateFPA(
+					APPEAL_CASE_STATUS.AWAITING_TRANSFER,
+					APPEAL_CASE_STATUS.TRANSFERRED,
+					APPEAL_CASE_PROCEDURE.INQUIRY
+				)
+			).toBe(APPEAL_CASE_STATUS.TRANSFERRED);
+		});
+	});
+});

--- a/appeals/api/src/server/state/transition-state.js
+++ b/appeals/api/src/server/state/transition-state.js
@@ -74,7 +74,7 @@ const transitionState = async (appealId, azureAdUserId, trigger) => {
 
 	if (
 		newState === APPEAL_CASE_STATUS.EVENT &&
-		[APPEAL_TYPE_SHORTHAND_HAS, APPEAL_TYPE_SHORTHAND_FPA].includes(appealType.key) &&
+		[APPEAL_TYPE_SHORTHAND_HAS, APPEAL_TYPE_SHORTHAND_FPA].includes(appealTypeKey) &&
 		((appeal.procedureType?.key === APPEAL_CASE_PROCEDURE.WRITTEN && appeal.siteVisit) ||
 			(appeal.procedureType?.key === APPEAL_CASE_PROCEDURE.HEARING &&
 				appeal.hearing &&

--- a/packages/appeals/utils/__tests__/is-fpa.test.js
+++ b/packages/appeals/utils/__tests__/is-fpa.test.js
@@ -1,0 +1,34 @@
+import isFPA from '../is-fpa';
+import { APPEAL_CASE_TYPE } from 'pins-data-model';
+
+describe('isFPA', () => {
+	it('returns false for HAS appealType', () => {
+		expect(isFPA(APPEAL_CASE_TYPE.D)).toBe(false);
+	});
+
+	it('returns false for CAS planning appealType', () => {
+		expect(isFPA(APPEAL_CASE_TYPE.Z)).toBe(false);
+	});
+
+	it('returns false for empty string appealType', () => {
+		expect(isFPA('')).toBe(false);
+	});
+
+	it('returns true for S78 appealType', () => {
+		expect(isFPA(APPEAL_CASE_TYPE.W)).toBe(true);
+	});
+
+	it('returns true for S20 appealType', () => {
+		expect(isFPA(APPEAL_CASE_TYPE.Y)).toBe(true);
+	});
+
+	it('throws an error for null appealType', () => {
+		expect(() => isFPA(null)).toThrow('Appeal type - null not defined in isFPA baseCaseType');
+	});
+
+	it('throws an error for unknown appealType', () => {
+		expect(() => isFPA(APPEAL_CASE_TYPE.C)).toThrow(
+			'Appeal type - C not defined in isFPA baseCaseType'
+		);
+	});
+});

--- a/packages/appeals/utils/is-fpa.js
+++ b/packages/appeals/utils/is-fpa.js
@@ -1,9 +1,32 @@
-import { APPEAL_TYPE_SHORTHAND_HAS } from '@pins/appeals/constants/support.js';
+import {
+	APPEAL_TYPE_SHORTHAND_FPA,
+	APPEAL_TYPE_SHORTHAND_HAS
+} from '@pins/appeals/constants/support.js';
+import { APPEAL_CASE_TYPE } from 'pins-data-model';
+/**
+ * @typedef {typeof APPEAL_TYPE_SHORTHAND_HAS | typeof APPEAL_TYPE_SHORTHAND_FPA} BaseAppealType
+ * @typedef {Record<string, BaseAppealType>} BaseCaseType
+ */
+
+/** @type {BaseCaseType} */
+const baseCaseType = {
+	[APPEAL_CASE_TYPE.D]: APPEAL_TYPE_SHORTHAND_HAS,
+	[APPEAL_CASE_TYPE.Z]: APPEAL_TYPE_SHORTHAND_HAS,
+	[APPEAL_CASE_TYPE.W]: APPEAL_TYPE_SHORTHAND_FPA,
+	[APPEAL_CASE_TYPE.Y]: APPEAL_TYPE_SHORTHAND_FPA
+};
+
 /**
  * @param {string | null} appealType
  * @returns {boolean}
  */
-const isFPA = (appealType) => Boolean(appealType && appealType !== APPEAL_TYPE_SHORTHAND_HAS);
-//TODO: use a shared list to aggregate appeal types into 2 categories (HAS-type and S78-type)
+const isFPA = (appealType) => {
+	if (appealType === '') return false;
+
+	if (!appealType || !baseCaseType[appealType]) {
+		throw new Error(`Appeal type - ${appealType} not defined in isFPA baseCaseType`);
+	}
+	return Boolean(baseCaseType[appealType] === APPEAL_TYPE_SHORTHAND_FPA);
+};
 
 export default isFPA;


### PR DESCRIPTION
## Describe your changes

Updates isFPA function to handle additional caseTypes. Updates transition state to use isFPA derived appealTypeKey 

