### PR TITLE
fix(appeals): validate linkable appeal status (a2-3424)

### DIFF
--- a/appeals/api/src/server/endpoints/linkable-appeals/linkable-appeal.service.js
+++ b/appeals/api/src/server/endpoints/linkable-appeals/linkable-appeal.service.js
@@ -4,6 +4,14 @@ import { getAppealFromHorizon } from '#utils/horizon-gateway.js';
 import { formatLinkableAppealSummary } from './linkable-appeal.formatter.js';
 import { formatHorizonGetCaseData } from '#utils/mapping/map-horizon.js';
 import { APPEAL_CASE_STATUS } from 'pins-data-model';
+import { currentStatus } from '#utils/current-status.js';
+
+const linkableCaseStatuses = [
+	APPEAL_CASE_STATUS.ASSIGN_CASE_OFFICER,
+	APPEAL_CASE_STATUS.VALIDATION,
+	APPEAL_CASE_STATUS.READY_TO_START,
+	APPEAL_CASE_STATUS.LPA_QUESTIONNAIRE
+];
 
 /**
  *
@@ -18,7 +26,7 @@ export const getLinkableAppealSummaryByCaseReference = async (appealReference) =
 			throw error;
 		});
 		return formatHorizonGetCaseData(horizonAppeal);
-	} else if (appeal.appealStatus.some(({ status }) => status === APPEAL_CASE_STATUS.STATEMENTS)) {
+	} else if (!linkableCaseStatuses.includes(currentStatus(appeal))) {
 		throw 432;
 	} else {
 		return formatLinkableAppealSummary(appeal);


### PR DESCRIPTION
## Describe your changes
#### Validate linkable appeal status against specific linkable statuses (a2-3424)

### API:
- Change logic to test against a specific list of valid linkable statuses

### TEST:
- Made sure all unit tests pass
- Manually tested within browser

## Issue ticket number and link:
- [(A2-3424) Validation on 'Appeal reference' field when adding a linked appeal](https://pins-ds.atlassian.net/browse/A2-3424)

