### PR TITLE
feat(web): inquiry setup due dates (a2-3498)

### DIFF
--- a/appeals/web/src/server/appeals/appeal-details/inquiry/setup/__tests__/__snapshots__/set-up-inquiry.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/inquiry/setup/__tests__/__snapshots__/set-up-inquiry.test.js.snap
@@ -215,6 +215,224 @@ exports[`set up inquiry GET /inquiry/setup/estimation should match the snapshot 
 </main>"
 `;
 
+exports[`set up inquiry GET /inquiry/setup/timetable-due-dates should match the snapshot 1`] = `
+"<main class="govuk-main-wrapper" id="main-content">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Appeal 351062</span>
+            <h1 class="govuk-heading-l">Timetable due dates</h1>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <div class="govuk-grid-row">
+                <div class="govuk-grid-column-full">
+                    <form method="POST" novalidate="novalidate">
+                        <div class="govuk-form-group">
+                            <fieldset class="govuk-fieldset" role="group" aria-describedby="lpa-questionnaire-due-date-hint">
+                                <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">LPA questionnaire due date</legend>
+                                <div id="lpa-questionnaire-due-date-hint"
+                                class="govuk-hint">For example, 31 3 2025</div>
+                                <div class="govuk-date-input" id="lpa-questionnaire-due-date">
+                                    <div class="govuk-date-input__item">
+                                        <div class="govuk-form-group">
+                                            <label class="govuk-label govuk-date-input__label" for="lpa-questionnaire-due-date-day">Day</label>
+                                            <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
+                                            id="lpa-questionnaire-due-date-day" name="lpa-questionnaire-due-date-day"
+                                            type="text" inputmode="numeric">
+                                        </div>
+                                    </div>
+                                    <div class="govuk-date-input__item">
+                                        <div class="govuk-form-group">
+                                            <label class="govuk-label govuk-date-input__label" for="lpa-questionnaire-due-date-month">Month</label>
+                                            <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
+                                            id="lpa-questionnaire-due-date-month" name="lpa-questionnaire-due-date-month"
+                                            type="text" inputmode="numeric">
+                                        </div>
+                                    </div>
+                                    <div class="govuk-date-input__item">
+                                        <div class="govuk-form-group">
+                                            <label class="govuk-label govuk-date-input__label" for="lpa-questionnaire-due-date-year">Year</label>
+                                            <input class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input govuk-date-input__input"
+                                            id="lpa-questionnaire-due-date-year" name="lpa-questionnaire-due-date-year"
+                                            type="text" inputmode="numeric">
+                                        </div>
+                                    </div>
+                                </div>
+                            </fieldset>
+                        </div>
+                        <div class="govuk-form-group">
+                            <fieldset class="govuk-fieldset" role="group" aria-describedby="statement-due-date-hint">
+                                <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">Statement due date</legend>
+                                <div id="statement-due-date-hint" class="govuk-hint">For example, 31 3 2025</div>
+                                <div class="govuk-date-input" id="statement-due-date">
+                                    <div class="govuk-date-input__item">
+                                        <div class="govuk-form-group">
+                                            <label class="govuk-label govuk-date-input__label" for="statement-due-date-day">Day</label>
+                                            <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
+                                            id="statement-due-date-day" name="statement-due-date-day" type="text" inputmode="numeric">
+                                        </div>
+                                    </div>
+                                    <div class="govuk-date-input__item">
+                                        <div class="govuk-form-group">
+                                            <label class="govuk-label govuk-date-input__label" for="statement-due-date-month">Month</label>
+                                            <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
+                                            id="statement-due-date-month" name="statement-due-date-month" type="text"
+                                            inputmode="numeric">
+                                        </div>
+                                    </div>
+                                    <div class="govuk-date-input__item">
+                                        <div class="govuk-form-group">
+                                            <label class="govuk-label govuk-date-input__label" for="statement-due-date-year">Year</label>
+                                            <input class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input govuk-date-input__input"
+                                            id="statement-due-date-year" name="statement-due-date-year" type="text"
+                                            inputmode="numeric">
+                                        </div>
+                                    </div>
+                                </div>
+                            </fieldset>
+                        </div>
+                        <div class="govuk-form-group">
+                            <fieldset class="govuk-fieldset" role="group" aria-describedby="ip-comments-due-date-hint">
+                                <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">Interested party comments</legend>
+                                <div id="ip-comments-due-date-hint"
+                                class="govuk-hint">For example, 31 3 2025</div>
+                                <div class="govuk-date-input" id="ip-comments-due-date">
+                                    <div class="govuk-date-input__item">
+                                        <div class="govuk-form-group">
+                                            <label class="govuk-label govuk-date-input__label" for="ip-comments-due-date-day">Day</label>
+                                            <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
+                                            id="ip-comments-due-date-day" name="ip-comments-due-date-day" type="text"
+                                            inputmode="numeric">
+                                        </div>
+                                    </div>
+                                    <div class="govuk-date-input__item">
+                                        <div class="govuk-form-group">
+                                            <label class="govuk-label govuk-date-input__label" for="ip-comments-due-date-month">Month</label>
+                                            <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
+                                            id="ip-comments-due-date-month" name="ip-comments-due-date-month" type="text"
+                                            inputmode="numeric">
+                                        </div>
+                                    </div>
+                                    <div class="govuk-date-input__item">
+                                        <div class="govuk-form-group">
+                                            <label class="govuk-label govuk-date-input__label" for="ip-comments-due-date-year">Year</label>
+                                            <input class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input govuk-date-input__input"
+                                            id="ip-comments-due-date-year" name="ip-comments-due-date-year" type="text"
+                                            inputmode="numeric">
+                                        </div>
+                                    </div>
+                                </div>
+                            </fieldset>
+                        </div>
+                        <div class="govuk-form-group">
+                            <fieldset class="govuk-fieldset" role="group" aria-describedby="statement-of-common-ground-due-date-hint">
+                                <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">Statement of common ground due date</legend>
+                                <div id="statement-of-common-ground-due-date-hint"
+                                class="govuk-hint">For example, 31 3 2025</div>
+                                <div class="govuk-date-input" id="statement-of-common-ground-due-date">
+                                    <div class="govuk-date-input__item">
+                                        <div class="govuk-form-group">
+                                            <label class="govuk-label govuk-date-input__label" for="statement-of-common-ground-due-date-day">Day</label>
+                                            <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
+                                            id="statement-of-common-ground-due-date-day" name="statement-of-common-ground-due-date-day"
+                                            type="text" inputmode="numeric">
+                                        </div>
+                                    </div>
+                                    <div class="govuk-date-input__item">
+                                        <div class="govuk-form-group">
+                                            <label class="govuk-label govuk-date-input__label" for="statement-of-common-ground-due-date-month">Month</label>
+                                            <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
+                                            id="statement-of-common-ground-due-date-month" name="statement-of-common-ground-due-date-month"
+                                            type="text" inputmode="numeric">
+                                        </div>
+                                    </div>
+                                    <div class="govuk-date-input__item">
+                                        <div class="govuk-form-group">
+                                            <label class="govuk-label govuk-date-input__label" for="statement-of-common-ground-due-date-year">Year</label>
+                                            <input class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input govuk-date-input__input"
+                                            id="statement-of-common-ground-due-date-year" name="statement-of-common-ground-due-date-year"
+                                            type="text" inputmode="numeric">
+                                        </div>
+                                    </div>
+                                </div>
+                            </fieldset>
+                        </div>
+                        <div class="govuk-form-group">
+                            <fieldset class="govuk-fieldset" role="group" aria-describedby="proof-of-evidence-and-witnesses-due-date-hint">
+                                <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">Proof of evidence and witnesses due date</legend>
+                                <div id="proof-of-evidence-and-witnesses-due-date-hint"
+                                class="govuk-hint">For example, 31 3 2025</div>
+                                <div class="govuk-date-input" id="proof-of-evidence-and-witnesses-due-date">
+                                    <div class="govuk-date-input__item">
+                                        <div class="govuk-form-group">
+                                            <label class="govuk-label govuk-date-input__label" for="proof-of-evidence-and-witnesses-due-date-day">Day</label>
+                                            <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
+                                            id="proof-of-evidence-and-witnesses-due-date-day" name="proof-of-evidence-and-witnesses-due-date-day"
+                                            type="text" inputmode="numeric">
+                                        </div>
+                                    </div>
+                                    <div class="govuk-date-input__item">
+                                        <div class="govuk-form-group">
+                                            <label class="govuk-label govuk-date-input__label" for="proof-of-evidence-and-witnesses-due-date-month">Month</label>
+                                            <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
+                                            id="proof-of-evidence-and-witnesses-due-date-month" name="proof-of-evidence-and-witnesses-due-date-month"
+                                            type="text" inputmode="numeric">
+                                        </div>
+                                    </div>
+                                    <div class="govuk-date-input__item">
+                                        <div class="govuk-form-group">
+                                            <label class="govuk-label govuk-date-input__label" for="proof-of-evidence-and-witnesses-due-date-year">Year</label>
+                                            <input class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input govuk-date-input__input"
+                                            id="proof-of-evidence-and-witnesses-due-date-year" name="proof-of-evidence-and-witnesses-due-date-year"
+                                            type="text" inputmode="numeric">
+                                        </div>
+                                    </div>
+                                </div>
+                            </fieldset>
+                        </div>
+                        <div class="govuk-form-group">
+                            <fieldset class="govuk-fieldset" role="group" aria-describedby="planning-obligation-due-date-hint">
+                                <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">Planning obligation due date</legend>
+                                <div id="planning-obligation-due-date-hint"
+                                class="govuk-hint">For example, 31 3 2025</div>
+                                <div class="govuk-date-input" id="planning-obligation-due-date">
+                                    <div class="govuk-date-input__item">
+                                        <div class="govuk-form-group">
+                                            <label class="govuk-label govuk-date-input__label" for="planning-obligation-due-date-day">Day</label>
+                                            <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
+                                            id="planning-obligation-due-date-day" name="planning-obligation-due-date-day"
+                                            type="text" inputmode="numeric">
+                                        </div>
+                                    </div>
+                                    <div class="govuk-date-input__item">
+                                        <div class="govuk-form-group">
+                                            <label class="govuk-label govuk-date-input__label" for="planning-obligation-due-date-month">Month</label>
+                                            <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
+                                            id="planning-obligation-due-date-month" name="planning-obligation-due-date-month"
+                                            type="text" inputmode="numeric">
+                                        </div>
+                                    </div>
+                                    <div class="govuk-date-input__item">
+                                        <div class="govuk-form-group">
+                                            <label class="govuk-label govuk-date-input__label" for="planning-obligation-due-date-year">Year</label>
+                                            <input class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input govuk-date-input__input"
+                                            id="planning-obligation-due-date-year" name="planning-obligation-due-date-year"
+                                            type="text" inputmode="numeric">
+                                        </div>
+                                    </div>
+                                </div>
+                            </fieldset>
+                        </div>
+                        <button type="submit" data-prevent-double-click="true" class="govuk-button"
+                        data-module="govuk-button">Continue</button>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </div>
+</main>"
+`;
+
 exports[`set up inquiry POST /inquiry/setup/address-details should re-render the page if addressLine1 is an empty string 1`] = `
 "<div class="govuk-error-summary" data-module="govuk-error-summary">
     <div role="alert">

--- a/appeals/web/src/server/appeals/appeal-details/inquiry/setup/__tests__/set-up-inquiry.test.js
+++ b/appeals/web/src/server/appeals/appeal-details/inquiry/setup/__tests__/set-up-inquiry.test.js
@@ -659,7 +659,7 @@ describe('set up inquiry', () => {
 		});
 
 		//TODO: To be added back when CYA view is applied
-
+		//
 		// eslint-disable-next-line jest/no-commented-out-tests
 		// it('should redirect to /inquiry/setup/check-details with valid inputs', async () => {
 		// 	const response = await request

--- a/appeals/web/src/server/appeals/appeal-details/inquiry/setup/__tests__/set-up-inquiry.test.js
+++ b/appeals/web/src/server/appeals/appeal-details/inquiry/setup/__tests__/set-up-inquiry.test.js
@@ -462,4 +462,231 @@ describe('set up inquiry', () => {
 			url: `${baseUrl}/${appealId}/Inquiry/setup/address-details`
 		});
 	});
+
+	describe('GET /inquiry/setup/timetable-due-dates', () => {
+		const appealId = 2;
+
+		let pageHtml;
+
+		beforeAll(async () => {
+			nock('http://test/')
+				.get(`/appeals/${appealId}`)
+				.reply(200, { ...appealData, appealId });
+
+			const response = await request.get(
+				`${baseUrl}/${appealId}/Inquiry/setup/timetable-due-dates`
+			);
+			pageHtml = parseHtml(response.text);
+		});
+
+		it('should match the snapshot', () => {
+			expect(pageHtml.innerHTML).toMatchSnapshot();
+		});
+
+		it('should render the correct heading', () => {
+			expect(pageHtml.querySelector('h1')?.innerHTML.trim()).toBe('Timetable due dates');
+		});
+
+		it('should render a date input for LPA questionnaire date', () => {
+			expect(pageHtml.querySelector('input#lpa-questionnaire-due-date-day')).not.toBeNull();
+			expect(pageHtml.querySelector('input#lpa-questionnaire-due-date-month')).not.toBeNull();
+			expect(pageHtml.querySelector('input#lpa-questionnaire-due-date-year')).not.toBeNull();
+		});
+
+		it('should render a date input for statements date', () => {
+			expect(pageHtml.querySelector('input#statement-due-date-day')).not.toBeNull();
+			expect(pageHtml.querySelector('input#statement-due-date-month')).not.toBeNull();
+			expect(pageHtml.querySelector('input#statement-due-date-year')).not.toBeNull();
+		});
+
+		it('should render a date input for IP comments date', () => {
+			expect(pageHtml.querySelector('input#ip-comments-due-date-day')).not.toBeNull();
+			expect(pageHtml.querySelector('input#ip-comments-due-date-month')).not.toBeNull();
+			expect(pageHtml.querySelector('input#ip-comments-due-date-year')).not.toBeNull();
+		});
+
+		it('should render a date input for statement of common ground date', () => {
+			expect(
+				pageHtml.querySelector('input#statement-of-common-ground-due-date-day')
+			).not.toBeNull();
+			expect(
+				pageHtml.querySelector('input#statement-of-common-ground-due-date-month')
+			).not.toBeNull();
+			expect(
+				pageHtml.querySelector('input#statement-of-common-ground-due-date-year')
+			).not.toBeNull();
+		});
+
+		it('should render a date input for proof of evidence and witnesses date', () => {
+			expect(
+				pageHtml.querySelector('input#proof-of-evidence-and-witnesses-due-date-day')
+			).not.toBeNull();
+			expect(
+				pageHtml.querySelector('input#proof-of-evidence-and-witnesses-due-date-month')
+			).not.toBeNull();
+			expect(
+				pageHtml.querySelector('input#proof-of-evidence-and-witnesses-due-date-year')
+			).not.toBeNull();
+		});
+
+		it('should render a date input for planning obligation date', () => {
+			expect(pageHtml.querySelector('input#planning-obligation-due-date-day')).not.toBeNull();
+			expect(pageHtml.querySelector('input#planning-obligation-due-date-month')).not.toBeNull();
+			expect(pageHtml.querySelector('input#planning-obligation-due-date-year')).not.toBeNull();
+		});
+	});
+
+	describe('POST /inquiry/setup/timetable-due-dates', () => {
+		const appealId = 2;
+
+		beforeEach(() => {
+			nock('http://test/')
+				.get(`/appeals/${appealId}`)
+				.reply(200, { ...appealData, appealId });
+		});
+
+		it('should return 400 with an error when all fields are blank', async () => {
+			const appealId = 2;
+			// Use a clearly past date
+			const response = await request
+				.post(`${baseUrl}/${appealId}/Inquiry/setup/timetable-due-dates`)
+				.send({});
+
+			expect(response.statusCode).toBe(400);
+
+			const errorSummaryHtml = parseHtml(response.text, {
+				rootElement: '.govuk-error-summary',
+				skipPrettyPrint: true
+			}).innerHTML;
+
+			expect(errorSummaryHtml).toContain('There is a problem</h2>');
+			expect(errorSummaryHtml).toContain('Enter timetable due dates');
+		});
+
+		it('should return 400 with an error when statement due date is in the past', async () => {
+			const appealId = 2;
+			// Use a clearly past date
+			const response = await request
+				.post(`${baseUrl}/${appealId}/Inquiry/setup/timetable-due-dates`)
+				.send({
+					'statement-due-date-day': '01',
+					'statement-due-date-month': '01',
+					'statement-due-date-year': '2000'
+				});
+
+			expect(response.statusCode).toBe(400);
+
+			const errorSummaryHtml = parseHtml(response.text, {
+				rootElement: '.govuk-error-summary',
+				skipPrettyPrint: true
+			}).innerHTML;
+
+			expect(errorSummaryHtml).toContain('There is a problem</h2>');
+			expect(errorSummaryHtml).toContain('statement due date must be in the future');
+		});
+
+		it('should return 400 with an error when incorrect date is entered', async () => {
+			const appealId = 2;
+			// Use a clearly past date
+			const response = await request
+				.post(`${baseUrl}/${appealId}/Inquiry/setup/timetable-due-dates`)
+				.send({
+					'statement-due-date-day': '32',
+					'statement-due-date-month': '12',
+					'statement-due-date-year': '2000'
+				});
+
+			expect(response.statusCode).toBe(400);
+
+			const errorSummaryHtml = parseHtml(response.text, {
+				rootElement: '.govuk-error-summary',
+				skipPrettyPrint: true
+			}).innerHTML;
+
+			expect(errorSummaryHtml).toContain('There is a problem</h2>');
+			expect(errorSummaryHtml).toContain('Statement due date day must be between 1 and 31');
+		});
+
+		it('should return 400 with an error when a non-business day is entered', async () => {
+			const appealId = 2;
+			// Use a clearly past date
+			const response = await request
+				.post(`${baseUrl}/${appealId}/Inquiry/setup/timetable-due-dates`)
+				.send({
+					'statement-due-date-day': '25',
+					'statement-due-date-month': '12',
+					'statement-due-date-year': '2040'
+				});
+
+			expect(response.statusCode).toBe(400);
+
+			const errorSummaryHtml = parseHtml(response.text, {
+				rootElement: '.govuk-error-summary',
+				skipPrettyPrint: true
+			}).innerHTML;
+
+			expect(errorSummaryHtml).toContain('There is a problem</h2>');
+			expect(errorSummaryHtml).toContain('The statement due date must be a business day');
+		});
+
+		it('should return 400 with a specific date field error when full date is not entered', async () => {
+			const appealId = 2;
+			// Use a clearly past date
+			const response = await request
+				.post(`${baseUrl}/${appealId}/Inquiry/setup/timetable-due-dates`)
+				.send({
+					'statement-due-date-day': '01',
+					'statement-due-date-month': '01',
+					'lpa-questionnaire-due-date-year': '2025',
+					'lpa-questionnaire-due-date-day': '01',
+					'planning-obligation-due-date-month': '01',
+					'planning-obligation-due-date-year': '2025'
+				});
+
+			expect(response.statusCode).toBe(400);
+
+			const errorSummaryHtml = parseHtml(response.text, {
+				rootElement: '.govuk-error-summary',
+				skipPrettyPrint: true
+			}).innerHTML;
+
+			expect(errorSummaryHtml).toContain('There is a problem</h2>');
+			expect(errorSummaryHtml).toContain('Statement due date must include a year');
+			expect(errorSummaryHtml).toContain('LPA questionnaire due date must include a month');
+			expect(errorSummaryHtml).toContain('Planning obligation due date must include a day');
+			expect(errorSummaryHtml).toContain('Enter the statement of common ground due date');
+			expect(errorSummaryHtml).toContain('Enter the proof of evidence and witnesses due date');
+		});
+
+		//TODO: To be added back when CYA view is applied
+
+		// eslint-disable-next-line jest/no-commented-out-tests
+		// it('should redirect to /inquiry/setup/check-details with valid inputs', async () => {
+		// 	const response = await request
+		// 		.post(`${baseUrl}/${appealId}/inquiry/setup/timetable-due-dates`)
+		// 		.send({
+		// 			'lpa-questionnaire-due-date-day': '01',
+		// 			'lpa-questionnaire-due-date-month': '02',
+		// 			'lpa-questionnaire-due-date-year': '3025',
+		// 			'statement-due-date-day': '01',
+		// 			'statement-due-date-month': '02',
+		// 			'statement-due-date-year': '3025',
+		// 			'ip-comments-due-date-day': '01',
+		// 			'ip-comments-due-date-month': '02',
+		// 			'ip-comments-due-date-year': '3025',
+		// 			'statement-of-common-ground-due-date-day': '01',
+		// 			'statement-of-common-ground-due-date-month': '02',
+		// 			'statement-of-common-ground-due-date-year': '3025',
+		// 			'proof-of-evidence-and-witnesses-due-date-day': '01',
+		// 			'proof-of-evidence-and-witnesses-due-date-month': '02',
+		// 			'proof-of-evidence-and-witnesses-due-date-year': '3025',
+		// 			'planning-obligation-due-date-day': '01',
+		// 			'planning-obligation-due-date-month': '02',
+		// 			'planning-obligation-due-date-year': '3025'
+		// 		});
+		//
+		// 	expect(response.statusCode).toBe(302);
+		// 	expect(response.headers.location).toBe(`${baseUrl}/${appealId}/inquiry/setup/check-details`);
+		// });
+	});
 });

--- a/appeals/web/src/server/appeals/appeal-details/inquiry/setup/set-up-inquiry-validators.js
+++ b/appeals/web/src/server/appeals/appeal-details/inquiry/setup/set-up-inquiry-validators.js
@@ -1,12 +1,16 @@
 import { createValidator } from '@pins/express';
-import { createDateInputFieldsValidator } from '#lib/validators/date-input.validator.js';
-import { createDateInputDateValidityValidator } from '#lib/validators/date-input.validator.js';
 import { createTimeInputValidator } from '#lib/validators/time-input.validator.js';
-import { createDateInputDateInFutureValidator } from '#lib/validators/date-input.validator.js';
 import { textInputCharacterLimits } from '#appeals/appeal.constants.js';
 import { createYesNoRadioValidator } from '#lib/validators/radio.validator.js';
 import { createTextInputOptionalValidator } from '#lib/validators/text-input-validator.js';
 import { createPostcodeValidator } from '#lib/validators/address.validator.js';
+import {
+	createDateInputFieldsValidator,
+	createDateInputDateValidityValidator,
+	createDateInputDateInFutureValidator,
+	createDateInputDateBusinessDayValidator,
+	extractAndProcessDateErrors
+} from '#lib/validators/date-input.validator.js';
 import { capitalize } from 'lodash-es';
 import { body } from 'express-validator';
 
@@ -15,6 +19,32 @@ import {
 	createAddressLine2Validator,
 	createTownValidator
 } from '#lib/validators/address.validator.js';
+
+const maxLength = textInputCharacterLimits.defaultAddressInputLength;
+
+export const validateInquiryDateTime = createValidator(
+	createDateInputFieldsValidator('inquiry-date', 'Inquiry date'),
+	createDateInputDateValidityValidator('inquiry-date', 'Inquiry date'),
+	createDateInputDateInFutureValidator('inquiry-date', 'Inquiry date'),
+	createTimeInputValidator('inquiry-time', 'inquiry time')
+);
+
+export const validateAddressKnown = createYesNoRadioValidator(
+	'addressKnown',
+	'Select yes if you know the address of where the inquiry will take place'
+);
+
+export const validateInquiryAddress = createValidator(
+	createAddressLine1Validator(),
+	createAddressLine2Validator(),
+	createTownValidator(),
+	createTextInputOptionalValidator(
+		'county',
+		maxLength,
+		`County must be ${maxLength} characters or less`
+	),
+	createPostcodeValidator()
+);
 
 export const validateYesNoInput = createYesNoRadioValidator(
 	'inquiryEstimationYesNo',
@@ -41,28 +71,94 @@ export const validateEstimationInput = createValidator(
 		.withMessage(capitalize('Number of days must be a whole or half number, like 3 or 3.5'))
 );
 
-export const validateAddressKnown = createYesNoRadioValidator(
-	'addressKnown',
-	'Select yes if you know the address of where the inquiry will take place'
-);
+/**
+ * @type {import('express').RequestHandler}
+ */
+export const runDueDateDaysValidator = async (req, res, next) => {
+	if (req.errored) {
+		next();
+		return;
+	}
+	const validators = dueDateDaysInputValidator();
+	let index = 0;
+	// @ts-ignore
+	const runNext = (err) => {
+		if (err) return next(err);
+		const validator = validators[index++];
+		if (!validator) return next();
+		validator(req, res, runNext);
+	};
+	runNext();
+};
 
-const maxLength = textInputCharacterLimits.defaultAddressInputLength;
+/**
+ * @param {string} fieldName
+ * @param {string} label
+ * @returns
+ */
+export const createDueDateValidators = (fieldName, label) => [
+	createDateInputFieldsValidator(fieldName, label),
+	createDateInputDateValidityValidator(fieldName, label),
+	createDateInputDateInFutureValidator(fieldName, label),
+	createDateInputDateBusinessDayValidator(fieldName, label)
+];
 
-export const validateInquiryAddress = createValidator(
-	createAddressLine1Validator(),
-	createAddressLine2Validator(),
-	createTownValidator(),
-	createTextInputOptionalValidator(
-		'county',
-		maxLength,
-		`County must be ${maxLength} characters or less`
-	),
-	createPostcodeValidator()
-);
+/**
+ * @returns {import('express').RequestHandler[]}
+ */
+export const dueDateDaysInputValidator = () => {
+	/** @type {import('express').RequestHandler[]} */
+	const validatorsList = [];
+	const validatorsMap = {
+		lpaQuestionnaireDueDate: {
+			id: 'lpa-questionnaire-due-date',
+			label: 'LPA questionnaire due date'
+		},
+		statementDueDate: {
+			id: 'statement-due-date',
+			label: 'Statement due date'
+		},
+		ipCommentsDueDate: {
+			id: 'ip-comments-due-date',
+			label: 'Interested party comments due date'
+		},
+		proofsOfEvidenceDueDate: {
+			id: 'proof-of-evidence-and-witnesses-due-date',
+			label: 'Proof of evidence and witnesses due date'
+		},
+		statementOfCommonGroundDueDate: {
+			id: 'statement-of-common-ground-due-date',
+			label: 'Statement of common ground due date'
+		},
+		planningObligationDueDate: {
+			id: 'planning-obligation-due-date',
+			label: 'Planning obligation due date'
+		}
+	};
 
-export const validateInquiryDateTime = createValidator(
-	createDateInputFieldsValidator('inquiry-date', 'Inquiry date'),
-	createDateInputDateValidityValidator('inquiry-date', 'Inquiry date'),
-	createDateInputDateInFutureValidator('inquiry-date', 'Inquiry date'),
-	createTimeInputValidator('inquiry-time', 'inquiry time')
-);
+	Object.values(validatorsMap).forEach((validatorType) => {
+		validatorsList.push(...createDueDateValidators(validatorType.id, validatorType.label));
+	});
+
+	validatorsList.push(
+		extractAndProcessDateErrors({
+			fieldNamePrefix: 'lpa-questionnaire-due-date'
+		}),
+		extractAndProcessDateErrors({
+			fieldNamePrefix: 'statement-due-date'
+		}),
+		extractAndProcessDateErrors({
+			fieldNamePrefix: 'ip-comments-due-date'
+		}),
+		extractAndProcessDateErrors({
+			fieldNamePrefix: 'proof-of-evidence-and-witnesses-due-date'
+		}),
+		extractAndProcessDateErrors({
+			fieldNamePrefix: 'statement-of-common-ground-due-date'
+		}),
+		extractAndProcessDateErrors({
+			fieldNamePrefix: 'planning-obligation-due-date'
+		})
+	);
+	return validatorsList;
+};

--- a/appeals/web/src/server/appeals/appeal-details/inquiry/setup/set-up-inquiry.controller.js
+++ b/appeals/web/src/server/appeals/appeal-details/inquiry/setup/set-up-inquiry.controller.js
@@ -1,4 +1,9 @@
-import { inquiryDatePage, addressDetailsPage, addressKnownPage } from './set-up-inquiry.mapper.js';
+import {
+	inquiryDatePage,
+	addressDetailsPage,
+	addressKnownPage,
+	inquiryDueDatesPage
+} from './set-up-inquiry.mapper.js';
 import { inquiryEstimationPage } from './set-up-inquiry.mapper.js';
 import { isEmpty, has, pick } from 'lodash-es';
 
@@ -203,6 +208,48 @@ export const postInquiryAddressDetails = async (request, response) => {
 
 	return response.redirect(
 		`/appeals-service/appeal-details/${appealId}/inquiry/setup/timetable-due-dates`
+	);
+};
+
+/**
+ * @param {import('@pins/express/types/express.js').Request} request
+ * @param {import('@pins/express/types/express.js').RenderedResponse<any, any, Number>} response
+ */
+export const getInquiryDueDates = async (request, response) => {
+	const values = request.session['setUpInquiry'] || {};
+
+	return renderInquiryDueDates(request, response, values);
+};
+
+/**
+ * @param {import('@pins/express/types/express.js').Request} request
+ * @param {import('@pins/express/types/express.js').RenderedResponse<any, any, Number>} response
+ * @param {import('@pins/appeals').Address} values
+ */
+export const renderInquiryDueDates = async (request, response, values) => {
+	const { currentAppeal, errors } = request;
+	const mappedPageContent = await inquiryDueDatesPage(currentAppeal, values, errors);
+
+	return response.status(errors ? 400 : 200).render('patterns/change-page.pattern.njk', {
+		pageContent: mappedPageContent,
+		errors
+	});
+};
+
+/**
+ * @param {import('@pins/express/types/express.js').Request} request
+ * @param {import('@pins/express/types/express.js').RenderedResponse<any, any, Number>} response
+ */
+export const postInquiryDueDates = async (request, response) => {
+	if (request.errors) {
+		const values = request.session['setUpInquiry'] || {};
+		return renderInquiryDueDates(request, response, values);
+	}
+
+	const { appealId } = request.currentAppeal;
+
+	return response.redirect(
+		`/appeals-service/appeal-details/${appealId}/inquiry/setup/check-details`
 	);
 };
 

--- a/appeals/web/src/server/appeals/appeal-details/inquiry/setup/set-up-inquiry.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/inquiry/setup/set-up-inquiry.mapper.js
@@ -157,3 +157,97 @@ export function addressDetailsPage(appealData, action, currentAddress, errors) {
 		pageComponents: addressInputs({ address: currentAddress, errors })
 	};
 }
+
+/**
+ * @param {Appeal} appealDetails
+ * @param {import('@pins/appeals').Address} values
+ * @param {import("@pins/express").ValidationErrors | undefined} errors
+ * @returns Promise<PageContent>
+ */
+export const inquiryDueDatesPage = async (appealDetails, values, errors = undefined) => {
+	/**
+	 * @type {{backLinkUrl: string, heading: string, title: string, preHeading: string, pageComponents?: PageComponent[]}}
+	 */
+	let pageContent = {
+		title: `Timetable due dates`,
+		backLinkUrl:
+			values.addressLine1 || values.addressLine2
+				? `/appeals-service/appeal-details/${appealDetails.appealId}/inquiry/setup/address-details`
+				: `/appeals-service/appeal-details/${appealDetails.appealId}/inquiry/setup/address`,
+		preHeading: `Appeal ${appealShortReference(appealDetails.appealReference)}`,
+		heading: `Timetable due dates`,
+		pageComponents: []
+	};
+	/**
+	 *
+	 * @type {string[]}
+	 */
+	const dueDateFields = [
+		'lpaQuestionnaireDueDate',
+		'statementDueDate',
+		'ipCommentsDueDate',
+		'statementOfCommonGroundDueDate',
+		'proofOfEvidenceAndWitnessesDueDate',
+		'planningObligationDueDate'
+	];
+
+	pageContent.pageComponents = dueDateFields.map((dateField) => {
+		const fieldType = getDueDateFieldNameAndID(dateField);
+		if (fieldType === undefined) {
+			throw new Error(`Unknown date field: ${dateField}`);
+		}
+		return dateInput({
+			name: `${fieldType.id}`,
+			id: `${fieldType.id}`,
+			namePrefix: `${fieldType.id}`,
+			legendText: `${fieldType.name}`,
+			hint: 'For example, 31 3 2025',
+			legendClasses: 'govuk-fieldset__legend--m',
+			errors: errors
+		});
+	});
+
+	return pageContent;
+};
+
+/**
+ *
+ * @param {string} dateField
+ * @returns {undefined | {name: string, id: string}}
+ */
+export const getDueDateFieldNameAndID = (dateField) => {
+	switch (dateField) {
+		case 'lpaQuestionnaireDueDate':
+			return {
+				id: 'lpa-questionnaire-due-date',
+				name: 'LPA questionnaire due date'
+			};
+		case 'statementDueDate':
+			return {
+				id: 'statement-due-date',
+				name: 'Statement due date'
+			};
+		case 'ipCommentsDueDate':
+			return {
+				id: 'ip-comments-due-date',
+				name: 'Interested party comments'
+			};
+		case 'statementOfCommonGroundDueDate':
+			return {
+				id: 'statement-of-common-ground-due-date',
+				name: 'Statement of common ground due date'
+			};
+		case 'proofOfEvidenceAndWitnessesDueDate':
+			return {
+				id: 'proof-of-evidence-and-witnesses-due-date',
+				name: 'Proof of evidence and witnesses due date'
+			};
+		case 'planningObligationDueDate':
+			return {
+				id: 'planning-obligation-due-date',
+				name: 'Planning obligation due date'
+			};
+		default:
+			return undefined;
+	}
+};

--- a/appeals/web/src/server/appeals/appeal-details/inquiry/setup/set-up-inquiry.router.js
+++ b/appeals/web/src/server/appeals/appeal-details/inquiry/setup/set-up-inquiry.router.js
@@ -3,6 +3,8 @@ import { asyncHandler } from '@pins/express';
 import * as controller from './set-up-inquiry.controller.js';
 import { saveBodyToSession } from '#lib/middleware/save-body-to-session.js';
 import * as validators from './set-up-inquiry-validators.js';
+import { runDueDateDaysValidator } from './set-up-inquiry-validators.js';
+import { createNotEmptyBodyValidator } from '#lib/validators/generic.validator.js';
 
 const router = createRouter({ mergeParams: true });
 
@@ -43,6 +45,16 @@ router
 		validators.validateInquiryAddress,
 		saveBodyToSession('setUpInquiry'),
 		asyncHandler(controller.postInquiryAddressDetails)
+	);
+
+router
+	.route('/timetable-due-dates')
+	.get(asyncHandler(controller.getInquiryDueDates))
+	.post(
+		createNotEmptyBodyValidator('whole-page::Enter timetable due dates'),
+		runDueDateDaysValidator,
+		saveBodyToSession('setUpInquiry'),
+		asyncHandler(controller.postInquiryDueDates)
 	);
 
 export default router;

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/__tests__/__snapshots__/lpa-questionnaire.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/__tests__/__snapshots__/lpa-questionnaire.test.js.snap
@@ -3928,33 +3928,7 @@ data-index="0">
 </div>"
 `;
 
-exports[`LPA Questionnaire review Notification banners should render a "Safety risks updated" success notification banner when the safety risks (lpa) is updated 2`] = `
-"<div class="govuk-notification-banner govuk-notification-banner--success govuk-!-margin-bottom-5"
-role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner"
-data-index="0">
-    <div class="govuk-notification-banner__header">
-        <h3 class="govuk-notification-banner__title" id="govuk-notification-banner-title"> Success</h3>
-    </div>
-    <div class="govuk-notification-banner__content">
-        <p class="govuk-notification-banner__heading">Site health and safety risks (LPA answer) updated</p>
-    </div>
-</div>"
-`;
-
 exports[`LPA Questionnaire review Notification banners should render a success notification banner when "green belt" is updated 1`] = `
-"<div class="govuk-notification-banner govuk-notification-banner--success govuk-!-margin-bottom-5"
-role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner"
-data-index="0">
-    <div class="govuk-notification-banner__header">
-        <h3 class="govuk-notification-banner__title" id="govuk-notification-banner-title"> Success</h3>
-    </div>
-    <div class="govuk-notification-banner__content">
-        <p class="govuk-notification-banner__heading">Green belt status updated</p>
-    </div>
-</div>"
-`;
-
-exports[`LPA Questionnaire review Notification banners should render a success notification banner when "green belt" is updated 2`] = `
 "<div class="govuk-notification-banner govuk-notification-banner--success govuk-!-margin-bottom-5"
 role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner"
 data-index="0">

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/__tests__/__snapshots__/lpa-questionnaire.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/__tests__/__snapshots__/lpa-questionnaire.test.js.snap
@@ -3928,7 +3928,33 @@ data-index="0">
 </div>"
 `;
 
+exports[`LPA Questionnaire review Notification banners should render a "Safety risks updated" success notification banner when the safety risks (lpa) is updated 2`] = `
+"<div class="govuk-notification-banner govuk-notification-banner--success govuk-!-margin-bottom-5"
+role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner"
+data-index="0">
+    <div class="govuk-notification-banner__header">
+        <h3 class="govuk-notification-banner__title" id="govuk-notification-banner-title"> Success</h3>
+    </div>
+    <div class="govuk-notification-banner__content">
+        <p class="govuk-notification-banner__heading">Site health and safety risks (LPA answer) updated</p>
+    </div>
+</div>"
+`;
+
 exports[`LPA Questionnaire review Notification banners should render a success notification banner when "green belt" is updated 1`] = `
+"<div class="govuk-notification-banner govuk-notification-banner--success govuk-!-margin-bottom-5"
+role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner"
+data-index="0">
+    <div class="govuk-notification-banner__header">
+        <h3 class="govuk-notification-banner__title" id="govuk-notification-banner-title"> Success</h3>
+    </div>
+    <div class="govuk-notification-banner__content">
+        <p class="govuk-notification-banner__heading">Green belt status updated</p>
+    </div>
+</div>"
+`;
+
+exports[`LPA Questionnaire review Notification banners should render a success notification banner when "green belt" is updated 2`] = `
 "<div class="govuk-notification-banner govuk-notification-banner--success govuk-!-margin-bottom-5"
 role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner"
 data-index="0">

--- a/appeals/web/src/server/lib/validators/date-input.validator.js
+++ b/appeals/web/src/server/lib/validators/date-input.validator.js
@@ -341,6 +341,17 @@ export const extractAndProcessDateErrors = ({ fieldNamePrefix }) => {
 		if (!req.errors) {
 			return next();
 		}
+		for (const e of Object.keys(req.errors)) {
+			if (req.errors[e].msg.includes('whole-page')) {
+				const [cause, message] = req.errors[e].msg.split('::');
+				req.errors[e].param = `${cause}`;
+				req.errors[e].msg = message;
+				req.errors = {
+					e: req.errors[e]
+				};
+				return next();
+			}
+		}
 
 		const dateFields = [
 			`${fieldNamePrefix}`,

--- a/appeals/web/src/server/lib/validators/generic.validator.js
+++ b/appeals/web/src/server/lib/validators/generic.validator.js
@@ -1,0 +1,17 @@
+import { createValidator } from '@pins/express';
+import { body } from 'express-validator';
+
+/**
+ *
+ * @param {string} errorMessage
+ */
+export const createNotEmptyBodyValidator = (errorMessage) => {
+	return createValidator(
+		body().custom((_, { req }) => {
+			if (Object.keys(req.body).length === 0 || Object.values(req.body).every((value) => !value)) {
+				throw new Error(errorMessage, { cause: 'all-fields' });
+			}
+			return true;
+		})
+	);
+};


### PR DESCRIPTION
- Added route, controller, mapper and validators for inquiry setup due dates
- Added generic validator for empty input
- Amended date validator to read when all inputs are blank 
- Added tests
- Added snapshot

https://pins-ds.atlassian.net/browse/A2-3498?atlOrigin=eyJpIjoiZTE4MTExNTUzYmZiNGMwNjgwYjkxYzYyODlkNGM2MjEiLCJwIjoiaiJ9