### PR TITLE
feat(appeals): updating notify tests and docs for listed building

### DIFF
--- a/appeals/api/src/server/endpoints/appeal-decision/__tests__/appeal-decision.test.js
+++ b/appeals/api/src/server/endpoints/appeal-decision/__tests__/appeal-decision.test.js
@@ -2,7 +2,7 @@
 import { request } from '../../../app-test.js';
 import { jest } from '@jest/globals';
 import { azureAdUserId } from '#tests/shared/mocks.js';
-import { householdAppeal } from '#tests/appeals/mocks.js';
+import { fullPlanningAppeal, householdAppeal, listedBuildingAppeal } from '#tests/appeals/mocks.js';
 import { documentCreated } from '#tests/documents/mocks.js';
 import formatDate from '@pins/appeals/utils/date-formatter.js';
 import { add, sub } from 'date-fns';
@@ -148,9 +148,14 @@ describe('appeal decision routes', () => {
 				}
 			});
 		});
-		test('returns 200 when all good', async () => {
+
+		test.each([
+			['householdAppeal', householdAppeal],
+			['fullPlanningAppeal', fullPlanningAppeal],
+			['listedBuildingAppeal', listedBuildingAppeal]
+		])('returns 200 when all good, appeal type: %s', async (_, appeal) => {
 			const correctAppealState = {
-				...householdAppeal,
+				...appeal,
 				appealStatus: [
 					{
 						status: APPEAL_CASE_STATUS.ISSUE_DETERMINATION,
@@ -170,7 +175,7 @@ describe('appeal decision routes', () => {
 			const utcDate = setTimeInTimeZone(withoutWeekends, 0, 0);
 
 			const response = await request
-				.post(`/appeals/${householdAppeal.id}/inspector-decision`)
+				.post(`/appeals/${appeal.id}/inspector-decision`)
 				.send({
 					outcome: 'allowed',
 					documentDate: utcDate.toISOString(),
@@ -184,26 +189,26 @@ describe('appeal decision routes', () => {
 				notifyClient: expect.any(Object),
 				templateName: 'decision-is-allowed-split-dismissed-appellant',
 				personalisation: {
-					appeal_reference_number: '1345264',
-					lpa_reference: '48269/APP/2021/1482',
-					site_address: '96 The Avenue, Leftfield, Maidstone, Kent, MD21 5XY, United Kingdom',
+					appeal_reference_number: appeal.reference,
+					lpa_reference: appeal.applicationReference,
+					site_address: `${appeal.address.addressLine1}, ${appeal.address.addressLine2}, ${appeal.address.addressTown}, ${appeal.address.addressCounty}, ${appeal.address.postcode}, ${appeal.address.addressCountry}`,
 					decision_date: formatDate(utcDate, false),
-					front_office_url: 'https://appeal-planning-decision.service.gov.uk/appeals/1345264'
+					front_office_url: `https://appeal-planning-decision.service.gov.uk/appeals/${appeal.reference}`
 				},
-				recipientEmail: 'test@136s7.com'
+				recipientEmail: appeal.agent.email
 			});
 
 			expect(mockNotifySend).toHaveBeenCalledWith({
 				notifyClient: expect.any(Object),
 				personalisation: {
-					appeal_reference_number: '1345264',
-					lpa_reference: '48269/APP/2021/1482',
-					site_address: '96 The Avenue, Leftfield, Maidstone, Kent, MD21 5XY, United Kingdom',
+					appeal_reference_number: appeal.reference,
+					lpa_reference: appeal.applicationReference,
+					site_address: `${appeal.address.addressLine1}, ${appeal.address.addressLine2}, ${appeal.address.addressTown}, ${appeal.address.addressCounty}, ${appeal.address.postcode}, ${appeal.address.addressCountry}`,
 					decision_date: formatDate(utcDate, false),
-					front_office_url: 'https://appeal-planning-decision.service.gov.uk/appeals/1345264'
+					front_office_url: `https://appeal-planning-decision.service.gov.uk/appeals/${appeal.reference}`
 				},
-				templateName: 'decision-is-allowed-split-dismissed-appellant',
-				recipientEmail: 'test@136s7.com'
+				templateName: 'decision-is-allowed-split-dismissed-lpa',
+				recipientEmail: appeal.lpa.email
 			});
 
 			expect(response.status).toEqual(201);

--- a/appeals/api/src/server/tests/appeals/mocks.js
+++ b/appeals/api/src/server/tests/appeals/mocks.js
@@ -460,8 +460,29 @@ export const fullPlanningAppealAppellantCaseInvalid = {
 
 export const fullPlanningAppealLPAQuestionnaireIncomplete = {
 	...fullPlanningAppeal,
+	appealStatus: [
+		{
+			status: APPEAL_CASE_STATUS.LPA_QUESTIONNAIRE,
+			valid: true
+		}
+	],
 	lpaQuestionnaire: {
 		...fullPlanningAppeal.lpaQuestionnaire,
+		...incompleteLPAQuestionnaireOutcome
+	},
+	id: 5
+};
+
+export const listedBuildingAppealLPAQuestionnaireIncomplete = {
+	...listedBuildingAppeal,
+	appealStatus: [
+		{
+			status: APPEAL_CASE_STATUS.LPA_QUESTIONNAIRE,
+			valid: true
+		}
+	],
+	lpaQuestionnaire: {
+		...listedBuildingAppeal.lpaQuestionnaire,
 		...incompleteLPAQuestionnaireOutcome
 	},
 	id: 5

--- a/docs/notifications-and-triggers.md
+++ b/docs/notifications-and-triggers.md
@@ -48,15 +48,15 @@ The following notifications are sent from the back-office using these [Notify Te
 
 ### Appeal valid start case s78 appellant
 
-- **Appeal type:** s78
+- **Appeal type:** s78, s20
 - **Notify Template:** [appeal-valid-start-case-s78-appellant](../appeals/api/src/server/notify/templates/appeal-valid-start-case-s78-appellant.content.md)
-- **Trigger:** Start a full planning case, select an appeal procedure, and confirm.
+- **Trigger:** Start a full planning or listed building case, select an appeal procedure, and confirm.
 
 ### Appeal valid start case s78 lpa
 
-- **Appeal type:** s78
+- **Appeal type:** s78, s20
 - **Notify Template:** [appeal-valid-start-case-s78-lpa](../appeals/api/src/server/notify/templates/appeal-valid-start-case-s78-lpa.content.md)
-- **Trigger:** Start a full planning case, select an appeal procedure, and confirm.
+- **Trigger:** Start a full planning or listed building case, select an appeal procedure, and confirm.
 
 ### Appeal valid start case householder appellant
 
@@ -86,7 +86,7 @@ The following notifications are sent from the back-office using these [Notify Te
 
 ### Lpaq complete s78 appellant
 
-- **Appeal type:** s78
+- **Appeal type:** s78, s20
 - **Notify Template:** [lpaq-complete-appellant](../appeals/api/src/server/notify/templates/lpaq-complete-appellant.content.md)
 - **Trigger:** Review a Lpaq and mark it as complete by selecting "Complete" and continue
 
@@ -112,46 +112,46 @@ The following notifications are sent from the back-office using these [Notify Te
 
 ### Lpa statement incomplete
 
-- **Appeal type:** s78
+- **Appeal type:** s78, s20
 - **Notify Template:** [lpa-statement-incomplete](../appeals/api/src/server/notify/templates/lpa-statement-incomplete.content.md)
 - **Trigger:** Review a lpa statement and mark it as incomplete by selecting "Incomplete" and continue
 
 ### Ip comment rejected
 
-- **Appeal type:** s78
+- **Appeal type:** s78, s20
 - **Notify Template:** [ip-comment-rejected](../appeals/api/src/server/notify/templates/ip-comment-rejected.content.md)
 - **Trigger:** Review an ip comment and mark it as rejected by selecting "Reject" and continue
 
 ### Ip comment rejected deadline extended
 
-- **Appeal type:** s78
-- **Notify Template:** [ip-comment-rejected](../appeals/api/src/server/notify/templates/ip-comment-rejected.content.md)
+- **Appeal type:** s78, s20
+- **Notify Template:** [ip-comment-rejected-deadline-extended](../appeals/api/src/server/notify/templates/ip-comment-rejected-deadline-extended.content.md)
 - **Trigger:** Update and extend the ip comment due date and then review an ip comment and mark it as rejected by selecting "Reject" and continue
 
 ## Final comments
 
 ### Final comments done appellant
 
-- **Appeal type:** s78
+- **Appeal type:** s78, s20
 - **Notify Template:** [final-comments-done-appellant](../appeals/api/src/server/notify/templates/final-comments-done-appellant.content.md)
 - **Trigger:** Review final comments and mark as accepted and continue
 
 ### Final comments done lpa
 
-- **Appeal type:** s78
+- **Appeal type:** s78, s20
 - **Notify Template:** [final-comments-done-lpa](../appeals/api/src/server/notify/templates/final-comments-done-lpa.content.md)
 - **Trigger:** Review final comments and mark as accepted and continue
 
 ### Final comment rejected appellant
 
-- **Appeal type:** s78
+- **Appeal type:** s78, s20
 - **Notify Template:** [final-comment-rejected-appellant](../appeals/api/src/server/notify/templates/final-comment-rejected-appellant.content.md)
 - **Trigger:** Review final comments and mark as rejected, add some reasons and continue
 -
 
 ### Final comment rejected lpa
 
-- **Appeal type:** s78
+- **Appeal type:** s78, s20
 - **Notify Template:** [final-comment-rejected-lpa](../appeals/api/src/server/notify/templates/final-comment-rejected-lpa.content.md)
 - **Trigger:** Review final comments and mark as rejected, add some reasons and continue
 


### PR DESCRIPTION
## Describe your changes

Updating/adding tests for:
- decision-is-allowed-split-dismissed(-lpa/-appellant)
- lpaq-incomplete
- ip-comment-rejected
- ip-comment-rejected-deadline-extended
- lpa-statement-incomplete

Updating the documentation to include the S20 notifies

## Issue ticket number and link

[Ticket](https://pins-ds.atlassian.net/browse/A2-3581)
