### PR TITLE
feat(web): add documentId to param for reissue decision (A2-3295)

### DIFF
--- a/appeals/web/src/server/appeals/appeal-details/issue-decision/issue-decision.controller.js
+++ b/appeals/web/src/server/appeals/appeal-details/issue-decision/issue-decision.controller.js
@@ -194,6 +194,13 @@ export const renderDecisionLetterUpload = async (request, response) => {
 		? 'update decision letter'
 		: 'issue decision';
 
+	if (shouldFollowReIssueDecisionFlow(currentAppeal)) {
+		request.params = {
+			...request.params,
+			documentId: currentAppeal.decision.documentId
+		};
+	}
+
 	await renderDocumentUpload({
 		request,
 		response,

--- a/appeals/web/src/server/appeals/appeal-details/update-decision-letter/__tests__/__snapshots__/update-decision-letter.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/update-decision-letter/__tests__/__snapshots__/update-decision-letter.test.js.snap
@@ -16,8 +16,8 @@ exports[`update-decision-letter GET /decision-letter-upload should render the de
             data-form-id="1" data-case-id="1" data-case-reference="APP/Q9999/D/21/351062"
             data-folder-id="123" data-document-type="caseDecisionLetter" data-document-stage="appeal-decision"
             data-blob-storage-host="https://127.0.0.1:10000/devstoreaccount1" data-blob-storage-container="document-service-uploads"
-            data-document-title="decision letter" data-allowed-types="application/pdf"
-            data-formatted-allowed-types="PDF">
+            data-document-id="e1e90a49-fab3-44b8-a21a-bb73af089f6b" data-document-title="decision letter"
+            data-allowed-types="application/pdf" data-formatted-allowed-types="PDF">
                 <form method="POST" novalidate="novalidate" class="govuk-grid-column-two-thirds"
                 data-filenames-in-folder="">
                     <div class="pins-file-upload__container">


### PR DESCRIPTION
## Describe your changes

### WEB
- added logic to add the documentId to the parameter for reissue decision letter to set the correct storage address 

### TEST
- manual testing within browser
- Updated snapshots

## Issue ticket number and link

[Ticket](https://pins-ds.atlassian.net.mcas.ms/browse/A2-3295)
