### PR TITLE
Add invalid issue decision journey automation

### DIFF
--- a/appeals/e2e/cypress/e2e/back-office-appeals/issueDecisionInvalid.spec.js
+++ b/appeals/e2e/cypress/e2e/back-office-appeals/issueDecisionInvalid.spec.js
@@ -8,10 +8,16 @@ import { DateTimeSection } from '../../page_objects/dateTimeSection';
 import { urlPaths } from '../../support/urlPaths.js';
 import { tag } from '../../support/tag';
 import { happyPathHelper } from '../../support/happyPathHelper.js';
+import { formatDateAndTime } from '../../support/utils/formatDateAndTime';
 
 const listCasesPage = new ListCasesPage();
 const dateTimeSection = new DateTimeSection();
 const caseDetailsPage = new CaseDetailsPage();
+
+let sampleFiles = caseDetailsPage.sampleFiles;
+
+const now = new Date();
+const formattedDate = formatDateAndTime(now);
 
 describe('Issue Decision', () => {
 	beforeEach(() => {
@@ -19,9 +25,6 @@ describe('Issue Decision', () => {
 	});
 
 	it('Issue Decision is Invalid ', { tags: tag.smoke }, () => {
-		let futureDate = new Date();
-		futureDate.setDate(futureDate.getDate() + 28);
-
 		cy.createCase().then((caseRef) => {
 			cy.addLpaqSubmissionToCase(caseRef);
 			happyPathHelper.assignCaseOfficer(caseRef);
@@ -32,17 +35,41 @@ describe('Issue Decision', () => {
 			cy.simulateSiteVisit(caseRef).then((caseRef) => {
 				cy.reload();
 			});
-			caseDetailsPage.clickIssueDecision(caseRef);
+			caseDetailsPage.clickIssueDecision();
+
+			//issue decision
 			caseDetailsPage.selectRadioButtonByValue('Invalid');
-			caseDetailsPage.clickButtonByText('Continue');
 			caseDetailsPage.fillTextArea('The appeal is invalid because of X reason', 0);
 			caseDetailsPage.clickButtonByText('Continue');
-			caseDetailsPage.selectRadioButtonByValue('No');
+
+			//Appellant costs
+			caseDetailsPage.selectRadioButtonByValue('Yes');
 			caseDetailsPage.clickButtonByText('Continue');
-			caseDetailsPage.selectRadioButtonByValue('No');
+			caseDetailsPage.uploadSampleFile(sampleFiles.pdf);
 			caseDetailsPage.clickButtonByText('Continue');
+
+			//LPA costs
+			caseDetailsPage.selectRadioButtonByValue('Yes');
+			caseDetailsPage.clickButtonByText('Continue');
+			caseDetailsPage.uploadSampleFile(sampleFiles.pdf);
+			caseDetailsPage.clickButtonByText('Continue');
+
+			//CYA
 			caseDetailsPage.clickButtonByText('Issue decision');
+
+			//Case details inset text
+			caseDetailsPage.validateBannerMessage('Success', 'Appeal invalid');
 			caseDetailsPage.checkStatusOfCase('Invalid', 0);
+			caseDetailsPage.checkDecisionOutcome('Decision: Invalid');
+			caseDetailsPage.checkDecisionOutcome(`Decision issued on ${formattedDate.date}`);
+			caseDetailsPage.checkDecisionOutcome('Appellant costs decision: Issued');
+			caseDetailsPage.checkDecisionOutcome('LPA costs decision: Issued');
+			caseDetailsPage.viewDecisionLetter('View decision');
+
+			//Notify
+			const expectedNotifies = ['decision-is-invalid-lpa', 'decision-is-invalid-appellant'];
+
+			cy.checkNotifySent(caseRef, expectedNotifies);
 		});
 	});
 });


### PR DESCRIPTION
## Describe your changes

Adds the journey for issuing an invalid decision, including appellant and LPA costs, file uploads, CYA page, banner message validation, case status and outcome checks, decision letter, and notify checks.

## Issue ticket number and link

[A2-3795](https://pins-ds.atlassian.net/browse/A2-3795)


[A2-3795]: https://pins-ds.atlassian.net/browse/A2-3795?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ