### PR TITLE
feat(A2-3782): Only validating due dates that have been changed

### DIFF
--- a/appeals/api/src/server/endpoints/appeal-timetables/appeal-timetables.service.js
+++ b/appeals/api/src/server/endpoints/appeal-timetables/appeal-timetables.service.js
@@ -256,7 +256,9 @@ const dueDateToAppealTimetableTextMapper = {
 	lpaQuestionnaireDueDate: 'LPA questionnaire',
 	ipCommentsDueDate: 'Interested party comments',
 	lpaStatementDueDate: 'Statements',
-	finalCommentsDueDate: 'Final comments'
+	finalCommentsDueDate: 'Final comments',
+	statementOfCommonGroundDueDate: 'Statement of common ground',
+	planningObligationDueDate: 'Planning obligation'
 };
 
 /**

--- a/appeals/web/src/server/appeals/appeal-details/timetable/__tests__/__snapshots__/timetable.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/timetable/__tests__/__snapshots__/timetable.test.js.snap
@@ -1059,7 +1059,7 @@ exports[`Timetable POST /edit Householder should re-render edit timetable page w
                             <label class="govuk-label govuk-date-input__label" for="lpa-questionnaire-due-date-month">Month</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="lpa-questionnaire-due-date-month" name="lpa-questionnaire-due-date-month"
-                            type="text" inputmode="numeric">
+                            type="text" value="10" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -1067,7 +1067,7 @@ exports[`Timetable POST /edit Householder should re-render edit timetable page w
                             <label class="govuk-label govuk-date-input__label" for="lpa-questionnaire-due-date-year">Year</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input govuk-date-input__input"
                             id="lpa-questionnaire-due-date-year" name="lpa-questionnaire-due-date-year"
-                            type="text" inputmode="numeric">
+                            type="text" value="2050" inputmode="numeric">
                         </div>
                     </div>
                 </div>
@@ -1119,7 +1119,7 @@ exports[`Timetable POST /edit Householder should re-render edit timetable page w
                             <label class="govuk-label govuk-date-input__label" for="lpa-questionnaire-due-date-day">Day</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="lpa-questionnaire-due-date-day" name="lpa-questionnaire-due-date-day"
-                            type="text" inputmode="numeric">
+                            type="text" value="10" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -1135,7 +1135,7 @@ exports[`Timetable POST /edit Householder should re-render edit timetable page w
                             <label class="govuk-label govuk-date-input__label" for="lpa-questionnaire-due-date-year">Year</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input govuk-date-input__input"
                             id="lpa-questionnaire-due-date-year" name="lpa-questionnaire-due-date-year"
-                            type="text" inputmode="numeric">
+                            type="text" value="2050" inputmode="numeric">
                         </div>
                     </div>
                 </div>
@@ -1187,7 +1187,7 @@ exports[`Timetable POST /edit Householder should re-render edit timetable page w
                             <label class="govuk-label govuk-date-input__label" for="lpa-questionnaire-due-date-day">Day</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="lpa-questionnaire-due-date-day" name="lpa-questionnaire-due-date-day"
-                            type="text" inputmode="numeric">
+                            type="text" value="10" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -1195,7 +1195,7 @@ exports[`Timetable POST /edit Householder should re-render edit timetable page w
                             <label class="govuk-label govuk-date-input__label" for="lpa-questionnaire-due-date-month">Month</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="lpa-questionnaire-due-date-month" name="lpa-questionnaire-due-date-month"
-                            type="text" inputmode="numeric">
+                            type="text" value="12" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -1255,7 +1255,7 @@ exports[`Timetable POST /edit Householder should re-render edit timetable page w
                             <label class="govuk-label govuk-date-input__label" for="lpa-questionnaire-due-date-day">Day</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input govuk-input--error"
                             id="lpa-questionnaire-due-date-day" name="lpa-questionnaire-due-date-day"
-                            type="text" inputmode="numeric">
+                            type="text" value="25" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -1263,7 +1263,7 @@ exports[`Timetable POST /edit Householder should re-render edit timetable page w
                             <label class="govuk-label govuk-date-input__label" for="lpa-questionnaire-due-date-month">Month</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input govuk-input--error"
                             id="lpa-questionnaire-due-date-month" name="lpa-questionnaire-due-date-month"
-                            type="text" inputmode="numeric">
+                            type="text" value="2" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -1271,7 +1271,7 @@ exports[`Timetable POST /edit Householder should re-render edit timetable page w
                             <label class="govuk-label govuk-date-input__label" for="lpa-questionnaire-due-date-year">Year</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input govuk-date-input__input govuk-input--error"
                             id="lpa-questionnaire-due-date-year" name="lpa-questionnaire-due-date-year"
-                            type="text" inputmode="numeric">
+                            type="text" value="1950" inputmode="numeric">
                         </div>
                     </div>
                 </div>
@@ -1323,7 +1323,7 @@ exports[`Timetable POST /edit Householder should re-render edit timetable page w
                             <label class="govuk-label govuk-date-input__label" for="lpa-questionnaire-due-date-day">Day</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input govuk-input--error"
                             id="lpa-questionnaire-due-date-day" name="lpa-questionnaire-due-date-day"
-                            type="text" inputmode="numeric">
+                            type="text" value="29" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -1331,7 +1331,7 @@ exports[`Timetable POST /edit Householder should re-render edit timetable page w
                             <label class="govuk-label govuk-date-input__label" for="lpa-questionnaire-due-date-month">Month</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input govuk-input--error"
                             id="lpa-questionnaire-due-date-month" name="lpa-questionnaire-due-date-month"
-                            type="text" inputmode="numeric">
+                            type="text" value="2" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -1339,7 +1339,7 @@ exports[`Timetable POST /edit Householder should re-render edit timetable page w
                             <label class="govuk-label govuk-date-input__label" for="lpa-questionnaire-due-date-year">Year</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input govuk-date-input__input govuk-input--error"
                             id="lpa-questionnaire-due-date-year" name="lpa-questionnaire-due-date-year"
-                            type="text" inputmode="numeric">
+                            type="text" value="3000" inputmode="numeric">
                         </div>
                     </div>
                 </div>
@@ -1389,7 +1389,7 @@ exports[`Timetable POST /edit S78 hearing Interested party comments should re-re
                             <label class="govuk-label govuk-date-input__label" for="lpa-questionnaire-due-date-day">Day</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="lpa-questionnaire-due-date-day" name="lpa-questionnaire-due-date-day"
-                            type="text" inputmode="numeric">
+                            type="text" value="01" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -1397,7 +1397,7 @@ exports[`Timetable POST /edit S78 hearing Interested party comments should re-re
                             <label class="govuk-label govuk-date-input__label" for="lpa-questionnaire-due-date-month">Month</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="lpa-questionnaire-due-date-month" name="lpa-questionnaire-due-date-month"
-                            type="text" inputmode="numeric">
+                            type="text" value="10" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -1405,7 +1405,7 @@ exports[`Timetable POST /edit S78 hearing Interested party comments should re-re
                             <label class="govuk-label govuk-date-input__label" for="lpa-questionnaire-due-date-year">Year</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input govuk-date-input__input"
                             id="lpa-questionnaire-due-date-year" name="lpa-questionnaire-due-date-year"
-                            type="text" inputmode="numeric">
+                            type="text" value="2050" inputmode="numeric">
                         </div>
                     </div>
                 </div>
@@ -1421,7 +1421,7 @@ exports[`Timetable POST /edit S78 hearing Interested party comments should re-re
                             <label class="govuk-label govuk-date-input__label" for="lpa-statement-due-date-day">Day</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="lpa-statement-due-date-day" name="lpa-statement-due-date-day" type="text"
-                            inputmode="numeric">
+                            value="02" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -1429,7 +1429,7 @@ exports[`Timetable POST /edit S78 hearing Interested party comments should re-re
                             <label class="govuk-label govuk-date-input__label" for="lpa-statement-due-date-month">Month</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="lpa-statement-due-date-month" name="lpa-statement-due-date-month" type="text"
-                            inputmode="numeric">
+                            value="10" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -1437,7 +1437,7 @@ exports[`Timetable POST /edit S78 hearing Interested party comments should re-re
                             <label class="govuk-label govuk-date-input__label" for="lpa-statement-due-date-year">Year</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input govuk-date-input__input"
                             id="lpa-statement-due-date-year" name="lpa-statement-due-date-year" type="text"
-                            inputmode="numeric">
+                            value="2050" inputmode="numeric">
                         </div>
                     </div>
                 </div>
@@ -1464,7 +1464,7 @@ exports[`Timetable POST /edit S78 hearing Interested party comments should re-re
                             <label class="govuk-label govuk-date-input__label" for="ip-comments-due-date-month">Month</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="ip-comments-due-date-month" name="ip-comments-due-date-month" type="text"
-                            inputmode="numeric">
+                            value="10" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -1472,7 +1472,7 @@ exports[`Timetable POST /edit S78 hearing Interested party comments should re-re
                             <label class="govuk-label govuk-date-input__label" for="ip-comments-due-date-year">Year</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input govuk-date-input__input"
                             id="ip-comments-due-date-year" name="ip-comments-due-date-year" type="text"
-                            inputmode="numeric">
+                            value="2050" inputmode="numeric">
                         </div>
                     </div>
                 </div>
@@ -1489,7 +1489,7 @@ exports[`Timetable POST /edit S78 hearing Interested party comments should re-re
                             <label class="govuk-label govuk-date-input__label" for="statement-of-common-ground-due-date-day">Day</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="statement-of-common-ground-due-date-day" name="statement-of-common-ground-due-date-day"
-                            type="text" inputmode="numeric">
+                            type="text" value="04" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -1497,7 +1497,7 @@ exports[`Timetable POST /edit S78 hearing Interested party comments should re-re
                             <label class="govuk-label govuk-date-input__label" for="statement-of-common-ground-due-date-month">Month</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="statement-of-common-ground-due-date-month" name="statement-of-common-ground-due-date-month"
-                            type="text" inputmode="numeric">
+                            type="text" value="10" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -1505,7 +1505,7 @@ exports[`Timetable POST /edit S78 hearing Interested party comments should re-re
                             <label class="govuk-label govuk-date-input__label" for="statement-of-common-ground-due-date-year">Year</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input govuk-date-input__input"
                             id="statement-of-common-ground-due-date-year" name="statement-of-common-ground-due-date-year"
-                            type="text" inputmode="numeric">
+                            type="text" value="2050" inputmode="numeric">
                         </div>
                     </div>
                 </div>
@@ -1522,7 +1522,7 @@ exports[`Timetable POST /edit S78 hearing Interested party comments should re-re
                             <label class="govuk-label govuk-date-input__label" for="planning-obligation-due-date-day">Day</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="planning-obligation-due-date-day" name="planning-obligation-due-date-day"
-                            type="text" inputmode="numeric">
+                            type="text" value="05" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -1530,7 +1530,7 @@ exports[`Timetable POST /edit S78 hearing Interested party comments should re-re
                             <label class="govuk-label govuk-date-input__label" for="planning-obligation-due-date-month">Month</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="planning-obligation-due-date-month" name="planning-obligation-due-date-month"
-                            type="text" inputmode="numeric">
+                            type="text" value="10" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -1538,7 +1538,7 @@ exports[`Timetable POST /edit S78 hearing Interested party comments should re-re
                             <label class="govuk-label govuk-date-input__label" for="planning-obligation-due-date-year">Year</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input govuk-date-input__input"
                             id="planning-obligation-due-date-year" name="planning-obligation-due-date-year"
-                            type="text" inputmode="numeric">
+                            type="text" value="2050" inputmode="numeric">
                         </div>
                     </div>
                 </div>
@@ -1588,7 +1588,7 @@ exports[`Timetable POST /edit S78 hearing Interested party comments should re-re
                             <label class="govuk-label govuk-date-input__label" for="lpa-questionnaire-due-date-day">Day</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="lpa-questionnaire-due-date-day" name="lpa-questionnaire-due-date-day"
-                            type="text" inputmode="numeric">
+                            type="text" value="01" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -1596,7 +1596,7 @@ exports[`Timetable POST /edit S78 hearing Interested party comments should re-re
                             <label class="govuk-label govuk-date-input__label" for="lpa-questionnaire-due-date-month">Month</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="lpa-questionnaire-due-date-month" name="lpa-questionnaire-due-date-month"
-                            type="text" inputmode="numeric">
+                            type="text" value="10" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -1604,7 +1604,7 @@ exports[`Timetable POST /edit S78 hearing Interested party comments should re-re
                             <label class="govuk-label govuk-date-input__label" for="lpa-questionnaire-due-date-year">Year</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input govuk-date-input__input"
                             id="lpa-questionnaire-due-date-year" name="lpa-questionnaire-due-date-year"
-                            type="text" inputmode="numeric">
+                            type="text" value="2050" inputmode="numeric">
                         </div>
                     </div>
                 </div>
@@ -1620,7 +1620,7 @@ exports[`Timetable POST /edit S78 hearing Interested party comments should re-re
                             <label class="govuk-label govuk-date-input__label" for="lpa-statement-due-date-day">Day</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="lpa-statement-due-date-day" name="lpa-statement-due-date-day" type="text"
-                            inputmode="numeric">
+                            value="02" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -1628,7 +1628,7 @@ exports[`Timetable POST /edit S78 hearing Interested party comments should re-re
                             <label class="govuk-label govuk-date-input__label" for="lpa-statement-due-date-month">Month</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="lpa-statement-due-date-month" name="lpa-statement-due-date-month" type="text"
-                            inputmode="numeric">
+                            value="10" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -1636,7 +1636,7 @@ exports[`Timetable POST /edit S78 hearing Interested party comments should re-re
                             <label class="govuk-label govuk-date-input__label" for="lpa-statement-due-date-year">Year</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input govuk-date-input__input"
                             id="lpa-statement-due-date-year" name="lpa-statement-due-date-year" type="text"
-                            inputmode="numeric">
+                            value="2050" inputmode="numeric">
                         </div>
                     </div>
                 </div>
@@ -1655,7 +1655,7 @@ exports[`Timetable POST /edit S78 hearing Interested party comments should re-re
                             <label class="govuk-label govuk-date-input__label" for="ip-comments-due-date-day">Day</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="ip-comments-due-date-day" name="ip-comments-due-date-day" type="text"
-                            inputmode="numeric">
+                            value="10" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -1671,7 +1671,7 @@ exports[`Timetable POST /edit S78 hearing Interested party comments should re-re
                             <label class="govuk-label govuk-date-input__label" for="ip-comments-due-date-year">Year</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input govuk-date-input__input"
                             id="ip-comments-due-date-year" name="ip-comments-due-date-year" type="text"
-                            inputmode="numeric">
+                            value="2050" inputmode="numeric">
                         </div>
                     </div>
                 </div>
@@ -1688,7 +1688,7 @@ exports[`Timetable POST /edit S78 hearing Interested party comments should re-re
                             <label class="govuk-label govuk-date-input__label" for="statement-of-common-ground-due-date-day">Day</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="statement-of-common-ground-due-date-day" name="statement-of-common-ground-due-date-day"
-                            type="text" inputmode="numeric">
+                            type="text" value="04" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -1696,7 +1696,7 @@ exports[`Timetable POST /edit S78 hearing Interested party comments should re-re
                             <label class="govuk-label govuk-date-input__label" for="statement-of-common-ground-due-date-month">Month</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="statement-of-common-ground-due-date-month" name="statement-of-common-ground-due-date-month"
-                            type="text" inputmode="numeric">
+                            type="text" value="10" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -1704,7 +1704,7 @@ exports[`Timetable POST /edit S78 hearing Interested party comments should re-re
                             <label class="govuk-label govuk-date-input__label" for="statement-of-common-ground-due-date-year">Year</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input govuk-date-input__input"
                             id="statement-of-common-ground-due-date-year" name="statement-of-common-ground-due-date-year"
-                            type="text" inputmode="numeric">
+                            type="text" value="2050" inputmode="numeric">
                         </div>
                     </div>
                 </div>
@@ -1721,7 +1721,7 @@ exports[`Timetable POST /edit S78 hearing Interested party comments should re-re
                             <label class="govuk-label govuk-date-input__label" for="planning-obligation-due-date-day">Day</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="planning-obligation-due-date-day" name="planning-obligation-due-date-day"
-                            type="text" inputmode="numeric">
+                            type="text" value="05" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -1729,7 +1729,7 @@ exports[`Timetable POST /edit S78 hearing Interested party comments should re-re
                             <label class="govuk-label govuk-date-input__label" for="planning-obligation-due-date-month">Month</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="planning-obligation-due-date-month" name="planning-obligation-due-date-month"
-                            type="text" inputmode="numeric">
+                            type="text" value="10" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -1737,7 +1737,7 @@ exports[`Timetable POST /edit S78 hearing Interested party comments should re-re
                             <label class="govuk-label govuk-date-input__label" for="planning-obligation-due-date-year">Year</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input govuk-date-input__input"
                             id="planning-obligation-due-date-year" name="planning-obligation-due-date-year"
-                            type="text" inputmode="numeric">
+                            type="text" value="2050" inputmode="numeric">
                         </div>
                     </div>
                 </div>
@@ -1787,7 +1787,7 @@ exports[`Timetable POST /edit S78 hearing Interested party comments should re-re
                             <label class="govuk-label govuk-date-input__label" for="lpa-questionnaire-due-date-day">Day</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="lpa-questionnaire-due-date-day" name="lpa-questionnaire-due-date-day"
-                            type="text" inputmode="numeric">
+                            type="text" value="01" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -1795,7 +1795,7 @@ exports[`Timetable POST /edit S78 hearing Interested party comments should re-re
                             <label class="govuk-label govuk-date-input__label" for="lpa-questionnaire-due-date-month">Month</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="lpa-questionnaire-due-date-month" name="lpa-questionnaire-due-date-month"
-                            type="text" inputmode="numeric">
+                            type="text" value="10" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -1803,7 +1803,7 @@ exports[`Timetable POST /edit S78 hearing Interested party comments should re-re
                             <label class="govuk-label govuk-date-input__label" for="lpa-questionnaire-due-date-year">Year</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input govuk-date-input__input"
                             id="lpa-questionnaire-due-date-year" name="lpa-questionnaire-due-date-year"
-                            type="text" inputmode="numeric">
+                            type="text" value="2050" inputmode="numeric">
                         </div>
                     </div>
                 </div>
@@ -1819,7 +1819,7 @@ exports[`Timetable POST /edit S78 hearing Interested party comments should re-re
                             <label class="govuk-label govuk-date-input__label" for="lpa-statement-due-date-day">Day</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="lpa-statement-due-date-day" name="lpa-statement-due-date-day" type="text"
-                            inputmode="numeric">
+                            value="02" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -1827,7 +1827,7 @@ exports[`Timetable POST /edit S78 hearing Interested party comments should re-re
                             <label class="govuk-label govuk-date-input__label" for="lpa-statement-due-date-month">Month</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="lpa-statement-due-date-month" name="lpa-statement-due-date-month" type="text"
-                            inputmode="numeric">
+                            value="10" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -1835,7 +1835,7 @@ exports[`Timetable POST /edit S78 hearing Interested party comments should re-re
                             <label class="govuk-label govuk-date-input__label" for="lpa-statement-due-date-year">Year</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input govuk-date-input__input"
                             id="lpa-statement-due-date-year" name="lpa-statement-due-date-year" type="text"
-                            inputmode="numeric">
+                            value="2050" inputmode="numeric">
                         </div>
                     </div>
                 </div>
@@ -1854,7 +1854,7 @@ exports[`Timetable POST /edit S78 hearing Interested party comments should re-re
                             <label class="govuk-label govuk-date-input__label" for="ip-comments-due-date-day">Day</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="ip-comments-due-date-day" name="ip-comments-due-date-day" type="text"
-                            inputmode="numeric">
+                            value="10" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -1862,7 +1862,7 @@ exports[`Timetable POST /edit S78 hearing Interested party comments should re-re
                             <label class="govuk-label govuk-date-input__label" for="ip-comments-due-date-month">Month</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="ip-comments-due-date-month" name="ip-comments-due-date-month" type="text"
-                            inputmode="numeric">
+                            value="12" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -1887,7 +1887,7 @@ exports[`Timetable POST /edit S78 hearing Interested party comments should re-re
                             <label class="govuk-label govuk-date-input__label" for="statement-of-common-ground-due-date-day">Day</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="statement-of-common-ground-due-date-day" name="statement-of-common-ground-due-date-day"
-                            type="text" inputmode="numeric">
+                            type="text" value="04" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -1895,7 +1895,7 @@ exports[`Timetable POST /edit S78 hearing Interested party comments should re-re
                             <label class="govuk-label govuk-date-input__label" for="statement-of-common-ground-due-date-month">Month</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="statement-of-common-ground-due-date-month" name="statement-of-common-ground-due-date-month"
-                            type="text" inputmode="numeric">
+                            type="text" value="10" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -1903,7 +1903,7 @@ exports[`Timetable POST /edit S78 hearing Interested party comments should re-re
                             <label class="govuk-label govuk-date-input__label" for="statement-of-common-ground-due-date-year">Year</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input govuk-date-input__input"
                             id="statement-of-common-ground-due-date-year" name="statement-of-common-ground-due-date-year"
-                            type="text" inputmode="numeric">
+                            type="text" value="2050" inputmode="numeric">
                         </div>
                     </div>
                 </div>
@@ -1920,7 +1920,7 @@ exports[`Timetable POST /edit S78 hearing Interested party comments should re-re
                             <label class="govuk-label govuk-date-input__label" for="planning-obligation-due-date-day">Day</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="planning-obligation-due-date-day" name="planning-obligation-due-date-day"
-                            type="text" inputmode="numeric">
+                            type="text" value="05" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -1928,7 +1928,7 @@ exports[`Timetable POST /edit S78 hearing Interested party comments should re-re
                             <label class="govuk-label govuk-date-input__label" for="planning-obligation-due-date-month">Month</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="planning-obligation-due-date-month" name="planning-obligation-due-date-month"
-                            type="text" inputmode="numeric">
+                            type="text" value="10" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -1936,7 +1936,7 @@ exports[`Timetable POST /edit S78 hearing Interested party comments should re-re
                             <label class="govuk-label govuk-date-input__label" for="planning-obligation-due-date-year">Year</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input govuk-date-input__input"
                             id="planning-obligation-due-date-year" name="planning-obligation-due-date-year"
-                            type="text" inputmode="numeric">
+                            type="text" value="2050" inputmode="numeric">
                         </div>
                     </div>
                 </div>
@@ -1986,7 +1986,7 @@ exports[`Timetable POST /edit S78 hearing Interested party comments should re-re
                             <label class="govuk-label govuk-date-input__label" for="lpa-questionnaire-due-date-day">Day</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="lpa-questionnaire-due-date-day" name="lpa-questionnaire-due-date-day"
-                            type="text" inputmode="numeric">
+                            type="text" value="01" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -1994,7 +1994,7 @@ exports[`Timetable POST /edit S78 hearing Interested party comments should re-re
                             <label class="govuk-label govuk-date-input__label" for="lpa-questionnaire-due-date-month">Month</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="lpa-questionnaire-due-date-month" name="lpa-questionnaire-due-date-month"
-                            type="text" inputmode="numeric">
+                            type="text" value="10" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -2002,7 +2002,7 @@ exports[`Timetable POST /edit S78 hearing Interested party comments should re-re
                             <label class="govuk-label govuk-date-input__label" for="lpa-questionnaire-due-date-year">Year</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input govuk-date-input__input"
                             id="lpa-questionnaire-due-date-year" name="lpa-questionnaire-due-date-year"
-                            type="text" inputmode="numeric">
+                            type="text" value="2050" inputmode="numeric">
                         </div>
                     </div>
                 </div>
@@ -2018,7 +2018,7 @@ exports[`Timetable POST /edit S78 hearing Interested party comments should re-re
                             <label class="govuk-label govuk-date-input__label" for="lpa-statement-due-date-day">Day</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="lpa-statement-due-date-day" name="lpa-statement-due-date-day" type="text"
-                            inputmode="numeric">
+                            value="02" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -2026,7 +2026,7 @@ exports[`Timetable POST /edit S78 hearing Interested party comments should re-re
                             <label class="govuk-label govuk-date-input__label" for="lpa-statement-due-date-month">Month</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="lpa-statement-due-date-month" name="lpa-statement-due-date-month" type="text"
-                            inputmode="numeric">
+                            value="10" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -2034,7 +2034,7 @@ exports[`Timetable POST /edit S78 hearing Interested party comments should re-re
                             <label class="govuk-label govuk-date-input__label" for="lpa-statement-due-date-year">Year</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input govuk-date-input__input"
                             id="lpa-statement-due-date-year" name="lpa-statement-due-date-year" type="text"
-                            inputmode="numeric">
+                            value="2050" inputmode="numeric">
                         </div>
                     </div>
                 </div>
@@ -2054,7 +2054,7 @@ exports[`Timetable POST /edit S78 hearing Interested party comments should re-re
                             <label class="govuk-label govuk-date-input__label" for="ip-comments-due-date-day">Day</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input govuk-input--error"
                             id="ip-comments-due-date-day" name="ip-comments-due-date-day" type="text"
-                            inputmode="numeric">
+                            value="25" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -2062,7 +2062,7 @@ exports[`Timetable POST /edit S78 hearing Interested party comments should re-re
                             <label class="govuk-label govuk-date-input__label" for="ip-comments-due-date-month">Month</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input govuk-input--error"
                             id="ip-comments-due-date-month" name="ip-comments-due-date-month" type="text"
-                            inputmode="numeric">
+                            value="2" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -2070,7 +2070,7 @@ exports[`Timetable POST /edit S78 hearing Interested party comments should re-re
                             <label class="govuk-label govuk-date-input__label" for="ip-comments-due-date-year">Year</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input govuk-date-input__input govuk-input--error"
                             id="ip-comments-due-date-year" name="ip-comments-due-date-year" type="text"
-                            inputmode="numeric">
+                            value="1950" inputmode="numeric">
                         </div>
                     </div>
                 </div>
@@ -2087,7 +2087,7 @@ exports[`Timetable POST /edit S78 hearing Interested party comments should re-re
                             <label class="govuk-label govuk-date-input__label" for="statement-of-common-ground-due-date-day">Day</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="statement-of-common-ground-due-date-day" name="statement-of-common-ground-due-date-day"
-                            type="text" inputmode="numeric">
+                            type="text" value="04" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -2095,7 +2095,7 @@ exports[`Timetable POST /edit S78 hearing Interested party comments should re-re
                             <label class="govuk-label govuk-date-input__label" for="statement-of-common-ground-due-date-month">Month</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="statement-of-common-ground-due-date-month" name="statement-of-common-ground-due-date-month"
-                            type="text" inputmode="numeric">
+                            type="text" value="10" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -2103,7 +2103,7 @@ exports[`Timetable POST /edit S78 hearing Interested party comments should re-re
                             <label class="govuk-label govuk-date-input__label" for="statement-of-common-ground-due-date-year">Year</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input govuk-date-input__input"
                             id="statement-of-common-ground-due-date-year" name="statement-of-common-ground-due-date-year"
-                            type="text" inputmode="numeric">
+                            type="text" value="2050" inputmode="numeric">
                         </div>
                     </div>
                 </div>
@@ -2120,7 +2120,7 @@ exports[`Timetable POST /edit S78 hearing Interested party comments should re-re
                             <label class="govuk-label govuk-date-input__label" for="planning-obligation-due-date-day">Day</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="planning-obligation-due-date-day" name="planning-obligation-due-date-day"
-                            type="text" inputmode="numeric">
+                            type="text" value="05" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -2128,7 +2128,7 @@ exports[`Timetable POST /edit S78 hearing Interested party comments should re-re
                             <label class="govuk-label govuk-date-input__label" for="planning-obligation-due-date-month">Month</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="planning-obligation-due-date-month" name="planning-obligation-due-date-month"
-                            type="text" inputmode="numeric">
+                            type="text" value="10" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -2136,7 +2136,7 @@ exports[`Timetable POST /edit S78 hearing Interested party comments should re-re
                             <label class="govuk-label govuk-date-input__label" for="planning-obligation-due-date-year">Year</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input govuk-date-input__input"
                             id="planning-obligation-due-date-year" name="planning-obligation-due-date-year"
-                            type="text" inputmode="numeric">
+                            type="text" value="2050" inputmode="numeric">
                         </div>
                     </div>
                 </div>
@@ -2186,7 +2186,7 @@ exports[`Timetable POST /edit S78 hearing Interested party comments should re-re
                             <label class="govuk-label govuk-date-input__label" for="lpa-questionnaire-due-date-day">Day</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="lpa-questionnaire-due-date-day" name="lpa-questionnaire-due-date-day"
-                            type="text" inputmode="numeric">
+                            type="text" value="01" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -2194,7 +2194,7 @@ exports[`Timetable POST /edit S78 hearing Interested party comments should re-re
                             <label class="govuk-label govuk-date-input__label" for="lpa-questionnaire-due-date-month">Month</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="lpa-questionnaire-due-date-month" name="lpa-questionnaire-due-date-month"
-                            type="text" inputmode="numeric">
+                            type="text" value="10" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -2202,7 +2202,7 @@ exports[`Timetable POST /edit S78 hearing Interested party comments should re-re
                             <label class="govuk-label govuk-date-input__label" for="lpa-questionnaire-due-date-year">Year</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input govuk-date-input__input"
                             id="lpa-questionnaire-due-date-year" name="lpa-questionnaire-due-date-year"
-                            type="text" inputmode="numeric">
+                            type="text" value="2050" inputmode="numeric">
                         </div>
                     </div>
                 </div>
@@ -2218,7 +2218,7 @@ exports[`Timetable POST /edit S78 hearing Interested party comments should re-re
                             <label class="govuk-label govuk-date-input__label" for="lpa-statement-due-date-day">Day</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="lpa-statement-due-date-day" name="lpa-statement-due-date-day" type="text"
-                            inputmode="numeric">
+                            value="02" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -2226,7 +2226,7 @@ exports[`Timetable POST /edit S78 hearing Interested party comments should re-re
                             <label class="govuk-label govuk-date-input__label" for="lpa-statement-due-date-month">Month</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="lpa-statement-due-date-month" name="lpa-statement-due-date-month" type="text"
-                            inputmode="numeric">
+                            value="10" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -2234,7 +2234,7 @@ exports[`Timetable POST /edit S78 hearing Interested party comments should re-re
                             <label class="govuk-label govuk-date-input__label" for="lpa-statement-due-date-year">Year</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input govuk-date-input__input"
                             id="lpa-statement-due-date-year" name="lpa-statement-due-date-year" type="text"
-                            inputmode="numeric">
+                            value="2050" inputmode="numeric">
                         </div>
                     </div>
                 </div>
@@ -2253,7 +2253,7 @@ exports[`Timetable POST /edit S78 hearing Interested party comments should re-re
                             <label class="govuk-label govuk-date-input__label" for="ip-comments-due-date-day">Day</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input govuk-input--error"
                             id="ip-comments-due-date-day" name="ip-comments-due-date-day" type="text"
-                            inputmode="numeric">
+                            value="29" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -2261,7 +2261,7 @@ exports[`Timetable POST /edit S78 hearing Interested party comments should re-re
                             <label class="govuk-label govuk-date-input__label" for="ip-comments-due-date-month">Month</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input govuk-input--error"
                             id="ip-comments-due-date-month" name="ip-comments-due-date-month" type="text"
-                            inputmode="numeric">
+                            value="2" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -2269,7 +2269,7 @@ exports[`Timetable POST /edit S78 hearing Interested party comments should re-re
                             <label class="govuk-label govuk-date-input__label" for="ip-comments-due-date-year">Year</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input govuk-date-input__input govuk-input--error"
                             id="ip-comments-due-date-year" name="ip-comments-due-date-year" type="text"
-                            inputmode="numeric">
+                            value="3000" inputmode="numeric">
                         </div>
                     </div>
                 </div>
@@ -2286,7 +2286,7 @@ exports[`Timetable POST /edit S78 hearing Interested party comments should re-re
                             <label class="govuk-label govuk-date-input__label" for="statement-of-common-ground-due-date-day">Day</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="statement-of-common-ground-due-date-day" name="statement-of-common-ground-due-date-day"
-                            type="text" inputmode="numeric">
+                            type="text" value="04" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -2294,7 +2294,7 @@ exports[`Timetable POST /edit S78 hearing Interested party comments should re-re
                             <label class="govuk-label govuk-date-input__label" for="statement-of-common-ground-due-date-month">Month</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="statement-of-common-ground-due-date-month" name="statement-of-common-ground-due-date-month"
-                            type="text" inputmode="numeric">
+                            type="text" value="10" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -2302,7 +2302,7 @@ exports[`Timetable POST /edit S78 hearing Interested party comments should re-re
                             <label class="govuk-label govuk-date-input__label" for="statement-of-common-ground-due-date-year">Year</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input govuk-date-input__input"
                             id="statement-of-common-ground-due-date-year" name="statement-of-common-ground-due-date-year"
-                            type="text" inputmode="numeric">
+                            type="text" value="2050" inputmode="numeric">
                         </div>
                     </div>
                 </div>
@@ -2319,7 +2319,7 @@ exports[`Timetable POST /edit S78 hearing Interested party comments should re-re
                             <label class="govuk-label govuk-date-input__label" for="planning-obligation-due-date-day">Day</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="planning-obligation-due-date-day" name="planning-obligation-due-date-day"
-                            type="text" inputmode="numeric">
+                            type="text" value="05" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -2327,7 +2327,7 @@ exports[`Timetable POST /edit S78 hearing Interested party comments should re-re
                             <label class="govuk-label govuk-date-input__label" for="planning-obligation-due-date-month">Month</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="planning-obligation-due-date-month" name="planning-obligation-due-date-month"
-                            type="text" inputmode="numeric">
+                            type="text" value="10" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -2335,7 +2335,7 @@ exports[`Timetable POST /edit S78 hearing Interested party comments should re-re
                             <label class="govuk-label govuk-date-input__label" for="planning-obligation-due-date-year">Year</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input govuk-date-input__input"
                             id="planning-obligation-due-date-year" name="planning-obligation-due-date-year"
-                            type="text" inputmode="numeric">
+                            type="text" value="2050" inputmode="numeric">
                         </div>
                     </div>
                 </div>
@@ -2396,7 +2396,7 @@ exports[`Timetable POST /edit S78 hearing LPA questionnaire should re-render edi
                             <label class="govuk-label govuk-date-input__label" for="lpa-questionnaire-due-date-month">Month</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="lpa-questionnaire-due-date-month" name="lpa-questionnaire-due-date-month"
-                            type="text" inputmode="numeric">
+                            type="text" value="10" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -2404,7 +2404,7 @@ exports[`Timetable POST /edit S78 hearing LPA questionnaire should re-render edi
                             <label class="govuk-label govuk-date-input__label" for="lpa-questionnaire-due-date-year">Year</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input govuk-date-input__input"
                             id="lpa-questionnaire-due-date-year" name="lpa-questionnaire-due-date-year"
-                            type="text" inputmode="numeric">
+                            type="text" value="2050" inputmode="numeric">
                         </div>
                     </div>
                 </div>
@@ -2420,7 +2420,7 @@ exports[`Timetable POST /edit S78 hearing LPA questionnaire should re-render edi
                             <label class="govuk-label govuk-date-input__label" for="lpa-statement-due-date-day">Day</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="lpa-statement-due-date-day" name="lpa-statement-due-date-day" type="text"
-                            inputmode="numeric">
+                            value="02" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -2428,7 +2428,7 @@ exports[`Timetable POST /edit S78 hearing LPA questionnaire should re-render edi
                             <label class="govuk-label govuk-date-input__label" for="lpa-statement-due-date-month">Month</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="lpa-statement-due-date-month" name="lpa-statement-due-date-month" type="text"
-                            inputmode="numeric">
+                            value="10" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -2436,7 +2436,7 @@ exports[`Timetable POST /edit S78 hearing LPA questionnaire should re-render edi
                             <label class="govuk-label govuk-date-input__label" for="lpa-statement-due-date-year">Year</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input govuk-date-input__input"
                             id="lpa-statement-due-date-year" name="lpa-statement-due-date-year" type="text"
-                            inputmode="numeric">
+                            value="2050" inputmode="numeric">
                         </div>
                     </div>
                 </div>
@@ -2453,7 +2453,7 @@ exports[`Timetable POST /edit S78 hearing LPA questionnaire should re-render edi
                             <label class="govuk-label govuk-date-input__label" for="ip-comments-due-date-day">Day</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="ip-comments-due-date-day" name="ip-comments-due-date-day" type="text"
-                            inputmode="numeric">
+                            value="03" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -2461,7 +2461,7 @@ exports[`Timetable POST /edit S78 hearing LPA questionnaire should re-render edi
                             <label class="govuk-label govuk-date-input__label" for="ip-comments-due-date-month">Month</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="ip-comments-due-date-month" name="ip-comments-due-date-month" type="text"
-                            inputmode="numeric">
+                            value="10" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -2469,7 +2469,7 @@ exports[`Timetable POST /edit S78 hearing LPA questionnaire should re-render edi
                             <label class="govuk-label govuk-date-input__label" for="ip-comments-due-date-year">Year</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input govuk-date-input__input"
                             id="ip-comments-due-date-year" name="ip-comments-due-date-year" type="text"
-                            inputmode="numeric">
+                            value="2050" inputmode="numeric">
                         </div>
                     </div>
                 </div>
@@ -2486,7 +2486,7 @@ exports[`Timetable POST /edit S78 hearing LPA questionnaire should re-render edi
                             <label class="govuk-label govuk-date-input__label" for="statement-of-common-ground-due-date-day">Day</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="statement-of-common-ground-due-date-day" name="statement-of-common-ground-due-date-day"
-                            type="text" inputmode="numeric">
+                            type="text" value="04" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -2494,7 +2494,7 @@ exports[`Timetable POST /edit S78 hearing LPA questionnaire should re-render edi
                             <label class="govuk-label govuk-date-input__label" for="statement-of-common-ground-due-date-month">Month</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="statement-of-common-ground-due-date-month" name="statement-of-common-ground-due-date-month"
-                            type="text" inputmode="numeric">
+                            type="text" value="10" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -2502,7 +2502,7 @@ exports[`Timetable POST /edit S78 hearing LPA questionnaire should re-render edi
                             <label class="govuk-label govuk-date-input__label" for="statement-of-common-ground-due-date-year">Year</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input govuk-date-input__input"
                             id="statement-of-common-ground-due-date-year" name="statement-of-common-ground-due-date-year"
-                            type="text" inputmode="numeric">
+                            type="text" value="2050" inputmode="numeric">
                         </div>
                     </div>
                 </div>
@@ -2519,7 +2519,7 @@ exports[`Timetable POST /edit S78 hearing LPA questionnaire should re-render edi
                             <label class="govuk-label govuk-date-input__label" for="planning-obligation-due-date-day">Day</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="planning-obligation-due-date-day" name="planning-obligation-due-date-day"
-                            type="text" inputmode="numeric">
+                            type="text" value="05" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -2527,7 +2527,7 @@ exports[`Timetable POST /edit S78 hearing LPA questionnaire should re-render edi
                             <label class="govuk-label govuk-date-input__label" for="planning-obligation-due-date-month">Month</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="planning-obligation-due-date-month" name="planning-obligation-due-date-month"
-                            type="text" inputmode="numeric">
+                            type="text" value="10" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -2535,7 +2535,7 @@ exports[`Timetable POST /edit S78 hearing LPA questionnaire should re-render edi
                             <label class="govuk-label govuk-date-input__label" for="planning-obligation-due-date-year">Year</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input govuk-date-input__input"
                             id="planning-obligation-due-date-year" name="planning-obligation-due-date-year"
-                            type="text" inputmode="numeric">
+                            type="text" value="2050" inputmode="numeric">
                         </div>
                     </div>
                 </div>
@@ -2588,7 +2588,7 @@ exports[`Timetable POST /edit S78 hearing LPA questionnaire should re-render edi
                             <label class="govuk-label govuk-date-input__label" for="lpa-questionnaire-due-date-day">Day</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="lpa-questionnaire-due-date-day" name="lpa-questionnaire-due-date-day"
-                            type="text" inputmode="numeric">
+                            type="text" value="10" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -2604,7 +2604,7 @@ exports[`Timetable POST /edit S78 hearing LPA questionnaire should re-render edi
                             <label class="govuk-label govuk-date-input__label" for="lpa-questionnaire-due-date-year">Year</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input govuk-date-input__input"
                             id="lpa-questionnaire-due-date-year" name="lpa-questionnaire-due-date-year"
-                            type="text" inputmode="numeric">
+                            type="text" value="2050" inputmode="numeric">
                         </div>
                     </div>
                 </div>
@@ -2620,7 +2620,7 @@ exports[`Timetable POST /edit S78 hearing LPA questionnaire should re-render edi
                             <label class="govuk-label govuk-date-input__label" for="lpa-statement-due-date-day">Day</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="lpa-statement-due-date-day" name="lpa-statement-due-date-day" type="text"
-                            inputmode="numeric">
+                            value="02" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -2628,7 +2628,7 @@ exports[`Timetable POST /edit S78 hearing LPA questionnaire should re-render edi
                             <label class="govuk-label govuk-date-input__label" for="lpa-statement-due-date-month">Month</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="lpa-statement-due-date-month" name="lpa-statement-due-date-month" type="text"
-                            inputmode="numeric">
+                            value="10" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -2636,7 +2636,7 @@ exports[`Timetable POST /edit S78 hearing LPA questionnaire should re-render edi
                             <label class="govuk-label govuk-date-input__label" for="lpa-statement-due-date-year">Year</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input govuk-date-input__input"
                             id="lpa-statement-due-date-year" name="lpa-statement-due-date-year" type="text"
-                            inputmode="numeric">
+                            value="2050" inputmode="numeric">
                         </div>
                     </div>
                 </div>
@@ -2653,7 +2653,7 @@ exports[`Timetable POST /edit S78 hearing LPA questionnaire should re-render edi
                             <label class="govuk-label govuk-date-input__label" for="ip-comments-due-date-day">Day</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="ip-comments-due-date-day" name="ip-comments-due-date-day" type="text"
-                            inputmode="numeric">
+                            value="03" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -2661,7 +2661,7 @@ exports[`Timetable POST /edit S78 hearing LPA questionnaire should re-render edi
                             <label class="govuk-label govuk-date-input__label" for="ip-comments-due-date-month">Month</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="ip-comments-due-date-month" name="ip-comments-due-date-month" type="text"
-                            inputmode="numeric">
+                            value="10" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -2669,7 +2669,7 @@ exports[`Timetable POST /edit S78 hearing LPA questionnaire should re-render edi
                             <label class="govuk-label govuk-date-input__label" for="ip-comments-due-date-year">Year</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input govuk-date-input__input"
                             id="ip-comments-due-date-year" name="ip-comments-due-date-year" type="text"
-                            inputmode="numeric">
+                            value="2050" inputmode="numeric">
                         </div>
                     </div>
                 </div>
@@ -2686,7 +2686,7 @@ exports[`Timetable POST /edit S78 hearing LPA questionnaire should re-render edi
                             <label class="govuk-label govuk-date-input__label" for="statement-of-common-ground-due-date-day">Day</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="statement-of-common-ground-due-date-day" name="statement-of-common-ground-due-date-day"
-                            type="text" inputmode="numeric">
+                            type="text" value="04" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -2694,7 +2694,7 @@ exports[`Timetable POST /edit S78 hearing LPA questionnaire should re-render edi
                             <label class="govuk-label govuk-date-input__label" for="statement-of-common-ground-due-date-month">Month</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="statement-of-common-ground-due-date-month" name="statement-of-common-ground-due-date-month"
-                            type="text" inputmode="numeric">
+                            type="text" value="10" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -2702,7 +2702,7 @@ exports[`Timetable POST /edit S78 hearing LPA questionnaire should re-render edi
                             <label class="govuk-label govuk-date-input__label" for="statement-of-common-ground-due-date-year">Year</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input govuk-date-input__input"
                             id="statement-of-common-ground-due-date-year" name="statement-of-common-ground-due-date-year"
-                            type="text" inputmode="numeric">
+                            type="text" value="2050" inputmode="numeric">
                         </div>
                     </div>
                 </div>
@@ -2719,7 +2719,7 @@ exports[`Timetable POST /edit S78 hearing LPA questionnaire should re-render edi
                             <label class="govuk-label govuk-date-input__label" for="planning-obligation-due-date-day">Day</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="planning-obligation-due-date-day" name="planning-obligation-due-date-day"
-                            type="text" inputmode="numeric">
+                            type="text" value="05" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -2727,7 +2727,7 @@ exports[`Timetable POST /edit S78 hearing LPA questionnaire should re-render edi
                             <label class="govuk-label govuk-date-input__label" for="planning-obligation-due-date-month">Month</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="planning-obligation-due-date-month" name="planning-obligation-due-date-month"
-                            type="text" inputmode="numeric">
+                            type="text" value="10" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -2735,7 +2735,7 @@ exports[`Timetable POST /edit S78 hearing LPA questionnaire should re-render edi
                             <label class="govuk-label govuk-date-input__label" for="planning-obligation-due-date-year">Year</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input govuk-date-input__input"
                             id="planning-obligation-due-date-year" name="planning-obligation-due-date-year"
-                            type="text" inputmode="numeric">
+                            type="text" value="2050" inputmode="numeric">
                         </div>
                     </div>
                 </div>
@@ -2788,7 +2788,7 @@ exports[`Timetable POST /edit S78 hearing LPA questionnaire should re-render edi
                             <label class="govuk-label govuk-date-input__label" for="lpa-questionnaire-due-date-day">Day</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="lpa-questionnaire-due-date-day" name="lpa-questionnaire-due-date-day"
-                            type="text" inputmode="numeric">
+                            type="text" value="10" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -2796,7 +2796,7 @@ exports[`Timetable POST /edit S78 hearing LPA questionnaire should re-render edi
                             <label class="govuk-label govuk-date-input__label" for="lpa-questionnaire-due-date-month">Month</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="lpa-questionnaire-due-date-month" name="lpa-questionnaire-due-date-month"
-                            type="text" inputmode="numeric">
+                            type="text" value="12" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -2820,7 +2820,7 @@ exports[`Timetable POST /edit S78 hearing LPA questionnaire should re-render edi
                             <label class="govuk-label govuk-date-input__label" for="lpa-statement-due-date-day">Day</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="lpa-statement-due-date-day" name="lpa-statement-due-date-day" type="text"
-                            inputmode="numeric">
+                            value="02" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -2828,7 +2828,7 @@ exports[`Timetable POST /edit S78 hearing LPA questionnaire should re-render edi
                             <label class="govuk-label govuk-date-input__label" for="lpa-statement-due-date-month">Month</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="lpa-statement-due-date-month" name="lpa-statement-due-date-month" type="text"
-                            inputmode="numeric">
+                            value="10" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -2836,7 +2836,7 @@ exports[`Timetable POST /edit S78 hearing LPA questionnaire should re-render edi
                             <label class="govuk-label govuk-date-input__label" for="lpa-statement-due-date-year">Year</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input govuk-date-input__input"
                             id="lpa-statement-due-date-year" name="lpa-statement-due-date-year" type="text"
-                            inputmode="numeric">
+                            value="2050" inputmode="numeric">
                         </div>
                     </div>
                 </div>
@@ -2853,7 +2853,7 @@ exports[`Timetable POST /edit S78 hearing LPA questionnaire should re-render edi
                             <label class="govuk-label govuk-date-input__label" for="ip-comments-due-date-day">Day</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="ip-comments-due-date-day" name="ip-comments-due-date-day" type="text"
-                            inputmode="numeric">
+                            value="03" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -2861,7 +2861,7 @@ exports[`Timetable POST /edit S78 hearing LPA questionnaire should re-render edi
                             <label class="govuk-label govuk-date-input__label" for="ip-comments-due-date-month">Month</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="ip-comments-due-date-month" name="ip-comments-due-date-month" type="text"
-                            inputmode="numeric">
+                            value="10" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -2869,7 +2869,7 @@ exports[`Timetable POST /edit S78 hearing LPA questionnaire should re-render edi
                             <label class="govuk-label govuk-date-input__label" for="ip-comments-due-date-year">Year</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input govuk-date-input__input"
                             id="ip-comments-due-date-year" name="ip-comments-due-date-year" type="text"
-                            inputmode="numeric">
+                            value="2050" inputmode="numeric">
                         </div>
                     </div>
                 </div>
@@ -2886,7 +2886,7 @@ exports[`Timetable POST /edit S78 hearing LPA questionnaire should re-render edi
                             <label class="govuk-label govuk-date-input__label" for="statement-of-common-ground-due-date-day">Day</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="statement-of-common-ground-due-date-day" name="statement-of-common-ground-due-date-day"
-                            type="text" inputmode="numeric">
+                            type="text" value="04" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -2894,7 +2894,7 @@ exports[`Timetable POST /edit S78 hearing LPA questionnaire should re-render edi
                             <label class="govuk-label govuk-date-input__label" for="statement-of-common-ground-due-date-month">Month</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="statement-of-common-ground-due-date-month" name="statement-of-common-ground-due-date-month"
-                            type="text" inputmode="numeric">
+                            type="text" value="10" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -2902,7 +2902,7 @@ exports[`Timetable POST /edit S78 hearing LPA questionnaire should re-render edi
                             <label class="govuk-label govuk-date-input__label" for="statement-of-common-ground-due-date-year">Year</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input govuk-date-input__input"
                             id="statement-of-common-ground-due-date-year" name="statement-of-common-ground-due-date-year"
-                            type="text" inputmode="numeric">
+                            type="text" value="2050" inputmode="numeric">
                         </div>
                     </div>
                 </div>
@@ -2919,7 +2919,7 @@ exports[`Timetable POST /edit S78 hearing LPA questionnaire should re-render edi
                             <label class="govuk-label govuk-date-input__label" for="planning-obligation-due-date-day">Day</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="planning-obligation-due-date-day" name="planning-obligation-due-date-day"
-                            type="text" inputmode="numeric">
+                            type="text" value="05" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -2927,7 +2927,7 @@ exports[`Timetable POST /edit S78 hearing LPA questionnaire should re-render edi
                             <label class="govuk-label govuk-date-input__label" for="planning-obligation-due-date-month">Month</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="planning-obligation-due-date-month" name="planning-obligation-due-date-month"
-                            type="text" inputmode="numeric">
+                            type="text" value="10" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -2935,7 +2935,7 @@ exports[`Timetable POST /edit S78 hearing LPA questionnaire should re-render edi
                             <label class="govuk-label govuk-date-input__label" for="planning-obligation-due-date-year">Year</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input govuk-date-input__input"
                             id="planning-obligation-due-date-year" name="planning-obligation-due-date-year"
-                            type="text" inputmode="numeric">
+                            type="text" value="2050" inputmode="numeric">
                         </div>
                     </div>
                 </div>
@@ -2988,7 +2988,7 @@ exports[`Timetable POST /edit S78 hearing LPA questionnaire should re-render edi
                             <label class="govuk-label govuk-date-input__label" for="lpa-questionnaire-due-date-day">Day</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input govuk-input--error"
                             id="lpa-questionnaire-due-date-day" name="lpa-questionnaire-due-date-day"
-                            type="text" inputmode="numeric">
+                            type="text" value="25" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -2996,7 +2996,7 @@ exports[`Timetable POST /edit S78 hearing LPA questionnaire should re-render edi
                             <label class="govuk-label govuk-date-input__label" for="lpa-questionnaire-due-date-month">Month</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input govuk-input--error"
                             id="lpa-questionnaire-due-date-month" name="lpa-questionnaire-due-date-month"
-                            type="text" inputmode="numeric">
+                            type="text" value="2" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -3004,7 +3004,7 @@ exports[`Timetable POST /edit S78 hearing LPA questionnaire should re-render edi
                             <label class="govuk-label govuk-date-input__label" for="lpa-questionnaire-due-date-year">Year</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input govuk-date-input__input govuk-input--error"
                             id="lpa-questionnaire-due-date-year" name="lpa-questionnaire-due-date-year"
-                            type="text" inputmode="numeric">
+                            type="text" value="1950" inputmode="numeric">
                         </div>
                     </div>
                 </div>
@@ -3020,7 +3020,7 @@ exports[`Timetable POST /edit S78 hearing LPA questionnaire should re-render edi
                             <label class="govuk-label govuk-date-input__label" for="lpa-statement-due-date-day">Day</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="lpa-statement-due-date-day" name="lpa-statement-due-date-day" type="text"
-                            inputmode="numeric">
+                            value="02" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -3028,7 +3028,7 @@ exports[`Timetable POST /edit S78 hearing LPA questionnaire should re-render edi
                             <label class="govuk-label govuk-date-input__label" for="lpa-statement-due-date-month">Month</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="lpa-statement-due-date-month" name="lpa-statement-due-date-month" type="text"
-                            inputmode="numeric">
+                            value="10" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -3036,7 +3036,7 @@ exports[`Timetable POST /edit S78 hearing LPA questionnaire should re-render edi
                             <label class="govuk-label govuk-date-input__label" for="lpa-statement-due-date-year">Year</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input govuk-date-input__input"
                             id="lpa-statement-due-date-year" name="lpa-statement-due-date-year" type="text"
-                            inputmode="numeric">
+                            value="2050" inputmode="numeric">
                         </div>
                     </div>
                 </div>
@@ -3053,7 +3053,7 @@ exports[`Timetable POST /edit S78 hearing LPA questionnaire should re-render edi
                             <label class="govuk-label govuk-date-input__label" for="ip-comments-due-date-day">Day</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="ip-comments-due-date-day" name="ip-comments-due-date-day" type="text"
-                            inputmode="numeric">
+                            value="03" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -3061,7 +3061,7 @@ exports[`Timetable POST /edit S78 hearing LPA questionnaire should re-render edi
                             <label class="govuk-label govuk-date-input__label" for="ip-comments-due-date-month">Month</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="ip-comments-due-date-month" name="ip-comments-due-date-month" type="text"
-                            inputmode="numeric">
+                            value="10" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -3069,7 +3069,7 @@ exports[`Timetable POST /edit S78 hearing LPA questionnaire should re-render edi
                             <label class="govuk-label govuk-date-input__label" for="ip-comments-due-date-year">Year</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input govuk-date-input__input"
                             id="ip-comments-due-date-year" name="ip-comments-due-date-year" type="text"
-                            inputmode="numeric">
+                            value="2050" inputmode="numeric">
                         </div>
                     </div>
                 </div>
@@ -3086,7 +3086,7 @@ exports[`Timetable POST /edit S78 hearing LPA questionnaire should re-render edi
                             <label class="govuk-label govuk-date-input__label" for="statement-of-common-ground-due-date-day">Day</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="statement-of-common-ground-due-date-day" name="statement-of-common-ground-due-date-day"
-                            type="text" inputmode="numeric">
+                            type="text" value="04" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -3094,7 +3094,7 @@ exports[`Timetable POST /edit S78 hearing LPA questionnaire should re-render edi
                             <label class="govuk-label govuk-date-input__label" for="statement-of-common-ground-due-date-month">Month</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="statement-of-common-ground-due-date-month" name="statement-of-common-ground-due-date-month"
-                            type="text" inputmode="numeric">
+                            type="text" value="10" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -3102,7 +3102,7 @@ exports[`Timetable POST /edit S78 hearing LPA questionnaire should re-render edi
                             <label class="govuk-label govuk-date-input__label" for="statement-of-common-ground-due-date-year">Year</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input govuk-date-input__input"
                             id="statement-of-common-ground-due-date-year" name="statement-of-common-ground-due-date-year"
-                            type="text" inputmode="numeric">
+                            type="text" value="2050" inputmode="numeric">
                         </div>
                     </div>
                 </div>
@@ -3119,7 +3119,7 @@ exports[`Timetable POST /edit S78 hearing LPA questionnaire should re-render edi
                             <label class="govuk-label govuk-date-input__label" for="planning-obligation-due-date-day">Day</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="planning-obligation-due-date-day" name="planning-obligation-due-date-day"
-                            type="text" inputmode="numeric">
+                            type="text" value="05" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -3127,7 +3127,7 @@ exports[`Timetable POST /edit S78 hearing LPA questionnaire should re-render edi
                             <label class="govuk-label govuk-date-input__label" for="planning-obligation-due-date-month">Month</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="planning-obligation-due-date-month" name="planning-obligation-due-date-month"
-                            type="text" inputmode="numeric">
+                            type="text" value="10" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -3135,7 +3135,7 @@ exports[`Timetable POST /edit S78 hearing LPA questionnaire should re-render edi
                             <label class="govuk-label govuk-date-input__label" for="planning-obligation-due-date-year">Year</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input govuk-date-input__input"
                             id="planning-obligation-due-date-year" name="planning-obligation-due-date-year"
-                            type="text" inputmode="numeric">
+                            type="text" value="2050" inputmode="numeric">
                         </div>
                     </div>
                 </div>
@@ -3188,7 +3188,7 @@ exports[`Timetable POST /edit S78 hearing LPA questionnaire should re-render edi
                             <label class="govuk-label govuk-date-input__label" for="lpa-questionnaire-due-date-day">Day</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input govuk-input--error"
                             id="lpa-questionnaire-due-date-day" name="lpa-questionnaire-due-date-day"
-                            type="text" inputmode="numeric">
+                            type="text" value="29" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -3196,7 +3196,7 @@ exports[`Timetable POST /edit S78 hearing LPA questionnaire should re-render edi
                             <label class="govuk-label govuk-date-input__label" for="lpa-questionnaire-due-date-month">Month</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input govuk-input--error"
                             id="lpa-questionnaire-due-date-month" name="lpa-questionnaire-due-date-month"
-                            type="text" inputmode="numeric">
+                            type="text" value="2" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -3204,7 +3204,7 @@ exports[`Timetable POST /edit S78 hearing LPA questionnaire should re-render edi
                             <label class="govuk-label govuk-date-input__label" for="lpa-questionnaire-due-date-year">Year</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input govuk-date-input__input govuk-input--error"
                             id="lpa-questionnaire-due-date-year" name="lpa-questionnaire-due-date-year"
-                            type="text" inputmode="numeric">
+                            type="text" value="3000" inputmode="numeric">
                         </div>
                     </div>
                 </div>
@@ -3220,7 +3220,7 @@ exports[`Timetable POST /edit S78 hearing LPA questionnaire should re-render edi
                             <label class="govuk-label govuk-date-input__label" for="lpa-statement-due-date-day">Day</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="lpa-statement-due-date-day" name="lpa-statement-due-date-day" type="text"
-                            inputmode="numeric">
+                            value="02" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -3228,7 +3228,7 @@ exports[`Timetable POST /edit S78 hearing LPA questionnaire should re-render edi
                             <label class="govuk-label govuk-date-input__label" for="lpa-statement-due-date-month">Month</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="lpa-statement-due-date-month" name="lpa-statement-due-date-month" type="text"
-                            inputmode="numeric">
+                            value="10" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -3236,7 +3236,7 @@ exports[`Timetable POST /edit S78 hearing LPA questionnaire should re-render edi
                             <label class="govuk-label govuk-date-input__label" for="lpa-statement-due-date-year">Year</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input govuk-date-input__input"
                             id="lpa-statement-due-date-year" name="lpa-statement-due-date-year" type="text"
-                            inputmode="numeric">
+                            value="2050" inputmode="numeric">
                         </div>
                     </div>
                 </div>
@@ -3253,7 +3253,7 @@ exports[`Timetable POST /edit S78 hearing LPA questionnaire should re-render edi
                             <label class="govuk-label govuk-date-input__label" for="ip-comments-due-date-day">Day</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="ip-comments-due-date-day" name="ip-comments-due-date-day" type="text"
-                            inputmode="numeric">
+                            value="03" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -3261,7 +3261,7 @@ exports[`Timetable POST /edit S78 hearing LPA questionnaire should re-render edi
                             <label class="govuk-label govuk-date-input__label" for="ip-comments-due-date-month">Month</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="ip-comments-due-date-month" name="ip-comments-due-date-month" type="text"
-                            inputmode="numeric">
+                            value="10" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -3269,7 +3269,7 @@ exports[`Timetable POST /edit S78 hearing LPA questionnaire should re-render edi
                             <label class="govuk-label govuk-date-input__label" for="ip-comments-due-date-year">Year</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input govuk-date-input__input"
                             id="ip-comments-due-date-year" name="ip-comments-due-date-year" type="text"
-                            inputmode="numeric">
+                            value="2050" inputmode="numeric">
                         </div>
                     </div>
                 </div>
@@ -3286,7 +3286,7 @@ exports[`Timetable POST /edit S78 hearing LPA questionnaire should re-render edi
                             <label class="govuk-label govuk-date-input__label" for="statement-of-common-ground-due-date-day">Day</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="statement-of-common-ground-due-date-day" name="statement-of-common-ground-due-date-day"
-                            type="text" inputmode="numeric">
+                            type="text" value="04" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -3294,7 +3294,7 @@ exports[`Timetable POST /edit S78 hearing LPA questionnaire should re-render edi
                             <label class="govuk-label govuk-date-input__label" for="statement-of-common-ground-due-date-month">Month</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="statement-of-common-ground-due-date-month" name="statement-of-common-ground-due-date-month"
-                            type="text" inputmode="numeric">
+                            type="text" value="10" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -3302,7 +3302,7 @@ exports[`Timetable POST /edit S78 hearing LPA questionnaire should re-render edi
                             <label class="govuk-label govuk-date-input__label" for="statement-of-common-ground-due-date-year">Year</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input govuk-date-input__input"
                             id="statement-of-common-ground-due-date-year" name="statement-of-common-ground-due-date-year"
-                            type="text" inputmode="numeric">
+                            type="text" value="2050" inputmode="numeric">
                         </div>
                     </div>
                 </div>
@@ -3319,7 +3319,7 @@ exports[`Timetable POST /edit S78 hearing LPA questionnaire should re-render edi
                             <label class="govuk-label govuk-date-input__label" for="planning-obligation-due-date-day">Day</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="planning-obligation-due-date-day" name="planning-obligation-due-date-day"
-                            type="text" inputmode="numeric">
+                            type="text" value="05" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -3327,7 +3327,7 @@ exports[`Timetable POST /edit S78 hearing LPA questionnaire should re-render edi
                             <label class="govuk-label govuk-date-input__label" for="planning-obligation-due-date-month">Month</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="planning-obligation-due-date-month" name="planning-obligation-due-date-month"
-                            type="text" inputmode="numeric">
+                            type="text" value="10" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -3335,7 +3335,7 @@ exports[`Timetable POST /edit S78 hearing LPA questionnaire should re-render edi
                             <label class="govuk-label govuk-date-input__label" for="planning-obligation-due-date-year">Year</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input govuk-date-input__input"
                             id="planning-obligation-due-date-year" name="planning-obligation-due-date-year"
-                            type="text" inputmode="numeric">
+                            type="text" value="2050" inputmode="numeric">
                         </div>
                     </div>
                 </div>
@@ -3357,7 +3357,7 @@ exports[`Timetable POST /edit S78 hearing Planning obligation should re-render e
                     <h2 class="govuk-error-summary__title"> There is a problem</h2>
                     <div class="govuk-error-summary__body">
                         <ul class="govuk-list govuk-error-summary__list">
-                            <li><a href="#planning-obligation-due-date">day::Planning obligation due date must include a day</a>
+                            <li><a href="#planning-obligation-due-date-day">Planning obligation due date must include a day</a>
                             </li>
                         </ul>
                     </div>
@@ -3385,7 +3385,7 @@ exports[`Timetable POST /edit S78 hearing Planning obligation should re-render e
                             <label class="govuk-label govuk-date-input__label" for="lpa-questionnaire-due-date-day">Day</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="lpa-questionnaire-due-date-day" name="lpa-questionnaire-due-date-day"
-                            type="text" inputmode="numeric">
+                            type="text" value="01" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -3393,7 +3393,7 @@ exports[`Timetable POST /edit S78 hearing Planning obligation should re-render e
                             <label class="govuk-label govuk-date-input__label" for="lpa-questionnaire-due-date-month">Month</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="lpa-questionnaire-due-date-month" name="lpa-questionnaire-due-date-month"
-                            type="text" inputmode="numeric">
+                            type="text" value="10" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -3401,7 +3401,7 @@ exports[`Timetable POST /edit S78 hearing Planning obligation should re-render e
                             <label class="govuk-label govuk-date-input__label" for="lpa-questionnaire-due-date-year">Year</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input govuk-date-input__input"
                             id="lpa-questionnaire-due-date-year" name="lpa-questionnaire-due-date-year"
-                            type="text" inputmode="numeric">
+                            type="text" value="2050" inputmode="numeric">
                         </div>
                     </div>
                 </div>
@@ -3417,7 +3417,7 @@ exports[`Timetable POST /edit S78 hearing Planning obligation should re-render e
                             <label class="govuk-label govuk-date-input__label" for="lpa-statement-due-date-day">Day</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="lpa-statement-due-date-day" name="lpa-statement-due-date-day" type="text"
-                            inputmode="numeric">
+                            value="02" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -3425,7 +3425,7 @@ exports[`Timetable POST /edit S78 hearing Planning obligation should re-render e
                             <label class="govuk-label govuk-date-input__label" for="lpa-statement-due-date-month">Month</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="lpa-statement-due-date-month" name="lpa-statement-due-date-month" type="text"
-                            inputmode="numeric">
+                            value="10" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -3433,7 +3433,7 @@ exports[`Timetable POST /edit S78 hearing Planning obligation should re-render e
                             <label class="govuk-label govuk-date-input__label" for="lpa-statement-due-date-year">Year</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input govuk-date-input__input"
                             id="lpa-statement-due-date-year" name="lpa-statement-due-date-year" type="text"
-                            inputmode="numeric">
+                            value="2050" inputmode="numeric">
                         </div>
                     </div>
                 </div>
@@ -3450,7 +3450,7 @@ exports[`Timetable POST /edit S78 hearing Planning obligation should re-render e
                             <label class="govuk-label govuk-date-input__label" for="ip-comments-due-date-day">Day</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="ip-comments-due-date-day" name="ip-comments-due-date-day" type="text"
-                            inputmode="numeric">
+                            value="03" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -3458,7 +3458,7 @@ exports[`Timetable POST /edit S78 hearing Planning obligation should re-render e
                             <label class="govuk-label govuk-date-input__label" for="ip-comments-due-date-month">Month</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="ip-comments-due-date-month" name="ip-comments-due-date-month" type="text"
-                            inputmode="numeric">
+                            value="10" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -3466,7 +3466,7 @@ exports[`Timetable POST /edit S78 hearing Planning obligation should re-render e
                             <label class="govuk-label govuk-date-input__label" for="ip-comments-due-date-year">Year</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input govuk-date-input__input"
                             id="ip-comments-due-date-year" name="ip-comments-due-date-year" type="text"
-                            inputmode="numeric">
+                            value="2050" inputmode="numeric">
                         </div>
                     </div>
                 </div>
@@ -3483,7 +3483,7 @@ exports[`Timetable POST /edit S78 hearing Planning obligation should re-render e
                             <label class="govuk-label govuk-date-input__label" for="statement-of-common-ground-due-date-day">Day</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="statement-of-common-ground-due-date-day" name="statement-of-common-ground-due-date-day"
-                            type="text" inputmode="numeric">
+                            type="text" value="04" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -3491,7 +3491,7 @@ exports[`Timetable POST /edit S78 hearing Planning obligation should re-render e
                             <label class="govuk-label govuk-date-input__label" for="statement-of-common-ground-due-date-month">Month</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="statement-of-common-ground-due-date-month" name="statement-of-common-ground-due-date-month"
-                            type="text" inputmode="numeric">
+                            type="text" value="10" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -3499,22 +3499,25 @@ exports[`Timetable POST /edit S78 hearing Planning obligation should re-render e
                             <label class="govuk-label govuk-date-input__label" for="statement-of-common-ground-due-date-year">Year</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input govuk-date-input__input"
                             id="statement-of-common-ground-due-date-year" name="statement-of-common-ground-due-date-year"
-                            type="text" inputmode="numeric">
+                            type="text" value="2050" inputmode="numeric">
                         </div>
                     </div>
                 </div>
             </fieldset>
         </div>
-        <div class="govuk-form-group">
-            <fieldset class="govuk-fieldset" role="group" aria-describedby="planning-obligation-due-date-hint">
+        <div class="govuk-form-group govuk-form-group--error">
+            <fieldset class="govuk-fieldset" role="group" aria-describedby="planning-obligation-due-date-hint planning-obligation-due-date-error">
                 <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">Planning obligation due</legend>
                 <div id="planning-obligation-due-date-hint"
                 class="govuk-hint">For example, 29 10 2024</div>
+                <p id="planning-obligation-due-date-error"
+                class="govuk-error-message"><span class="govuk-visually-hidden">Error:</span> Planning obligation due
+                    date must include a day</p>
                 <div class="govuk-date-input" id="planning-obligation-due-date">
                     <div class="govuk-date-input__item">
                         <div class="govuk-form-group">
                             <label class="govuk-label govuk-date-input__label" for="planning-obligation-due-date-day">Day</label>
-                            <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input govuk-input--error"
                             id="planning-obligation-due-date-day" name="planning-obligation-due-date-day"
                             type="text" inputmode="numeric">
                         </div>
@@ -3524,7 +3527,7 @@ exports[`Timetable POST /edit S78 hearing Planning obligation should re-render e
                             <label class="govuk-label govuk-date-input__label" for="planning-obligation-due-date-month">Month</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="planning-obligation-due-date-month" name="planning-obligation-due-date-month"
-                            type="text" inputmode="numeric">
+                            type="text" value="10" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -3532,7 +3535,7 @@ exports[`Timetable POST /edit S78 hearing Planning obligation should re-render e
                             <label class="govuk-label govuk-date-input__label" for="planning-obligation-due-date-year">Year</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input govuk-date-input__input"
                             id="planning-obligation-due-date-year" name="planning-obligation-due-date-year"
-                            type="text" inputmode="numeric">
+                            type="text" value="2050" inputmode="numeric">
                         </div>
                     </div>
                 </div>
@@ -3554,7 +3557,7 @@ exports[`Timetable POST /edit S78 hearing Planning obligation should re-render e
                     <h2 class="govuk-error-summary__title"> There is a problem</h2>
                     <div class="govuk-error-summary__body">
                         <ul class="govuk-list govuk-error-summary__list">
-                            <li><a href="#planning-obligation-due-date">month::Planning obligation due date must include a month</a>
+                            <li><a href="#planning-obligation-due-date-month">Planning obligation due date must include a month</a>
                             </li>
                         </ul>
                     </div>
@@ -3582,7 +3585,7 @@ exports[`Timetable POST /edit S78 hearing Planning obligation should re-render e
                             <label class="govuk-label govuk-date-input__label" for="lpa-questionnaire-due-date-day">Day</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="lpa-questionnaire-due-date-day" name="lpa-questionnaire-due-date-day"
-                            type="text" inputmode="numeric">
+                            type="text" value="01" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -3590,7 +3593,7 @@ exports[`Timetable POST /edit S78 hearing Planning obligation should re-render e
                             <label class="govuk-label govuk-date-input__label" for="lpa-questionnaire-due-date-month">Month</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="lpa-questionnaire-due-date-month" name="lpa-questionnaire-due-date-month"
-                            type="text" inputmode="numeric">
+                            type="text" value="10" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -3598,7 +3601,7 @@ exports[`Timetable POST /edit S78 hearing Planning obligation should re-render e
                             <label class="govuk-label govuk-date-input__label" for="lpa-questionnaire-due-date-year">Year</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input govuk-date-input__input"
                             id="lpa-questionnaire-due-date-year" name="lpa-questionnaire-due-date-year"
-                            type="text" inputmode="numeric">
+                            type="text" value="2050" inputmode="numeric">
                         </div>
                     </div>
                 </div>
@@ -3614,7 +3617,7 @@ exports[`Timetable POST /edit S78 hearing Planning obligation should re-render e
                             <label class="govuk-label govuk-date-input__label" for="lpa-statement-due-date-day">Day</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="lpa-statement-due-date-day" name="lpa-statement-due-date-day" type="text"
-                            inputmode="numeric">
+                            value="02" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -3622,7 +3625,7 @@ exports[`Timetable POST /edit S78 hearing Planning obligation should re-render e
                             <label class="govuk-label govuk-date-input__label" for="lpa-statement-due-date-month">Month</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="lpa-statement-due-date-month" name="lpa-statement-due-date-month" type="text"
-                            inputmode="numeric">
+                            value="10" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -3630,7 +3633,7 @@ exports[`Timetable POST /edit S78 hearing Planning obligation should re-render e
                             <label class="govuk-label govuk-date-input__label" for="lpa-statement-due-date-year">Year</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input govuk-date-input__input"
                             id="lpa-statement-due-date-year" name="lpa-statement-due-date-year" type="text"
-                            inputmode="numeric">
+                            value="2050" inputmode="numeric">
                         </div>
                     </div>
                 </div>
@@ -3647,7 +3650,7 @@ exports[`Timetable POST /edit S78 hearing Planning obligation should re-render e
                             <label class="govuk-label govuk-date-input__label" for="ip-comments-due-date-day">Day</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="ip-comments-due-date-day" name="ip-comments-due-date-day" type="text"
-                            inputmode="numeric">
+                            value="03" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -3655,7 +3658,7 @@ exports[`Timetable POST /edit S78 hearing Planning obligation should re-render e
                             <label class="govuk-label govuk-date-input__label" for="ip-comments-due-date-month">Month</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="ip-comments-due-date-month" name="ip-comments-due-date-month" type="text"
-                            inputmode="numeric">
+                            value="10" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -3663,7 +3666,7 @@ exports[`Timetable POST /edit S78 hearing Planning obligation should re-render e
                             <label class="govuk-label govuk-date-input__label" for="ip-comments-due-date-year">Year</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input govuk-date-input__input"
                             id="ip-comments-due-date-year" name="ip-comments-due-date-year" type="text"
-                            inputmode="numeric">
+                            value="2050" inputmode="numeric">
                         </div>
                     </div>
                 </div>
@@ -3680,7 +3683,7 @@ exports[`Timetable POST /edit S78 hearing Planning obligation should re-render e
                             <label class="govuk-label govuk-date-input__label" for="statement-of-common-ground-due-date-day">Day</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="statement-of-common-ground-due-date-day" name="statement-of-common-ground-due-date-day"
-                            type="text" inputmode="numeric">
+                            type="text" value="04" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -3688,7 +3691,7 @@ exports[`Timetable POST /edit S78 hearing Planning obligation should re-render e
                             <label class="govuk-label govuk-date-input__label" for="statement-of-common-ground-due-date-month">Month</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="statement-of-common-ground-due-date-month" name="statement-of-common-ground-due-date-month"
-                            type="text" inputmode="numeric">
+                            type="text" value="10" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -3696,30 +3699,33 @@ exports[`Timetable POST /edit S78 hearing Planning obligation should re-render e
                             <label class="govuk-label govuk-date-input__label" for="statement-of-common-ground-due-date-year">Year</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input govuk-date-input__input"
                             id="statement-of-common-ground-due-date-year" name="statement-of-common-ground-due-date-year"
-                            type="text" inputmode="numeric">
+                            type="text" value="2050" inputmode="numeric">
                         </div>
                     </div>
                 </div>
             </fieldset>
         </div>
-        <div class="govuk-form-group">
-            <fieldset class="govuk-fieldset" role="group" aria-describedby="planning-obligation-due-date-hint">
+        <div class="govuk-form-group govuk-form-group--error">
+            <fieldset class="govuk-fieldset" role="group" aria-describedby="planning-obligation-due-date-hint planning-obligation-due-date-error">
                 <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">Planning obligation due</legend>
                 <div id="planning-obligation-due-date-hint"
                 class="govuk-hint">For example, 29 10 2024</div>
+                <p id="planning-obligation-due-date-error"
+                class="govuk-error-message"><span class="govuk-visually-hidden">Error:</span> Planning obligation due
+                    date must include a month</p>
                 <div class="govuk-date-input" id="planning-obligation-due-date">
                     <div class="govuk-date-input__item">
                         <div class="govuk-form-group">
                             <label class="govuk-label govuk-date-input__label" for="planning-obligation-due-date-day">Day</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="planning-obligation-due-date-day" name="planning-obligation-due-date-day"
-                            type="text" inputmode="numeric">
+                            type="text" value="10" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
                         <div class="govuk-form-group">
                             <label class="govuk-label govuk-date-input__label" for="planning-obligation-due-date-month">Month</label>
-                            <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input govuk-input--error"
                             id="planning-obligation-due-date-month" name="planning-obligation-due-date-month"
                             type="text" inputmode="numeric">
                         </div>
@@ -3729,7 +3735,7 @@ exports[`Timetable POST /edit S78 hearing Planning obligation should re-render e
                             <label class="govuk-label govuk-date-input__label" for="planning-obligation-due-date-year">Year</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input govuk-date-input__input"
                             id="planning-obligation-due-date-year" name="planning-obligation-due-date-year"
-                            type="text" inputmode="numeric">
+                            type="text" value="2050" inputmode="numeric">
                         </div>
                     </div>
                 </div>
@@ -3751,7 +3757,7 @@ exports[`Timetable POST /edit S78 hearing Planning obligation should re-render e
                     <h2 class="govuk-error-summary__title"> There is a problem</h2>
                     <div class="govuk-error-summary__body">
                         <ul class="govuk-list govuk-error-summary__list">
-                            <li><a href="#planning-obligation-due-date">year::Planning obligation due date must include a year</a>
+                            <li><a href="#planning-obligation-due-date-year">Planning obligation due date must include a year</a>
                             </li>
                         </ul>
                     </div>
@@ -3779,7 +3785,7 @@ exports[`Timetable POST /edit S78 hearing Planning obligation should re-render e
                             <label class="govuk-label govuk-date-input__label" for="lpa-questionnaire-due-date-day">Day</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="lpa-questionnaire-due-date-day" name="lpa-questionnaire-due-date-day"
-                            type="text" inputmode="numeric">
+                            type="text" value="01" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -3787,7 +3793,7 @@ exports[`Timetable POST /edit S78 hearing Planning obligation should re-render e
                             <label class="govuk-label govuk-date-input__label" for="lpa-questionnaire-due-date-month">Month</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="lpa-questionnaire-due-date-month" name="lpa-questionnaire-due-date-month"
-                            type="text" inputmode="numeric">
+                            type="text" value="10" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -3795,7 +3801,7 @@ exports[`Timetable POST /edit S78 hearing Planning obligation should re-render e
                             <label class="govuk-label govuk-date-input__label" for="lpa-questionnaire-due-date-year">Year</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input govuk-date-input__input"
                             id="lpa-questionnaire-due-date-year" name="lpa-questionnaire-due-date-year"
-                            type="text" inputmode="numeric">
+                            type="text" value="2050" inputmode="numeric">
                         </div>
                     </div>
                 </div>
@@ -3811,7 +3817,7 @@ exports[`Timetable POST /edit S78 hearing Planning obligation should re-render e
                             <label class="govuk-label govuk-date-input__label" for="lpa-statement-due-date-day">Day</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="lpa-statement-due-date-day" name="lpa-statement-due-date-day" type="text"
-                            inputmode="numeric">
+                            value="02" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -3819,7 +3825,7 @@ exports[`Timetable POST /edit S78 hearing Planning obligation should re-render e
                             <label class="govuk-label govuk-date-input__label" for="lpa-statement-due-date-month">Month</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="lpa-statement-due-date-month" name="lpa-statement-due-date-month" type="text"
-                            inputmode="numeric">
+                            value="10" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -3827,7 +3833,7 @@ exports[`Timetable POST /edit S78 hearing Planning obligation should re-render e
                             <label class="govuk-label govuk-date-input__label" for="lpa-statement-due-date-year">Year</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input govuk-date-input__input"
                             id="lpa-statement-due-date-year" name="lpa-statement-due-date-year" type="text"
-                            inputmode="numeric">
+                            value="2050" inputmode="numeric">
                         </div>
                     </div>
                 </div>
@@ -3844,7 +3850,7 @@ exports[`Timetable POST /edit S78 hearing Planning obligation should re-render e
                             <label class="govuk-label govuk-date-input__label" for="ip-comments-due-date-day">Day</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="ip-comments-due-date-day" name="ip-comments-due-date-day" type="text"
-                            inputmode="numeric">
+                            value="03" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -3852,7 +3858,7 @@ exports[`Timetable POST /edit S78 hearing Planning obligation should re-render e
                             <label class="govuk-label govuk-date-input__label" for="ip-comments-due-date-month">Month</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="ip-comments-due-date-month" name="ip-comments-due-date-month" type="text"
-                            inputmode="numeric">
+                            value="10" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -3860,7 +3866,7 @@ exports[`Timetable POST /edit S78 hearing Planning obligation should re-render e
                             <label class="govuk-label govuk-date-input__label" for="ip-comments-due-date-year">Year</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input govuk-date-input__input"
                             id="ip-comments-due-date-year" name="ip-comments-due-date-year" type="text"
-                            inputmode="numeric">
+                            value="2050" inputmode="numeric">
                         </div>
                     </div>
                 </div>
@@ -3877,7 +3883,7 @@ exports[`Timetable POST /edit S78 hearing Planning obligation should re-render e
                             <label class="govuk-label govuk-date-input__label" for="statement-of-common-ground-due-date-day">Day</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="statement-of-common-ground-due-date-day" name="statement-of-common-ground-due-date-day"
-                            type="text" inputmode="numeric">
+                            type="text" value="04" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -3885,7 +3891,7 @@ exports[`Timetable POST /edit S78 hearing Planning obligation should re-render e
                             <label class="govuk-label govuk-date-input__label" for="statement-of-common-ground-due-date-month">Month</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="statement-of-common-ground-due-date-month" name="statement-of-common-ground-due-date-month"
-                            type="text" inputmode="numeric">
+                            type="text" value="10" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -3893,24 +3899,27 @@ exports[`Timetable POST /edit S78 hearing Planning obligation should re-render e
                             <label class="govuk-label govuk-date-input__label" for="statement-of-common-ground-due-date-year">Year</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input govuk-date-input__input"
                             id="statement-of-common-ground-due-date-year" name="statement-of-common-ground-due-date-year"
-                            type="text" inputmode="numeric">
+                            type="text" value="2050" inputmode="numeric">
                         </div>
                     </div>
                 </div>
             </fieldset>
         </div>
-        <div class="govuk-form-group">
-            <fieldset class="govuk-fieldset" role="group" aria-describedby="planning-obligation-due-date-hint">
+        <div class="govuk-form-group govuk-form-group--error">
+            <fieldset class="govuk-fieldset" role="group" aria-describedby="planning-obligation-due-date-hint planning-obligation-due-date-error">
                 <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">Planning obligation due</legend>
                 <div id="planning-obligation-due-date-hint"
                 class="govuk-hint">For example, 29 10 2024</div>
+                <p id="planning-obligation-due-date-error"
+                class="govuk-error-message"><span class="govuk-visually-hidden">Error:</span> Planning obligation due
+                    date must include a year</p>
                 <div class="govuk-date-input" id="planning-obligation-due-date">
                     <div class="govuk-date-input__item">
                         <div class="govuk-form-group">
                             <label class="govuk-label govuk-date-input__label" for="planning-obligation-due-date-day">Day</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="planning-obligation-due-date-day" name="planning-obligation-due-date-day"
-                            type="text" inputmode="numeric">
+                            type="text" value="10" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -3918,13 +3927,13 @@ exports[`Timetable POST /edit S78 hearing Planning obligation should re-render e
                             <label class="govuk-label govuk-date-input__label" for="planning-obligation-due-date-month">Month</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="planning-obligation-due-date-month" name="planning-obligation-due-date-month"
-                            type="text" inputmode="numeric">
+                            type="text" value="12" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
                         <div class="govuk-form-group">
                             <label class="govuk-label govuk-date-input__label" for="planning-obligation-due-date-year">Year</label>
-                            <input class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input govuk-date-input__input"
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input govuk-date-input__input govuk-input--error"
                             id="planning-obligation-due-date-year" name="planning-obligation-due-date-year"
                             type="text" inputmode="numeric">
                         </div>
@@ -3948,7 +3957,7 @@ exports[`Timetable POST /edit S78 hearing Planning obligation should re-render e
                     <h2 class="govuk-error-summary__title"> There is a problem</h2>
                     <div class="govuk-error-summary__body">
                         <ul class="govuk-list govuk-error-summary__list">
-                            <li><a href="#planning-obligation-due-date">all-fields::The planning obligation due date must be in the future</a>
+                            <li><a href="#planning-obligation-due-date-day">The planning obligation due date must be in the future</a>
                             </li>
                         </ul>
                     </div>
@@ -3976,7 +3985,7 @@ exports[`Timetable POST /edit S78 hearing Planning obligation should re-render e
                             <label class="govuk-label govuk-date-input__label" for="lpa-questionnaire-due-date-day">Day</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="lpa-questionnaire-due-date-day" name="lpa-questionnaire-due-date-day"
-                            type="text" inputmode="numeric">
+                            type="text" value="01" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -3984,7 +3993,7 @@ exports[`Timetable POST /edit S78 hearing Planning obligation should re-render e
                             <label class="govuk-label govuk-date-input__label" for="lpa-questionnaire-due-date-month">Month</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="lpa-questionnaire-due-date-month" name="lpa-questionnaire-due-date-month"
-                            type="text" inputmode="numeric">
+                            type="text" value="10" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -3992,7 +4001,7 @@ exports[`Timetable POST /edit S78 hearing Planning obligation should re-render e
                             <label class="govuk-label govuk-date-input__label" for="lpa-questionnaire-due-date-year">Year</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input govuk-date-input__input"
                             id="lpa-questionnaire-due-date-year" name="lpa-questionnaire-due-date-year"
-                            type="text" inputmode="numeric">
+                            type="text" value="2050" inputmode="numeric">
                         </div>
                     </div>
                 </div>
@@ -4008,7 +4017,7 @@ exports[`Timetable POST /edit S78 hearing Planning obligation should re-render e
                             <label class="govuk-label govuk-date-input__label" for="lpa-statement-due-date-day">Day</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="lpa-statement-due-date-day" name="lpa-statement-due-date-day" type="text"
-                            inputmode="numeric">
+                            value="02" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -4016,7 +4025,7 @@ exports[`Timetable POST /edit S78 hearing Planning obligation should re-render e
                             <label class="govuk-label govuk-date-input__label" for="lpa-statement-due-date-month">Month</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="lpa-statement-due-date-month" name="lpa-statement-due-date-month" type="text"
-                            inputmode="numeric">
+                            value="10" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -4024,7 +4033,7 @@ exports[`Timetable POST /edit S78 hearing Planning obligation should re-render e
                             <label class="govuk-label govuk-date-input__label" for="lpa-statement-due-date-year">Year</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input govuk-date-input__input"
                             id="lpa-statement-due-date-year" name="lpa-statement-due-date-year" type="text"
-                            inputmode="numeric">
+                            value="2050" inputmode="numeric">
                         </div>
                     </div>
                 </div>
@@ -4041,7 +4050,7 @@ exports[`Timetable POST /edit S78 hearing Planning obligation should re-render e
                             <label class="govuk-label govuk-date-input__label" for="ip-comments-due-date-day">Day</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="ip-comments-due-date-day" name="ip-comments-due-date-day" type="text"
-                            inputmode="numeric">
+                            value="03" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -4049,7 +4058,7 @@ exports[`Timetable POST /edit S78 hearing Planning obligation should re-render e
                             <label class="govuk-label govuk-date-input__label" for="ip-comments-due-date-month">Month</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="ip-comments-due-date-month" name="ip-comments-due-date-month" type="text"
-                            inputmode="numeric">
+                            value="10" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -4057,7 +4066,7 @@ exports[`Timetable POST /edit S78 hearing Planning obligation should re-render e
                             <label class="govuk-label govuk-date-input__label" for="ip-comments-due-date-year">Year</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input govuk-date-input__input"
                             id="ip-comments-due-date-year" name="ip-comments-due-date-year" type="text"
-                            inputmode="numeric">
+                            value="2050" inputmode="numeric">
                         </div>
                     </div>
                 </div>
@@ -4074,7 +4083,7 @@ exports[`Timetable POST /edit S78 hearing Planning obligation should re-render e
                             <label class="govuk-label govuk-date-input__label" for="statement-of-common-ground-due-date-day">Day</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="statement-of-common-ground-due-date-day" name="statement-of-common-ground-due-date-day"
-                            type="text" inputmode="numeric">
+                            type="text" value="04" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -4082,7 +4091,7 @@ exports[`Timetable POST /edit S78 hearing Planning obligation should re-render e
                             <label class="govuk-label govuk-date-input__label" for="statement-of-common-ground-due-date-month">Month</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="statement-of-common-ground-due-date-month" name="statement-of-common-ground-due-date-month"
-                            type="text" inputmode="numeric">
+                            type="text" value="10" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -4090,40 +4099,43 @@ exports[`Timetable POST /edit S78 hearing Planning obligation should re-render e
                             <label class="govuk-label govuk-date-input__label" for="statement-of-common-ground-due-date-year">Year</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input govuk-date-input__input"
                             id="statement-of-common-ground-due-date-year" name="statement-of-common-ground-due-date-year"
-                            type="text" inputmode="numeric">
+                            type="text" value="2050" inputmode="numeric">
                         </div>
                     </div>
                 </div>
             </fieldset>
         </div>
-        <div class="govuk-form-group">
-            <fieldset class="govuk-fieldset" role="group" aria-describedby="planning-obligation-due-date-hint">
+        <div class="govuk-form-group govuk-form-group--error">
+            <fieldset class="govuk-fieldset" role="group" aria-describedby="planning-obligation-due-date-hint planning-obligation-due-date-error">
                 <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">Planning obligation due</legend>
                 <div id="planning-obligation-due-date-hint"
                 class="govuk-hint">For example, 29 10 2024</div>
+                <p id="planning-obligation-due-date-error"
+                class="govuk-error-message"><span class="govuk-visually-hidden">Error:</span> The planning obligation
+                    due date must be in the future</p>
                 <div class="govuk-date-input" id="planning-obligation-due-date">
                     <div class="govuk-date-input__item">
                         <div class="govuk-form-group">
                             <label class="govuk-label govuk-date-input__label" for="planning-obligation-due-date-day">Day</label>
-                            <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input govuk-input--error"
                             id="planning-obligation-due-date-day" name="planning-obligation-due-date-day"
-                            type="text" inputmode="numeric">
+                            type="text" value="25" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
                         <div class="govuk-form-group">
                             <label class="govuk-label govuk-date-input__label" for="planning-obligation-due-date-month">Month</label>
-                            <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input govuk-input--error"
                             id="planning-obligation-due-date-month" name="planning-obligation-due-date-month"
-                            type="text" inputmode="numeric">
+                            type="text" value="2" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
                         <div class="govuk-form-group">
                             <label class="govuk-label govuk-date-input__label" for="planning-obligation-due-date-year">Year</label>
-                            <input class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input govuk-date-input__input"
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input govuk-date-input__input govuk-input--error"
                             id="planning-obligation-due-date-year" name="planning-obligation-due-date-year"
-                            type="text" inputmode="numeric">
+                            type="text" value="1950" inputmode="numeric">
                         </div>
                     </div>
                 </div>
@@ -4145,7 +4157,7 @@ exports[`Timetable POST /edit S78 hearing Planning obligation should re-render e
                     <h2 class="govuk-error-summary__title"> There is a problem</h2>
                     <div class="govuk-error-summary__body">
                         <ul class="govuk-list govuk-error-summary__list">
-                            <li><a href="#planning-obligation-due-date">all-fields::Planning obligation due date must be a real date</a>
+                            <li><a href="#planning-obligation-due-date-day">Planning obligation due date must be a real date</a>
                             </li>
                         </ul>
                     </div>
@@ -4173,7 +4185,7 @@ exports[`Timetable POST /edit S78 hearing Planning obligation should re-render e
                             <label class="govuk-label govuk-date-input__label" for="lpa-questionnaire-due-date-day">Day</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="lpa-questionnaire-due-date-day" name="lpa-questionnaire-due-date-day"
-                            type="text" inputmode="numeric">
+                            type="text" value="01" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -4181,7 +4193,7 @@ exports[`Timetable POST /edit S78 hearing Planning obligation should re-render e
                             <label class="govuk-label govuk-date-input__label" for="lpa-questionnaire-due-date-month">Month</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="lpa-questionnaire-due-date-month" name="lpa-questionnaire-due-date-month"
-                            type="text" inputmode="numeric">
+                            type="text" value="10" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -4189,7 +4201,7 @@ exports[`Timetable POST /edit S78 hearing Planning obligation should re-render e
                             <label class="govuk-label govuk-date-input__label" for="lpa-questionnaire-due-date-year">Year</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input govuk-date-input__input"
                             id="lpa-questionnaire-due-date-year" name="lpa-questionnaire-due-date-year"
-                            type="text" inputmode="numeric">
+                            type="text" value="2050" inputmode="numeric">
                         </div>
                     </div>
                 </div>
@@ -4205,7 +4217,7 @@ exports[`Timetable POST /edit S78 hearing Planning obligation should re-render e
                             <label class="govuk-label govuk-date-input__label" for="lpa-statement-due-date-day">Day</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="lpa-statement-due-date-day" name="lpa-statement-due-date-day" type="text"
-                            inputmode="numeric">
+                            value="02" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -4213,7 +4225,7 @@ exports[`Timetable POST /edit S78 hearing Planning obligation should re-render e
                             <label class="govuk-label govuk-date-input__label" for="lpa-statement-due-date-month">Month</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="lpa-statement-due-date-month" name="lpa-statement-due-date-month" type="text"
-                            inputmode="numeric">
+                            value="10" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -4221,7 +4233,7 @@ exports[`Timetable POST /edit S78 hearing Planning obligation should re-render e
                             <label class="govuk-label govuk-date-input__label" for="lpa-statement-due-date-year">Year</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input govuk-date-input__input"
                             id="lpa-statement-due-date-year" name="lpa-statement-due-date-year" type="text"
-                            inputmode="numeric">
+                            value="2050" inputmode="numeric">
                         </div>
                     </div>
                 </div>
@@ -4238,7 +4250,7 @@ exports[`Timetable POST /edit S78 hearing Planning obligation should re-render e
                             <label class="govuk-label govuk-date-input__label" for="ip-comments-due-date-day">Day</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="ip-comments-due-date-day" name="ip-comments-due-date-day" type="text"
-                            inputmode="numeric">
+                            value="03" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -4246,7 +4258,7 @@ exports[`Timetable POST /edit S78 hearing Planning obligation should re-render e
                             <label class="govuk-label govuk-date-input__label" for="ip-comments-due-date-month">Month</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="ip-comments-due-date-month" name="ip-comments-due-date-month" type="text"
-                            inputmode="numeric">
+                            value="10" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -4254,7 +4266,7 @@ exports[`Timetable POST /edit S78 hearing Planning obligation should re-render e
                             <label class="govuk-label govuk-date-input__label" for="ip-comments-due-date-year">Year</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input govuk-date-input__input"
                             id="ip-comments-due-date-year" name="ip-comments-due-date-year" type="text"
-                            inputmode="numeric">
+                            value="2050" inputmode="numeric">
                         </div>
                     </div>
                 </div>
@@ -4271,7 +4283,7 @@ exports[`Timetable POST /edit S78 hearing Planning obligation should re-render e
                             <label class="govuk-label govuk-date-input__label" for="statement-of-common-ground-due-date-day">Day</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="statement-of-common-ground-due-date-day" name="statement-of-common-ground-due-date-day"
-                            type="text" inputmode="numeric">
+                            type="text" value="04" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -4279,7 +4291,7 @@ exports[`Timetable POST /edit S78 hearing Planning obligation should re-render e
                             <label class="govuk-label govuk-date-input__label" for="statement-of-common-ground-due-date-month">Month</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="statement-of-common-ground-due-date-month" name="statement-of-common-ground-due-date-month"
-                            type="text" inputmode="numeric">
+                            type="text" value="10" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -4287,40 +4299,43 @@ exports[`Timetable POST /edit S78 hearing Planning obligation should re-render e
                             <label class="govuk-label govuk-date-input__label" for="statement-of-common-ground-due-date-year">Year</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input govuk-date-input__input"
                             id="statement-of-common-ground-due-date-year" name="statement-of-common-ground-due-date-year"
-                            type="text" inputmode="numeric">
+                            type="text" value="2050" inputmode="numeric">
                         </div>
                     </div>
                 </div>
             </fieldset>
         </div>
-        <div class="govuk-form-group">
-            <fieldset class="govuk-fieldset" role="group" aria-describedby="planning-obligation-due-date-hint">
+        <div class="govuk-form-group govuk-form-group--error">
+            <fieldset class="govuk-fieldset" role="group" aria-describedby="planning-obligation-due-date-hint planning-obligation-due-date-error">
                 <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">Planning obligation due</legend>
                 <div id="planning-obligation-due-date-hint"
                 class="govuk-hint">For example, 29 10 2024</div>
+                <p id="planning-obligation-due-date-error"
+                class="govuk-error-message"><span class="govuk-visually-hidden">Error:</span> Planning obligation due
+                    date must be a real date</p>
                 <div class="govuk-date-input" id="planning-obligation-due-date">
                     <div class="govuk-date-input__item">
                         <div class="govuk-form-group">
                             <label class="govuk-label govuk-date-input__label" for="planning-obligation-due-date-day">Day</label>
-                            <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input govuk-input--error"
                             id="planning-obligation-due-date-day" name="planning-obligation-due-date-day"
-                            type="text" inputmode="numeric">
+                            type="text" value="29" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
                         <div class="govuk-form-group">
                             <label class="govuk-label govuk-date-input__label" for="planning-obligation-due-date-month">Month</label>
-                            <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input govuk-input--error"
                             id="planning-obligation-due-date-month" name="planning-obligation-due-date-month"
-                            type="text" inputmode="numeric">
+                            type="text" value="2" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
                         <div class="govuk-form-group">
                             <label class="govuk-label govuk-date-input__label" for="planning-obligation-due-date-year">Year</label>
-                            <input class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input govuk-date-input__input"
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input govuk-date-input__input govuk-input--error"
                             id="planning-obligation-due-date-year" name="planning-obligation-due-date-year"
-                            type="text" inputmode="numeric">
+                            type="text" value="3000" inputmode="numeric">
                         </div>
                     </div>
                 </div>
@@ -4342,7 +4357,7 @@ exports[`Timetable POST /edit S78 hearing Statement of common ground should re-r
                     <h2 class="govuk-error-summary__title"> There is a problem</h2>
                     <div class="govuk-error-summary__body">
                         <ul class="govuk-list govuk-error-summary__list">
-                            <li><a href="#statement-of-common-ground-due-date">day::Statement of common ground due date must include a day</a>
+                            <li><a href="#statement-of-common-ground-due-date-day">Statement of common ground due date must include a day</a>
                             </li>
                         </ul>
                     </div>
@@ -4370,7 +4385,7 @@ exports[`Timetable POST /edit S78 hearing Statement of common ground should re-r
                             <label class="govuk-label govuk-date-input__label" for="lpa-questionnaire-due-date-day">Day</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="lpa-questionnaire-due-date-day" name="lpa-questionnaire-due-date-day"
-                            type="text" inputmode="numeric">
+                            type="text" value="01" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -4378,7 +4393,7 @@ exports[`Timetable POST /edit S78 hearing Statement of common ground should re-r
                             <label class="govuk-label govuk-date-input__label" for="lpa-questionnaire-due-date-month">Month</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="lpa-questionnaire-due-date-month" name="lpa-questionnaire-due-date-month"
-                            type="text" inputmode="numeric">
+                            type="text" value="10" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -4386,7 +4401,7 @@ exports[`Timetable POST /edit S78 hearing Statement of common ground should re-r
                             <label class="govuk-label govuk-date-input__label" for="lpa-questionnaire-due-date-year">Year</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input govuk-date-input__input"
                             id="lpa-questionnaire-due-date-year" name="lpa-questionnaire-due-date-year"
-                            type="text" inputmode="numeric">
+                            type="text" value="2050" inputmode="numeric">
                         </div>
                     </div>
                 </div>
@@ -4402,7 +4417,7 @@ exports[`Timetable POST /edit S78 hearing Statement of common ground should re-r
                             <label class="govuk-label govuk-date-input__label" for="lpa-statement-due-date-day">Day</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="lpa-statement-due-date-day" name="lpa-statement-due-date-day" type="text"
-                            inputmode="numeric">
+                            value="02" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -4410,7 +4425,7 @@ exports[`Timetable POST /edit S78 hearing Statement of common ground should re-r
                             <label class="govuk-label govuk-date-input__label" for="lpa-statement-due-date-month">Month</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="lpa-statement-due-date-month" name="lpa-statement-due-date-month" type="text"
-                            inputmode="numeric">
+                            value="10" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -4418,7 +4433,7 @@ exports[`Timetable POST /edit S78 hearing Statement of common ground should re-r
                             <label class="govuk-label govuk-date-input__label" for="lpa-statement-due-date-year">Year</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input govuk-date-input__input"
                             id="lpa-statement-due-date-year" name="lpa-statement-due-date-year" type="text"
-                            inputmode="numeric">
+                            value="2050" inputmode="numeric">
                         </div>
                     </div>
                 </div>
@@ -4435,7 +4450,7 @@ exports[`Timetable POST /edit S78 hearing Statement of common ground should re-r
                             <label class="govuk-label govuk-date-input__label" for="ip-comments-due-date-day">Day</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="ip-comments-due-date-day" name="ip-comments-due-date-day" type="text"
-                            inputmode="numeric">
+                            value="03" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -4443,7 +4458,7 @@ exports[`Timetable POST /edit S78 hearing Statement of common ground should re-r
                             <label class="govuk-label govuk-date-input__label" for="ip-comments-due-date-month">Month</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="ip-comments-due-date-month" name="ip-comments-due-date-month" type="text"
-                            inputmode="numeric">
+                            value="10" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -4451,22 +4466,25 @@ exports[`Timetable POST /edit S78 hearing Statement of common ground should re-r
                             <label class="govuk-label govuk-date-input__label" for="ip-comments-due-date-year">Year</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input govuk-date-input__input"
                             id="ip-comments-due-date-year" name="ip-comments-due-date-year" type="text"
-                            inputmode="numeric">
+                            value="2050" inputmode="numeric">
                         </div>
                     </div>
                 </div>
             </fieldset>
         </div>
-        <div class="govuk-form-group">
-            <fieldset class="govuk-fieldset" role="group" aria-describedby="statement-of-common-ground-due-date-hint">
+        <div class="govuk-form-group govuk-form-group--error">
+            <fieldset class="govuk-fieldset" role="group" aria-describedby="statement-of-common-ground-due-date-hint statement-of-common-ground-due-date-error">
                 <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">Statement of common ground due</legend>
                 <div id="statement-of-common-ground-due-date-hint"
                 class="govuk-hint">For example, 29 10 2024</div>
+                <p id="statement-of-common-ground-due-date-error"
+                class="govuk-error-message"><span class="govuk-visually-hidden">Error:</span> Statement of common ground
+                    due date must include a day</p>
                 <div class="govuk-date-input" id="statement-of-common-ground-due-date">
                     <div class="govuk-date-input__item">
                         <div class="govuk-form-group">
                             <label class="govuk-label govuk-date-input__label" for="statement-of-common-ground-due-date-day">Day</label>
-                            <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input govuk-input--error"
                             id="statement-of-common-ground-due-date-day" name="statement-of-common-ground-due-date-day"
                             type="text" inputmode="numeric">
                         </div>
@@ -4476,7 +4494,7 @@ exports[`Timetable POST /edit S78 hearing Statement of common ground should re-r
                             <label class="govuk-label govuk-date-input__label" for="statement-of-common-ground-due-date-month">Month</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="statement-of-common-ground-due-date-month" name="statement-of-common-ground-due-date-month"
-                            type="text" inputmode="numeric">
+                            type="text" value="10" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -4484,7 +4502,7 @@ exports[`Timetable POST /edit S78 hearing Statement of common ground should re-r
                             <label class="govuk-label govuk-date-input__label" for="statement-of-common-ground-due-date-year">Year</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input govuk-date-input__input"
                             id="statement-of-common-ground-due-date-year" name="statement-of-common-ground-due-date-year"
-                            type="text" inputmode="numeric">
+                            type="text" value="2050" inputmode="numeric">
                         </div>
                     </div>
                 </div>
@@ -4501,7 +4519,7 @@ exports[`Timetable POST /edit S78 hearing Statement of common ground should re-r
                             <label class="govuk-label govuk-date-input__label" for="planning-obligation-due-date-day">Day</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="planning-obligation-due-date-day" name="planning-obligation-due-date-day"
-                            type="text" inputmode="numeric">
+                            type="text" value="05" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -4509,7 +4527,7 @@ exports[`Timetable POST /edit S78 hearing Statement of common ground should re-r
                             <label class="govuk-label govuk-date-input__label" for="planning-obligation-due-date-month">Month</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="planning-obligation-due-date-month" name="planning-obligation-due-date-month"
-                            type="text" inputmode="numeric">
+                            type="text" value="10" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -4517,7 +4535,7 @@ exports[`Timetable POST /edit S78 hearing Statement of common ground should re-r
                             <label class="govuk-label govuk-date-input__label" for="planning-obligation-due-date-year">Year</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input govuk-date-input__input"
                             id="planning-obligation-due-date-year" name="planning-obligation-due-date-year"
-                            type="text" inputmode="numeric">
+                            type="text" value="2050" inputmode="numeric">
                         </div>
                     </div>
                 </div>
@@ -4539,7 +4557,7 @@ exports[`Timetable POST /edit S78 hearing Statement of common ground should re-r
                     <h2 class="govuk-error-summary__title"> There is a problem</h2>
                     <div class="govuk-error-summary__body">
                         <ul class="govuk-list govuk-error-summary__list">
-                            <li><a href="#statement-of-common-ground-due-date">month::Statement of common ground due date must include a month</a>
+                            <li><a href="#statement-of-common-ground-due-date-month">Statement of common ground due date must include a month</a>
                             </li>
                         </ul>
                     </div>
@@ -4567,7 +4585,7 @@ exports[`Timetable POST /edit S78 hearing Statement of common ground should re-r
                             <label class="govuk-label govuk-date-input__label" for="lpa-questionnaire-due-date-day">Day</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="lpa-questionnaire-due-date-day" name="lpa-questionnaire-due-date-day"
-                            type="text" inputmode="numeric">
+                            type="text" value="01" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -4575,7 +4593,7 @@ exports[`Timetable POST /edit S78 hearing Statement of common ground should re-r
                             <label class="govuk-label govuk-date-input__label" for="lpa-questionnaire-due-date-month">Month</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="lpa-questionnaire-due-date-month" name="lpa-questionnaire-due-date-month"
-                            type="text" inputmode="numeric">
+                            type="text" value="10" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -4583,7 +4601,7 @@ exports[`Timetable POST /edit S78 hearing Statement of common ground should re-r
                             <label class="govuk-label govuk-date-input__label" for="lpa-questionnaire-due-date-year">Year</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input govuk-date-input__input"
                             id="lpa-questionnaire-due-date-year" name="lpa-questionnaire-due-date-year"
-                            type="text" inputmode="numeric">
+                            type="text" value="2050" inputmode="numeric">
                         </div>
                     </div>
                 </div>
@@ -4599,7 +4617,7 @@ exports[`Timetable POST /edit S78 hearing Statement of common ground should re-r
                             <label class="govuk-label govuk-date-input__label" for="lpa-statement-due-date-day">Day</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="lpa-statement-due-date-day" name="lpa-statement-due-date-day" type="text"
-                            inputmode="numeric">
+                            value="02" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -4607,7 +4625,7 @@ exports[`Timetable POST /edit S78 hearing Statement of common ground should re-r
                             <label class="govuk-label govuk-date-input__label" for="lpa-statement-due-date-month">Month</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="lpa-statement-due-date-month" name="lpa-statement-due-date-month" type="text"
-                            inputmode="numeric">
+                            value="10" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -4615,7 +4633,7 @@ exports[`Timetable POST /edit S78 hearing Statement of common ground should re-r
                             <label class="govuk-label govuk-date-input__label" for="lpa-statement-due-date-year">Year</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input govuk-date-input__input"
                             id="lpa-statement-due-date-year" name="lpa-statement-due-date-year" type="text"
-                            inputmode="numeric">
+                            value="2050" inputmode="numeric">
                         </div>
                     </div>
                 </div>
@@ -4632,7 +4650,7 @@ exports[`Timetable POST /edit S78 hearing Statement of common ground should re-r
                             <label class="govuk-label govuk-date-input__label" for="ip-comments-due-date-day">Day</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="ip-comments-due-date-day" name="ip-comments-due-date-day" type="text"
-                            inputmode="numeric">
+                            value="03" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -4640,7 +4658,7 @@ exports[`Timetable POST /edit S78 hearing Statement of common ground should re-r
                             <label class="govuk-label govuk-date-input__label" for="ip-comments-due-date-month">Month</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="ip-comments-due-date-month" name="ip-comments-due-date-month" type="text"
-                            inputmode="numeric">
+                            value="10" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -4648,30 +4666,33 @@ exports[`Timetable POST /edit S78 hearing Statement of common ground should re-r
                             <label class="govuk-label govuk-date-input__label" for="ip-comments-due-date-year">Year</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input govuk-date-input__input"
                             id="ip-comments-due-date-year" name="ip-comments-due-date-year" type="text"
-                            inputmode="numeric">
+                            value="2050" inputmode="numeric">
                         </div>
                     </div>
                 </div>
             </fieldset>
         </div>
-        <div class="govuk-form-group">
-            <fieldset class="govuk-fieldset" role="group" aria-describedby="statement-of-common-ground-due-date-hint">
+        <div class="govuk-form-group govuk-form-group--error">
+            <fieldset class="govuk-fieldset" role="group" aria-describedby="statement-of-common-ground-due-date-hint statement-of-common-ground-due-date-error">
                 <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">Statement of common ground due</legend>
                 <div id="statement-of-common-ground-due-date-hint"
                 class="govuk-hint">For example, 29 10 2024</div>
+                <p id="statement-of-common-ground-due-date-error"
+                class="govuk-error-message"><span class="govuk-visually-hidden">Error:</span> Statement of common ground
+                    due date must include a month</p>
                 <div class="govuk-date-input" id="statement-of-common-ground-due-date">
                     <div class="govuk-date-input__item">
                         <div class="govuk-form-group">
                             <label class="govuk-label govuk-date-input__label" for="statement-of-common-ground-due-date-day">Day</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="statement-of-common-ground-due-date-day" name="statement-of-common-ground-due-date-day"
-                            type="text" inputmode="numeric">
+                            type="text" value="10" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
                         <div class="govuk-form-group">
                             <label class="govuk-label govuk-date-input__label" for="statement-of-common-ground-due-date-month">Month</label>
-                            <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input govuk-input--error"
                             id="statement-of-common-ground-due-date-month" name="statement-of-common-ground-due-date-month"
                             type="text" inputmode="numeric">
                         </div>
@@ -4681,7 +4702,7 @@ exports[`Timetable POST /edit S78 hearing Statement of common ground should re-r
                             <label class="govuk-label govuk-date-input__label" for="statement-of-common-ground-due-date-year">Year</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input govuk-date-input__input"
                             id="statement-of-common-ground-due-date-year" name="statement-of-common-ground-due-date-year"
-                            type="text" inputmode="numeric">
+                            type="text" value="2050" inputmode="numeric">
                         </div>
                     </div>
                 </div>
@@ -4698,7 +4719,7 @@ exports[`Timetable POST /edit S78 hearing Statement of common ground should re-r
                             <label class="govuk-label govuk-date-input__label" for="planning-obligation-due-date-day">Day</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="planning-obligation-due-date-day" name="planning-obligation-due-date-day"
-                            type="text" inputmode="numeric">
+                            type="text" value="05" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -4706,7 +4727,7 @@ exports[`Timetable POST /edit S78 hearing Statement of common ground should re-r
                             <label class="govuk-label govuk-date-input__label" for="planning-obligation-due-date-month">Month</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="planning-obligation-due-date-month" name="planning-obligation-due-date-month"
-                            type="text" inputmode="numeric">
+                            type="text" value="10" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -4714,7 +4735,7 @@ exports[`Timetable POST /edit S78 hearing Statement of common ground should re-r
                             <label class="govuk-label govuk-date-input__label" for="planning-obligation-due-date-year">Year</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input govuk-date-input__input"
                             id="planning-obligation-due-date-year" name="planning-obligation-due-date-year"
-                            type="text" inputmode="numeric">
+                            type="text" value="2050" inputmode="numeric">
                         </div>
                     </div>
                 </div>
@@ -4736,7 +4757,7 @@ exports[`Timetable POST /edit S78 hearing Statement of common ground should re-r
                     <h2 class="govuk-error-summary__title"> There is a problem</h2>
                     <div class="govuk-error-summary__body">
                         <ul class="govuk-list govuk-error-summary__list">
-                            <li><a href="#statement-of-common-ground-due-date">year::Statement of common ground due date must include a year</a>
+                            <li><a href="#statement-of-common-ground-due-date-year">Statement of common ground due date must include a year</a>
                             </li>
                         </ul>
                     </div>
@@ -4764,7 +4785,7 @@ exports[`Timetable POST /edit S78 hearing Statement of common ground should re-r
                             <label class="govuk-label govuk-date-input__label" for="lpa-questionnaire-due-date-day">Day</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="lpa-questionnaire-due-date-day" name="lpa-questionnaire-due-date-day"
-                            type="text" inputmode="numeric">
+                            type="text" value="01" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -4772,7 +4793,7 @@ exports[`Timetable POST /edit S78 hearing Statement of common ground should re-r
                             <label class="govuk-label govuk-date-input__label" for="lpa-questionnaire-due-date-month">Month</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="lpa-questionnaire-due-date-month" name="lpa-questionnaire-due-date-month"
-                            type="text" inputmode="numeric">
+                            type="text" value="10" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -4780,7 +4801,7 @@ exports[`Timetable POST /edit S78 hearing Statement of common ground should re-r
                             <label class="govuk-label govuk-date-input__label" for="lpa-questionnaire-due-date-year">Year</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input govuk-date-input__input"
                             id="lpa-questionnaire-due-date-year" name="lpa-questionnaire-due-date-year"
-                            type="text" inputmode="numeric">
+                            type="text" value="2050" inputmode="numeric">
                         </div>
                     </div>
                 </div>
@@ -4796,7 +4817,7 @@ exports[`Timetable POST /edit S78 hearing Statement of common ground should re-r
                             <label class="govuk-label govuk-date-input__label" for="lpa-statement-due-date-day">Day</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="lpa-statement-due-date-day" name="lpa-statement-due-date-day" type="text"
-                            inputmode="numeric">
+                            value="02" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -4804,7 +4825,7 @@ exports[`Timetable POST /edit S78 hearing Statement of common ground should re-r
                             <label class="govuk-label govuk-date-input__label" for="lpa-statement-due-date-month">Month</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="lpa-statement-due-date-month" name="lpa-statement-due-date-month" type="text"
-                            inputmode="numeric">
+                            value="10" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -4812,7 +4833,7 @@ exports[`Timetable POST /edit S78 hearing Statement of common ground should re-r
                             <label class="govuk-label govuk-date-input__label" for="lpa-statement-due-date-year">Year</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input govuk-date-input__input"
                             id="lpa-statement-due-date-year" name="lpa-statement-due-date-year" type="text"
-                            inputmode="numeric">
+                            value="2050" inputmode="numeric">
                         </div>
                     </div>
                 </div>
@@ -4829,7 +4850,7 @@ exports[`Timetable POST /edit S78 hearing Statement of common ground should re-r
                             <label class="govuk-label govuk-date-input__label" for="ip-comments-due-date-day">Day</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="ip-comments-due-date-day" name="ip-comments-due-date-day" type="text"
-                            inputmode="numeric">
+                            value="03" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -4837,7 +4858,7 @@ exports[`Timetable POST /edit S78 hearing Statement of common ground should re-r
                             <label class="govuk-label govuk-date-input__label" for="ip-comments-due-date-month">Month</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="ip-comments-due-date-month" name="ip-comments-due-date-month" type="text"
-                            inputmode="numeric">
+                            value="10" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -4845,24 +4866,27 @@ exports[`Timetable POST /edit S78 hearing Statement of common ground should re-r
                             <label class="govuk-label govuk-date-input__label" for="ip-comments-due-date-year">Year</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input govuk-date-input__input"
                             id="ip-comments-due-date-year" name="ip-comments-due-date-year" type="text"
-                            inputmode="numeric">
+                            value="2050" inputmode="numeric">
                         </div>
                     </div>
                 </div>
             </fieldset>
         </div>
-        <div class="govuk-form-group">
-            <fieldset class="govuk-fieldset" role="group" aria-describedby="statement-of-common-ground-due-date-hint">
+        <div class="govuk-form-group govuk-form-group--error">
+            <fieldset class="govuk-fieldset" role="group" aria-describedby="statement-of-common-ground-due-date-hint statement-of-common-ground-due-date-error">
                 <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">Statement of common ground due</legend>
                 <div id="statement-of-common-ground-due-date-hint"
                 class="govuk-hint">For example, 29 10 2024</div>
+                <p id="statement-of-common-ground-due-date-error"
+                class="govuk-error-message"><span class="govuk-visually-hidden">Error:</span> Statement of common ground
+                    due date must include a year</p>
                 <div class="govuk-date-input" id="statement-of-common-ground-due-date">
                     <div class="govuk-date-input__item">
                         <div class="govuk-form-group">
                             <label class="govuk-label govuk-date-input__label" for="statement-of-common-ground-due-date-day">Day</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="statement-of-common-ground-due-date-day" name="statement-of-common-ground-due-date-day"
-                            type="text" inputmode="numeric">
+                            type="text" value="10" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -4870,13 +4894,13 @@ exports[`Timetable POST /edit S78 hearing Statement of common ground should re-r
                             <label class="govuk-label govuk-date-input__label" for="statement-of-common-ground-due-date-month">Month</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="statement-of-common-ground-due-date-month" name="statement-of-common-ground-due-date-month"
-                            type="text" inputmode="numeric">
+                            type="text" value="12" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
                         <div class="govuk-form-group">
                             <label class="govuk-label govuk-date-input__label" for="statement-of-common-ground-due-date-year">Year</label>
-                            <input class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input govuk-date-input__input"
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input govuk-date-input__input govuk-input--error"
                             id="statement-of-common-ground-due-date-year" name="statement-of-common-ground-due-date-year"
                             type="text" inputmode="numeric">
                         </div>
@@ -4895,7 +4919,7 @@ exports[`Timetable POST /edit S78 hearing Statement of common ground should re-r
                             <label class="govuk-label govuk-date-input__label" for="planning-obligation-due-date-day">Day</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="planning-obligation-due-date-day" name="planning-obligation-due-date-day"
-                            type="text" inputmode="numeric">
+                            type="text" value="05" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -4903,7 +4927,7 @@ exports[`Timetable POST /edit S78 hearing Statement of common ground should re-r
                             <label class="govuk-label govuk-date-input__label" for="planning-obligation-due-date-month">Month</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="planning-obligation-due-date-month" name="planning-obligation-due-date-month"
-                            type="text" inputmode="numeric">
+                            type="text" value="10" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -4911,7 +4935,7 @@ exports[`Timetable POST /edit S78 hearing Statement of common ground should re-r
                             <label class="govuk-label govuk-date-input__label" for="planning-obligation-due-date-year">Year</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input govuk-date-input__input"
                             id="planning-obligation-due-date-year" name="planning-obligation-due-date-year"
-                            type="text" inputmode="numeric">
+                            type="text" value="2050" inputmode="numeric">
                         </div>
                     </div>
                 </div>
@@ -4933,7 +4957,7 @@ exports[`Timetable POST /edit S78 hearing Statement of common ground should re-r
                     <h2 class="govuk-error-summary__title"> There is a problem</h2>
                     <div class="govuk-error-summary__body">
                         <ul class="govuk-list govuk-error-summary__list">
-                            <li><a href="#statement-of-common-ground-due-date">all-fields::The statement of common ground due date must be in the future</a>
+                            <li><a href="#statement-of-common-ground-due-date-day">The statement of common ground due date must be in the future</a>
                             </li>
                         </ul>
                     </div>
@@ -4961,7 +4985,7 @@ exports[`Timetable POST /edit S78 hearing Statement of common ground should re-r
                             <label class="govuk-label govuk-date-input__label" for="lpa-questionnaire-due-date-day">Day</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="lpa-questionnaire-due-date-day" name="lpa-questionnaire-due-date-day"
-                            type="text" inputmode="numeric">
+                            type="text" value="01" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -4969,7 +4993,7 @@ exports[`Timetable POST /edit S78 hearing Statement of common ground should re-r
                             <label class="govuk-label govuk-date-input__label" for="lpa-questionnaire-due-date-month">Month</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="lpa-questionnaire-due-date-month" name="lpa-questionnaire-due-date-month"
-                            type="text" inputmode="numeric">
+                            type="text" value="10" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -4977,7 +5001,7 @@ exports[`Timetable POST /edit S78 hearing Statement of common ground should re-r
                             <label class="govuk-label govuk-date-input__label" for="lpa-questionnaire-due-date-year">Year</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input govuk-date-input__input"
                             id="lpa-questionnaire-due-date-year" name="lpa-questionnaire-due-date-year"
-                            type="text" inputmode="numeric">
+                            type="text" value="2050" inputmode="numeric">
                         </div>
                     </div>
                 </div>
@@ -4993,7 +5017,7 @@ exports[`Timetable POST /edit S78 hearing Statement of common ground should re-r
                             <label class="govuk-label govuk-date-input__label" for="lpa-statement-due-date-day">Day</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="lpa-statement-due-date-day" name="lpa-statement-due-date-day" type="text"
-                            inputmode="numeric">
+                            value="02" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -5001,7 +5025,7 @@ exports[`Timetable POST /edit S78 hearing Statement of common ground should re-r
                             <label class="govuk-label govuk-date-input__label" for="lpa-statement-due-date-month">Month</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="lpa-statement-due-date-month" name="lpa-statement-due-date-month" type="text"
-                            inputmode="numeric">
+                            value="10" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -5009,7 +5033,7 @@ exports[`Timetable POST /edit S78 hearing Statement of common ground should re-r
                             <label class="govuk-label govuk-date-input__label" for="lpa-statement-due-date-year">Year</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input govuk-date-input__input"
                             id="lpa-statement-due-date-year" name="lpa-statement-due-date-year" type="text"
-                            inputmode="numeric">
+                            value="2050" inputmode="numeric">
                         </div>
                     </div>
                 </div>
@@ -5026,7 +5050,7 @@ exports[`Timetable POST /edit S78 hearing Statement of common ground should re-r
                             <label class="govuk-label govuk-date-input__label" for="ip-comments-due-date-day">Day</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="ip-comments-due-date-day" name="ip-comments-due-date-day" type="text"
-                            inputmode="numeric">
+                            value="03" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -5034,7 +5058,7 @@ exports[`Timetable POST /edit S78 hearing Statement of common ground should re-r
                             <label class="govuk-label govuk-date-input__label" for="ip-comments-due-date-month">Month</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="ip-comments-due-date-month" name="ip-comments-due-date-month" type="text"
-                            inputmode="numeric">
+                            value="10" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -5042,40 +5066,44 @@ exports[`Timetable POST /edit S78 hearing Statement of common ground should re-r
                             <label class="govuk-label govuk-date-input__label" for="ip-comments-due-date-year">Year</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input govuk-date-input__input"
                             id="ip-comments-due-date-year" name="ip-comments-due-date-year" type="text"
-                            inputmode="numeric">
+                            value="2050" inputmode="numeric">
                         </div>
                     </div>
                 </div>
             </fieldset>
         </div>
-        <div class="govuk-form-group">
-            <fieldset class="govuk-fieldset" role="group" aria-describedby="statement-of-common-ground-due-date-hint">
+        <div class="govuk-form-group govuk-form-group--error">
+            <fieldset class="govuk-fieldset" role="group" aria-describedby="statement-of-common-ground-due-date-hint statement-of-common-ground-due-date-error">
                 <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">Statement of common ground due</legend>
                 <div id="statement-of-common-ground-due-date-hint"
                 class="govuk-hint">For example, 29 10 2024</div>
-                <div class="govuk-date-input" id="statement-of-common-ground-due-date">
+                <p id="statement-of-common-ground-due-date-error"
+                class="govuk-error-message"><span class="govuk-visually-hidden">Error:</span> The statement of common
+                    ground due date must be in the future</p>
+                <div class="govuk-date-input"
+                id="statement-of-common-ground-due-date">
                     <div class="govuk-date-input__item">
                         <div class="govuk-form-group">
                             <label class="govuk-label govuk-date-input__label" for="statement-of-common-ground-due-date-day">Day</label>
-                            <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input govuk-input--error"
                             id="statement-of-common-ground-due-date-day" name="statement-of-common-ground-due-date-day"
-                            type="text" inputmode="numeric">
+                            type="text" value="25" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
                         <div class="govuk-form-group">
                             <label class="govuk-label govuk-date-input__label" for="statement-of-common-ground-due-date-month">Month</label>
-                            <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input govuk-input--error"
                             id="statement-of-common-ground-due-date-month" name="statement-of-common-ground-due-date-month"
-                            type="text" inputmode="numeric">
+                            type="text" value="2" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
                         <div class="govuk-form-group">
                             <label class="govuk-label govuk-date-input__label" for="statement-of-common-ground-due-date-year">Year</label>
-                            <input class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input govuk-date-input__input"
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input govuk-date-input__input govuk-input--error"
                             id="statement-of-common-ground-due-date-year" name="statement-of-common-ground-due-date-year"
-                            type="text" inputmode="numeric">
+                            type="text" value="1950" inputmode="numeric">
                         </div>
                     </div>
                 </div>
@@ -5092,7 +5120,7 @@ exports[`Timetable POST /edit S78 hearing Statement of common ground should re-r
                             <label class="govuk-label govuk-date-input__label" for="planning-obligation-due-date-day">Day</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="planning-obligation-due-date-day" name="planning-obligation-due-date-day"
-                            type="text" inputmode="numeric">
+                            type="text" value="05" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -5100,7 +5128,7 @@ exports[`Timetable POST /edit S78 hearing Statement of common ground should re-r
                             <label class="govuk-label govuk-date-input__label" for="planning-obligation-due-date-month">Month</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="planning-obligation-due-date-month" name="planning-obligation-due-date-month"
-                            type="text" inputmode="numeric">
+                            type="text" value="10" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -5108,7 +5136,7 @@ exports[`Timetable POST /edit S78 hearing Statement of common ground should re-r
                             <label class="govuk-label govuk-date-input__label" for="planning-obligation-due-date-year">Year</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input govuk-date-input__input"
                             id="planning-obligation-due-date-year" name="planning-obligation-due-date-year"
-                            type="text" inputmode="numeric">
+                            type="text" value="2050" inputmode="numeric">
                         </div>
                     </div>
                 </div>
@@ -5130,7 +5158,7 @@ exports[`Timetable POST /edit S78 hearing Statement of common ground should re-r
                     <h2 class="govuk-error-summary__title"> There is a problem</h2>
                     <div class="govuk-error-summary__body">
                         <ul class="govuk-list govuk-error-summary__list">
-                            <li><a href="#statement-of-common-ground-due-date">all-fields::Statement of common ground due date must be a real date</a>
+                            <li><a href="#statement-of-common-ground-due-date-day">Statement of common ground due date must be a real date</a>
                             </li>
                         </ul>
                     </div>
@@ -5158,7 +5186,7 @@ exports[`Timetable POST /edit S78 hearing Statement of common ground should re-r
                             <label class="govuk-label govuk-date-input__label" for="lpa-questionnaire-due-date-day">Day</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="lpa-questionnaire-due-date-day" name="lpa-questionnaire-due-date-day"
-                            type="text" inputmode="numeric">
+                            type="text" value="01" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -5166,7 +5194,7 @@ exports[`Timetable POST /edit S78 hearing Statement of common ground should re-r
                             <label class="govuk-label govuk-date-input__label" for="lpa-questionnaire-due-date-month">Month</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="lpa-questionnaire-due-date-month" name="lpa-questionnaire-due-date-month"
-                            type="text" inputmode="numeric">
+                            type="text" value="10" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -5174,7 +5202,7 @@ exports[`Timetable POST /edit S78 hearing Statement of common ground should re-r
                             <label class="govuk-label govuk-date-input__label" for="lpa-questionnaire-due-date-year">Year</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input govuk-date-input__input"
                             id="lpa-questionnaire-due-date-year" name="lpa-questionnaire-due-date-year"
-                            type="text" inputmode="numeric">
+                            type="text" value="2050" inputmode="numeric">
                         </div>
                     </div>
                 </div>
@@ -5190,7 +5218,7 @@ exports[`Timetable POST /edit S78 hearing Statement of common ground should re-r
                             <label class="govuk-label govuk-date-input__label" for="lpa-statement-due-date-day">Day</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="lpa-statement-due-date-day" name="lpa-statement-due-date-day" type="text"
-                            inputmode="numeric">
+                            value="02" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -5198,7 +5226,7 @@ exports[`Timetable POST /edit S78 hearing Statement of common ground should re-r
                             <label class="govuk-label govuk-date-input__label" for="lpa-statement-due-date-month">Month</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="lpa-statement-due-date-month" name="lpa-statement-due-date-month" type="text"
-                            inputmode="numeric">
+                            value="10" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -5206,7 +5234,7 @@ exports[`Timetable POST /edit S78 hearing Statement of common ground should re-r
                             <label class="govuk-label govuk-date-input__label" for="lpa-statement-due-date-year">Year</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input govuk-date-input__input"
                             id="lpa-statement-due-date-year" name="lpa-statement-due-date-year" type="text"
-                            inputmode="numeric">
+                            value="2050" inputmode="numeric">
                         </div>
                     </div>
                 </div>
@@ -5223,7 +5251,7 @@ exports[`Timetable POST /edit S78 hearing Statement of common ground should re-r
                             <label class="govuk-label govuk-date-input__label" for="ip-comments-due-date-day">Day</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="ip-comments-due-date-day" name="ip-comments-due-date-day" type="text"
-                            inputmode="numeric">
+                            value="03" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -5231,7 +5259,7 @@ exports[`Timetable POST /edit S78 hearing Statement of common ground should re-r
                             <label class="govuk-label govuk-date-input__label" for="ip-comments-due-date-month">Month</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="ip-comments-due-date-month" name="ip-comments-due-date-month" type="text"
-                            inputmode="numeric">
+                            value="10" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -5239,40 +5267,43 @@ exports[`Timetable POST /edit S78 hearing Statement of common ground should re-r
                             <label class="govuk-label govuk-date-input__label" for="ip-comments-due-date-year">Year</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input govuk-date-input__input"
                             id="ip-comments-due-date-year" name="ip-comments-due-date-year" type="text"
-                            inputmode="numeric">
+                            value="2050" inputmode="numeric">
                         </div>
                     </div>
                 </div>
             </fieldset>
         </div>
-        <div class="govuk-form-group">
-            <fieldset class="govuk-fieldset" role="group" aria-describedby="statement-of-common-ground-due-date-hint">
+        <div class="govuk-form-group govuk-form-group--error">
+            <fieldset class="govuk-fieldset" role="group" aria-describedby="statement-of-common-ground-due-date-hint statement-of-common-ground-due-date-error">
                 <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">Statement of common ground due</legend>
                 <div id="statement-of-common-ground-due-date-hint"
                 class="govuk-hint">For example, 29 10 2024</div>
+                <p id="statement-of-common-ground-due-date-error"
+                class="govuk-error-message"><span class="govuk-visually-hidden">Error:</span> Statement of common ground
+                    due date must be a real date</p>
                 <div class="govuk-date-input" id="statement-of-common-ground-due-date">
                     <div class="govuk-date-input__item">
                         <div class="govuk-form-group">
                             <label class="govuk-label govuk-date-input__label" for="statement-of-common-ground-due-date-day">Day</label>
-                            <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input govuk-input--error"
                             id="statement-of-common-ground-due-date-day" name="statement-of-common-ground-due-date-day"
-                            type="text" inputmode="numeric">
+                            type="text" value="29" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
                         <div class="govuk-form-group">
                             <label class="govuk-label govuk-date-input__label" for="statement-of-common-ground-due-date-month">Month</label>
-                            <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input govuk-input--error"
                             id="statement-of-common-ground-due-date-month" name="statement-of-common-ground-due-date-month"
-                            type="text" inputmode="numeric">
+                            type="text" value="2" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
                         <div class="govuk-form-group">
                             <label class="govuk-label govuk-date-input__label" for="statement-of-common-ground-due-date-year">Year</label>
-                            <input class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input govuk-date-input__input"
+                            <input class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input govuk-date-input__input govuk-input--error"
                             id="statement-of-common-ground-due-date-year" name="statement-of-common-ground-due-date-year"
-                            type="text" inputmode="numeric">
+                            type="text" value="3000" inputmode="numeric">
                         </div>
                     </div>
                 </div>
@@ -5289,7 +5320,7 @@ exports[`Timetable POST /edit S78 hearing Statement of common ground should re-r
                             <label class="govuk-label govuk-date-input__label" for="planning-obligation-due-date-day">Day</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="planning-obligation-due-date-day" name="planning-obligation-due-date-day"
-                            type="text" inputmode="numeric">
+                            type="text" value="05" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -5297,7 +5328,7 @@ exports[`Timetable POST /edit S78 hearing Statement of common ground should re-r
                             <label class="govuk-label govuk-date-input__label" for="planning-obligation-due-date-month">Month</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="planning-obligation-due-date-month" name="planning-obligation-due-date-month"
-                            type="text" inputmode="numeric">
+                            type="text" value="10" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -5305,7 +5336,7 @@ exports[`Timetable POST /edit S78 hearing Statement of common ground should re-r
                             <label class="govuk-label govuk-date-input__label" for="planning-obligation-due-date-year">Year</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input govuk-date-input__input"
                             id="planning-obligation-due-date-year" name="planning-obligation-due-date-year"
-                            type="text" inputmode="numeric">
+                            type="text" value="2050" inputmode="numeric">
                         </div>
                     </div>
                 </div>
@@ -5355,7 +5386,7 @@ exports[`Timetable POST /edit S78 hearing Statements should re-render edit timet
                             <label class="govuk-label govuk-date-input__label" for="lpa-questionnaire-due-date-day">Day</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="lpa-questionnaire-due-date-day" name="lpa-questionnaire-due-date-day"
-                            type="text" inputmode="numeric">
+                            type="text" value="01" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -5363,7 +5394,7 @@ exports[`Timetable POST /edit S78 hearing Statements should re-render edit timet
                             <label class="govuk-label govuk-date-input__label" for="lpa-questionnaire-due-date-month">Month</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="lpa-questionnaire-due-date-month" name="lpa-questionnaire-due-date-month"
-                            type="text" inputmode="numeric">
+                            type="text" value="10" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -5371,7 +5402,7 @@ exports[`Timetable POST /edit S78 hearing Statements should re-render edit timet
                             <label class="govuk-label govuk-date-input__label" for="lpa-questionnaire-due-date-year">Year</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input govuk-date-input__input"
                             id="lpa-questionnaire-due-date-year" name="lpa-questionnaire-due-date-year"
-                            type="text" inputmode="numeric">
+                            type="text" value="2050" inputmode="numeric">
                         </div>
                     </div>
                 </div>
@@ -5397,7 +5428,7 @@ exports[`Timetable POST /edit S78 hearing Statements should re-render edit timet
                             <label class="govuk-label govuk-date-input__label" for="lpa-statement-due-date-month">Month</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="lpa-statement-due-date-month" name="lpa-statement-due-date-month" type="text"
-                            inputmode="numeric">
+                            value="10" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -5405,7 +5436,7 @@ exports[`Timetable POST /edit S78 hearing Statements should re-render edit timet
                             <label class="govuk-label govuk-date-input__label" for="lpa-statement-due-date-year">Year</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input govuk-date-input__input"
                             id="lpa-statement-due-date-year" name="lpa-statement-due-date-year" type="text"
-                            inputmode="numeric">
+                            value="2050" inputmode="numeric">
                         </div>
                     </div>
                 </div>
@@ -5422,7 +5453,7 @@ exports[`Timetable POST /edit S78 hearing Statements should re-render edit timet
                             <label class="govuk-label govuk-date-input__label" for="ip-comments-due-date-day">Day</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="ip-comments-due-date-day" name="ip-comments-due-date-day" type="text"
-                            inputmode="numeric">
+                            value="03" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -5430,7 +5461,7 @@ exports[`Timetable POST /edit S78 hearing Statements should re-render edit timet
                             <label class="govuk-label govuk-date-input__label" for="ip-comments-due-date-month">Month</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="ip-comments-due-date-month" name="ip-comments-due-date-month" type="text"
-                            inputmode="numeric">
+                            value="10" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -5438,7 +5469,7 @@ exports[`Timetable POST /edit S78 hearing Statements should re-render edit timet
                             <label class="govuk-label govuk-date-input__label" for="ip-comments-due-date-year">Year</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input govuk-date-input__input"
                             id="ip-comments-due-date-year" name="ip-comments-due-date-year" type="text"
-                            inputmode="numeric">
+                            value="2050" inputmode="numeric">
                         </div>
                     </div>
                 </div>
@@ -5455,7 +5486,7 @@ exports[`Timetable POST /edit S78 hearing Statements should re-render edit timet
                             <label class="govuk-label govuk-date-input__label" for="statement-of-common-ground-due-date-day">Day</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="statement-of-common-ground-due-date-day" name="statement-of-common-ground-due-date-day"
-                            type="text" inputmode="numeric">
+                            type="text" value="04" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -5463,7 +5494,7 @@ exports[`Timetable POST /edit S78 hearing Statements should re-render edit timet
                             <label class="govuk-label govuk-date-input__label" for="statement-of-common-ground-due-date-month">Month</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="statement-of-common-ground-due-date-month" name="statement-of-common-ground-due-date-month"
-                            type="text" inputmode="numeric">
+                            type="text" value="10" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -5471,7 +5502,7 @@ exports[`Timetable POST /edit S78 hearing Statements should re-render edit timet
                             <label class="govuk-label govuk-date-input__label" for="statement-of-common-ground-due-date-year">Year</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input govuk-date-input__input"
                             id="statement-of-common-ground-due-date-year" name="statement-of-common-ground-due-date-year"
-                            type="text" inputmode="numeric">
+                            type="text" value="2050" inputmode="numeric">
                         </div>
                     </div>
                 </div>
@@ -5488,7 +5519,7 @@ exports[`Timetable POST /edit S78 hearing Statements should re-render edit timet
                             <label class="govuk-label govuk-date-input__label" for="planning-obligation-due-date-day">Day</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="planning-obligation-due-date-day" name="planning-obligation-due-date-day"
-                            type="text" inputmode="numeric">
+                            type="text" value="05" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -5496,7 +5527,7 @@ exports[`Timetable POST /edit S78 hearing Statements should re-render edit timet
                             <label class="govuk-label govuk-date-input__label" for="planning-obligation-due-date-month">Month</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="planning-obligation-due-date-month" name="planning-obligation-due-date-month"
-                            type="text" inputmode="numeric">
+                            type="text" value="10" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -5504,7 +5535,7 @@ exports[`Timetable POST /edit S78 hearing Statements should re-render edit timet
                             <label class="govuk-label govuk-date-input__label" for="planning-obligation-due-date-year">Year</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input govuk-date-input__input"
                             id="planning-obligation-due-date-year" name="planning-obligation-due-date-year"
-                            type="text" inputmode="numeric">
+                            type="text" value="2050" inputmode="numeric">
                         </div>
                     </div>
                 </div>
@@ -5554,7 +5585,7 @@ exports[`Timetable POST /edit S78 hearing Statements should re-render edit timet
                             <label class="govuk-label govuk-date-input__label" for="lpa-questionnaire-due-date-day">Day</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="lpa-questionnaire-due-date-day" name="lpa-questionnaire-due-date-day"
-                            type="text" inputmode="numeric">
+                            type="text" value="01" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -5562,7 +5593,7 @@ exports[`Timetable POST /edit S78 hearing Statements should re-render edit timet
                             <label class="govuk-label govuk-date-input__label" for="lpa-questionnaire-due-date-month">Month</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="lpa-questionnaire-due-date-month" name="lpa-questionnaire-due-date-month"
-                            type="text" inputmode="numeric">
+                            type="text" value="10" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -5570,7 +5601,7 @@ exports[`Timetable POST /edit S78 hearing Statements should re-render edit timet
                             <label class="govuk-label govuk-date-input__label" for="lpa-questionnaire-due-date-year">Year</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input govuk-date-input__input"
                             id="lpa-questionnaire-due-date-year" name="lpa-questionnaire-due-date-year"
-                            type="text" inputmode="numeric">
+                            type="text" value="2050" inputmode="numeric">
                         </div>
                     </div>
                 </div>
@@ -5588,7 +5619,7 @@ exports[`Timetable POST /edit S78 hearing Statements should re-render edit timet
                             <label class="govuk-label govuk-date-input__label" for="lpa-statement-due-date-day">Day</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="lpa-statement-due-date-day" name="lpa-statement-due-date-day" type="text"
-                            inputmode="numeric">
+                            value="10" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -5604,7 +5635,7 @@ exports[`Timetable POST /edit S78 hearing Statements should re-render edit timet
                             <label class="govuk-label govuk-date-input__label" for="lpa-statement-due-date-year">Year</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input govuk-date-input__input"
                             id="lpa-statement-due-date-year" name="lpa-statement-due-date-year" type="text"
-                            inputmode="numeric">
+                            value="2050" inputmode="numeric">
                         </div>
                     </div>
                 </div>
@@ -5621,7 +5652,7 @@ exports[`Timetable POST /edit S78 hearing Statements should re-render edit timet
                             <label class="govuk-label govuk-date-input__label" for="ip-comments-due-date-day">Day</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="ip-comments-due-date-day" name="ip-comments-due-date-day" type="text"
-                            inputmode="numeric">
+                            value="03" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -5629,7 +5660,7 @@ exports[`Timetable POST /edit S78 hearing Statements should re-render edit timet
                             <label class="govuk-label govuk-date-input__label" for="ip-comments-due-date-month">Month</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="ip-comments-due-date-month" name="ip-comments-due-date-month" type="text"
-                            inputmode="numeric">
+                            value="10" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -5637,7 +5668,7 @@ exports[`Timetable POST /edit S78 hearing Statements should re-render edit timet
                             <label class="govuk-label govuk-date-input__label" for="ip-comments-due-date-year">Year</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input govuk-date-input__input"
                             id="ip-comments-due-date-year" name="ip-comments-due-date-year" type="text"
-                            inputmode="numeric">
+                            value="2050" inputmode="numeric">
                         </div>
                     </div>
                 </div>
@@ -5654,7 +5685,7 @@ exports[`Timetable POST /edit S78 hearing Statements should re-render edit timet
                             <label class="govuk-label govuk-date-input__label" for="statement-of-common-ground-due-date-day">Day</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="statement-of-common-ground-due-date-day" name="statement-of-common-ground-due-date-day"
-                            type="text" inputmode="numeric">
+                            type="text" value="04" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -5662,7 +5693,7 @@ exports[`Timetable POST /edit S78 hearing Statements should re-render edit timet
                             <label class="govuk-label govuk-date-input__label" for="statement-of-common-ground-due-date-month">Month</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="statement-of-common-ground-due-date-month" name="statement-of-common-ground-due-date-month"
-                            type="text" inputmode="numeric">
+                            type="text" value="10" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -5670,7 +5701,7 @@ exports[`Timetable POST /edit S78 hearing Statements should re-render edit timet
                             <label class="govuk-label govuk-date-input__label" for="statement-of-common-ground-due-date-year">Year</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input govuk-date-input__input"
                             id="statement-of-common-ground-due-date-year" name="statement-of-common-ground-due-date-year"
-                            type="text" inputmode="numeric">
+                            type="text" value="2050" inputmode="numeric">
                         </div>
                     </div>
                 </div>
@@ -5687,7 +5718,7 @@ exports[`Timetable POST /edit S78 hearing Statements should re-render edit timet
                             <label class="govuk-label govuk-date-input__label" for="planning-obligation-due-date-day">Day</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="planning-obligation-due-date-day" name="planning-obligation-due-date-day"
-                            type="text" inputmode="numeric">
+                            type="text" value="05" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -5695,7 +5726,7 @@ exports[`Timetable POST /edit S78 hearing Statements should re-render edit timet
                             <label class="govuk-label govuk-date-input__label" for="planning-obligation-due-date-month">Month</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="planning-obligation-due-date-month" name="planning-obligation-due-date-month"
-                            type="text" inputmode="numeric">
+                            type="text" value="10" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -5703,7 +5734,7 @@ exports[`Timetable POST /edit S78 hearing Statements should re-render edit timet
                             <label class="govuk-label govuk-date-input__label" for="planning-obligation-due-date-year">Year</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input govuk-date-input__input"
                             id="planning-obligation-due-date-year" name="planning-obligation-due-date-year"
-                            type="text" inputmode="numeric">
+                            type="text" value="2050" inputmode="numeric">
                         </div>
                     </div>
                 </div>
@@ -5753,7 +5784,7 @@ exports[`Timetable POST /edit S78 hearing Statements should re-render edit timet
                             <label class="govuk-label govuk-date-input__label" for="lpa-questionnaire-due-date-day">Day</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="lpa-questionnaire-due-date-day" name="lpa-questionnaire-due-date-day"
-                            type="text" inputmode="numeric">
+                            type="text" value="01" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -5761,7 +5792,7 @@ exports[`Timetable POST /edit S78 hearing Statements should re-render edit timet
                             <label class="govuk-label govuk-date-input__label" for="lpa-questionnaire-due-date-month">Month</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="lpa-questionnaire-due-date-month" name="lpa-questionnaire-due-date-month"
-                            type="text" inputmode="numeric">
+                            type="text" value="10" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -5769,7 +5800,7 @@ exports[`Timetable POST /edit S78 hearing Statements should re-render edit timet
                             <label class="govuk-label govuk-date-input__label" for="lpa-questionnaire-due-date-year">Year</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input govuk-date-input__input"
                             id="lpa-questionnaire-due-date-year" name="lpa-questionnaire-due-date-year"
-                            type="text" inputmode="numeric">
+                            type="text" value="2050" inputmode="numeric">
                         </div>
                     </div>
                 </div>
@@ -5787,7 +5818,7 @@ exports[`Timetable POST /edit S78 hearing Statements should re-render edit timet
                             <label class="govuk-label govuk-date-input__label" for="lpa-statement-due-date-day">Day</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="lpa-statement-due-date-day" name="lpa-statement-due-date-day" type="text"
-                            inputmode="numeric">
+                            value="10" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -5795,7 +5826,7 @@ exports[`Timetable POST /edit S78 hearing Statements should re-render edit timet
                             <label class="govuk-label govuk-date-input__label" for="lpa-statement-due-date-month">Month</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="lpa-statement-due-date-month" name="lpa-statement-due-date-month" type="text"
-                            inputmode="numeric">
+                            value="12" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -5820,7 +5851,7 @@ exports[`Timetable POST /edit S78 hearing Statements should re-render edit timet
                             <label class="govuk-label govuk-date-input__label" for="ip-comments-due-date-day">Day</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="ip-comments-due-date-day" name="ip-comments-due-date-day" type="text"
-                            inputmode="numeric">
+                            value="03" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -5828,7 +5859,7 @@ exports[`Timetable POST /edit S78 hearing Statements should re-render edit timet
                             <label class="govuk-label govuk-date-input__label" for="ip-comments-due-date-month">Month</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="ip-comments-due-date-month" name="ip-comments-due-date-month" type="text"
-                            inputmode="numeric">
+                            value="10" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -5836,7 +5867,7 @@ exports[`Timetable POST /edit S78 hearing Statements should re-render edit timet
                             <label class="govuk-label govuk-date-input__label" for="ip-comments-due-date-year">Year</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input govuk-date-input__input"
                             id="ip-comments-due-date-year" name="ip-comments-due-date-year" type="text"
-                            inputmode="numeric">
+                            value="2050" inputmode="numeric">
                         </div>
                     </div>
                 </div>
@@ -5853,7 +5884,7 @@ exports[`Timetable POST /edit S78 hearing Statements should re-render edit timet
                             <label class="govuk-label govuk-date-input__label" for="statement-of-common-ground-due-date-day">Day</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="statement-of-common-ground-due-date-day" name="statement-of-common-ground-due-date-day"
-                            type="text" inputmode="numeric">
+                            type="text" value="04" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -5861,7 +5892,7 @@ exports[`Timetable POST /edit S78 hearing Statements should re-render edit timet
                             <label class="govuk-label govuk-date-input__label" for="statement-of-common-ground-due-date-month">Month</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="statement-of-common-ground-due-date-month" name="statement-of-common-ground-due-date-month"
-                            type="text" inputmode="numeric">
+                            type="text" value="10" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -5869,7 +5900,7 @@ exports[`Timetable POST /edit S78 hearing Statements should re-render edit timet
                             <label class="govuk-label govuk-date-input__label" for="statement-of-common-ground-due-date-year">Year</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input govuk-date-input__input"
                             id="statement-of-common-ground-due-date-year" name="statement-of-common-ground-due-date-year"
-                            type="text" inputmode="numeric">
+                            type="text" value="2050" inputmode="numeric">
                         </div>
                     </div>
                 </div>
@@ -5886,7 +5917,7 @@ exports[`Timetable POST /edit S78 hearing Statements should re-render edit timet
                             <label class="govuk-label govuk-date-input__label" for="planning-obligation-due-date-day">Day</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="planning-obligation-due-date-day" name="planning-obligation-due-date-day"
-                            type="text" inputmode="numeric">
+                            type="text" value="05" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -5894,7 +5925,7 @@ exports[`Timetable POST /edit S78 hearing Statements should re-render edit timet
                             <label class="govuk-label govuk-date-input__label" for="planning-obligation-due-date-month">Month</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="planning-obligation-due-date-month" name="planning-obligation-due-date-month"
-                            type="text" inputmode="numeric">
+                            type="text" value="10" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -5902,7 +5933,7 @@ exports[`Timetable POST /edit S78 hearing Statements should re-render edit timet
                             <label class="govuk-label govuk-date-input__label" for="planning-obligation-due-date-year">Year</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input govuk-date-input__input"
                             id="planning-obligation-due-date-year" name="planning-obligation-due-date-year"
-                            type="text" inputmode="numeric">
+                            type="text" value="2050" inputmode="numeric">
                         </div>
                     </div>
                 </div>
@@ -5952,7 +5983,7 @@ exports[`Timetable POST /edit S78 hearing Statements should re-render edit timet
                             <label class="govuk-label govuk-date-input__label" for="lpa-questionnaire-due-date-day">Day</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="lpa-questionnaire-due-date-day" name="lpa-questionnaire-due-date-day"
-                            type="text" inputmode="numeric">
+                            type="text" value="01" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -5960,7 +5991,7 @@ exports[`Timetable POST /edit S78 hearing Statements should re-render edit timet
                             <label class="govuk-label govuk-date-input__label" for="lpa-questionnaire-due-date-month">Month</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="lpa-questionnaire-due-date-month" name="lpa-questionnaire-due-date-month"
-                            type="text" inputmode="numeric">
+                            type="text" value="10" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -5968,7 +5999,7 @@ exports[`Timetable POST /edit S78 hearing Statements should re-render edit timet
                             <label class="govuk-label govuk-date-input__label" for="lpa-questionnaire-due-date-year">Year</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input govuk-date-input__input"
                             id="lpa-questionnaire-due-date-year" name="lpa-questionnaire-due-date-year"
-                            type="text" inputmode="numeric">
+                            type="text" value="2050" inputmode="numeric">
                         </div>
                     </div>
                 </div>
@@ -5986,7 +6017,7 @@ exports[`Timetable POST /edit S78 hearing Statements should re-render edit timet
                             <label class="govuk-label govuk-date-input__label" for="lpa-statement-due-date-day">Day</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input govuk-input--error"
                             id="lpa-statement-due-date-day" name="lpa-statement-due-date-day" type="text"
-                            inputmode="numeric">
+                            value="25" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -5994,7 +6025,7 @@ exports[`Timetable POST /edit S78 hearing Statements should re-render edit timet
                             <label class="govuk-label govuk-date-input__label" for="lpa-statement-due-date-month">Month</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input govuk-input--error"
                             id="lpa-statement-due-date-month" name="lpa-statement-due-date-month" type="text"
-                            inputmode="numeric">
+                            value="2" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -6002,7 +6033,7 @@ exports[`Timetable POST /edit S78 hearing Statements should re-render edit timet
                             <label class="govuk-label govuk-date-input__label" for="lpa-statement-due-date-year">Year</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input govuk-date-input__input govuk-input--error"
                             id="lpa-statement-due-date-year" name="lpa-statement-due-date-year" type="text"
-                            inputmode="numeric">
+                            value="1950" inputmode="numeric">
                         </div>
                     </div>
                 </div>
@@ -6019,7 +6050,7 @@ exports[`Timetable POST /edit S78 hearing Statements should re-render edit timet
                             <label class="govuk-label govuk-date-input__label" for="ip-comments-due-date-day">Day</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="ip-comments-due-date-day" name="ip-comments-due-date-day" type="text"
-                            inputmode="numeric">
+                            value="03" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -6027,7 +6058,7 @@ exports[`Timetable POST /edit S78 hearing Statements should re-render edit timet
                             <label class="govuk-label govuk-date-input__label" for="ip-comments-due-date-month">Month</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="ip-comments-due-date-month" name="ip-comments-due-date-month" type="text"
-                            inputmode="numeric">
+                            value="10" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -6035,7 +6066,7 @@ exports[`Timetable POST /edit S78 hearing Statements should re-render edit timet
                             <label class="govuk-label govuk-date-input__label" for="ip-comments-due-date-year">Year</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input govuk-date-input__input"
                             id="ip-comments-due-date-year" name="ip-comments-due-date-year" type="text"
-                            inputmode="numeric">
+                            value="2050" inputmode="numeric">
                         </div>
                     </div>
                 </div>
@@ -6052,7 +6083,7 @@ exports[`Timetable POST /edit S78 hearing Statements should re-render edit timet
                             <label class="govuk-label govuk-date-input__label" for="statement-of-common-ground-due-date-day">Day</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="statement-of-common-ground-due-date-day" name="statement-of-common-ground-due-date-day"
-                            type="text" inputmode="numeric">
+                            type="text" value="04" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -6060,7 +6091,7 @@ exports[`Timetable POST /edit S78 hearing Statements should re-render edit timet
                             <label class="govuk-label govuk-date-input__label" for="statement-of-common-ground-due-date-month">Month</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="statement-of-common-ground-due-date-month" name="statement-of-common-ground-due-date-month"
-                            type="text" inputmode="numeric">
+                            type="text" value="10" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -6068,7 +6099,7 @@ exports[`Timetable POST /edit S78 hearing Statements should re-render edit timet
                             <label class="govuk-label govuk-date-input__label" for="statement-of-common-ground-due-date-year">Year</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input govuk-date-input__input"
                             id="statement-of-common-ground-due-date-year" name="statement-of-common-ground-due-date-year"
-                            type="text" inputmode="numeric">
+                            type="text" value="2050" inputmode="numeric">
                         </div>
                     </div>
                 </div>
@@ -6085,7 +6116,7 @@ exports[`Timetable POST /edit S78 hearing Statements should re-render edit timet
                             <label class="govuk-label govuk-date-input__label" for="planning-obligation-due-date-day">Day</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="planning-obligation-due-date-day" name="planning-obligation-due-date-day"
-                            type="text" inputmode="numeric">
+                            type="text" value="05" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -6093,7 +6124,7 @@ exports[`Timetable POST /edit S78 hearing Statements should re-render edit timet
                             <label class="govuk-label govuk-date-input__label" for="planning-obligation-due-date-month">Month</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="planning-obligation-due-date-month" name="planning-obligation-due-date-month"
-                            type="text" inputmode="numeric">
+                            type="text" value="10" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -6101,7 +6132,7 @@ exports[`Timetable POST /edit S78 hearing Statements should re-render edit timet
                             <label class="govuk-label govuk-date-input__label" for="planning-obligation-due-date-year">Year</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input govuk-date-input__input"
                             id="planning-obligation-due-date-year" name="planning-obligation-due-date-year"
-                            type="text" inputmode="numeric">
+                            type="text" value="2050" inputmode="numeric">
                         </div>
                     </div>
                 </div>
@@ -6151,7 +6182,7 @@ exports[`Timetable POST /edit S78 hearing Statements should re-render edit timet
                             <label class="govuk-label govuk-date-input__label" for="lpa-questionnaire-due-date-day">Day</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="lpa-questionnaire-due-date-day" name="lpa-questionnaire-due-date-day"
-                            type="text" inputmode="numeric">
+                            type="text" value="01" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -6159,7 +6190,7 @@ exports[`Timetable POST /edit S78 hearing Statements should re-render edit timet
                             <label class="govuk-label govuk-date-input__label" for="lpa-questionnaire-due-date-month">Month</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="lpa-questionnaire-due-date-month" name="lpa-questionnaire-due-date-month"
-                            type="text" inputmode="numeric">
+                            type="text" value="10" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -6167,7 +6198,7 @@ exports[`Timetable POST /edit S78 hearing Statements should re-render edit timet
                             <label class="govuk-label govuk-date-input__label" for="lpa-questionnaire-due-date-year">Year</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input govuk-date-input__input"
                             id="lpa-questionnaire-due-date-year" name="lpa-questionnaire-due-date-year"
-                            type="text" inputmode="numeric">
+                            type="text" value="2050" inputmode="numeric">
                         </div>
                     </div>
                 </div>
@@ -6185,7 +6216,7 @@ exports[`Timetable POST /edit S78 hearing Statements should re-render edit timet
                             <label class="govuk-label govuk-date-input__label" for="lpa-statement-due-date-day">Day</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input govuk-input--error"
                             id="lpa-statement-due-date-day" name="lpa-statement-due-date-day" type="text"
-                            inputmode="numeric">
+                            value="29" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -6193,7 +6224,7 @@ exports[`Timetable POST /edit S78 hearing Statements should re-render edit timet
                             <label class="govuk-label govuk-date-input__label" for="lpa-statement-due-date-month">Month</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input govuk-input--error"
                             id="lpa-statement-due-date-month" name="lpa-statement-due-date-month" type="text"
-                            inputmode="numeric">
+                            value="2" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -6201,7 +6232,7 @@ exports[`Timetable POST /edit S78 hearing Statements should re-render edit timet
                             <label class="govuk-label govuk-date-input__label" for="lpa-statement-due-date-year">Year</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input govuk-date-input__input govuk-input--error"
                             id="lpa-statement-due-date-year" name="lpa-statement-due-date-year" type="text"
-                            inputmode="numeric">
+                            value="3000" inputmode="numeric">
                         </div>
                     </div>
                 </div>
@@ -6218,7 +6249,7 @@ exports[`Timetable POST /edit S78 hearing Statements should re-render edit timet
                             <label class="govuk-label govuk-date-input__label" for="ip-comments-due-date-day">Day</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="ip-comments-due-date-day" name="ip-comments-due-date-day" type="text"
-                            inputmode="numeric">
+                            value="03" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -6226,7 +6257,7 @@ exports[`Timetable POST /edit S78 hearing Statements should re-render edit timet
                             <label class="govuk-label govuk-date-input__label" for="ip-comments-due-date-month">Month</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="ip-comments-due-date-month" name="ip-comments-due-date-month" type="text"
-                            inputmode="numeric">
+                            value="10" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -6234,7 +6265,7 @@ exports[`Timetable POST /edit S78 hearing Statements should re-render edit timet
                             <label class="govuk-label govuk-date-input__label" for="ip-comments-due-date-year">Year</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input govuk-date-input__input"
                             id="ip-comments-due-date-year" name="ip-comments-due-date-year" type="text"
-                            inputmode="numeric">
+                            value="2050" inputmode="numeric">
                         </div>
                     </div>
                 </div>
@@ -6251,7 +6282,7 @@ exports[`Timetable POST /edit S78 hearing Statements should re-render edit timet
                             <label class="govuk-label govuk-date-input__label" for="statement-of-common-ground-due-date-day">Day</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="statement-of-common-ground-due-date-day" name="statement-of-common-ground-due-date-day"
-                            type="text" inputmode="numeric">
+                            type="text" value="04" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -6259,7 +6290,7 @@ exports[`Timetable POST /edit S78 hearing Statements should re-render edit timet
                             <label class="govuk-label govuk-date-input__label" for="statement-of-common-ground-due-date-month">Month</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="statement-of-common-ground-due-date-month" name="statement-of-common-ground-due-date-month"
-                            type="text" inputmode="numeric">
+                            type="text" value="10" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -6267,7 +6298,7 @@ exports[`Timetable POST /edit S78 hearing Statements should re-render edit timet
                             <label class="govuk-label govuk-date-input__label" for="statement-of-common-ground-due-date-year">Year</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input govuk-date-input__input"
                             id="statement-of-common-ground-due-date-year" name="statement-of-common-ground-due-date-year"
-                            type="text" inputmode="numeric">
+                            type="text" value="2050" inputmode="numeric">
                         </div>
                     </div>
                 </div>
@@ -6284,7 +6315,7 @@ exports[`Timetable POST /edit S78 hearing Statements should re-render edit timet
                             <label class="govuk-label govuk-date-input__label" for="planning-obligation-due-date-day">Day</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="planning-obligation-due-date-day" name="planning-obligation-due-date-day"
-                            type="text" inputmode="numeric">
+                            type="text" value="05" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -6292,7 +6323,7 @@ exports[`Timetable POST /edit S78 hearing Statements should re-render edit timet
                             <label class="govuk-label govuk-date-input__label" for="planning-obligation-due-date-month">Month</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="planning-obligation-due-date-month" name="planning-obligation-due-date-month"
-                            type="text" inputmode="numeric">
+                            type="text" value="10" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -6300,7 +6331,7 @@ exports[`Timetable POST /edit S78 hearing Statements should re-render edit timet
                             <label class="govuk-label govuk-date-input__label" for="planning-obligation-due-date-year">Year</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input govuk-date-input__input"
                             id="planning-obligation-due-date-year" name="planning-obligation-due-date-year"
-                            type="text" inputmode="numeric">
+                            type="text" value="2050" inputmode="numeric">
                         </div>
                     </div>
                 </div>
@@ -6350,7 +6381,7 @@ exports[`Timetable POST /edit S78 written Final comments should re-render edit t
                             <label class="govuk-label govuk-date-input__label" for="lpa-questionnaire-due-date-day">Day</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="lpa-questionnaire-due-date-day" name="lpa-questionnaire-due-date-day"
-                            type="text" inputmode="numeric">
+                            type="text" value="01" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -6358,7 +6389,7 @@ exports[`Timetable POST /edit S78 written Final comments should re-render edit t
                             <label class="govuk-label govuk-date-input__label" for="lpa-questionnaire-due-date-month">Month</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="lpa-questionnaire-due-date-month" name="lpa-questionnaire-due-date-month"
-                            type="text" inputmode="numeric">
+                            type="text" value="10" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -6366,7 +6397,7 @@ exports[`Timetable POST /edit S78 written Final comments should re-render edit t
                             <label class="govuk-label govuk-date-input__label" for="lpa-questionnaire-due-date-year">Year</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input govuk-date-input__input"
                             id="lpa-questionnaire-due-date-year" name="lpa-questionnaire-due-date-year"
-                            type="text" inputmode="numeric">
+                            type="text" value="2050" inputmode="numeric">
                         </div>
                     </div>
                 </div>
@@ -6382,7 +6413,7 @@ exports[`Timetable POST /edit S78 written Final comments should re-render edit t
                             <label class="govuk-label govuk-date-input__label" for="lpa-statement-due-date-day">Day</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="lpa-statement-due-date-day" name="lpa-statement-due-date-day" type="text"
-                            inputmode="numeric">
+                            value="02" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -6390,7 +6421,7 @@ exports[`Timetable POST /edit S78 written Final comments should re-render edit t
                             <label class="govuk-label govuk-date-input__label" for="lpa-statement-due-date-month">Month</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="lpa-statement-due-date-month" name="lpa-statement-due-date-month" type="text"
-                            inputmode="numeric">
+                            value="10" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -6398,7 +6429,7 @@ exports[`Timetable POST /edit S78 written Final comments should re-render edit t
                             <label class="govuk-label govuk-date-input__label" for="lpa-statement-due-date-year">Year</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input govuk-date-input__input"
                             id="lpa-statement-due-date-year" name="lpa-statement-due-date-year" type="text"
-                            inputmode="numeric">
+                            value="2050" inputmode="numeric">
                         </div>
                     </div>
                 </div>
@@ -6415,7 +6446,7 @@ exports[`Timetable POST /edit S78 written Final comments should re-render edit t
                             <label class="govuk-label govuk-date-input__label" for="ip-comments-due-date-day">Day</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="ip-comments-due-date-day" name="ip-comments-due-date-day" type="text"
-                            inputmode="numeric">
+                            value="03" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -6423,7 +6454,7 @@ exports[`Timetable POST /edit S78 written Final comments should re-render edit t
                             <label class="govuk-label govuk-date-input__label" for="ip-comments-due-date-month">Month</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="ip-comments-due-date-month" name="ip-comments-due-date-month" type="text"
-                            inputmode="numeric">
+                            value="10" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -6431,7 +6462,7 @@ exports[`Timetable POST /edit S78 written Final comments should re-render edit t
                             <label class="govuk-label govuk-date-input__label" for="ip-comments-due-date-year">Year</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input govuk-date-input__input"
                             id="ip-comments-due-date-year" name="ip-comments-due-date-year" type="text"
-                            inputmode="numeric">
+                            value="2050" inputmode="numeric">
                         </div>
                     </div>
                 </div>
@@ -6457,7 +6488,7 @@ exports[`Timetable POST /edit S78 written Final comments should re-render edit t
                             <label class="govuk-label govuk-date-input__label" for="final-comments-due-date-month">Month</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="final-comments-due-date-month" name="final-comments-due-date-month"
-                            type="text" inputmode="numeric">
+                            type="text" value="10" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -6465,7 +6496,7 @@ exports[`Timetable POST /edit S78 written Final comments should re-render edit t
                             <label class="govuk-label govuk-date-input__label" for="final-comments-due-date-year">Year</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input govuk-date-input__input"
                             id="final-comments-due-date-year" name="final-comments-due-date-year" type="text"
-                            inputmode="numeric">
+                            value="2050" inputmode="numeric">
                         </div>
                     </div>
                 </div>
@@ -6515,7 +6546,7 @@ exports[`Timetable POST /edit S78 written Final comments should re-render edit t
                             <label class="govuk-label govuk-date-input__label" for="lpa-questionnaire-due-date-day">Day</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="lpa-questionnaire-due-date-day" name="lpa-questionnaire-due-date-day"
-                            type="text" inputmode="numeric">
+                            type="text" value="01" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -6523,7 +6554,7 @@ exports[`Timetable POST /edit S78 written Final comments should re-render edit t
                             <label class="govuk-label govuk-date-input__label" for="lpa-questionnaire-due-date-month">Month</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="lpa-questionnaire-due-date-month" name="lpa-questionnaire-due-date-month"
-                            type="text" inputmode="numeric">
+                            type="text" value="10" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -6531,7 +6562,7 @@ exports[`Timetable POST /edit S78 written Final comments should re-render edit t
                             <label class="govuk-label govuk-date-input__label" for="lpa-questionnaire-due-date-year">Year</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input govuk-date-input__input"
                             id="lpa-questionnaire-due-date-year" name="lpa-questionnaire-due-date-year"
-                            type="text" inputmode="numeric">
+                            type="text" value="2050" inputmode="numeric">
                         </div>
                     </div>
                 </div>
@@ -6547,7 +6578,7 @@ exports[`Timetable POST /edit S78 written Final comments should re-render edit t
                             <label class="govuk-label govuk-date-input__label" for="lpa-statement-due-date-day">Day</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="lpa-statement-due-date-day" name="lpa-statement-due-date-day" type="text"
-                            inputmode="numeric">
+                            value="02" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -6555,7 +6586,7 @@ exports[`Timetable POST /edit S78 written Final comments should re-render edit t
                             <label class="govuk-label govuk-date-input__label" for="lpa-statement-due-date-month">Month</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="lpa-statement-due-date-month" name="lpa-statement-due-date-month" type="text"
-                            inputmode="numeric">
+                            value="10" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -6563,7 +6594,7 @@ exports[`Timetable POST /edit S78 written Final comments should re-render edit t
                             <label class="govuk-label govuk-date-input__label" for="lpa-statement-due-date-year">Year</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input govuk-date-input__input"
                             id="lpa-statement-due-date-year" name="lpa-statement-due-date-year" type="text"
-                            inputmode="numeric">
+                            value="2050" inputmode="numeric">
                         </div>
                     </div>
                 </div>
@@ -6580,7 +6611,7 @@ exports[`Timetable POST /edit S78 written Final comments should re-render edit t
                             <label class="govuk-label govuk-date-input__label" for="ip-comments-due-date-day">Day</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="ip-comments-due-date-day" name="ip-comments-due-date-day" type="text"
-                            inputmode="numeric">
+                            value="03" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -6588,7 +6619,7 @@ exports[`Timetable POST /edit S78 written Final comments should re-render edit t
                             <label class="govuk-label govuk-date-input__label" for="ip-comments-due-date-month">Month</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="ip-comments-due-date-month" name="ip-comments-due-date-month" type="text"
-                            inputmode="numeric">
+                            value="10" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -6596,7 +6627,7 @@ exports[`Timetable POST /edit S78 written Final comments should re-render edit t
                             <label class="govuk-label govuk-date-input__label" for="ip-comments-due-date-year">Year</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input govuk-date-input__input"
                             id="ip-comments-due-date-year" name="ip-comments-due-date-year" type="text"
-                            inputmode="numeric">
+                            value="2050" inputmode="numeric">
                         </div>
                     </div>
                 </div>
@@ -6614,7 +6645,7 @@ exports[`Timetable POST /edit S78 written Final comments should re-render edit t
                             <label class="govuk-label govuk-date-input__label" for="final-comments-due-date-day">Day</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="final-comments-due-date-day" name="final-comments-due-date-day" type="text"
-                            inputmode="numeric">
+                            value="10" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -6630,7 +6661,7 @@ exports[`Timetable POST /edit S78 written Final comments should re-render edit t
                             <label class="govuk-label govuk-date-input__label" for="final-comments-due-date-year">Year</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input govuk-date-input__input"
                             id="final-comments-due-date-year" name="final-comments-due-date-year" type="text"
-                            inputmode="numeric">
+                            value="2050" inputmode="numeric">
                         </div>
                     </div>
                 </div>
@@ -6680,7 +6711,7 @@ exports[`Timetable POST /edit S78 written Final comments should re-render edit t
                             <label class="govuk-label govuk-date-input__label" for="lpa-questionnaire-due-date-day">Day</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="lpa-questionnaire-due-date-day" name="lpa-questionnaire-due-date-day"
-                            type="text" inputmode="numeric">
+                            type="text" value="01" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -6688,7 +6719,7 @@ exports[`Timetable POST /edit S78 written Final comments should re-render edit t
                             <label class="govuk-label govuk-date-input__label" for="lpa-questionnaire-due-date-month">Month</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="lpa-questionnaire-due-date-month" name="lpa-questionnaire-due-date-month"
-                            type="text" inputmode="numeric">
+                            type="text" value="10" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -6696,7 +6727,7 @@ exports[`Timetable POST /edit S78 written Final comments should re-render edit t
                             <label class="govuk-label govuk-date-input__label" for="lpa-questionnaire-due-date-year">Year</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input govuk-date-input__input"
                             id="lpa-questionnaire-due-date-year" name="lpa-questionnaire-due-date-year"
-                            type="text" inputmode="numeric">
+                            type="text" value="2050" inputmode="numeric">
                         </div>
                     </div>
                 </div>
@@ -6712,7 +6743,7 @@ exports[`Timetable POST /edit S78 written Final comments should re-render edit t
                             <label class="govuk-label govuk-date-input__label" for="lpa-statement-due-date-day">Day</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="lpa-statement-due-date-day" name="lpa-statement-due-date-day" type="text"
-                            inputmode="numeric">
+                            value="02" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -6720,7 +6751,7 @@ exports[`Timetable POST /edit S78 written Final comments should re-render edit t
                             <label class="govuk-label govuk-date-input__label" for="lpa-statement-due-date-month">Month</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="lpa-statement-due-date-month" name="lpa-statement-due-date-month" type="text"
-                            inputmode="numeric">
+                            value="10" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -6728,7 +6759,7 @@ exports[`Timetable POST /edit S78 written Final comments should re-render edit t
                             <label class="govuk-label govuk-date-input__label" for="lpa-statement-due-date-year">Year</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input govuk-date-input__input"
                             id="lpa-statement-due-date-year" name="lpa-statement-due-date-year" type="text"
-                            inputmode="numeric">
+                            value="2050" inputmode="numeric">
                         </div>
                     </div>
                 </div>
@@ -6745,7 +6776,7 @@ exports[`Timetable POST /edit S78 written Final comments should re-render edit t
                             <label class="govuk-label govuk-date-input__label" for="ip-comments-due-date-day">Day</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="ip-comments-due-date-day" name="ip-comments-due-date-day" type="text"
-                            inputmode="numeric">
+                            value="03" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -6753,7 +6784,7 @@ exports[`Timetable POST /edit S78 written Final comments should re-render edit t
                             <label class="govuk-label govuk-date-input__label" for="ip-comments-due-date-month">Month</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="ip-comments-due-date-month" name="ip-comments-due-date-month" type="text"
-                            inputmode="numeric">
+                            value="10" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -6761,7 +6792,7 @@ exports[`Timetable POST /edit S78 written Final comments should re-render edit t
                             <label class="govuk-label govuk-date-input__label" for="ip-comments-due-date-year">Year</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input govuk-date-input__input"
                             id="ip-comments-due-date-year" name="ip-comments-due-date-year" type="text"
-                            inputmode="numeric">
+                            value="2050" inputmode="numeric">
                         </div>
                     </div>
                 </div>
@@ -6779,7 +6810,7 @@ exports[`Timetable POST /edit S78 written Final comments should re-render edit t
                             <label class="govuk-label govuk-date-input__label" for="final-comments-due-date-day">Day</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="final-comments-due-date-day" name="final-comments-due-date-day" type="text"
-                            inputmode="numeric">
+                            value="10" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -6787,7 +6818,7 @@ exports[`Timetable POST /edit S78 written Final comments should re-render edit t
                             <label class="govuk-label govuk-date-input__label" for="final-comments-due-date-month">Month</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="final-comments-due-date-month" name="final-comments-due-date-month"
-                            type="text" inputmode="numeric">
+                            type="text" value="12" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -6845,7 +6876,7 @@ exports[`Timetable POST /edit S78 written Final comments should re-render edit t
                             <label class="govuk-label govuk-date-input__label" for="lpa-questionnaire-due-date-day">Day</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="lpa-questionnaire-due-date-day" name="lpa-questionnaire-due-date-day"
-                            type="text" inputmode="numeric">
+                            type="text" value="01" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -6853,7 +6884,7 @@ exports[`Timetable POST /edit S78 written Final comments should re-render edit t
                             <label class="govuk-label govuk-date-input__label" for="lpa-questionnaire-due-date-month">Month</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="lpa-questionnaire-due-date-month" name="lpa-questionnaire-due-date-month"
-                            type="text" inputmode="numeric">
+                            type="text" value="10" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -6861,7 +6892,7 @@ exports[`Timetable POST /edit S78 written Final comments should re-render edit t
                             <label class="govuk-label govuk-date-input__label" for="lpa-questionnaire-due-date-year">Year</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input govuk-date-input__input"
                             id="lpa-questionnaire-due-date-year" name="lpa-questionnaire-due-date-year"
-                            type="text" inputmode="numeric">
+                            type="text" value="2050" inputmode="numeric">
                         </div>
                     </div>
                 </div>
@@ -6877,7 +6908,7 @@ exports[`Timetable POST /edit S78 written Final comments should re-render edit t
                             <label class="govuk-label govuk-date-input__label" for="lpa-statement-due-date-day">Day</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="lpa-statement-due-date-day" name="lpa-statement-due-date-day" type="text"
-                            inputmode="numeric">
+                            value="02" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -6885,7 +6916,7 @@ exports[`Timetable POST /edit S78 written Final comments should re-render edit t
                             <label class="govuk-label govuk-date-input__label" for="lpa-statement-due-date-month">Month</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="lpa-statement-due-date-month" name="lpa-statement-due-date-month" type="text"
-                            inputmode="numeric">
+                            value="10" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -6893,7 +6924,7 @@ exports[`Timetable POST /edit S78 written Final comments should re-render edit t
                             <label class="govuk-label govuk-date-input__label" for="lpa-statement-due-date-year">Year</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input govuk-date-input__input"
                             id="lpa-statement-due-date-year" name="lpa-statement-due-date-year" type="text"
-                            inputmode="numeric">
+                            value="2050" inputmode="numeric">
                         </div>
                     </div>
                 </div>
@@ -6910,7 +6941,7 @@ exports[`Timetable POST /edit S78 written Final comments should re-render edit t
                             <label class="govuk-label govuk-date-input__label" for="ip-comments-due-date-day">Day</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="ip-comments-due-date-day" name="ip-comments-due-date-day" type="text"
-                            inputmode="numeric">
+                            value="03" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -6918,7 +6949,7 @@ exports[`Timetable POST /edit S78 written Final comments should re-render edit t
                             <label class="govuk-label govuk-date-input__label" for="ip-comments-due-date-month">Month</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="ip-comments-due-date-month" name="ip-comments-due-date-month" type="text"
-                            inputmode="numeric">
+                            value="10" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -6926,7 +6957,7 @@ exports[`Timetable POST /edit S78 written Final comments should re-render edit t
                             <label class="govuk-label govuk-date-input__label" for="ip-comments-due-date-year">Year</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input govuk-date-input__input"
                             id="ip-comments-due-date-year" name="ip-comments-due-date-year" type="text"
-                            inputmode="numeric">
+                            value="2050" inputmode="numeric">
                         </div>
                     </div>
                 </div>
@@ -6944,7 +6975,7 @@ exports[`Timetable POST /edit S78 written Final comments should re-render edit t
                             <label class="govuk-label govuk-date-input__label" for="final-comments-due-date-day">Day</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input govuk-input--error"
                             id="final-comments-due-date-day" name="final-comments-due-date-day" type="text"
-                            inputmode="numeric">
+                            value="25" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -6952,7 +6983,7 @@ exports[`Timetable POST /edit S78 written Final comments should re-render edit t
                             <label class="govuk-label govuk-date-input__label" for="final-comments-due-date-month">Month</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input govuk-input--error"
                             id="final-comments-due-date-month" name="final-comments-due-date-month"
-                            type="text" inputmode="numeric">
+                            type="text" value="2" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -6960,7 +6991,7 @@ exports[`Timetable POST /edit S78 written Final comments should re-render edit t
                             <label class="govuk-label govuk-date-input__label" for="final-comments-due-date-year">Year</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input govuk-date-input__input govuk-input--error"
                             id="final-comments-due-date-year" name="final-comments-due-date-year" type="text"
-                            inputmode="numeric">
+                            value="1950" inputmode="numeric">
                         </div>
                     </div>
                 </div>
@@ -7010,7 +7041,7 @@ exports[`Timetable POST /edit S78 written Final comments should re-render edit t
                             <label class="govuk-label govuk-date-input__label" for="lpa-questionnaire-due-date-day">Day</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="lpa-questionnaire-due-date-day" name="lpa-questionnaire-due-date-day"
-                            type="text" inputmode="numeric">
+                            type="text" value="01" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -7018,7 +7049,7 @@ exports[`Timetable POST /edit S78 written Final comments should re-render edit t
                             <label class="govuk-label govuk-date-input__label" for="lpa-questionnaire-due-date-month">Month</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="lpa-questionnaire-due-date-month" name="lpa-questionnaire-due-date-month"
-                            type="text" inputmode="numeric">
+                            type="text" value="10" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -7026,7 +7057,7 @@ exports[`Timetable POST /edit S78 written Final comments should re-render edit t
                             <label class="govuk-label govuk-date-input__label" for="lpa-questionnaire-due-date-year">Year</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input govuk-date-input__input"
                             id="lpa-questionnaire-due-date-year" name="lpa-questionnaire-due-date-year"
-                            type="text" inputmode="numeric">
+                            type="text" value="2050" inputmode="numeric">
                         </div>
                     </div>
                 </div>
@@ -7042,7 +7073,7 @@ exports[`Timetable POST /edit S78 written Final comments should re-render edit t
                             <label class="govuk-label govuk-date-input__label" for="lpa-statement-due-date-day">Day</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="lpa-statement-due-date-day" name="lpa-statement-due-date-day" type="text"
-                            inputmode="numeric">
+                            value="02" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -7050,7 +7081,7 @@ exports[`Timetable POST /edit S78 written Final comments should re-render edit t
                             <label class="govuk-label govuk-date-input__label" for="lpa-statement-due-date-month">Month</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="lpa-statement-due-date-month" name="lpa-statement-due-date-month" type="text"
-                            inputmode="numeric">
+                            value="10" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -7058,7 +7089,7 @@ exports[`Timetable POST /edit S78 written Final comments should re-render edit t
                             <label class="govuk-label govuk-date-input__label" for="lpa-statement-due-date-year">Year</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input govuk-date-input__input"
                             id="lpa-statement-due-date-year" name="lpa-statement-due-date-year" type="text"
-                            inputmode="numeric">
+                            value="2050" inputmode="numeric">
                         </div>
                     </div>
                 </div>
@@ -7075,7 +7106,7 @@ exports[`Timetable POST /edit S78 written Final comments should re-render edit t
                             <label class="govuk-label govuk-date-input__label" for="ip-comments-due-date-day">Day</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="ip-comments-due-date-day" name="ip-comments-due-date-day" type="text"
-                            inputmode="numeric">
+                            value="03" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -7083,7 +7114,7 @@ exports[`Timetable POST /edit S78 written Final comments should re-render edit t
                             <label class="govuk-label govuk-date-input__label" for="ip-comments-due-date-month">Month</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="ip-comments-due-date-month" name="ip-comments-due-date-month" type="text"
-                            inputmode="numeric">
+                            value="10" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -7091,7 +7122,7 @@ exports[`Timetable POST /edit S78 written Final comments should re-render edit t
                             <label class="govuk-label govuk-date-input__label" for="ip-comments-due-date-year">Year</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input govuk-date-input__input"
                             id="ip-comments-due-date-year" name="ip-comments-due-date-year" type="text"
-                            inputmode="numeric">
+                            value="2050" inputmode="numeric">
                         </div>
                     </div>
                 </div>
@@ -7109,7 +7140,7 @@ exports[`Timetable POST /edit S78 written Final comments should re-render edit t
                             <label class="govuk-label govuk-date-input__label" for="final-comments-due-date-day">Day</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input govuk-input--error"
                             id="final-comments-due-date-day" name="final-comments-due-date-day" type="text"
-                            inputmode="numeric">
+                            value="29" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -7117,7 +7148,7 @@ exports[`Timetable POST /edit S78 written Final comments should re-render edit t
                             <label class="govuk-label govuk-date-input__label" for="final-comments-due-date-month">Month</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input govuk-input--error"
                             id="final-comments-due-date-month" name="final-comments-due-date-month"
-                            type="text" inputmode="numeric">
+                            type="text" value="2" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -7125,7 +7156,7 @@ exports[`Timetable POST /edit S78 written Final comments should re-render edit t
                             <label class="govuk-label govuk-date-input__label" for="final-comments-due-date-year">Year</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input govuk-date-input__input govuk-input--error"
                             id="final-comments-due-date-year" name="final-comments-due-date-year" type="text"
-                            inputmode="numeric">
+                            value="3000" inputmode="numeric">
                         </div>
                     </div>
                 </div>
@@ -7175,7 +7206,7 @@ exports[`Timetable POST /edit S78 written Interested party comments should re-re
                             <label class="govuk-label govuk-date-input__label" for="lpa-questionnaire-due-date-day">Day</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="lpa-questionnaire-due-date-day" name="lpa-questionnaire-due-date-day"
-                            type="text" inputmode="numeric">
+                            type="text" value="01" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -7183,7 +7214,7 @@ exports[`Timetable POST /edit S78 written Interested party comments should re-re
                             <label class="govuk-label govuk-date-input__label" for="lpa-questionnaire-due-date-month">Month</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="lpa-questionnaire-due-date-month" name="lpa-questionnaire-due-date-month"
-                            type="text" inputmode="numeric">
+                            type="text" value="10" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -7191,7 +7222,7 @@ exports[`Timetable POST /edit S78 written Interested party comments should re-re
                             <label class="govuk-label govuk-date-input__label" for="lpa-questionnaire-due-date-year">Year</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input govuk-date-input__input"
                             id="lpa-questionnaire-due-date-year" name="lpa-questionnaire-due-date-year"
-                            type="text" inputmode="numeric">
+                            type="text" value="2050" inputmode="numeric">
                         </div>
                     </div>
                 </div>
@@ -7207,7 +7238,7 @@ exports[`Timetable POST /edit S78 written Interested party comments should re-re
                             <label class="govuk-label govuk-date-input__label" for="lpa-statement-due-date-day">Day</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="lpa-statement-due-date-day" name="lpa-statement-due-date-day" type="text"
-                            inputmode="numeric">
+                            value="02" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -7215,7 +7246,7 @@ exports[`Timetable POST /edit S78 written Interested party comments should re-re
                             <label class="govuk-label govuk-date-input__label" for="lpa-statement-due-date-month">Month</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="lpa-statement-due-date-month" name="lpa-statement-due-date-month" type="text"
-                            inputmode="numeric">
+                            value="10" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -7223,7 +7254,7 @@ exports[`Timetable POST /edit S78 written Interested party comments should re-re
                             <label class="govuk-label govuk-date-input__label" for="lpa-statement-due-date-year">Year</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input govuk-date-input__input"
                             id="lpa-statement-due-date-year" name="lpa-statement-due-date-year" type="text"
-                            inputmode="numeric">
+                            value="2050" inputmode="numeric">
                         </div>
                     </div>
                 </div>
@@ -7250,7 +7281,7 @@ exports[`Timetable POST /edit S78 written Interested party comments should re-re
                             <label class="govuk-label govuk-date-input__label" for="ip-comments-due-date-month">Month</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="ip-comments-due-date-month" name="ip-comments-due-date-month" type="text"
-                            inputmode="numeric">
+                            value="10" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -7258,7 +7289,7 @@ exports[`Timetable POST /edit S78 written Interested party comments should re-re
                             <label class="govuk-label govuk-date-input__label" for="ip-comments-due-date-year">Year</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input govuk-date-input__input"
                             id="ip-comments-due-date-year" name="ip-comments-due-date-year" type="text"
-                            inputmode="numeric">
+                            value="2050" inputmode="numeric">
                         </div>
                     </div>
                 </div>
@@ -7274,7 +7305,7 @@ exports[`Timetable POST /edit S78 written Interested party comments should re-re
                             <label class="govuk-label govuk-date-input__label" for="final-comments-due-date-day">Day</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="final-comments-due-date-day" name="final-comments-due-date-day" type="text"
-                            inputmode="numeric">
+                            value="04" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -7282,7 +7313,7 @@ exports[`Timetable POST /edit S78 written Interested party comments should re-re
                             <label class="govuk-label govuk-date-input__label" for="final-comments-due-date-month">Month</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="final-comments-due-date-month" name="final-comments-due-date-month"
-                            type="text" inputmode="numeric">
+                            type="text" value="10" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -7290,7 +7321,7 @@ exports[`Timetable POST /edit S78 written Interested party comments should re-re
                             <label class="govuk-label govuk-date-input__label" for="final-comments-due-date-year">Year</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input govuk-date-input__input"
                             id="final-comments-due-date-year" name="final-comments-due-date-year" type="text"
-                            inputmode="numeric">
+                            value="2050" inputmode="numeric">
                         </div>
                     </div>
                 </div>
@@ -7340,7 +7371,7 @@ exports[`Timetable POST /edit S78 written Interested party comments should re-re
                             <label class="govuk-label govuk-date-input__label" for="lpa-questionnaire-due-date-day">Day</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="lpa-questionnaire-due-date-day" name="lpa-questionnaire-due-date-day"
-                            type="text" inputmode="numeric">
+                            type="text" value="01" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -7348,7 +7379,7 @@ exports[`Timetable POST /edit S78 written Interested party comments should re-re
                             <label class="govuk-label govuk-date-input__label" for="lpa-questionnaire-due-date-month">Month</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="lpa-questionnaire-due-date-month" name="lpa-questionnaire-due-date-month"
-                            type="text" inputmode="numeric">
+                            type="text" value="10" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -7356,7 +7387,7 @@ exports[`Timetable POST /edit S78 written Interested party comments should re-re
                             <label class="govuk-label govuk-date-input__label" for="lpa-questionnaire-due-date-year">Year</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input govuk-date-input__input"
                             id="lpa-questionnaire-due-date-year" name="lpa-questionnaire-due-date-year"
-                            type="text" inputmode="numeric">
+                            type="text" value="2050" inputmode="numeric">
                         </div>
                     </div>
                 </div>
@@ -7372,7 +7403,7 @@ exports[`Timetable POST /edit S78 written Interested party comments should re-re
                             <label class="govuk-label govuk-date-input__label" for="lpa-statement-due-date-day">Day</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="lpa-statement-due-date-day" name="lpa-statement-due-date-day" type="text"
-                            inputmode="numeric">
+                            value="02" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -7380,7 +7411,7 @@ exports[`Timetable POST /edit S78 written Interested party comments should re-re
                             <label class="govuk-label govuk-date-input__label" for="lpa-statement-due-date-month">Month</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="lpa-statement-due-date-month" name="lpa-statement-due-date-month" type="text"
-                            inputmode="numeric">
+                            value="10" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -7388,7 +7419,7 @@ exports[`Timetable POST /edit S78 written Interested party comments should re-re
                             <label class="govuk-label govuk-date-input__label" for="lpa-statement-due-date-year">Year</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input govuk-date-input__input"
                             id="lpa-statement-due-date-year" name="lpa-statement-due-date-year" type="text"
-                            inputmode="numeric">
+                            value="2050" inputmode="numeric">
                         </div>
                     </div>
                 </div>
@@ -7407,7 +7438,7 @@ exports[`Timetable POST /edit S78 written Interested party comments should re-re
                             <label class="govuk-label govuk-date-input__label" for="ip-comments-due-date-day">Day</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="ip-comments-due-date-day" name="ip-comments-due-date-day" type="text"
-                            inputmode="numeric">
+                            value="10" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -7423,7 +7454,7 @@ exports[`Timetable POST /edit S78 written Interested party comments should re-re
                             <label class="govuk-label govuk-date-input__label" for="ip-comments-due-date-year">Year</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input govuk-date-input__input"
                             id="ip-comments-due-date-year" name="ip-comments-due-date-year" type="text"
-                            inputmode="numeric">
+                            value="2050" inputmode="numeric">
                         </div>
                     </div>
                 </div>
@@ -7439,7 +7470,7 @@ exports[`Timetable POST /edit S78 written Interested party comments should re-re
                             <label class="govuk-label govuk-date-input__label" for="final-comments-due-date-day">Day</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="final-comments-due-date-day" name="final-comments-due-date-day" type="text"
-                            inputmode="numeric">
+                            value="04" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -7447,7 +7478,7 @@ exports[`Timetable POST /edit S78 written Interested party comments should re-re
                             <label class="govuk-label govuk-date-input__label" for="final-comments-due-date-month">Month</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="final-comments-due-date-month" name="final-comments-due-date-month"
-                            type="text" inputmode="numeric">
+                            type="text" value="10" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -7455,7 +7486,7 @@ exports[`Timetable POST /edit S78 written Interested party comments should re-re
                             <label class="govuk-label govuk-date-input__label" for="final-comments-due-date-year">Year</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input govuk-date-input__input"
                             id="final-comments-due-date-year" name="final-comments-due-date-year" type="text"
-                            inputmode="numeric">
+                            value="2050" inputmode="numeric">
                         </div>
                     </div>
                 </div>
@@ -7505,7 +7536,7 @@ exports[`Timetable POST /edit S78 written Interested party comments should re-re
                             <label class="govuk-label govuk-date-input__label" for="lpa-questionnaire-due-date-day">Day</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="lpa-questionnaire-due-date-day" name="lpa-questionnaire-due-date-day"
-                            type="text" inputmode="numeric">
+                            type="text" value="01" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -7513,7 +7544,7 @@ exports[`Timetable POST /edit S78 written Interested party comments should re-re
                             <label class="govuk-label govuk-date-input__label" for="lpa-questionnaire-due-date-month">Month</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="lpa-questionnaire-due-date-month" name="lpa-questionnaire-due-date-month"
-                            type="text" inputmode="numeric">
+                            type="text" value="10" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -7521,7 +7552,7 @@ exports[`Timetable POST /edit S78 written Interested party comments should re-re
                             <label class="govuk-label govuk-date-input__label" for="lpa-questionnaire-due-date-year">Year</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input govuk-date-input__input"
                             id="lpa-questionnaire-due-date-year" name="lpa-questionnaire-due-date-year"
-                            type="text" inputmode="numeric">
+                            type="text" value="2050" inputmode="numeric">
                         </div>
                     </div>
                 </div>
@@ -7537,7 +7568,7 @@ exports[`Timetable POST /edit S78 written Interested party comments should re-re
                             <label class="govuk-label govuk-date-input__label" for="lpa-statement-due-date-day">Day</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="lpa-statement-due-date-day" name="lpa-statement-due-date-day" type="text"
-                            inputmode="numeric">
+                            value="02" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -7545,7 +7576,7 @@ exports[`Timetable POST /edit S78 written Interested party comments should re-re
                             <label class="govuk-label govuk-date-input__label" for="lpa-statement-due-date-month">Month</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="lpa-statement-due-date-month" name="lpa-statement-due-date-month" type="text"
-                            inputmode="numeric">
+                            value="10" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -7553,7 +7584,7 @@ exports[`Timetable POST /edit S78 written Interested party comments should re-re
                             <label class="govuk-label govuk-date-input__label" for="lpa-statement-due-date-year">Year</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input govuk-date-input__input"
                             id="lpa-statement-due-date-year" name="lpa-statement-due-date-year" type="text"
-                            inputmode="numeric">
+                            value="2050" inputmode="numeric">
                         </div>
                     </div>
                 </div>
@@ -7572,7 +7603,7 @@ exports[`Timetable POST /edit S78 written Interested party comments should re-re
                             <label class="govuk-label govuk-date-input__label" for="ip-comments-due-date-day">Day</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="ip-comments-due-date-day" name="ip-comments-due-date-day" type="text"
-                            inputmode="numeric">
+                            value="10" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -7580,7 +7611,7 @@ exports[`Timetable POST /edit S78 written Interested party comments should re-re
                             <label class="govuk-label govuk-date-input__label" for="ip-comments-due-date-month">Month</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="ip-comments-due-date-month" name="ip-comments-due-date-month" type="text"
-                            inputmode="numeric">
+                            value="12" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -7604,7 +7635,7 @@ exports[`Timetable POST /edit S78 written Interested party comments should re-re
                             <label class="govuk-label govuk-date-input__label" for="final-comments-due-date-day">Day</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="final-comments-due-date-day" name="final-comments-due-date-day" type="text"
-                            inputmode="numeric">
+                            value="04" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -7612,7 +7643,7 @@ exports[`Timetable POST /edit S78 written Interested party comments should re-re
                             <label class="govuk-label govuk-date-input__label" for="final-comments-due-date-month">Month</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="final-comments-due-date-month" name="final-comments-due-date-month"
-                            type="text" inputmode="numeric">
+                            type="text" value="10" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -7620,7 +7651,7 @@ exports[`Timetable POST /edit S78 written Interested party comments should re-re
                             <label class="govuk-label govuk-date-input__label" for="final-comments-due-date-year">Year</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input govuk-date-input__input"
                             id="final-comments-due-date-year" name="final-comments-due-date-year" type="text"
-                            inputmode="numeric">
+                            value="2050" inputmode="numeric">
                         </div>
                     </div>
                 </div>
@@ -7670,7 +7701,7 @@ exports[`Timetable POST /edit S78 written Interested party comments should re-re
                             <label class="govuk-label govuk-date-input__label" for="lpa-questionnaire-due-date-day">Day</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="lpa-questionnaire-due-date-day" name="lpa-questionnaire-due-date-day"
-                            type="text" inputmode="numeric">
+                            type="text" value="01" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -7678,7 +7709,7 @@ exports[`Timetable POST /edit S78 written Interested party comments should re-re
                             <label class="govuk-label govuk-date-input__label" for="lpa-questionnaire-due-date-month">Month</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="lpa-questionnaire-due-date-month" name="lpa-questionnaire-due-date-month"
-                            type="text" inputmode="numeric">
+                            type="text" value="10" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -7686,7 +7717,7 @@ exports[`Timetable POST /edit S78 written Interested party comments should re-re
                             <label class="govuk-label govuk-date-input__label" for="lpa-questionnaire-due-date-year">Year</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input govuk-date-input__input"
                             id="lpa-questionnaire-due-date-year" name="lpa-questionnaire-due-date-year"
-                            type="text" inputmode="numeric">
+                            type="text" value="2050" inputmode="numeric">
                         </div>
                     </div>
                 </div>
@@ -7702,7 +7733,7 @@ exports[`Timetable POST /edit S78 written Interested party comments should re-re
                             <label class="govuk-label govuk-date-input__label" for="lpa-statement-due-date-day">Day</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="lpa-statement-due-date-day" name="lpa-statement-due-date-day" type="text"
-                            inputmode="numeric">
+                            value="02" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -7710,7 +7741,7 @@ exports[`Timetable POST /edit S78 written Interested party comments should re-re
                             <label class="govuk-label govuk-date-input__label" for="lpa-statement-due-date-month">Month</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="lpa-statement-due-date-month" name="lpa-statement-due-date-month" type="text"
-                            inputmode="numeric">
+                            value="10" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -7718,7 +7749,7 @@ exports[`Timetable POST /edit S78 written Interested party comments should re-re
                             <label class="govuk-label govuk-date-input__label" for="lpa-statement-due-date-year">Year</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input govuk-date-input__input"
                             id="lpa-statement-due-date-year" name="lpa-statement-due-date-year" type="text"
-                            inputmode="numeric">
+                            value="2050" inputmode="numeric">
                         </div>
                     </div>
                 </div>
@@ -7738,7 +7769,7 @@ exports[`Timetable POST /edit S78 written Interested party comments should re-re
                             <label class="govuk-label govuk-date-input__label" for="ip-comments-due-date-day">Day</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input govuk-input--error"
                             id="ip-comments-due-date-day" name="ip-comments-due-date-day" type="text"
-                            inputmode="numeric">
+                            value="25" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -7746,7 +7777,7 @@ exports[`Timetable POST /edit S78 written Interested party comments should re-re
                             <label class="govuk-label govuk-date-input__label" for="ip-comments-due-date-month">Month</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input govuk-input--error"
                             id="ip-comments-due-date-month" name="ip-comments-due-date-month" type="text"
-                            inputmode="numeric">
+                            value="2" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -7754,7 +7785,7 @@ exports[`Timetable POST /edit S78 written Interested party comments should re-re
                             <label class="govuk-label govuk-date-input__label" for="ip-comments-due-date-year">Year</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input govuk-date-input__input govuk-input--error"
                             id="ip-comments-due-date-year" name="ip-comments-due-date-year" type="text"
-                            inputmode="numeric">
+                            value="1950" inputmode="numeric">
                         </div>
                     </div>
                 </div>
@@ -7770,7 +7801,7 @@ exports[`Timetable POST /edit S78 written Interested party comments should re-re
                             <label class="govuk-label govuk-date-input__label" for="final-comments-due-date-day">Day</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="final-comments-due-date-day" name="final-comments-due-date-day" type="text"
-                            inputmode="numeric">
+                            value="04" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -7778,7 +7809,7 @@ exports[`Timetable POST /edit S78 written Interested party comments should re-re
                             <label class="govuk-label govuk-date-input__label" for="final-comments-due-date-month">Month</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="final-comments-due-date-month" name="final-comments-due-date-month"
-                            type="text" inputmode="numeric">
+                            type="text" value="10" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -7786,7 +7817,7 @@ exports[`Timetable POST /edit S78 written Interested party comments should re-re
                             <label class="govuk-label govuk-date-input__label" for="final-comments-due-date-year">Year</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input govuk-date-input__input"
                             id="final-comments-due-date-year" name="final-comments-due-date-year" type="text"
-                            inputmode="numeric">
+                            value="2050" inputmode="numeric">
                         </div>
                     </div>
                 </div>
@@ -7836,7 +7867,7 @@ exports[`Timetable POST /edit S78 written Interested party comments should re-re
                             <label class="govuk-label govuk-date-input__label" for="lpa-questionnaire-due-date-day">Day</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="lpa-questionnaire-due-date-day" name="lpa-questionnaire-due-date-day"
-                            type="text" inputmode="numeric">
+                            type="text" value="01" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -7844,7 +7875,7 @@ exports[`Timetable POST /edit S78 written Interested party comments should re-re
                             <label class="govuk-label govuk-date-input__label" for="lpa-questionnaire-due-date-month">Month</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="lpa-questionnaire-due-date-month" name="lpa-questionnaire-due-date-month"
-                            type="text" inputmode="numeric">
+                            type="text" value="10" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -7852,7 +7883,7 @@ exports[`Timetable POST /edit S78 written Interested party comments should re-re
                             <label class="govuk-label govuk-date-input__label" for="lpa-questionnaire-due-date-year">Year</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input govuk-date-input__input"
                             id="lpa-questionnaire-due-date-year" name="lpa-questionnaire-due-date-year"
-                            type="text" inputmode="numeric">
+                            type="text" value="2050" inputmode="numeric">
                         </div>
                     </div>
                 </div>
@@ -7868,7 +7899,7 @@ exports[`Timetable POST /edit S78 written Interested party comments should re-re
                             <label class="govuk-label govuk-date-input__label" for="lpa-statement-due-date-day">Day</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="lpa-statement-due-date-day" name="lpa-statement-due-date-day" type="text"
-                            inputmode="numeric">
+                            value="02" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -7876,7 +7907,7 @@ exports[`Timetable POST /edit S78 written Interested party comments should re-re
                             <label class="govuk-label govuk-date-input__label" for="lpa-statement-due-date-month">Month</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="lpa-statement-due-date-month" name="lpa-statement-due-date-month" type="text"
-                            inputmode="numeric">
+                            value="10" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -7884,7 +7915,7 @@ exports[`Timetable POST /edit S78 written Interested party comments should re-re
                             <label class="govuk-label govuk-date-input__label" for="lpa-statement-due-date-year">Year</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input govuk-date-input__input"
                             id="lpa-statement-due-date-year" name="lpa-statement-due-date-year" type="text"
-                            inputmode="numeric">
+                            value="2050" inputmode="numeric">
                         </div>
                     </div>
                 </div>
@@ -7903,7 +7934,7 @@ exports[`Timetable POST /edit S78 written Interested party comments should re-re
                             <label class="govuk-label govuk-date-input__label" for="ip-comments-due-date-day">Day</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input govuk-input--error"
                             id="ip-comments-due-date-day" name="ip-comments-due-date-day" type="text"
-                            inputmode="numeric">
+                            value="29" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -7911,7 +7942,7 @@ exports[`Timetable POST /edit S78 written Interested party comments should re-re
                             <label class="govuk-label govuk-date-input__label" for="ip-comments-due-date-month">Month</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input govuk-input--error"
                             id="ip-comments-due-date-month" name="ip-comments-due-date-month" type="text"
-                            inputmode="numeric">
+                            value="2" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -7919,7 +7950,7 @@ exports[`Timetable POST /edit S78 written Interested party comments should re-re
                             <label class="govuk-label govuk-date-input__label" for="ip-comments-due-date-year">Year</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input govuk-date-input__input govuk-input--error"
                             id="ip-comments-due-date-year" name="ip-comments-due-date-year" type="text"
-                            inputmode="numeric">
+                            value="3000" inputmode="numeric">
                         </div>
                     </div>
                 </div>
@@ -7935,7 +7966,7 @@ exports[`Timetable POST /edit S78 written Interested party comments should re-re
                             <label class="govuk-label govuk-date-input__label" for="final-comments-due-date-day">Day</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="final-comments-due-date-day" name="final-comments-due-date-day" type="text"
-                            inputmode="numeric">
+                            value="04" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -7943,7 +7974,7 @@ exports[`Timetable POST /edit S78 written Interested party comments should re-re
                             <label class="govuk-label govuk-date-input__label" for="final-comments-due-date-month">Month</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="final-comments-due-date-month" name="final-comments-due-date-month"
-                            type="text" inputmode="numeric">
+                            type="text" value="10" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -7951,7 +7982,7 @@ exports[`Timetable POST /edit S78 written Interested party comments should re-re
                             <label class="govuk-label govuk-date-input__label" for="final-comments-due-date-year">Year</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input govuk-date-input__input"
                             id="final-comments-due-date-year" name="final-comments-due-date-year" type="text"
-                            inputmode="numeric">
+                            value="2050" inputmode="numeric">
                         </div>
                     </div>
                 </div>
@@ -8012,7 +8043,7 @@ exports[`Timetable POST /edit S78 written LPA questionnaire should re-render edi
                             <label class="govuk-label govuk-date-input__label" for="lpa-questionnaire-due-date-month">Month</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="lpa-questionnaire-due-date-month" name="lpa-questionnaire-due-date-month"
-                            type="text" inputmode="numeric">
+                            type="text" value="10" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -8020,7 +8051,7 @@ exports[`Timetable POST /edit S78 written LPA questionnaire should re-render edi
                             <label class="govuk-label govuk-date-input__label" for="lpa-questionnaire-due-date-year">Year</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input govuk-date-input__input"
                             id="lpa-questionnaire-due-date-year" name="lpa-questionnaire-due-date-year"
-                            type="text" inputmode="numeric">
+                            type="text" value="2050" inputmode="numeric">
                         </div>
                     </div>
                 </div>
@@ -8036,7 +8067,7 @@ exports[`Timetable POST /edit S78 written LPA questionnaire should re-render edi
                             <label class="govuk-label govuk-date-input__label" for="lpa-statement-due-date-day">Day</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="lpa-statement-due-date-day" name="lpa-statement-due-date-day" type="text"
-                            inputmode="numeric">
+                            value="02" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -8044,7 +8075,7 @@ exports[`Timetable POST /edit S78 written LPA questionnaire should re-render edi
                             <label class="govuk-label govuk-date-input__label" for="lpa-statement-due-date-month">Month</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="lpa-statement-due-date-month" name="lpa-statement-due-date-month" type="text"
-                            inputmode="numeric">
+                            value="10" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -8052,7 +8083,7 @@ exports[`Timetable POST /edit S78 written LPA questionnaire should re-render edi
                             <label class="govuk-label govuk-date-input__label" for="lpa-statement-due-date-year">Year</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input govuk-date-input__input"
                             id="lpa-statement-due-date-year" name="lpa-statement-due-date-year" type="text"
-                            inputmode="numeric">
+                            value="2050" inputmode="numeric">
                         </div>
                     </div>
                 </div>
@@ -8069,7 +8100,7 @@ exports[`Timetable POST /edit S78 written LPA questionnaire should re-render edi
                             <label class="govuk-label govuk-date-input__label" for="ip-comments-due-date-day">Day</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="ip-comments-due-date-day" name="ip-comments-due-date-day" type="text"
-                            inputmode="numeric">
+                            value="03" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -8077,7 +8108,7 @@ exports[`Timetable POST /edit S78 written LPA questionnaire should re-render edi
                             <label class="govuk-label govuk-date-input__label" for="ip-comments-due-date-month">Month</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="ip-comments-due-date-month" name="ip-comments-due-date-month" type="text"
-                            inputmode="numeric">
+                            value="10" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -8085,7 +8116,7 @@ exports[`Timetable POST /edit S78 written LPA questionnaire should re-render edi
                             <label class="govuk-label govuk-date-input__label" for="ip-comments-due-date-year">Year</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input govuk-date-input__input"
                             id="ip-comments-due-date-year" name="ip-comments-due-date-year" type="text"
-                            inputmode="numeric">
+                            value="2050" inputmode="numeric">
                         </div>
                     </div>
                 </div>
@@ -8101,7 +8132,7 @@ exports[`Timetable POST /edit S78 written LPA questionnaire should re-render edi
                             <label class="govuk-label govuk-date-input__label" for="final-comments-due-date-day">Day</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="final-comments-due-date-day" name="final-comments-due-date-day" type="text"
-                            inputmode="numeric">
+                            value="04" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -8109,7 +8140,7 @@ exports[`Timetable POST /edit S78 written LPA questionnaire should re-render edi
                             <label class="govuk-label govuk-date-input__label" for="final-comments-due-date-month">Month</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="final-comments-due-date-month" name="final-comments-due-date-month"
-                            type="text" inputmode="numeric">
+                            type="text" value="10" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -8117,7 +8148,7 @@ exports[`Timetable POST /edit S78 written LPA questionnaire should re-render edi
                             <label class="govuk-label govuk-date-input__label" for="final-comments-due-date-year">Year</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input govuk-date-input__input"
                             id="final-comments-due-date-year" name="final-comments-due-date-year" type="text"
-                            inputmode="numeric">
+                            value="2050" inputmode="numeric">
                         </div>
                     </div>
                 </div>
@@ -8170,7 +8201,7 @@ exports[`Timetable POST /edit S78 written LPA questionnaire should re-render edi
                             <label class="govuk-label govuk-date-input__label" for="lpa-questionnaire-due-date-day">Day</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="lpa-questionnaire-due-date-day" name="lpa-questionnaire-due-date-day"
-                            type="text" inputmode="numeric">
+                            type="text" value="10" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -8186,7 +8217,7 @@ exports[`Timetable POST /edit S78 written LPA questionnaire should re-render edi
                             <label class="govuk-label govuk-date-input__label" for="lpa-questionnaire-due-date-year">Year</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input govuk-date-input__input"
                             id="lpa-questionnaire-due-date-year" name="lpa-questionnaire-due-date-year"
-                            type="text" inputmode="numeric">
+                            type="text" value="2050" inputmode="numeric">
                         </div>
                     </div>
                 </div>
@@ -8202,7 +8233,7 @@ exports[`Timetable POST /edit S78 written LPA questionnaire should re-render edi
                             <label class="govuk-label govuk-date-input__label" for="lpa-statement-due-date-day">Day</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="lpa-statement-due-date-day" name="lpa-statement-due-date-day" type="text"
-                            inputmode="numeric">
+                            value="02" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -8210,7 +8241,7 @@ exports[`Timetable POST /edit S78 written LPA questionnaire should re-render edi
                             <label class="govuk-label govuk-date-input__label" for="lpa-statement-due-date-month">Month</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="lpa-statement-due-date-month" name="lpa-statement-due-date-month" type="text"
-                            inputmode="numeric">
+                            value="10" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -8218,7 +8249,7 @@ exports[`Timetable POST /edit S78 written LPA questionnaire should re-render edi
                             <label class="govuk-label govuk-date-input__label" for="lpa-statement-due-date-year">Year</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input govuk-date-input__input"
                             id="lpa-statement-due-date-year" name="lpa-statement-due-date-year" type="text"
-                            inputmode="numeric">
+                            value="2050" inputmode="numeric">
                         </div>
                     </div>
                 </div>
@@ -8235,7 +8266,7 @@ exports[`Timetable POST /edit S78 written LPA questionnaire should re-render edi
                             <label class="govuk-label govuk-date-input__label" for="ip-comments-due-date-day">Day</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="ip-comments-due-date-day" name="ip-comments-due-date-day" type="text"
-                            inputmode="numeric">
+                            value="03" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -8243,7 +8274,7 @@ exports[`Timetable POST /edit S78 written LPA questionnaire should re-render edi
                             <label class="govuk-label govuk-date-input__label" for="ip-comments-due-date-month">Month</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="ip-comments-due-date-month" name="ip-comments-due-date-month" type="text"
-                            inputmode="numeric">
+                            value="10" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -8251,7 +8282,7 @@ exports[`Timetable POST /edit S78 written LPA questionnaire should re-render edi
                             <label class="govuk-label govuk-date-input__label" for="ip-comments-due-date-year">Year</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input govuk-date-input__input"
                             id="ip-comments-due-date-year" name="ip-comments-due-date-year" type="text"
-                            inputmode="numeric">
+                            value="2050" inputmode="numeric">
                         </div>
                     </div>
                 </div>
@@ -8267,7 +8298,7 @@ exports[`Timetable POST /edit S78 written LPA questionnaire should re-render edi
                             <label class="govuk-label govuk-date-input__label" for="final-comments-due-date-day">Day</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="final-comments-due-date-day" name="final-comments-due-date-day" type="text"
-                            inputmode="numeric">
+                            value="04" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -8275,7 +8306,7 @@ exports[`Timetable POST /edit S78 written LPA questionnaire should re-render edi
                             <label class="govuk-label govuk-date-input__label" for="final-comments-due-date-month">Month</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="final-comments-due-date-month" name="final-comments-due-date-month"
-                            type="text" inputmode="numeric">
+                            type="text" value="10" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -8283,7 +8314,7 @@ exports[`Timetable POST /edit S78 written LPA questionnaire should re-render edi
                             <label class="govuk-label govuk-date-input__label" for="final-comments-due-date-year">Year</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input govuk-date-input__input"
                             id="final-comments-due-date-year" name="final-comments-due-date-year" type="text"
-                            inputmode="numeric">
+                            value="2050" inputmode="numeric">
                         </div>
                     </div>
                 </div>
@@ -8336,7 +8367,7 @@ exports[`Timetable POST /edit S78 written LPA questionnaire should re-render edi
                             <label class="govuk-label govuk-date-input__label" for="lpa-questionnaire-due-date-day">Day</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="lpa-questionnaire-due-date-day" name="lpa-questionnaire-due-date-day"
-                            type="text" inputmode="numeric">
+                            type="text" value="10" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -8344,7 +8375,7 @@ exports[`Timetable POST /edit S78 written LPA questionnaire should re-render edi
                             <label class="govuk-label govuk-date-input__label" for="lpa-questionnaire-due-date-month">Month</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="lpa-questionnaire-due-date-month" name="lpa-questionnaire-due-date-month"
-                            type="text" inputmode="numeric">
+                            type="text" value="12" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -8368,7 +8399,7 @@ exports[`Timetable POST /edit S78 written LPA questionnaire should re-render edi
                             <label class="govuk-label govuk-date-input__label" for="lpa-statement-due-date-day">Day</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="lpa-statement-due-date-day" name="lpa-statement-due-date-day" type="text"
-                            inputmode="numeric">
+                            value="02" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -8376,7 +8407,7 @@ exports[`Timetable POST /edit S78 written LPA questionnaire should re-render edi
                             <label class="govuk-label govuk-date-input__label" for="lpa-statement-due-date-month">Month</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="lpa-statement-due-date-month" name="lpa-statement-due-date-month" type="text"
-                            inputmode="numeric">
+                            value="10" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -8384,7 +8415,7 @@ exports[`Timetable POST /edit S78 written LPA questionnaire should re-render edi
                             <label class="govuk-label govuk-date-input__label" for="lpa-statement-due-date-year">Year</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input govuk-date-input__input"
                             id="lpa-statement-due-date-year" name="lpa-statement-due-date-year" type="text"
-                            inputmode="numeric">
+                            value="2050" inputmode="numeric">
                         </div>
                     </div>
                 </div>
@@ -8401,7 +8432,7 @@ exports[`Timetable POST /edit S78 written LPA questionnaire should re-render edi
                             <label class="govuk-label govuk-date-input__label" for="ip-comments-due-date-day">Day</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="ip-comments-due-date-day" name="ip-comments-due-date-day" type="text"
-                            inputmode="numeric">
+                            value="03" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -8409,7 +8440,7 @@ exports[`Timetable POST /edit S78 written LPA questionnaire should re-render edi
                             <label class="govuk-label govuk-date-input__label" for="ip-comments-due-date-month">Month</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="ip-comments-due-date-month" name="ip-comments-due-date-month" type="text"
-                            inputmode="numeric">
+                            value="10" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -8417,7 +8448,7 @@ exports[`Timetable POST /edit S78 written LPA questionnaire should re-render edi
                             <label class="govuk-label govuk-date-input__label" for="ip-comments-due-date-year">Year</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input govuk-date-input__input"
                             id="ip-comments-due-date-year" name="ip-comments-due-date-year" type="text"
-                            inputmode="numeric">
+                            value="2050" inputmode="numeric">
                         </div>
                     </div>
                 </div>
@@ -8433,7 +8464,7 @@ exports[`Timetable POST /edit S78 written LPA questionnaire should re-render edi
                             <label class="govuk-label govuk-date-input__label" for="final-comments-due-date-day">Day</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="final-comments-due-date-day" name="final-comments-due-date-day" type="text"
-                            inputmode="numeric">
+                            value="04" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -8441,7 +8472,7 @@ exports[`Timetable POST /edit S78 written LPA questionnaire should re-render edi
                             <label class="govuk-label govuk-date-input__label" for="final-comments-due-date-month">Month</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="final-comments-due-date-month" name="final-comments-due-date-month"
-                            type="text" inputmode="numeric">
+                            type="text" value="10" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -8449,7 +8480,7 @@ exports[`Timetable POST /edit S78 written LPA questionnaire should re-render edi
                             <label class="govuk-label govuk-date-input__label" for="final-comments-due-date-year">Year</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input govuk-date-input__input"
                             id="final-comments-due-date-year" name="final-comments-due-date-year" type="text"
-                            inputmode="numeric">
+                            value="2050" inputmode="numeric">
                         </div>
                     </div>
                 </div>
@@ -8502,7 +8533,7 @@ exports[`Timetable POST /edit S78 written LPA questionnaire should re-render edi
                             <label class="govuk-label govuk-date-input__label" for="lpa-questionnaire-due-date-day">Day</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input govuk-input--error"
                             id="lpa-questionnaire-due-date-day" name="lpa-questionnaire-due-date-day"
-                            type="text" inputmode="numeric">
+                            type="text" value="25" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -8510,7 +8541,7 @@ exports[`Timetable POST /edit S78 written LPA questionnaire should re-render edi
                             <label class="govuk-label govuk-date-input__label" for="lpa-questionnaire-due-date-month">Month</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input govuk-input--error"
                             id="lpa-questionnaire-due-date-month" name="lpa-questionnaire-due-date-month"
-                            type="text" inputmode="numeric">
+                            type="text" value="2" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -8518,7 +8549,7 @@ exports[`Timetable POST /edit S78 written LPA questionnaire should re-render edi
                             <label class="govuk-label govuk-date-input__label" for="lpa-questionnaire-due-date-year">Year</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input govuk-date-input__input govuk-input--error"
                             id="lpa-questionnaire-due-date-year" name="lpa-questionnaire-due-date-year"
-                            type="text" inputmode="numeric">
+                            type="text" value="1950" inputmode="numeric">
                         </div>
                     </div>
                 </div>
@@ -8534,7 +8565,7 @@ exports[`Timetable POST /edit S78 written LPA questionnaire should re-render edi
                             <label class="govuk-label govuk-date-input__label" for="lpa-statement-due-date-day">Day</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="lpa-statement-due-date-day" name="lpa-statement-due-date-day" type="text"
-                            inputmode="numeric">
+                            value="02" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -8542,7 +8573,7 @@ exports[`Timetable POST /edit S78 written LPA questionnaire should re-render edi
                             <label class="govuk-label govuk-date-input__label" for="lpa-statement-due-date-month">Month</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="lpa-statement-due-date-month" name="lpa-statement-due-date-month" type="text"
-                            inputmode="numeric">
+                            value="10" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -8550,7 +8581,7 @@ exports[`Timetable POST /edit S78 written LPA questionnaire should re-render edi
                             <label class="govuk-label govuk-date-input__label" for="lpa-statement-due-date-year">Year</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input govuk-date-input__input"
                             id="lpa-statement-due-date-year" name="lpa-statement-due-date-year" type="text"
-                            inputmode="numeric">
+                            value="2050" inputmode="numeric">
                         </div>
                     </div>
                 </div>
@@ -8567,7 +8598,7 @@ exports[`Timetable POST /edit S78 written LPA questionnaire should re-render edi
                             <label class="govuk-label govuk-date-input__label" for="ip-comments-due-date-day">Day</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="ip-comments-due-date-day" name="ip-comments-due-date-day" type="text"
-                            inputmode="numeric">
+                            value="03" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -8575,7 +8606,7 @@ exports[`Timetable POST /edit S78 written LPA questionnaire should re-render edi
                             <label class="govuk-label govuk-date-input__label" for="ip-comments-due-date-month">Month</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="ip-comments-due-date-month" name="ip-comments-due-date-month" type="text"
-                            inputmode="numeric">
+                            value="10" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -8583,7 +8614,7 @@ exports[`Timetable POST /edit S78 written LPA questionnaire should re-render edi
                             <label class="govuk-label govuk-date-input__label" for="ip-comments-due-date-year">Year</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input govuk-date-input__input"
                             id="ip-comments-due-date-year" name="ip-comments-due-date-year" type="text"
-                            inputmode="numeric">
+                            value="2050" inputmode="numeric">
                         </div>
                     </div>
                 </div>
@@ -8599,7 +8630,7 @@ exports[`Timetable POST /edit S78 written LPA questionnaire should re-render edi
                             <label class="govuk-label govuk-date-input__label" for="final-comments-due-date-day">Day</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="final-comments-due-date-day" name="final-comments-due-date-day" type="text"
-                            inputmode="numeric">
+                            value="04" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -8607,7 +8638,7 @@ exports[`Timetable POST /edit S78 written LPA questionnaire should re-render edi
                             <label class="govuk-label govuk-date-input__label" for="final-comments-due-date-month">Month</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="final-comments-due-date-month" name="final-comments-due-date-month"
-                            type="text" inputmode="numeric">
+                            type="text" value="10" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -8615,7 +8646,7 @@ exports[`Timetable POST /edit S78 written LPA questionnaire should re-render edi
                             <label class="govuk-label govuk-date-input__label" for="final-comments-due-date-year">Year</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input govuk-date-input__input"
                             id="final-comments-due-date-year" name="final-comments-due-date-year" type="text"
-                            inputmode="numeric">
+                            value="2050" inputmode="numeric">
                         </div>
                     </div>
                 </div>
@@ -8668,7 +8699,7 @@ exports[`Timetable POST /edit S78 written LPA questionnaire should re-render edi
                             <label class="govuk-label govuk-date-input__label" for="lpa-questionnaire-due-date-day">Day</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input govuk-input--error"
                             id="lpa-questionnaire-due-date-day" name="lpa-questionnaire-due-date-day"
-                            type="text" inputmode="numeric">
+                            type="text" value="29" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -8676,7 +8707,7 @@ exports[`Timetable POST /edit S78 written LPA questionnaire should re-render edi
                             <label class="govuk-label govuk-date-input__label" for="lpa-questionnaire-due-date-month">Month</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input govuk-input--error"
                             id="lpa-questionnaire-due-date-month" name="lpa-questionnaire-due-date-month"
-                            type="text" inputmode="numeric">
+                            type="text" value="2" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -8684,7 +8715,7 @@ exports[`Timetable POST /edit S78 written LPA questionnaire should re-render edi
                             <label class="govuk-label govuk-date-input__label" for="lpa-questionnaire-due-date-year">Year</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input govuk-date-input__input govuk-input--error"
                             id="lpa-questionnaire-due-date-year" name="lpa-questionnaire-due-date-year"
-                            type="text" inputmode="numeric">
+                            type="text" value="3000" inputmode="numeric">
                         </div>
                     </div>
                 </div>
@@ -8700,7 +8731,7 @@ exports[`Timetable POST /edit S78 written LPA questionnaire should re-render edi
                             <label class="govuk-label govuk-date-input__label" for="lpa-statement-due-date-day">Day</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="lpa-statement-due-date-day" name="lpa-statement-due-date-day" type="text"
-                            inputmode="numeric">
+                            value="02" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -8708,7 +8739,7 @@ exports[`Timetable POST /edit S78 written LPA questionnaire should re-render edi
                             <label class="govuk-label govuk-date-input__label" for="lpa-statement-due-date-month">Month</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="lpa-statement-due-date-month" name="lpa-statement-due-date-month" type="text"
-                            inputmode="numeric">
+                            value="10" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -8716,7 +8747,7 @@ exports[`Timetable POST /edit S78 written LPA questionnaire should re-render edi
                             <label class="govuk-label govuk-date-input__label" for="lpa-statement-due-date-year">Year</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input govuk-date-input__input"
                             id="lpa-statement-due-date-year" name="lpa-statement-due-date-year" type="text"
-                            inputmode="numeric">
+                            value="2050" inputmode="numeric">
                         </div>
                     </div>
                 </div>
@@ -8733,7 +8764,7 @@ exports[`Timetable POST /edit S78 written LPA questionnaire should re-render edi
                             <label class="govuk-label govuk-date-input__label" for="ip-comments-due-date-day">Day</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="ip-comments-due-date-day" name="ip-comments-due-date-day" type="text"
-                            inputmode="numeric">
+                            value="03" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -8741,7 +8772,7 @@ exports[`Timetable POST /edit S78 written LPA questionnaire should re-render edi
                             <label class="govuk-label govuk-date-input__label" for="ip-comments-due-date-month">Month</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="ip-comments-due-date-month" name="ip-comments-due-date-month" type="text"
-                            inputmode="numeric">
+                            value="10" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -8749,7 +8780,7 @@ exports[`Timetable POST /edit S78 written LPA questionnaire should re-render edi
                             <label class="govuk-label govuk-date-input__label" for="ip-comments-due-date-year">Year</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input govuk-date-input__input"
                             id="ip-comments-due-date-year" name="ip-comments-due-date-year" type="text"
-                            inputmode="numeric">
+                            value="2050" inputmode="numeric">
                         </div>
                     </div>
                 </div>
@@ -8765,7 +8796,7 @@ exports[`Timetable POST /edit S78 written LPA questionnaire should re-render edi
                             <label class="govuk-label govuk-date-input__label" for="final-comments-due-date-day">Day</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="final-comments-due-date-day" name="final-comments-due-date-day" type="text"
-                            inputmode="numeric">
+                            value="04" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -8773,7 +8804,7 @@ exports[`Timetable POST /edit S78 written LPA questionnaire should re-render edi
                             <label class="govuk-label govuk-date-input__label" for="final-comments-due-date-month">Month</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="final-comments-due-date-month" name="final-comments-due-date-month"
-                            type="text" inputmode="numeric">
+                            type="text" value="10" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -8781,7 +8812,7 @@ exports[`Timetable POST /edit S78 written LPA questionnaire should re-render edi
                             <label class="govuk-label govuk-date-input__label" for="final-comments-due-date-year">Year</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input govuk-date-input__input"
                             id="final-comments-due-date-year" name="final-comments-due-date-year" type="text"
-                            inputmode="numeric">
+                            value="2050" inputmode="numeric">
                         </div>
                     </div>
                 </div>
@@ -8831,7 +8862,7 @@ exports[`Timetable POST /edit S78 written Statements should re-render edit timet
                             <label class="govuk-label govuk-date-input__label" for="lpa-questionnaire-due-date-day">Day</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="lpa-questionnaire-due-date-day" name="lpa-questionnaire-due-date-day"
-                            type="text" inputmode="numeric">
+                            type="text" value="01" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -8839,7 +8870,7 @@ exports[`Timetable POST /edit S78 written Statements should re-render edit timet
                             <label class="govuk-label govuk-date-input__label" for="lpa-questionnaire-due-date-month">Month</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="lpa-questionnaire-due-date-month" name="lpa-questionnaire-due-date-month"
-                            type="text" inputmode="numeric">
+                            type="text" value="10" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -8847,7 +8878,7 @@ exports[`Timetable POST /edit S78 written Statements should re-render edit timet
                             <label class="govuk-label govuk-date-input__label" for="lpa-questionnaire-due-date-year">Year</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input govuk-date-input__input"
                             id="lpa-questionnaire-due-date-year" name="lpa-questionnaire-due-date-year"
-                            type="text" inputmode="numeric">
+                            type="text" value="2050" inputmode="numeric">
                         </div>
                     </div>
                 </div>
@@ -8873,7 +8904,7 @@ exports[`Timetable POST /edit S78 written Statements should re-render edit timet
                             <label class="govuk-label govuk-date-input__label" for="lpa-statement-due-date-month">Month</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="lpa-statement-due-date-month" name="lpa-statement-due-date-month" type="text"
-                            inputmode="numeric">
+                            value="10" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -8881,7 +8912,7 @@ exports[`Timetable POST /edit S78 written Statements should re-render edit timet
                             <label class="govuk-label govuk-date-input__label" for="lpa-statement-due-date-year">Year</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input govuk-date-input__input"
                             id="lpa-statement-due-date-year" name="lpa-statement-due-date-year" type="text"
-                            inputmode="numeric">
+                            value="2050" inputmode="numeric">
                         </div>
                     </div>
                 </div>
@@ -8898,7 +8929,7 @@ exports[`Timetable POST /edit S78 written Statements should re-render edit timet
                             <label class="govuk-label govuk-date-input__label" for="ip-comments-due-date-day">Day</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="ip-comments-due-date-day" name="ip-comments-due-date-day" type="text"
-                            inputmode="numeric">
+                            value="03" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -8906,7 +8937,7 @@ exports[`Timetable POST /edit S78 written Statements should re-render edit timet
                             <label class="govuk-label govuk-date-input__label" for="ip-comments-due-date-month">Month</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="ip-comments-due-date-month" name="ip-comments-due-date-month" type="text"
-                            inputmode="numeric">
+                            value="10" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -8914,7 +8945,7 @@ exports[`Timetable POST /edit S78 written Statements should re-render edit timet
                             <label class="govuk-label govuk-date-input__label" for="ip-comments-due-date-year">Year</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input govuk-date-input__input"
                             id="ip-comments-due-date-year" name="ip-comments-due-date-year" type="text"
-                            inputmode="numeric">
+                            value="2050" inputmode="numeric">
                         </div>
                     </div>
                 </div>
@@ -8930,7 +8961,7 @@ exports[`Timetable POST /edit S78 written Statements should re-render edit timet
                             <label class="govuk-label govuk-date-input__label" for="final-comments-due-date-day">Day</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="final-comments-due-date-day" name="final-comments-due-date-day" type="text"
-                            inputmode="numeric">
+                            value="04" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -8938,7 +8969,7 @@ exports[`Timetable POST /edit S78 written Statements should re-render edit timet
                             <label class="govuk-label govuk-date-input__label" for="final-comments-due-date-month">Month</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="final-comments-due-date-month" name="final-comments-due-date-month"
-                            type="text" inputmode="numeric">
+                            type="text" value="10" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -8946,7 +8977,7 @@ exports[`Timetable POST /edit S78 written Statements should re-render edit timet
                             <label class="govuk-label govuk-date-input__label" for="final-comments-due-date-year">Year</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input govuk-date-input__input"
                             id="final-comments-due-date-year" name="final-comments-due-date-year" type="text"
-                            inputmode="numeric">
+                            value="2050" inputmode="numeric">
                         </div>
                     </div>
                 </div>
@@ -8996,7 +9027,7 @@ exports[`Timetable POST /edit S78 written Statements should re-render edit timet
                             <label class="govuk-label govuk-date-input__label" for="lpa-questionnaire-due-date-day">Day</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="lpa-questionnaire-due-date-day" name="lpa-questionnaire-due-date-day"
-                            type="text" inputmode="numeric">
+                            type="text" value="01" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -9004,7 +9035,7 @@ exports[`Timetable POST /edit S78 written Statements should re-render edit timet
                             <label class="govuk-label govuk-date-input__label" for="lpa-questionnaire-due-date-month">Month</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="lpa-questionnaire-due-date-month" name="lpa-questionnaire-due-date-month"
-                            type="text" inputmode="numeric">
+                            type="text" value="10" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -9012,7 +9043,7 @@ exports[`Timetable POST /edit S78 written Statements should re-render edit timet
                             <label class="govuk-label govuk-date-input__label" for="lpa-questionnaire-due-date-year">Year</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input govuk-date-input__input"
                             id="lpa-questionnaire-due-date-year" name="lpa-questionnaire-due-date-year"
-                            type="text" inputmode="numeric">
+                            type="text" value="2050" inputmode="numeric">
                         </div>
                     </div>
                 </div>
@@ -9030,7 +9061,7 @@ exports[`Timetable POST /edit S78 written Statements should re-render edit timet
                             <label class="govuk-label govuk-date-input__label" for="lpa-statement-due-date-day">Day</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="lpa-statement-due-date-day" name="lpa-statement-due-date-day" type="text"
-                            inputmode="numeric">
+                            value="10" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -9046,7 +9077,7 @@ exports[`Timetable POST /edit S78 written Statements should re-render edit timet
                             <label class="govuk-label govuk-date-input__label" for="lpa-statement-due-date-year">Year</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input govuk-date-input__input"
                             id="lpa-statement-due-date-year" name="lpa-statement-due-date-year" type="text"
-                            inputmode="numeric">
+                            value="2050" inputmode="numeric">
                         </div>
                     </div>
                 </div>
@@ -9063,7 +9094,7 @@ exports[`Timetable POST /edit S78 written Statements should re-render edit timet
                             <label class="govuk-label govuk-date-input__label" for="ip-comments-due-date-day">Day</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="ip-comments-due-date-day" name="ip-comments-due-date-day" type="text"
-                            inputmode="numeric">
+                            value="03" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -9071,7 +9102,7 @@ exports[`Timetable POST /edit S78 written Statements should re-render edit timet
                             <label class="govuk-label govuk-date-input__label" for="ip-comments-due-date-month">Month</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="ip-comments-due-date-month" name="ip-comments-due-date-month" type="text"
-                            inputmode="numeric">
+                            value="10" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -9079,7 +9110,7 @@ exports[`Timetable POST /edit S78 written Statements should re-render edit timet
                             <label class="govuk-label govuk-date-input__label" for="ip-comments-due-date-year">Year</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input govuk-date-input__input"
                             id="ip-comments-due-date-year" name="ip-comments-due-date-year" type="text"
-                            inputmode="numeric">
+                            value="2050" inputmode="numeric">
                         </div>
                     </div>
                 </div>
@@ -9095,7 +9126,7 @@ exports[`Timetable POST /edit S78 written Statements should re-render edit timet
                             <label class="govuk-label govuk-date-input__label" for="final-comments-due-date-day">Day</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="final-comments-due-date-day" name="final-comments-due-date-day" type="text"
-                            inputmode="numeric">
+                            value="04" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -9103,7 +9134,7 @@ exports[`Timetable POST /edit S78 written Statements should re-render edit timet
                             <label class="govuk-label govuk-date-input__label" for="final-comments-due-date-month">Month</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="final-comments-due-date-month" name="final-comments-due-date-month"
-                            type="text" inputmode="numeric">
+                            type="text" value="10" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -9111,7 +9142,7 @@ exports[`Timetable POST /edit S78 written Statements should re-render edit timet
                             <label class="govuk-label govuk-date-input__label" for="final-comments-due-date-year">Year</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input govuk-date-input__input"
                             id="final-comments-due-date-year" name="final-comments-due-date-year" type="text"
-                            inputmode="numeric">
+                            value="2050" inputmode="numeric">
                         </div>
                     </div>
                 </div>
@@ -9161,7 +9192,7 @@ exports[`Timetable POST /edit S78 written Statements should re-render edit timet
                             <label class="govuk-label govuk-date-input__label" for="lpa-questionnaire-due-date-day">Day</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="lpa-questionnaire-due-date-day" name="lpa-questionnaire-due-date-day"
-                            type="text" inputmode="numeric">
+                            type="text" value="01" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -9169,7 +9200,7 @@ exports[`Timetable POST /edit S78 written Statements should re-render edit timet
                             <label class="govuk-label govuk-date-input__label" for="lpa-questionnaire-due-date-month">Month</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="lpa-questionnaire-due-date-month" name="lpa-questionnaire-due-date-month"
-                            type="text" inputmode="numeric">
+                            type="text" value="10" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -9177,7 +9208,7 @@ exports[`Timetable POST /edit S78 written Statements should re-render edit timet
                             <label class="govuk-label govuk-date-input__label" for="lpa-questionnaire-due-date-year">Year</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input govuk-date-input__input"
                             id="lpa-questionnaire-due-date-year" name="lpa-questionnaire-due-date-year"
-                            type="text" inputmode="numeric">
+                            type="text" value="2050" inputmode="numeric">
                         </div>
                     </div>
                 </div>
@@ -9195,7 +9226,7 @@ exports[`Timetable POST /edit S78 written Statements should re-render edit timet
                             <label class="govuk-label govuk-date-input__label" for="lpa-statement-due-date-day">Day</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="lpa-statement-due-date-day" name="lpa-statement-due-date-day" type="text"
-                            inputmode="numeric">
+                            value="10" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -9203,7 +9234,7 @@ exports[`Timetable POST /edit S78 written Statements should re-render edit timet
                             <label class="govuk-label govuk-date-input__label" for="lpa-statement-due-date-month">Month</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="lpa-statement-due-date-month" name="lpa-statement-due-date-month" type="text"
-                            inputmode="numeric">
+                            value="12" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -9228,7 +9259,7 @@ exports[`Timetable POST /edit S78 written Statements should re-render edit timet
                             <label class="govuk-label govuk-date-input__label" for="ip-comments-due-date-day">Day</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="ip-comments-due-date-day" name="ip-comments-due-date-day" type="text"
-                            inputmode="numeric">
+                            value="03" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -9236,7 +9267,7 @@ exports[`Timetable POST /edit S78 written Statements should re-render edit timet
                             <label class="govuk-label govuk-date-input__label" for="ip-comments-due-date-month">Month</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="ip-comments-due-date-month" name="ip-comments-due-date-month" type="text"
-                            inputmode="numeric">
+                            value="10" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -9244,7 +9275,7 @@ exports[`Timetable POST /edit S78 written Statements should re-render edit timet
                             <label class="govuk-label govuk-date-input__label" for="ip-comments-due-date-year">Year</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input govuk-date-input__input"
                             id="ip-comments-due-date-year" name="ip-comments-due-date-year" type="text"
-                            inputmode="numeric">
+                            value="2050" inputmode="numeric">
                         </div>
                     </div>
                 </div>
@@ -9260,7 +9291,7 @@ exports[`Timetable POST /edit S78 written Statements should re-render edit timet
                             <label class="govuk-label govuk-date-input__label" for="final-comments-due-date-day">Day</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="final-comments-due-date-day" name="final-comments-due-date-day" type="text"
-                            inputmode="numeric">
+                            value="04" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -9268,7 +9299,7 @@ exports[`Timetable POST /edit S78 written Statements should re-render edit timet
                             <label class="govuk-label govuk-date-input__label" for="final-comments-due-date-month">Month</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="final-comments-due-date-month" name="final-comments-due-date-month"
-                            type="text" inputmode="numeric">
+                            type="text" value="10" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -9276,7 +9307,7 @@ exports[`Timetable POST /edit S78 written Statements should re-render edit timet
                             <label class="govuk-label govuk-date-input__label" for="final-comments-due-date-year">Year</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input govuk-date-input__input"
                             id="final-comments-due-date-year" name="final-comments-due-date-year" type="text"
-                            inputmode="numeric">
+                            value="2050" inputmode="numeric">
                         </div>
                     </div>
                 </div>
@@ -9326,7 +9357,7 @@ exports[`Timetable POST /edit S78 written Statements should re-render edit timet
                             <label class="govuk-label govuk-date-input__label" for="lpa-questionnaire-due-date-day">Day</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="lpa-questionnaire-due-date-day" name="lpa-questionnaire-due-date-day"
-                            type="text" inputmode="numeric">
+                            type="text" value="01" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -9334,7 +9365,7 @@ exports[`Timetable POST /edit S78 written Statements should re-render edit timet
                             <label class="govuk-label govuk-date-input__label" for="lpa-questionnaire-due-date-month">Month</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="lpa-questionnaire-due-date-month" name="lpa-questionnaire-due-date-month"
-                            type="text" inputmode="numeric">
+                            type="text" value="10" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -9342,7 +9373,7 @@ exports[`Timetable POST /edit S78 written Statements should re-render edit timet
                             <label class="govuk-label govuk-date-input__label" for="lpa-questionnaire-due-date-year">Year</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input govuk-date-input__input"
                             id="lpa-questionnaire-due-date-year" name="lpa-questionnaire-due-date-year"
-                            type="text" inputmode="numeric">
+                            type="text" value="2050" inputmode="numeric">
                         </div>
                     </div>
                 </div>
@@ -9360,7 +9391,7 @@ exports[`Timetable POST /edit S78 written Statements should re-render edit timet
                             <label class="govuk-label govuk-date-input__label" for="lpa-statement-due-date-day">Day</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input govuk-input--error"
                             id="lpa-statement-due-date-day" name="lpa-statement-due-date-day" type="text"
-                            inputmode="numeric">
+                            value="25" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -9368,7 +9399,7 @@ exports[`Timetable POST /edit S78 written Statements should re-render edit timet
                             <label class="govuk-label govuk-date-input__label" for="lpa-statement-due-date-month">Month</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input govuk-input--error"
                             id="lpa-statement-due-date-month" name="lpa-statement-due-date-month" type="text"
-                            inputmode="numeric">
+                            value="2" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -9376,7 +9407,7 @@ exports[`Timetable POST /edit S78 written Statements should re-render edit timet
                             <label class="govuk-label govuk-date-input__label" for="lpa-statement-due-date-year">Year</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input govuk-date-input__input govuk-input--error"
                             id="lpa-statement-due-date-year" name="lpa-statement-due-date-year" type="text"
-                            inputmode="numeric">
+                            value="1950" inputmode="numeric">
                         </div>
                     </div>
                 </div>
@@ -9393,7 +9424,7 @@ exports[`Timetable POST /edit S78 written Statements should re-render edit timet
                             <label class="govuk-label govuk-date-input__label" for="ip-comments-due-date-day">Day</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="ip-comments-due-date-day" name="ip-comments-due-date-day" type="text"
-                            inputmode="numeric">
+                            value="03" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -9401,7 +9432,7 @@ exports[`Timetable POST /edit S78 written Statements should re-render edit timet
                             <label class="govuk-label govuk-date-input__label" for="ip-comments-due-date-month">Month</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="ip-comments-due-date-month" name="ip-comments-due-date-month" type="text"
-                            inputmode="numeric">
+                            value="10" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -9409,7 +9440,7 @@ exports[`Timetable POST /edit S78 written Statements should re-render edit timet
                             <label class="govuk-label govuk-date-input__label" for="ip-comments-due-date-year">Year</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input govuk-date-input__input"
                             id="ip-comments-due-date-year" name="ip-comments-due-date-year" type="text"
-                            inputmode="numeric">
+                            value="2050" inputmode="numeric">
                         </div>
                     </div>
                 </div>
@@ -9425,7 +9456,7 @@ exports[`Timetable POST /edit S78 written Statements should re-render edit timet
                             <label class="govuk-label govuk-date-input__label" for="final-comments-due-date-day">Day</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="final-comments-due-date-day" name="final-comments-due-date-day" type="text"
-                            inputmode="numeric">
+                            value="04" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -9433,7 +9464,7 @@ exports[`Timetable POST /edit S78 written Statements should re-render edit timet
                             <label class="govuk-label govuk-date-input__label" for="final-comments-due-date-month">Month</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="final-comments-due-date-month" name="final-comments-due-date-month"
-                            type="text" inputmode="numeric">
+                            type="text" value="10" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -9441,7 +9472,7 @@ exports[`Timetable POST /edit S78 written Statements should re-render edit timet
                             <label class="govuk-label govuk-date-input__label" for="final-comments-due-date-year">Year</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input govuk-date-input__input"
                             id="final-comments-due-date-year" name="final-comments-due-date-year" type="text"
-                            inputmode="numeric">
+                            value="2050" inputmode="numeric">
                         </div>
                     </div>
                 </div>
@@ -9491,7 +9522,7 @@ exports[`Timetable POST /edit S78 written Statements should re-render edit timet
                             <label class="govuk-label govuk-date-input__label" for="lpa-questionnaire-due-date-day">Day</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="lpa-questionnaire-due-date-day" name="lpa-questionnaire-due-date-day"
-                            type="text" inputmode="numeric">
+                            type="text" value="01" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -9499,7 +9530,7 @@ exports[`Timetable POST /edit S78 written Statements should re-render edit timet
                             <label class="govuk-label govuk-date-input__label" for="lpa-questionnaire-due-date-month">Month</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="lpa-questionnaire-due-date-month" name="lpa-questionnaire-due-date-month"
-                            type="text" inputmode="numeric">
+                            type="text" value="10" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -9507,7 +9538,7 @@ exports[`Timetable POST /edit S78 written Statements should re-render edit timet
                             <label class="govuk-label govuk-date-input__label" for="lpa-questionnaire-due-date-year">Year</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input govuk-date-input__input"
                             id="lpa-questionnaire-due-date-year" name="lpa-questionnaire-due-date-year"
-                            type="text" inputmode="numeric">
+                            type="text" value="2050" inputmode="numeric">
                         </div>
                     </div>
                 </div>
@@ -9525,7 +9556,7 @@ exports[`Timetable POST /edit S78 written Statements should re-render edit timet
                             <label class="govuk-label govuk-date-input__label" for="lpa-statement-due-date-day">Day</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input govuk-input--error"
                             id="lpa-statement-due-date-day" name="lpa-statement-due-date-day" type="text"
-                            inputmode="numeric">
+                            value="29" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -9533,7 +9564,7 @@ exports[`Timetable POST /edit S78 written Statements should re-render edit timet
                             <label class="govuk-label govuk-date-input__label" for="lpa-statement-due-date-month">Month</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input govuk-input--error"
                             id="lpa-statement-due-date-month" name="lpa-statement-due-date-month" type="text"
-                            inputmode="numeric">
+                            value="2" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -9541,7 +9572,7 @@ exports[`Timetable POST /edit S78 written Statements should re-render edit timet
                             <label class="govuk-label govuk-date-input__label" for="lpa-statement-due-date-year">Year</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input govuk-date-input__input govuk-input--error"
                             id="lpa-statement-due-date-year" name="lpa-statement-due-date-year" type="text"
-                            inputmode="numeric">
+                            value="3000" inputmode="numeric">
                         </div>
                     </div>
                 </div>
@@ -9558,7 +9589,7 @@ exports[`Timetable POST /edit S78 written Statements should re-render edit timet
                             <label class="govuk-label govuk-date-input__label" for="ip-comments-due-date-day">Day</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="ip-comments-due-date-day" name="ip-comments-due-date-day" type="text"
-                            inputmode="numeric">
+                            value="03" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -9566,7 +9597,7 @@ exports[`Timetable POST /edit S78 written Statements should re-render edit timet
                             <label class="govuk-label govuk-date-input__label" for="ip-comments-due-date-month">Month</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="ip-comments-due-date-month" name="ip-comments-due-date-month" type="text"
-                            inputmode="numeric">
+                            value="10" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -9574,7 +9605,7 @@ exports[`Timetable POST /edit S78 written Statements should re-render edit timet
                             <label class="govuk-label govuk-date-input__label" for="ip-comments-due-date-year">Year</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input govuk-date-input__input"
                             id="ip-comments-due-date-year" name="ip-comments-due-date-year" type="text"
-                            inputmode="numeric">
+                            value="2050" inputmode="numeric">
                         </div>
                     </div>
                 </div>
@@ -9590,7 +9621,7 @@ exports[`Timetable POST /edit S78 written Statements should re-render edit timet
                             <label class="govuk-label govuk-date-input__label" for="final-comments-due-date-day">Day</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="final-comments-due-date-day" name="final-comments-due-date-day" type="text"
-                            inputmode="numeric">
+                            value="04" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -9598,7 +9629,7 @@ exports[`Timetable POST /edit S78 written Statements should re-render edit timet
                             <label class="govuk-label govuk-date-input__label" for="final-comments-due-date-month">Month</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
                             id="final-comments-due-date-month" name="final-comments-due-date-month"
-                            type="text" inputmode="numeric">
+                            type="text" value="10" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -9606,7 +9637,7 @@ exports[`Timetable POST /edit S78 written Statements should re-render edit timet
                             <label class="govuk-label govuk-date-input__label" for="final-comments-due-date-year">Year</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input govuk-date-input__input"
                             id="final-comments-due-date-year" name="final-comments-due-date-year" type="text"
-                            inputmode="numeric">
+                            value="2050" inputmode="numeric">
                         </div>
                     </div>
                 </div>
@@ -9694,7 +9725,7 @@ exports[`Timetable POST /edit S78 written should re-render edit timetable page a
                             <label class="govuk-label govuk-date-input__label" for="lpa-statement-due-date-day">Day</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input govuk-input--error"
                             id="lpa-statement-due-date-day" name="lpa-statement-due-date-day" type="text"
-                            value="25" inputmode="numeric">
+                            inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -9702,7 +9733,7 @@ exports[`Timetable POST /edit S78 written should re-render edit timetable page a
                             <label class="govuk-label govuk-date-input__label" for="lpa-statement-due-date-month">Month</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input govuk-input--error"
                             id="lpa-statement-due-date-month" name="lpa-statement-due-date-month" type="text"
-                            value="7" inputmode="numeric">
+                            inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -9710,7 +9741,7 @@ exports[`Timetable POST /edit S78 written should re-render edit timetable page a
                             <label class="govuk-label govuk-date-input__label" for="lpa-statement-due-date-year">Year</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input govuk-date-input__input govuk-input--error"
                             id="lpa-statement-due-date-year" name="lpa-statement-due-date-year" type="text"
-                            value="2025" inputmode="numeric">
+                            inputmode="numeric">
                         </div>
                     </div>
                 </div>
@@ -9729,7 +9760,7 @@ exports[`Timetable POST /edit S78 written should re-render edit timetable page a
                             <label class="govuk-label govuk-date-input__label" for="ip-comments-due-date-day">Day</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input govuk-input--error"
                             id="ip-comments-due-date-day" name="ip-comments-due-date-day" type="text"
-                            value="26" inputmode="numeric">
+                            inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -9737,7 +9768,7 @@ exports[`Timetable POST /edit S78 written should re-render edit timetable page a
                             <label class="govuk-label govuk-date-input__label" for="ip-comments-due-date-month">Month</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input govuk-input--error"
                             id="ip-comments-due-date-month" name="ip-comments-due-date-month" type="text"
-                            value="8" inputmode="numeric">
+                            inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -9745,7 +9776,7 @@ exports[`Timetable POST /edit S78 written should re-render edit timetable page a
                             <label class="govuk-label govuk-date-input__label" for="ip-comments-due-date-year">Year</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input govuk-date-input__input govuk-input--error"
                             id="ip-comments-due-date-year" name="ip-comments-due-date-year" type="text"
-                            value="2025" inputmode="numeric">
+                            inputmode="numeric">
                         </div>
                     </div>
                 </div>
@@ -9763,7 +9794,7 @@ exports[`Timetable POST /edit S78 written should re-render edit timetable page a
                             <label class="govuk-label govuk-date-input__label" for="final-comments-due-date-day">Day</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input govuk-input--error"
                             id="final-comments-due-date-day" name="final-comments-due-date-day" type="text"
-                            value="7" inputmode="numeric">
+                            inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -9771,7 +9802,7 @@ exports[`Timetable POST /edit S78 written should re-render edit timetable page a
                             <label class="govuk-label govuk-date-input__label" for="final-comments-due-date-month">Month</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input govuk-input--error"
                             id="final-comments-due-date-month" name="final-comments-due-date-month"
-                            type="text" value="8" inputmode="numeric">
+                            type="text" inputmode="numeric">
                         </div>
                     </div>
                     <div class="govuk-date-input__item">
@@ -9779,7 +9810,7 @@ exports[`Timetable POST /edit S78 written should re-render edit timetable page a
                             <label class="govuk-label govuk-date-input__label" for="final-comments-due-date-year">Year</label>
                             <input class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input govuk-date-input__input govuk-input--error"
                             id="final-comments-due-date-year" name="final-comments-due-date-year" type="text"
-                            value="2025" inputmode="numeric">
+                            inputmode="numeric">
                         </div>
                     </div>
                 </div>
@@ -9801,11 +9832,11 @@ exports[`Timetable POST /edit S78 written should re-render edit timetable page w
                     <h2 class="govuk-error-summary__title"> There is a problem</h2>
                     <div class="govuk-error-summary__body">
                         <ul class="govuk-list govuk-error-summary__list">
-                            <li><a href="#lpa-statement-due-date-day">Statements due date must be after the LPA questionnaire due date on 27 June 2025</a>
+                            <li><a href="#lpa-statement-due-date-day">Statements due date must be after the LPA questionnaire due date on 5 October 2050</a>
                             </li>
-                            <li><a href="#ip-comments-due-date-day">Interested party comments due date must be after the LPA questionnaire due date on 27 June 2025</a>
+                            <li><a href="#ip-comments-due-date-day">Interested party comments due date must be after the LPA questionnaire due date on 5 October 2050</a>
                             </li>
-                            <li><a href="#final-comments-due-date-day">Final comments due date must be after the statements due date on 25 July 2025</a>
+                            <li><a href="#final-comments-due-date-day">Final comments due date must be after the statements due date on 4 October 2050</a>
                             </li>
                         </ul>
                     </div>
@@ -9860,7 +9891,7 @@ exports[`Timetable POST /edit S78 written should re-render edit timetable page w
                 <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">Statements due</legend>
                 <div id="lpa-statement-due-date-hint" class="govuk-hint">For example, 29 10 2024</div>
                 <p id="lpa-statement-due-date-error" class="govuk-error-message"><span class="govuk-visually-hidden">Error:</span> Statements due date must
-                    be after the LPA questionnaire due date on 27 June 2025</p>
+                    be after the LPA questionnaire due date on 5 October 2050</p>
                 <div class="govuk-date-input"
                 id="lpa-statement-due-date">
                     <div class="govuk-date-input__item">
@@ -9896,7 +9927,7 @@ exports[`Timetable POST /edit S78 written should re-render edit timetable page w
                 <div id="ip-comments-due-date-hint"
                 class="govuk-hint">For example, 29 10 2024</div>
                 <p id="ip-comments-due-date-error" class="govuk-error-message"><span class="govuk-visually-hidden">Error:</span> Interested party comments
-                    due date must be after the LPA questionnaire due date on 27 June 2025</p>
+                    due date must be after the LPA questionnaire due date on 5 October 2050</p>
                 <div                 class="govuk-date-input" id="ip-comments-due-date">
                     <div class="govuk-date-input__item">
                         <div class="govuk-form-group">
@@ -9930,7 +9961,7 @@ exports[`Timetable POST /edit S78 written should re-render edit timetable page w
                 <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">Final comments due</legend>
                 <div id="final-comments-due-date-hint" class="govuk-hint">For example, 29 10 2024</div>
                 <p id="final-comments-due-date-error" class="govuk-error-message"><span class="govuk-visually-hidden">Error:</span> Final comments due date
-                    must be after the statements due date on 25 July 2025</p>
+                    must be after the statements due date on 4 October 2050</p>
                 <div class="govuk-date-input"
                 id="final-comments-due-date">
                     <div class="govuk-date-input__item">

--- a/appeals/web/src/server/appeals/appeal-details/timetable/__tests__/timetable.test.js
+++ b/appeals/web/src/server/appeals/appeal-details/timetable/__tests__/timetable.test.js
@@ -608,13 +608,13 @@ describe('Timetable', () => {
 					'<h2 class="govuk-error-summary__title"> There is a problem</h2>'
 				);
 				expect(element.innerHTML).toContain(
-					'Statements due date must be after the LPA questionnaire due date on 27 June 2025</a>'
+					'Statements due date must be after the LPA questionnaire due date on 5 October 2050</a>'
 				);
 				expect(element.innerHTML).toContain(
-					'Interested party comments due date must be after the LPA questionnaire due date on 27 June 2025</a>'
+					'Interested party comments due date must be after the LPA questionnaire due date on 5 October 2050</a>'
 				);
 				expect(element.innerHTML).toContain(
-					'Final comments due date must be after the statements due date on 25 July 2025</a>'
+					'Final comments due date must be after the statements due date on 4 October 2050</a>'
 				);
 			});
 

--- a/appeals/web/src/server/appeals/appeal-details/timetable/timetable.controller.js
+++ b/appeals/web/src/server/appeals/appeal-details/timetable/timetable.controller.js
@@ -4,18 +4,12 @@ import { setAppealTimetables } from './timetable.service.js';
 import {
 	mapEditTimetablePage,
 	getAppealTimetableTypes,
-	getIdText,
 	getTimetableTypeText
 } from './timetable.mapper.js';
 import { addNotificationBannerToSession } from '#lib/session-utilities.js';
-import {
-	dateISOStringToDisplayDate,
-	dayMonthYearHourMinuteToISOString,
-	setTimeInTimeZone
-} from '#lib/dates.js';
+import { dateISOStringToDisplayDate } from '#lib/dates.js';
 import { renderCheckYourAnswersComponent } from '#lib/mappers/components/page-components/check-your-answers.js';
 import { simpleHtmlComponent } from '#lib/mappers/index.js';
-import { DEADLINE_HOUR, DEADLINE_MINUTE } from '@pins/appeals/constants/dates.js';
 
 /** @type {import('@pins/express').RequestHandler<Response>}  */
 export const getEditTimetable = async (request, response) => {
@@ -29,34 +23,10 @@ export const getEditTimetable = async (request, response) => {
  */
 export const postEditTimetable = async (request, response) => {
 	const { appealId } = request.params;
-	const { errors, session } = request;
+	const { errors } = request;
 	if (errors) {
 		return renderEditTimetable(request, response);
 	}
-
-	const appealDetails = request.currentAppeal;
-
-	session.appealTimetable = {};
-
-	const { appellantCase } = request.locals;
-
-	const timeTableTypes = getAppealTimetableTypes(appealDetails, appellantCase);
-
-	timeTableTypes.forEach((timetableType) => {
-		const idText = getIdText(timetableType);
-		const updatedDueDateDay = parseInt(request.body[`${idText}-due-date-day`], 10);
-		const updatedDueDateMonth = parseInt(request.body[`${idText}-due-date-month`], 10);
-		const updatedDueDateYear = parseInt(request.body[`${idText}-due-date-year`], 10);
-
-		const updatedDueDateDayString = `0${updatedDueDateDay}`.slice(-2);
-		const updatedDueDateMonthString = `0${updatedDueDateMonth}`.slice(-2);
-
-		session.appealTimetable[timetableType] = dayMonthYearHourMinuteToISOString({
-			year: updatedDueDateYear,
-			month: updatedDueDateMonthString,
-			day: updatedDueDateDayString
-		});
-	});
 
 	return response.redirect(`/appeals-service/appeal-details/${appealId}/timetable/edit/check`);
 };
@@ -170,12 +140,7 @@ export const postAppealTimetables = async (request, response) => {
 	const originalTimetable = appealDetails.appealTimetable || {};
 
 	for (const key of Object.keys(sessionTimetable)) {
-		const sessionDate = setTimeInTimeZone(
-			sessionTimetable[key],
-			DEADLINE_HOUR,
-			DEADLINE_MINUTE
-		).toISOString();
-		if (sessionDate === originalTimetable[key]) {
+		if (sessionTimetable[key] === originalTimetable[key]) {
 			delete sessionTimetable[key];
 		}
 	}

--- a/appeals/web/src/server/appeals/appeal-details/timetable/timetable.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/timetable/timetable.mapper.js
@@ -56,13 +56,14 @@ export const mapEditTimetablePage = (
 			name: `${idText}-due-date`,
 			id: `${idText}-due-date`,
 			namePrefix: `${idText}-due-date`,
-			value: currentDueDateDayMonthYear
-				? {
-						day: body[`${idText}-due-date-day`] ?? currentDueDateDayMonthYear?.day,
-						month: body[`${idText}-due-date-month`] ?? currentDueDateDayMonthYear?.month,
-						year: body[`${idText}-due-date-year`] ?? currentDueDateDayMonthYear?.year
-				  }
-				: {},
+			value: {
+				// @ts-ignore
+				day: body[`${idText}-due-date-day`] ?? currentDueDateDayMonthYear?.day,
+				// @ts-ignore
+				month: body[`${idText}-due-date-month`] ?? currentDueDateDayMonthYear?.month,
+				// @ts-ignore
+				year: body[`${idText}-due-date-year`] ?? currentDueDateDayMonthYear?.year
+			},
 			legendText: `${timetableTypeText} due`,
 			hint: `For example, ${getExampleDateHint(45)}`,
 			legendClasses:

--- a/appeals/web/src/server/appeals/appeal-details/timetable/timetable.validators.js
+++ b/appeals/web/src/server/appeals/appeal-details/timetable/timetable.validators.js
@@ -6,7 +6,10 @@ import {
 	extractAndProcessDateErrors,
 	createDateInputDateInFutureOfDateValidator
 } from '#lib/validators/date-input.validator.js';
-import { getAppealTimetableTypes } from './timetable.mapper.js';
+import { DEADLINE_HOUR } from '@pins/appeals/constants/dates.js';
+import { getAppealTimetableTypes, getIdText } from './timetable.mapper.js';
+import { DEADLINE_MINUTE } from '@pins/appeals/constants/dates.js';
+import { setTimeInTimeZone } from '#lib/dates.js';
 
 /**
  *
@@ -29,72 +32,120 @@ export const createTimetableValidators = (fieldName, label, fieldNameToCompare, 
  * @returns {import('express').RequestHandler[]}
  */
 export const selectTimetableValidators = (req) => {
-	const { currentAppeal } = req || {};
+	const { currentAppeal, session } = req || {};
 	/** @type {import('express').RequestHandler[]} */
 	const validatorsList = [];
 	const { appellantCase } = req.locals;
-	const timetableTypes = getAppealTimetableTypes(currentAppeal, appellantCase);
 
-	const validatorsMap = {
-		lpaQuestionnaireDueDate: {
-			id: 'lpa-questionnaire-due-date',
-			label: 'LPA questionnaire due date'
-		},
-		lpaStatementDueDate: {
-			id: 'lpa-statement-due-date',
-			label: 'Statements due date',
-			idToCompare: 'lpa-questionnaire-due-date',
-			labelToCompare: 'LPA questionnaire due date'
-		},
-		ipCommentsDueDate: {
-			id: 'ip-comments-due-date',
-			label: 'Interested party comments due date',
-			idToCompare: 'lpa-questionnaire-due-date',
-			labelToCompare: 'LPA questionnaire due date'
-		},
-		finalCommentsDueDate: {
-			id: 'final-comments-due-date',
-			label: 'Final comments due date',
-			idToCompare: 'lpa-statement-due-date',
-			labelToCompare: 'statements due date'
-		},
-		statementOfCommonGroundDueDate: {
-			id: 'statement-of-common-ground-due-date',
-			label: 'Statement of common ground due date'
-		},
-		planningObligationDueDate: {
-			id: 'planning-obligation-due-date',
-			label: 'Planning obligation due date'
-		}
-	};
+	let timetableTypes = getAppealTimetableTypes(currentAppeal, appellantCase);
+
+	const originalTimetable = currentAppeal.appealTimetable || {};
+	session.appealTimetable = session.appealTimetable || {};
 
 	timetableTypes.forEach((timetableType) => {
-		const validatorConfig = validatorsMap[timetableType];
-		const idToCompare = 'idToCompare' in validatorConfig ? validatorConfig.idToCompare : '';
-		const labelToCompare =
-			'labelToCompare' in validatorConfig ? validatorConfig.labelToCompare : '';
-		validatorsList.push(
-			...createTimetableValidators(
-				validatorConfig.id,
-				validatorConfig.label,
-				idToCompare,
-				labelToCompare
-			)
-		);
+		const idText = getIdText(timetableType);
+		const sessionDate = buildSessionDate(req, idText);
+
+		if (sessionDate !== originalTimetable[timetableType]) {
+			//only validate due dates that have changed
+			const validatorConfig = validatorsMap[timetableType];
+			const idToCompare = 'idToCompare' in validatorConfig ? validatorConfig.idToCompare : '';
+			const labelToCompare =
+				'labelToCompare' in validatorConfig ? validatorConfig.labelToCompare : '';
+			validatorsList.push(
+				...createTimetableValidators(
+					validatorConfig.id,
+					validatorConfig.label,
+					idToCompare,
+					labelToCompare
+				)
+			);
+		}
+		session.appealTimetable[timetableType] = sessionDate;
 	});
-	validatorsList.push(
-		extractAndProcessDateErrors({
-			fieldNamePrefix: 'lpa-questionnaire-due-date'
-		}),
-		extractAndProcessDateErrors({
-			fieldNamePrefix: 'lpa-statement-due-date'
-		}),
-		extractAndProcessDateErrors({
-			fieldNamePrefix: 'ip-comments-due-date'
-		}),
-		extractAndProcessDateErrors({
-			fieldNamePrefix: 'final-comments-due-date'
-		})
-	);
+	validatorsList.push(...getAllDateErrorExtractors());
 	return validatorsList;
+};
+
+const validatorsMap = {
+	lpaQuestionnaireDueDate: {
+		id: 'lpa-questionnaire-due-date',
+		label: 'LPA questionnaire due date'
+	},
+	lpaStatementDueDate: {
+		id: 'lpa-statement-due-date',
+		label: 'Statements due date',
+		idToCompare: 'lpa-questionnaire-due-date',
+		labelToCompare: 'LPA questionnaire due date'
+	},
+	ipCommentsDueDate: {
+		id: 'ip-comments-due-date',
+		label: 'Interested party comments due date',
+		idToCompare: 'lpa-questionnaire-due-date',
+		labelToCompare: 'LPA questionnaire due date'
+	},
+	finalCommentsDueDate: {
+		id: 'final-comments-due-date',
+		label: 'Final comments due date',
+		idToCompare: 'lpa-statement-due-date',
+		labelToCompare: 'statements due date'
+	},
+	statementOfCommonGroundDueDate: {
+		id: 'statement-of-common-ground-due-date',
+		label: 'Statement of common ground due date'
+	},
+	planningObligationDueDate: {
+		id: 'planning-obligation-due-date',
+		label: 'Planning obligation due date'
+	}
+};
+
+/**
+ * Builds a session date string from request body fields.
+ * @param {import('express').Request} req
+ * @param {string} idText
+ * @returns {string}
+ */
+const buildSessionDate = (req, idText) => {
+	const updatedDueDateDay = parseInt(req.body[`${idText}-due-date-day`], 10);
+	const updatedDueDateMonth = parseInt(req.body[`${idText}-due-date-month`], 10);
+	const updatedDueDateYear = parseInt(req.body[`${idText}-due-date-year`], 10);
+
+	const updatedDueDateDayString = `0${updatedDueDateDay}`.slice(-2);
+	const updatedDueDateMonthString = `0${updatedDueDateMonth}`.slice(-2);
+
+	if (!isValidDayMonthYear(updatedDueDateDay, updatedDueDateMonth, updatedDueDateYear)) {
+		return '';
+	}
+
+	// Build the local time string
+	const localDateString = `${updatedDueDateYear}-${updatedDueDateMonthString}-${updatedDueDateDayString}`;
+
+	const utcDate = setTimeInTimeZone(new Date(localDateString), DEADLINE_HOUR, DEADLINE_MINUTE);
+
+	return utcDate.toISOString();
+};
+
+/**
+ * Extracts and processes date errors for all timetable fields.
+ * @returns {import('express').RequestHandler[]}
+ */
+const getAllDateErrorExtractors = () => [
+	extractAndProcessDateErrors({ fieldNamePrefix: 'lpa-questionnaire-due-date' }),
+	extractAndProcessDateErrors({ fieldNamePrefix: 'lpa-statement-due-date' }),
+	extractAndProcessDateErrors({ fieldNamePrefix: 'ip-comments-due-date' }),
+	extractAndProcessDateErrors({ fieldNamePrefix: 'final-comments-due-date' }),
+	extractAndProcessDateErrors({ fieldNamePrefix: 'statement-of-common-ground-due-date' }),
+	extractAndProcessDateErrors({ fieldNamePrefix: 'planning-obligation-due-date' })
+];
+
+/**
+ * Checks if the provided day, month, and year are valid calendar values.
+ * @param {number} day
+ * @param {number} month
+ * @param {number} year
+ * @returns {boolean}
+ */
+const isValidDayMonthYear = (day, month, year) => {
+	return !!day && !!month && !!year && day >= 1 && day <= 31 && month >= 1 && month <= 12;
 };

--- a/appeals/web/src/server/lib/validators/date-input.validator.js
+++ b/appeals/web/src/server/lib/validators/date-input.validator.js
@@ -319,7 +319,11 @@ export const createDateInputDateInFutureOfDateValidator = (
 					{ day: compareDay, month: compareMonth, year: compareYear }
 				)
 			) {
-				const formattedDate = storedDateToCompare.toLocaleDateString('en-GB', {
+				const formattedDate = new Date(
+					compareYear,
+					compareMonth - 1,
+					compareDay
+				).toLocaleDateString('en-GB', {
 					day: 'numeric',
 					month: 'long',
 					year: 'numeric'


### PR DESCRIPTION
## Describe your changes
- Updating the validation logic so that only due dates that have been updated are validated against
- Moving sessionTimetable logic from the POST to the validator
- saving timetable dates in session as UTC  
- Fixed issues for showing errors for hearing timetable due dates
- Added a fix for [A2-3823](https://pins-ds.atlassian.net/browse/A2-3823) 

<!--
    Please include a summary of the change along with any relevant context.
    List any dependencies that are required for this change.
-->

## Issue ticket number and link

[Ticket](https://pins-ds.atlassian.net.mcas.ms/browse/A2-3782)


[A2-3823]: https://pins-ds.atlassian.net/browse/A2-3823?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ