### PR TITLE
fix(web): forget editEntrypoint when going to CYA page from address known page

### DIFF
--- a/appeals/web/src/server/appeals/appeal-details/hearing/setup/__tests__/change-hearing.test.js
+++ b/appeals/web/src/server/appeals/appeal-details/hearing/setup/__tests__/change-hearing.test.js
@@ -417,22 +417,26 @@ describe('change hearing', () => {
 		});
 
 		it('should redirect to /hearing/change/confirmation when answering no', async () => {
-			const response = await request.post(`${baseUrl}/${appealId}/hearing/change/address`).send({
-				addressKnown: 'no'
-			});
+			const response = await request
+				.post(`${baseUrl}/${appealId}/hearing/change/address?editEntrypoint=remove-me`)
+				.send({
+					addressKnown: 'no'
+				});
 
 			expect(response.statusCode).toBe(302);
 			expect(response.headers.location).toBe(`${baseUrl}/${appealId}/hearing/change/check-details`);
 		});
 
 		it('should redirect to /hearing/change/address-details when answering yes', async () => {
-			const response = await request.post(`${baseUrl}/${appealId}/hearing/change/address`).send({
-				addressKnown: 'yes'
-			});
+			const response = await request
+				.post(`${baseUrl}/${appealId}/hearing/change/address?editEntrypoint=keep-me`)
+				.send({
+					addressKnown: 'yes'
+				});
 
 			expect(response.statusCode).toBe(302);
 			expect(response.headers.location).toBe(
-				`${baseUrl}/${appealId}/hearing/change/address-details`
+				`${baseUrl}/${appealId}/hearing/change/address-details?editEntrypoint=keep-me`
 			);
 		});
 

--- a/appeals/web/src/server/appeals/appeal-details/hearing/setup/__tests__/set-up-hearing.test.js
+++ b/appeals/web/src/server/appeals/appeal-details/hearing/setup/__tests__/set-up-hearing.test.js
@@ -346,22 +346,26 @@ describe('set up hearing', () => {
 		});
 
 		it('should redirect to /hearing/setup/confirmation when answering no', async () => {
-			const response = await request.post(`${baseUrl}/${appealId}/hearing/setup/address`).send({
-				addressKnown: 'no'
-			});
+			const response = await request
+				.post(`${baseUrl}/${appealId}/hearing/setup/address?editEntrypoint=remove-me`)
+				.send({
+					addressKnown: 'no'
+				});
 
 			expect(response.statusCode).toBe(302);
 			expect(response.headers.location).toBe(`${baseUrl}/${appealId}/hearing/setup/check-details`);
 		});
 
 		it('should redirect to /hearing/setup/address-details when answering yes', async () => {
-			const response = await request.post(`${baseUrl}/${appealId}/hearing/setup/address`).send({
-				addressKnown: 'yes'
-			});
+			const response = await request
+				.post(`${baseUrl}/${appealId}/hearing/setup/address?editEntrypoint=keep-me`)
+				.send({
+					addressKnown: 'yes'
+				});
 
 			expect(response.statusCode).toBe(302);
 			expect(response.headers.location).toBe(
-				`${baseUrl}/${appealId}/hearing/setup/address-details`
+				`${baseUrl}/${appealId}/hearing/setup/address-details?editEntrypoint=keep-me`
 			);
 		});
 

--- a/appeals/web/src/server/appeals/appeal-details/hearing/setup/set-up-hearing.controller.js
+++ b/appeals/web/src/server/appeals/appeal-details/hearing/setup/set-up-hearing.controller.js
@@ -215,14 +215,13 @@ export const postHearingAddress = async (request, response) => {
 
 	const { appealId } = request.currentAppeal;
 
-	const nextStep = request.body.addressKnown === 'yes' ? 'address-details' : 'check-details';
+	const baseUrl = `/appeals-service/appeal-details/${appealId}/hearing/setup`;
+	const nextStepUrl =
+		request.body.addressKnown === 'yes'
+			? preserveQueryString(request, `${baseUrl}/address-details`)
+			: preserveQueryString(request, `${baseUrl}/check-details`, { exclude: ['editEntrypoint'] });
 
-	return response.redirect(
-		preserveQueryString(
-			request,
-			`/appeals-service/appeal-details/${appealId}/hearing/setup/${nextStep}`
-		)
-	);
+	return response.redirect(nextStepUrl);
 };
 
 /**
@@ -236,14 +235,13 @@ export const postChangeHearingAddress = async (request, response) => {
 
 	const { appealId } = request.currentAppeal;
 
-	const nextStep = request.body.addressKnown === 'yes' ? 'address-details' : 'check-details';
+	const baseUrl = `/appeals-service/appeal-details/${appealId}/hearing/change`;
+	const nextStepUrl =
+		request.body.addressKnown === 'yes'
+			? preserveQueryString(request, `${baseUrl}/address-details`)
+			: preserveQueryString(request, `${baseUrl}/check-details`, { exclude: ['editEntrypoint'] });
 
-	return response.redirect(
-		preserveQueryString(
-			request,
-			`/appeals-service/appeal-details/${appealId}/hearing/change/${nextStep}`
-		)
-	);
+	return response.redirect(nextStepUrl);
 };
 
 /**


### PR DESCRIPTION
## Describe your changes

Get rid of `editEntrypoint` query param when going to CYA page from address known page. This doesn't really affect the functionality but it makes the URLs cleaner.

## Issue ticket number and link

[A2-3157](https://pins-ds.atlassian.net/browse/A2-3157)
