### PR TITLE
feat(A2-3497): Adding empty states for shared ip comments for address comments columns

### DIFF
--- a/appeals/web/src/server/appeals/appeal-details/representations/interested-party-comments/__tests__/__snapshots__/shared-interested-party-comments.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/representations/interested-party-comments/__tests__/__snapshots__/shared-interested-party-comments.test.js.snap
@@ -43,18 +43,26 @@ exports[`Interested Party Comments (Shared/Published View) GET /interested-party
         </thead>
         <tbody class="govuk-table__body">
             <tr class="govuk-table__row">
-                <td class="govuk-table__cell"></td>
+                <td class="govuk-table__cell">No address</td>
                 <td class="govuk-table__cell">
                     <div class="pins-show-more" data-label="Read more" data-mode="html">Comment 1</div>
                 </td>
-                <td class="govuk-table__cell"></td>
+                <td class="govuk-table__cell">
+                    <ol class="govuk-list govuk-!-margin-top-0 govuk-!-padding-left-0">
+                        <li>No documents</li>
+                    </ol>
+                </td>
             </tr>
             <tr class="govuk-table__row">
-                <td class="govuk-table__cell"></td>
+                <td class="govuk-table__cell">No address</td>
                 <td class="govuk-table__cell">
                     <div class="pins-show-more" data-label="Read more" data-mode="html">Comment 2</div>
                 </td>
-                <td class="govuk-table__cell"></td>
+                <td class="govuk-table__cell">
+                    <ol class="govuk-list govuk-!-margin-top-0 govuk-!-padding-left-0">
+                        <li>No documents</li>
+                    </ol>
+                </td>
             </tr>
         </tbody>
     </table>

--- a/appeals/web/src/server/appeals/appeal-details/representations/interested-party-comments/interested-party-comments.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/representations/interested-party-comments/interested-party-comments.mapper.js
@@ -138,7 +138,7 @@ export function sharedIpCommentsPage(appealDetails, comments) {
 			],
 			rows: comments.map((comment) => [
 				{
-					html: addressToString(comment.represented.address)
+					html: addressToString(comment.represented.address) || 'No address'
 				},
 				{
 					html: '',
@@ -151,7 +151,7 @@ export function sharedIpCommentsPage(appealDetails, comments) {
 											comment.redactedRepresentation,
 											comment.originalRepresentation
 									  )
-									: comment.originalRepresentation,
+									: comment.originalRepresentation || 'No comment',
 								labelText: 'Read more'
 							}
 						}
@@ -159,14 +159,16 @@ export function sharedIpCommentsPage(appealDetails, comments) {
 				},
 				{
 					html: buildHtmlList({
-						items: comment.attachments.map(
-							(a) =>
-								`<a class="govuk-link" href="${mapDocumentDownloadUrl(
-									a.documentVersion.document.caseId,
-									a.documentVersion.document.guid,
-									a.documentVersion.document.name
-								)}" target="_blank">${a.documentVersion.document.name}</a>`
-						),
+						items: comment.attachments?.length
+							? comment.attachments.map(
+									(a) =>
+										`<a class="govuk-link" href="${mapDocumentDownloadUrl(
+											a.documentVersion.document.caseId,
+											a.documentVersion.document.guid,
+											a.documentVersion.document.name
+										)}" target="_blank">${a.documentVersion.document.name}</a>`
+							  )
+							: ['No documents'],
 						isOrderedList: true,
 						isNumberedList: comment.attachments.length > 1
 					})


### PR DESCRIPTION
## Describe your changes
- If address/comments/supporting docs are null then showing default values for shared ip comments page

<!--
    Please include a summary of the change along with any relevant context.
    List any dependencies that are required for this change.
-->

## Issue ticket number and link

[Ticket](https://pins-ds.atlassian.net.mcas.ms/browse/A2-3497)
