### PR TITLE
feat(web): adding lpaq for CAS (A2-3266)

### DIFF
--- a/appeals/api/src/database/seed/data-samples.js
+++ b/appeals/api/src/database/seed/data-samples.js
@@ -279,6 +279,20 @@ export function createLPAQuestionnaireForAppealType(appealTypeShorthand) {
 				reasonForNeighbourVisits: randomArrayValue(['test reason for neighbour visits text', null]),
 				designatedSiteNameCustom: 'A custom value'
 			};
+		case APPEAL_CASE_TYPE.ZP:
+			return {
+				siteSafetyDetails: 'There may be no mobile reception at the site',
+				siteAccessDetails:
+					'There is a tall hedge around the site which obstructs the view of the site',
+				inConservationArea: true,
+				isCorrectAppealType: true,
+				lpaStatement: null,
+				newConditionDetails: null,
+				lpaCostsAppliedFor: false,
+				lpaqCreatedDate: new Date(2023, 4, 9),
+				lpaQuestionnaireSubmittedDate: new Date(2023, 4, 9),
+				isGreenBelt: randomBool()
+			};
 		default:
 			return;
 	}

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/__tests__/__snapshots__/lpa-questionnaire.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/__tests__/__snapshots__/lpa-questionnaire.test.js.snap
@@ -185,7 +185,7 @@ exports[`LPA Questionnaire review GET / should render review outcome form fields
                 </div>
                 <div class="govuk-summary-card__content">
                     <dl class="govuk-summary-list" id="supplementary-documents-summary">
-                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Planning officer&#39;s report</dt>
+                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Planning officer’s report</dt>
                             <dd                             class="govuk-summary-list__value">
                                 <ul class="govuk-list pins-file-list">
                                     <li><span><div class="govuk-body govuk-!-margin-bottom-2">officersReport.docx</div><strong class="govuk-tag govuk-tag--yellow">Virus scanning</strong></span>
@@ -195,10 +195,10 @@ exports[`LPA Questionnaire review GET / should render review outcome form fields
                                 <dd class="govuk-summary-list__actions">
                                     <ul class="govuk-summary-list__actions-list">
                                         <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/manage-documents/7/"
-                                            data-cy="manage-officers-report">Change<span class="govuk-visually-hidden"> Planning officer&#39;s report (4. Planning officer’s report and supplementary documents)</span></a>
+                                            data-cy="manage-officers-report">Change<span class="govuk-visually-hidden"> Planning officer’s report (4. Planning officer’s report and supplementary documents)</span></a>
                                         </li>
                                         <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/add-documents/7"
-                                            data-cy="add-officers-report">Add<span class="govuk-visually-hidden"> Planning officer&#39;s report (4. Planning officer’s report and supplementary documents)</span></a>
+                                            data-cy="add-officers-report">Add<span class="govuk-visually-hidden"> Planning officer’s report (4. Planning officer’s report and supplementary documents)</span></a>
                                         </li>
                                     </ul>
                                 </dd>
@@ -363,6 +363,333 @@ exports[`LPA Questionnaire review GET / should render review outcome form fields
         <button type="submit" class="govuk-button" data-module="govuk-button">Confirm</button>
         </form>
     </div>
+    </div>
+</main>"
+`;
+
+exports[`LPA Questionnaire review GET / should render the CAS planning LPA Questionnaire page with the expected content 1`] = `
+"<main class="govuk-main-wrapper" id="main-content">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Appeal 351062</span>
+            <h1 class="govuk-heading-xl govuk-!-margin-bottom-3">LPA questionnaire</h1>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
+            <dl class="govuk-summary-list govuk-summary-list--no-border">
+                <div class="govuk-summary-list__row appeal-site-address"><dt class="govuk-summary-list__key"> Site address</dt>
+                    <dd class="govuk-summary-list__value">21 The Pavement, Wandsworth, SW4 0HY</dd>
+                </div>
+                <div class="govuk-summary-list__row appeal-local-planning-authority"><dt class="govuk-summary-list__key"> LPA</dt>
+                    <dd class="govuk-summary-list__value">Wiltshire Council</dd>
+                </div>
+            </dl>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
+            <div class="govuk-summary-card">
+                <div class="govuk-summary-card__title-wrapper">
+                    <h2 class="govuk-summary-card__title"> 1. Constraints, designations and other issues</h2>
+                </div>
+                <div class="govuk-summary-card__content">
+                    <dl class="govuk-summary-list" id="constraints-summary">
+                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Is CAS planning the correct type of appeal?</dt>
+                            <dd                             class="govuk-summary-list__value">Yes</dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/3/lpa-questionnaire/1/is-correct-appeal-type/change"
+                                    data-cy="change-is-correct-appeal-type">Change<span class="govuk-visually-hidden"> Is CAS planning the correct type of appeal? (1. Constraints, designations and other issues)</span></a>
+                                </dd>
+                        </div>
+                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Does the development affect the setting of listed buildings?</dt>
+                            <dd                             class="govuk-summary-list__value">
+                                <ul class="govuk-list">
+                                    <li><a href='https://historicengland.org.uk/listing/the-list/list-entry/123456'
+                                        class="govuk-link" aria-label="Listed building number 1 2 3 4 5 6">123456</a>
+                                    </li>
+                                    <li><a href='https://historicengland.org.uk/listing/the-list/list-entry/123457'
+                                        class="govuk-link" aria-label="Listed building number 1 2 3 4 5 7">123457</a>
+                                    </li>
+                                </ul>
+                                </dd>
+                                <dd class="govuk-summary-list__actions">
+                                    <ul class="govuk-summary-list__actions-list">
+                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/3/lpa-questionnaire/1/affected-listed-buildings/manage"
+                                            lpaQuestionnaireData-cy="manage-affected-listed-building">Change<span class="govuk-visually-hidden"> affected listed building (1. Constraints, designations and other issues)</span></a>
+                                        </li>
+                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/3/lpa-questionnaire/1/affected-listed-buildings/add"
+                                            lpaQuestionnaireData-cy="add-affected-listed-building">Add<span class="govuk-visually-hidden"> affected listed building (1. Constraints, designations and other issues)</span></a>
+                                        </li>
+                                    </ul>
+                                </dd>
+                        </div>
+                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Conservation area map and guidance</dt>
+                            <dd                             class="govuk-summary-list__value">
+                                <ul class="govuk-list pins-file-list">
+                                    <li><span><div class="govuk-body govuk-!-margin-bottom-2">conservationAreaMap.docx</div><strong class="govuk-tag govuk-tag--yellow">Virus scanning</strong></span>
+                                    </li>
+                                </ul>
+                                </dd>
+                                <dd class="govuk-summary-list__actions">
+                                    <ul class="govuk-summary-list__actions-list">
+                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/1/manage-documents/1/"
+                                            data-cy="manage-conservation-area-map-and-guidance">Change<span class="govuk-visually-hidden"> Conservation area map and guidance (1. Constraints, designations and other issues)</span></a>
+                                        </li>
+                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/1/add-documents/1"
+                                            data-cy="add-conservation-area-map-and-guidance">Add<span class="govuk-visually-hidden"> Conservation area map and guidance (1. Constraints, designations and other issues)</span></a>
+                                        </li>
+                                    </ul>
+                                </dd>
+                        </div>
+                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Green belt</dt>
+                            <dd class="govuk-summary-list__value"></dd>
+                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/3/lpa-questionnaire/1/green-belt/change/lpa"
+                                data-cy="change-site-within-green-belt">Change<span class="govuk-visually-hidden"> Green belt (1. Constraints, designations and other issues)</span></a>
+                            </dd>
+                        </div>
+                    </dl>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
+            <div class="govuk-summary-card">
+                <div class="govuk-summary-card__title-wrapper">
+                    <h2 class="govuk-summary-card__title"> 2. Notifying relevant parties</h2>
+                </div>
+                <div class="govuk-summary-card__content">
+                    <dl class="govuk-summary-list" id="notifications-summary">
+                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Who did you notify about this application?</dt>
+                            <dd                             class="govuk-summary-list__value">
+                                <ul class="govuk-list pins-file-list">
+                                    <li><span><div class="govuk-body govuk-!-margin-bottom-2">notifyingParties.docx</div><strong class="govuk-tag govuk-tag--yellow">Virus scanning</strong></span>
+                                    </li>
+                                </ul>
+                                </dd>
+                                <dd class="govuk-summary-list__actions">
+                                    <ul class="govuk-summary-list__actions-list">
+                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/1/manage-documents/2/"
+                                            data-cy="manage-notifying-parties">Change<span class="govuk-visually-hidden"> Who did you notify about this application? (2. Notifying relevant parties)</span></a>
+                                        </li>
+                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/1/add-documents/2"
+                                            data-cy="add-notifying-parties">Add<span class="govuk-visually-hidden"> Who did you notify about this application? (2. Notifying relevant parties)</span></a>
+                                        </li>
+                                    </ul>
+                                </dd>
+                        </div>
+                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> How did you notify relevant parties about this application?</dt>
+                            <dd                             class="govuk-summary-list__value">
+                                <ul class="pins-summary-list-sublist">
+                                    <li>A site notice</li>
+                                    <li>Letter/email to interested parties</li>
+                                </ul>
+                                </dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/3/lpa-questionnaire/1/notification-methods/change"
+                                    data-cy="change-notification-methods">Change<span class="govuk-visually-hidden"> How did you notify relevant parties about this application? (2. Notifying relevant parties)</span></a>
+                                </dd>
+                        </div>
+                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Site notice</dt>
+                            <dd class="govuk-summary-list__value">No documents</dd>
+                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="#" data-cy="add-site-notice">Add<span class="govuk-visually-hidden"> Site notice (2. Notifying relevant parties)</span></a>
+                            </dd>
+                        </div>
+                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Letter or email notification</dt>
+                            <dd                             class="govuk-summary-list__value">No documents</dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="#" data-cy="add-letter-or-email-notification">Add<span class="govuk-visually-hidden"> Letter or email notification (2. Notifying relevant parties)</span></a>
+                                </dd>
+                        </div>
+                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Press advertisement</dt>
+                            <dd class="govuk-summary-list__value">No documents</dd>
+                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="#" data-cy="add-press-advert-notification">Add<span class="govuk-visually-hidden"> Press advertisement (2. Notifying relevant parties)</span></a>
+                            </dd>
+                        </div>
+                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Appeal notification letter</dt>
+                            <dd                             class="govuk-summary-list__value">No documents</dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="#" data-cy="add-appeal-notification-letter">Add<span class="govuk-visually-hidden"> Appeal notification letter (2. Notifying relevant parties)</span></a>
+                                </dd>
+                        </div>
+                    </dl>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
+            <div class="govuk-summary-card">
+                <div class="govuk-summary-card__title-wrapper">
+                    <h2 class="govuk-summary-card__title"> 3. Consultation responses and representations</h2>
+                </div>
+                <div class="govuk-summary-card__content">
+                    <dl class="govuk-summary-list" id="representations-summary">
+                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Representations from members of the public or other parties</dt>
+                            <dd                             class="govuk-summary-list__value">
+                                <ul class="govuk-list pins-file-list">
+                                    <li><span><div class="govuk-body govuk-!-margin-bottom-2">representations.docx</div><strong class="govuk-tag govuk-tag--yellow">Virus scanning</strong></span>
+                                    </li>
+                                </ul>
+                                </dd>
+                                <dd class="govuk-summary-list__actions">
+                                    <ul class="govuk-summary-list__actions-list">
+                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/1/manage-documents/6/"
+                                            data-cy="manage-representations-from-other-parties">Change<span class="govuk-visually-hidden"> Representations from members of the public or other parties (3. Consultation responses and representations)</span></a>
+                                        </li>
+                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/1/add-documents/6"
+                                            data-cy="add-representations-from-other-parties">Add<span class="govuk-visually-hidden"> Representations from members of the public or other parties (3. Consultation responses and representations)</span></a>
+                                        </li>
+                                    </ul>
+                                </dd>
+                        </div>
+                    </dl>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
+            <div class="govuk-summary-card">
+                <div class="govuk-summary-card__title-wrapper">
+                    <h2 class="govuk-summary-card__title"> 4. Planning officer’s report and supplementary documents</h2>
+                </div>
+                <div class="govuk-summary-card__content">
+                    <dl class="govuk-summary-list" id="supplementary-documents-summary">
+                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Planning officer’s report</dt>
+                            <dd                             class="govuk-summary-list__value">
+                                <ul class="govuk-list pins-file-list">
+                                    <li><span><div class="govuk-body govuk-!-margin-bottom-2">officersReport.docx</div><strong class="govuk-tag govuk-tag--yellow">Virus scanning</strong></span>
+                                    </li>
+                                </ul>
+                                </dd>
+                                <dd class="govuk-summary-list__actions">
+                                    <ul class="govuk-summary-list__actions-list">
+                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/1/manage-documents/7/"
+                                            data-cy="manage-officers-report">Change<span class="govuk-visually-hidden"> Planning officer’s report (4. Planning officer’s report and supplementary documents)</span></a>
+                                        </li>
+                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/1/add-documents/7"
+                                            data-cy="add-officers-report">Add<span class="govuk-visually-hidden"> Planning officer’s report (4. Planning officer’s report and supplementary documents)</span></a>
+                                        </li>
+                                    </ul>
+                                </dd>
+                        </div>
+                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Relevant policies from statutory development plan</dt>
+                            <dd                             class="govuk-summary-list__value">No documents</dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="#" data-cy="add-development-plan-policies">Add<span class="govuk-visually-hidden"> Relevant policies from statutory development plan (4. Planning officer’s report and supplementary documents)</span></a>
+                                </dd>
+                        </div>
+                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Supplementary planning documents</dt>
+                            <dd                             class="govuk-summary-list__value">No documents</dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="#" data-cy="add-supplementary-planning">Add<span class="govuk-visually-hidden"> Supplementary planning documents (4. Planning officer’s report and supplementary documents)</span></a>
+                                </dd>
+                        </div>
+                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Emerging plan relevant to appeal</dt>
+                            <dd                             class="govuk-summary-list__value">No documents</dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="#" data-cy="add-emerging-plan">Add<span class="govuk-visually-hidden"> Emerging plan relevant to appeal (4. Planning officer’s report and supplementary documents)</span></a>
+                                </dd>
+                        </div>
+                    </dl>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
+            <div class="govuk-summary-card">
+                <div class="govuk-summary-card__title-wrapper">
+                    <h2 class="govuk-summary-card__title"> 5. Site access</h2>
+                </div>
+                <div class="govuk-summary-card__content">
+                    <dl class="govuk-summary-list" id="site-access-summary">
+                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Might the inspector need access to the appellant’s land or property?</dt>
+                            <dd                             class="govuk-summary-list__value"><span>No answer provided</span>
+                                </dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/3/lpa-questionnaire/1/inspector-access/change/lpa"
+                                    data-cy="change-does-site-require-inspector-access">Change<span class="govuk-visually-hidden"> Might the inspector need access to the appellant’s land or property? (5. Site access)</span></a>
+                                </dd>
+                        </div>
+                        <div class="govuk-summary-list__row appeal-neighbouring-sites-inspector"><dt class="govuk-summary-list__key"> Address of the neighbour’s land or property</dt>
+                            <dd                             class="govuk-summary-list__value">
+                                <ul class="govuk-list govuk-list--bullet">
+                                    <li>1 Grove Cottage, Shotesham Road, Woodton, Devon, NR35 2ND</li>
+                                </ul>
+                                </dd>
+                                <dd class="govuk-summary-list__actions">
+                                    <ul class="govuk-summary-list__actions-list">
+                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/3/lpa-questionnaire/1/neighbouring-sites/manage">Manage<span class="govuk-visually-hidden"> Neighbouring sites (L P A) (5. Site access)</span></a>
+                                        </li>
+                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/3/lpa-questionnaire/1/neighbouring-sites/add/lpa"
+                                            data-cy="add-neighbouring-site-lpa">Add<span class="govuk-visually-hidden"> Neighbouring sites (LPA) (5. Site access)</span></a>
+                                        </li>
+                                    </ul>
+                                </dd>
+                        </div>
+                        <div class="govuk-summary-list__row lpa-health-and-safety"><dt class="govuk-summary-list__key"> Are there any potential safety risks?</dt>
+                            <dd                             class="govuk-summary-list__value"><span>No answer provided</span>
+                                </dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/3/lpa-questionnaire/1/safety-risks/change/lpa"
+                                    data-cy="change-health-and-safety">Change<span class="govuk-visually-hidden"> Are there any potential safety risks? (5. Site access)</span></a>
+                                </dd>
+                        </div>
+                    </dl>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
+            <div class="govuk-summary-card">
+                <div class="govuk-summary-card__title-wrapper">
+                    <h2 class="govuk-summary-card__title"> 6. Appeal process</h2>
+                </div>
+                <div class="govuk-summary-card__content">
+                    <dl class="govuk-summary-list" id="appeal-process-summary">
+                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Are there any other ongoing appeals next to, or close to the site?</dt>
+                            <dd                             class="govuk-summary-list__value"><span>No</span>
+                                </dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/3/lpa-questionnaire/1/other-appeals/add"
+                                    data-cy="add-related-appeals">Add<span class="govuk-visually-hidden"> Related appeals (6. Appeal process)</span></a>
+                                </dd>
+                        </div>
+                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Are there any new conditions?</dt>
+                            <dd                             class="govuk-summary-list__value"><span>Yes</span>
+                                <br><span>Some extra conditions</span>
+                                </dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/3/lpa-questionnaire/1/extra-conditions/change">Change<span class="govuk-visually-hidden"> Are there any new conditions? (6. Appeal process)</span></a>
+                                </dd>
+                        </div>
+                    </dl>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
+            <div class="govuk-summary-card">
+                <div class="govuk-summary-card__title-wrapper">
+                    <h2 class="govuk-summary-card__title"> Additional documents</h2>
+                    <ul class="govuk-summary-card__actions">
+                        <li class="govuk-summary-card__action"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/1/manage-documents/21/">Manage<span class="govuk-visually-hidden"> additional documents (Additional documents)</span></a>
+                        </li>
+                        <li class="govuk-summary-card__action"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/1/add-documents/21">Add<span class="govuk-visually-hidden"> additional documents (Additional documents)</span></a>
+                        </li>
+                    </ul>
+                </div>
+                <div class="govuk-summary-card__content">
+                    <dl class="govuk-summary-list pins-summary-list--fullwidth-value">
+                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key govuk-visually-hidden"> Additional documents</dt>
+                            <dd                             class="govuk-summary-list__value">
+                                <ol class="govuk-list govuk-list--number pins-file-list">
+                                    <li class="govuk-!-margin-bottom-0 govuk-!-padding-bottom-2 pins-border-bottom"><span><a href='/documents/1/download/undefined/ph0.jpg' data-cy='document-undefined' target="_blank" class="govuk-link">ph0.jpg</a></span>
+                                    </li>
+                                    <li class="govuk-!-margin-bottom-0 govuk-!-padding-top-2 govuk-!-padding-bottom-2 pins-border-bottom"><span><a href='/documents/1/download/undefined/ph1.jpg' data-cy='document-undefined' target="_blank" class="govuk-link">ph1.jpg</a></span>
+                                    </li>
+                                    <li class="govuk-!-margin-bottom-0 govuk-!-padding-top-2 govuk-!-padding-bottom-2"><span><a href='/documents/1/download/undefined/ph2.jpg' data-cy='document-undefined' target="_blank" class="govuk-link">ph2.jpg</a></span>
+                                    </li>
+                                </ol>
+                                </dd>
+                        </div>
+                    </dl>
+                </div>
+            </div>
+        </div>
     </div>
 </main>"
 `;
@@ -552,7 +879,7 @@ exports[`LPA Questionnaire review GET / should render the Householder LPA Questi
                 </div>
                 <div class="govuk-summary-card__content">
                     <dl class="govuk-summary-list" id="supplementary-documents-summary">
-                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Planning officer&#39;s report</dt>
+                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Planning officer’s report</dt>
                             <dd                             class="govuk-summary-list__value">
                                 <ul class="govuk-list pins-file-list">
                                     <li><span><div class="govuk-body govuk-!-margin-bottom-2">officersReport.docx</div><strong class="govuk-tag govuk-tag--yellow">Virus scanning</strong></span>
@@ -562,10 +889,10 @@ exports[`LPA Questionnaire review GET / should render the Householder LPA Questi
                                 <dd class="govuk-summary-list__actions">
                                     <ul class="govuk-summary-list__actions-list">
                                         <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/manage-documents/7/"
-                                            data-cy="manage-officers-report">Change<span class="govuk-visually-hidden"> Planning officer&#39;s report (4. Planning officer’s report and supplementary documents)</span></a>
+                                            data-cy="manage-officers-report">Change<span class="govuk-visually-hidden"> Planning officer’s report (4. Planning officer’s report and supplementary documents)</span></a>
                                         </li>
                                         <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/add-documents/7"
-                                            data-cy="add-officers-report">Add<span class="govuk-visually-hidden"> Planning officer&#39;s report (4. Planning officer’s report and supplementary documents)</span></a>
+                                            data-cy="add-officers-report">Add<span class="govuk-visually-hidden"> Planning officer’s report (4. Planning officer’s report and supplementary documents)</span></a>
                                         </li>
                                     </ul>
                                 </dd>
@@ -1016,7 +1343,7 @@ exports[`LPA Questionnaire review GET / should render the S78 LPA Questionnaire 
                 </div>
                 <div class="govuk-summary-card__content">
                     <dl class="govuk-summary-list">
-                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Planning officer&#39;s report</dt>
+                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Planning officer’s report</dt>
                             <dd                             class="govuk-summary-list__value">
                                 <ul class="govuk-list pins-file-list">
                                     <li><span><div class="govuk-body govuk-!-margin-bottom-2">officersReport.docx</div><strong class="govuk-tag govuk-tag--yellow">Virus scanning</strong></span>
@@ -1026,10 +1353,10 @@ exports[`LPA Questionnaire review GET / should render the S78 LPA Questionnaire 
                                 <dd class="govuk-summary-list__actions">
                                     <ul class="govuk-summary-list__actions-list">
                                         <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/1/manage-documents/7/"
-                                            data-cy="manage-officers-report">Change<span class="govuk-visually-hidden"> Planning officer&#39;s report (5. Planning officer’s report and supplementary documents)</span></a>
+                                            data-cy="manage-officers-report">Change<span class="govuk-visually-hidden"> Planning officer’s report (5. Planning officer’s report and supplementary documents)</span></a>
                                         </li>
                                         <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/1/add-documents/7"
-                                            data-cy="add-officers-report">Add<span class="govuk-visually-hidden"> Planning officer&#39;s report (5. Planning officer’s report and supplementary documents)</span></a>
+                                            data-cy="add-officers-report">Add<span class="govuk-visually-hidden"> Planning officer’s report (5. Planning officer’s report and supplementary documents)</span></a>
                                         </li>
                                     </ul>
                                 </dd>
@@ -1463,7 +1790,7 @@ exports[`LPA Questionnaire review GET / with unchecked documents should render a
                 </div>
                 <div class="govuk-summary-card__content">
                     <dl class="govuk-summary-list" id="supplementary-documents-summary">
-                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Planning officer&#39;s report</dt>
+                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Planning officer’s report</dt>
                             <dd                             class="govuk-summary-list__value">
                                 <ul class="govuk-list pins-file-list">
                                     <li><span><div class="govuk-body govuk-!-margin-bottom-2">officersReport.docx</div><strong class="govuk-tag govuk-tag--yellow">Virus scanning</strong></span>
@@ -1473,10 +1800,10 @@ exports[`LPA Questionnaire review GET / with unchecked documents should render a
                                 <dd class="govuk-summary-list__actions">
                                     <ul class="govuk-summary-list__actions-list">
                                         <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/manage-documents/7/"
-                                            data-cy="manage-officers-report">Change<span class="govuk-visually-hidden"> Planning officer&#39;s report (4. Planning officer’s report and supplementary documents)</span></a>
+                                            data-cy="manage-officers-report">Change<span class="govuk-visually-hidden"> Planning officer’s report (4. Planning officer’s report and supplementary documents)</span></a>
                                         </li>
                                         <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/add-documents/7"
-                                            data-cy="add-officers-report">Add<span class="govuk-visually-hidden"> Planning officer&#39;s report (4. Planning officer’s report and supplementary documents)</span></a>
+                                            data-cy="add-officers-report">Add<span class="govuk-visually-hidden"> Planning officer’s report (4. Planning officer’s report and supplementary documents)</span></a>
                                         </li>
                                     </ul>
                                 </dd>
@@ -1812,7 +2139,7 @@ exports[`LPA Questionnaire review GET / with unchecked documents should render a
                 </div>
                 <div class="govuk-summary-card__content">
                     <dl class="govuk-summary-list" id="supplementary-documents-summary">
-                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Planning officer&#39;s report</dt>
+                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Planning officer’s report</dt>
                             <dd                             class="govuk-summary-list__value">
                                 <ul class="govuk-list pins-file-list">
                                     <li><span><div class="govuk-body govuk-!-margin-bottom-2">officersReport.docx</div><strong class="govuk-tag govuk-tag--yellow">Virus scanning</strong></span>
@@ -1822,10 +2149,10 @@ exports[`LPA Questionnaire review GET / with unchecked documents should render a
                                 <dd class="govuk-summary-list__actions">
                                     <ul class="govuk-summary-list__actions-list">
                                         <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/manage-documents/7/"
-                                            data-cy="manage-officers-report">Change<span class="govuk-visually-hidden"> Planning officer&#39;s report (4. Planning officer’s report and supplementary documents)</span></a>
+                                            data-cy="manage-officers-report">Change<span class="govuk-visually-hidden"> Planning officer’s report (4. Planning officer’s report and supplementary documents)</span></a>
                                         </li>
                                         <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/add-documents/7"
-                                            data-cy="add-officers-report">Add<span class="govuk-visually-hidden"> Planning officer&#39;s report (4. Planning officer’s report and supplementary documents)</span></a>
+                                            data-cy="add-officers-report">Add<span class="govuk-visually-hidden"> Planning officer’s report (4. Planning officer’s report and supplementary documents)</span></a>
                                         </li>
                                     </ul>
                                 </dd>
@@ -4262,7 +4589,7 @@ exports[`LPA Questionnaire review POST / should render LPA Questionnaire review 
                 </div>
                 <div class="govuk-summary-card__content">
                     <dl class="govuk-summary-list" id="supplementary-documents-summary">
-                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Planning officer&#39;s report</dt>
+                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Planning officer’s report</dt>
                             <dd                             class="govuk-summary-list__value">
                                 <ul class="govuk-list pins-file-list">
                                     <li><span><div class="govuk-body govuk-!-margin-bottom-2">officersReport.docx</div><strong class="govuk-tag govuk-tag--yellow">Virus scanning</strong></span>
@@ -4272,10 +4599,10 @@ exports[`LPA Questionnaire review POST / should render LPA Questionnaire review 
                                 <dd class="govuk-summary-list__actions">
                                     <ul class="govuk-summary-list__actions-list">
                                         <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/manage-documents/7/"
-                                            data-cy="manage-officers-report">Change<span class="govuk-visually-hidden"> Planning officer&#39;s report (4. Planning officer’s report and supplementary documents)</span></a>
+                                            data-cy="manage-officers-report">Change<span class="govuk-visually-hidden"> Planning officer’s report (4. Planning officer’s report and supplementary documents)</span></a>
                                         </li>
                                         <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/2/add-documents/7"
-                                            data-cy="add-officers-report">Add<span class="govuk-visually-hidden"> Planning officer&#39;s report (4. Planning officer’s report and supplementary documents)</span></a>
+                                            data-cy="add-officers-report">Add<span class="govuk-visually-hidden"> Planning officer’s report (4. Planning officer’s report and supplementary documents)</span></a>
                                         </li>
                                     </ul>
                                 </dd>

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/__tests__/lpa-questionnaire.test.js
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/__tests__/lpa-questionnaire.test.js
@@ -75,6 +75,11 @@ const appealDataFullPlanning = {
 	appealType: 'Planning appeal'
 };
 
+const appealDataCasPlanning = {
+	...lpaqAppealData,
+	appealType: 'CAS planning'
+};
+
 describe('LPA Questionnaire review', () => {
 	beforeEach(installMockApi);
 	afterEach(teardown);
@@ -582,7 +587,7 @@ describe('LPA Questionnaire review', () => {
 				},
 				{
 					folderPath: `${APPEAL_CASE_STAGE.LPA_QUESTIONNAIRE}/${APPEAL_DOCUMENT_TYPE.PLANNING_OFFICER_REPORT}`,
-					label: 'Planning officer&#39;s report'
+					label: 'Planning officer’s report'
 				},
 				{
 					folderPath: `${APPEAL_CASE_STAGE.LPA_QUESTIONNAIRE}/${APPEAL_DOCUMENT_TYPE.PLANS_DRAWINGS}`,
@@ -764,14 +769,52 @@ describe('LPA Questionnaire review', () => {
 
 			expect(element.innerHTML).toMatchSnapshot();
 			expect(element.innerHTML).toContain('LPA questionnaire</h1>');
+
 			expect(element.innerHTML).toContain('1. Constraints, designations and other issues</h2>');
+			expect(element.innerHTML).toContain('Is householder the correct type of appeal?</dt>');
+			expect(element.innerHTML).toContain(
+				'Does the development affect the setting of listed buildings?</dt>'
+			);
+			expect(element.innerHTML).toContain('Conservation area map and guidance</dt>');
+			expect(element.innerHTML).toContain('Green belt</dt>');
+
 			expect(element.innerHTML).toContain('2. Notifying relevant parties</h2>');
+			expect(element.innerHTML).toContain('Who did you notify about this application?</dt>');
+			expect(element.innerHTML).toContain(
+				'How did you notify relevant parties about this application?</dt>'
+			);
+			expect(element.innerHTML).toContain('Site notice</dt>');
+			expect(element.innerHTML).toContain('Letter or email notification</dt>');
+			expect(element.innerHTML).toContain('Press advertisement</dt>');
+			expect(element.innerHTML).toContain('Appeal notification letter</dt>');
+
 			expect(element.innerHTML).toContain('3. Consultation responses and representations</h2>');
+			expect(element.innerHTML).toContain(
+				'Representations from members of the public or other parties</dt>'
+			);
+
 			expect(element.innerHTML).toContain(
 				'4. Planning officer’s report and supplementary documents</h2>'
 			);
+			expect(element.innerHTML).toContain('Planning officer’s report</dt>');
+			expect(element.innerHTML).toContain('Plans, drawings and list of plans</dt>');
+			expect(element.innerHTML).toContain('Relevant policies from statutory development plan</dt>');
+			expect(element.innerHTML).toContain('Supplementary planning documents</dt>');
+			expect(element.innerHTML).toContain('Emerging plan relevant to appeal</dt>');
+
 			expect(element.innerHTML).toContain('5. Site access</h2>');
+			expect(element.innerHTML).toContain(
+				'Might the inspector need access to the appellant’s land or property?</dt>'
+			);
+			expect(element.innerHTML).toContain('Address of the neighbour’s land or property</dt>');
+			expect(element.innerHTML).toContain('Are there any potential safety risks?</dt>');
+
 			expect(element.innerHTML).toContain('6. Appeal process</h2>');
+			expect(element.innerHTML).toContain(
+				'Are there any other ongoing appeals next to, or close to the site?</dt>'
+			);
+			expect(element.innerHTML).toContain('Are there any new conditions?</dt>');
+
 			expect(element.innerHTML).toContain('Additional documents</h2>');
 		}, 10000);
 
@@ -803,6 +846,74 @@ describe('LPA Questionnaire review', () => {
 			);
 			expect(element.innerHTML).toContain('6. Site access</h2>');
 			expect(element.innerHTML).toContain('7. Appeal process</h2>');
+			expect(element.innerHTML).toContain('Additional documents</h2>');
+		}, 10000);
+
+		it('should render the CAS planning LPA Questionnaire page with the expected content', async () => {
+			nock('http://test/')
+				.get('/appeals/3')
+				.reply(200, {
+					...appealDataCasPlanning,
+					appealId: 3
+				});
+			nock('http://test/')
+				.get('/appeals/3/lpa-questionnaires/1')
+				.reply(200, {
+					...lpaQuestionnaireDataNotValidated,
+					lpaQuestionnaireId: 1
+				});
+
+			const response = await request.get('/appeals-service/appeal-details/3/lpa-questionnaire/1');
+			const element = parseHtml(response.text);
+
+			expect(element.innerHTML).toMatchSnapshot();
+			expect(element.innerHTML).toContain('LPA questionnaire</h1>');
+
+			expect(element.innerHTML).toContain('1. Constraints, designations and other issues</h2>');
+			expect(element.innerHTML).toContain('Is CAS planning the correct type of appeal?</dt>');
+			expect(element.innerHTML).toContain(
+				'Does the development affect the setting of listed buildings?</dt>'
+			);
+			expect(element.innerHTML).toContain('Conservation area map and guidance</dt>');
+			expect(element.innerHTML).toContain('Green belt</dt>');
+
+			expect(element.innerHTML).toContain('2. Notifying relevant parties</h2>');
+			expect(element.innerHTML).toContain('Who did you notify about this application?</dt>');
+			expect(element.innerHTML).toContain(
+				'How did you notify relevant parties about this application?</dt>'
+			);
+			expect(element.innerHTML).toContain('Site notice</dt>');
+			expect(element.innerHTML).toContain('Letter or email notification</dt>');
+			expect(element.innerHTML).toContain('Press advertisement</dt>');
+			expect(element.innerHTML).toContain('Appeal notification letter</dt>');
+
+			expect(element.innerHTML).toContain('3. Consultation responses and representations</h2>');
+			expect(element.innerHTML).toContain(
+				'Representations from members of the public or other parties</dt>'
+			);
+
+			expect(element.innerHTML).toContain(
+				'4. Planning officer’s report and supplementary documents</h2>'
+			);
+			expect(element.innerHTML).toContain('Planning officer’s report</dt>');
+			expect(element.innerHTML).not.toContain('Plans, drawings and list of plans</dt>'); // here CAS differs from HAS
+			expect(element.innerHTML).toContain('Relevant policies from statutory development plan</dt>');
+			expect(element.innerHTML).toContain('Supplementary planning documents</dt>');
+			expect(element.innerHTML).toContain('Emerging plan relevant to appeal</dt>');
+
+			expect(element.innerHTML).toContain('5. Site access</h2>');
+			expect(element.innerHTML).toContain(
+				'Might the inspector need access to the appellant’s land or property?</dt>'
+			);
+			expect(element.innerHTML).toContain('Address of the neighbour’s land or property</dt>');
+			expect(element.innerHTML).toContain('Are there any potential safety risks?</dt>');
+
+			expect(element.innerHTML).toContain('6. Appeal process</h2>');
+			expect(element.innerHTML).toContain(
+				'Are there any other ongoing appeals next to, or close to the site?</dt>'
+			);
+			expect(element.innerHTML).toContain('Are there any new conditions?</dt>');
+
 			expect(element.innerHTML).toContain('Additional documents</h2>');
 		}, 10000);
 

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/lpa-questionnaire.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/lpa-questionnaire.mapper.js
@@ -735,7 +735,7 @@ function generateCaseTypeSpecificComponents(appealDetails, mappedAppealDetails, 
 			return generateHASLpaQuestionnaireComponents(mappedLPAQData, mappedAppealDetails);
 		case APPEAL_TYPE.CAS_PLANNING:
 			if (isFeatureActive(FEATURE_FLAG_NAMES.CAS)) {
-				return generateHASLpaQuestionnaireComponents(mappedLPAQData, mappedAppealDetails);
+				return generateCasPlanningLpaQuestionnaireComponents(mappedLPAQData, mappedAppealDetails);
 			} else {
 				throw new Error('Feature flag inactive for CAS');
 			}
@@ -857,6 +857,163 @@ const generateHASLpaQuestionnaireComponents = (mappedLPAQData, mappedAppealDetai
 			rows: [
 				mappedLPAQData.lpaq?.officersReport?.display.summaryListItem,
 				mappedLPAQData.lpaq?.plansDrawings?.display.summaryListItem,
+				mappedLPAQData.lpaq?.developmentPlanPolicies?.display.summaryListItem,
+				mappedLPAQData.lpaq?.supplementaryPlanning?.display.summaryListItem,
+				mappedLPAQData.lpaq?.emergingPlan?.display.summaryListItem
+			].filter(isDefined)
+		}
+	});
+
+	pageComponents.push({
+		/** @type {'summary-list'} */
+		type: 'summary-list',
+		wrapperHtml: {
+			opening: '<div class="govuk-grid-row"><div class="govuk-grid-column-full">',
+			closing: '</div></div>'
+		},
+		parameters: {
+			card: {
+				title: {
+					text: '5. Site access'
+				}
+			},
+			attributes: {
+				id: 'site-access-summary'
+			},
+			rows: [
+				mappedLPAQData.lpaq?.siteAccess?.display.summaryListItem,
+				mappedAppealDetails.appeal.lpaNeighbouringSites?.display.summaryListItem,
+				mappedLPAQData.lpaq?.lpaHealthAndSafety?.display.summaryListItem
+			].filter(isDefined)
+		}
+	});
+
+	pageComponents.push({
+		/** @type {'summary-list'} */
+		type: 'summary-list',
+		wrapperHtml: {
+			opening: '<div class="govuk-grid-row"><div class="govuk-grid-column-full">',
+			closing: '</div></div>'
+		},
+		parameters: {
+			card: {
+				title: {
+					text: '6. Appeal process'
+				}
+			},
+			attributes: {
+				id: 'appeal-process-summary'
+			},
+			rows: [
+				mappedLPAQData.lpaq?.otherAppeals?.display.summaryListItem,
+				mappedLPAQData.lpaq?.extraConditions?.display.summaryListItem
+			].filter(isDefined)
+		}
+	});
+
+	return pageComponents;
+};
+
+/**
+ *
+ * @param {{lpaq: MappedInstructions}} mappedLPAQData
+ * @param {{appeal: MappedInstructions}} mappedAppealDetails
+ * @returns {PageComponent[]}
+ */
+const generateCasPlanningLpaQuestionnaireComponents = (mappedLPAQData, mappedAppealDetails) => {
+	/** @type {PageComponent[]} */
+	const pageComponents = [];
+
+	pageComponents.push({
+		/** @type {'summary-list'} */
+		type: 'summary-list',
+		wrapperHtml: {
+			opening: '<div class="govuk-grid-row"><div class="govuk-grid-column-full">',
+			closing: '</div></div>'
+		},
+		parameters: {
+			attributes: {
+				id: 'constraints-summary'
+			},
+			card: {
+				title: {
+					text: '1. Constraints, designations and other issues'
+				}
+			},
+			rows: [
+				mappedLPAQData.lpaq?.isCorrectAppealType?.display.summaryListItem,
+				mappedLPAQData.lpaq?.affectsListedBuildingDetails?.display.summaryListItem,
+				mappedLPAQData.lpaq?.conservationAreaMap?.display.summaryListItem,
+				mappedLPAQData.lpaq?.siteWithinGreenBelt?.display.summaryListItem
+			].filter(isDefined)
+		}
+	});
+
+	pageComponents.push({
+		/** @type {'summary-list'} */
+		type: 'summary-list',
+		wrapperHtml: {
+			opening: '<div class="govuk-grid-row"><div class="govuk-grid-column-full">',
+			closing: '</div></div>'
+		},
+		parameters: {
+			card: {
+				title: {
+					text: '2. Notifying relevant parties'
+				}
+			},
+			attributes: {
+				id: 'notifications-summary'
+			},
+			rows: [
+				mappedLPAQData.lpaq?.notifyingParties?.display.summaryListItem,
+				mappedLPAQData.lpaq?.notificationMethods?.display.summaryListItem,
+				mappedLPAQData.lpaq?.siteNotice?.display.summaryListItem,
+				mappedLPAQData.lpaq?.lettersToNeighbours?.display.summaryListItem,
+				mappedLPAQData.lpaq?.pressAdvert?.display.summaryListItem,
+				mappedLPAQData.lpaq?.appealNotification?.display.summaryListItem
+			].filter(isDefined)
+		}
+	});
+
+	pageComponents.push({
+		/** @type {'summary-list'} */
+		type: 'summary-list',
+		wrapperHtml: {
+			opening: '<div class="govuk-grid-row"><div class="govuk-grid-column-full">',
+			closing: '</div></div>'
+		},
+		parameters: {
+			card: {
+				title: {
+					text: '3. Consultation responses and representations'
+				}
+			},
+			attributes: {
+				id: 'representations-summary'
+			},
+			rows: [mappedLPAQData.lpaq?.representations?.display.summaryListItem].filter(isDefined)
+		}
+	});
+
+	pageComponents.push({
+		/** @type {'summary-list'} */
+		type: 'summary-list',
+		wrapperHtml: {
+			opening: '<div class="govuk-grid-row"><div class="govuk-grid-column-full">',
+			closing: '</div></div>'
+		},
+		parameters: {
+			card: {
+				title: {
+					text: '4. Planning officer’s report and supplementary documents'
+				}
+			},
+			attributes: {
+				id: 'supplementary-documents-summary'
+			},
+			rows: [
+				mappedLPAQData.lpaq?.officersReport?.display.summaryListItem,
 				mappedLPAQData.lpaq?.developmentPlanPolicies?.display.summaryListItem,
 				mappedLPAQData.lpaq?.supplementaryPlanning?.display.summaryListItem,
 				mappedLPAQData.lpaq?.emergingPlan?.display.summaryListItem

--- a/appeals/web/src/server/lib/mappers/data/lpa-questionnaire/submappers/map-is-correct-appeal-type.js
+++ b/appeals/web/src/server/lib/mappers/data/lpa-questionnaire/submappers/map-is-correct-appeal-type.js
@@ -9,7 +9,9 @@ export const mapIsCorrectAppealType = ({
 }) =>
 	booleanSummaryListItem({
 		id: 'is-correct-appeal-type',
-		text: `Is ${appealDetails.appealType?.toLowerCase()} the correct type of appeal?`,
+		text: `Is ${appealDetails.appealType
+			?.toLowerCase()
+			.replace('cas', 'CAS')} the correct type of appeal?`,
 		value: lpaQuestionnaireData.isCorrectAppealType,
 		defaultText: '',
 		addCyAttribute: true,

--- a/appeals/web/src/server/lib/mappers/data/lpa-questionnaire/submappers/map-officers-report.js
+++ b/appeals/web/src/server/lib/mappers/data/lpa-questionnaire/submappers/map-officers-report.js
@@ -4,7 +4,7 @@ import { documentInstruction } from '../common.js';
 export const mapOfficersReport = ({ lpaQuestionnaireData, session }) =>
 	documentInstruction({
 		id: 'officers-report',
-		text: `Planning officer's report`,
+		text: `Planning officer’s report`,
 		folderInfo: lpaQuestionnaireData.documents.planningOfficerReport,
 		lpaQuestionnaireData,
 		session

--- a/appeals/web/src/server/lib/mappers/utils/__tests__/documents-and-folders.test.js
+++ b/appeals/web/src/server/lib/mappers/utils/__tests__/documents-and-folders.test.js
@@ -83,7 +83,7 @@ describe('documents and folders', () => {
 			},
 			{
 				documentType: APPEAL_DOCUMENT_TYPE.PLANNING_OFFICER_REPORT,
-				label: `Planning officer's report`
+				label: `Planning officer’s report`
 			},
 			{
 				documentType: APPEAL_DOCUMENT_TYPE.DEVELOPMENT_PLAN_POLICIES,

--- a/packages/appeals/constants/documents.js
+++ b/packages/appeals/constants/documents.js
@@ -103,7 +103,7 @@ export const DOCUMENT_FOLDER_DISPLAY_LABELS = Object.freeze({
 	[APPEAL_DOCUMENT_TYPE.CONSERVATION_MAP]: 'Conservation area map and guidance',
 	[APPEAL_DOCUMENT_TYPE.OTHER_PARTY_REPRESENTATIONS]:
 		'Representations from other parties documents',
-	[APPEAL_DOCUMENT_TYPE.PLANNING_OFFICER_REPORT]: `Planning officer's report`,
+	[APPEAL_DOCUMENT_TYPE.PLANNING_OFFICER_REPORT]: 'Planning officer’s report',
 	[APPEAL_DOCUMENT_TYPE.DEVELOPMENT_PLAN_POLICIES]:
 		'Relevant policies from statutory development plan',
 	[APPEAL_DOCUMENT_TYPE.TREE_PRESERVATION_PLAN]: 'Tree Preservation Order',


### PR DESCRIPTION
## Describe your changes

- Adding the LPAQ for CAS (and relevant tests)
- Adding the LPAQ to the seeded data for CAS
- Changing ' to ’ in 'Planning officer’s report' for consistency
- Adding a function to convert the appealType to the text we want displayed (CAS planning)

## Issue ticket number and link

[Ticket](https://pins-ds.atlassian.net/browse/A2-3266)
