### PR TITLE
fix(appeals): sort lead and child correctly (a2-3794)

### DIFF
--- a/appeals/api/src/server/utils/__tests__/sort-appeals.test.js
+++ b/appeals/api/src/server/utils/__tests__/sort-appeals.test.js
@@ -1,11 +1,12 @@
+// @ts-nocheck
 import { sortAppeals } from '#utils/appeal-sorter.js';
 
 describe('Sort appeals', () => {
 	test('match results', () => {
 		const appeals = [
-			{ appealId: 1, createdAt: '2024-01-01', dueDate: new Date('2024-02-01') },
-			{ appealId: 2, createdAt: '2024-01-03', dueDate: new Date('2023-12-31') },
-			{ appealId: 3, createdAt: '2024-01-02', dueDate: new Date('2024-01-31') }
+			{ appealId: 1, dueDate: '2024-02-01' },
+			{ appealId: 2, dueDate: '2023-12-31' },
+			{ appealId: 3, dueDate: '2024-01-31' }
 		];
 
 		//@ts-ignore
@@ -17,9 +18,9 @@ describe('Sort appeals', () => {
 
 	test('handles undefined dueDate', () => {
 		const appeals = [
-			{ appealId: 1, createdAt: '2024-01-01', dueDate: undefined },
-			{ appealId: 2, createdAt: '2024-01-03', dueDate: new Date('2023-12-31') },
-			{ appealId: 3, createdAt: '2024-01-02', dueDate: undefined }
+			{ appealId: 1, dueDate: undefined },
+			{ appealId: 2, dueDate: '2023-12-31' },
+			{ appealId: 3, dueDate: undefined }
 		];
 
 		//@ts-ignore
@@ -27,5 +28,24 @@ describe('Sort appeals', () => {
 		const result = data.map((a) => a?.appealId);
 
 		expect(result).toEqual([2, 1, 3]);
+	});
+
+	test('handles linked appeals', () => {
+		const appeals = [
+			{ appealId: 1, dueDate: '2024-12-31', isParentAppeal: true },
+			{ appealId: 2, dueDate: '2021-10-30', isChildAppeal: true },
+			{ appealId: 3, dueDate: '2024-11-30', isChildAppeal: true },
+			{ appealId: 4, dueDate: '2021-10-10' },
+			{ appealId: 5, dueDate: '2023-12-30', isParentAppeal: true },
+			{ appealId: 6, dueDate: undefined, isChildAppeal: true },
+			{ appealId: 7, dueDate: '2022-12-30', isChildAppeal: true },
+			{ appealId: 8, dueDate: '2025-12-30' }
+		];
+
+		//@ts-ignore
+		const data = sortAppeals(appeals);
+		const result = data.map((a) => a?.appealId);
+
+		expect(result).toEqual([4, 5, 6, 7, 1, 2, 3, 8]);
 	});
 });

--- a/appeals/api/src/server/utils/appeal-sorter.js
+++ b/appeals/api/src/server/utils/appeal-sorter.js
@@ -1,15 +1,83 @@
 /** @typedef {import('@pins/appeals.api').Appeals.AppealListResponse} AppealListResponse */
 
+import { isFeatureActive } from '#utils/feature-flags.js';
+import { FEATURE_FLAG_NAMES } from '@pins/appeals/constants/common.js';
+
+const DEFAULT_SORT_VALUE = 'DEFAULT_SORT_VALUE';
 /**
  *
  * @param {AppealListResponse[]} appeals
  * @returns {AppealListResponse[]}
  */
 export const sortAppeals = (appeals) => {
+	if (!isFeatureActive(FEATURE_FLAG_NAMES.LINKED_APPEALS)) {
+		return sortByDueDate(appeals);
+	}
+	return sortLinkedAppeals(appeals);
+};
+
+/**
+ *
+ * @param {AppealListResponse[]} appeals
+ * @returns {AppealListResponse[]}
+ */
+const sortByDueDate = (appeals) => {
 	return appeals.sort((a, b) => {
 		if (!a.dueDate) return 1;
 		if (!b.dueDate) return -1;
-
 		return new Date(a.dueDate).getTime() - new Date(b.dueDate).getTime();
 	});
+};
+
+/**
+ *
+ * @param {AppealListResponse[]} appeals
+ * @returns {AppealListResponse[]}
+ */
+const sortLinkedAppeals = (appeals) => {
+	const sortKeys = buildSortKeys(appeals);
+
+	return appeals.sort((a, b) => {
+		const aKey = sortKeys.get(a.appealId) ?? DEFAULT_SORT_VALUE;
+		const bKey = sortKeys.get(b.appealId) ?? DEFAULT_SORT_VALUE;
+		if (aKey === bKey) return 0;
+		return aKey < bKey ? -1 : 1;
+	});
+};
+
+/**
+ *
+ * @param {AppealListResponse[]} appeals
+ * @returns {Map<Number, string>}
+ */
+const buildSortKeys = (appeals) => {
+	const sortKeys = new Map();
+	let group = { leadId: 0, dueDate: DEFAULT_SORT_VALUE, children: [] };
+
+	const finalizeGroup = () => {
+		if (group.leadId && group.dueDate) {
+			sortKeys.set(group.leadId, group.dueDate + 'A');
+			group.children.forEach((id, i) => sortKeys.set(id, group.dueDate + 'B' + i));
+		}
+		group = { leadId: 0, dueDate: DEFAULT_SORT_VALUE, children: [] };
+	};
+
+	appeals.forEach((appeal) => {
+		const dueDate = appeal.dueDate ? new Date(appeal.dueDate).getTime() : DEFAULT_SORT_VALUE;
+
+		if (appeal.isParentAppeal) {
+			finalizeGroup();
+			group.leadId = appeal.appealId;
+			group.dueDate = dueDate + '';
+		} else if (appeal.isChildAppeal) {
+			// @ts-ignore
+			group.children.push(appeal.appealId);
+		} else {
+			finalizeGroup();
+			sortKeys.set(appeal.appealId, dueDate + 'C');
+		}
+	});
+
+	finalizeGroup();
+	return sortKeys;
 };


### PR DESCRIPTION
## Describe your changes
#### Group linked appeals within personal list correctly (a2-3794)

### API:
- Return linked child appeals grouped with each lead appeal based on the lead appeal's due date when retrieving /appeals/my-appeals

### TEST:
- Added more complex unit tests
- Made sure all unit tests pass
- Manually tested within browser

## Issue ticket number and link:
- [(A2-3794) How are linked appeals currently grouped together in test/prod on 'Cases assigned to you' screen?](https://pins-ds.atlassian.net/browse/A2-3794)

