### PR TITLE
feat(A2-3789): toggling decision label depending on appellant decision

### DIFF
--- a/appeals/api/src/server/endpoints/appeals/appeals.formatter.js
+++ b/appeals/api/src/server/endpoints/appeals/appeals.formatter.js
@@ -262,13 +262,10 @@ export const mapAppealToDueDate = async (appeal, appellantCaseStatus, appellantC
 			});
 		}
 		case APPEAL_CASE_STATUS.AWAITING_EVENT: {
-			if (appeal.procedureType?.key === APPEAL_CASE_PROCEDURE.WRITTEN) {
-				return appeal.siteVisit ? new Date(appeal.siteVisit?.visitDate || 0) : undefined;
-			}
 			if (appeal.procedureType?.key === APPEAL_CASE_PROCEDURE.HEARING) {
 				return appeal.hearing ? new Date(appeal.hearing?.hearingStartTime || 0) : undefined;
 			}
-			return undefined;
+			return appeal.siteVisit ? new Date(appeal.siteVisit?.visitDate || 0) : undefined;
 		}
 		case APPEAL_CASE_STATUS.EVENT: {
 			return new Date(

--- a/appeals/web/src/server/appeals/appeal-details/appellant-case/application-decision-date/__tests__/__snapshots__/application-decision-date.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/appellant-case/application-decision-date/__tests__/__snapshots__/application-decision-date.test.js.snap
@@ -53,6 +53,59 @@ exports[`application-decision-date GET /change should render the application dec
 </main>"
 `;
 
+exports[`application-decision-date GET /change should render the application decision date change page when decision not received 1`] = `
+"<main class="govuk-main-wrapper" id="main-content">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Appeal 351062</span>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <div class="govuk-grid-row">
+                <div class="govuk-grid-column-full">
+                    <form method="POST" novalidate="novalidate">
+                        <div class="govuk-form-group">
+                            <fieldset class="govuk-fieldset" role="group" aria-describedby="application-decision-date-hint">
+                                <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">What date was your decision due from the local planning authority?</legend>
+                                <div                                 id="application-decision-date-hint" class="govuk-hint">For example, 27 3 2007</div>
+                        <div class="govuk-date-input" id="application-decision-date">
+                            <div class="govuk-date-input__item">
+                                <div class="govuk-form-group">
+                                    <label class="govuk-label govuk-date-input__label" for="application-decision-date-day">Day</label>
+                                    <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
+                                    id="application-decision-date-day" name="application-decision-date-day"
+                                    type="text" value="" inputmode="numeric">
+                                </div>
+                            </div>
+                            <div class="govuk-date-input__item">
+                                <div class="govuk-form-group">
+                                    <label class="govuk-label govuk-date-input__label" for="application-decision-date-month">Month</label>
+                                    <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
+                                    id="application-decision-date-month" name="application-decision-date-month"
+                                    type="text" value="" inputmode="numeric">
+                                </div>
+                            </div>
+                            <div class="govuk-date-input__item">
+                                <div class="govuk-form-group">
+                                    <label class="govuk-label govuk-date-input__label" for="application-decision-date-year">Year</label>
+                                    <input class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input govuk-date-input__input"
+                                    id="application-decision-date-year" name="application-decision-date-year"
+                                    type="text" value="" inputmode="numeric">
+                                </div>
+                            </div>
+                        </div>
+                        </fieldset>
+                </div>
+                <button type="submit" data-prevent-double-click="true" class="govuk-button"
+                data-module="govuk-button">Continue</button>
+                </form>
+            </div>
+        </div>
+    </div>
+    </div>
+</main>"
+`;
+
 exports[`application-decision-date POST /change should re-render applicationdecisionDate change page if day is not valid 1`] = `
 "<main class="govuk-main-wrapper" id="main-content">
     <div class="govuk-grid-row">

--- a/appeals/web/src/server/appeals/appeal-details/appellant-case/application-decision-date/__tests__/application-decision-date.test.js
+++ b/appeals/web/src/server/appeals/appeal-details/appellant-case/application-decision-date/__tests__/application-decision-date.test.js
@@ -27,6 +27,24 @@ describe('application-decision-date', () => {
 				'What’s the date on the decision letter from the local planning authority?​'
 			);
 		});
+
+		it('should render the application decision date change page when decision not received', async () => {
+			const appellantCaseData = {
+				...appellantCaseDataNotValidated,
+				applicationDecision: 'not_received'
+			};
+			nock('http://test/')
+				.get(`/appeals/${appealId}/appellant-cases/${appellantCaseId}`)
+				.reply(200, appellantCaseData);
+			const response = await request.get(`${baseUrl}/application-decision-date/change`);
+
+			const elementInnerHtml = parseHtml(response.text).innerHTML;
+
+			expect(elementInnerHtml).toMatchSnapshot();
+			expect(elementInnerHtml).toContain(
+				'What date was your decision due from the local planning authority?'
+			);
+		});
 	});
 
 	describe('POST /change', () => {

--- a/appeals/web/src/server/appeals/appeal-details/appellant-case/application-decision-date/application-decision-date.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/appellant-case/application-decision-date/application-decision-date.mapper.js
@@ -43,9 +43,14 @@ export const changeApplicationDecisionDatePage = (
 		year = String(formattedApplicationDecisionDate.year);
 	}
 
+	const title =
+		appellantCaseData.applicationDecision == 'not_received'
+			? 'What date was your decision due from the local planning authority?'
+			: 'What’s the date on the decision letter from the local planning authority?​';
+
 	/** @type {PageContent} */
 	const pageContent = {
-		title: 'What’s the date on the decision letter from the local planning authority?​',
+		title,
 		backLinkUrl: `/appeals-service/appeal-details/${appealData.appealId}/appellant-case`,
 		preHeading: `Appeal ${shortAppealReference}`,
 		pageComponents: [
@@ -58,7 +63,7 @@ export const changeApplicationDecisionDatePage = (
 					month: month,
 					year: year
 				},
-				legendText: 'What’s the date on the decision letter from the local planning authority?​',
+				legendText: title,
 				hint: 'For example, 27 3 2007',
 				errors: errors
 			})

--- a/appeals/web/src/server/lib/mappers/data/appellant-case/submappers/application-decision-date.js
+++ b/appeals/web/src/server/lib/mappers/data/appellant-case/submappers/application-decision-date.js
@@ -9,7 +9,10 @@ export const mapApplicationDecisionDate = ({
 }) =>
 	textSummaryListItem({
 		id: 'application-decision-date',
-		text: 'What’s the date on the decision letter from the local planning authority?​',
+		text:
+			appellantCaseData.applicationDecision == 'not_received'
+				? 'What date was your decision due from the local planning authority?'
+				: 'What’s the date on the decision letter from the local planning authority?​',
 		value: dateISOStringToDisplayDate(appellantCaseData.applicationDecisionDate, 'No data'),
 		link: `${currentRoute}/application-decision-date/change`,
 		editable: userHasUpdateCase


### PR DESCRIPTION

## Describe your changes
- Toggling the application decision label on appellant case page depending on actual decision
- Added new unit test to cover this new label
- This also includes a small bug fix for displaying site visit due date as default when procedure type not specified
<!--
    Please include a summary of the change along with any relevant context.
    List any dependencies that are required for this change.
-->

## Issue ticket number and link

[Ticket](https://pins-ds.atlassian.net.mcas.ms/browse/A2-3789)
