### PR TITLE
feat(web): refactored audit rep log function (a2-3864)

### DIFF
--- a/appeals/api/src/server/endpoints/representations/representations.service.js
+++ b/appeals/api/src/server/endpoints/representations/representations.service.js
@@ -22,6 +22,8 @@ import { EventType } from '@pins/event-client';
 import { broadcasters } from '#endpoints/integrations/integrations.broadcasters.js';
 import { isCurrentStatus } from '#utils/current-status.js';
 import config from '#config/config.js';
+import * as CONSTANTS from '@pins/appeals/constants/support.js';
+import { camelToScreamingSnake } from '#utils/string-utils.js';
 
 /** @typedef {import('@pins/appeals.api').Schema.Appeal} Appeal */
 /** @typedef {import('@pins/appeals.api').Schema.Representation} Representation */
@@ -65,6 +67,34 @@ export const getRepresentationCounts = async (appealId, options = {}) => {
  * @param {number} id
  */
 export const getRepresentation = representationRepository.getById;
+
+/**
+ *
+ * @param {string} status
+ * @param {string} repType
+ * @param {Boolean} redactedRep
+ * @returns String
+ */
+export const getRepStatusAuditLogDetails = (status, repType, redactedRep) => {
+	let auditText;
+	const auditTitle = 'AUDIT_TRAIL_REP_';
+	const valid = '_STATUS_VALID';
+	const invalid = '_STATUS_INVALID';
+	const incomplete = '_STATUS_INCOMPLETE';
+	const redactedAccepted = '_STATUS_REDACTED_AND_ACCEPTED';
+
+	if (status === APPEAL_REPRESENTATION_STATUS.VALID && redactedRep === true) {
+		auditText = auditTitle + camelToScreamingSnake(repType) + redactedAccepted;
+	} else if (status === APPEAL_REPRESENTATION_STATUS.VALID) {
+		auditText = auditTitle + camelToScreamingSnake(repType) + valid;
+	} else if (status === APPEAL_REPRESENTATION_STATUS.INVALID) {
+		auditText = auditTitle + camelToScreamingSnake(repType) + invalid;
+	} else if (status === APPEAL_REPRESENTATION_STATUS.INCOMPLETE) {
+		auditText = auditTitle + camelToScreamingSnake(repType) + incomplete;
+	}
+	// @ts-ignore
+	return CONSTANTS[auditText];
+};
 
 /** @typedef {Awaited<ReturnType<getRepresentation>>} DBRepresentation */
 

--- a/packages/appeals/constants/support.js
+++ b/packages/appeals/constants/support.js
@@ -19,26 +19,35 @@ export const DECISION_TYPE_APPELLANT_COSTS = 'appellant-costs-decision';
 export const DECISION_TYPE_LPA_COSTS = 'lpa-costs-decision';
 
 export const AUDIT_TRAIL_REP_SHARED = '{replacement0} shared';
-export const AUDIT_TRAIL_REP_LPA_STATEMENT_STATUS_UPDATED =
-	'LPA statement status updated to {replacement0}';
-export const AUDIT_TRAIL_REP_LPA_STATEMENT_REDACTED_AND_ACCEPTED =
-	'LPA statement redacted and accepted';
+
 export const AUDIT_TRAIL_REP_APPELLANT_STATEMENT_STATUS_UPDATED =
 	'Appellant statement status updated to {replacement0}';
-export const AUDIT_TRAIL_REP_COMMENT_STATUS_UPDATED = 'Comment status updated to {replacement0}';
 
+//LPA statement rep logs
+export const AUDIT_TRAIL_REP_LPA_STATEMENT_STATUS_VALID = 'LPA statement accepted';
+export const AUDIT_TRAIL_REP_LPA_STATEMENT_STATUS_INCOMPLETE = 'LPA statement incomplete';
+export const AUDIT_TRAIL_REP_LPA_STATEMENT_STATUS_REDACTED_AND_ACCEPTED =
+	'LPA statement redacted and accepted';
+
+//Interested party comment rep logs
+export const AUDIT_TRAIL_REP_COMMENT_STATUS_VALID = 'Interested party comment accepted';
+export const AUDIT_TRAIL_REP_COMMENT_STATUS_INVALID = 'Interested party comment rejected';
+export const AUDIT_TRAIL_REP_COMMENT_STATUS_REDACTED_AND_ACCEPTED =
+	'Interested party comment redacted and accepted';
+
+//LPA final comment rep logs
 export const AUDIT_TRAIL_REP_LPA_FINAL_COMMENT_STATUS_VALID = 'LPA final comments accepted';
+export const AUDIT_TRAIL_REP_LPA_FINAL_COMMENT_STATUS_INVALID = 'LPA final comments rejected';
+export const AUDIT_TRAIL_REP_LPA_FINAL_COMMENT_STATUS_REDACTED_AND_ACCEPTED =
+	'LPA final comments redacted and accepted';
+
+//Appellant final comment rep logs
 export const AUDIT_TRAIL_REP_APPELLANT_FINAL_COMMENT_STATUS_VALID =
 	'Appellant final comments accepted';
-export const AUDIT_TRAIL_REP_LPA_FINAL_COMMENT_INVALID = 'LPA final comments rejected';
-export const AUDIT_TRAIL_REP_APPELLANT_FINAL_COMMENT_INVALID = 'Appellant final comments rejected';
-export const AUDIT_TRAIL_REP_LPA_FINAL_COMMENT_REDACTED_AND_ACCEPTED =
-	'LPA final comments redacted and accepted';
-export const AUDIT_TRAIL_REP_APPELLANT_FINAL_COMMENT_REDACTED_AND_ACCEPTED =
+export const AUDIT_TRAIL_REP_APPELLANT_FINAL_COMMENT_STATUS_INVALID =
+	'Appellant final comments rejected';
+export const AUDIT_TRAIL_REP_APPELLANT_FINAL_COMMENT_STATUS_REDACTED_AND_ACCEPTED =
 	'Appellant final comments redacted and accepted';
-export const AUDIT_TRAIL_REP_LPA_FINAL_COMMENT_STATUS_UPDATED = 'LPA final comments {replacement0}';
-export const AUDIT_TRAIL_REP_APPELLANT_FINAL_COMMENT_STATUS_UPDATED =
-	'Appellant final comments {replacement0}';
 
 export const APPEAL_TYPE_SHORTHAND_FPA = 'W';
 export const APPEAL_TYPE_SHORTHAND_HAS = 'D';


### PR DESCRIPTION
- Refactored code segment handling rep audit logs into a service function
- Removed "updated to" wording in rep audit log string values
- Rewrote string values to ensure accept/reject/redact status logs match design requirements 
- Rewrote const titles in common.js into a uniform pattern for reps (fixing calls to AUDIT_TRAIL_REP_LPA_STATEMENT_STATUS_VALID & AUDIT_TRAIL_REP_LPA_STATEMENT_STATUS_INCOMPLETE)

Link to requirements for rep logs for reference:
https://pins-ds.atlassian.net/wiki/spaces/BO/pages/1988558868/Case+history

https://pins-ds.atlassian.net/browse/A2-3864