### PR TITLE
feat(appeals): fix personal list sort (a2-3794)

### DIFF
--- a/appeals/api/src/server/utils/__tests__/sort-appeals.test.js
+++ b/appeals/api/src/server/utils/__tests__/sort-appeals.test.js
@@ -4,47 +4,47 @@ import { sortAppeals } from '#utils/appeal-sorter.js';
 describe('Sort appeals', () => {
 	test('match results', () => {
 		const appeals = [
-			{ appealId: 1, dueDate: '2024-02-01' },
-			{ appealId: 2, dueDate: '2023-12-31' },
-			{ appealId: 3, dueDate: '2024-01-31' }
+			{ appealReference: 1, dueDate: '2024-02-01' },
+			{ appealReference: 2, dueDate: '2023-12-31' },
+			{ appealReference: 3, dueDate: '2024-01-31' }
 		];
 
 		//@ts-ignore
 		const data = sortAppeals(appeals);
-		const result = data.map((a) => a?.appealId);
+		const result = data.map((a) => a?.appealReference);
 
 		expect(result).toEqual([2, 3, 1]);
 	});
 
 	test('handles undefined dueDate', () => {
 		const appeals = [
-			{ appealId: 1, dueDate: undefined },
-			{ appealId: 2, dueDate: '2023-12-31' },
-			{ appealId: 3, dueDate: undefined }
+			{ appealReference: 1, dueDate: undefined },
+			{ appealReference: 2, dueDate: '2023-12-31' },
+			{ appealReference: 3, dueDate: undefined }
 		];
 
 		//@ts-ignore
 		const data = sortAppeals(appeals);
-		const result = data.map((a) => a?.appealId);
+		const result = data.map((a) => a?.appealReference);
 
 		expect(result).toEqual([2, 1, 3]);
 	});
 
 	test('handles linked appeals', () => {
 		const appeals = [
-			{ appealId: 1, dueDate: '2024-12-31', isParentAppeal: true },
-			{ appealId: 2, dueDate: '2021-10-30', isChildAppeal: true },
-			{ appealId: 3, dueDate: '2024-11-30', isChildAppeal: true },
-			{ appealId: 4, dueDate: '2021-10-10' },
-			{ appealId: 5, dueDate: '2023-12-30', isParentAppeal: true },
-			{ appealId: 6, dueDate: undefined, isChildAppeal: true },
-			{ appealId: 7, dueDate: '2022-12-30', isChildAppeal: true },
-			{ appealId: 8, dueDate: '2025-12-30' }
+			{ appealReference: 1, dueDate: '2024-12-31', isParentAppeal: true },
+			{ appealReference: 2, dueDate: '2021-10-30', isChildAppeal: true },
+			{ appealReference: 3, dueDate: '2024-11-30', isChildAppeal: true },
+			{ appealReference: 4, dueDate: '2021-10-10' },
+			{ appealReference: 5, dueDate: '2023-12-30', isParentAppeal: true },
+			{ appealReference: 6, dueDate: undefined, isChildAppeal: true },
+			{ appealReference: 7, dueDate: '2022-12-30', isChildAppeal: true },
+			{ appealReference: 8, dueDate: '2025-12-30' }
 		];
 
 		//@ts-ignore
 		const data = sortAppeals(appeals);
-		const result = data.map((a) => a?.appealId);
+		const result = data.map((a) => a?.appealReference);
 
 		expect(result).toEqual([4, 5, 6, 7, 1, 2, 3, 8]);
 	});

--- a/appeals/api/src/server/utils/appeal-sorter.js
+++ b/appeals/api/src/server/utils/appeal-sorter.js
@@ -38,8 +38,8 @@ const sortLinkedAppeals = (appeals) => {
 	const sortKeys = buildSortKeys(appeals);
 
 	return appeals.sort((a, b) => {
-		const aKey = sortKeys.get(a.appealId) ?? DEFAULT_SORT_VALUE;
-		const bKey = sortKeys.get(b.appealId) ?? DEFAULT_SORT_VALUE;
+		const aKey = sortKeys.get(a.appealReference) ?? DEFAULT_SORT_VALUE;
+		const bKey = sortKeys.get(b.appealReference) ?? DEFAULT_SORT_VALUE;
 		if (aKey === bKey) return 0;
 		return aKey < bKey ? -1 : 1;
 	});
@@ -48,18 +48,20 @@ const sortLinkedAppeals = (appeals) => {
 /**
  *
  * @param {AppealListResponse[]} appeals
- * @returns {Map<Number, string>}
+ * @returns {Map<string, string>}
  */
 const buildSortKeys = (appeals) => {
 	const sortKeys = new Map();
-	let group = { leadId: 0, dueDate: DEFAULT_SORT_VALUE, children: [] };
+	let group = { leadReference: '', dueDate: DEFAULT_SORT_VALUE, children: [] };
 
 	const finalizeGroup = () => {
-		if (group.leadId && group.dueDate) {
-			sortKeys.set(group.leadId, group.dueDate + 'A');
-			group.children.forEach((id, i) => sortKeys.set(id, group.dueDate + 'B' + i));
+		if (group.leadReference && group.dueDate) {
+			sortKeys.set(group.leadReference, group.dueDate + '-' + group.leadReference + '-A-0');
+			group.children.forEach((reference, i) =>
+				sortKeys.set(reference, group.dueDate + '-' + group.leadReference + '-B-' + i)
+			);
 		}
-		group = { leadId: 0, dueDate: DEFAULT_SORT_VALUE, children: [] };
+		group = { leadReference: '', dueDate: DEFAULT_SORT_VALUE, children: [] };
 	};
 
 	appeals.forEach((appeal) => {
@@ -67,14 +69,14 @@ const buildSortKeys = (appeals) => {
 
 		if (appeal.isParentAppeal) {
 			finalizeGroup();
-			group.leadId = appeal.appealId;
+			group.leadReference = appeal.appealReference;
 			group.dueDate = dueDate + '';
 		} else if (appeal.isChildAppeal) {
 			// @ts-ignore
-			group.children.push(appeal.appealId);
+			group.children.push(appeal.appealReference);
 		} else {
 			finalizeGroup();
-			sortKeys.set(appeal.appealId, dueDate + 'C');
+			sortKeys.set(appeal.appealReference, dueDate + '-' + appeal.appealReference + '-C-0');
 		}
 	});
 


### PR DESCRIPTION
## Describe your changes
#### Group linked appeals within personal list correctly even when dates are the same (a2-3794)

### API:
- Return linked child appeals grouped with each lead appeal based on the lead appeal's due date when retrieving /appeals/my-appeals even when dates are the same.  Achieved by sorting by lead duedate, lead (if linked), child (if linked).

### TEST:
- Fixed unit tests
- Made sure all unit tests pass
- Manually tested within browser

## Issue ticket number and link:
- [(A2-3794) How are linked appeals currently grouped together in test/prod on 'Cases assigned to you' screen?](https://pins-ds.atlassian.net/browse/A2-3794)

