### PR TITLE
fix(A2-3945): filtering out "related" appeals from buildListOfLinkedAppeals

### DIFF
--- a/appeals/api/src/server/utils/build-list-of-linked-appeals.js
+++ b/appeals/api/src/server/utils/build-list-of-linked-appeals.js
@@ -22,7 +22,9 @@ function augmentChildAppealWithParentAppealRelationshipData(parentAppeal, childA
  * @returns {Promise<(Appeal|(Appeal&{parentAppeals: Appeal}))[]>}
  */
 export async function buildListOfLinkedAppeals(parentAppeal) {
-	const childAppealIds = parentAppeal.childAppeals?.map((childAppeal) => childAppeal.childId);
+	const childAppealIds = parentAppeal.childAppeals
+		?.filter((childAppeal) => childAppeal.type === 'linked')
+		.map((childAppeal) => childAppeal.childId);
 
 	// @ts-ignore
 	const childAppeals = await appealRepository.getAppealsByIds(childAppealIds);


### PR DESCRIPTION
## Describe your changes
- Adding filter to ensure only 'linked' child appeals are added to list of LinkedAppeals. 
- (raising separate tech debt ticket to add tests for utility file)
<!--
    Please include a summary of the change along with any relevant context.
    List any dependencies that are required for this change.
-->

## Issue ticket number and link

[Ticket](https://pins-ds.atlassian.net/browse/A2-3945)
