### PR TITLE
fix(appeals): make changeAppealType optional for db migration

### DIFF
--- a/appeals/api/src/database/migrations/20250722152830_add_change_appeal_types_to_appeal_types/migration.sql
+++ b/appeals/api/src/database/migrations/20250722152830_add_change_appeal_types_to_appeal_types/migration.sql
@@ -10,7 +10,7 @@ BEGIN TRY
 BEGIN TRAN;
 
 -- AlterTable
-ALTER TABLE [dbo].[AppealType] ADD [changeAppealType] NVARCHAR(1000) NOT NULL;
+ALTER TABLE [dbo].[AppealType] ADD [changeAppealType] NVARCHAR(1000);
 
 -- CreateIndex
 ALTER TABLE [dbo].[AppealType] ADD CONSTRAINT [AppealType_changeAppealType_key] UNIQUE NONCLUSTERED ([changeAppealType]);

--- a/appeals/api/src/database/schema.prisma
+++ b/appeals/api/src/database/schema.prisma
@@ -101,7 +101,7 @@ model AppealRelationship {
 model AppealType {
   id               Int      @id @default(autoincrement())
   type             String   @unique
-  changeAppealType String   @unique
+  changeAppealType String?  @unique
   key              String   @unique
   processCode      String?
   enabled          Boolean?


### PR DESCRIPTION
## Describe your changes

- Db migration to make `changeAppealType` optional

## Issue ticket number and link

[Ticket](https://pins-ds.atlassian.net/browse/A2-3615)
