### PR TITLE
fix(A2-3965): fixing related appeals to self issue

### DIFF
--- a/appeals/api/src/server/mappers/api/shared/map-appeal-relationships.js
+++ b/appeals/api/src/server/mappers/api/shared/map-appeal-relationships.js
@@ -61,20 +61,21 @@ export const mapAppealRelationships = (data) => {
 		? appealRelationships
 				.filter((relationship) => relationship.type === CASE_RELATIONSHIP_RELATED)
 				.map((relationship) => {
-					const appealType = relationship.child
+					const isChild = relationship.child !== undefined;
+					const appealType = isChild
 						? `${relationship.child?.appealType?.type} (${relationship.child?.appealType?.key})`
 						: `${relationship.parent?.appealType?.type} (${relationship.parent?.appealType?.key})`;
 
 					return {
-						appealId: relationship.childId,
-						appealReference: relationship.childRef,
+						appealId: isChild ? relationship.childId : relationship.parentId,
+						appealReference: isChild ? relationship.childRef : relationship.parentRef,
 						externalSource: relationship.externalSource === true,
 						linkingDate: relationship.linkingDate.toISOString(),
 						appealType,
 						externalAppealType: relationship.externalAppealType,
 						relationshipId: relationship.id,
 						externalId: relationship.externalId,
-						isParentAppeal: false
+						isParentAppeal: isChild ? false : true
 					};
 				})
 		: [];


### PR DESCRIPTION
## Describe your changes
- For related appeals, we hadn't considered parent and child appeals properly - all were considered child appeals which caused appeals to link to themselves (the child) rather than referring to the "parent" 

<!--
    Please include a summary of the change along with any relevant context.
    List any dependencies that are required for this change.
-->

## Issue ticket number and link

[Ticket](https://pins-ds.atlassian.net/browse/A2-3965)
