### PR TITLE
test(api): updating notify tests to cover cas planning decisions

### DIFF
--- a/appeals/api/src/server/endpoints/appeal-decision/__tests__/appeal-decision.test.js
+++ b/appeals/api/src/server/endpoints/appeal-decision/__tests__/appeal-decision.test.js
@@ -2,7 +2,12 @@
 import { request } from '../../../app-test.js';
 import { jest } from '@jest/globals';
 import { azureAdUserId } from '#tests/shared/mocks.js';
-import { fullPlanningAppeal, householdAppeal, listedBuildingAppeal } from '#tests/appeals/mocks.js';
+import {
+	householdAppeal,
+	casPlanningAppeal,
+	fullPlanningAppeal,
+	listedBuildingAppeal
+} from '#tests/appeals/mocks.js';
 import { documentCreated } from '#tests/documents/mocks.js';
 import formatDate from '@pins/appeals/utils/date-formatter.js';
 import { add, sub } from 'date-fns';
@@ -151,6 +156,7 @@ describe('appeal decision routes', () => {
 
 		test.each([
 			['householdAppeal', householdAppeal],
+			['casPlanningAppeal', casPlanningAppeal],
 			['fullPlanningAppeal', fullPlanningAppeal],
 			['listedBuildingAppeal', listedBuildingAppeal]
 		])('returns 200 when all good, appeal type: %s', async (_, appeal) => {

--- a/appeals/api/src/server/endpoints/decision/__tests__/decision.test.js
+++ b/appeals/api/src/server/endpoints/decision/__tests__/decision.test.js
@@ -2,7 +2,12 @@
 import { request } from '../../../app-test.js';
 import { jest } from '@jest/globals';
 import { azureAdUserId } from '#tests/shared/mocks.js';
-import { householdAppeal, fullPlanningAppeal, listedBuildingAppeal } from '#tests/appeals/mocks.js';
+import {
+	householdAppeal,
+	casPlanningAppeal,
+	fullPlanningAppeal,
+	listedBuildingAppeal
+} from '#tests/appeals/mocks.js';
 import { documentCreated } from '#tests/documents/mocks.js';
 import formatDate from '@pins/appeals/utils/date-formatter.js';
 import { add, sub } from 'date-fns';
@@ -188,6 +193,7 @@ describe('decision routes', () => {
 
 		test.each([
 			['householdAppeal', householdAppeal],
+			['casPlanningAppeal', casPlanningAppeal],
 			['fullPlanningAppeal', fullPlanningAppeal],
 			['listedBuildingAppeal', listedBuildingAppeal]
 		])('returns 200 when all good, appeal type: %s', async (_, appeal) => {

--- a/appeals/api/src/server/endpoints/invalid-appeal-decision/__tests__/invalid-appeal-decision.test.js
+++ b/appeals/api/src/server/endpoints/invalid-appeal-decision/__tests__/invalid-appeal-decision.test.js
@@ -2,7 +2,12 @@
 import { request } from '../../../app-test.js';
 import { jest } from '@jest/globals';
 import { azureAdUserId } from '#tests/shared/mocks.js';
-import { householdAppeal, fullPlanningAppeal, listedBuildingAppeal } from '#tests/appeals/mocks.js';
+import {
+	householdAppeal,
+	casPlanningAppeal,
+	fullPlanningAppeal,
+	listedBuildingAppeal
+} from '#tests/appeals/mocks.js';
 import { documentCreated } from '#tests/documents/mocks.js';
 import { APPEAL_CASE_STATUS } from '@planning-inspectorate/data-model';
 import { ERROR_CANNOT_BE_EMPTY_STRING } from '@pins/appeals/constants/support.js';
@@ -83,6 +88,7 @@ describe('invalid appeal decision routes', () => {
 
 		test.each([
 			['householdAppeal', householdAppeal],
+			['casPlanningAppeal', casPlanningAppeal],
 			['fullPlanningAppeal', fullPlanningAppeal],
 			['listedBuildingAppeal', listedBuildingAppeal]
 		])('returns 200 and send 2 notify emails when all good, appeal type: %s', async (_, appeal) => {

--- a/appeals/api/src/server/tests/appeals/mocks.js
+++ b/appeals/api/src/server/tests/appeals/mocks.js
@@ -269,6 +269,21 @@ export const householdAppeal = {
 	}
 };
 
+export const casPlanningAppeal = {
+	...householdAppeal,
+	id: 7,
+	appealType: {
+		id: 13,
+		type: 'CAS planning',
+		key: 'ZP'
+	},
+	appellantCase: {
+		...householdAppeal.appellantCase,
+		hasDesignAndAccessStatement: true,
+		hasNewPlansOrDrawings: true
+	}
+};
+
 export const fullPlanningAppeal = {
 	...householdAppeal,
 	id: 2,


### PR DESCRIPTION
## Describe your changes

- Adding tests for notify for CAS planning decisions
- Adding a mock CAS planning appeal

## Issue ticket number and link

[Ticket](https://pins-ds.atlassian.net/browse/A2-3793)
