### PR TITLE
feat(api): updating questionnaire notifies to include cas planning

### DIFF
--- a/appeals/api/src/server/endpoints/lpa-questionnaires/__tests__/lpa-questionnaires.test.js
+++ b/appeals/api/src/server/endpoints/lpa-questionnaires/__tests__/lpa-questionnaires.test.js
@@ -29,6 +29,8 @@ import {
 	householdAppeal,
 	householdAppealLPAQuestionnaireComplete,
 	householdAppealLPAQuestionnaireIncomplete,
+	casPlanningAppeal,
+	casPlanningAppealLPAQuestionnaireIncomplete,
 	listedBuildingAppeal,
 	listedBuildingAppealLPAQuestionnaireIncomplete
 } from '#tests/appeals/mocks.js';
@@ -244,40 +246,61 @@ describe('lpa questionnaires routes', () => {
 			});
 
 			test.each([
-				{
-					appeal: householdAppeal,
-					templateName: 'lpaq-complete-has-appellant',
-					personalisation: {
-						lpa_reference: householdAppeal.applicationReference,
-						appeal_reference_number: householdAppeal.reference,
-						site_address: `${householdAppeal.address.addressLine1}, ${householdAppeal.address.addressLine2}, ${householdAppeal.address.addressTown}, ${householdAppeal.address.addressCounty}, ${householdAppeal.address.postcode}, ${householdAppeal.address.addressCountry}`
+				[
+					'householdAppeal',
+					{
+						appeal: householdAppeal,
+						templateName: 'lpaq-complete-has-appellant',
+						personalisation: {
+							lpa_reference: householdAppeal.applicationReference,
+							appeal_reference_number: householdAppeal.reference,
+							site_address: `${householdAppeal.address.addressLine1}, ${householdAppeal.address.addressLine2}, ${householdAppeal.address.addressTown}, ${householdAppeal.address.addressCounty}, ${householdAppeal.address.postcode}, ${householdAppeal.address.addressCountry}`
+						}
 					}
-				},
-				{
-					appeal: fullPlanningAppeal,
-					templateName: 'lpaq-complete-appellant',
-					personalisation: {
-						lpa_reference: fullPlanningAppeal.applicationReference,
-						appeal_reference_number: fullPlanningAppeal.reference,
-						site_address: `${fullPlanningAppeal.address.addressLine1}, ${fullPlanningAppeal.address.addressLine2}, ${fullPlanningAppeal.address.addressTown}, ${fullPlanningAppeal.address.addressCounty}, ${fullPlanningAppeal.address.postcode}, ${fullPlanningAppeal.address.addressCountry}`,
-						what_happens_next:
-							'We will send you another email when the local planning authority submits their statement and we receive any comments from interested parties.'
+				],
+				[
+					'casPlanningAppeal',
+					{
+						appeal: casPlanningAppeal,
+						templateName: 'lpaq-complete-has-appellant',
+						personalisation: {
+							lpa_reference: casPlanningAppeal.applicationReference,
+							appeal_reference_number: casPlanningAppeal.reference,
+							site_address: `${casPlanningAppeal.address.addressLine1}, ${casPlanningAppeal.address.addressLine2}, ${casPlanningAppeal.address.addressTown}, ${casPlanningAppeal.address.addressCounty}, ${casPlanningAppeal.address.postcode}, ${casPlanningAppeal.address.addressCountry}`
+						}
 					}
-				},
-				{
-					appeal: listedBuildingAppeal,
-					templateName: 'lpaq-complete-appellant',
-					personalisation: {
-						lpa_reference: listedBuildingAppeal.applicationReference,
-						appeal_reference_number: listedBuildingAppeal.reference,
-						site_address: `${listedBuildingAppeal.address.addressLine1}, ${listedBuildingAppeal.address.addressLine2}, ${listedBuildingAppeal.address.addressTown}, ${listedBuildingAppeal.address.addressCounty}, ${listedBuildingAppeal.address.postcode}, ${listedBuildingAppeal.address.addressCountry}`,
-						what_happens_next:
-							'We will send you another email when the local planning authority submits their statement and we receive any comments from interested parties.'
+				],
+				[
+					'fullPlanningAppeal',
+					{
+						appeal: fullPlanningAppeal,
+						templateName: 'lpaq-complete-appellant',
+						personalisation: {
+							lpa_reference: fullPlanningAppeal.applicationReference,
+							appeal_reference_number: fullPlanningAppeal.reference,
+							site_address: `${fullPlanningAppeal.address.addressLine1}, ${fullPlanningAppeal.address.addressLine2}, ${fullPlanningAppeal.address.addressTown}, ${fullPlanningAppeal.address.addressCounty}, ${fullPlanningAppeal.address.postcode}, ${fullPlanningAppeal.address.addressCountry}`,
+							what_happens_next:
+								'We will send you another email when the local planning authority submits their statement and we receive any comments from interested parties.'
+						}
 					}
-				}
+				],
+				[
+					'listedBuildingAppeal',
+					{
+						appeal: listedBuildingAppeal,
+						templateName: 'lpaq-complete-appellant',
+						personalisation: {
+							lpa_reference: listedBuildingAppeal.applicationReference,
+							appeal_reference_number: listedBuildingAppeal.reference,
+							site_address: `${listedBuildingAppeal.address.addressLine1}, ${listedBuildingAppeal.address.addressLine2}, ${listedBuildingAppeal.address.addressTown}, ${listedBuildingAppeal.address.addressCounty}, ${listedBuildingAppeal.address.postcode}, ${listedBuildingAppeal.address.addressCountry}`,
+							what_happens_next:
+								'We will send you another email when the local planning authority submits their statement and we receive any comments from interested parties.'
+						}
+					}
+				]
 			])(
 				'sends a correctly formatted notify email when the outcome is complete for an appeal of type %s',
-				async (test) => {
+				async (_, test) => {
 					// @ts-ignore
 					databaseConnector.appeal.findUnique
 						.mockResolvedValueOnce({
@@ -969,6 +992,7 @@ describe('lpa questionnaires routes', () => {
 
 			test.each([
 				['household', householdAppealLPAQuestionnaireIncomplete],
+				['cas planning', casPlanningAppealLPAQuestionnaireIncomplete],
 				['full planning', fullPlanningAppealLPAQuestionnaireIncomplete],
 				['listed building', listedBuildingAppealLPAQuestionnaireIncomplete]
 			])(

--- a/appeals/api/src/server/endpoints/lpa-questionnaires/lpa-questionnaires.service.js
+++ b/appeals/api/src/server/endpoints/lpa-questionnaires/lpa-questionnaires.service.js
@@ -178,6 +178,7 @@ function sendLpaqCompleteEmailToAppellant(notifyClient, appeal, siteAddress, azu
 
 	switch (appeal.appealType?.type) {
 		case APPEAL_TYPE.HOUSEHOLDER:
+		case APPEAL_TYPE.CAS_PLANNING:
 			return sendLpaqCompleteEmail(
 				notifyClient,
 				appeal,

--- a/appeals/api/src/server/tests/appeals/mocks.js
+++ b/appeals/api/src/server/tests/appeals/mocks.js
@@ -462,6 +462,21 @@ export const householdAppealLPAQuestionnaireIncomplete = {
 	id: 3
 };
 
+export const casPlanningAppealLPAQuestionnaireIncomplete = {
+	...casPlanningAppeal,
+	appealStatus: [
+		{
+			status: APPEAL_CASE_STATUS.LPA_QUESTIONNAIRE,
+			valid: true
+		}
+	],
+	lpaQuestionnaire: {
+		...casPlanningAppeal.lpaQuestionnaire,
+		...incompleteLPAQuestionnaireOutcome
+	},
+	id: 4
+};
+
 export const fullPlanningAppealAppellantCaseIncomplete = {
 	...fullPlanningAppeal,
 	appellantCase: {

--- a/docs/notifications-and-triggers.md
+++ b/docs/notifications-and-triggers.md
@@ -92,7 +92,7 @@ The following notifications are sent from the back-office using these [Notify Te
 
 ### Lpaq complete householder appellant
 
-- **Appeal type:** householder
+- **Appeal type:** householder, CAS planning
 - **Notify Template:** [lpaq-complete-has-appellant](../appeals/api/src/server/notify/templates/lpaq-complete-has-appellant.content.md)
 - **Trigger:** Review a Lpaq and mark it as complete by selecting "Complete" and continue
 


### PR DESCRIPTION
## Describe your changes

- Updating the code to send notifies for CAS planning LPAQ complete
- Updating tests to cover CAS planning questionnaire notifies
- Updating mocks to contain LPAQ incomplete data for CAS planning
- Updating the documentation to reflect the cases where CAS planning notifies are sent
- Changing the adding a name in the input structure on one of the test each so that the test title displays nicely

## Issue ticket number and link

[Ticket](https://pins-ds.atlassian.net/browse/A2-3668)
