### PR TITLE
fix(api): improve API performance for GET /appeals endpoint

### DIFF
--- a/appeals/api/setup-tests.js
+++ b/appeals/api/setup-tests.js
@@ -19,6 +19,7 @@ const mockAppealFindUnique = jest.fn().mockResolvedValue({});
 const mockAppealCreate = jest.fn().mockResolvedValue({});
 const mocklPAQuestionnaireCreate = jest.fn().mockResolvedValue({});
 const mocklPAQuestionnaireUpdate = jest.fn().mockResolvedValue({});
+const mockAppealStatusFindMany = jest.fn().mockResolvedValue([]);
 const mockAppealStatusUpdateMany = jest.fn().mockResolvedValue({});
 const mockAppealStatusCreate = jest.fn().mockResolvedValue({});
 const mockAppealUpdate = jest.fn().mockResolvedValue({});
@@ -206,7 +207,8 @@ class MockPrismaClient {
 		return {
 			updateMany: mockAppealStatusUpdateMany,
 			create: mockAppealStatusCreate,
-			createMany: mockAppealStatusCreateMany
+			createMany: mockAppealStatusCreateMany,
+			findMany: mockAppealStatusFindMany
 		};
 	}
 

--- a/appeals/api/src/server/endpoints/appeals/appeals.service.js
+++ b/appeals/api/src/server/endpoints/appeals/appeals.service.js
@@ -169,17 +169,27 @@ const retrieveAppealListData = async (
 		inspectorId && Number(inspectorId),
 		caseOfficerId && Number(caseOfficerId),
 		isGreenBelt,
-		appealTypeId
+		appealTypeId,
+		pageNumber,
+		pageSize
 	);
 
-	const start = (pageNumber - 1) * pageSize;
-	const end = start + pageSize;
-	const mappedAppeals = await mapAppeals(appeals.slice(start, end));
+	const mappedAppeals = await mapAppeals(appeals);
 	const mappedStatuses = mapAppealStatuses(appeals);
 	const mappedLPAs = mapAppealLPAs(appeals);
 	const mappedInspectors = await mapInspectors(appeals);
 	const mappedCaseOfficers = await mapCaseOfficers(appeals);
 	const statusesInNationalList = await appealListRepository.getAppealsStatusesInNationalList();
+	const itemCount = await appealListRepository.getAllAppealsCount(
+		searchTerm,
+		status,
+		hasInspector,
+		lpaCode,
+		inspectorId,
+		caseOfficerId,
+		isGreenBelt,
+		appealTypeId
+	);
 
 	return {
 		mappedStatuses,
@@ -188,7 +198,7 @@ const retrieveAppealListData = async (
 		mappedInspectors,
 		mappedCaseOfficers,
 		mappedAppeals,
-		itemCount: appeals.length
+		itemCount
 	};
 };
 


### PR DESCRIPTION
## Describe your changes

Use DB-level paging to improve performance. We were getting all records and then splitting them up in the code. The query that it was generating actually broke the DB when there were more than 2100 records. We now only get one page of records and do a separate COUNT query to get the total number of matched records for pagination purposes. Also I have simplified the query for getting all unique statuses from the national list as that was also broken when there were > 2100 records.


## Issue ticket number and link

[A2-3901](https://pins-ds.atlassian.net/browse/A2-3901)


[A2-3901]: https://pins-ds.atlassian.net/browse/A2-3901?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ