### PR TITLE
fix(appeals): no action links for arrange site visit in the personal list (a2-3890)

### DIFF
--- a/appeals/web/src/server/lib/mappers/utils/__tests__/required-actions.test.js
+++ b/appeals/web/src/server/lib/mappers/utils/__tests__/required-actions.test.js
@@ -1102,7 +1102,9 @@ describe('required actions', () => {
 					)
 				).toEqual(['reviewAppellantFinalComments', 'reviewLpaFinalComments']);
 			});
+		});
 
+		describe('when appeal status is "EVENT"', () => {
 			it('should return "setup hearing" if appeal status is "EVENT"', () => {
 				expect(
 					getRequiredActionsForAppeal(
@@ -1161,6 +1163,18 @@ describe('required actions', () => {
 						'summary'
 					)
 				).toEqual(['addHearingAddress']);
+			});
+
+			it('should return "arrange site visit" if appeal status is "EVENT" and procedure type is not hearing', () => {
+				expect(
+					getRequiredActionsForAppeal(
+						{
+							...appealData,
+							appealStatus: APPEAL_CASE_STATUS.EVENT
+						},
+						'detail'
+					)
+				).toEqual(['arrangeSiteVisit']);
 			});
 		});
 	});

--- a/appeals/web/src/server/lib/mappers/utils/required-actions.js
+++ b/appeals/web/src/server/lib/mappers/utils/required-actions.js
@@ -31,40 +31,35 @@ export function getRequiredActionsForAppeal(appealDetails, view) {
 			actions.push('addHorizonReference');
 			break;
 		case APPEAL_CASE_STATUS.EVENT:
-			// @ts-ignore
 			if (
-				appealDetails.procedureType?.toLowerCase() === APPEAL_CASE_PROCEDURE.WRITTEN.toLowerCase()
+				appealDetails.procedureType?.toLowerCase() !== APPEAL_CASE_PROCEDURE.HEARING.toLowerCase()
 			) {
 				actions.push('arrangeSiteVisit');
+				break;
+			}
+			// @ts-ignore
+			if (
+				// @ts-ignore
+				(view === 'detail' && !appealDetails.hearing) ||
+				// @ts-ignore
+				(view === 'summary' && !appealDetails.isHearingSetup)
+			) {
+				actions.push('setupHearing');
+				break;
 			}
 
 			if (
-				appealDetails.procedureType?.toLowerCase() === APPEAL_CASE_PROCEDURE.HEARING.toLowerCase()
-			) {
+				(view === 'detail' &&
+					// @ts-ignore
+					appealDetails.hearing &&
+					// @ts-ignore
+					!appealDetails.hearing?.addressId &&
+					// @ts-ignore
+					!appealDetails.hearing?.address) ||
 				// @ts-ignore
-				if (
-					// @ts-ignore
-					(view === 'detail' && !appealDetails.hearing) ||
-					// @ts-ignore
-					(view === 'summary' && !appealDetails.isHearingSetup)
-				) {
-					actions.push('setupHearing');
-					break;
-				}
-
-				if (
-					(view === 'detail' &&
-						// @ts-ignore
-						appealDetails.hearing &&
-						// @ts-ignore
-						!appealDetails.hearing?.addressId &&
-						// @ts-ignore
-						!appealDetails.hearing?.address) ||
-					// @ts-ignore
-					(view === 'summary' && !appealDetails.hasHearingAddress)
-				) {
-					actions.push('addHearingAddress');
-				}
+				(view === 'summary' && !appealDetails.hasHearingAddress)
+			) {
+				actions.push('addHearingAddress');
 			}
 			break;
 		case APPEAL_CASE_STATUS.ISSUE_DETERMINATION:


### PR DESCRIPTION
## Describe your changes
#### Display action links for arrange site visit in the personal list (a2-3890)

### WEB:
- Default the action link in the personal list to arrange site visit.

### TEST:
- Fixed unit tests
- Made sure all unit tests pass
- Manually tested within browser

## Issue ticket number and link:
- [(A2-3890) No action link on 'Cases assigned to you' screen when appeal is at 'Site visit ready to set up' stage](https://pins-ds.atlassian.net/browse/A2-3890)

