### PR TITLE
fix(api): make sure all values for filter dropdowns are returned

### DIFF
--- a/appeals/api/setup-tests.js
+++ b/appeals/api/setup-tests.js
@@ -99,6 +99,7 @@ const mockLPANotificationMethodsFindMany = jest.fn().mockResolvedValue({});
 const mockLPADesignatedSitesFindMany = jest.fn().mockResolvedValue({});
 const mockProcedureTypeFindMany = jest.fn().mockResolvedValue({});
 const mockAppellantUpdate = jest.fn().mockResolvedValue({});
+const mockUserFindMany = jest.fn().mockResolvedValue({});
 const mockUserUpsert = jest.fn().mockResolvedValue({});
 const mockAppellantCaseIncompleteReasonTextDeleteMany = jest.fn().mockResolvedValue({});
 const mockAppellantCaseIncompleteReasonTextCreateMany = jest.fn().mockResolvedValue({});
@@ -437,6 +438,7 @@ class MockPrismaClient {
 
 	get user() {
 		return {
+			findMany: mockUserFindMany,
 			upsert: mockUserUpsert
 		};
 	}

--- a/appeals/api/src/server/repositories/appeal-lists.repository.js
+++ b/appeals/api/src/server/repositories/appeal-lists.repository.js
@@ -139,6 +139,40 @@ const getAllAppealsCount = async (
  * @param {boolean} isGreenBelt
  * @param {number} appealTypeId
  */
+const getAppealsWithoutIncludes = async (
+	searchTerm,
+	status,
+	hasInspector,
+	lpaCode,
+	inspectorId,
+	caseOfficerId,
+	isGreenBelt,
+	appealTypeId
+) => {
+	const where = buildAllAppealsWhereClause(
+		searchTerm,
+		status,
+		hasInspector,
+		lpaCode,
+		inspectorId,
+		caseOfficerId,
+		isGreenBelt,
+		appealTypeId
+	);
+
+	return databaseConnector.appeal.findMany({ where });
+};
+
+/**
+ * @param {string} searchTerm
+ * @param {string} status
+ * @param {string} hasInspector
+ * @param {string} lpaCode
+ * @param {number} inspectorId
+ * @param {number} caseOfficerId
+ * @param {boolean} isGreenBelt
+ * @param {number} appealTypeId
+ */
 const buildAllAppealsWhereClause = (
 	searchTerm,
 	status,
@@ -404,5 +438,6 @@ export default {
 	getAllAppeals,
 	getAllAppealsCount,
 	getUserAppeals,
-	getAppealsStatusesInNationalList
+	getAppealsStatusesInNationalList,
+	getAppealsWithoutIncludes
 };

--- a/appeals/api/src/server/repositories/lpa.repository.js
+++ b/appeals/api/src/server/repositories/lpa.repository.js
@@ -32,7 +32,20 @@ const updateLpaByAppealId = (appeal, newLpaId) => {
 	});
 };
 
+/**
+ * Get LPAs by IDs
+ * @param {number[]} ids
+ * @returns {PrismaPromise<LPA[]>}
+ */
+const getLpasByIds = (ids) => {
+	return databaseConnector.lPA.findMany({
+		where: { id: { in: ids } },
+		orderBy: { name: 'asc' }
+	});
+};
+
 export default {
 	getLpaById,
-	updateLpaByAppealId
+	updateLpaByAppealId,
+	getLpasByIds
 };

--- a/appeals/api/src/server/repositories/user.repository.js
+++ b/appeals/api/src/server/repositories/user.repository.js
@@ -21,4 +21,15 @@ const findOrCreateUser = (azureAdUserId) =>
 		}
 	});
 
-export default { findOrCreateUser };
+/**
+ * Get users by IDs
+ * @param {number[]} ids
+ * @returns {PrismaPromise<User[]>}
+ */
+const getUsersByIds = (ids) => {
+	return databaseConnector.user.findMany({
+		where: { id: { in: ids } }
+	});
+};
+
+export default { findOrCreateUser, getUsersByIds };


### PR DESCRIPTION
## Describe your changes

The `GET /appeals` endpoint returns some extra values for populating the filter dropdowns. Now that we are paging the results at the DB level, only the values for appeals on the current page were showing in some of the dropdowns. So we do need to grab all of the appeals for the purpose of knowing which values to show, but that can be done as a second query without including all of the relationships for all of the appeals, which makes it more performant and stops it breaking when there are many appeals in the DB. A couple of extra queries are required to translate IDs/keys into names but there are not too demanding. At some point in the future we will be looking at using stored procedures as an option for further improving the performance here.

## Issue ticket number and link

[A2-3901](https://pins-ds.atlassian.net/browse/A2-3901)


[A2-3901]: https://pins-ds.atlassian.net/browse/A2-3901?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ