### PR TITLE
feat(api): adding cas planning timetable notifies logic and tests (A2…

### DIFF
--- a/appeals/api/src/server/endpoints/appeal-timetables/appeal-timetables.service.js
+++ b/appeals/api/src/server/endpoints/appeal-timetables/appeal-timetables.service.js
@@ -84,7 +84,8 @@ const sendStartCaseNotifies = async (
 	const appealTypeMap = {
 		D: '-',
 		W: '-s78-',
-		Y: '-s78-'
+		Y: '-s78-',
+		ZP: '-'
 	};
 
 	const { type = '', key: appealTypeKey = 'D' } = appeal.appealType || {};
@@ -355,7 +356,7 @@ const sendTimetableUpdateNotify = async (appeal, processedBody, notifyClient, az
 	const recipientEmail = appeal.agent?.email || appeal.appellant?.email;
 	const lpaEmail = appeal.lpa?.email || '';
 	const templateName =
-		appeal.appealType?.key === APPEAL_TYPE_SHORTHAND_HAS
+		appeal.appealType?.key === APPEAL_TYPE_SHORTHAND_HAS || appeal.appealType?.key === 'ZP'
 			? 'has-appeal-timetable-updated'
 			: 'appeal-timetable-updated';
 
@@ -388,6 +389,7 @@ const sendTimetableUpdateNotify = async (appeal, processedBody, notifyClient, az
 const shouldSendNotify = (appealTypeShorthand, procedureType) => {
 	return (
 		appealTypeShorthand === APPEAL_TYPE_SHORTHAND_HAS ||
+		appealTypeShorthand === 'ZP' ||
 		(appealTypeShorthand === 'W' && procedureType === APPEAL_CASE_PROCEDURE.WRITTEN) ||
 		(appealTypeShorthand === 'Y' && procedureType === APPEAL_CASE_PROCEDURE.WRITTEN) ||
 		procedureType === undefined

--- a/docs/notifications-and-triggers.md
+++ b/docs/notifications-and-triggers.md
@@ -60,13 +60,13 @@ The following notifications are sent from the back-office using these [Notify Te
 
 ### Appeal valid start case householder appellant
 
-- **Appeal type:** householder
+- **Appeal type:** householder, CAS planning
 - **Notify Template:** [appeal-valid-start-case-appellant](../appeals/api/src/server/notify/templates/appeal-valid-start-case-appellant.content.md)
 - **Trigger:** Start a householder case, select an appeal procedure, and confirm.
 
 ### Appeal valid start case householder lpa
 
-- **Appeal type:** householder
+- **Appeal type:** householder, CAS planning
 - **Notify Template:** [appeal-valid-start-case-lpa](../appeals/api/src/server/notify/templates/appeal-valid-start-case-lpa.content.md)
 - **Trigger:** Start a householder case, select an appeal procedure, and confirm.
 


### PR DESCRIPTION
…-3679)

## Describe your changes

- Updating to send the correct notify templates for CAS planning timetable notifies
- Adding tests for CAS planning
- Updating the documentation to reflect which notifies are sent for CAS planning

## Issue ticket number and link

[Ticket](https://pins-ds.atlassian.net/browse/A2-3679)
