### PR TITLE
fix(api): extend file upload hex signature list to allow common uploads

### DIFF
--- a/packages/appeals/constants/documents.js
+++ b/packages/appeals/constants/documents.js
@@ -73,9 +73,12 @@ export const VALID_MIME_TYPES = Object.freeze({
 		extensions: ['xlsx']
 	},
 	'application/vnd.ms-outlook': { hexSignature: 'D0CF11E0', extensions: ['msg'] },
-	'image/jpeg': { hexSignature: 'FFD8FFE0', extensions: ['jpg', 'jpeg'] },
+	'image/jpeg': {
+		hexSignature: 'FFD8FFE0, FFD8FFE1, FFD8FFE8, FFD8FFEE',
+		extensions: ['jpg', 'jpeg']
+	},
 	'video/mpeg': { hexSignature: '000001B3, 000001BA', extensions: ['mpeg'] },
-	'audio/mpeg': { hexSignature: 'FFFB, 494433', extensions: ['mp3'] },
+	'audio/mpeg': { hexSignature: 'FFFB, FFF2, FFF3, 494433', extensions: ['mp3'] },
 	'video/mp4': { hexSignature: '66747970', offset: 8, extensions: ['mp4'] },
 	'video/quicktime': { hexSignature: '0000001466747970', extensions: ['mov'] },
 	'image/png': { hexSignature: '89504E47', extensions: ['png'] },


### PR DESCRIPTION
## Describe your changes

Extending the list of valid hex signatures used when validating mime types
Added a few more from https://en.wikipedia.org/wiki/List_of_file_signatures

## Issue ticket number and link

[Ticket](https://pins-ds.atlassian.net/browse/A2-4039)
