### PR TITLE
fix(A2-3984): adding hearing event type for lpa withdrawal notify

### DIFF
--- a/appeals/api/src/server/endpoints/withdrawal/__tests__/withdrawal.test.js
+++ b/appeals/api/src/server/endpoints/withdrawal/__tests__/withdrawal.test.js
@@ -80,7 +80,8 @@ describe('appeal withdrawal routes', () => {
 						status: APPEAL_CASE_STATUS.EVENT,
 						valid: true
 					}
-				]
+				],
+				hearing: null
 			};
 			databaseConnector.appeal.findUnique.mockResolvedValue(correctAppealState);
 

--- a/appeals/api/src/server/endpoints/withdrawal/withdrawal.service.js
+++ b/appeals/api/src/server/endpoints/withdrawal/withdrawal.service.js
@@ -4,6 +4,7 @@ import { broadcasters } from '#endpoints/integrations/integrations.broadcasters.
 import { APPEAL_CASE_STATUS } from '@planning-inspectorate/data-model';
 import formatDate from '@pins/appeals/utils/date-formatter.js';
 import { notifySend } from '#notify/notify-send.js';
+import { PROCEDURE_TYPE_ID_MAP } from '@pins/appeals/constants/common.js';
 
 /** @typedef {import('@pins/appeals.api').Schema.Appeal} Appeal */
 
@@ -31,7 +32,7 @@ export const publishWithdrawal = async (
 	const recipientEmail = appeal.agent?.email || appeal.appellant?.email;
 	const lpaEmail = appeal.lpa?.email || '';
 
-	const eventType = appeal.siteVisit ? 'site visit' : '';
+	const eventType = getEventType(appeal);
 	const personalisation = {
 		appeal_reference_number: appeal.reference,
 		lpa_reference: appeal.applicationReference || '',
@@ -67,4 +68,19 @@ export const publishWithdrawal = async (
 	}
 
 	return null;
+};
+
+/**
+ * @param {Appeal} appeal
+ * @returns
+ */
+const getEventType = (appeal) => {
+	let eventType = '';
+
+	if (appeal.hearing && appeal.procedureType?.id === PROCEDURE_TYPE_ID_MAP.hearing) {
+		eventType = 'hearing';
+	} else if (appeal.siteVisit) {
+		eventType = 'site visit';
+	}
+	return eventType;
 };

--- a/appeals/api/src/server/notify/templates/__tests__/notify-appeal-withdrawn-lpa.test.js
+++ b/appeals/api/src/server/notify/templates/__tests__/notify-appeal-withdrawn-lpa.test.js
@@ -122,3 +122,65 @@ test('should call notify sendEmail for appeal-withdrawn-lpa without site visit c
 		}
 	);
 });
+
+test('should call notify sendEmail for appeal-withdrawn-lpa with the correct data for hearing', async () => {
+	const notifySendData = {
+		doNotMockNotifySend: true,
+		templateName: 'appeal-withdrawn-lpa',
+		notifyClient: {
+			sendEmail: jest.fn()
+		},
+		recipientEmail: 'test@136s7.com',
+		personalisation: {
+			appeal_reference_number: '234567',
+			lpa_reference: '48269/APP/2021/1483',
+			site_address: '98 The Avenue, Leftfield, Maidstone, Kent, MD21 5YY, United Kingdom',
+			withdrawal_date: '03 January 2025',
+			event_set: true,
+			event_type: 'hearing'
+		},
+		appeal: {
+			id: 'mock-appeal-generic-id',
+			reference: '234567'
+		},
+		startDate: new Date('2025-01-01')
+	};
+
+	const expectedContent = [
+		"We have withdrawn the appeal after the appellant's request.",
+		'',
+		'# Appeal details',
+		'',
+		'^Appeal reference number: 234567',
+		'Address: 98 The Avenue, Leftfield, Maidstone, Kent, MD21 5YY, United Kingdom',
+		'Planning application reference: 48269/APP/2021/1483',
+		'',
+		'# What happens next',
+		'',
+		'The appeal is closed.',
+		'',
+		'',
+		'We have cancelled the hearing.',
+		'',
+		'',
+		'# Feedback',
+		'',
+		'We welcome your feedback on our appeals process. Tell us on this short [feedback form](https://forms.office.com/pages/responsepage.aspx?id=mN94WIhvq0iTIpmM5VcIjfMZj__F6D9LmMUUyoUrZDZUOERYMEFBN0NCOFdNU1BGWEhHUFQxWVhUUy4u).',
+		'',
+		'The Planning Inspectorate',
+		'caseofficers@planninginspectorate.gov.uk'
+	].join('\n');
+
+	await notifySend(notifySendData);
+
+	expect(notifySendData.notifyClient.sendEmail).toHaveBeenCalledWith(
+		{
+			id: 'mock-appeal-generic-id'
+		},
+		'test@136s7.com',
+		{
+			content: expectedContent,
+			subject: 'Appeal withdrawn: 234567'
+		}
+	);
+});


### PR DESCRIPTION
## Describe your changes
- Updated the logic for the LPA withdrawal notify to determine eventType and include hearing in this to ensure "hearing cancelled" is included on the notify email (when it's been set up).
- Added new unit test for updated content
<!--
    Please include a summary of the change along with any relevant context.
    List any dependencies that are required for this change.
-->

## Issue ticket number and link

[Ticket](https://pins-ds.atlassian.net.mcas.ms/browse/A2-3984)
