### PR TITLE
fix(appeals): small refactor for awaiting appeals when statuses are different

### DIFF
--- a/appeals/api/src/server/mappers/mapper-factory.js
+++ b/appeals/api/src/server/mappers/mapper-factory.js
@@ -17,7 +17,7 @@ import mergeMaps from '#utils/merge-maps.js';
 /** @typedef {import('@planning-inspectorate/data-model').Schemas.AppealS78Case} AppealS78Case */
 /** @typedef {AppealDTO|AppellantCaseDto|LpaQuestionnaireDTO|AppealHASCase|AppealS78Case} MapResult */
 /** @typedef {import('@pins/appeals.api').Api.Folder} Folder */
-/** @typedef {{ appeal: Appeal, appealTypes?: AppealType[]|undefined, context: keyof contextEnum|undefined }} MappingRequest */
+/** @typedef {{ appeal: Appeal, appealTypes?: AppealType[]|undefined, linkedAppeals?: *[]|undefined, context: keyof contextEnum|undefined }} MappingRequest */
 
 /**
  *
@@ -27,6 +27,7 @@ import mergeMaps from '#utils/merge-maps.js';
 export const mapCase = ({
 	appeal,
 	appealTypes = [],
+	linkedAppeals = [],
 	context = /** @type {keyof contextEnum} */ (contextEnum.appealDetails)
 }) => {
 	if (!context || !appeal?.id || !appeal?.caseCreatedDate) {
@@ -36,7 +37,7 @@ export const mapCase = ({
 	const caseMap =
 		context === contextEnum.broadcast
 			? createIntegrationMap({ appeal, context })
-			: createDataMap({ appeal, appealTypes, context });
+			: createDataMap({ appeal, appealTypes, linkedAppeals, context });
 
 	return createDataLayout(caseMap, { appeal, context });
 };

--- a/appeals/api/src/server/utils/is-awaiting-linked-appeal.js
+++ b/appeals/api/src/server/utils/is-awaiting-linked-appeal.js
@@ -8,6 +8,9 @@ import { APPEAL_CASE_STATUS } from '@planning-inspectorate/data-model';
  * @returns {boolean}
  */
 export const isAwaitingLinkedAppeal = (appeal, linkedAppeals) => {
+	if (!allLinkedAppealsHaveSameAppealStatus(appeal, linkedAppeals)) {
+		return true;
+	}
 	switch (currentStatus(appeal)) {
 		case APPEAL_CASE_STATUS.LPA_QUESTIONNAIRE: {
 			const validationOutcome =
@@ -33,9 +36,45 @@ export const allLpaQuestionnaireOutcomesAreComplete = (linkedAppeals) => {
 		return true;
 	}
 	// @ts-ignore
-	return linkedAppeals.every((appeal) => {
+	return linkedAppeals.every((linkedAppeal) => {
+		// Make sure the linked appeal is the actual appeal and not a wrapper
+		const appeal = linkedAppeal.appeal || linkedAppeal;
 		const validationOutcome =
 			appeal.lpaQuestionnaire?.lpaQuestionnaireValidationOutcome?.name?.toLowerCase();
 		return validationOutcome === 'complete';
+	});
+};
+
+/**
+ *
+ * @param {*} appeal
+ * @param {*[]}linkedAppeals
+ * @returns {*|boolean}
+ */
+const allLinkedAppealsHaveSameAppealStatus = (appeal, linkedAppeals) => {
+	if (!linkedAppeals.length) {
+		return true;
+	}
+
+	const appealStatus = currentStatus(appeal);
+
+	return linkedAppeals.every((linkedAppeal) => {
+		// If the linked appeal is an appeal wrapper
+		if (linkedAppeal.appeal) {
+			//@ts-ignore
+			return linkedAppeal.appeal.appealStatus.find((item) => item.status === appealStatus);
+		}
+		if (linkedAppeal.child && linkedAppeal.parent) {
+			return (
+				//@ts-ignore
+				linkedAppeal.child.appealStatus.find((item) => item.status === appealStatus) &&
+				//@ts-ignore
+				linkedAppeal.parent.appealStatus.find((item) => item.status === appealStatus)
+			);
+		}
+		return (
+			appealStatus === linkedAppeal.currentStatus ||
+			linkedAppeal.completedStateList.includes(appealStatus)
+		);
 	});
 };

--- a/appeals/web/src/server/appeals/personal-list/personal-list.mapper.js
+++ b/appeals/web/src/server/appeals/personal-list/personal-list.mapper.js
@@ -18,7 +18,11 @@ import { isChildAppeal } from '#lib/mappers/utils/is-child-appeal.js';
 /** @typedef {import('../../app/auth/auth.service').AccountInfo} AccountInfo */
 /** @typedef {Partial<AppealSummary & { appealTimetable: Record<string,string> }>} PersonalListAppeal */
 
-const ALLOWED_CHILD_APPEAL_ACTION_STATUSES = [APPEAL_CASE_STATUS.LPA_QUESTIONNAIRE];
+const ALLOWED_CHILD_APPEAL_ACTION_STATUSES = [
+	APPEAL_CASE_STATUS.ASSIGN_CASE_OFFICER,
+	APPEAL_CASE_STATUS.VALIDATION,
+	APPEAL_CASE_STATUS.LPA_QUESTIONNAIRE
+];
 
 /**
  * @param {AppealSummary} appeal
@@ -156,6 +160,9 @@ export function personalListPage(
 					appeal.isParentAppeal,
 					appeal.isChildAppeal
 				);
+				const actionLinks = canDisplayAction(appeal)
+					? mapActionLinksForAppeal(appeal, isCaseOfficer, request)
+					: '';
 
 				return [
 					{
@@ -181,12 +188,10 @@ export function personalListPage(
 					},
 					{
 						classes: 'action-required',
-						html: canDisplayAction(appeal)
-							? mapActionLinksForAppeal(appeal, isCaseOfficer, request)
-							: ''
+						html: actionLinks || ''
 					},
 					{
-						text: canDisplayAction(appeal) ? dateISOStringToDisplayDate(appeal.dueDate) || '' : ''
+						text: actionLinks?.length ? dateISOStringToDisplayDate(appeal.dueDate) || '' : ''
 					},
 					{
 						html: '',

--- a/appeals/web/src/server/lib/mappers/utils/required-actions.js
+++ b/appeals/web/src/server/lib/mappers/utils/required-actions.js
@@ -27,7 +27,11 @@ export function getRequiredActionsForAppeal(appealDetails, view) {
 		case APPEAL_CASE_STATUS.ASSIGN_CASE_OFFICER:
 			actions.push('assignCaseOfficer');
 			break;
-		case APPEAL_CASE_STATUS.READY_TO_START:
+		case APPEAL_CASE_STATUS.READY_TO_START: // @ts-ignore
+			if (appealDetails.awaitingLinkedAppeal && config.featureFlags.featureFlagLinkedAppeals) {
+				actions.push('awaitingLinkedAppeal');
+				break;
+			}
 			actions.push('startAppeal');
 			break;
 		case APPEAL_CASE_STATUS.AWAITING_TRANSFER:


### PR DESCRIPTION
## Describe your changes
#### Small refactor for awaiting linked appeals when statuses are different (a2-3630)

### API:
- awaitingLinkedAppeals flag should be true when at least one sibling or parent  appeal (when linked) is on a previous status.
- reuse mapping linked appeal for child and parent appeals

### TEST:
- Made sure all unit tests pass
- Manually tested within browser
- Tested with feature flag on and off 

## Issue ticket number and link:
- [(A2-3630) Reviewing questionnaires for linked written rep S78 planning appeals (where the appeals have all been started together) - part 4](https://pins-ds.atlassian.net/browse/A2-3630)

