### PR TITLE
fix(web): changing the change date page to show the next working day …

### DIFF
--- a/appeals/web/src/server/appeals/appeal-details/start-case/start-case.controller.js
+++ b/appeals/web/src/server/appeals/appeal-details/start-case/start-case.controller.js
@@ -13,6 +13,7 @@ import featureFlags from '#common/feature-flags.js';
 import { FEATURE_FLAG_NAMES, APPEAL_TYPE } from '@pins/appeals/constants/common.js';
 import { getBackLinkUrlFromQuery } from '#lib/url-utilities.js';
 import { APPEAL_CASE_PROCEDURE } from '@planning-inspectorate/data-model';
+import { recalculateDateIfNotBusinessDay } from '@pins/appeals/utils/business-days.js';
 
 /** @type {import('@pins/express').RequestHandler<Response>}  */
 export const getStartDate = async (request, response) => {
@@ -106,10 +107,13 @@ const renderChangeDatePage = async (request, response) => {
 	if (!startedAt || documentationSummary?.lpaQuestionnaire?.status !== 'not_received') {
 		return response.render('app/500.njk');
 	}
+
+	const nextBusinessDayFromToday = await recalculateDateIfNotBusinessDay(getTodaysISOString());
+
 	const mappedPageContent = changeDatePage(
 		appealId,
 		appealReference,
-		dateISOStringToDisplayDate(getTodaysISOString())
+		dateISOStringToDisplayDate(nextBusinessDayFromToday)
 	);
 
 	return response.render('patterns/display-page.pattern.njk', {


### PR DESCRIPTION
…(A2-3983)

## Describe your changes

- Changing the 'Change start date' to show the next working day
- Adding a test to check this works as expected

## Issue ticket number and link

[Ticket](https://pins-ds.atlassian.net/browse/A2-3983)

Addressing the comment on the ticket (the rest of the work on this ticket was done in [this PR](https://github.com/Planning-Inspectorate/appeals-back-office/pull/1756))
