### PR TITLE
Feat/a2 3645 ascending order for filters in the personal and national case lists

### DIFF
--- a/appeals/web/src/server/appeals/national-list/__tests__/__snapshots__/national-list.test.js.snap
+++ b/appeals/web/src/server/appeals/national-list/__tests__/__snapshots__/national-list.test.js.snap
@@ -56,13 +56,13 @@ exports[`national-list GET / should render national list - 10 pages - all page i
                             name="appealStatusFilter" data-cy="filter-by-case-status">
                                 <option value="all">All</option>
                                 <option value="assign_case_officer">Assign case officer</option>
-                                <option value="lpa_questionnaire">LPA questionnaire</option>
-                                <option value="statements">Statements</option>
-                                <option value="ready_to_start">Ready to start</option>
-                                <option value="validation">Validation</option>
                                 <option value="final_comments">Final comments</option>
                                 <option value="invalid">Invalid</option>
                                 <option value="issue_determination">Issue decision</option>
+                                <option value="lpa_questionnaire">LPA questionnaire</option>
+                                <option value="ready_to_start">Ready to start</option>
+                                <option value="statements">Statements</option>
+                                <option value="validation">Validation</option>
                                 <option value="withdrawn">Withdrawn</option>
                             </select>
                         </div>
@@ -260,13 +260,13 @@ exports[`national-list GET / should render national list - 15 pages - pagination
                             name="appealStatusFilter" data-cy="filter-by-case-status">
                                 <option value="all">All</option>
                                 <option value="assign_case_officer">Assign case officer</option>
-                                <option value="lpa_questionnaire">LPA questionnaire</option>
-                                <option value="statements">Statements</option>
-                                <option value="ready_to_start">Ready to start</option>
-                                <option value="validation">Validation</option>
                                 <option value="final_comments">Final comments</option>
                                 <option value="invalid">Invalid</option>
                                 <option value="issue_determination">Issue decision</option>
+                                <option value="lpa_questionnaire">LPA questionnaire</option>
+                                <option value="ready_to_start">Ready to start</option>
+                                <option value="statements">Statements</option>
+                                <option value="validation">Validation</option>
                                 <option value="withdrawn">Withdrawn</option>
                             </select>
                         </div>
@@ -594,13 +594,13 @@ exports[`national-list GET / should render national list - no pagination 1`] = `
                             name="appealStatusFilter" data-cy="filter-by-case-status">
                                 <option value="all">All</option>
                                 <option value="assign_case_officer">Assign case officer</option>
-                                <option value="lpa_questionnaire">LPA questionnaire</option>
-                                <option value="statements">Statements</option>
-                                <option value="ready_to_start">Ready to start</option>
-                                <option value="validation">Validation</option>
                                 <option value="final_comments">Final comments</option>
                                 <option value="invalid">Invalid</option>
                                 <option value="issue_determination">Issue decision</option>
+                                <option value="lpa_questionnaire">LPA questionnaire</option>
+                                <option value="ready_to_start">Ready to start</option>
+                                <option value="statements">Statements</option>
+                                <option value="validation">Validation</option>
                                 <option value="withdrawn">Withdrawn</option>
                             </select>
                         </div>
@@ -760,13 +760,13 @@ exports[`national-list GET / should render national list - no search term - filt
                             name="appealStatusFilter" data-cy="filter-by-case-status">
                                 <option value="all">All</option>
                                 <option value="assign_case_officer">Assign case officer</option>
-                                <option value="lpa_questionnaire" selected>LPA questionnaire</option>
-                                <option value="statements">Statements</option>
-                                <option value="ready_to_start">Ready to start</option>
-                                <option value="validation">Validation</option>
                                 <option value="final_comments">Final comments</option>
                                 <option value="invalid">Invalid</option>
                                 <option value="issue_determination">Issue decision</option>
+                                <option value="lpa_questionnaire" selected>LPA questionnaire</option>
+                                <option value="ready_to_start">Ready to start</option>
+                                <option value="statements">Statements</option>
+                                <option value="validation">Validation</option>
                                 <option value="withdrawn">Withdrawn</option>
                             </select>
                         </div>
@@ -921,13 +921,13 @@ exports[`national-list GET / should render national list - search term - filter 
                             name="appealStatusFilter" data-cy="filter-by-case-status">
                                 <option value="all">All</option>
                                 <option value="assign_case_officer">Assign case officer</option>
-                                <option value="lpa_questionnaire" selected>LPA questionnaire</option>
-                                <option value="statements">Statements</option>
-                                <option value="ready_to_start">Ready to start</option>
-                                <option value="validation">Validation</option>
                                 <option value="final_comments">Final comments</option>
                                 <option value="invalid">Invalid</option>
                                 <option value="issue_determination">Issue decision</option>
+                                <option value="lpa_questionnaire" selected>LPA questionnaire</option>
+                                <option value="ready_to_start">Ready to start</option>
+                                <option value="statements">Statements</option>
+                                <option value="validation">Validation</option>
                                 <option value="withdrawn">Withdrawn</option>
                             </select>
                         </div>
@@ -1202,13 +1202,13 @@ exports[`national-list GET / should render national list - search term 1`] = `
                             name="appealStatusFilter" data-cy="filter-by-case-status">
                                 <option value="all">All</option>
                                 <option value="assign_case_officer">Assign case officer</option>
-                                <option value="lpa_questionnaire">LPA questionnaire</option>
-                                <option value="statements">Statements</option>
-                                <option value="ready_to_start">Ready to start</option>
-                                <option value="validation">Validation</option>
                                 <option value="final_comments">Final comments</option>
                                 <option value="invalid">Invalid</option>
                                 <option value="issue_determination">Issue decision</option>
+                                <option value="lpa_questionnaire">LPA questionnaire</option>
+                                <option value="ready_to_start">Ready to start</option>
+                                <option value="statements">Statements</option>
+                                <option value="validation">Validation</option>
                                 <option value="withdrawn">Withdrawn</option>
                             </select>
                         </div>
@@ -1365,13 +1365,13 @@ exports[`national-list GET / should render the header with navigation containing
                             name="appealStatusFilter" data-cy="filter-by-case-status">
                                 <option value="all">All</option>
                                 <option value="assign_case_officer">Assign case officer</option>
-                                <option value="lpa_questionnaire">LPA questionnaire</option>
-                                <option value="statements">Statements</option>
-                                <option value="ready_to_start">Ready to start</option>
-                                <option value="validation">Validation</option>
                                 <option value="final_comments">Final comments</option>
                                 <option value="invalid">Invalid</option>
                                 <option value="issue_determination">Issue decision</option>
+                                <option value="lpa_questionnaire">LPA questionnaire</option>
+                                <option value="ready_to_start">Ready to start</option>
+                                <option value="statements">Statements</option>
+                                <option value="validation">Validation</option>
                                 <option value="withdrawn">Withdrawn</option>
                             </select>
                         </div>

--- a/appeals/web/src/server/appeals/national-list/national-list.mapper.js
+++ b/appeals/web/src/server/appeals/national-list/national-list.mapper.js
@@ -55,13 +55,13 @@ export function nationalListPage(
 			inspectorFilter
 		].some((filter) => filter && filter !== 'all');
 
-	const appealStatusFilterItemsArray = ['all', ...(appeals?.statusesInNationalList || [])].map(
-		(appealStatus) => ({
+	const appealStatusFilterItemsArray = ['all', ...(appeals?.statusesInNationalList || [])]
+		.map((appealStatus) => ({
 			text: mapStatusFilterLabel(appealStatus),
 			value: appealStatus,
 			selected: appealStatusFilter === appealStatus
-		})
-	);
+		}))
+		.sort((a, b) => a.text.toLowerCase().localeCompare(b.text.toLowerCase()));
 
 	const inspectorStatusFilterItemsArray = ['all', 'assigned', 'unassigned'].map(
 		(inspectorStatus) => ({

--- a/appeals/web/src/server/appeals/personal-list/__tests__/__snapshots__/personal-list.test.js.snap
+++ b/appeals/web/src/server/appeals/personal-list/__tests__/__snapshots__/personal-list.test.js.snap
@@ -21,8 +21,8 @@ exports[`personal-list GET / should render a child status tag in the lead or chi
                                 <option value="all">All</option>
                                 <option value="final_comments">Final comments</option>
                                 <option value="lpa_questionnaire">LPA questionnaire</option>
-                                <option value="statements">Statements</option>
                                 <option value="ready_to_start">Ready to start</option>
+                                <option value="statements">Statements</option>
                                 <option value="validation">Validation</option>
                             </select>
                         </div>
@@ -148,8 +148,8 @@ exports[`personal-list GET / should render a lead status tag in the lead or chil
                                 <option value="all">All</option>
                                 <option value="final_comments">Final comments</option>
                                 <option value="lpa_questionnaire">LPA questionnaire</option>
-                                <option value="statements">Statements</option>
                                 <option value="ready_to_start">Ready to start</option>
+                                <option value="statements">Statements</option>
                                 <option value="validation">Validation</option>
                             </select>
                         </div>
@@ -290,8 +290,8 @@ exports[`personal-list GET / should render an empty cell in the lead or child co
                                 <option value="all">All</option>
                                 <option value="final_comments">Final comments</option>
                                 <option value="lpa_questionnaire">LPA questionnaire</option>
-                                <option value="statements">Statements</option>
                                 <option value="ready_to_start">Ready to start</option>
+                                <option value="statements">Statements</option>
                                 <option value="validation">Validation</option>
                             </select>
                         </div>
@@ -417,8 +417,8 @@ exports[`personal-list GET / should render the first page of the personal list w
                                 <option value="all">All</option>
                                 <option value="final_comments">Final comments</option>
                                 <option value="lpa_questionnaire">LPA questionnaire</option>
-                                <option value="statements">Statements</option>
                                 <option value="ready_to_start">Ready to start</option>
+                                <option value="statements">Statements</option>
                                 <option value="validation">Validation</option>
                             </select>
                         </div>
@@ -572,8 +572,8 @@ exports[`personal-list GET / should render the second page of the personal list 
                                 <option value="all">All</option>
                                 <option value="awaiting_transfer">Awaiting transfer</option>
                                 <option value="event">Event ready to set up</option>
-                                <option value="lpa_questionnaire" selected>LPA questionnaire</option>
                                 <option value="final_comments">Final comments</option>
+                                <option value="lpa_questionnaire" selected>LPA questionnaire</option>
                             </select>
                         </div>
                         <div class="govuk-button-group">
@@ -697,8 +697,8 @@ exports[`personal-list GET / should render the second page of the personal list 
                                 <option value="all">All</option>
                                 <option value="awaiting_transfer">Awaiting transfer</option>
                                 <option value="event">Event ready to set up</option>
-                                <option value="lpa_questionnaire">LPA questionnaire</option>
                                 <option value="final_comments">Final comments</option>
+                                <option value="lpa_questionnaire">LPA questionnaire</option>
                             </select>
                         </div>
                         <div class="govuk-button-group">

--- a/appeals/web/src/server/appeals/personal-list/personal-list.mapper.js
+++ b/appeals/web/src/server/appeals/personal-list/personal-list.mapper.js
@@ -5,7 +5,6 @@ import { preRenderPageComponents } from '#lib/nunjucks-template-builders/page-co
 import { dateISOStringToDisplayDate } from '#lib/dates.js';
 import { numberToAccessibleDigitLabel } from '#lib/accessibility.js';
 import * as authSession from '../../app/auth/auth-session.service.js';
-import { capitalizeFirstLetter } from '#lib/string-utilities.js';
 import { mapStatusText, mapStatusFilterLabel } from '#lib/appeal-status.js';
 import { getRequiredActionsForAppeal } from '#lib/mappers/utils/required-actions.js';
 import { addBackLinkQueryToUrl } from '#lib/url-utilities.js';
@@ -54,7 +53,7 @@ export function personalListPage(
 	const isCaseOfficer = userGroups.includes(config.referenceData.appeals.caseOfficerGroupId);
 	const filterItemsArray = ['all', ...(appealsAssignedToCurrentUser?.statuses || [])]
 		.map((appealStatus) => ({
-			text: capitalizeFirstLetter(mapStatusFilterLabel(appealStatus)),
+			text: mapStatusFilterLabel(appealStatus),
 			value: appealStatus,
 			selected: appealStatusFilter === appealStatus
 		}))

--- a/appeals/web/src/server/appeals/personal-list/personal-list.mapper.js
+++ b/appeals/web/src/server/appeals/personal-list/personal-list.mapper.js
@@ -52,13 +52,13 @@ export function personalListPage(
 	const account = /** @type {AccountInfo} */ (authSession.getAccount(session));
 	const userGroups = account?.idTokenClaims?.groups ?? [];
 	const isCaseOfficer = userGroups.includes(config.referenceData.appeals.caseOfficerGroupId);
-	const filterItemsArray = ['all', ...(appealsAssignedToCurrentUser?.statuses || [])].map(
-		(appealStatus) => ({
+	const filterItemsArray = ['all', ...(appealsAssignedToCurrentUser?.statuses || [])]
+		.map((appealStatus) => ({
 			text: capitalizeFirstLetter(mapStatusFilterLabel(appealStatus)),
 			value: appealStatus,
 			selected: appealStatusFilter === appealStatus
-		})
-	);
+		}))
+		.sort((a, b) => a.text.toLowerCase().localeCompare(b.text.toLowerCase()));
 
 	/** @type {PageComponent} */
 	const searchAllCasesButton = {

--- a/appeals/web/src/server/lib/appeal-status.js
+++ b/appeals/web/src/server/lib/appeal-status.js
@@ -66,9 +66,7 @@ export function mapStatusFilterLabel(appealStatus) {
 		appealStatus
 			.replace('issue_determination', 'issue_decision')
 			.replace('lpa_', 'LPA_')
-			.replace('awaiting_event', 'awaiting_EVENT')
-			.replace('event', 'EVENT_ready_to_set_up')
-			.replace('EVENT', 'event')
+			.replace(/^event$/, 'event_ready_to_set_up')
 			.replaceAll('_', ' ')
 	);
 }


### PR DESCRIPTION
## Describe your changes

<!--
    Please include a summary of the change along with any relevant context.
    List any dependencies that are required for this change.
-->

-  sort cases in alphabetical order for the case status in national and personal lists
-  update test snapshots for the respective changes
-  use regex to match and replace the exact string
- remove redundant use of capitalizeFirstLetter()

## Issue ticket number and link

[A2-3645](https://pins-ds.atlassian.net/browse/A2-3645)


[A2-3645]: https://pins-ds.atlassian.net/browse/A2-3645?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ