### PR TITLE
feat(appeals): awaiting linked appeal banner pre starting (a2-4065)

### DIFF
--- a/appeals/api/src/server/endpoints/appeal-details/appeal-details.service.js
+++ b/appeals/api/src/server/endpoints/appeal-details/appeal-details.service.js
@@ -176,14 +176,20 @@ const loadAppealTypes = async () => {
  * @returns {Promise<*[]>}
  */
 const loadLinkedAppeals = async (appeal) => {
+	const parentAppeals = appeal?.parentAppeals?.filter(
+		(parentAppeal) => parentAppeal.type === CASE_RELATIONSHIP_LINKED
+	);
+	const childAppeals = appeal?.childAppeals?.filter(
+		(childAppeal) => childAppeal.type === CASE_RELATIONSHIP_LINKED
+	);
 	if (
 		!isFeatureActive(FEATURE_FLAG_NAMES.LINKED_APPEALS) ||
-		(!appeal?.parentAppeals?.length && !appeal?.childAppeals?.length)
+		(!parentAppeals?.length && !childAppeals?.length)
 	) {
 		return [];
 	}
 
-	const parentRef = appeal.parentAppeals?.[0]?.parentRef ?? appeal.reference;
+	const parentRef = parentAppeals?.[0]?.parentRef ?? appeal.reference;
 	return appealRepository.getLinkedAppeals(parentRef, CASE_RELATIONSHIP_LINKED);
 };
 

--- a/appeals/api/src/server/endpoints/appeals.d.ts
+++ b/appeals/api/src/server/endpoints/appeals.d.ts
@@ -281,6 +281,8 @@ interface UpdateAppellantCaseValidationOutcomeParams {
 		id: number;
 		reference: string;
 		applicationReference: string;
+		parentAppeals: AppealRelationship[] | undefined;
+		childAppeals: AppealRelationship[] | undefined;
 	};
 	appellantCaseId: number;
 	azureAdUserId: string;

--- a/appeals/api/src/server/endpoints/appellant-cases/appellant-cases.controller.js
+++ b/appeals/api/src/server/endpoints/appellant-cases/appellant-cases.controller.js
@@ -88,7 +88,9 @@ const updateAppellantCaseById = async (req, res) => {
 							agent: appeal.agent,
 							id: appeal.id,
 							reference: appeal.reference,
-							applicationReference: appeal.applicationReference || ''
+							applicationReference: appeal.applicationReference || '',
+							parentAppeals: appeal.parentAppeals,
+							childAppeals: appeal.childAppeals
 						},
 						appellantCaseId,
 						azureAdUserId,

--- a/appeals/api/src/server/repositories/appeal-lists.repository.js
+++ b/appeals/api/src/server/repositories/appeal-lists.repository.js
@@ -325,11 +325,7 @@ const getUserAppeals = (userId, pageNumber, pageSize, status) => {
 			where,
 			include: {
 				address: true,
-				appealStatus: {
-					where: {
-						valid: true
-					}
-				},
+				appealStatus: true,
 				appealTimetable: true,
 				appealType: true,
 				procedureType: true,

--- a/appeals/api/src/server/repositories/appeal.repository.js
+++ b/appeals/api/src/server/repositories/appeal.repository.js
@@ -22,7 +22,8 @@ const linkedAppealsInclude = isFeatureActive(FEATURE_FLAG_NAMES.LINKED_APPEALS)
 	? {
 			appealType: true,
 			appealStatus: true,
-			lpaQuestionnaire: { include: { lpaQuestionnaireValidationOutcome: true } }
+			lpaQuestionnaire: { include: { lpaQuestionnaireValidationOutcome: true } },
+			appellantCase: { include: { appellantCaseValidationOutcome: true } }
 	  }
 	: {
 			appealType: true

--- a/appeals/web/src/server/appeals/appeal-details/appellant-case/appellant-case.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/appellant-case/appellant-case.mapper.js
@@ -147,6 +147,7 @@ export async function appellantCasePage(
 	if (
 		reviewOutcomeRadiosInputInstruction &&
 		appealDetails.appealStatus === APPEAL_CASE_STATUS.VALIDATION &&
+		appealDetails.documentationSummary?.appellantCase?.status?.toLowerCase() !== 'valid' &&
 		userHasPermission(permissionNames.setStageOutcome, session)
 	) {
 		reviewOutcomeComponents.push({

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/lpa-questionnaire.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/lpa-questionnaire.mapper.js
@@ -155,6 +155,7 @@ export async function lpaQuestionnairePage(
 	if (
 		reviewOutcomeRadiosInputInstruction &&
 		appealDetails.appealStatus === APPEAL_CASE_STATUS.LPA_QUESTIONNAIRE &&
+		appealDetails.documentationSummary?.lpaQuestionnaire?.status?.toLowerCase() !== 'complete' &&
 		userHasPermission(permissionNames.setStageOutcome, session)
 	) {
 		reviewOutcomeComponents.push({

--- a/appeals/web/src/server/appeals/personal-list/personal-list.mapper.js
+++ b/appeals/web/src/server/appeals/personal-list/personal-list.mapper.js
@@ -16,7 +16,7 @@ import { isChildAppeal } from '#lib/mappers/utils/is-child-appeal.js';
 /** @typedef {import('@pins/appeals').AppealList} AppealList */
 /** @typedef {import('@pins/appeals').Pagination} Pagination */
 /** @typedef {import('../../app/auth/auth.service').AccountInfo} AccountInfo */
-/** @typedef {Partial<AppealSummary & { appealTimetable: Record<string,string> }>} PersonalListAppeal */
+/** @typedef {Partial<AppealSummary & { appealTimetable: Record<string,string>, awaitingLinkedAppeal: boolean}>} PersonalListAppeal */
 
 const ALLOWED_CHILD_APPEAL_ACTION_STATUSES = [
 	APPEAL_CASE_STATUS.ASSIGN_CASE_OFFICER,
@@ -292,6 +292,12 @@ function mapRequiredActionToPersonalListActionHtml(
 						`/appeals-service/appeal-details/${appealId}/appellant-case`
 				  )}">Awaiting appellant update<span class="govuk-visually-hidden"> for appeal ${appealId}</span></a>`
 				: 'Awaiting appellant update';
+		}
+		case 'assignCaseOfficer': {
+			return `<a class="govuk-link" href="${addBackLinkQueryToUrl(
+				request,
+				`/appeals-service/appeal-details/${appealId}/assign-case-officer/search-case-officer`
+			)}">Assign case officer<span class="govuk-visually-hidden"> for appeal ${appealId}</span></a>`;
 		}
 		case 'awaitingFinalComments': {
 			return 'Awaiting final comments';

--- a/appeals/web/src/server/lib/mappers/utils/required-actions.js
+++ b/appeals/web/src/server/lib/mappers/utils/required-actions.js
@@ -27,7 +27,7 @@ export function getRequiredActionsForAppeal(appealDetails, view) {
 		case APPEAL_CASE_STATUS.ASSIGN_CASE_OFFICER:
 			actions.push('assignCaseOfficer');
 			break;
-		case APPEAL_CASE_STATUS.READY_TO_START: // @ts-ignore
+		case APPEAL_CASE_STATUS.READY_TO_START:
 			if (appealDetails.awaitingLinkedAppeal && config.featureFlags.featureFlagLinkedAppeals) {
 				actions.push('awaitingLinkedAppeal');
 				break;
@@ -73,6 +73,11 @@ export function getRequiredActionsForAppeal(appealDetails, view) {
 			actions.push('issueDecision');
 			break;
 		case APPEAL_CASE_STATUS.VALIDATION: {
+			if (appealDetails.awaitingLinkedAppeal && config.featureFlags.featureFlagLinkedAppeals) {
+				actions.push('awaitingLinkedAppeal');
+				break;
+			}
+
 			const appellantCaseOverdue =
 				appealDetails.documentationSummary.appellantCase?.dueDate &&
 				dateIsInThePast(
@@ -92,6 +97,7 @@ export function getRequiredActionsForAppeal(appealDetails, view) {
 			} else if (appellantCaseReceived) {
 				actions.push('reviewAppellantCase');
 			}
+
 			break;
 		}
 		case APPEAL_CASE_STATUS.LPA_QUESTIONNAIRE: {


### PR DESCRIPTION
## Describe your changes
#### Awaiting linked appeal banner pre starting (a2-4065)

### API:
- The awaitingLinkedAppeal flag should be true for a validated appeal within a group of linked appeals (lead and one or more children) all with status 'validation' when at least one member of the group has not yet been validated.
- When the last member of a group of linked appeals with status 'validation' is validated, they will all transition to the status 'lpq-questionnaire'.
- Fix a small bug to make sure the load-linked-appeals function works with linked and not related appeals.

### WEB:
- Display "Awaiting linked appeal" when a validated appeal is waiting for linked appeals to be validated.
- An additional check for reviewing the Appellant case is necessary to prevent the radio buttons being displayed when viewing after it has been validated as the status will not transition until all linked appeals have been validated.
- An additional check for reviewing the LPA questionnaire is necessary to prevent the radio buttons being displayed when viewing after it has been completed as the status will not transition until all linked appeals have been completed.

### TEST:
- Made sure all unit tests pass
- Manually tested within browser
- Tested with feature flag on and off 

## Issue ticket number and link:
- [(A2-4065) Linked appeals - Awaiting linked appeal banner pre starting](https://pins-ds.atlassian.net/browse/A2-4065)

