### PR TITLE
fix(api): increase requet body size limit for bodyParser (a2-4073)

### DIFF
--- a/appeals/api/src/server/build-app.js
+++ b/appeals/api/src/server/build-app.js
@@ -22,7 +22,7 @@ const buildApp = (
 		addSwaggerUi(app);
 	}
 
-	app.use(bodyParser.json());
+	app.use(bodyParser.json({ limit: '200kb' }));
 
 	app.use(compression());
 	app.use(morgan('combined'));


### PR DESCRIPTION
## Describe your changes

Appellant submission with large number of files failed
Bumping up the request limit as a quick solution

## Issue ticket number and link

[Ticket](https://pins-ds.atlassian.net/browse/A2-4073)
