### PR TITLE
feat(appeals): hide site section when linking appeals that are proceeding (a2-3925)

### DIFF
--- a/appeals/web/src/server/appeals/appeal-details/__tests__/__snapshots__/appeal-details.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/__tests__/__snapshots__/appeal-details.test.js.snap
@@ -1656,59 +1656,9 @@ exports[`appeal-details GET /:appealId should not render a "Appeal valid" notifi
                 </div>
                 <div class="govuk-accordion__section">
                     <div class="govuk-accordion__section-header">
-                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default2-heading-2"> Site</span></h2>
+                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default2-heading-2"> Timetable</span></h2>
                     </div>
                     <div id="accordion-default2-content-2" class="govuk-accordion__section-content">
-                        <dl class="govuk-summary-list">
-                            <div class="govuk-summary-list__row appeal-visit-type"><dt class="govuk-summary-list__key"> Visit type</dt>
-                                <dd class="govuk-summary-list__value">Accompanied</dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/site-visit/visit-booked?backUrl=%2Fappeals-service%2Fappeal-details%2F2"
-                                    data-cy="change-set-visit-type">Change<span class="govuk-visually-hidden"> Visit type</span></a>
-                                </dd>
-                            </div>
-                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Date</dt>
-                                <dd class="govuk-summary-list__value">9 October 2023</dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/site-visit/visit-booked"
-                                    data-cy="change-site-visit-date">Change<span class="govuk-visually-hidden"> Date</span></a>
-                                </dd>
-                            </div>
-                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Start time</dt>
-                                <dd class="govuk-summary-list__value">9:38am</dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/site-visit/visit-booked"
-                                    data-cy="change-site-visit-start-time">Change<span class="govuk-visually-hidden"> Start time</span></a>
-                                </dd>
-                            </div>
-                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> End time</dt>
-                                <dd class="govuk-summary-list__value">10:00am</dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/site-visit/visit-booked"
-                                    data-cy="change-site-visit-end-time">Change<span class="govuk-visually-hidden"> End time</span></a>
-                                </dd>
-                            </div>
-                            <div class="govuk-summary-list__row appeal-neighbouring-sites-inspector"><dt class="govuk-summary-list__key"> Interested party and neighbour addresses</dt>
-                                <dd                                 class="govuk-summary-list__value">
-                                    <ul class="govuk-list govuk-list--bullet">
-                                        <li>2 Grove Cottage, Shotesham Road, Woodton, Devon, NR35 2ND</li>
-                                    </ul>
-                                    </dd>
-                                    <dd class="govuk-summary-list__actions">
-                                        <ul class="govuk-summary-list__actions-list">
-                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/2/neighbouring-sites/manage"
-                                                data-cy="manage-neighbouring-sites-inspector">Manage<span class="govuk-visually-hidden"> Interested party and neighbour addresses</span></a>
-                                            </li>
-                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/2/neighbouring-sites/add/back-office"
-                                                data-cy="add-neighbouring-sites-inspector">Add<span class="govuk-visually-hidden"> Interested party and neighbour addresses</span></a>
-                                            </li>
-                                        </ul>
-                                    </dd>
-                            </div>
-                        </dl>
-                    </div>
-                </div>
-                <div class="govuk-accordion__section">
-                    <div class="govuk-accordion__section-header">
-                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default2-heading-3"> Timetable</span></h2>
-                    </div>
-                    <div id="accordion-default2-content-3" class="govuk-accordion__section-content">
                         <dl class="govuk-summary-list appeal-case-timetable">
                             <div class="govuk-summary-list__row appeal-valid-date"><dt class="govuk-summary-list__key"> Valid date</dt>
                                 <dd class="govuk-summary-list__value">23 May 2023</dd>
@@ -1735,9 +1685,9 @@ exports[`appeal-details GET /:appealId should not render a "Appeal valid" notifi
                 </div>
                 <div class="govuk-accordion__section">
                     <div class="govuk-accordion__section-header">
-                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default2-heading-4"> Documentation</span></h2>
+                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default2-heading-3"> Documentation</span></h2>
                     </div>
-                    <div id="accordion-default2-content-4" class="govuk-accordion__section-content">
+                    <div id="accordion-default2-content-3" class="govuk-accordion__section-content">
                         <table class="govuk-table">
                             <thead class="govuk-table__head">
                                 <tr class="govuk-table__row">
@@ -1768,9 +1718,9 @@ exports[`appeal-details GET /:appealId should not render a "Appeal valid" notifi
                 </div>
                 <div class="govuk-accordion__section">
                     <div class="govuk-accordion__section-header">
-                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default2-heading-5"> Costs</span></h2>
+                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default2-heading-4"> Costs</span></h2>
                     </div>
-                    <div id="accordion-default2-content-5" class="govuk-accordion__section-content">
+                    <div id="accordion-default2-content-4" class="govuk-accordion__section-content">
                         <table class="govuk-table">
                             <thead class="govuk-table__head">
                                 <tr class="govuk-table__row">
@@ -1846,9 +1796,9 @@ exports[`appeal-details GET /:appealId should not render a "Appeal valid" notifi
                 </div>
                 <div class="govuk-accordion__section">
                     <div class="govuk-accordion__section-header">
-                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default2-heading-6"> Contacts</span></h2>
+                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default2-heading-5"> Contacts</span></h2>
                     </div>
-                    <div id="accordion-default2-content-6" class="govuk-accordion__section-content">
+                    <div id="accordion-default2-content-5" class="govuk-accordion__section-content">
                         <dl class="govuk-summary-list">
                             <div class="govuk-summary-list__row appeal-appellant"><dt class="govuk-summary-list__key"> Appellant</dt>
                                 <dd class="govuk-summary-list__value">
@@ -1888,9 +1838,9 @@ exports[`appeal-details GET /:appealId should not render a "Appeal valid" notifi
                 </div>
                 <div class="govuk-accordion__section">
                     <div class="govuk-accordion__section-header">
-                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default2-heading-7"> Team</span></h2>
+                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default2-heading-6"> Team</span></h2>
                     </div>
-                    <div id="accordion-default2-content-7" class="govuk-accordion__section-content">
+                    <div id="accordion-default2-content-6" class="govuk-accordion__section-content">
                         <dl class="govuk-summary-list">
                             <div class="govuk-summary-list__row appeal-case-officer"><dt class="govuk-summary-list__key"> Case officer</dt>
                                 <dd class="govuk-summary-list__value">
@@ -1913,9 +1863,9 @@ exports[`appeal-details GET /:appealId should not render a "Appeal valid" notifi
                 </div>
                 <div class="govuk-accordion__section">
                     <div class="govuk-accordion__section-header">
-                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default2-heading-8"> Case management</span></h2>
+                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default2-heading-7"> Case management</span></h2>
                     </div>
-                    <div id="accordion-default2-content-8" class="govuk-accordion__section-content">
+                    <div id="accordion-default2-content-7" class="govuk-accordion__section-content">
                         <dl class="govuk-summary-list">
                             <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Cross-team correspondence</dt>
                                 <dd                                 class="govuk-summary-list__value">No documents</dd>
@@ -3900,59 +3850,9 @@ exports[`appeal-details GET /:appealId should render a child tag next to the app
                 </div>
                 <div class="govuk-accordion__section">
                     <div class="govuk-accordion__section-header">
-                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-2"> Site</span></h2>
+                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-2"> Timetable</span></h2>
                     </div>
                     <div id="accordion-default1-content-2" class="govuk-accordion__section-content">
-                        <dl class="govuk-summary-list">
-                            <div class="govuk-summary-list__row appeal-visit-type"><dt class="govuk-summary-list__key"> Visit type</dt>
-                                <dd class="govuk-summary-list__value">Accompanied</dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/visit-booked?backUrl=%2Fappeals-service%2Fappeal-details%2F1"
-                                    data-cy="change-set-visit-type">Change<span class="govuk-visually-hidden"> Visit type</span></a>
-                                </dd>
-                            </div>
-                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Date</dt>
-                                <dd class="govuk-summary-list__value">9 October 2023</dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/visit-booked"
-                                    data-cy="change-site-visit-date">Change<span class="govuk-visually-hidden"> Date</span></a>
-                                </dd>
-                            </div>
-                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Start time</dt>
-                                <dd class="govuk-summary-list__value">9:38am</dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/visit-booked"
-                                    data-cy="change-site-visit-start-time">Change<span class="govuk-visually-hidden"> Start time</span></a>
-                                </dd>
-                            </div>
-                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> End time</dt>
-                                <dd class="govuk-summary-list__value">10:00am</dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/visit-booked"
-                                    data-cy="change-site-visit-end-time">Change<span class="govuk-visually-hidden"> End time</span></a>
-                                </dd>
-                            </div>
-                            <div class="govuk-summary-list__row appeal-neighbouring-sites-inspector"><dt class="govuk-summary-list__key"> Interested party and neighbour addresses</dt>
-                                <dd                                 class="govuk-summary-list__value">
-                                    <ul class="govuk-list govuk-list--bullet">
-                                        <li>2 Grove Cottage, Shotesham Road, Woodton, Devon, NR35 2ND</li>
-                                    </ul>
-                                    </dd>
-                                    <dd class="govuk-summary-list__actions">
-                                        <ul class="govuk-summary-list__actions-list">
-                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/neighbouring-sites/manage"
-                                                data-cy="manage-neighbouring-sites-inspector">Manage<span class="govuk-visually-hidden"> Interested party and neighbour addresses</span></a>
-                                            </li>
-                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/neighbouring-sites/add/back-office"
-                                                data-cy="add-neighbouring-sites-inspector">Add<span class="govuk-visually-hidden"> Interested party and neighbour addresses</span></a>
-                                            </li>
-                                        </ul>
-                                    </dd>
-                            </div>
-                        </dl>
-                    </div>
-                </div>
-                <div class="govuk-accordion__section">
-                    <div class="govuk-accordion__section-header">
-                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-3"> Timetable</span></h2>
-                    </div>
-                    <div id="accordion-default1-content-3" class="govuk-accordion__section-content">
                         <dl class="govuk-summary-list appeal-case-timetable">
                             <div class="govuk-summary-list__row appeal-valid-date"><dt class="govuk-summary-list__key"> Valid date</dt>
                                 <dd class="govuk-summary-list__value">23 May 2023</dd>
@@ -3979,9 +3879,9 @@ exports[`appeal-details GET /:appealId should render a child tag next to the app
                 </div>
                 <div class="govuk-accordion__section">
                     <div class="govuk-accordion__section-header">
-                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-4"> Documentation</span></h2>
+                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-3"> Documentation</span></h2>
                     </div>
-                    <div id="accordion-default1-content-4" class="govuk-accordion__section-content">
+                    <div id="accordion-default1-content-3" class="govuk-accordion__section-content">
                         <table class="govuk-table">
                             <thead class="govuk-table__head">
                                 <tr class="govuk-table__row">
@@ -4012,9 +3912,9 @@ exports[`appeal-details GET /:appealId should render a child tag next to the app
                 </div>
                 <div class="govuk-accordion__section">
                     <div class="govuk-accordion__section-header">
-                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-5"> Costs</span></h2>
+                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-4"> Costs</span></h2>
                     </div>
-                    <div id="accordion-default1-content-5" class="govuk-accordion__section-content">
+                    <div id="accordion-default1-content-4" class="govuk-accordion__section-content">
                         <table class="govuk-table">
                             <thead class="govuk-table__head">
                                 <tr class="govuk-table__row">
@@ -4090,9 +3990,9 @@ exports[`appeal-details GET /:appealId should render a child tag next to the app
                 </div>
                 <div class="govuk-accordion__section">
                     <div class="govuk-accordion__section-header">
-                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-6"> Contacts</span></h2>
+                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-5"> Contacts</span></h2>
                     </div>
-                    <div id="accordion-default1-content-6" class="govuk-accordion__section-content">
+                    <div id="accordion-default1-content-5" class="govuk-accordion__section-content">
                         <dl class="govuk-summary-list">
                             <div class="govuk-summary-list__row appeal-appellant"><dt class="govuk-summary-list__key"> Appellant</dt>
                                 <dd class="govuk-summary-list__value">
@@ -4132,9 +4032,9 @@ exports[`appeal-details GET /:appealId should render a child tag next to the app
                 </div>
                 <div class="govuk-accordion__section">
                     <div class="govuk-accordion__section-header">
-                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-7"> Team</span></h2>
+                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-6"> Team</span></h2>
                     </div>
-                    <div id="accordion-default1-content-7" class="govuk-accordion__section-content">
+                    <div id="accordion-default1-content-6" class="govuk-accordion__section-content">
                         <dl class="govuk-summary-list">
                             <div class="govuk-summary-list__row appeal-case-officer"><dt class="govuk-summary-list__key"> Case officer</dt>
                                 <dd class="govuk-summary-list__value">
@@ -4157,9 +4057,9 @@ exports[`appeal-details GET /:appealId should render a child tag next to the app
                 </div>
                 <div class="govuk-accordion__section">
                     <div class="govuk-accordion__section-header">
-                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-8"> Case management</span></h2>
+                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-7"> Case management</span></h2>
                     </div>
-                    <div id="accordion-default1-content-8" class="govuk-accordion__section-content">
+                    <div id="accordion-default1-content-7" class="govuk-accordion__section-content">
                         <dl class="govuk-summary-list">
                             <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Cross-team correspondence</dt>
                                 <dd                                 class="govuk-summary-list__value">No documents</dd>

--- a/appeals/web/src/server/appeals/appeal-details/accordions/has.js
+++ b/appeals/web/src/server/appeals/appeal-details/accordions/has.js
@@ -9,6 +9,7 @@ import { getCaseTeam } from './common/case-team.js';
 import { getSiteDetails } from './common/site-details.js';
 import { removeAccordionComponentsActions } from './utils/index.js';
 import { APPEAL_CASE_STATUS } from '@planning-inspectorate/data-model';
+import { isChildAppeal } from '#lib/mappers/utils/is-child-appeal.js';
 
 /**
  * @param {import('../appeal-details.types.js').WebAppeal} appealDetails
@@ -19,7 +20,7 @@ import { APPEAL_CASE_STATUS } from '@planning-inspectorate/data-model';
 export function generateAccordion(appealDetails, mappedData, session) {
 	const caseOverview = getCaseOverview(mappedData);
 
-	const siteDetails = getSiteDetails(mappedData, appealDetails);
+	const siteDetails = isChildAppeal(appealDetails) ? [] : getSiteDetails(mappedData, appealDetails);
 
 	/** @type {PageComponent[]} */
 	const caseTimetable = appealDetails.startedAt

--- a/appeals/web/src/server/appeals/appeal-details/accordions/s78.js
+++ b/appeals/web/src/server/appeals/appeal-details/accordions/s78.js
@@ -23,7 +23,7 @@ import { isChildAppeal } from '#lib/mappers/utils/is-child-appeal.js';
 export function generateAccordion(appealDetails, mappedData, session) {
 	const caseOverview = getCaseOverview(mappedData);
 
-	const siteDetails = getSiteDetails(mappedData, appealDetails);
+	const siteDetails = isChildAppeal(appealDetails) ? [] : getSiteDetails(mappedData, appealDetails);
 
 	/** @type {PageComponent[]} */
 	const caseTimetable = [


### PR DESCRIPTION
## Describe your changes
#### Hide site section when linking appeals that are proceeding (a2-3925)

### WEB:
- Only display site section when appeals are NOT linked child appeals

### TEST:
- Fixed snapshots
- Made sure all unit tests pass
- Manually tested within browser
- Tested with feature flag on and off 

## Issue ticket number and link:
- [(A2-4065) Linked appeals - Awaiting linked appeal banner pre starting](https://pins-ds.atlassian.net/browse/A2-4065)

