### PR TITLE
feat(A2-3840): adding cancel appeal section to appeal details

### DIFF
--- a/appeals/web/src/server/appeals/appeal-details/__tests__/__snapshots__/appeal-details.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/__tests__/__snapshots__/appeal-details.test.js.snap
@@ -463,6 +463,4979 @@ exports[`appeal-details GET /:appealId LPA costs decision should render a row in
 
 exports[`appeal-details GET /:appealId LPA costs decision should render a row in the case overview accordion, if the appeal status is "issue_determination" or after (issue_determination) 1`] = `"<div class="govuk-summary-list__row costs-lpa-decision"><dt class="govuk-summary-list__key"> LPA costs decision</dt><dd class="govuk-summary-list__value"> Not issued</dd><dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/issue-decision/issue-lpa-costs-decision-letter-upload?backUrl=%2Fappeals-service%2Fappeal-details%2F2" data-cy="issue-lpa-costs-decision">Issue<span class="govuk-visually-hidden"> LPA costs decision</span></a></dd></div>"`;
 
+exports[`appeal-details GET /:appealId Linked appeals should not render a "Appeal valid" notification banner when status is "READY_TO_START" and appeal is a linked child appeal 1`] = `
+"<main class="govuk-main-wrapper" id="main-content">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Appeal 351062</span>
+            <h1 class="govuk-heading-xl govuk-!-margin-bottom-3">Case details</h1>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full"><strong class="govuk-tag govuk-tag--green pins-status-tag--full-width">Ready to start</strong>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
+            <dl class="govuk-summary-list pins-summary-list--no-border">
+                <div class="govuk-summary-list__row appeal-case-officer"><dt class="govuk-summary-list__key"> Case officer</dt>
+                    <dd class="govuk-summary-list__value">
+                        <p class="govuk-body">Not assigned</p>
+                    </dd>
+                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/assign-case-officer/search-case-officer"
+                        data-cy="assign-case-officer-name">Assign<span class="govuk-visually-hidden"> Case officer</span></a>
+                    </dd>
+                </div>
+                <div class="govuk-summary-list__row appeal-site-address"><dt class="govuk-summary-list__key"> Site address</dt>
+                    <dd class="govuk-summary-list__value">21 The Pavement, Wandsworth, SW4 0HY</dd>
+                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/site-address/change/1?backUrl=%2Fappeals-service%2Fappeal-details%2F2"
+                        data-cy="change-site-address">Change<span class="govuk-visually-hidden"> Site address</span></a>
+                    </dd>
+                </div>
+                <div class="govuk-summary-list__row appeal-local-planning-authority"><dt class="govuk-summary-list__key"> LPA</dt>
+                    <dd class="govuk-summary-list__value">Wiltshire Council</dd>
+                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/change-appeal-details/local-planning-authority"
+                        data-cy="change-local-planning-authority">Change<span class="govuk-visually-hidden"> LPA</span></a>
+                    </dd>
+                </div>
+            </dl>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
+            <p class="govuk-body govuk-!-margin-bottom-6" id="download-case-files"
+            data-cy="download-case-files"><a class="govuk-link" href="/documents/2/bulk-download/case-APP/Q9999/D/21/351062.zip">Download case</a>
+            </p>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
+            <details class="govuk-details">
+                <summary class="govuk-details__summary"><span class="govuk-details__summary-text"> 2 case notes</span>
+                </summary>
+                <div class="govuk-details__text">
+                    <form method="POST" novalidate="novalidate">
+                        <div class="govuk-grid-row">
+                            <div class="govuk-grid-column-two-thirds">
+                                <div class="govuk-form-group govuk-character-count" data-module="govuk-character-count"
+                                data-maxlength="500">
+                                    <textarea class="govuk-textarea govuk-js-character-count" id="comment"
+                                    name="comment" rows="5" aria-describedby="comment-info"></textarea>
+                                    <div id="comment-info" class="govuk-hint govuk-character-count__message">You can enter up to 500 characters</div>
+                                </div>
+                            </div>
+                        </div>
+                        <button type="submit" data-prevent-double-click="true" class="govuk-button govuk-button--secondary govuk-!-margin-bottom-1"
+                        data-module="govuk-button">Add case note</button>
+                    </form>
+                    <div>
+                        <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+                        <section>
+                            <p class="govuk-body govuk-!-margin-bottom-1">A case note you should see.</p>
+                            <p class="govuk-hint govuk-!-margin-bottom-6">11:00am on Tuesday 1 October 2024 by John.Smith</p>
+                            <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+                        </section>
+                        <section>
+                            <p class="govuk-body govuk-!-margin-bottom-1">A case note you should see.</p>
+                            <p class="govuk-hint govuk-!-margin-bottom-6">11:00am on Tuesday 1 October 2024 by John.Smith</p>
+                            <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+                        </section>
+                    </div>
+                </div>
+            </details>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
+            <div class="govuk-accordion" data-module="govuk-accordion" id="accordion-default2">
+                <div class="govuk-accordion__section">
+                    <div class="govuk-accordion__section-header">
+                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default2-heading-1"> Overview</span></h2>
+                    </div>
+                    <div id="accordion-default2-content-1" class="govuk-accordion__section-content">
+                        <dl class="govuk-summary-list">
+                            <div class="govuk-summary-list__row govuk-summary-list__row--no-actions appeal-lpa-reference"><dt class="govuk-summary-list__key"> Planning application reference</dt>
+                                <dd                                 class="govuk-summary-list__value">48269/APP/2021/1482</dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-appeal-type"><dt class="govuk-summary-list__key"> Appeal type</dt>
+                                <dd class="govuk-summary-list__value">Householder</dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/change-appeal-type/appeal-type"
+                                    data-cy="change-appeal-type">Change<span class="govuk-visually-hidden"> Appeal type</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row govuk-summary-list__row--no-actions appeal-case-procedure"><dt class="govuk-summary-list__key"> Appeal procedure</dt>
+                                <dd class="govuk-summary-list__value">Written</dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-allocation-details"><dt class="govuk-summary-list__key"> Allocation level</dt>
+                                <dd class="govuk-summary-list__value">
+                                    <ul class="govuk-!-margin-0">
+                                        <li>Level: A</li>
+                                        <li>Historic heritage</li>
+                                        <li>Architecture design</li>
+                                    </ul>
+                                </dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/allocation-details/allocation-level"
+                                    data-cy="change-allocation-details">Change<span class="govuk-visually-hidden"> Allocation level</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-linked-appeals"><dt class="govuk-summary-list__key"> Linked appeals</dt>
+                                <dd class="govuk-summary-list__value"><span>No linked appeals</span>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-other-appeals"><dt class="govuk-summary-list__key"> Related appeals</dt>
+                                <dd class="govuk-summary-list__value"><span>No</span>
+                                </dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/other-appeals/add"
+                                    data-cy="add-related-appeals">Add<span class="govuk-visually-hidden"> Related appeals</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-decision"><dt class="govuk-summary-list__key"> Decision</dt>
+                                <dd class="govuk-summary-list__value">Dismissed</dd>
+                            </div>
+                        </dl>
+                    </div>
+                </div>
+                <div class="govuk-accordion__section">
+                    <div class="govuk-accordion__section-header">
+                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default2-heading-2"> Site</span></h2>
+                    </div>
+                    <div id="accordion-default2-content-2" class="govuk-accordion__section-content">
+                        <dl class="govuk-summary-list">
+                            <div class="govuk-summary-list__row appeal-visit-type"><dt class="govuk-summary-list__key"> Visit type</dt>
+                                <dd class="govuk-summary-list__value">Accompanied</dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/site-visit/visit-booked?backUrl=%2Fappeals-service%2Fappeal-details%2F2"
+                                    data-cy="change-set-visit-type">Change<span class="govuk-visually-hidden"> Visit type</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Date</dt>
+                                <dd class="govuk-summary-list__value">9 October 2023</dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/site-visit/visit-booked"
+                                    data-cy="change-site-visit-date">Change<span class="govuk-visually-hidden"> Date</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Start time</dt>
+                                <dd class="govuk-summary-list__value">9:38am</dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/site-visit/visit-booked"
+                                    data-cy="change-site-visit-start-time">Change<span class="govuk-visually-hidden"> Start time</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> End time</dt>
+                                <dd class="govuk-summary-list__value">10:00am</dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/site-visit/visit-booked"
+                                    data-cy="change-site-visit-end-time">Change<span class="govuk-visually-hidden"> End time</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-neighbouring-sites-inspector"><dt class="govuk-summary-list__key"> Interested party and neighbour addresses</dt>
+                                <dd                                 class="govuk-summary-list__value">
+                                    <ul class="govuk-list govuk-list--bullet">
+                                        <li>2 Grove Cottage, Shotesham Road, Woodton, Devon, NR35 2ND</li>
+                                    </ul>
+                                    </dd>
+                                    <dd class="govuk-summary-list__actions">
+                                        <ul class="govuk-summary-list__actions-list">
+                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/2/neighbouring-sites/manage"
+                                                data-cy="manage-neighbouring-sites-inspector">Manage<span class="govuk-visually-hidden"> Interested party and neighbour addresses</span></a>
+                                            </li>
+                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/2/neighbouring-sites/add/back-office"
+                                                data-cy="add-neighbouring-sites-inspector">Add<span class="govuk-visually-hidden"> Interested party and neighbour addresses</span></a>
+                                            </li>
+                                        </ul>
+                                    </dd>
+                            </div>
+                        </dl>
+                    </div>
+                </div>
+                <div class="govuk-accordion__section">
+                    <div class="govuk-accordion__section-header">
+                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default2-heading-3"> Timetable</span></h2>
+                    </div>
+                    <div id="accordion-default2-content-3" class="govuk-accordion__section-content">
+                        <dl class="govuk-summary-list appeal-case-timetable">
+                            <div class="govuk-summary-list__row appeal-valid-date"><dt class="govuk-summary-list__key"> Valid date</dt>
+                                <dd class="govuk-summary-list__value">23 May 2023</dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/appellant-case/valid/date"
+                                    data-cy="-valid-date"><span class="govuk-visually-hidden"> Valid date</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-start-date"><dt class="govuk-summary-list__key"> Start date</dt>
+                                <dd class="govuk-summary-list__value">23 May 2023</dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-lpa-questionnaire-due-date"><dt class="govuk-summary-list__key"> LPA questionnaire due</dt>
+                                <dd class="govuk-summary-list__value">11 October 2023</dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-site-visit"><dt class="govuk-summary-list__key"> Site visit</dt>
+                                <dd class="govuk-summary-list__value">
+                                    <ul class="govuk-list govuk-!-margin-top-0 govuk-!-padding-left-0">
+                                        <li>9 October 2023</li>
+                                        <li>9:38am - 10:00am</li>
+                                    </ul>
+                                </dd>
+                            </div>
+                        </dl>
+                    </div>
+                </div>
+                <div class="govuk-accordion__section">
+                    <div class="govuk-accordion__section-header">
+                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default2-heading-4"> Documentation</span></h2>
+                    </div>
+                    <div id="accordion-default2-content-4" class="govuk-accordion__section-content">
+                        <table class="govuk-table">
+                            <thead class="govuk-table__head">
+                                <tr class="govuk-table__row">
+                                    <th scope="col" class="govuk-table__header">Documentation</th>
+                                    <th scope="col" class="govuk-table__header">Status</th>
+                                    <th scope="col" class="govuk-table__header">Received</th>
+                                    <th scope="col" class="govuk-table__header govuk-!-text-align-right">Action</th>
+                                </tr>
+                            </thead>
+                            <tbody class="govuk-table__body">
+                                <tr class="govuk-table__row">
+                                    <th scope="row" class="govuk-table__header">Appeal</th>
+                                    <td class="govuk-table__cell">Ready to review</td>
+                                    <td class="govuk-table__cell">2 August 2024</td>
+                                    <td class="govuk-table__cell govuk-!-text-align-right"><a href="/appeals-service/appeal-details/2/appellant-case?backUrl=%2Fappeals-service%2Fappeal-details%2F2"
+                                        data-cy="review-appellant-case" class="govuk-link">Review<span class="govuk-visually-hidden"> appellant case</span></a>
+                                    </td>
+                                </tr>
+                                <tr class="govuk-table__row">
+                                    <th scope="row" class="govuk-table__header">LPA questionnaire</th>
+                                    <td class="govuk-table__cell">Overdue</td>
+                                    <td class="govuk-table__cell">Due by 11 October 2023</td>
+                                    <td class="govuk-table__cell govuk-!-text-align-right"></td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
+                <div class="govuk-accordion__section">
+                    <div class="govuk-accordion__section-header">
+                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default2-heading-5"> Costs</span></h2>
+                    </div>
+                    <div id="accordion-default2-content-5" class="govuk-accordion__section-content">
+                        <table class="govuk-table">
+                            <thead class="govuk-table__head">
+                                <tr class="govuk-table__row">
+                                    <th scope="col" class="govuk-table__header">Documentation</th>
+                                    <th scope="col" class="govuk-table__header">Status</th>
+                                    <th scope="col" class="govuk-table__header govuk-!-text-align-right">Action</th>
+                                </tr>
+                            </thead>
+                            <tbody class="govuk-table__body">
+                                <tr class="govuk-table__row">
+                                    <th scope="row" class="govuk-table__header appeal-costs-appellant-application-documentation">Appellant application</th>
+                                    <td class="govuk-table__cell appeal-costs-appellant-application-status">No documents available</td>
+                                    <td class="govuk-table__cell appeal-costs-appellant-application-actions govuk-!-text-align-right">
+                                        <ul class="govuk-summary-list__actions-list">
+                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-appellant-application" href="/appeals-service/appeal-details/2/costs/appellant/application/upload-documents/1">Add<span class="govuk-visually-hidden"> Appellant application</span></a>
+                                            </li>
+                                        </ul>
+                                    </td>
+                                </tr>
+                                <tr class="govuk-table__row">
+                                    <th scope="row" class="govuk-table__header appeal-costs-appellant-withdrawal-documentation">Appellant withdrawal</th>
+                                    <td class="govuk-table__cell appeal-costs-appellant-withdrawal-status">No documents available</td>
+                                    <td class="govuk-table__cell appeal-costs-appellant-withdrawal-actions govuk-!-text-align-right">
+                                        <ul class="govuk-summary-list__actions-list">
+                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-appellant-withdrawal" href="/appeals-service/appeal-details/2/costs/appellant/withdrawal/upload-documents/2">Add<span class="govuk-visually-hidden"> Appellant withdrawal</span></a>
+                                            </li>
+                                        </ul>
+                                    </td>
+                                </tr>
+                                <tr class="govuk-table__row">
+                                    <th scope="row" class="govuk-table__header appeal-costs-appellant-correspondence-documentation">Appellant correspondence</th>
+                                    <td class="govuk-table__cell appeal-costs-appellant-correspondence-status">No documents available</td>
+                                    <td class="govuk-table__cell appeal-costs-appellant-correspondence-actions govuk-!-text-align-right">
+                                        <ul class="govuk-summary-list__actions-list">
+                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-appellant-correspondence" href="/appeals-service/appeal-details/2/costs/appellant/correspondence/upload-documents/3">Add<span class="govuk-visually-hidden"> Appellant correspondence</span></a>
+                                            </li>
+                                        </ul>
+                                    </td>
+                                </tr>
+                                <tr class="govuk-table__row">
+                                    <th scope="row" class="govuk-table__header appeal-costs-lpa-application-documentation">LPA application</th>
+                                    <td class="govuk-table__cell appeal-costs-lpa-application-status">No documents available</td>
+                                    <td class="govuk-table__cell appeal-costs-lpa-application-actions govuk-!-text-align-right">
+                                        <ul class="govuk-summary-list__actions-list">
+                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-lpa-application" href="/appeals-service/appeal-details/2/costs/lpa/application/upload-documents/4">Add<span class="govuk-visually-hidden"> LPA application</span></a>
+                                            </li>
+                                        </ul>
+                                    </td>
+                                </tr>
+                                <tr class="govuk-table__row">
+                                    <th scope="row" class="govuk-table__header appeal-costs-lpa-withdrawal-documentation">LPA withdrawal</th>
+                                    <td class="govuk-table__cell appeal-costs-lpa-withdrawal-status">No documents available</td>
+                                    <td class="govuk-table__cell appeal-costs-lpa-withdrawal-actions govuk-!-text-align-right">
+                                        <ul class="govuk-summary-list__actions-list">
+                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-lpa-withdrawal" href="/appeals-service/appeal-details/2/costs/lpa/withdrawal/upload-documents/5">Add<span class="govuk-visually-hidden"> LPA withdrawal</span></a>
+                                            </li>
+                                        </ul>
+                                    </td>
+                                </tr>
+                                <tr class="govuk-table__row">
+                                    <th scope="row" class="govuk-table__header appeal-costs-lpa-correspondence-documentation">LPA correspondence</th>
+                                    <td class="govuk-table__cell appeal-costs-lpa-correspondence-status">No documents available</td>
+                                    <td class="govuk-table__cell appeal-costs-lpa-correspondence-actions govuk-!-text-align-right">
+                                        <ul class="govuk-summary-list__actions-list">
+                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-lpa-correspondence" href="/appeals-service/appeal-details/2/costs/lpa/correspondence/upload-documents/6">Add<span class="govuk-visually-hidden"> LPA correspondence</span></a>
+                                            </li>
+                                        </ul>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
+                <div class="govuk-accordion__section">
+                    <div class="govuk-accordion__section-header">
+                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default2-heading-6"> Contacts</span></h2>
+                    </div>
+                    <div id="accordion-default2-content-6" class="govuk-accordion__section-content">
+                        <dl class="govuk-summary-list">
+                            <div class="govuk-summary-list__row appeal-appellant"><dt class="govuk-summary-list__key"> Appellant</dt>
+                                <dd class="govuk-summary-list__value">
+                                    <ul class="govuk-list">
+                                        <li>Roger Simmons</li>
+                                        <li>test3@example.com</li>
+                                    </ul>
+                                </dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/service-user/change/appellant"
+                                    data-cy="change-appellant">Change<span class="govuk-visually-hidden"> Appellant</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-agent"><dt class="govuk-summary-list__key"> Agent</dt>
+                                <dd class="govuk-summary-list__value">
+                                    <ul class="govuk-list">
+                                        <li>Fiona Shell</li>
+                                        <li>test2@example.com</li>
+                                    </ul>
+                                </dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/service-user/change/agent"
+                                    data-cy="change-agent">Change<span class="govuk-visually-hidden"> Agent</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-lpa-contact-details"><dt class="govuk-summary-list__key"> LPA</dt>
+                                <dd class="govuk-summary-list__value">
+                                    <ul class="govuk-list">
+                                        <li>Wiltshire Council</li>
+                                        <li>wilt@lpa-email.gov.uk</li>
+                                    </ul>
+                                </dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/change-appeal-details/local-planning-authority"
+                                    data-cy="change-lpa-contact-details">Change<span class="govuk-visually-hidden"> Local planning authority (LPA)</span></a>
+                                </dd>
+                            </div>
+                        </dl>
+                    </div>
+                </div>
+                <div class="govuk-accordion__section">
+                    <div class="govuk-accordion__section-header">
+                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default2-heading-7"> Team</span></h2>
+                    </div>
+                    <div id="accordion-default2-content-7" class="govuk-accordion__section-content">
+                        <dl class="govuk-summary-list">
+                            <div class="govuk-summary-list__row appeal-case-officer"><dt class="govuk-summary-list__key"> Case officer</dt>
+                                <dd class="govuk-summary-list__value">
+                                    <p class="govuk-body">Not assigned</p>
+                                </dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/assign-case-officer/search-case-officer"
+                                    data-cy="assign-case-officer">Assign<span class="govuk-visually-hidden"> Case officer</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-inspector"><dt class="govuk-summary-list__key"> Inspector</dt>
+                                <dd class="govuk-summary-list__value">
+                                    <p class="govuk-body">Not assigned</p>
+                                </dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/assign-inspector/search-inspector"
+                                    data-cy="assign-inspector">Assign<span class="govuk-visually-hidden"> Inspector</span></a>
+                                </dd>
+                            </div>
+                        </dl>
+                    </div>
+                </div>
+                <div class="govuk-accordion__section">
+                    <div class="govuk-accordion__section-header">
+                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default2-heading-8"> Case management</span></h2>
+                    </div>
+                    <div id="accordion-default2-content-8" class="govuk-accordion__section-content">
+                        <dl class="govuk-summary-list">
+                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Cross-team correspondence</dt>
+                                <dd                                 class="govuk-summary-list__value">No documents</dd>
+                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/internal-correspondence/cross-team/upload-documents/10"
+                                        data-cy="add-cross-team-correspondence">Add<span class="govuk-visually-hidden"> Cross-team correspondence</span></a>
+                                    </dd>
+                            </div>
+                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Inspector correspondence</dt>
+                                <dd                                 class="govuk-summary-list__value">No documents</dd>
+                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/internal-correspondence/inspector/upload-documents/11"
+                                        data-cy="add-inspector-correspondence">Add<span class="govuk-visually-hidden"> Inspector correspondence</span></a>
+                                    </dd>
+                            </div>
+                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Main party correspondence</dt>
+                                <dd                                 class="govuk-summary-list__value">No documents</dd>
+                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/internal-correspondence/main-party/upload-documents/22"
+                                        data-cy="add-main-party-correspondence">Add<span class="govuk-visually-hidden"> Main party correspondence</span></a>
+                                    </dd>
+                            </div>
+                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Case history</dt>
+                                <dd class="govuk-summary-list__value"></dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/audit" data-cy="view-case-history">View<span class="govuk-visually-hidden"> Case history</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Appeal withdrawal</dt>
+                                <dd class="govuk-summary-list__value"></dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/withdrawal/start"
+                                    data-cy="start-appeal-withdrawal">Start<span class="govuk-visually-hidden"> Appeal withdrawal</span></a>
+                                </dd>
+                            </div>
+                        </dl>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div id="case-details-cancel-section">
+        <h3 class="govuk-heading-m">Cancel appeal</h3>
+        <div>
+            <p><a id="cancelCase" class="govuk-body govuk-link" href="/appeals-service/appeal-details/2/cancel">Cancel appeal</a>
+            </p>
+        </div>
+    </div>
+</main>"
+`;
+
+exports[`appeal-details GET /:appealId Linked appeals should not render action links to the manage linked appeals page or the add linked appeal page in the linked appeals row, if the appeal is linked as a child of an external lead appeal 1`] = `
+"<main class="govuk-main-wrapper" id="main-content">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Appeal 351062</span>
+            <h1 class="govuk-heading-xl govuk-!-margin-bottom-3">Case details</h1>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full"><strong class="govuk-tag govuk-tag--grey pins-status-tag--full-width">Received appeal</strong>
+            <strong             class="govuk-tag govuk-tag--grey govuk-!-margin-left-1 govuk-!-margin-bottom-4"></strong>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
+            <dl class="govuk-summary-list pins-summary-list--no-border">
+                <div class="govuk-summary-list__row appeal-case-officer"><dt class="govuk-summary-list__key"> Case officer</dt>
+                    <dd class="govuk-summary-list__value">
+                        <p class="govuk-body">Not assigned</p>
+                    </dd>
+                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/assign-case-officer/search-case-officer"
+                        data-cy="assign-case-officer-name">Assign<span class="govuk-visually-hidden"> Case officer</span></a>
+                    </dd>
+                </div>
+                <div class="govuk-summary-list__row appeal-site-address"><dt class="govuk-summary-list__key"> Site address</dt>
+                    <dd class="govuk-summary-list__value">21 The Pavement, Wandsworth, SW4 0HY</dd>
+                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-address/change/1?backUrl=%2Fappeals-service%2Fappeal-details%2F1"
+                        data-cy="change-site-address">Change<span class="govuk-visually-hidden"> Site address</span></a>
+                    </dd>
+                </div>
+                <div class="govuk-summary-list__row appeal-local-planning-authority"><dt class="govuk-summary-list__key"> LPA</dt>
+                    <dd class="govuk-summary-list__value">Wiltshire Council</dd>
+                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/change-appeal-details/local-planning-authority"
+                        data-cy="change-local-planning-authority">Change<span class="govuk-visually-hidden"> LPA</span></a>
+                    </dd>
+                </div>
+            </dl>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
+            <p class="govuk-body govuk-!-margin-bottom-6" id="download-case-files"
+            data-cy="download-case-files"><a class="govuk-link" href="/documents/1/bulk-download/case-APP/Q9999/D/21/351062.zip">Download case</a>
+            </p>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
+            <details class="govuk-details">
+                <summary class="govuk-details__summary"><span class="govuk-details__summary-text"> 2 case notes</span>
+                </summary>
+                <div class="govuk-details__text">
+                    <form method="POST" novalidate="novalidate">
+                        <div class="govuk-grid-row">
+                            <div class="govuk-grid-column-two-thirds">
+                                <div class="govuk-form-group govuk-character-count" data-module="govuk-character-count"
+                                data-maxlength="500">
+                                    <textarea class="govuk-textarea govuk-js-character-count" id="comment"
+                                    name="comment" rows="5" aria-describedby="comment-info"></textarea>
+                                    <div id="comment-info" class="govuk-hint govuk-character-count__message">You can enter up to 500 characters</div>
+                                </div>
+                            </div>
+                        </div>
+                        <button type="submit" data-prevent-double-click="true" class="govuk-button govuk-button--secondary govuk-!-margin-bottom-1"
+                        data-module="govuk-button">Add case note</button>
+                    </form>
+                    <div>
+                        <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+                        <section>
+                            <p class="govuk-body govuk-!-margin-bottom-1">A case note you should see.</p>
+                            <p class="govuk-hint govuk-!-margin-bottom-6">11:00am on Tuesday 1 October 2024 by John.Smith</p>
+                            <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+                        </section>
+                        <section>
+                            <p class="govuk-body govuk-!-margin-bottom-1">A case note you should see.</p>
+                            <p class="govuk-hint govuk-!-margin-bottom-6">11:00am on Tuesday 1 October 2024 by John.Smith</p>
+                            <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+                        </section>
+                    </div>
+                </div>
+            </details>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
+            <div class="govuk-accordion" data-module="govuk-accordion" id="accordion-default1">
+                <div class="govuk-accordion__section">
+                    <div class="govuk-accordion__section-header">
+                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-1"> Overview</span></h2>
+                    </div>
+                    <div id="accordion-default1-content-1" class="govuk-accordion__section-content">
+                        <dl class="govuk-summary-list">
+                            <div class="govuk-summary-list__row govuk-summary-list__row--no-actions appeal-lpa-reference"><dt class="govuk-summary-list__key"> Planning application reference</dt>
+                                <dd                                 class="govuk-summary-list__value">48269/APP/2021/1482</dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-appeal-type"><dt class="govuk-summary-list__key"> Appeal type</dt>
+                                <dd class="govuk-summary-list__value">Householder</dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/change-appeal-type/appeal-type"
+                                    data-cy="change-appeal-type">Change<span class="govuk-visually-hidden"> Appeal type</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row govuk-summary-list__row--no-actions appeal-case-procedure"><dt class="govuk-summary-list__key"> Appeal procedure</dt>
+                                <dd class="govuk-summary-list__value">Written</dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-allocation-details"><dt class="govuk-summary-list__key"> Allocation level</dt>
+                                <dd class="govuk-summary-list__value">
+                                    <ul class="govuk-!-margin-0">
+                                        <li>Level: A</li>
+                                        <li>Historic heritage</li>
+                                        <li>Architecture design</li>
+                                    </ul>
+                                </dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/allocation-details/allocation-level"
+                                    data-cy="change-allocation-details">Change<span class="govuk-visually-hidden"> Allocation level</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-linked-appeals"><dt class="govuk-summary-list__key"> Linked appeals</dt>
+                                <dd class="govuk-summary-list__value">
+                                    <ul class="govuk-list govuk-list--bullet">
+                                        <li><a href="/appeals-service/appeal-details/5449" class="govuk-link" data-cy="linked-appeal-784706"
+                                            aria-label="Appeal 7 8 4 7 0 6">784706</a>
+                                        </li>
+                                        <li><span class="govuk-body">87326527</span>
+                                        </li>
+                                        <li><a href="/appeals-service/appeal-details/5464" class="govuk-link" data-cy="linked-appeal-140079"
+                                            aria-label="Appeal 1 4 0 0 7 9">140079</a> (lead)</li>
+                                        <li><a href="/appeals-service/appeal-details/5451" class="govuk-link" data-cy="linked-appeal-721086"
+                                            aria-label="Appeal 7 2 1 0 8 6">721086</a>
+                                        </li>
+                                        <li><span class="govuk-body">76215416</span> (lead)</li>
+                                    </ul>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-other-appeals"><dt class="govuk-summary-list__key"> Related appeals</dt>
+                                <dd class="govuk-summary-list__value"><span>No</span>
+                                </dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/other-appeals/add"
+                                    data-cy="add-related-appeals">Add<span class="govuk-visually-hidden"> Related appeals</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-decision"><dt class="govuk-summary-list__key"> Decision</dt>
+                                <dd class="govuk-summary-list__value">Dismissed</dd>
+                            </div>
+                        </dl>
+                    </div>
+                </div>
+                <div class="govuk-accordion__section">
+                    <div class="govuk-accordion__section-header">
+                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-2"> Site</span></h2>
+                    </div>
+                    <div id="accordion-default1-content-2" class="govuk-accordion__section-content">
+                        <dl class="govuk-summary-list">
+                            <div class="govuk-summary-list__row appeal-visit-type"><dt class="govuk-summary-list__key"> Visit type</dt>
+                                <dd class="govuk-summary-list__value">Accompanied</dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/visit-booked?backUrl=%2Fappeals-service%2Fappeal-details%2F1"
+                                    data-cy="change-set-visit-type">Change<span class="govuk-visually-hidden"> Visit type</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Date</dt>
+                                <dd class="govuk-summary-list__value">9 October 2023</dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/visit-booked"
+                                    data-cy="change-site-visit-date">Change<span class="govuk-visually-hidden"> Date</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Start time</dt>
+                                <dd class="govuk-summary-list__value">9:38am</dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/visit-booked"
+                                    data-cy="change-site-visit-start-time">Change<span class="govuk-visually-hidden"> Start time</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> End time</dt>
+                                <dd class="govuk-summary-list__value">10:00am</dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/visit-booked"
+                                    data-cy="change-site-visit-end-time">Change<span class="govuk-visually-hidden"> End time</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-neighbouring-sites-inspector"><dt class="govuk-summary-list__key"> Interested party and neighbour addresses</dt>
+                                <dd                                 class="govuk-summary-list__value">
+                                    <ul class="govuk-list govuk-list--bullet">
+                                        <li>2 Grove Cottage, Shotesham Road, Woodton, Devon, NR35 2ND</li>
+                                    </ul>
+                                    </dd>
+                                    <dd class="govuk-summary-list__actions">
+                                        <ul class="govuk-summary-list__actions-list">
+                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/neighbouring-sites/manage"
+                                                data-cy="manage-neighbouring-sites-inspector">Manage<span class="govuk-visually-hidden"> Interested party and neighbour addresses</span></a>
+                                            </li>
+                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/neighbouring-sites/add/back-office"
+                                                data-cy="add-neighbouring-sites-inspector">Add<span class="govuk-visually-hidden"> Interested party and neighbour addresses</span></a>
+                                            </li>
+                                        </ul>
+                                    </dd>
+                            </div>
+                        </dl>
+                    </div>
+                </div>
+                <div class="govuk-accordion__section">
+                    <div class="govuk-accordion__section-header">
+                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-3"> Timetable</span></h2>
+                    </div>
+                    <div id="accordion-default1-content-3" class="govuk-accordion__section-content">
+                        <dl class="govuk-summary-list appeal-case-timetable">
+                            <div class="govuk-summary-list__row appeal-valid-date"><dt class="govuk-summary-list__key"> Valid date</dt>
+                                <dd class="govuk-summary-list__value">23 May 2023</dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/valid/date"
+                                    data-cy="-valid-date"><span class="govuk-visually-hidden"> Valid date</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-start-date"><dt class="govuk-summary-list__key"> Start date</dt>
+                                <dd class="govuk-summary-list__value">23 May 2023</dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/start-case/change"
+                                    data-cy="change-start-case-date">Change<span class="govuk-visually-hidden"> Start date</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-lpa-questionnaire-due-date"><dt class="govuk-summary-list__key"> LPA questionnaire due</dt>
+                                <dd class="govuk-summary-list__value">11 October 2023</dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-site-visit"><dt class="govuk-summary-list__key"> Site visit</dt>
+                                <dd class="govuk-summary-list__value">
+                                    <ul class="govuk-list govuk-!-margin-top-0 govuk-!-padding-left-0">
+                                        <li>9 October 2023</li>
+                                        <li>9:38am - 10:00am</li>
+                                    </ul>
+                                </dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/manage-visit?backUrl=%2Fappeals-service%2Fappeal-details%2F1"
+                                    data-cy="change-schedule-visit">Change<span class="govuk-visually-hidden"> Site visit</span></a>
+                                </dd>
+                            </div>
+                        </dl>
+                    </div>
+                </div>
+                <div class="govuk-accordion__section">
+                    <div class="govuk-accordion__section-header">
+                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-4"> Documentation</span></h2>
+                    </div>
+                    <div id="accordion-default1-content-4" class="govuk-accordion__section-content">
+                        <table class="govuk-table">
+                            <thead class="govuk-table__head">
+                                <tr class="govuk-table__row">
+                                    <th scope="col" class="govuk-table__header">Documentation</th>
+                                    <th scope="col" class="govuk-table__header">Status</th>
+                                    <th scope="col" class="govuk-table__header">Received</th>
+                                    <th scope="col" class="govuk-table__header govuk-!-text-align-right">Action</th>
+                                </tr>
+                            </thead>
+                            <tbody class="govuk-table__body">
+                                <tr class="govuk-table__row">
+                                    <th scope="row" class="govuk-table__header">Appeal</th>
+                                    <td class="govuk-table__cell">Ready to review</td>
+                                    <td class="govuk-table__cell">2 August 2024</td>
+                                    <td class="govuk-table__cell govuk-!-text-align-right"><a href="/appeals-service/appeal-details/1/appellant-case?backUrl=%2Fappeals-service%2Fappeal-details%2F1"
+                                        data-cy="review-appellant-case" class="govuk-link">Review<span class="govuk-visually-hidden"> appellant case</span></a>
+                                    </td>
+                                </tr>
+                                <tr class="govuk-table__row">
+                                    <th scope="row" class="govuk-table__header">LPA questionnaire</th>
+                                    <td class="govuk-table__cell">Overdue</td>
+                                    <td class="govuk-table__cell">Due by 11 October 2023</td>
+                                    <td class="govuk-table__cell govuk-!-text-align-right"></td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
+                <div class="govuk-accordion__section">
+                    <div class="govuk-accordion__section-header">
+                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-5"> Costs</span></h2>
+                    </div>
+                    <div id="accordion-default1-content-5" class="govuk-accordion__section-content">
+                        <table class="govuk-table">
+                            <thead class="govuk-table__head">
+                                <tr class="govuk-table__row">
+                                    <th scope="col" class="govuk-table__header">Documentation</th>
+                                    <th scope="col" class="govuk-table__header">Status</th>
+                                    <th scope="col" class="govuk-table__header govuk-!-text-align-right">Action</th>
+                                </tr>
+                            </thead>
+                            <tbody class="govuk-table__body">
+                                <tr class="govuk-table__row">
+                                    <th scope="row" class="govuk-table__header appeal-costs-appellant-application-documentation">Appellant application</th>
+                                    <td class="govuk-table__cell appeal-costs-appellant-application-status">No documents available</td>
+                                    <td class="govuk-table__cell appeal-costs-appellant-application-actions govuk-!-text-align-right">
+                                        <ul class="govuk-summary-list__actions-list">
+                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-appellant-application" href="/appeals-service/appeal-details/1/costs/appellant/application/upload-documents/1">Add<span class="govuk-visually-hidden"> Appellant application</span></a>
+                                            </li>
+                                        </ul>
+                                    </td>
+                                </tr>
+                                <tr class="govuk-table__row">
+                                    <th scope="row" class="govuk-table__header appeal-costs-appellant-withdrawal-documentation">Appellant withdrawal</th>
+                                    <td class="govuk-table__cell appeal-costs-appellant-withdrawal-status">No documents available</td>
+                                    <td class="govuk-table__cell appeal-costs-appellant-withdrawal-actions govuk-!-text-align-right">
+                                        <ul class="govuk-summary-list__actions-list">
+                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-appellant-withdrawal" href="/appeals-service/appeal-details/1/costs/appellant/withdrawal/upload-documents/2">Add<span class="govuk-visually-hidden"> Appellant withdrawal</span></a>
+                                            </li>
+                                        </ul>
+                                    </td>
+                                </tr>
+                                <tr class="govuk-table__row">
+                                    <th scope="row" class="govuk-table__header appeal-costs-appellant-correspondence-documentation">Appellant correspondence</th>
+                                    <td class="govuk-table__cell appeal-costs-appellant-correspondence-status">No documents available</td>
+                                    <td class="govuk-table__cell appeal-costs-appellant-correspondence-actions govuk-!-text-align-right">
+                                        <ul class="govuk-summary-list__actions-list">
+                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-appellant-correspondence" href="/appeals-service/appeal-details/1/costs/appellant/correspondence/upload-documents/3">Add<span class="govuk-visually-hidden"> Appellant correspondence</span></a>
+                                            </li>
+                                        </ul>
+                                    </td>
+                                </tr>
+                                <tr class="govuk-table__row">
+                                    <th scope="row" class="govuk-table__header appeal-costs-lpa-application-documentation">LPA application</th>
+                                    <td class="govuk-table__cell appeal-costs-lpa-application-status">No documents available</td>
+                                    <td class="govuk-table__cell appeal-costs-lpa-application-actions govuk-!-text-align-right">
+                                        <ul class="govuk-summary-list__actions-list">
+                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-lpa-application" href="/appeals-service/appeal-details/1/costs/lpa/application/upload-documents/4">Add<span class="govuk-visually-hidden"> LPA application</span></a>
+                                            </li>
+                                        </ul>
+                                    </td>
+                                </tr>
+                                <tr class="govuk-table__row">
+                                    <th scope="row" class="govuk-table__header appeal-costs-lpa-withdrawal-documentation">LPA withdrawal</th>
+                                    <td class="govuk-table__cell appeal-costs-lpa-withdrawal-status">No documents available</td>
+                                    <td class="govuk-table__cell appeal-costs-lpa-withdrawal-actions govuk-!-text-align-right">
+                                        <ul class="govuk-summary-list__actions-list">
+                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-lpa-withdrawal" href="/appeals-service/appeal-details/1/costs/lpa/withdrawal/upload-documents/5">Add<span class="govuk-visually-hidden"> LPA withdrawal</span></a>
+                                            </li>
+                                        </ul>
+                                    </td>
+                                </tr>
+                                <tr class="govuk-table__row">
+                                    <th scope="row" class="govuk-table__header appeal-costs-lpa-correspondence-documentation">LPA correspondence</th>
+                                    <td class="govuk-table__cell appeal-costs-lpa-correspondence-status">No documents available</td>
+                                    <td class="govuk-table__cell appeal-costs-lpa-correspondence-actions govuk-!-text-align-right">
+                                        <ul class="govuk-summary-list__actions-list">
+                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-lpa-correspondence" href="/appeals-service/appeal-details/1/costs/lpa/correspondence/upload-documents/6">Add<span class="govuk-visually-hidden"> LPA correspondence</span></a>
+                                            </li>
+                                        </ul>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
+                <div class="govuk-accordion__section">
+                    <div class="govuk-accordion__section-header">
+                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-6"> Contacts</span></h2>
+                    </div>
+                    <div id="accordion-default1-content-6" class="govuk-accordion__section-content">
+                        <dl class="govuk-summary-list">
+                            <div class="govuk-summary-list__row appeal-appellant"><dt class="govuk-summary-list__key"> Appellant</dt>
+                                <dd class="govuk-summary-list__value">
+                                    <ul class="govuk-list">
+                                        <li>Roger Simmons</li>
+                                        <li>test3@example.com</li>
+                                    </ul>
+                                </dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/service-user/change/appellant"
+                                    data-cy="change-appellant">Change<span class="govuk-visually-hidden"> Appellant</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-agent"><dt class="govuk-summary-list__key"> Agent</dt>
+                                <dd class="govuk-summary-list__value">
+                                    <ul class="govuk-list">
+                                        <li>Fiona Shell</li>
+                                        <li>test2@example.com</li>
+                                    </ul>
+                                </dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/service-user/change/agent"
+                                    data-cy="change-agent">Change<span class="govuk-visually-hidden"> Agent</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-lpa-contact-details"><dt class="govuk-summary-list__key"> LPA</dt>
+                                <dd class="govuk-summary-list__value">
+                                    <ul class="govuk-list">
+                                        <li>Wiltshire Council</li>
+                                        <li>wilt@lpa-email.gov.uk</li>
+                                    </ul>
+                                </dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/change-appeal-details/local-planning-authority"
+                                    data-cy="change-lpa-contact-details">Change<span class="govuk-visually-hidden"> Local planning authority (LPA)</span></a>
+                                </dd>
+                            </div>
+                        </dl>
+                    </div>
+                </div>
+                <div class="govuk-accordion__section">
+                    <div class="govuk-accordion__section-header">
+                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-7"> Team</span></h2>
+                    </div>
+                    <div id="accordion-default1-content-7" class="govuk-accordion__section-content">
+                        <dl class="govuk-summary-list">
+                            <div class="govuk-summary-list__row appeal-case-officer"><dt class="govuk-summary-list__key"> Case officer</dt>
+                                <dd class="govuk-summary-list__value">
+                                    <p class="govuk-body">Not assigned</p>
+                                </dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/assign-case-officer/search-case-officer"
+                                    data-cy="assign-case-officer">Assign<span class="govuk-visually-hidden"> Case officer</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-inspector"><dt class="govuk-summary-list__key"> Inspector</dt>
+                                <dd class="govuk-summary-list__value">
+                                    <p class="govuk-body">Not assigned</p>
+                                </dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/assign-inspector/search-inspector"
+                                    data-cy="assign-inspector">Assign<span class="govuk-visually-hidden"> Inspector</span></a>
+                                </dd>
+                            </div>
+                        </dl>
+                    </div>
+                </div>
+                <div class="govuk-accordion__section">
+                    <div class="govuk-accordion__section-header">
+                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-8"> Case management</span></h2>
+                    </div>
+                    <div id="accordion-default1-content-8" class="govuk-accordion__section-content">
+                        <dl class="govuk-summary-list">
+                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Cross-team correspondence</dt>
+                                <dd                                 class="govuk-summary-list__value">No documents</dd>
+                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/internal-correspondence/cross-team/upload-documents/10"
+                                        data-cy="add-cross-team-correspondence">Add<span class="govuk-visually-hidden"> Cross-team correspondence</span></a>
+                                    </dd>
+                            </div>
+                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Inspector correspondence</dt>
+                                <dd                                 class="govuk-summary-list__value">No documents</dd>
+                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/internal-correspondence/inspector/upload-documents/11"
+                                        data-cy="add-inspector-correspondence">Add<span class="govuk-visually-hidden"> Inspector correspondence</span></a>
+                                    </dd>
+                            </div>
+                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Main party correspondence</dt>
+                                <dd                                 class="govuk-summary-list__value">No documents</dd>
+                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/internal-correspondence/main-party/upload-documents/22"
+                                        data-cy="add-main-party-correspondence">Add<span class="govuk-visually-hidden"> Main party correspondence</span></a>
+                                    </dd>
+                            </div>
+                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Case history</dt>
+                                <dd class="govuk-summary-list__value"></dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/audit" data-cy="view-case-history">View<span class="govuk-visually-hidden"> Case history</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Appeal withdrawal</dt>
+                                <dd class="govuk-summary-list__value"></dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/withdrawal/start"
+                                    data-cy="start-appeal-withdrawal">Start<span class="govuk-visually-hidden"> Appeal withdrawal</span></a>
+                                </dd>
+                            </div>
+                        </dl>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div id="case-details-cancel-section">
+        <h3 class="govuk-heading-m">Cancel appeal</h3>
+        <div>
+            <p><a id="cancelCase" class="govuk-body govuk-link" href="/appeals-service/appeal-details/1/cancel">Cancel appeal</a>
+            </p>
+        </div>
+    </div>
+</main>"
+`;
+
+exports[`appeal-details GET /:appealId Linked appeals should render a child tag next to the appeal status tag if the appeal is a child 1`] = `
+"<main class="govuk-main-wrapper" id="main-content">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Appeal 351062</span>
+            <h1 class="govuk-heading-xl govuk-!-margin-bottom-3">Case details</h1>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full"><strong class="govuk-tag govuk-tag--grey pins-status-tag--full-width">Received appeal</strong>
+            <strong             class="govuk-tag govuk-tag--grey govuk-!-margin-left-1 govuk-!-margin-bottom-4">Child</strong>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
+            <dl class="govuk-summary-list pins-summary-list--no-border">
+                <div class="govuk-summary-list__row appeal-case-officer"><dt class="govuk-summary-list__key"> Case officer</dt>
+                    <dd class="govuk-summary-list__value">
+                        <p class="govuk-body">Not assigned</p>
+                    </dd>
+                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/assign-case-officer/search-case-officer"
+                        data-cy="assign-case-officer-name">Assign<span class="govuk-visually-hidden"> Case officer</span></a>
+                    </dd>
+                </div>
+                <div class="govuk-summary-list__row appeal-site-address"><dt class="govuk-summary-list__key"> Site address</dt>
+                    <dd class="govuk-summary-list__value">21 The Pavement, Wandsworth, SW4 0HY</dd>
+                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-address/change/1?backUrl=%2Fappeals-service%2Fappeal-details%2F1"
+                        data-cy="change-site-address">Change<span class="govuk-visually-hidden"> Site address</span></a>
+                    </dd>
+                </div>
+                <div class="govuk-summary-list__row appeal-local-planning-authority"><dt class="govuk-summary-list__key"> LPA</dt>
+                    <dd class="govuk-summary-list__value">Wiltshire Council</dd>
+                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/change-appeal-details/local-planning-authority"
+                        data-cy="change-local-planning-authority">Change<span class="govuk-visually-hidden"> LPA</span></a>
+                    </dd>
+                </div>
+            </dl>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
+            <p class="govuk-body govuk-!-margin-bottom-6" id="download-case-files"
+            data-cy="download-case-files"><a class="govuk-link" href="/documents/1/bulk-download/case-APP/Q9999/D/21/351062.zip">Download case</a>
+            </p>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
+            <details class="govuk-details">
+                <summary class="govuk-details__summary"><span class="govuk-details__summary-text"> 2 case notes</span>
+                </summary>
+                <div class="govuk-details__text">
+                    <form method="POST" novalidate="novalidate">
+                        <div class="govuk-grid-row">
+                            <div class="govuk-grid-column-two-thirds">
+                                <div class="govuk-form-group govuk-character-count" data-module="govuk-character-count"
+                                data-maxlength="500">
+                                    <textarea class="govuk-textarea govuk-js-character-count" id="comment"
+                                    name="comment" rows="5" aria-describedby="comment-info"></textarea>
+                                    <div id="comment-info" class="govuk-hint govuk-character-count__message">You can enter up to 500 characters</div>
+                                </div>
+                            </div>
+                        </div>
+                        <button type="submit" data-prevent-double-click="true" class="govuk-button govuk-button--secondary govuk-!-margin-bottom-1"
+                        data-module="govuk-button">Add case note</button>
+                    </form>
+                    <div>
+                        <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+                        <section>
+                            <p class="govuk-body govuk-!-margin-bottom-1">A case note you should see.</p>
+                            <p class="govuk-hint govuk-!-margin-bottom-6">11:00am on Tuesday 1 October 2024 by John.Smith</p>
+                            <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+                        </section>
+                        <section>
+                            <p class="govuk-body govuk-!-margin-bottom-1">A case note you should see.</p>
+                            <p class="govuk-hint govuk-!-margin-bottom-6">11:00am on Tuesday 1 October 2024 by John.Smith</p>
+                            <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+                        </section>
+                    </div>
+                </div>
+            </details>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
+            <div class="govuk-accordion" data-module="govuk-accordion" id="accordion-default1">
+                <div class="govuk-accordion__section">
+                    <div class="govuk-accordion__section-header">
+                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-1"> Overview</span></h2>
+                    </div>
+                    <div id="accordion-default1-content-1" class="govuk-accordion__section-content">
+                        <dl class="govuk-summary-list">
+                            <div class="govuk-summary-list__row govuk-summary-list__row--no-actions appeal-lpa-reference"><dt class="govuk-summary-list__key"> Planning application reference</dt>
+                                <dd                                 class="govuk-summary-list__value">48269/APP/2021/1482</dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-appeal-type"><dt class="govuk-summary-list__key"> Appeal type</dt>
+                                <dd class="govuk-summary-list__value">Householder</dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/change-appeal-type/appeal-type"
+                                    data-cy="change-appeal-type">Change<span class="govuk-visually-hidden"> Appeal type</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row govuk-summary-list__row--no-actions appeal-case-procedure"><dt class="govuk-summary-list__key"> Appeal procedure</dt>
+                                <dd class="govuk-summary-list__value">Written</dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-allocation-details"><dt class="govuk-summary-list__key"> Allocation level</dt>
+                                <dd class="govuk-summary-list__value">
+                                    <ul class="govuk-!-margin-0">
+                                        <li>Level: A</li>
+                                        <li>Historic heritage</li>
+                                        <li>Architecture design</li>
+                                    </ul>
+                                </dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/allocation-details/allocation-level"
+                                    data-cy="change-allocation-details">Change<span class="govuk-visually-hidden"> Allocation level</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-linked-appeals"><dt class="govuk-summary-list__key"> Linked appeals</dt>
+                                <dd class="govuk-summary-list__value"><a href="/appeals-service/appeal-details/5464" class="govuk-link" data-cy="linked-appeal-140079"
+                                    aria-label="Appeal 1 4 0 0 7 9">140079</a> (lead)</dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-other-appeals"><dt class="govuk-summary-list__key"> Related appeals</dt>
+                                <dd class="govuk-summary-list__value"><span>No</span>
+                                </dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/other-appeals/add"
+                                    data-cy="add-related-appeals">Add<span class="govuk-visually-hidden"> Related appeals</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-decision"><dt class="govuk-summary-list__key"> Decision</dt>
+                                <dd class="govuk-summary-list__value">Dismissed</dd>
+                            </div>
+                        </dl>
+                    </div>
+                </div>
+                <div class="govuk-accordion__section">
+                    <div class="govuk-accordion__section-header">
+                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-2"> Site</span></h2>
+                    </div>
+                    <div id="accordion-default1-content-2" class="govuk-accordion__section-content">
+                        <dl class="govuk-summary-list">
+                            <div class="govuk-summary-list__row appeal-visit-type"><dt class="govuk-summary-list__key"> Visit type</dt>
+                                <dd class="govuk-summary-list__value">Accompanied</dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/visit-booked?backUrl=%2Fappeals-service%2Fappeal-details%2F1"
+                                    data-cy="change-set-visit-type">Change<span class="govuk-visually-hidden"> Visit type</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Date</dt>
+                                <dd class="govuk-summary-list__value">9 October 2023</dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/visit-booked"
+                                    data-cy="change-site-visit-date">Change<span class="govuk-visually-hidden"> Date</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Start time</dt>
+                                <dd class="govuk-summary-list__value">9:38am</dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/visit-booked"
+                                    data-cy="change-site-visit-start-time">Change<span class="govuk-visually-hidden"> Start time</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> End time</dt>
+                                <dd class="govuk-summary-list__value">10:00am</dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/visit-booked"
+                                    data-cy="change-site-visit-end-time">Change<span class="govuk-visually-hidden"> End time</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-neighbouring-sites-inspector"><dt class="govuk-summary-list__key"> Interested party and neighbour addresses</dt>
+                                <dd                                 class="govuk-summary-list__value">
+                                    <ul class="govuk-list govuk-list--bullet">
+                                        <li>2 Grove Cottage, Shotesham Road, Woodton, Devon, NR35 2ND</li>
+                                    </ul>
+                                    </dd>
+                                    <dd class="govuk-summary-list__actions">
+                                        <ul class="govuk-summary-list__actions-list">
+                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/neighbouring-sites/manage"
+                                                data-cy="manage-neighbouring-sites-inspector">Manage<span class="govuk-visually-hidden"> Interested party and neighbour addresses</span></a>
+                                            </li>
+                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/neighbouring-sites/add/back-office"
+                                                data-cy="add-neighbouring-sites-inspector">Add<span class="govuk-visually-hidden"> Interested party and neighbour addresses</span></a>
+                                            </li>
+                                        </ul>
+                                    </dd>
+                            </div>
+                        </dl>
+                    </div>
+                </div>
+                <div class="govuk-accordion__section">
+                    <div class="govuk-accordion__section-header">
+                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-3"> Timetable</span></h2>
+                    </div>
+                    <div id="accordion-default1-content-3" class="govuk-accordion__section-content">
+                        <dl class="govuk-summary-list appeal-case-timetable">
+                            <div class="govuk-summary-list__row appeal-valid-date"><dt class="govuk-summary-list__key"> Valid date</dt>
+                                <dd class="govuk-summary-list__value">23 May 2023</dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/valid/date"
+                                    data-cy="-valid-date"><span class="govuk-visually-hidden"> Valid date</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-start-date"><dt class="govuk-summary-list__key"> Start date</dt>
+                                <dd class="govuk-summary-list__value">23 May 2023</dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-lpa-questionnaire-due-date"><dt class="govuk-summary-list__key"> LPA questionnaire due</dt>
+                                <dd class="govuk-summary-list__value">11 October 2023</dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-site-visit"><dt class="govuk-summary-list__key"> Site visit</dt>
+                                <dd class="govuk-summary-list__value">
+                                    <ul class="govuk-list govuk-!-margin-top-0 govuk-!-padding-left-0">
+                                        <li>9 October 2023</li>
+                                        <li>9:38am - 10:00am</li>
+                                    </ul>
+                                </dd>
+                            </div>
+                        </dl>
+                    </div>
+                </div>
+                <div class="govuk-accordion__section">
+                    <div class="govuk-accordion__section-header">
+                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-4"> Documentation</span></h2>
+                    </div>
+                    <div id="accordion-default1-content-4" class="govuk-accordion__section-content">
+                        <table class="govuk-table">
+                            <thead class="govuk-table__head">
+                                <tr class="govuk-table__row">
+                                    <th scope="col" class="govuk-table__header">Documentation</th>
+                                    <th scope="col" class="govuk-table__header">Status</th>
+                                    <th scope="col" class="govuk-table__header">Received</th>
+                                    <th scope="col" class="govuk-table__header govuk-!-text-align-right">Action</th>
+                                </tr>
+                            </thead>
+                            <tbody class="govuk-table__body">
+                                <tr class="govuk-table__row">
+                                    <th scope="row" class="govuk-table__header">Appeal</th>
+                                    <td class="govuk-table__cell">Ready to review</td>
+                                    <td class="govuk-table__cell">2 August 2024</td>
+                                    <td class="govuk-table__cell govuk-!-text-align-right"><a href="/appeals-service/appeal-details/1/appellant-case?backUrl=%2Fappeals-service%2Fappeal-details%2F1"
+                                        data-cy="review-appellant-case" class="govuk-link">Review<span class="govuk-visually-hidden"> appellant case</span></a>
+                                    </td>
+                                </tr>
+                                <tr class="govuk-table__row">
+                                    <th scope="row" class="govuk-table__header">LPA questionnaire</th>
+                                    <td class="govuk-table__cell">Overdue</td>
+                                    <td class="govuk-table__cell">Due by 11 October 2023</td>
+                                    <td class="govuk-table__cell govuk-!-text-align-right"></td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
+                <div class="govuk-accordion__section">
+                    <div class="govuk-accordion__section-header">
+                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-5"> Costs</span></h2>
+                    </div>
+                    <div id="accordion-default1-content-5" class="govuk-accordion__section-content">
+                        <table class="govuk-table">
+                            <thead class="govuk-table__head">
+                                <tr class="govuk-table__row">
+                                    <th scope="col" class="govuk-table__header">Documentation</th>
+                                    <th scope="col" class="govuk-table__header">Status</th>
+                                    <th scope="col" class="govuk-table__header govuk-!-text-align-right">Action</th>
+                                </tr>
+                            </thead>
+                            <tbody class="govuk-table__body">
+                                <tr class="govuk-table__row">
+                                    <th scope="row" class="govuk-table__header appeal-costs-appellant-application-documentation">Appellant application</th>
+                                    <td class="govuk-table__cell appeal-costs-appellant-application-status">No documents available</td>
+                                    <td class="govuk-table__cell appeal-costs-appellant-application-actions govuk-!-text-align-right">
+                                        <ul class="govuk-summary-list__actions-list">
+                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-appellant-application" href="/appeals-service/appeal-details/1/costs/appellant/application/upload-documents/1">Add<span class="govuk-visually-hidden"> Appellant application</span></a>
+                                            </li>
+                                        </ul>
+                                    </td>
+                                </tr>
+                                <tr class="govuk-table__row">
+                                    <th scope="row" class="govuk-table__header appeal-costs-appellant-withdrawal-documentation">Appellant withdrawal</th>
+                                    <td class="govuk-table__cell appeal-costs-appellant-withdrawal-status">No documents available</td>
+                                    <td class="govuk-table__cell appeal-costs-appellant-withdrawal-actions govuk-!-text-align-right">
+                                        <ul class="govuk-summary-list__actions-list">
+                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-appellant-withdrawal" href="/appeals-service/appeal-details/1/costs/appellant/withdrawal/upload-documents/2">Add<span class="govuk-visually-hidden"> Appellant withdrawal</span></a>
+                                            </li>
+                                        </ul>
+                                    </td>
+                                </tr>
+                                <tr class="govuk-table__row">
+                                    <th scope="row" class="govuk-table__header appeal-costs-appellant-correspondence-documentation">Appellant correspondence</th>
+                                    <td class="govuk-table__cell appeal-costs-appellant-correspondence-status">No documents available</td>
+                                    <td class="govuk-table__cell appeal-costs-appellant-correspondence-actions govuk-!-text-align-right">
+                                        <ul class="govuk-summary-list__actions-list">
+                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-appellant-correspondence" href="/appeals-service/appeal-details/1/costs/appellant/correspondence/upload-documents/3">Add<span class="govuk-visually-hidden"> Appellant correspondence</span></a>
+                                            </li>
+                                        </ul>
+                                    </td>
+                                </tr>
+                                <tr class="govuk-table__row">
+                                    <th scope="row" class="govuk-table__header appeal-costs-lpa-application-documentation">LPA application</th>
+                                    <td class="govuk-table__cell appeal-costs-lpa-application-status">No documents available</td>
+                                    <td class="govuk-table__cell appeal-costs-lpa-application-actions govuk-!-text-align-right">
+                                        <ul class="govuk-summary-list__actions-list">
+                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-lpa-application" href="/appeals-service/appeal-details/1/costs/lpa/application/upload-documents/4">Add<span class="govuk-visually-hidden"> LPA application</span></a>
+                                            </li>
+                                        </ul>
+                                    </td>
+                                </tr>
+                                <tr class="govuk-table__row">
+                                    <th scope="row" class="govuk-table__header appeal-costs-lpa-withdrawal-documentation">LPA withdrawal</th>
+                                    <td class="govuk-table__cell appeal-costs-lpa-withdrawal-status">No documents available</td>
+                                    <td class="govuk-table__cell appeal-costs-lpa-withdrawal-actions govuk-!-text-align-right">
+                                        <ul class="govuk-summary-list__actions-list">
+                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-lpa-withdrawal" href="/appeals-service/appeal-details/1/costs/lpa/withdrawal/upload-documents/5">Add<span class="govuk-visually-hidden"> LPA withdrawal</span></a>
+                                            </li>
+                                        </ul>
+                                    </td>
+                                </tr>
+                                <tr class="govuk-table__row">
+                                    <th scope="row" class="govuk-table__header appeal-costs-lpa-correspondence-documentation">LPA correspondence</th>
+                                    <td class="govuk-table__cell appeal-costs-lpa-correspondence-status">No documents available</td>
+                                    <td class="govuk-table__cell appeal-costs-lpa-correspondence-actions govuk-!-text-align-right">
+                                        <ul class="govuk-summary-list__actions-list">
+                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-lpa-correspondence" href="/appeals-service/appeal-details/1/costs/lpa/correspondence/upload-documents/6">Add<span class="govuk-visually-hidden"> LPA correspondence</span></a>
+                                            </li>
+                                        </ul>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
+                <div class="govuk-accordion__section">
+                    <div class="govuk-accordion__section-header">
+                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-6"> Contacts</span></h2>
+                    </div>
+                    <div id="accordion-default1-content-6" class="govuk-accordion__section-content">
+                        <dl class="govuk-summary-list">
+                            <div class="govuk-summary-list__row appeal-appellant"><dt class="govuk-summary-list__key"> Appellant</dt>
+                                <dd class="govuk-summary-list__value">
+                                    <ul class="govuk-list">
+                                        <li>Roger Simmons</li>
+                                        <li>test3@example.com</li>
+                                    </ul>
+                                </dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/service-user/change/appellant"
+                                    data-cy="change-appellant">Change<span class="govuk-visually-hidden"> Appellant</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-agent"><dt class="govuk-summary-list__key"> Agent</dt>
+                                <dd class="govuk-summary-list__value">
+                                    <ul class="govuk-list">
+                                        <li>Fiona Shell</li>
+                                        <li>test2@example.com</li>
+                                    </ul>
+                                </dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/service-user/change/agent"
+                                    data-cy="change-agent">Change<span class="govuk-visually-hidden"> Agent</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-lpa-contact-details"><dt class="govuk-summary-list__key"> LPA</dt>
+                                <dd class="govuk-summary-list__value">
+                                    <ul class="govuk-list">
+                                        <li>Wiltshire Council</li>
+                                        <li>wilt@lpa-email.gov.uk</li>
+                                    </ul>
+                                </dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/change-appeal-details/local-planning-authority"
+                                    data-cy="change-lpa-contact-details">Change<span class="govuk-visually-hidden"> Local planning authority (LPA)</span></a>
+                                </dd>
+                            </div>
+                        </dl>
+                    </div>
+                </div>
+                <div class="govuk-accordion__section">
+                    <div class="govuk-accordion__section-header">
+                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-7"> Team</span></h2>
+                    </div>
+                    <div id="accordion-default1-content-7" class="govuk-accordion__section-content">
+                        <dl class="govuk-summary-list">
+                            <div class="govuk-summary-list__row appeal-case-officer"><dt class="govuk-summary-list__key"> Case officer</dt>
+                                <dd class="govuk-summary-list__value">
+                                    <p class="govuk-body">Not assigned</p>
+                                </dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/assign-case-officer/search-case-officer"
+                                    data-cy="assign-case-officer">Assign<span class="govuk-visually-hidden"> Case officer</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-inspector"><dt class="govuk-summary-list__key"> Inspector</dt>
+                                <dd class="govuk-summary-list__value">
+                                    <p class="govuk-body">Not assigned</p>
+                                </dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/assign-inspector/search-inspector"
+                                    data-cy="assign-inspector">Assign<span class="govuk-visually-hidden"> Inspector</span></a>
+                                </dd>
+                            </div>
+                        </dl>
+                    </div>
+                </div>
+                <div class="govuk-accordion__section">
+                    <div class="govuk-accordion__section-header">
+                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-8"> Case management</span></h2>
+                    </div>
+                    <div id="accordion-default1-content-8" class="govuk-accordion__section-content">
+                        <dl class="govuk-summary-list">
+                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Cross-team correspondence</dt>
+                                <dd                                 class="govuk-summary-list__value">No documents</dd>
+                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/internal-correspondence/cross-team/upload-documents/10"
+                                        data-cy="add-cross-team-correspondence">Add<span class="govuk-visually-hidden"> Cross-team correspondence</span></a>
+                                    </dd>
+                            </div>
+                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Inspector correspondence</dt>
+                                <dd                                 class="govuk-summary-list__value">No documents</dd>
+                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/internal-correspondence/inspector/upload-documents/11"
+                                        data-cy="add-inspector-correspondence">Add<span class="govuk-visually-hidden"> Inspector correspondence</span></a>
+                                    </dd>
+                            </div>
+                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Main party correspondence</dt>
+                                <dd                                 class="govuk-summary-list__value">No documents</dd>
+                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/internal-correspondence/main-party/upload-documents/22"
+                                        data-cy="add-main-party-correspondence">Add<span class="govuk-visually-hidden"> Main party correspondence</span></a>
+                                    </dd>
+                            </div>
+                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Case history</dt>
+                                <dd class="govuk-summary-list__value"></dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/audit" data-cy="view-case-history">View<span class="govuk-visually-hidden"> Case history</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Appeal withdrawal</dt>
+                                <dd class="govuk-summary-list__value"></dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/withdrawal/start"
+                                    data-cy="start-appeal-withdrawal">Start<span class="govuk-visually-hidden"> Appeal withdrawal</span></a>
+                                </dd>
+                            </div>
+                        </dl>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div id="case-details-cancel-section">
+        <h3 class="govuk-heading-m">Cancel appeal</h3>
+        <div>
+            <p><a id="cancelCase" class="govuk-body govuk-link" href="/appeals-service/appeal-details/1/cancel">Cancel appeal</a>
+            </p>
+        </div>
+    </div>
+</main>"
+`;
+
+exports[`appeal-details GET /:appealId Linked appeals should render a lead tag next to the appeal status tag if the appeal is a parent 1`] = `
+"<main class="govuk-main-wrapper" id="main-content">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Appeal 351062</span>
+            <h1 class="govuk-heading-xl govuk-!-margin-bottom-3">Case details</h1>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full"><strong class="govuk-tag govuk-tag--grey pins-status-tag--full-width">Received appeal</strong>
+            <strong             class="govuk-tag govuk-tag--grey govuk-!-margin-left-1 govuk-!-margin-bottom-4">Lead</strong>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
+            <dl class="govuk-summary-list pins-summary-list--no-border">
+                <div class="govuk-summary-list__row appeal-case-officer"><dt class="govuk-summary-list__key"> Case officer</dt>
+                    <dd class="govuk-summary-list__value">
+                        <p class="govuk-body">Not assigned</p>
+                    </dd>
+                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/assign-case-officer/search-case-officer"
+                        data-cy="assign-case-officer-name">Assign<span class="govuk-visually-hidden"> Case officer</span></a>
+                    </dd>
+                </div>
+                <div class="govuk-summary-list__row appeal-site-address"><dt class="govuk-summary-list__key"> Site address</dt>
+                    <dd class="govuk-summary-list__value">21 The Pavement, Wandsworth, SW4 0HY</dd>
+                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-address/change/1?backUrl=%2Fappeals-service%2Fappeal-details%2F1"
+                        data-cy="change-site-address">Change<span class="govuk-visually-hidden"> Site address</span></a>
+                    </dd>
+                </div>
+                <div class="govuk-summary-list__row appeal-local-planning-authority"><dt class="govuk-summary-list__key"> LPA</dt>
+                    <dd class="govuk-summary-list__value">Wiltshire Council</dd>
+                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/change-appeal-details/local-planning-authority"
+                        data-cy="change-local-planning-authority">Change<span class="govuk-visually-hidden"> LPA</span></a>
+                    </dd>
+                </div>
+            </dl>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
+            <p class="govuk-body govuk-!-margin-bottom-6" id="download-case-files"
+            data-cy="download-case-files"><a class="govuk-link" href="/documents/1/bulk-download/case-APP/Q9999/D/21/351062.zip">Download case</a>
+            </p>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
+            <details class="govuk-details">
+                <summary class="govuk-details__summary"><span class="govuk-details__summary-text"> 2 case notes</span>
+                </summary>
+                <div class="govuk-details__text">
+                    <form method="POST" novalidate="novalidate">
+                        <div class="govuk-grid-row">
+                            <div class="govuk-grid-column-two-thirds">
+                                <div class="govuk-form-group govuk-character-count" data-module="govuk-character-count"
+                                data-maxlength="500">
+                                    <textarea class="govuk-textarea govuk-js-character-count" id="comment"
+                                    name="comment" rows="5" aria-describedby="comment-info"></textarea>
+                                    <div id="comment-info" class="govuk-hint govuk-character-count__message">You can enter up to 500 characters</div>
+                                </div>
+                            </div>
+                        </div>
+                        <button type="submit" data-prevent-double-click="true" class="govuk-button govuk-button--secondary govuk-!-margin-bottom-1"
+                        data-module="govuk-button">Add case note</button>
+                    </form>
+                    <div>
+                        <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+                        <section>
+                            <p class="govuk-body govuk-!-margin-bottom-1">A case note you should see.</p>
+                            <p class="govuk-hint govuk-!-margin-bottom-6">11:00am on Tuesday 1 October 2024 by John.Smith</p>
+                            <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+                        </section>
+                        <section>
+                            <p class="govuk-body govuk-!-margin-bottom-1">A case note you should see.</p>
+                            <p class="govuk-hint govuk-!-margin-bottom-6">11:00am on Tuesday 1 October 2024 by John.Smith</p>
+                            <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+                        </section>
+                    </div>
+                </div>
+            </details>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
+            <div class="govuk-accordion" data-module="govuk-accordion" id="accordion-default1">
+                <div class="govuk-accordion__section">
+                    <div class="govuk-accordion__section-header">
+                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-1"> Overview</span></h2>
+                    </div>
+                    <div id="accordion-default1-content-1" class="govuk-accordion__section-content">
+                        <dl class="govuk-summary-list">
+                            <div class="govuk-summary-list__row govuk-summary-list__row--no-actions appeal-lpa-reference"><dt class="govuk-summary-list__key"> Planning application reference</dt>
+                                <dd                                 class="govuk-summary-list__value">48269/APP/2021/1482</dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-appeal-type"><dt class="govuk-summary-list__key"> Appeal type</dt>
+                                <dd class="govuk-summary-list__value">Householder</dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/change-appeal-type/appeal-type"
+                                    data-cy="change-appeal-type">Change<span class="govuk-visually-hidden"> Appeal type</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row govuk-summary-list__row--no-actions appeal-case-procedure"><dt class="govuk-summary-list__key"> Appeal procedure</dt>
+                                <dd class="govuk-summary-list__value">Written</dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-allocation-details"><dt class="govuk-summary-list__key"> Allocation level</dt>
+                                <dd class="govuk-summary-list__value">
+                                    <ul class="govuk-!-margin-0">
+                                        <li>Level: A</li>
+                                        <li>Historic heritage</li>
+                                        <li>Architecture design</li>
+                                    </ul>
+                                </dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/allocation-details/allocation-level"
+                                    data-cy="change-allocation-details">Change<span class="govuk-visually-hidden"> Allocation level</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-linked-appeals"><dt class="govuk-summary-list__key"> Linked appeals</dt>
+                                <dd class="govuk-summary-list__value">
+                                    <ul class="govuk-list govuk-list--bullet">
+                                        <li><a href="/appeals-service/appeal-details/5449" class="govuk-link" data-cy="linked-appeal-784706"
+                                            aria-label="Appeal 7 8 4 7 0 6">784706</a>
+                                        </li>
+                                        <li><span class="govuk-body">87326527</span>
+                                        </li>
+                                        <li><a href="/appeals-service/appeal-details/5451" class="govuk-link" data-cy="linked-appeal-721086"
+                                            aria-label="Appeal 7 2 1 0 8 6">721086</a>
+                                        </li>
+                                    </ul>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-other-appeals"><dt class="govuk-summary-list__key"> Related appeals</dt>
+                                <dd class="govuk-summary-list__value"><span>No</span>
+                                </dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/other-appeals/add"
+                                    data-cy="add-related-appeals">Add<span class="govuk-visually-hidden"> Related appeals</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-decision"><dt class="govuk-summary-list__key"> Decision</dt>
+                                <dd class="govuk-summary-list__value">Dismissed</dd>
+                            </div>
+                        </dl>
+                    </div>
+                </div>
+                <div class="govuk-accordion__section">
+                    <div class="govuk-accordion__section-header">
+                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-2"> Site</span></h2>
+                    </div>
+                    <div id="accordion-default1-content-2" class="govuk-accordion__section-content">
+                        <dl class="govuk-summary-list">
+                            <div class="govuk-summary-list__row appeal-visit-type"><dt class="govuk-summary-list__key"> Visit type</dt>
+                                <dd class="govuk-summary-list__value">Accompanied</dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/visit-booked?backUrl=%2Fappeals-service%2Fappeal-details%2F1"
+                                    data-cy="change-set-visit-type">Change<span class="govuk-visually-hidden"> Visit type</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Date</dt>
+                                <dd class="govuk-summary-list__value">9 October 2023</dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/visit-booked"
+                                    data-cy="change-site-visit-date">Change<span class="govuk-visually-hidden"> Date</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Start time</dt>
+                                <dd class="govuk-summary-list__value">9:38am</dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/visit-booked"
+                                    data-cy="change-site-visit-start-time">Change<span class="govuk-visually-hidden"> Start time</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> End time</dt>
+                                <dd class="govuk-summary-list__value">10:00am</dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/visit-booked"
+                                    data-cy="change-site-visit-end-time">Change<span class="govuk-visually-hidden"> End time</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-neighbouring-sites-inspector"><dt class="govuk-summary-list__key"> Interested party and neighbour addresses</dt>
+                                <dd                                 class="govuk-summary-list__value">
+                                    <ul class="govuk-list govuk-list--bullet">
+                                        <li>2 Grove Cottage, Shotesham Road, Woodton, Devon, NR35 2ND</li>
+                                    </ul>
+                                    </dd>
+                                    <dd class="govuk-summary-list__actions">
+                                        <ul class="govuk-summary-list__actions-list">
+                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/neighbouring-sites/manage"
+                                                data-cy="manage-neighbouring-sites-inspector">Manage<span class="govuk-visually-hidden"> Interested party and neighbour addresses</span></a>
+                                            </li>
+                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/neighbouring-sites/add/back-office"
+                                                data-cy="add-neighbouring-sites-inspector">Add<span class="govuk-visually-hidden"> Interested party and neighbour addresses</span></a>
+                                            </li>
+                                        </ul>
+                                    </dd>
+                            </div>
+                        </dl>
+                    </div>
+                </div>
+                <div class="govuk-accordion__section">
+                    <div class="govuk-accordion__section-header">
+                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-3"> Timetable</span></h2>
+                    </div>
+                    <div id="accordion-default1-content-3" class="govuk-accordion__section-content">
+                        <dl class="govuk-summary-list appeal-case-timetable">
+                            <div class="govuk-summary-list__row appeal-valid-date"><dt class="govuk-summary-list__key"> Valid date</dt>
+                                <dd class="govuk-summary-list__value">23 May 2023</dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/valid/date"
+                                    data-cy="-valid-date"><span class="govuk-visually-hidden"> Valid date</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-start-date"><dt class="govuk-summary-list__key"> Start date</dt>
+                                <dd class="govuk-summary-list__value">23 May 2023</dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/start-case/change"
+                                    data-cy="change-start-case-date">Change<span class="govuk-visually-hidden"> Start date</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-lpa-questionnaire-due-date"><dt class="govuk-summary-list__key"> LPA questionnaire due</dt>
+                                <dd class="govuk-summary-list__value">11 October 2023</dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-site-visit"><dt class="govuk-summary-list__key"> Site visit</dt>
+                                <dd class="govuk-summary-list__value">
+                                    <ul class="govuk-list govuk-!-margin-top-0 govuk-!-padding-left-0">
+                                        <li>9 October 2023</li>
+                                        <li>9:38am - 10:00am</li>
+                                    </ul>
+                                </dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/manage-visit?backUrl=%2Fappeals-service%2Fappeal-details%2F1"
+                                    data-cy="change-schedule-visit">Change<span class="govuk-visually-hidden"> Site visit</span></a>
+                                </dd>
+                            </div>
+                        </dl>
+                    </div>
+                </div>
+                <div class="govuk-accordion__section">
+                    <div class="govuk-accordion__section-header">
+                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-4"> Documentation</span></h2>
+                    </div>
+                    <div id="accordion-default1-content-4" class="govuk-accordion__section-content">
+                        <table class="govuk-table">
+                            <thead class="govuk-table__head">
+                                <tr class="govuk-table__row">
+                                    <th scope="col" class="govuk-table__header">Documentation</th>
+                                    <th scope="col" class="govuk-table__header">Status</th>
+                                    <th scope="col" class="govuk-table__header">Received</th>
+                                    <th scope="col" class="govuk-table__header govuk-!-text-align-right">Action</th>
+                                </tr>
+                            </thead>
+                            <tbody class="govuk-table__body">
+                                <tr class="govuk-table__row">
+                                    <th scope="row" class="govuk-table__header">Appeal</th>
+                                    <td class="govuk-table__cell">Ready to review</td>
+                                    <td class="govuk-table__cell">2 August 2024</td>
+                                    <td class="govuk-table__cell govuk-!-text-align-right"><a href="/appeals-service/appeal-details/1/appellant-case?backUrl=%2Fappeals-service%2Fappeal-details%2F1"
+                                        data-cy="review-appellant-case" class="govuk-link">Review<span class="govuk-visually-hidden"> appellant case</span></a>
+                                    </td>
+                                </tr>
+                                <tr class="govuk-table__row">
+                                    <th scope="row" class="govuk-table__header">LPA questionnaire</th>
+                                    <td class="govuk-table__cell">Overdue</td>
+                                    <td class="govuk-table__cell">Due by 11 October 2023</td>
+                                    <td class="govuk-table__cell govuk-!-text-align-right"></td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
+                <div class="govuk-accordion__section">
+                    <div class="govuk-accordion__section-header">
+                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-5"> Costs</span></h2>
+                    </div>
+                    <div id="accordion-default1-content-5" class="govuk-accordion__section-content">
+                        <table class="govuk-table">
+                            <thead class="govuk-table__head">
+                                <tr class="govuk-table__row">
+                                    <th scope="col" class="govuk-table__header">Documentation</th>
+                                    <th scope="col" class="govuk-table__header">Status</th>
+                                    <th scope="col" class="govuk-table__header govuk-!-text-align-right">Action</th>
+                                </tr>
+                            </thead>
+                            <tbody class="govuk-table__body">
+                                <tr class="govuk-table__row">
+                                    <th scope="row" class="govuk-table__header appeal-costs-appellant-application-documentation">Appellant application</th>
+                                    <td class="govuk-table__cell appeal-costs-appellant-application-status">No documents available</td>
+                                    <td class="govuk-table__cell appeal-costs-appellant-application-actions govuk-!-text-align-right">
+                                        <ul class="govuk-summary-list__actions-list">
+                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-appellant-application" href="/appeals-service/appeal-details/1/costs/appellant/application/upload-documents/1">Add<span class="govuk-visually-hidden"> Appellant application</span></a>
+                                            </li>
+                                        </ul>
+                                    </td>
+                                </tr>
+                                <tr class="govuk-table__row">
+                                    <th scope="row" class="govuk-table__header appeal-costs-appellant-withdrawal-documentation">Appellant withdrawal</th>
+                                    <td class="govuk-table__cell appeal-costs-appellant-withdrawal-status">No documents available</td>
+                                    <td class="govuk-table__cell appeal-costs-appellant-withdrawal-actions govuk-!-text-align-right">
+                                        <ul class="govuk-summary-list__actions-list">
+                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-appellant-withdrawal" href="/appeals-service/appeal-details/1/costs/appellant/withdrawal/upload-documents/2">Add<span class="govuk-visually-hidden"> Appellant withdrawal</span></a>
+                                            </li>
+                                        </ul>
+                                    </td>
+                                </tr>
+                                <tr class="govuk-table__row">
+                                    <th scope="row" class="govuk-table__header appeal-costs-appellant-correspondence-documentation">Appellant correspondence</th>
+                                    <td class="govuk-table__cell appeal-costs-appellant-correspondence-status">No documents available</td>
+                                    <td class="govuk-table__cell appeal-costs-appellant-correspondence-actions govuk-!-text-align-right">
+                                        <ul class="govuk-summary-list__actions-list">
+                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-appellant-correspondence" href="/appeals-service/appeal-details/1/costs/appellant/correspondence/upload-documents/3">Add<span class="govuk-visually-hidden"> Appellant correspondence</span></a>
+                                            </li>
+                                        </ul>
+                                    </td>
+                                </tr>
+                                <tr class="govuk-table__row">
+                                    <th scope="row" class="govuk-table__header appeal-costs-lpa-application-documentation">LPA application</th>
+                                    <td class="govuk-table__cell appeal-costs-lpa-application-status">No documents available</td>
+                                    <td class="govuk-table__cell appeal-costs-lpa-application-actions govuk-!-text-align-right">
+                                        <ul class="govuk-summary-list__actions-list">
+                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-lpa-application" href="/appeals-service/appeal-details/1/costs/lpa/application/upload-documents/4">Add<span class="govuk-visually-hidden"> LPA application</span></a>
+                                            </li>
+                                        </ul>
+                                    </td>
+                                </tr>
+                                <tr class="govuk-table__row">
+                                    <th scope="row" class="govuk-table__header appeal-costs-lpa-withdrawal-documentation">LPA withdrawal</th>
+                                    <td class="govuk-table__cell appeal-costs-lpa-withdrawal-status">No documents available</td>
+                                    <td class="govuk-table__cell appeal-costs-lpa-withdrawal-actions govuk-!-text-align-right">
+                                        <ul class="govuk-summary-list__actions-list">
+                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-lpa-withdrawal" href="/appeals-service/appeal-details/1/costs/lpa/withdrawal/upload-documents/5">Add<span class="govuk-visually-hidden"> LPA withdrawal</span></a>
+                                            </li>
+                                        </ul>
+                                    </td>
+                                </tr>
+                                <tr class="govuk-table__row">
+                                    <th scope="row" class="govuk-table__header appeal-costs-lpa-correspondence-documentation">LPA correspondence</th>
+                                    <td class="govuk-table__cell appeal-costs-lpa-correspondence-status">No documents available</td>
+                                    <td class="govuk-table__cell appeal-costs-lpa-correspondence-actions govuk-!-text-align-right">
+                                        <ul class="govuk-summary-list__actions-list">
+                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-lpa-correspondence" href="/appeals-service/appeal-details/1/costs/lpa/correspondence/upload-documents/6">Add<span class="govuk-visually-hidden"> LPA correspondence</span></a>
+                                            </li>
+                                        </ul>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
+                <div class="govuk-accordion__section">
+                    <div class="govuk-accordion__section-header">
+                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-6"> Contacts</span></h2>
+                    </div>
+                    <div id="accordion-default1-content-6" class="govuk-accordion__section-content">
+                        <dl class="govuk-summary-list">
+                            <div class="govuk-summary-list__row appeal-appellant"><dt class="govuk-summary-list__key"> Appellant</dt>
+                                <dd class="govuk-summary-list__value">
+                                    <ul class="govuk-list">
+                                        <li>Roger Simmons</li>
+                                        <li>test3@example.com</li>
+                                    </ul>
+                                </dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/service-user/change/appellant"
+                                    data-cy="change-appellant">Change<span class="govuk-visually-hidden"> Appellant</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-agent"><dt class="govuk-summary-list__key"> Agent</dt>
+                                <dd class="govuk-summary-list__value">
+                                    <ul class="govuk-list">
+                                        <li>Fiona Shell</li>
+                                        <li>test2@example.com</li>
+                                    </ul>
+                                </dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/service-user/change/agent"
+                                    data-cy="change-agent">Change<span class="govuk-visually-hidden"> Agent</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-lpa-contact-details"><dt class="govuk-summary-list__key"> LPA</dt>
+                                <dd class="govuk-summary-list__value">
+                                    <ul class="govuk-list">
+                                        <li>Wiltshire Council</li>
+                                        <li>wilt@lpa-email.gov.uk</li>
+                                    </ul>
+                                </dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/change-appeal-details/local-planning-authority"
+                                    data-cy="change-lpa-contact-details">Change<span class="govuk-visually-hidden"> Local planning authority (LPA)</span></a>
+                                </dd>
+                            </div>
+                        </dl>
+                    </div>
+                </div>
+                <div class="govuk-accordion__section">
+                    <div class="govuk-accordion__section-header">
+                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-7"> Team</span></h2>
+                    </div>
+                    <div id="accordion-default1-content-7" class="govuk-accordion__section-content">
+                        <dl class="govuk-summary-list">
+                            <div class="govuk-summary-list__row appeal-case-officer"><dt class="govuk-summary-list__key"> Case officer</dt>
+                                <dd class="govuk-summary-list__value">
+                                    <p class="govuk-body">Not assigned</p>
+                                </dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/assign-case-officer/search-case-officer"
+                                    data-cy="assign-case-officer">Assign<span class="govuk-visually-hidden"> Case officer</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-inspector"><dt class="govuk-summary-list__key"> Inspector</dt>
+                                <dd class="govuk-summary-list__value">
+                                    <p class="govuk-body">Not assigned</p>
+                                </dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/assign-inspector/search-inspector"
+                                    data-cy="assign-inspector">Assign<span class="govuk-visually-hidden"> Inspector</span></a>
+                                </dd>
+                            </div>
+                        </dl>
+                    </div>
+                </div>
+                <div class="govuk-accordion__section">
+                    <div class="govuk-accordion__section-header">
+                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-8"> Case management</span></h2>
+                    </div>
+                    <div id="accordion-default1-content-8" class="govuk-accordion__section-content">
+                        <dl class="govuk-summary-list">
+                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Cross-team correspondence</dt>
+                                <dd                                 class="govuk-summary-list__value">No documents</dd>
+                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/internal-correspondence/cross-team/upload-documents/10"
+                                        data-cy="add-cross-team-correspondence">Add<span class="govuk-visually-hidden"> Cross-team correspondence</span></a>
+                                    </dd>
+                            </div>
+                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Inspector correspondence</dt>
+                                <dd                                 class="govuk-summary-list__value">No documents</dd>
+                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/internal-correspondence/inspector/upload-documents/11"
+                                        data-cy="add-inspector-correspondence">Add<span class="govuk-visually-hidden"> Inspector correspondence</span></a>
+                                    </dd>
+                            </div>
+                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Main party correspondence</dt>
+                                <dd                                 class="govuk-summary-list__value">No documents</dd>
+                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/internal-correspondence/main-party/upload-documents/22"
+                                        data-cy="add-main-party-correspondence">Add<span class="govuk-visually-hidden"> Main party correspondence</span></a>
+                                    </dd>
+                            </div>
+                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Case history</dt>
+                                <dd class="govuk-summary-list__value"></dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/audit" data-cy="view-case-history">View<span class="govuk-visually-hidden"> Case history</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Appeal withdrawal</dt>
+                                <dd class="govuk-summary-list__value"></dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/withdrawal/start"
+                                    data-cy="start-appeal-withdrawal">Start<span class="govuk-visually-hidden"> Appeal withdrawal</span></a>
+                                </dd>
+                            </div>
+                        </dl>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div id="case-details-cancel-section">
+        <h3 class="govuk-heading-m">Cancel appeal</h3>
+        <div>
+            <p><a id="cancelCase" class="govuk-body govuk-link" href="/appeals-service/appeal-details/1/cancel">Cancel appeal</a>
+            </p>
+        </div>
+    </div>
+</main>"
+`;
+
+exports[`appeal-details GET /:appealId Linked appeals should render an action link to the add linked appeals page, if the appeal is a lead appeal in a state before STATEMENTS 1`] = `
+"<main class="govuk-main-wrapper" id="main-content">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Appeal 351062</span>
+            <h1 class="govuk-heading-xl govuk-!-margin-bottom-3">Case details</h1>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full"><strong class="govuk-tag govuk-tag--green pins-status-tag--full-width">LPA questionnaire</strong>
+            <strong             class="govuk-tag govuk-tag--grey govuk-!-margin-left-1 govuk-!-margin-bottom-4">Lead</strong>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
+            <dl class="govuk-summary-list pins-summary-list--no-border">
+                <div class="govuk-summary-list__row appeal-case-officer"><dt class="govuk-summary-list__key"> Case officer</dt>
+                    <dd class="govuk-summary-list__value">
+                        <p class="govuk-body">Not assigned</p>
+                    </dd>
+                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/assign-case-officer/search-case-officer"
+                        data-cy="assign-case-officer-name">Assign<span class="govuk-visually-hidden"> Case officer</span></a>
+                    </dd>
+                </div>
+                <div class="govuk-summary-list__row appeal-site-address"><dt class="govuk-summary-list__key"> Site address</dt>
+                    <dd class="govuk-summary-list__value">21 The Pavement, Wandsworth, SW4 0HY</dd>
+                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-address/change/1?backUrl=%2Fappeals-service%2Fappeal-details%2F1"
+                        data-cy="change-site-address">Change<span class="govuk-visually-hidden"> Site address</span></a>
+                    </dd>
+                </div>
+                <div class="govuk-summary-list__row appeal-local-planning-authority"><dt class="govuk-summary-list__key"> LPA</dt>
+                    <dd class="govuk-summary-list__value">Wiltshire Council</dd>
+                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/change-appeal-details/local-planning-authority"
+                        data-cy="change-local-planning-authority">Change<span class="govuk-visually-hidden"> LPA</span></a>
+                    </dd>
+                </div>
+            </dl>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
+            <p class="govuk-body govuk-!-margin-bottom-6" id="download-case-files"
+            data-cy="download-case-files"><a class="govuk-link" href="/documents/1/bulk-download/case-APP/Q9999/D/21/351062.zip">Download case</a>
+            </p>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
+            <details class="govuk-details">
+                <summary class="govuk-details__summary"><span class="govuk-details__summary-text"> 2 case notes</span>
+                </summary>
+                <div class="govuk-details__text">
+                    <form method="POST" novalidate="novalidate">
+                        <div class="govuk-grid-row">
+                            <div class="govuk-grid-column-two-thirds">
+                                <div class="govuk-form-group govuk-character-count" data-module="govuk-character-count"
+                                data-maxlength="500">
+                                    <textarea class="govuk-textarea govuk-js-character-count" id="comment"
+                                    name="comment" rows="5" aria-describedby="comment-info"></textarea>
+                                    <div id="comment-info" class="govuk-hint govuk-character-count__message">You can enter up to 500 characters</div>
+                                </div>
+                            </div>
+                        </div>
+                        <button type="submit" data-prevent-double-click="true" class="govuk-button govuk-button--secondary govuk-!-margin-bottom-1"
+                        data-module="govuk-button">Add case note</button>
+                    </form>
+                    <div>
+                        <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+                        <section>
+                            <p class="govuk-body govuk-!-margin-bottom-1">A case note you should see.</p>
+                            <p class="govuk-hint govuk-!-margin-bottom-6">11:00am on Tuesday 1 October 2024 by John.Smith</p>
+                            <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+                        </section>
+                        <section>
+                            <p class="govuk-body govuk-!-margin-bottom-1">A case note you should see.</p>
+                            <p class="govuk-hint govuk-!-margin-bottom-6">11:00am on Tuesday 1 October 2024 by John.Smith</p>
+                            <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+                        </section>
+                    </div>
+                </div>
+            </details>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
+            <div class="govuk-accordion" data-module="govuk-accordion" id="accordion-default1">
+                <div class="govuk-accordion__section">
+                    <div class="govuk-accordion__section-header">
+                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-1"> Overview</span></h2>
+                    </div>
+                    <div id="accordion-default1-content-1" class="govuk-accordion__section-content">
+                        <dl class="govuk-summary-list">
+                            <div class="govuk-summary-list__row govuk-summary-list__row--no-actions appeal-lpa-reference"><dt class="govuk-summary-list__key"> Planning application reference</dt>
+                                <dd                                 class="govuk-summary-list__value">48269/APP/2021/1482</dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-appeal-type"><dt class="govuk-summary-list__key"> Appeal type</dt>
+                                <dd class="govuk-summary-list__value">Householder</dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/change-appeal-type/appeal-type"
+                                    data-cy="change-appeal-type">Change<span class="govuk-visually-hidden"> Appeal type</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row govuk-summary-list__row--no-actions appeal-case-procedure"><dt class="govuk-summary-list__key"> Appeal procedure</dt>
+                                <dd class="govuk-summary-list__value">Written</dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-allocation-details"><dt class="govuk-summary-list__key"> Allocation level</dt>
+                                <dd class="govuk-summary-list__value">
+                                    <ul class="govuk-!-margin-0">
+                                        <li>Level: A</li>
+                                        <li>Historic heritage</li>
+                                        <li>Architecture design</li>
+                                    </ul>
+                                </dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/allocation-details/allocation-level"
+                                    data-cy="change-allocation-details">Change<span class="govuk-visually-hidden"> Allocation level</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-linked-appeals"><dt class="govuk-summary-list__key"> Linked appeals</dt>
+                                <dd class="govuk-summary-list__value">
+                                    <ul class="govuk-list govuk-list--bullet">
+                                        <li><a href="/appeals-service/appeal-details/5449" class="govuk-link" data-cy="linked-appeal-784706"
+                                            aria-label="Appeal 7 8 4 7 0 6">784706</a>
+                                        </li>
+                                        <li><a href="/appeals-service/appeal-details/5451" class="govuk-link" data-cy="linked-appeal-721086"
+                                            aria-label="Appeal 7 2 1 0 8 6">721086</a>
+                                        </li>
+                                    </ul>
+                                </dd>
+                                <dd class="govuk-summary-list__actions">
+                                    <ul class="govuk-summary-list__actions-list">
+                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/linked-appeals/manage"
+                                            data-cy="manage-linked-appeals">Manage<span class="govuk-visually-hidden"> Linked appeals</span></a>
+                                        </li>
+                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/linked-appeals/add"
+                                            data-cy="add-linked-appeal">Add<span class="govuk-visually-hidden"> Linked appeals</span></a>
+                                        </li>
+                                    </ul>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-other-appeals"><dt class="govuk-summary-list__key"> Related appeals</dt>
+                                <dd class="govuk-summary-list__value"><span>No</span>
+                                </dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/other-appeals/add"
+                                    data-cy="add-related-appeals">Add<span class="govuk-visually-hidden"> Related appeals</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-decision"><dt class="govuk-summary-list__key"> Decision</dt>
+                                <dd class="govuk-summary-list__value">Dismissed</dd>
+                            </div>
+                        </dl>
+                    </div>
+                </div>
+                <div class="govuk-accordion__section">
+                    <div class="govuk-accordion__section-header">
+                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-2"> Site</span></h2>
+                    </div>
+                    <div id="accordion-default1-content-2" class="govuk-accordion__section-content">
+                        <dl class="govuk-summary-list">
+                            <div class="govuk-summary-list__row appeal-visit-type"><dt class="govuk-summary-list__key"> Visit type</dt>
+                                <dd class="govuk-summary-list__value">Accompanied</dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/visit-booked?backUrl=%2Fappeals-service%2Fappeal-details%2F1"
+                                    data-cy="change-set-visit-type">Change<span class="govuk-visually-hidden"> Visit type</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Date</dt>
+                                <dd class="govuk-summary-list__value">9 October 2023</dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/visit-booked"
+                                    data-cy="change-site-visit-date">Change<span class="govuk-visually-hidden"> Date</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Start time</dt>
+                                <dd class="govuk-summary-list__value">9:38am</dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/visit-booked"
+                                    data-cy="change-site-visit-start-time">Change<span class="govuk-visually-hidden"> Start time</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> End time</dt>
+                                <dd class="govuk-summary-list__value">10:00am</dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/visit-booked"
+                                    data-cy="change-site-visit-end-time">Change<span class="govuk-visually-hidden"> End time</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-neighbouring-sites-inspector"><dt class="govuk-summary-list__key"> Interested party and neighbour addresses</dt>
+                                <dd                                 class="govuk-summary-list__value">
+                                    <ul class="govuk-list govuk-list--bullet">
+                                        <li>2 Grove Cottage, Shotesham Road, Woodton, Devon, NR35 2ND</li>
+                                    </ul>
+                                    </dd>
+                                    <dd class="govuk-summary-list__actions">
+                                        <ul class="govuk-summary-list__actions-list">
+                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/neighbouring-sites/manage"
+                                                data-cy="manage-neighbouring-sites-inspector">Manage<span class="govuk-visually-hidden"> Interested party and neighbour addresses</span></a>
+                                            </li>
+                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/neighbouring-sites/add/back-office"
+                                                data-cy="add-neighbouring-sites-inspector">Add<span class="govuk-visually-hidden"> Interested party and neighbour addresses</span></a>
+                                            </li>
+                                        </ul>
+                                    </dd>
+                            </div>
+                        </dl>
+                    </div>
+                </div>
+                <div class="govuk-accordion__section">
+                    <div class="govuk-accordion__section-header">
+                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-3"> Timetable</span></h2>
+                    </div>
+                    <div id="accordion-default1-content-3" class="govuk-accordion__section-content">
+                        <dl class="govuk-summary-list appeal-case-timetable">
+                            <div class="govuk-summary-list__row appeal-valid-date"><dt class="govuk-summary-list__key"> Valid date</dt>
+                                <dd class="govuk-summary-list__value">23 May 2023</dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/valid/date"
+                                    data-cy="-valid-date"><span class="govuk-visually-hidden"> Valid date</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-start-date"><dt class="govuk-summary-list__key"> Start date</dt>
+                                <dd class="govuk-summary-list__value">23 May 2023</dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/start-case/change"
+                                    data-cy="change-start-case-date">Change<span class="govuk-visually-hidden"> Start date</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-lpa-questionnaire-due-date"><dt class="govuk-summary-list__key"> LPA questionnaire due</dt>
+                                <dd class="govuk-summary-list__value">11 October 2023</dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/timetable/edit"
+                                    data-cy="change-lpa-questionnaire-due-date">Change<span class="govuk-visually-hidden"> LPA questionnaire due</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-site-visit"><dt class="govuk-summary-list__key"> Site visit</dt>
+                                <dd class="govuk-summary-list__value">
+                                    <ul class="govuk-list govuk-!-margin-top-0 govuk-!-padding-left-0">
+                                        <li>9 October 2023</li>
+                                        <li>9:38am - 10:00am</li>
+                                    </ul>
+                                </dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/manage-visit?backUrl=%2Fappeals-service%2Fappeal-details%2F1"
+                                    data-cy="change-schedule-visit">Change<span class="govuk-visually-hidden"> Site visit</span></a>
+                                </dd>
+                            </div>
+                        </dl>
+                    </div>
+                </div>
+                <div class="govuk-accordion__section">
+                    <div class="govuk-accordion__section-header">
+                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-4"> Documentation</span></h2>
+                    </div>
+                    <div id="accordion-default1-content-4" class="govuk-accordion__section-content">
+                        <table class="govuk-table">
+                            <thead class="govuk-table__head">
+                                <tr class="govuk-table__row">
+                                    <th scope="col" class="govuk-table__header">Documentation</th>
+                                    <th scope="col" class="govuk-table__header">Status</th>
+                                    <th scope="col" class="govuk-table__header">Received</th>
+                                    <th scope="col" class="govuk-table__header govuk-!-text-align-right">Action</th>
+                                </tr>
+                            </thead>
+                            <tbody class="govuk-table__body">
+                                <tr class="govuk-table__row">
+                                    <th scope="row" class="govuk-table__header">Appeal</th>
+                                    <td class="govuk-table__cell">Ready to review</td>
+                                    <td class="govuk-table__cell">2 August 2024</td>
+                                    <td class="govuk-table__cell govuk-!-text-align-right"><a href="/appeals-service/appeal-details/1/appellant-case?backUrl=%2Fappeals-service%2Fappeal-details%2F1"
+                                        data-cy="review-appellant-case" class="govuk-link">Review<span class="govuk-visually-hidden"> appellant case</span></a>
+                                    </td>
+                                </tr>
+                                <tr class="govuk-table__row">
+                                    <th scope="row" class="govuk-table__header">LPA questionnaire</th>
+                                    <td class="govuk-table__cell">Overdue</td>
+                                    <td class="govuk-table__cell">Due by 11 October 2023</td>
+                                    <td class="govuk-table__cell govuk-!-text-align-right"></td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
+                <div class="govuk-accordion__section">
+                    <div class="govuk-accordion__section-header">
+                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-5"> Costs</span></h2>
+                    </div>
+                    <div id="accordion-default1-content-5" class="govuk-accordion__section-content">
+                        <table class="govuk-table">
+                            <thead class="govuk-table__head">
+                                <tr class="govuk-table__row">
+                                    <th scope="col" class="govuk-table__header">Documentation</th>
+                                    <th scope="col" class="govuk-table__header">Status</th>
+                                    <th scope="col" class="govuk-table__header govuk-!-text-align-right">Action</th>
+                                </tr>
+                            </thead>
+                            <tbody class="govuk-table__body">
+                                <tr class="govuk-table__row">
+                                    <th scope="row" class="govuk-table__header appeal-costs-appellant-application-documentation">Appellant application</th>
+                                    <td class="govuk-table__cell appeal-costs-appellant-application-status">No documents available</td>
+                                    <td class="govuk-table__cell appeal-costs-appellant-application-actions govuk-!-text-align-right">
+                                        <ul class="govuk-summary-list__actions-list">
+                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-appellant-application" href="/appeals-service/appeal-details/1/costs/appellant/application/upload-documents/1">Add<span class="govuk-visually-hidden"> Appellant application</span></a>
+                                            </li>
+                                        </ul>
+                                    </td>
+                                </tr>
+                                <tr class="govuk-table__row">
+                                    <th scope="row" class="govuk-table__header appeal-costs-appellant-withdrawal-documentation">Appellant withdrawal</th>
+                                    <td class="govuk-table__cell appeal-costs-appellant-withdrawal-status">No documents available</td>
+                                    <td class="govuk-table__cell appeal-costs-appellant-withdrawal-actions govuk-!-text-align-right">
+                                        <ul class="govuk-summary-list__actions-list">
+                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-appellant-withdrawal" href="/appeals-service/appeal-details/1/costs/appellant/withdrawal/upload-documents/2">Add<span class="govuk-visually-hidden"> Appellant withdrawal</span></a>
+                                            </li>
+                                        </ul>
+                                    </td>
+                                </tr>
+                                <tr class="govuk-table__row">
+                                    <th scope="row" class="govuk-table__header appeal-costs-appellant-correspondence-documentation">Appellant correspondence</th>
+                                    <td class="govuk-table__cell appeal-costs-appellant-correspondence-status">No documents available</td>
+                                    <td class="govuk-table__cell appeal-costs-appellant-correspondence-actions govuk-!-text-align-right">
+                                        <ul class="govuk-summary-list__actions-list">
+                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-appellant-correspondence" href="/appeals-service/appeal-details/1/costs/appellant/correspondence/upload-documents/3">Add<span class="govuk-visually-hidden"> Appellant correspondence</span></a>
+                                            </li>
+                                        </ul>
+                                    </td>
+                                </tr>
+                                <tr class="govuk-table__row">
+                                    <th scope="row" class="govuk-table__header appeal-costs-lpa-application-documentation">LPA application</th>
+                                    <td class="govuk-table__cell appeal-costs-lpa-application-status">No documents available</td>
+                                    <td class="govuk-table__cell appeal-costs-lpa-application-actions govuk-!-text-align-right">
+                                        <ul class="govuk-summary-list__actions-list">
+                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-lpa-application" href="/appeals-service/appeal-details/1/costs/lpa/application/upload-documents/4">Add<span class="govuk-visually-hidden"> LPA application</span></a>
+                                            </li>
+                                        </ul>
+                                    </td>
+                                </tr>
+                                <tr class="govuk-table__row">
+                                    <th scope="row" class="govuk-table__header appeal-costs-lpa-withdrawal-documentation">LPA withdrawal</th>
+                                    <td class="govuk-table__cell appeal-costs-lpa-withdrawal-status">No documents available</td>
+                                    <td class="govuk-table__cell appeal-costs-lpa-withdrawal-actions govuk-!-text-align-right">
+                                        <ul class="govuk-summary-list__actions-list">
+                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-lpa-withdrawal" href="/appeals-service/appeal-details/1/costs/lpa/withdrawal/upload-documents/5">Add<span class="govuk-visually-hidden"> LPA withdrawal</span></a>
+                                            </li>
+                                        </ul>
+                                    </td>
+                                </tr>
+                                <tr class="govuk-table__row">
+                                    <th scope="row" class="govuk-table__header appeal-costs-lpa-correspondence-documentation">LPA correspondence</th>
+                                    <td class="govuk-table__cell appeal-costs-lpa-correspondence-status">No documents available</td>
+                                    <td class="govuk-table__cell appeal-costs-lpa-correspondence-actions govuk-!-text-align-right">
+                                        <ul class="govuk-summary-list__actions-list">
+                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-lpa-correspondence" href="/appeals-service/appeal-details/1/costs/lpa/correspondence/upload-documents/6">Add<span class="govuk-visually-hidden"> LPA correspondence</span></a>
+                                            </li>
+                                        </ul>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
+                <div class="govuk-accordion__section">
+                    <div class="govuk-accordion__section-header">
+                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-6"> Contacts</span></h2>
+                    </div>
+                    <div id="accordion-default1-content-6" class="govuk-accordion__section-content">
+                        <dl class="govuk-summary-list">
+                            <div class="govuk-summary-list__row appeal-appellant"><dt class="govuk-summary-list__key"> Appellant</dt>
+                                <dd class="govuk-summary-list__value">
+                                    <ul class="govuk-list">
+                                        <li>Roger Simmons</li>
+                                        <li>test3@example.com</li>
+                                    </ul>
+                                </dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/service-user/change/appellant"
+                                    data-cy="change-appellant">Change<span class="govuk-visually-hidden"> Appellant</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-agent"><dt class="govuk-summary-list__key"> Agent</dt>
+                                <dd class="govuk-summary-list__value">
+                                    <ul class="govuk-list">
+                                        <li>Fiona Shell</li>
+                                        <li>test2@example.com</li>
+                                    </ul>
+                                </dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/service-user/change/agent"
+                                    data-cy="change-agent">Change<span class="govuk-visually-hidden"> Agent</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-lpa-contact-details"><dt class="govuk-summary-list__key"> LPA</dt>
+                                <dd class="govuk-summary-list__value">
+                                    <ul class="govuk-list">
+                                        <li>Wiltshire Council</li>
+                                        <li>wilt@lpa-email.gov.uk</li>
+                                    </ul>
+                                </dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/change-appeal-details/local-planning-authority"
+                                    data-cy="change-lpa-contact-details">Change<span class="govuk-visually-hidden"> Local planning authority (LPA)</span></a>
+                                </dd>
+                            </div>
+                        </dl>
+                    </div>
+                </div>
+                <div class="govuk-accordion__section">
+                    <div class="govuk-accordion__section-header">
+                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-7"> Team</span></h2>
+                    </div>
+                    <div id="accordion-default1-content-7" class="govuk-accordion__section-content">
+                        <dl class="govuk-summary-list">
+                            <div class="govuk-summary-list__row appeal-case-officer"><dt class="govuk-summary-list__key"> Case officer</dt>
+                                <dd class="govuk-summary-list__value">
+                                    <p class="govuk-body">Not assigned</p>
+                                </dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/assign-case-officer/search-case-officer"
+                                    data-cy="assign-case-officer">Assign<span class="govuk-visually-hidden"> Case officer</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-inspector"><dt class="govuk-summary-list__key"> Inspector</dt>
+                                <dd class="govuk-summary-list__value">
+                                    <p class="govuk-body">Not assigned</p>
+                                </dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/assign-inspector/search-inspector"
+                                    data-cy="assign-inspector">Assign<span class="govuk-visually-hidden"> Inspector</span></a>
+                                </dd>
+                            </div>
+                        </dl>
+                    </div>
+                </div>
+                <div class="govuk-accordion__section">
+                    <div class="govuk-accordion__section-header">
+                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-8"> Case management</span></h2>
+                    </div>
+                    <div id="accordion-default1-content-8" class="govuk-accordion__section-content">
+                        <dl class="govuk-summary-list">
+                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Cross-team correspondence</dt>
+                                <dd                                 class="govuk-summary-list__value">No documents</dd>
+                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/internal-correspondence/cross-team/upload-documents/10"
+                                        data-cy="add-cross-team-correspondence">Add<span class="govuk-visually-hidden"> Cross-team correspondence</span></a>
+                                    </dd>
+                            </div>
+                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Inspector correspondence</dt>
+                                <dd                                 class="govuk-summary-list__value">No documents</dd>
+                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/internal-correspondence/inspector/upload-documents/11"
+                                        data-cy="add-inspector-correspondence">Add<span class="govuk-visually-hidden"> Inspector correspondence</span></a>
+                                    </dd>
+                            </div>
+                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Main party correspondence</dt>
+                                <dd                                 class="govuk-summary-list__value">No documents</dd>
+                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/internal-correspondence/main-party/upload-documents/22"
+                                        data-cy="add-main-party-correspondence">Add<span class="govuk-visually-hidden"> Main party correspondence</span></a>
+                                    </dd>
+                            </div>
+                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Case history</dt>
+                                <dd class="govuk-summary-list__value"></dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/audit" data-cy="view-case-history">View<span class="govuk-visually-hidden"> Case history</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Appeal withdrawal</dt>
+                                <dd class="govuk-summary-list__value"></dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/withdrawal/start"
+                                    data-cy="start-appeal-withdrawal">Start<span class="govuk-visually-hidden"> Appeal withdrawal</span></a>
+                                </dd>
+                            </div>
+                        </dl>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div id="case-details-cancel-section">
+        <h3 class="govuk-heading-m">Cancel appeal</h3>
+        <div>
+            <p><a id="cancelCase" class="govuk-body govuk-link" href="/appeals-service/appeal-details/1/cancel">Cancel appeal</a>
+            </p>
+        </div>
+    </div>
+</main>"
+`;
+
+exports[`appeal-details GET /:appealId Linked appeals should render an action link to the manage linked appeals page, if there are linked appeals, the status is not past LPA Questionnaire, all the linked appeals are children and internal 1`] = `
+"<main class="govuk-main-wrapper" id="main-content">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Appeal 351062</span>
+            <h1 class="govuk-heading-xl govuk-!-margin-bottom-3">Case details</h1>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full"><strong class="govuk-tag govuk-tag--green pins-status-tag--full-width">LPA questionnaire</strong>
+            <strong             class="govuk-tag govuk-tag--grey govuk-!-margin-left-1 govuk-!-margin-bottom-4"></strong>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
+            <dl class="govuk-summary-list pins-summary-list--no-border">
+                <div class="govuk-summary-list__row appeal-case-officer"><dt class="govuk-summary-list__key"> Case officer</dt>
+                    <dd class="govuk-summary-list__value">
+                        <p class="govuk-body">Not assigned</p>
+                    </dd>
+                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/assign-case-officer/search-case-officer"
+                        data-cy="assign-case-officer-name">Assign<span class="govuk-visually-hidden"> Case officer</span></a>
+                    </dd>
+                </div>
+                <div class="govuk-summary-list__row appeal-site-address"><dt class="govuk-summary-list__key"> Site address</dt>
+                    <dd class="govuk-summary-list__value">21 The Pavement, Wandsworth, SW4 0HY</dd>
+                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-address/change/1?backUrl=%2Fappeals-service%2Fappeal-details%2F1"
+                        data-cy="change-site-address">Change<span class="govuk-visually-hidden"> Site address</span></a>
+                    </dd>
+                </div>
+                <div class="govuk-summary-list__row appeal-local-planning-authority"><dt class="govuk-summary-list__key"> LPA</dt>
+                    <dd class="govuk-summary-list__value">Wiltshire Council</dd>
+                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/change-appeal-details/local-planning-authority"
+                        data-cy="change-local-planning-authority">Change<span class="govuk-visually-hidden"> LPA</span></a>
+                    </dd>
+                </div>
+            </dl>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
+            <p class="govuk-body govuk-!-margin-bottom-6" id="download-case-files"
+            data-cy="download-case-files"><a class="govuk-link" href="/documents/1/bulk-download/case-APP/Q9999/D/21/351062.zip">Download case</a>
+            </p>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
+            <details class="govuk-details">
+                <summary class="govuk-details__summary"><span class="govuk-details__summary-text"> 2 case notes</span>
+                </summary>
+                <div class="govuk-details__text">
+                    <form method="POST" novalidate="novalidate">
+                        <div class="govuk-grid-row">
+                            <div class="govuk-grid-column-two-thirds">
+                                <div class="govuk-form-group govuk-character-count" data-module="govuk-character-count"
+                                data-maxlength="500">
+                                    <textarea class="govuk-textarea govuk-js-character-count" id="comment"
+                                    name="comment" rows="5" aria-describedby="comment-info"></textarea>
+                                    <div id="comment-info" class="govuk-hint govuk-character-count__message">You can enter up to 500 characters</div>
+                                </div>
+                            </div>
+                        </div>
+                        <button type="submit" data-prevent-double-click="true" class="govuk-button govuk-button--secondary govuk-!-margin-bottom-1"
+                        data-module="govuk-button">Add case note</button>
+                    </form>
+                    <div>
+                        <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+                        <section>
+                            <p class="govuk-body govuk-!-margin-bottom-1">A case note you should see.</p>
+                            <p class="govuk-hint govuk-!-margin-bottom-6">11:00am on Tuesday 1 October 2024 by John.Smith</p>
+                            <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+                        </section>
+                        <section>
+                            <p class="govuk-body govuk-!-margin-bottom-1">A case note you should see.</p>
+                            <p class="govuk-hint govuk-!-margin-bottom-6">11:00am on Tuesday 1 October 2024 by John.Smith</p>
+                            <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+                        </section>
+                    </div>
+                </div>
+            </details>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
+            <div class="govuk-accordion" data-module="govuk-accordion" id="accordion-default1">
+                <div class="govuk-accordion__section">
+                    <div class="govuk-accordion__section-header">
+                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-1"> Overview</span></h2>
+                    </div>
+                    <div id="accordion-default1-content-1" class="govuk-accordion__section-content">
+                        <dl class="govuk-summary-list">
+                            <div class="govuk-summary-list__row govuk-summary-list__row--no-actions appeal-lpa-reference"><dt class="govuk-summary-list__key"> Planning application reference</dt>
+                                <dd                                 class="govuk-summary-list__value">48269/APP/2021/1482</dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-appeal-type"><dt class="govuk-summary-list__key"> Appeal type</dt>
+                                <dd class="govuk-summary-list__value">Householder</dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/change-appeal-type/appeal-type"
+                                    data-cy="change-appeal-type">Change<span class="govuk-visually-hidden"> Appeal type</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row govuk-summary-list__row--no-actions appeal-case-procedure"><dt class="govuk-summary-list__key"> Appeal procedure</dt>
+                                <dd class="govuk-summary-list__value">Written</dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-allocation-details"><dt class="govuk-summary-list__key"> Allocation level</dt>
+                                <dd class="govuk-summary-list__value">
+                                    <ul class="govuk-!-margin-0">
+                                        <li>Level: A</li>
+                                        <li>Historic heritage</li>
+                                        <li>Architecture design</li>
+                                    </ul>
+                                </dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/allocation-details/allocation-level"
+                                    data-cy="change-allocation-details">Change<span class="govuk-visually-hidden"> Allocation level</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-linked-appeals"><dt class="govuk-summary-list__key"> Linked appeals</dt>
+                                <dd class="govuk-summary-list__value">
+                                    <ul class="govuk-list govuk-list--bullet">
+                                        <li><a href="/appeals-service/appeal-details/5449" class="govuk-link" data-cy="linked-appeal-784706"
+                                            aria-label="Appeal 7 8 4 7 0 6">784706</a>
+                                        </li>
+                                        <li><a href="/appeals-service/appeal-details/5451" class="govuk-link" data-cy="linked-appeal-721086"
+                                            aria-label="Appeal 7 2 1 0 8 6">721086</a>
+                                        </li>
+                                    </ul>
+                                </dd>
+                                <dd class="govuk-summary-list__actions">
+                                    <ul class="govuk-summary-list__actions-list">
+                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/linked-appeals/manage"
+                                            data-cy="manage-linked-appeals">Manage<span class="govuk-visually-hidden"> Linked appeals</span></a>
+                                        </li>
+                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/linked-appeals/add"
+                                            data-cy="add-linked-appeal">Add<span class="govuk-visually-hidden"> Linked appeals</span></a>
+                                        </li>
+                                    </ul>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-other-appeals"><dt class="govuk-summary-list__key"> Related appeals</dt>
+                                <dd class="govuk-summary-list__value"><span>No</span>
+                                </dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/other-appeals/add"
+                                    data-cy="add-related-appeals">Add<span class="govuk-visually-hidden"> Related appeals</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-decision"><dt class="govuk-summary-list__key"> Decision</dt>
+                                <dd class="govuk-summary-list__value">Dismissed</dd>
+                            </div>
+                        </dl>
+                    </div>
+                </div>
+                <div class="govuk-accordion__section">
+                    <div class="govuk-accordion__section-header">
+                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-2"> Site</span></h2>
+                    </div>
+                    <div id="accordion-default1-content-2" class="govuk-accordion__section-content">
+                        <dl class="govuk-summary-list">
+                            <div class="govuk-summary-list__row appeal-visit-type"><dt class="govuk-summary-list__key"> Visit type</dt>
+                                <dd class="govuk-summary-list__value">Accompanied</dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/visit-booked?backUrl=%2Fappeals-service%2Fappeal-details%2F1"
+                                    data-cy="change-set-visit-type">Change<span class="govuk-visually-hidden"> Visit type</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Date</dt>
+                                <dd class="govuk-summary-list__value">9 October 2023</dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/visit-booked"
+                                    data-cy="change-site-visit-date">Change<span class="govuk-visually-hidden"> Date</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Start time</dt>
+                                <dd class="govuk-summary-list__value">9:38am</dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/visit-booked"
+                                    data-cy="change-site-visit-start-time">Change<span class="govuk-visually-hidden"> Start time</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> End time</dt>
+                                <dd class="govuk-summary-list__value">10:00am</dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/visit-booked"
+                                    data-cy="change-site-visit-end-time">Change<span class="govuk-visually-hidden"> End time</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-neighbouring-sites-inspector"><dt class="govuk-summary-list__key"> Interested party and neighbour addresses</dt>
+                                <dd                                 class="govuk-summary-list__value">
+                                    <ul class="govuk-list govuk-list--bullet">
+                                        <li>2 Grove Cottage, Shotesham Road, Woodton, Devon, NR35 2ND</li>
+                                    </ul>
+                                    </dd>
+                                    <dd class="govuk-summary-list__actions">
+                                        <ul class="govuk-summary-list__actions-list">
+                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/neighbouring-sites/manage"
+                                                data-cy="manage-neighbouring-sites-inspector">Manage<span class="govuk-visually-hidden"> Interested party and neighbour addresses</span></a>
+                                            </li>
+                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/neighbouring-sites/add/back-office"
+                                                data-cy="add-neighbouring-sites-inspector">Add<span class="govuk-visually-hidden"> Interested party and neighbour addresses</span></a>
+                                            </li>
+                                        </ul>
+                                    </dd>
+                            </div>
+                        </dl>
+                    </div>
+                </div>
+                <div class="govuk-accordion__section">
+                    <div class="govuk-accordion__section-header">
+                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-3"> Timetable</span></h2>
+                    </div>
+                    <div id="accordion-default1-content-3" class="govuk-accordion__section-content">
+                        <dl class="govuk-summary-list appeal-case-timetable">
+                            <div class="govuk-summary-list__row appeal-valid-date"><dt class="govuk-summary-list__key"> Valid date</dt>
+                                <dd class="govuk-summary-list__value">23 May 2023</dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/valid/date"
+                                    data-cy="-valid-date"><span class="govuk-visually-hidden"> Valid date</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-start-date"><dt class="govuk-summary-list__key"> Start date</dt>
+                                <dd class="govuk-summary-list__value">23 May 2023</dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/start-case/change"
+                                    data-cy="change-start-case-date">Change<span class="govuk-visually-hidden"> Start date</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-lpa-questionnaire-due-date"><dt class="govuk-summary-list__key"> LPA questionnaire due</dt>
+                                <dd class="govuk-summary-list__value">11 October 2023</dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/timetable/edit"
+                                    data-cy="change-lpa-questionnaire-due-date">Change<span class="govuk-visually-hidden"> LPA questionnaire due</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-site-visit"><dt class="govuk-summary-list__key"> Site visit</dt>
+                                <dd class="govuk-summary-list__value">
+                                    <ul class="govuk-list govuk-!-margin-top-0 govuk-!-padding-left-0">
+                                        <li>9 October 2023</li>
+                                        <li>9:38am - 10:00am</li>
+                                    </ul>
+                                </dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/manage-visit?backUrl=%2Fappeals-service%2Fappeal-details%2F1"
+                                    data-cy="change-schedule-visit">Change<span class="govuk-visually-hidden"> Site visit</span></a>
+                                </dd>
+                            </div>
+                        </dl>
+                    </div>
+                </div>
+                <div class="govuk-accordion__section">
+                    <div class="govuk-accordion__section-header">
+                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-4"> Documentation</span></h2>
+                    </div>
+                    <div id="accordion-default1-content-4" class="govuk-accordion__section-content">
+                        <table class="govuk-table">
+                            <thead class="govuk-table__head">
+                                <tr class="govuk-table__row">
+                                    <th scope="col" class="govuk-table__header">Documentation</th>
+                                    <th scope="col" class="govuk-table__header">Status</th>
+                                    <th scope="col" class="govuk-table__header">Received</th>
+                                    <th scope="col" class="govuk-table__header govuk-!-text-align-right">Action</th>
+                                </tr>
+                            </thead>
+                            <tbody class="govuk-table__body">
+                                <tr class="govuk-table__row">
+                                    <th scope="row" class="govuk-table__header">Appeal</th>
+                                    <td class="govuk-table__cell">Ready to review</td>
+                                    <td class="govuk-table__cell">2 August 2024</td>
+                                    <td class="govuk-table__cell govuk-!-text-align-right"><a href="/appeals-service/appeal-details/1/appellant-case?backUrl=%2Fappeals-service%2Fappeal-details%2F1"
+                                        data-cy="review-appellant-case" class="govuk-link">Review<span class="govuk-visually-hidden"> appellant case</span></a>
+                                    </td>
+                                </tr>
+                                <tr class="govuk-table__row">
+                                    <th scope="row" class="govuk-table__header">LPA questionnaire</th>
+                                    <td class="govuk-table__cell">Overdue</td>
+                                    <td class="govuk-table__cell">Due by 11 October 2023</td>
+                                    <td class="govuk-table__cell govuk-!-text-align-right"></td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
+                <div class="govuk-accordion__section">
+                    <div class="govuk-accordion__section-header">
+                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-5"> Costs</span></h2>
+                    </div>
+                    <div id="accordion-default1-content-5" class="govuk-accordion__section-content">
+                        <table class="govuk-table">
+                            <thead class="govuk-table__head">
+                                <tr class="govuk-table__row">
+                                    <th scope="col" class="govuk-table__header">Documentation</th>
+                                    <th scope="col" class="govuk-table__header">Status</th>
+                                    <th scope="col" class="govuk-table__header govuk-!-text-align-right">Action</th>
+                                </tr>
+                            </thead>
+                            <tbody class="govuk-table__body">
+                                <tr class="govuk-table__row">
+                                    <th scope="row" class="govuk-table__header appeal-costs-appellant-application-documentation">Appellant application</th>
+                                    <td class="govuk-table__cell appeal-costs-appellant-application-status">No documents available</td>
+                                    <td class="govuk-table__cell appeal-costs-appellant-application-actions govuk-!-text-align-right">
+                                        <ul class="govuk-summary-list__actions-list">
+                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-appellant-application" href="/appeals-service/appeal-details/1/costs/appellant/application/upload-documents/1">Add<span class="govuk-visually-hidden"> Appellant application</span></a>
+                                            </li>
+                                        </ul>
+                                    </td>
+                                </tr>
+                                <tr class="govuk-table__row">
+                                    <th scope="row" class="govuk-table__header appeal-costs-appellant-withdrawal-documentation">Appellant withdrawal</th>
+                                    <td class="govuk-table__cell appeal-costs-appellant-withdrawal-status">No documents available</td>
+                                    <td class="govuk-table__cell appeal-costs-appellant-withdrawal-actions govuk-!-text-align-right">
+                                        <ul class="govuk-summary-list__actions-list">
+                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-appellant-withdrawal" href="/appeals-service/appeal-details/1/costs/appellant/withdrawal/upload-documents/2">Add<span class="govuk-visually-hidden"> Appellant withdrawal</span></a>
+                                            </li>
+                                        </ul>
+                                    </td>
+                                </tr>
+                                <tr class="govuk-table__row">
+                                    <th scope="row" class="govuk-table__header appeal-costs-appellant-correspondence-documentation">Appellant correspondence</th>
+                                    <td class="govuk-table__cell appeal-costs-appellant-correspondence-status">No documents available</td>
+                                    <td class="govuk-table__cell appeal-costs-appellant-correspondence-actions govuk-!-text-align-right">
+                                        <ul class="govuk-summary-list__actions-list">
+                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-appellant-correspondence" href="/appeals-service/appeal-details/1/costs/appellant/correspondence/upload-documents/3">Add<span class="govuk-visually-hidden"> Appellant correspondence</span></a>
+                                            </li>
+                                        </ul>
+                                    </td>
+                                </tr>
+                                <tr class="govuk-table__row">
+                                    <th scope="row" class="govuk-table__header appeal-costs-lpa-application-documentation">LPA application</th>
+                                    <td class="govuk-table__cell appeal-costs-lpa-application-status">No documents available</td>
+                                    <td class="govuk-table__cell appeal-costs-lpa-application-actions govuk-!-text-align-right">
+                                        <ul class="govuk-summary-list__actions-list">
+                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-lpa-application" href="/appeals-service/appeal-details/1/costs/lpa/application/upload-documents/4">Add<span class="govuk-visually-hidden"> LPA application</span></a>
+                                            </li>
+                                        </ul>
+                                    </td>
+                                </tr>
+                                <tr class="govuk-table__row">
+                                    <th scope="row" class="govuk-table__header appeal-costs-lpa-withdrawal-documentation">LPA withdrawal</th>
+                                    <td class="govuk-table__cell appeal-costs-lpa-withdrawal-status">No documents available</td>
+                                    <td class="govuk-table__cell appeal-costs-lpa-withdrawal-actions govuk-!-text-align-right">
+                                        <ul class="govuk-summary-list__actions-list">
+                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-lpa-withdrawal" href="/appeals-service/appeal-details/1/costs/lpa/withdrawal/upload-documents/5">Add<span class="govuk-visually-hidden"> LPA withdrawal</span></a>
+                                            </li>
+                                        </ul>
+                                    </td>
+                                </tr>
+                                <tr class="govuk-table__row">
+                                    <th scope="row" class="govuk-table__header appeal-costs-lpa-correspondence-documentation">LPA correspondence</th>
+                                    <td class="govuk-table__cell appeal-costs-lpa-correspondence-status">No documents available</td>
+                                    <td class="govuk-table__cell appeal-costs-lpa-correspondence-actions govuk-!-text-align-right">
+                                        <ul class="govuk-summary-list__actions-list">
+                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-lpa-correspondence" href="/appeals-service/appeal-details/1/costs/lpa/correspondence/upload-documents/6">Add<span class="govuk-visually-hidden"> LPA correspondence</span></a>
+                                            </li>
+                                        </ul>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
+                <div class="govuk-accordion__section">
+                    <div class="govuk-accordion__section-header">
+                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-6"> Contacts</span></h2>
+                    </div>
+                    <div id="accordion-default1-content-6" class="govuk-accordion__section-content">
+                        <dl class="govuk-summary-list">
+                            <div class="govuk-summary-list__row appeal-appellant"><dt class="govuk-summary-list__key"> Appellant</dt>
+                                <dd class="govuk-summary-list__value">
+                                    <ul class="govuk-list">
+                                        <li>Roger Simmons</li>
+                                        <li>test3@example.com</li>
+                                    </ul>
+                                </dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/service-user/change/appellant"
+                                    data-cy="change-appellant">Change<span class="govuk-visually-hidden"> Appellant</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-agent"><dt class="govuk-summary-list__key"> Agent</dt>
+                                <dd class="govuk-summary-list__value">
+                                    <ul class="govuk-list">
+                                        <li>Fiona Shell</li>
+                                        <li>test2@example.com</li>
+                                    </ul>
+                                </dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/service-user/change/agent"
+                                    data-cy="change-agent">Change<span class="govuk-visually-hidden"> Agent</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-lpa-contact-details"><dt class="govuk-summary-list__key"> LPA</dt>
+                                <dd class="govuk-summary-list__value">
+                                    <ul class="govuk-list">
+                                        <li>Wiltshire Council</li>
+                                        <li>wilt@lpa-email.gov.uk</li>
+                                    </ul>
+                                </dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/change-appeal-details/local-planning-authority"
+                                    data-cy="change-lpa-contact-details">Change<span class="govuk-visually-hidden"> Local planning authority (LPA)</span></a>
+                                </dd>
+                            </div>
+                        </dl>
+                    </div>
+                </div>
+                <div class="govuk-accordion__section">
+                    <div class="govuk-accordion__section-header">
+                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-7"> Team</span></h2>
+                    </div>
+                    <div id="accordion-default1-content-7" class="govuk-accordion__section-content">
+                        <dl class="govuk-summary-list">
+                            <div class="govuk-summary-list__row appeal-case-officer"><dt class="govuk-summary-list__key"> Case officer</dt>
+                                <dd class="govuk-summary-list__value">
+                                    <p class="govuk-body">Not assigned</p>
+                                </dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/assign-case-officer/search-case-officer"
+                                    data-cy="assign-case-officer">Assign<span class="govuk-visually-hidden"> Case officer</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-inspector"><dt class="govuk-summary-list__key"> Inspector</dt>
+                                <dd class="govuk-summary-list__value">
+                                    <p class="govuk-body">Not assigned</p>
+                                </dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/assign-inspector/search-inspector"
+                                    data-cy="assign-inspector">Assign<span class="govuk-visually-hidden"> Inspector</span></a>
+                                </dd>
+                            </div>
+                        </dl>
+                    </div>
+                </div>
+                <div class="govuk-accordion__section">
+                    <div class="govuk-accordion__section-header">
+                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-8"> Case management</span></h2>
+                    </div>
+                    <div id="accordion-default1-content-8" class="govuk-accordion__section-content">
+                        <dl class="govuk-summary-list">
+                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Cross-team correspondence</dt>
+                                <dd                                 class="govuk-summary-list__value">No documents</dd>
+                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/internal-correspondence/cross-team/upload-documents/10"
+                                        data-cy="add-cross-team-correspondence">Add<span class="govuk-visually-hidden"> Cross-team correspondence</span></a>
+                                    </dd>
+                            </div>
+                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Inspector correspondence</dt>
+                                <dd                                 class="govuk-summary-list__value">No documents</dd>
+                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/internal-correspondence/inspector/upload-documents/11"
+                                        data-cy="add-inspector-correspondence">Add<span class="govuk-visually-hidden"> Inspector correspondence</span></a>
+                                    </dd>
+                            </div>
+                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Main party correspondence</dt>
+                                <dd                                 class="govuk-summary-list__value">No documents</dd>
+                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/internal-correspondence/main-party/upload-documents/22"
+                                        data-cy="add-main-party-correspondence">Add<span class="govuk-visually-hidden"> Main party correspondence</span></a>
+                                    </dd>
+                            </div>
+                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Case history</dt>
+                                <dd class="govuk-summary-list__value"></dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/audit" data-cy="view-case-history">View<span class="govuk-visually-hidden"> Case history</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Appeal withdrawal</dt>
+                                <dd class="govuk-summary-list__value"></dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/withdrawal/start"
+                                    data-cy="start-appeal-withdrawal">Start<span class="govuk-visually-hidden"> Appeal withdrawal</span></a>
+                                </dd>
+                            </div>
+                        </dl>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div id="case-details-cancel-section">
+        <h3 class="govuk-heading-m">Cancel appeal</h3>
+        <div>
+            <p><a id="cancelCase" class="govuk-body govuk-link" href="/appeals-service/appeal-details/1/cancel">Cancel appeal</a>
+            </p>
+        </div>
+    </div>
+</main>"
+`;
+
+exports[`appeal-details GET /:appealId Linked appeals should render the case reference for each linked appeal in the linked appeals row, with each internal linked appeal item linking to the respective case details page, if there are linked appeals 1`] = `
+"<main class="govuk-main-wrapper" id="main-content">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Appeal 351062</span>
+            <h1 class="govuk-heading-xl govuk-!-margin-bottom-3">Case details</h1>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full"><strong class="govuk-tag govuk-tag--grey pins-status-tag--full-width">Received appeal</strong>
+            <strong             class="govuk-tag govuk-tag--grey govuk-!-margin-left-1 govuk-!-margin-bottom-4"></strong>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
+            <dl class="govuk-summary-list pins-summary-list--no-border">
+                <div class="govuk-summary-list__row appeal-case-officer"><dt class="govuk-summary-list__key"> Case officer</dt>
+                    <dd class="govuk-summary-list__value">
+                        <p class="govuk-body">Not assigned</p>
+                    </dd>
+                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/assign-case-officer/search-case-officer"
+                        data-cy="assign-case-officer-name">Assign<span class="govuk-visually-hidden"> Case officer</span></a>
+                    </dd>
+                </div>
+                <div class="govuk-summary-list__row appeal-site-address"><dt class="govuk-summary-list__key"> Site address</dt>
+                    <dd class="govuk-summary-list__value">21 The Pavement, Wandsworth, SW4 0HY</dd>
+                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-address/change/1?backUrl=%2Fappeals-service%2Fappeal-details%2F1"
+                        data-cy="change-site-address">Change<span class="govuk-visually-hidden"> Site address</span></a>
+                    </dd>
+                </div>
+                <div class="govuk-summary-list__row appeal-local-planning-authority"><dt class="govuk-summary-list__key"> LPA</dt>
+                    <dd class="govuk-summary-list__value">Wiltshire Council</dd>
+                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/change-appeal-details/local-planning-authority"
+                        data-cy="change-local-planning-authority">Change<span class="govuk-visually-hidden"> LPA</span></a>
+                    </dd>
+                </div>
+            </dl>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
+            <p class="govuk-body govuk-!-margin-bottom-6" id="download-case-files"
+            data-cy="download-case-files"><a class="govuk-link" href="/documents/1/bulk-download/case-APP/Q9999/D/21/351062.zip">Download case</a>
+            </p>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
+            <details class="govuk-details">
+                <summary class="govuk-details__summary"><span class="govuk-details__summary-text"> 2 case notes</span>
+                </summary>
+                <div class="govuk-details__text">
+                    <form method="POST" novalidate="novalidate">
+                        <div class="govuk-grid-row">
+                            <div class="govuk-grid-column-two-thirds">
+                                <div class="govuk-form-group govuk-character-count" data-module="govuk-character-count"
+                                data-maxlength="500">
+                                    <textarea class="govuk-textarea govuk-js-character-count" id="comment"
+                                    name="comment" rows="5" aria-describedby="comment-info"></textarea>
+                                    <div id="comment-info" class="govuk-hint govuk-character-count__message">You can enter up to 500 characters</div>
+                                </div>
+                            </div>
+                        </div>
+                        <button type="submit" data-prevent-double-click="true" class="govuk-button govuk-button--secondary govuk-!-margin-bottom-1"
+                        data-module="govuk-button">Add case note</button>
+                    </form>
+                    <div>
+                        <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+                        <section>
+                            <p class="govuk-body govuk-!-margin-bottom-1">A case note you should see.</p>
+                            <p class="govuk-hint govuk-!-margin-bottom-6">11:00am on Tuesday 1 October 2024 by John.Smith</p>
+                            <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+                        </section>
+                        <section>
+                            <p class="govuk-body govuk-!-margin-bottom-1">A case note you should see.</p>
+                            <p class="govuk-hint govuk-!-margin-bottom-6">11:00am on Tuesday 1 October 2024 by John.Smith</p>
+                            <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+                        </section>
+                    </div>
+                </div>
+            </details>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
+            <div class="govuk-accordion" data-module="govuk-accordion" id="accordion-default1">
+                <div class="govuk-accordion__section">
+                    <div class="govuk-accordion__section-header">
+                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-1"> Overview</span></h2>
+                    </div>
+                    <div id="accordion-default1-content-1" class="govuk-accordion__section-content">
+                        <dl class="govuk-summary-list">
+                            <div class="govuk-summary-list__row govuk-summary-list__row--no-actions appeal-lpa-reference"><dt class="govuk-summary-list__key"> Planning application reference</dt>
+                                <dd                                 class="govuk-summary-list__value">48269/APP/2021/1482</dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-appeal-type"><dt class="govuk-summary-list__key"> Appeal type</dt>
+                                <dd class="govuk-summary-list__value">Householder</dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/change-appeal-type/appeal-type"
+                                    data-cy="change-appeal-type">Change<span class="govuk-visually-hidden"> Appeal type</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row govuk-summary-list__row--no-actions appeal-case-procedure"><dt class="govuk-summary-list__key"> Appeal procedure</dt>
+                                <dd class="govuk-summary-list__value">Written</dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-allocation-details"><dt class="govuk-summary-list__key"> Allocation level</dt>
+                                <dd class="govuk-summary-list__value">
+                                    <ul class="govuk-!-margin-0">
+                                        <li>Level: A</li>
+                                        <li>Historic heritage</li>
+                                        <li>Architecture design</li>
+                                    </ul>
+                                </dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/allocation-details/allocation-level"
+                                    data-cy="change-allocation-details">Change<span class="govuk-visually-hidden"> Allocation level</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-linked-appeals"><dt class="govuk-summary-list__key"> Linked appeals</dt>
+                                <dd class="govuk-summary-list__value">
+                                    <ul class="govuk-list govuk-list--bullet">
+                                        <li><a href="/appeals-service/appeal-details/5449" class="govuk-link" data-cy="linked-appeal-784706"
+                                            aria-label="Appeal 7 8 4 7 0 6">784706</a>
+                                        </li>
+                                        <li><span class="govuk-body">87326527</span>
+                                        </li>
+                                        <li><a href="/appeals-service/appeal-details/5464" class="govuk-link" data-cy="linked-appeal-140079"
+                                            aria-label="Appeal 1 4 0 0 7 9">140079</a> (lead)</li>
+                                        <li><a href="/appeals-service/appeal-details/5451" class="govuk-link" data-cy="linked-appeal-721086"
+                                            aria-label="Appeal 7 2 1 0 8 6">721086</a>
+                                        </li>
+                                    </ul>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-other-appeals"><dt class="govuk-summary-list__key"> Related appeals</dt>
+                                <dd class="govuk-summary-list__value"><span>No</span>
+                                </dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/other-appeals/add"
+                                    data-cy="add-related-appeals">Add<span class="govuk-visually-hidden"> Related appeals</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-decision"><dt class="govuk-summary-list__key"> Decision</dt>
+                                <dd class="govuk-summary-list__value">Dismissed</dd>
+                            </div>
+                        </dl>
+                    </div>
+                </div>
+                <div class="govuk-accordion__section">
+                    <div class="govuk-accordion__section-header">
+                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-2"> Timetable</span></h2>
+                    </div>
+                    <div id="accordion-default1-content-2" class="govuk-accordion__section-content">
+                        <dl class="govuk-summary-list appeal-case-timetable">
+                            <div class="govuk-summary-list__row appeal-valid-date"><dt class="govuk-summary-list__key"> Valid date</dt>
+                                <dd class="govuk-summary-list__value">23 May 2023</dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/valid/date"
+                                    data-cy="-valid-date"><span class="govuk-visually-hidden"> Valid date</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-start-date"><dt class="govuk-summary-list__key"> Start date</dt>
+                                <dd class="govuk-summary-list__value">23 May 2023</dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/start-case/change"
+                                    data-cy="change-start-case-date">Change<span class="govuk-visually-hidden"> Start date</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-lpa-questionnaire-due-date"><dt class="govuk-summary-list__key"> LPA questionnaire due</dt>
+                                <dd class="govuk-summary-list__value">11 October 2023</dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-site-visit"><dt class="govuk-summary-list__key"> Site visit</dt>
+                                <dd class="govuk-summary-list__value">
+                                    <ul class="govuk-list govuk-!-margin-top-0 govuk-!-padding-left-0">
+                                        <li>9 October 2023</li>
+                                        <li>9:38am - 10:00am</li>
+                                    </ul>
+                                </dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/manage-visit?backUrl=%2Fappeals-service%2Fappeal-details%2F1"
+                                    data-cy="change-schedule-visit">Change<span class="govuk-visually-hidden"> Site visit</span></a>
+                                </dd>
+                            </div>
+                        </dl>
+                    </div>
+                </div>
+                <div class="govuk-accordion__section">
+                    <div class="govuk-accordion__section-header">
+                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-3"> Documentation</span></h2>
+                    </div>
+                    <div id="accordion-default1-content-3" class="govuk-accordion__section-content">
+                        <table class="govuk-table">
+                            <thead class="govuk-table__head">
+                                <tr class="govuk-table__row">
+                                    <th scope="col" class="govuk-table__header">Documentation</th>
+                                    <th scope="col" class="govuk-table__header">Status</th>
+                                    <th scope="col" class="govuk-table__header">Received</th>
+                                    <th scope="col" class="govuk-table__header govuk-!-text-align-right">Action</th>
+                                </tr>
+                            </thead>
+                            <tbody class="govuk-table__body">
+                                <tr class="govuk-table__row">
+                                    <th scope="row" class="govuk-table__header">Appeal</th>
+                                    <td class="govuk-table__cell">Ready to review</td>
+                                    <td class="govuk-table__cell">2 August 2024</td>
+                                    <td class="govuk-table__cell govuk-!-text-align-right"><a href="/appeals-service/appeal-details/1/appellant-case?backUrl=%2Fappeals-service%2Fappeal-details%2F1"
+                                        data-cy="review-appellant-case" class="govuk-link">Review<span class="govuk-visually-hidden"> appellant case</span></a>
+                                    </td>
+                                </tr>
+                                <tr class="govuk-table__row">
+                                    <th scope="row" class="govuk-table__header">LPA questionnaire</th>
+                                    <td class="govuk-table__cell">Overdue</td>
+                                    <td class="govuk-table__cell">Due by 11 October 2023</td>
+                                    <td class="govuk-table__cell govuk-!-text-align-right"></td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
+                <div class="govuk-accordion__section">
+                    <div class="govuk-accordion__section-header">
+                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-4"> Costs</span></h2>
+                    </div>
+                    <div id="accordion-default1-content-4" class="govuk-accordion__section-content">
+                        <table class="govuk-table">
+                            <thead class="govuk-table__head">
+                                <tr class="govuk-table__row">
+                                    <th scope="col" class="govuk-table__header">Documentation</th>
+                                    <th scope="col" class="govuk-table__header">Status</th>
+                                    <th scope="col" class="govuk-table__header govuk-!-text-align-right">Action</th>
+                                </tr>
+                            </thead>
+                            <tbody class="govuk-table__body">
+                                <tr class="govuk-table__row">
+                                    <th scope="row" class="govuk-table__header appeal-costs-appellant-application-documentation">Appellant application</th>
+                                    <td class="govuk-table__cell appeal-costs-appellant-application-status">No documents available</td>
+                                    <td class="govuk-table__cell appeal-costs-appellant-application-actions govuk-!-text-align-right">
+                                        <ul class="govuk-summary-list__actions-list">
+                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-appellant-application" href="/appeals-service/appeal-details/1/costs/appellant/application/upload-documents/1">Add<span class="govuk-visually-hidden"> Appellant application</span></a>
+                                            </li>
+                                        </ul>
+                                    </td>
+                                </tr>
+                                <tr class="govuk-table__row">
+                                    <th scope="row" class="govuk-table__header appeal-costs-appellant-withdrawal-documentation">Appellant withdrawal</th>
+                                    <td class="govuk-table__cell appeal-costs-appellant-withdrawal-status">No documents available</td>
+                                    <td class="govuk-table__cell appeal-costs-appellant-withdrawal-actions govuk-!-text-align-right">
+                                        <ul class="govuk-summary-list__actions-list">
+                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-appellant-withdrawal" href="/appeals-service/appeal-details/1/costs/appellant/withdrawal/upload-documents/2">Add<span class="govuk-visually-hidden"> Appellant withdrawal</span></a>
+                                            </li>
+                                        </ul>
+                                    </td>
+                                </tr>
+                                <tr class="govuk-table__row">
+                                    <th scope="row" class="govuk-table__header appeal-costs-appellant-correspondence-documentation">Appellant correspondence</th>
+                                    <td class="govuk-table__cell appeal-costs-appellant-correspondence-status">No documents available</td>
+                                    <td class="govuk-table__cell appeal-costs-appellant-correspondence-actions govuk-!-text-align-right">
+                                        <ul class="govuk-summary-list__actions-list">
+                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-appellant-correspondence" href="/appeals-service/appeal-details/1/costs/appellant/correspondence/upload-documents/3">Add<span class="govuk-visually-hidden"> Appellant correspondence</span></a>
+                                            </li>
+                                        </ul>
+                                    </td>
+                                </tr>
+                                <tr class="govuk-table__row">
+                                    <th scope="row" class="govuk-table__header appeal-costs-lpa-application-documentation">LPA application</th>
+                                    <td class="govuk-table__cell appeal-costs-lpa-application-status">No documents available</td>
+                                    <td class="govuk-table__cell appeal-costs-lpa-application-actions govuk-!-text-align-right">
+                                        <ul class="govuk-summary-list__actions-list">
+                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-lpa-application" href="/appeals-service/appeal-details/1/costs/lpa/application/upload-documents/4">Add<span class="govuk-visually-hidden"> LPA application</span></a>
+                                            </li>
+                                        </ul>
+                                    </td>
+                                </tr>
+                                <tr class="govuk-table__row">
+                                    <th scope="row" class="govuk-table__header appeal-costs-lpa-withdrawal-documentation">LPA withdrawal</th>
+                                    <td class="govuk-table__cell appeal-costs-lpa-withdrawal-status">No documents available</td>
+                                    <td class="govuk-table__cell appeal-costs-lpa-withdrawal-actions govuk-!-text-align-right">
+                                        <ul class="govuk-summary-list__actions-list">
+                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-lpa-withdrawal" href="/appeals-service/appeal-details/1/costs/lpa/withdrawal/upload-documents/5">Add<span class="govuk-visually-hidden"> LPA withdrawal</span></a>
+                                            </li>
+                                        </ul>
+                                    </td>
+                                </tr>
+                                <tr class="govuk-table__row">
+                                    <th scope="row" class="govuk-table__header appeal-costs-lpa-correspondence-documentation">LPA correspondence</th>
+                                    <td class="govuk-table__cell appeal-costs-lpa-correspondence-status">No documents available</td>
+                                    <td class="govuk-table__cell appeal-costs-lpa-correspondence-actions govuk-!-text-align-right">
+                                        <ul class="govuk-summary-list__actions-list">
+                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-lpa-correspondence" href="/appeals-service/appeal-details/1/costs/lpa/correspondence/upload-documents/6">Add<span class="govuk-visually-hidden"> LPA correspondence</span></a>
+                                            </li>
+                                        </ul>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
+                <div class="govuk-accordion__section">
+                    <div class="govuk-accordion__section-header">
+                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-5"> Contacts</span></h2>
+                    </div>
+                    <div id="accordion-default1-content-5" class="govuk-accordion__section-content">
+                        <dl class="govuk-summary-list">
+                            <div class="govuk-summary-list__row appeal-appellant"><dt class="govuk-summary-list__key"> Appellant</dt>
+                                <dd class="govuk-summary-list__value">
+                                    <ul class="govuk-list">
+                                        <li>Roger Simmons</li>
+                                        <li>test3@example.com</li>
+                                    </ul>
+                                </dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/service-user/change/appellant"
+                                    data-cy="change-appellant">Change<span class="govuk-visually-hidden"> Appellant</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-agent"><dt class="govuk-summary-list__key"> Agent</dt>
+                                <dd class="govuk-summary-list__value">
+                                    <ul class="govuk-list">
+                                        <li>Fiona Shell</li>
+                                        <li>test2@example.com</li>
+                                    </ul>
+                                </dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/service-user/change/agent"
+                                    data-cy="change-agent">Change<span class="govuk-visually-hidden"> Agent</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-lpa-contact-details"><dt class="govuk-summary-list__key"> LPA</dt>
+                                <dd class="govuk-summary-list__value">
+                                    <ul class="govuk-list">
+                                        <li>Wiltshire Council</li>
+                                        <li>wilt@lpa-email.gov.uk</li>
+                                    </ul>
+                                </dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/change-appeal-details/local-planning-authority"
+                                    data-cy="change-lpa-contact-details">Change<span class="govuk-visually-hidden"> Local planning authority (LPA)</span></a>
+                                </dd>
+                            </div>
+                        </dl>
+                    </div>
+                </div>
+                <div class="govuk-accordion__section">
+                    <div class="govuk-accordion__section-header">
+                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-6"> Team</span></h2>
+                    </div>
+                    <div id="accordion-default1-content-6" class="govuk-accordion__section-content">
+                        <dl class="govuk-summary-list">
+                            <div class="govuk-summary-list__row appeal-case-officer"><dt class="govuk-summary-list__key"> Case officer</dt>
+                                <dd class="govuk-summary-list__value">
+                                    <p class="govuk-body">Not assigned</p>
+                                </dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/assign-case-officer/search-case-officer"
+                                    data-cy="assign-case-officer">Assign<span class="govuk-visually-hidden"> Case officer</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-inspector"><dt class="govuk-summary-list__key"> Inspector</dt>
+                                <dd class="govuk-summary-list__value">
+                                    <p class="govuk-body">Not assigned</p>
+                                </dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/assign-inspector/search-inspector"
+                                    data-cy="assign-inspector">Assign<span class="govuk-visually-hidden"> Inspector</span></a>
+                                </dd>
+                            </div>
+                        </dl>
+                    </div>
+                </div>
+                <div class="govuk-accordion__section">
+                    <div class="govuk-accordion__section-header">
+                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-7"> Case management</span></h2>
+                    </div>
+                    <div id="accordion-default1-content-7" class="govuk-accordion__section-content">
+                        <dl class="govuk-summary-list">
+                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Cross-team correspondence</dt>
+                                <dd                                 class="govuk-summary-list__value">No documents</dd>
+                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/internal-correspondence/cross-team/upload-documents/10"
+                                        data-cy="add-cross-team-correspondence">Add<span class="govuk-visually-hidden"> Cross-team correspondence</span></a>
+                                    </dd>
+                            </div>
+                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Inspector correspondence</dt>
+                                <dd                                 class="govuk-summary-list__value">No documents</dd>
+                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/internal-correspondence/inspector/upload-documents/11"
+                                        data-cy="add-inspector-correspondence">Add<span class="govuk-visually-hidden"> Inspector correspondence</span></a>
+                                    </dd>
+                            </div>
+                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Main party correspondence</dt>
+                                <dd                                 class="govuk-summary-list__value">No documents</dd>
+                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/internal-correspondence/main-party/upload-documents/22"
+                                        data-cy="add-main-party-correspondence">Add<span class="govuk-visually-hidden"> Main party correspondence</span></a>
+                                    </dd>
+                            </div>
+                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Case history</dt>
+                                <dd class="govuk-summary-list__value"></dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/audit" data-cy="view-case-history">View<span class="govuk-visually-hidden"> Case history</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Appeal withdrawal</dt>
+                                <dd class="govuk-summary-list__value"></dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/withdrawal/start"
+                                    data-cy="start-appeal-withdrawal">Start<span class="govuk-visually-hidden"> Appeal withdrawal</span></a>
+                                </dd>
+                            </div>
+                        </dl>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div id="case-details-cancel-section">
+        <h3 class="govuk-heading-m">Cancel appeal</h3>
+        <div>
+            <p><a id="cancelCase" class="govuk-body govuk-link" href="/appeals-service/appeal-details/1/cancel">Cancel appeal</a>
+            </p>
+        </div>
+    </div>
+</main>"
+`;
+
+exports[`appeal-details GET /:appealId Linked appeals should render the lead or child status after the case reference link of each linked appeal in the linked appeals row, if there are linked appeals 1`] = `
+"<main class="govuk-main-wrapper" id="main-content">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Appeal 351062</span>
+            <h1 class="govuk-heading-xl govuk-!-margin-bottom-3">Case details</h1>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full"><strong class="govuk-tag govuk-tag--grey pins-status-tag--full-width">Received appeal</strong>
+            <strong             class="govuk-tag govuk-tag--grey govuk-!-margin-left-1 govuk-!-margin-bottom-4"></strong>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
+            <dl class="govuk-summary-list pins-summary-list--no-border">
+                <div class="govuk-summary-list__row appeal-case-officer"><dt class="govuk-summary-list__key"> Case officer</dt>
+                    <dd class="govuk-summary-list__value">
+                        <p class="govuk-body">Not assigned</p>
+                    </dd>
+                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/assign-case-officer/search-case-officer"
+                        data-cy="assign-case-officer-name">Assign<span class="govuk-visually-hidden"> Case officer</span></a>
+                    </dd>
+                </div>
+                <div class="govuk-summary-list__row appeal-site-address"><dt class="govuk-summary-list__key"> Site address</dt>
+                    <dd class="govuk-summary-list__value">21 The Pavement, Wandsworth, SW4 0HY</dd>
+                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-address/change/1?backUrl=%2Fappeals-service%2Fappeal-details%2F1"
+                        data-cy="change-site-address">Change<span class="govuk-visually-hidden"> Site address</span></a>
+                    </dd>
+                </div>
+                <div class="govuk-summary-list__row appeal-local-planning-authority"><dt class="govuk-summary-list__key"> LPA</dt>
+                    <dd class="govuk-summary-list__value">Wiltshire Council</dd>
+                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/change-appeal-details/local-planning-authority"
+                        data-cy="change-local-planning-authority">Change<span class="govuk-visually-hidden"> LPA</span></a>
+                    </dd>
+                </div>
+            </dl>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
+            <p class="govuk-body govuk-!-margin-bottom-6" id="download-case-files"
+            data-cy="download-case-files"><a class="govuk-link" href="/documents/1/bulk-download/case-APP/Q9999/D/21/351062.zip">Download case</a>
+            </p>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
+            <details class="govuk-details">
+                <summary class="govuk-details__summary"><span class="govuk-details__summary-text"> 2 case notes</span>
+                </summary>
+                <div class="govuk-details__text">
+                    <form method="POST" novalidate="novalidate">
+                        <div class="govuk-grid-row">
+                            <div class="govuk-grid-column-two-thirds">
+                                <div class="govuk-form-group govuk-character-count" data-module="govuk-character-count"
+                                data-maxlength="500">
+                                    <textarea class="govuk-textarea govuk-js-character-count" id="comment"
+                                    name="comment" rows="5" aria-describedby="comment-info"></textarea>
+                                    <div id="comment-info" class="govuk-hint govuk-character-count__message">You can enter up to 500 characters</div>
+                                </div>
+                            </div>
+                        </div>
+                        <button type="submit" data-prevent-double-click="true" class="govuk-button govuk-button--secondary govuk-!-margin-bottom-1"
+                        data-module="govuk-button">Add case note</button>
+                    </form>
+                    <div>
+                        <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+                        <section>
+                            <p class="govuk-body govuk-!-margin-bottom-1">A case note you should see.</p>
+                            <p class="govuk-hint govuk-!-margin-bottom-6">11:00am on Tuesday 1 October 2024 by John.Smith</p>
+                            <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+                        </section>
+                        <section>
+                            <p class="govuk-body govuk-!-margin-bottom-1">A case note you should see.</p>
+                            <p class="govuk-hint govuk-!-margin-bottom-6">11:00am on Tuesday 1 October 2024 by John.Smith</p>
+                            <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+                        </section>
+                    </div>
+                </div>
+            </details>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
+            <div class="govuk-accordion" data-module="govuk-accordion" id="accordion-default1">
+                <div class="govuk-accordion__section">
+                    <div class="govuk-accordion__section-header">
+                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-1"> Overview</span></h2>
+                    </div>
+                    <div id="accordion-default1-content-1" class="govuk-accordion__section-content">
+                        <dl class="govuk-summary-list">
+                            <div class="govuk-summary-list__row govuk-summary-list__row--no-actions appeal-lpa-reference"><dt class="govuk-summary-list__key"> Planning application reference</dt>
+                                <dd                                 class="govuk-summary-list__value">48269/APP/2021/1482</dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-appeal-type"><dt class="govuk-summary-list__key"> Appeal type</dt>
+                                <dd class="govuk-summary-list__value">Householder</dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/change-appeal-type/appeal-type"
+                                    data-cy="change-appeal-type">Change<span class="govuk-visually-hidden"> Appeal type</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row govuk-summary-list__row--no-actions appeal-case-procedure"><dt class="govuk-summary-list__key"> Appeal procedure</dt>
+                                <dd class="govuk-summary-list__value">Written</dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-allocation-details"><dt class="govuk-summary-list__key"> Allocation level</dt>
+                                <dd class="govuk-summary-list__value">
+                                    <ul class="govuk-!-margin-0">
+                                        <li>Level: A</li>
+                                        <li>Historic heritage</li>
+                                        <li>Architecture design</li>
+                                    </ul>
+                                </dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/allocation-details/allocation-level"
+                                    data-cy="change-allocation-details">Change<span class="govuk-visually-hidden"> Allocation level</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-linked-appeals"><dt class="govuk-summary-list__key"> Linked appeals</dt>
+                                <dd class="govuk-summary-list__value">
+                                    <ul class="govuk-list govuk-list--bullet">
+                                        <li><a href="/appeals-service/appeal-details/5449" class="govuk-link" data-cy="linked-appeal-784706"
+                                            aria-label="Appeal 7 8 4 7 0 6">784706</a>
+                                        </li>
+                                        <li><span class="govuk-body">87326527</span>
+                                        </li>
+                                        <li><a href="/appeals-service/appeal-details/5464" class="govuk-link" data-cy="linked-appeal-140079"
+                                            aria-label="Appeal 1 4 0 0 7 9">140079</a> (lead)</li>
+                                        <li><a href="/appeals-service/appeal-details/5451" class="govuk-link" data-cy="linked-appeal-721086"
+                                            aria-label="Appeal 7 2 1 0 8 6">721086</a>
+                                        </li>
+                                    </ul>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-other-appeals"><dt class="govuk-summary-list__key"> Related appeals</dt>
+                                <dd class="govuk-summary-list__value"><span>No</span>
+                                </dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/other-appeals/add"
+                                    data-cy="add-related-appeals">Add<span class="govuk-visually-hidden"> Related appeals</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-decision"><dt class="govuk-summary-list__key"> Decision</dt>
+                                <dd class="govuk-summary-list__value">Dismissed</dd>
+                            </div>
+                        </dl>
+                    </div>
+                </div>
+                <div class="govuk-accordion__section">
+                    <div class="govuk-accordion__section-header">
+                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-2"> Site</span></h2>
+                    </div>
+                    <div id="accordion-default1-content-2" class="govuk-accordion__section-content">
+                        <dl class="govuk-summary-list">
+                            <div class="govuk-summary-list__row appeal-visit-type"><dt class="govuk-summary-list__key"> Visit type</dt>
+                                <dd class="govuk-summary-list__value">Accompanied</dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/visit-booked?backUrl=%2Fappeals-service%2Fappeal-details%2F1"
+                                    data-cy="change-set-visit-type">Change<span class="govuk-visually-hidden"> Visit type</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Date</dt>
+                                <dd class="govuk-summary-list__value">9 October 2023</dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/visit-booked"
+                                    data-cy="change-site-visit-date">Change<span class="govuk-visually-hidden"> Date</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Start time</dt>
+                                <dd class="govuk-summary-list__value">9:38am</dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/visit-booked"
+                                    data-cy="change-site-visit-start-time">Change<span class="govuk-visually-hidden"> Start time</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> End time</dt>
+                                <dd class="govuk-summary-list__value">10:00am</dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/visit-booked"
+                                    data-cy="change-site-visit-end-time">Change<span class="govuk-visually-hidden"> End time</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-neighbouring-sites-inspector"><dt class="govuk-summary-list__key"> Interested party and neighbour addresses</dt>
+                                <dd                                 class="govuk-summary-list__value">
+                                    <ul class="govuk-list govuk-list--bullet">
+                                        <li>2 Grove Cottage, Shotesham Road, Woodton, Devon, NR35 2ND</li>
+                                    </ul>
+                                    </dd>
+                                    <dd class="govuk-summary-list__actions">
+                                        <ul class="govuk-summary-list__actions-list">
+                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/neighbouring-sites/manage"
+                                                data-cy="manage-neighbouring-sites-inspector">Manage<span class="govuk-visually-hidden"> Interested party and neighbour addresses</span></a>
+                                            </li>
+                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/neighbouring-sites/add/back-office"
+                                                data-cy="add-neighbouring-sites-inspector">Add<span class="govuk-visually-hidden"> Interested party and neighbour addresses</span></a>
+                                            </li>
+                                        </ul>
+                                    </dd>
+                            </div>
+                        </dl>
+                    </div>
+                </div>
+                <div class="govuk-accordion__section">
+                    <div class="govuk-accordion__section-header">
+                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-3"> Timetable</span></h2>
+                    </div>
+                    <div id="accordion-default1-content-3" class="govuk-accordion__section-content">
+                        <dl class="govuk-summary-list appeal-case-timetable">
+                            <div class="govuk-summary-list__row appeal-valid-date"><dt class="govuk-summary-list__key"> Valid date</dt>
+                                <dd class="govuk-summary-list__value">23 May 2023</dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/valid/date"
+                                    data-cy="-valid-date"><span class="govuk-visually-hidden"> Valid date</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-start-date"><dt class="govuk-summary-list__key"> Start date</dt>
+                                <dd class="govuk-summary-list__value">23 May 2023</dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/start-case/change"
+                                    data-cy="change-start-case-date">Change<span class="govuk-visually-hidden"> Start date</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-lpa-questionnaire-due-date"><dt class="govuk-summary-list__key"> LPA questionnaire due</dt>
+                                <dd class="govuk-summary-list__value">11 October 2023</dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-site-visit"><dt class="govuk-summary-list__key"> Site visit</dt>
+                                <dd class="govuk-summary-list__value">
+                                    <ul class="govuk-list govuk-!-margin-top-0 govuk-!-padding-left-0">
+                                        <li>9 October 2023</li>
+                                        <li>9:38am - 10:00am</li>
+                                    </ul>
+                                </dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/manage-visit?backUrl=%2Fappeals-service%2Fappeal-details%2F1"
+                                    data-cy="change-schedule-visit">Change<span class="govuk-visually-hidden"> Site visit</span></a>
+                                </dd>
+                            </div>
+                        </dl>
+                    </div>
+                </div>
+                <div class="govuk-accordion__section">
+                    <div class="govuk-accordion__section-header">
+                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-4"> Documentation</span></h2>
+                    </div>
+                    <div id="accordion-default1-content-4" class="govuk-accordion__section-content">
+                        <table class="govuk-table">
+                            <thead class="govuk-table__head">
+                                <tr class="govuk-table__row">
+                                    <th scope="col" class="govuk-table__header">Documentation</th>
+                                    <th scope="col" class="govuk-table__header">Status</th>
+                                    <th scope="col" class="govuk-table__header">Received</th>
+                                    <th scope="col" class="govuk-table__header govuk-!-text-align-right">Action</th>
+                                </tr>
+                            </thead>
+                            <tbody class="govuk-table__body">
+                                <tr class="govuk-table__row">
+                                    <th scope="row" class="govuk-table__header">Appeal</th>
+                                    <td class="govuk-table__cell">Ready to review</td>
+                                    <td class="govuk-table__cell">2 August 2024</td>
+                                    <td class="govuk-table__cell govuk-!-text-align-right"><a href="/appeals-service/appeal-details/1/appellant-case?backUrl=%2Fappeals-service%2Fappeal-details%2F1"
+                                        data-cy="review-appellant-case" class="govuk-link">Review<span class="govuk-visually-hidden"> appellant case</span></a>
+                                    </td>
+                                </tr>
+                                <tr class="govuk-table__row">
+                                    <th scope="row" class="govuk-table__header">LPA questionnaire</th>
+                                    <td class="govuk-table__cell">Overdue</td>
+                                    <td class="govuk-table__cell">Due by 11 October 2023</td>
+                                    <td class="govuk-table__cell govuk-!-text-align-right"></td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
+                <div class="govuk-accordion__section">
+                    <div class="govuk-accordion__section-header">
+                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-5"> Costs</span></h2>
+                    </div>
+                    <div id="accordion-default1-content-5" class="govuk-accordion__section-content">
+                        <table class="govuk-table">
+                            <thead class="govuk-table__head">
+                                <tr class="govuk-table__row">
+                                    <th scope="col" class="govuk-table__header">Documentation</th>
+                                    <th scope="col" class="govuk-table__header">Status</th>
+                                    <th scope="col" class="govuk-table__header govuk-!-text-align-right">Action</th>
+                                </tr>
+                            </thead>
+                            <tbody class="govuk-table__body">
+                                <tr class="govuk-table__row">
+                                    <th scope="row" class="govuk-table__header appeal-costs-appellant-application-documentation">Appellant application</th>
+                                    <td class="govuk-table__cell appeal-costs-appellant-application-status">No documents available</td>
+                                    <td class="govuk-table__cell appeal-costs-appellant-application-actions govuk-!-text-align-right">
+                                        <ul class="govuk-summary-list__actions-list">
+                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-appellant-application" href="/appeals-service/appeal-details/1/costs/appellant/application/upload-documents/1">Add<span class="govuk-visually-hidden"> Appellant application</span></a>
+                                            </li>
+                                        </ul>
+                                    </td>
+                                </tr>
+                                <tr class="govuk-table__row">
+                                    <th scope="row" class="govuk-table__header appeal-costs-appellant-withdrawal-documentation">Appellant withdrawal</th>
+                                    <td class="govuk-table__cell appeal-costs-appellant-withdrawal-status">No documents available</td>
+                                    <td class="govuk-table__cell appeal-costs-appellant-withdrawal-actions govuk-!-text-align-right">
+                                        <ul class="govuk-summary-list__actions-list">
+                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-appellant-withdrawal" href="/appeals-service/appeal-details/1/costs/appellant/withdrawal/upload-documents/2">Add<span class="govuk-visually-hidden"> Appellant withdrawal</span></a>
+                                            </li>
+                                        </ul>
+                                    </td>
+                                </tr>
+                                <tr class="govuk-table__row">
+                                    <th scope="row" class="govuk-table__header appeal-costs-appellant-correspondence-documentation">Appellant correspondence</th>
+                                    <td class="govuk-table__cell appeal-costs-appellant-correspondence-status">No documents available</td>
+                                    <td class="govuk-table__cell appeal-costs-appellant-correspondence-actions govuk-!-text-align-right">
+                                        <ul class="govuk-summary-list__actions-list">
+                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-appellant-correspondence" href="/appeals-service/appeal-details/1/costs/appellant/correspondence/upload-documents/3">Add<span class="govuk-visually-hidden"> Appellant correspondence</span></a>
+                                            </li>
+                                        </ul>
+                                    </td>
+                                </tr>
+                                <tr class="govuk-table__row">
+                                    <th scope="row" class="govuk-table__header appeal-costs-lpa-application-documentation">LPA application</th>
+                                    <td class="govuk-table__cell appeal-costs-lpa-application-status">No documents available</td>
+                                    <td class="govuk-table__cell appeal-costs-lpa-application-actions govuk-!-text-align-right">
+                                        <ul class="govuk-summary-list__actions-list">
+                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-lpa-application" href="/appeals-service/appeal-details/1/costs/lpa/application/upload-documents/4">Add<span class="govuk-visually-hidden"> LPA application</span></a>
+                                            </li>
+                                        </ul>
+                                    </td>
+                                </tr>
+                                <tr class="govuk-table__row">
+                                    <th scope="row" class="govuk-table__header appeal-costs-lpa-withdrawal-documentation">LPA withdrawal</th>
+                                    <td class="govuk-table__cell appeal-costs-lpa-withdrawal-status">No documents available</td>
+                                    <td class="govuk-table__cell appeal-costs-lpa-withdrawal-actions govuk-!-text-align-right">
+                                        <ul class="govuk-summary-list__actions-list">
+                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-lpa-withdrawal" href="/appeals-service/appeal-details/1/costs/lpa/withdrawal/upload-documents/5">Add<span class="govuk-visually-hidden"> LPA withdrawal</span></a>
+                                            </li>
+                                        </ul>
+                                    </td>
+                                </tr>
+                                <tr class="govuk-table__row">
+                                    <th scope="row" class="govuk-table__header appeal-costs-lpa-correspondence-documentation">LPA correspondence</th>
+                                    <td class="govuk-table__cell appeal-costs-lpa-correspondence-status">No documents available</td>
+                                    <td class="govuk-table__cell appeal-costs-lpa-correspondence-actions govuk-!-text-align-right">
+                                        <ul class="govuk-summary-list__actions-list">
+                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-lpa-correspondence" href="/appeals-service/appeal-details/1/costs/lpa/correspondence/upload-documents/6">Add<span class="govuk-visually-hidden"> LPA correspondence</span></a>
+                                            </li>
+                                        </ul>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
+                <div class="govuk-accordion__section">
+                    <div class="govuk-accordion__section-header">
+                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-6"> Contacts</span></h2>
+                    </div>
+                    <div id="accordion-default1-content-6" class="govuk-accordion__section-content">
+                        <dl class="govuk-summary-list">
+                            <div class="govuk-summary-list__row appeal-appellant"><dt class="govuk-summary-list__key"> Appellant</dt>
+                                <dd class="govuk-summary-list__value">
+                                    <ul class="govuk-list">
+                                        <li>Roger Simmons</li>
+                                        <li>test3@example.com</li>
+                                    </ul>
+                                </dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/service-user/change/appellant"
+                                    data-cy="change-appellant">Change<span class="govuk-visually-hidden"> Appellant</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-agent"><dt class="govuk-summary-list__key"> Agent</dt>
+                                <dd class="govuk-summary-list__value">
+                                    <ul class="govuk-list">
+                                        <li>Fiona Shell</li>
+                                        <li>test2@example.com</li>
+                                    </ul>
+                                </dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/service-user/change/agent"
+                                    data-cy="change-agent">Change<span class="govuk-visually-hidden"> Agent</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-lpa-contact-details"><dt class="govuk-summary-list__key"> LPA</dt>
+                                <dd class="govuk-summary-list__value">
+                                    <ul class="govuk-list">
+                                        <li>Wiltshire Council</li>
+                                        <li>wilt@lpa-email.gov.uk</li>
+                                    </ul>
+                                </dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/change-appeal-details/local-planning-authority"
+                                    data-cy="change-lpa-contact-details">Change<span class="govuk-visually-hidden"> Local planning authority (LPA)</span></a>
+                                </dd>
+                            </div>
+                        </dl>
+                    </div>
+                </div>
+                <div class="govuk-accordion__section">
+                    <div class="govuk-accordion__section-header">
+                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-7"> Team</span></h2>
+                    </div>
+                    <div id="accordion-default1-content-7" class="govuk-accordion__section-content">
+                        <dl class="govuk-summary-list">
+                            <div class="govuk-summary-list__row appeal-case-officer"><dt class="govuk-summary-list__key"> Case officer</dt>
+                                <dd class="govuk-summary-list__value">
+                                    <p class="govuk-body">Not assigned</p>
+                                </dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/assign-case-officer/search-case-officer"
+                                    data-cy="assign-case-officer">Assign<span class="govuk-visually-hidden"> Case officer</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-inspector"><dt class="govuk-summary-list__key"> Inspector</dt>
+                                <dd class="govuk-summary-list__value">
+                                    <p class="govuk-body">Not assigned</p>
+                                </dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/assign-inspector/search-inspector"
+                                    data-cy="assign-inspector">Assign<span class="govuk-visually-hidden"> Inspector</span></a>
+                                </dd>
+                            </div>
+                        </dl>
+                    </div>
+                </div>
+                <div class="govuk-accordion__section">
+                    <div class="govuk-accordion__section-header">
+                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-8"> Case management</span></h2>
+                    </div>
+                    <div id="accordion-default1-content-8" class="govuk-accordion__section-content">
+                        <dl class="govuk-summary-list">
+                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Cross-team correspondence</dt>
+                                <dd                                 class="govuk-summary-list__value">No documents</dd>
+                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/internal-correspondence/cross-team/upload-documents/10"
+                                        data-cy="add-cross-team-correspondence">Add<span class="govuk-visually-hidden"> Cross-team correspondence</span></a>
+                                    </dd>
+                            </div>
+                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Inspector correspondence</dt>
+                                <dd                                 class="govuk-summary-list__value">No documents</dd>
+                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/internal-correspondence/inspector/upload-documents/11"
+                                        data-cy="add-inspector-correspondence">Add<span class="govuk-visually-hidden"> Inspector correspondence</span></a>
+                                    </dd>
+                            </div>
+                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Main party correspondence</dt>
+                                <dd                                 class="govuk-summary-list__value">No documents</dd>
+                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/internal-correspondence/main-party/upload-documents/22"
+                                        data-cy="add-main-party-correspondence">Add<span class="govuk-visually-hidden"> Main party correspondence</span></a>
+                                    </dd>
+                            </div>
+                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Case history</dt>
+                                <dd class="govuk-summary-list__value"></dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/audit" data-cy="view-case-history">View<span class="govuk-visually-hidden"> Case history</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Appeal withdrawal</dt>
+                                <dd class="govuk-summary-list__value"></dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/withdrawal/start"
+                                    data-cy="start-appeal-withdrawal">Start<span class="govuk-visually-hidden"> Appeal withdrawal</span></a>
+                                </dd>
+                            </div>
+                        </dl>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div id="case-details-cancel-section">
+        <h3 class="govuk-heading-m">Cancel appeal</h3>
+        <div>
+            <p><a id="cancelCase" class="govuk-body govuk-link" href="/appeals-service/appeal-details/1/cancel">Cancel appeal</a>
+            </p>
+        </div>
+    </div>
+</main>"
+`;
+
+exports[`appeal-details GET /:appealId Linked appeals should render the received appeal details for a valid appealId with multiple linked/other appeals 1`] = `
+"<main class="govuk-main-wrapper" id="main-content">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Appeal 351062</span>
+            <h1 class="govuk-heading-xl govuk-!-margin-bottom-3">Case details</h1>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full"><strong class="govuk-tag govuk-tag--grey pins-status-tag--full-width">Received appeal</strong>
+            <strong             class="govuk-tag govuk-tag--grey govuk-!-margin-left-1 govuk-!-margin-bottom-4"></strong>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
+            <dl class="govuk-summary-list pins-summary-list--no-border">
+                <div class="govuk-summary-list__row appeal-case-officer"><dt class="govuk-summary-list__key"> Case officer</dt>
+                    <dd class="govuk-summary-list__value">
+                        <p class="govuk-body">Not assigned</p>
+                    </dd>
+                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/3/assign-case-officer/search-case-officer"
+                        data-cy="assign-case-officer-name">Assign<span class="govuk-visually-hidden"> Case officer</span></a>
+                    </dd>
+                </div>
+                <div class="govuk-summary-list__row appeal-site-address"><dt class="govuk-summary-list__key"> Site address</dt>
+                    <dd class="govuk-summary-list__value">21 The Pavement, Wandsworth, SW4 0HY</dd>
+                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/3/site-address/change/1?backUrl=%2Fappeals-service%2Fappeal-details%2F3"
+                        data-cy="change-site-address">Change<span class="govuk-visually-hidden"> Site address</span></a>
+                    </dd>
+                </div>
+                <div class="govuk-summary-list__row appeal-local-planning-authority"><dt class="govuk-summary-list__key"> LPA</dt>
+                    <dd class="govuk-summary-list__value">Wiltshire Council</dd>
+                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/3/change-appeal-details/local-planning-authority"
+                        data-cy="change-local-planning-authority">Change<span class="govuk-visually-hidden"> LPA</span></a>
+                    </dd>
+                </div>
+            </dl>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
+            <p class="govuk-body govuk-!-margin-bottom-6" id="download-case-files"
+            data-cy="download-case-files"><a class="govuk-link" href="/documents/3/bulk-download/case-APP/Q9999/D/21/351062.zip">Download case</a>
+            </p>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
+            <details class="govuk-details">
+                <summary class="govuk-details__summary"><span class="govuk-details__summary-text"> 2 case notes</span>
+                </summary>
+                <div class="govuk-details__text">
+                    <form method="POST" novalidate="novalidate">
+                        <div class="govuk-grid-row">
+                            <div class="govuk-grid-column-two-thirds">
+                                <div class="govuk-form-group govuk-character-count" data-module="govuk-character-count"
+                                data-maxlength="500">
+                                    <textarea class="govuk-textarea govuk-js-character-count" id="comment"
+                                    name="comment" rows="5" aria-describedby="comment-info"></textarea>
+                                    <div id="comment-info" class="govuk-hint govuk-character-count__message">You can enter up to 500 characters</div>
+                                </div>
+                            </div>
+                        </div>
+                        <button type="submit" data-prevent-double-click="true" class="govuk-button govuk-button--secondary govuk-!-margin-bottom-1"
+                        data-module="govuk-button">Add case note</button>
+                    </form>
+                    <div>
+                        <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+                        <section>
+                            <p class="govuk-body govuk-!-margin-bottom-1">A case note you should see.</p>
+                            <p class="govuk-hint govuk-!-margin-bottom-6">11:00am on Tuesday 1 October 2024 by John.Smith</p>
+                            <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+                        </section>
+                        <section>
+                            <p class="govuk-body govuk-!-margin-bottom-1">A case note you should see.</p>
+                            <p class="govuk-hint govuk-!-margin-bottom-6">11:00am on Tuesday 1 October 2024 by John.Smith</p>
+                            <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+                        </section>
+                    </div>
+                </div>
+            </details>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
+            <div class="govuk-accordion" data-module="govuk-accordion" id="accordion-default3">
+                <div class="govuk-accordion__section">
+                    <div class="govuk-accordion__section-header">
+                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default3-heading-1"> Overview</span></h2>
+                    </div>
+                    <div id="accordion-default3-content-1" class="govuk-accordion__section-content">
+                        <dl class="govuk-summary-list">
+                            <div class="govuk-summary-list__row govuk-summary-list__row--no-actions appeal-lpa-reference"><dt class="govuk-summary-list__key"> Planning application reference</dt>
+                                <dd                                 class="govuk-summary-list__value">48269/APP/2021/1482</dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-appeal-type"><dt class="govuk-summary-list__key"> Appeal type</dt>
+                                <dd class="govuk-summary-list__value">Householder</dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/3/change-appeal-type/appeal-type"
+                                    data-cy="change-appeal-type">Change<span class="govuk-visually-hidden"> Appeal type</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row govuk-summary-list__row--no-actions appeal-case-procedure"><dt class="govuk-summary-list__key"> Appeal procedure</dt>
+                                <dd class="govuk-summary-list__value">Written</dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-allocation-details"><dt class="govuk-summary-list__key"> Allocation level</dt>
+                                <dd class="govuk-summary-list__value">
+                                    <ul class="govuk-!-margin-0">
+                                        <li>Level: A</li>
+                                        <li>Historic heritage</li>
+                                        <li>Architecture design</li>
+                                    </ul>
+                                </dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/3/allocation-details/allocation-level"
+                                    data-cy="change-allocation-details">Change<span class="govuk-visually-hidden"> Allocation level</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-linked-appeals"><dt class="govuk-summary-list__key"> Linked appeals</dt>
+                                <dd class="govuk-summary-list__value">
+                                    <ul class="govuk-list govuk-list--bullet">
+                                        <li><a href="/appeals-service/appeal-details/4" class="govuk-link" data-cy="linked-appeal-725284"
+                                            aria-label="Appeal 7 2 5 2 8 4">725284</a>
+                                        </li>
+                                        <li><a href="/appeals-service/appeal-details/5" class="govuk-link" data-cy="linked-appeal-725285"
+                                            aria-label="Appeal 7 2 5 2 8 5">725285</a>
+                                        </li>
+                                    </ul>
+                                </dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/3/linked-appeals/manage"
+                                    data-cy="manage-linked-appeals">Manage<span class="govuk-visually-hidden"> Linked appeals</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-other-appeals"><dt class="govuk-summary-list__key"> Related appeals</dt>
+                                <dd class="govuk-summary-list__value">
+                                    <ul class="govuk-list govuk-list--bullet">
+                                        <li><a href="/appeals-service/appeal-details/6" class="govuk-link" data-cy="related-appeal-765413"
+                                            aria-label="Appeal 7 6 5 4 1 3">765413</a>
+                                        </li>
+                                        <li><a href="/appeals-service/appeal-details/7" class="govuk-link" data-cy="related-appeal-765414"
+                                            aria-label="Appeal 7 6 5 4 1 4">765414</a>
+                                        </li>
+                                    </ul>
+                                </dd>
+                                <dd class="govuk-summary-list__actions">
+                                    <ul class="govuk-summary-list__actions-list">
+                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/3/other-appeals/manage"
+                                            data-cy="manage-related-appeals">Manage<span class="govuk-visually-hidden"> Related appeals</span></a>
+                                        </li>
+                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/3/other-appeals/add"
+                                            data-cy="add-related-appeals">Add<span class="govuk-visually-hidden"> Related appeals</span></a>
+                                        </li>
+                                    </ul>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-decision"><dt class="govuk-summary-list__key"> Decision</dt>
+                                <dd class="govuk-summary-list__value">Dismissed</dd>
+                            </div>
+                        </dl>
+                    </div>
+                </div>
+                <div class="govuk-accordion__section">
+                    <div class="govuk-accordion__section-header">
+                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default3-heading-2"> Site</span></h2>
+                    </div>
+                    <div id="accordion-default3-content-2" class="govuk-accordion__section-content">
+                        <dl class="govuk-summary-list">
+                            <div class="govuk-summary-list__row appeal-visit-type"><dt class="govuk-summary-list__key"> Visit type</dt>
+                                <dd class="govuk-summary-list__value">Accompanied</dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/3/site-visit/visit-booked?backUrl=%2Fappeals-service%2Fappeal-details%2F3"
+                                    data-cy="change-set-visit-type">Change<span class="govuk-visually-hidden"> Visit type</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Date</dt>
+                                <dd class="govuk-summary-list__value">9 October 2023</dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/3/site-visit/visit-booked"
+                                    data-cy="change-site-visit-date">Change<span class="govuk-visually-hidden"> Date</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Start time</dt>
+                                <dd class="govuk-summary-list__value">9:38am</dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/3/site-visit/visit-booked"
+                                    data-cy="change-site-visit-start-time">Change<span class="govuk-visually-hidden"> Start time</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> End time</dt>
+                                <dd class="govuk-summary-list__value">10:00am</dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/3/site-visit/visit-booked"
+                                    data-cy="change-site-visit-end-time">Change<span class="govuk-visually-hidden"> End time</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-neighbouring-sites-inspector"><dt class="govuk-summary-list__key"> Interested party and neighbour addresses</dt>
+                                <dd                                 class="govuk-summary-list__value">
+                                    <ul class="govuk-list govuk-list--bullet">
+                                        <li>2 Grove Cottage, Shotesham Road, Woodton, Devon, NR35 2ND</li>
+                                    </ul>
+                                    </dd>
+                                    <dd class="govuk-summary-list__actions">
+                                        <ul class="govuk-summary-list__actions-list">
+                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/3/neighbouring-sites/manage"
+                                                data-cy="manage-neighbouring-sites-inspector">Manage<span class="govuk-visually-hidden"> Interested party and neighbour addresses</span></a>
+                                            </li>
+                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/3/neighbouring-sites/add/back-office"
+                                                data-cy="add-neighbouring-sites-inspector">Add<span class="govuk-visually-hidden"> Interested party and neighbour addresses</span></a>
+                                            </li>
+                                        </ul>
+                                    </dd>
+                            </div>
+                        </dl>
+                    </div>
+                </div>
+                <div class="govuk-accordion__section">
+                    <div class="govuk-accordion__section-header">
+                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default3-heading-3"> Timetable</span></h2>
+                    </div>
+                    <div id="accordion-default3-content-3" class="govuk-accordion__section-content">
+                        <dl class="govuk-summary-list appeal-case-timetable">
+                            <div class="govuk-summary-list__row appeal-valid-date"><dt class="govuk-summary-list__key"> Valid date</dt>
+                                <dd class="govuk-summary-list__value">23 May 2023</dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/3/appellant-case/valid/date"
+                                    data-cy="-valid-date"><span class="govuk-visually-hidden"> Valid date</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-start-date"><dt class="govuk-summary-list__key"> Start date</dt>
+                                <dd class="govuk-summary-list__value">23 May 2023</dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/3/start-case/change"
+                                    data-cy="change-start-case-date">Change<span class="govuk-visually-hidden"> Start date</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-lpa-questionnaire-due-date"><dt class="govuk-summary-list__key"> LPA questionnaire due</dt>
+                                <dd class="govuk-summary-list__value">11 October 2023</dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-site-visit"><dt class="govuk-summary-list__key"> Site visit</dt>
+                                <dd class="govuk-summary-list__value">
+                                    <ul class="govuk-list govuk-!-margin-top-0 govuk-!-padding-left-0">
+                                        <li>9 October 2023</li>
+                                        <li>9:38am - 10:00am</li>
+                                    </ul>
+                                </dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/3/site-visit/manage-visit?backUrl=%2Fappeals-service%2Fappeal-details%2F3"
+                                    data-cy="change-schedule-visit">Change<span class="govuk-visually-hidden"> Site visit</span></a>
+                                </dd>
+                            </div>
+                        </dl>
+                    </div>
+                </div>
+                <div class="govuk-accordion__section">
+                    <div class="govuk-accordion__section-header">
+                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default3-heading-4"> Documentation</span></h2>
+                    </div>
+                    <div id="accordion-default3-content-4" class="govuk-accordion__section-content">
+                        <table class="govuk-table">
+                            <thead class="govuk-table__head">
+                                <tr class="govuk-table__row">
+                                    <th scope="col" class="govuk-table__header">Documentation</th>
+                                    <th scope="col" class="govuk-table__header">Status</th>
+                                    <th scope="col" class="govuk-table__header">Received</th>
+                                    <th scope="col" class="govuk-table__header govuk-!-text-align-right">Action</th>
+                                </tr>
+                            </thead>
+                            <tbody class="govuk-table__body">
+                                <tr class="govuk-table__row">
+                                    <th scope="row" class="govuk-table__header">Appeal</th>
+                                    <td class="govuk-table__cell">Ready to review</td>
+                                    <td class="govuk-table__cell">2 August 2024</td>
+                                    <td class="govuk-table__cell govuk-!-text-align-right"><a href="/appeals-service/appeal-details/3/appellant-case?backUrl=%2Fappeals-service%2Fappeal-details%2F3"
+                                        data-cy="review-appellant-case" class="govuk-link">Review<span class="govuk-visually-hidden"> appellant case</span></a>
+                                    </td>
+                                </tr>
+                                <tr class="govuk-table__row">
+                                    <th scope="row" class="govuk-table__header">LPA questionnaire</th>
+                                    <td class="govuk-table__cell">Overdue</td>
+                                    <td class="govuk-table__cell">Due by 11 October 2023</td>
+                                    <td class="govuk-table__cell govuk-!-text-align-right"></td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
+                <div class="govuk-accordion__section">
+                    <div class="govuk-accordion__section-header">
+                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default3-heading-5"> Costs</span></h2>
+                    </div>
+                    <div id="accordion-default3-content-5" class="govuk-accordion__section-content">
+                        <table class="govuk-table">
+                            <thead class="govuk-table__head">
+                                <tr class="govuk-table__row">
+                                    <th scope="col" class="govuk-table__header">Documentation</th>
+                                    <th scope="col" class="govuk-table__header">Status</th>
+                                    <th scope="col" class="govuk-table__header govuk-!-text-align-right">Action</th>
+                                </tr>
+                            </thead>
+                            <tbody class="govuk-table__body">
+                                <tr class="govuk-table__row">
+                                    <th scope="row" class="govuk-table__header appeal-costs-appellant-application-documentation">Appellant application</th>
+                                    <td class="govuk-table__cell appeal-costs-appellant-application-status">No documents available</td>
+                                    <td class="govuk-table__cell appeal-costs-appellant-application-actions govuk-!-text-align-right">
+                                        <ul class="govuk-summary-list__actions-list">
+                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-appellant-application" href="/appeals-service/appeal-details/3/costs/appellant/application/upload-documents/1">Add<span class="govuk-visually-hidden"> Appellant application</span></a>
+                                            </li>
+                                        </ul>
+                                    </td>
+                                </tr>
+                                <tr class="govuk-table__row">
+                                    <th scope="row" class="govuk-table__header appeal-costs-appellant-withdrawal-documentation">Appellant withdrawal</th>
+                                    <td class="govuk-table__cell appeal-costs-appellant-withdrawal-status">No documents available</td>
+                                    <td class="govuk-table__cell appeal-costs-appellant-withdrawal-actions govuk-!-text-align-right">
+                                        <ul class="govuk-summary-list__actions-list">
+                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-appellant-withdrawal" href="/appeals-service/appeal-details/3/costs/appellant/withdrawal/upload-documents/2">Add<span class="govuk-visually-hidden"> Appellant withdrawal</span></a>
+                                            </li>
+                                        </ul>
+                                    </td>
+                                </tr>
+                                <tr class="govuk-table__row">
+                                    <th scope="row" class="govuk-table__header appeal-costs-appellant-correspondence-documentation">Appellant correspondence</th>
+                                    <td class="govuk-table__cell appeal-costs-appellant-correspondence-status">No documents available</td>
+                                    <td class="govuk-table__cell appeal-costs-appellant-correspondence-actions govuk-!-text-align-right">
+                                        <ul class="govuk-summary-list__actions-list">
+                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-appellant-correspondence" href="/appeals-service/appeal-details/3/costs/appellant/correspondence/upload-documents/3">Add<span class="govuk-visually-hidden"> Appellant correspondence</span></a>
+                                            </li>
+                                        </ul>
+                                    </td>
+                                </tr>
+                                <tr class="govuk-table__row">
+                                    <th scope="row" class="govuk-table__header appeal-costs-lpa-application-documentation">LPA application</th>
+                                    <td class="govuk-table__cell appeal-costs-lpa-application-status">No documents available</td>
+                                    <td class="govuk-table__cell appeal-costs-lpa-application-actions govuk-!-text-align-right">
+                                        <ul class="govuk-summary-list__actions-list">
+                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-lpa-application" href="/appeals-service/appeal-details/3/costs/lpa/application/upload-documents/4">Add<span class="govuk-visually-hidden"> LPA application</span></a>
+                                            </li>
+                                        </ul>
+                                    </td>
+                                </tr>
+                                <tr class="govuk-table__row">
+                                    <th scope="row" class="govuk-table__header appeal-costs-lpa-withdrawal-documentation">LPA withdrawal</th>
+                                    <td class="govuk-table__cell appeal-costs-lpa-withdrawal-status">No documents available</td>
+                                    <td class="govuk-table__cell appeal-costs-lpa-withdrawal-actions govuk-!-text-align-right">
+                                        <ul class="govuk-summary-list__actions-list">
+                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-lpa-withdrawal" href="/appeals-service/appeal-details/3/costs/lpa/withdrawal/upload-documents/5">Add<span class="govuk-visually-hidden"> LPA withdrawal</span></a>
+                                            </li>
+                                        </ul>
+                                    </td>
+                                </tr>
+                                <tr class="govuk-table__row">
+                                    <th scope="row" class="govuk-table__header appeal-costs-lpa-correspondence-documentation">LPA correspondence</th>
+                                    <td class="govuk-table__cell appeal-costs-lpa-correspondence-status">No documents available</td>
+                                    <td class="govuk-table__cell appeal-costs-lpa-correspondence-actions govuk-!-text-align-right">
+                                        <ul class="govuk-summary-list__actions-list">
+                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-lpa-correspondence" href="/appeals-service/appeal-details/3/costs/lpa/correspondence/upload-documents/6">Add<span class="govuk-visually-hidden"> LPA correspondence</span></a>
+                                            </li>
+                                        </ul>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
+                <div class="govuk-accordion__section">
+                    <div class="govuk-accordion__section-header">
+                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default3-heading-6"> Contacts</span></h2>
+                    </div>
+                    <div id="accordion-default3-content-6" class="govuk-accordion__section-content">
+                        <dl class="govuk-summary-list">
+                            <div class="govuk-summary-list__row appeal-appellant"><dt class="govuk-summary-list__key"> Appellant</dt>
+                                <dd class="govuk-summary-list__value">
+                                    <ul class="govuk-list">
+                                        <li>Roger Simmons</li>
+                                        <li>test3@example.com</li>
+                                    </ul>
+                                </dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/3/service-user/change/appellant"
+                                    data-cy="change-appellant">Change<span class="govuk-visually-hidden"> Appellant</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-agent"><dt class="govuk-summary-list__key"> Agent</dt>
+                                <dd class="govuk-summary-list__value">
+                                    <ul class="govuk-list">
+                                        <li>Fiona Shell</li>
+                                        <li>test2@example.com</li>
+                                    </ul>
+                                </dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/3/service-user/change/agent"
+                                    data-cy="change-agent">Change<span class="govuk-visually-hidden"> Agent</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-lpa-contact-details"><dt class="govuk-summary-list__key"> LPA</dt>
+                                <dd class="govuk-summary-list__value">
+                                    <ul class="govuk-list">
+                                        <li>Wiltshire Council</li>
+                                        <li>wilt@lpa-email.gov.uk</li>
+                                    </ul>
+                                </dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/3/change-appeal-details/local-planning-authority"
+                                    data-cy="change-lpa-contact-details">Change<span class="govuk-visually-hidden"> Local planning authority (LPA)</span></a>
+                                </dd>
+                            </div>
+                        </dl>
+                    </div>
+                </div>
+                <div class="govuk-accordion__section">
+                    <div class="govuk-accordion__section-header">
+                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default3-heading-7"> Team</span></h2>
+                    </div>
+                    <div id="accordion-default3-content-7" class="govuk-accordion__section-content">
+                        <dl class="govuk-summary-list">
+                            <div class="govuk-summary-list__row appeal-case-officer"><dt class="govuk-summary-list__key"> Case officer</dt>
+                                <dd class="govuk-summary-list__value">
+                                    <p class="govuk-body">Not assigned</p>
+                                </dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/3/assign-case-officer/search-case-officer"
+                                    data-cy="assign-case-officer">Assign<span class="govuk-visually-hidden"> Case officer</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-inspector"><dt class="govuk-summary-list__key"> Inspector</dt>
+                                <dd class="govuk-summary-list__value">
+                                    <p class="govuk-body">Not assigned</p>
+                                </dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/3/assign-inspector/search-inspector"
+                                    data-cy="assign-inspector">Assign<span class="govuk-visually-hidden"> Inspector</span></a>
+                                </dd>
+                            </div>
+                        </dl>
+                    </div>
+                </div>
+                <div class="govuk-accordion__section">
+                    <div class="govuk-accordion__section-header">
+                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default3-heading-8"> Case management</span></h2>
+                    </div>
+                    <div id="accordion-default3-content-8" class="govuk-accordion__section-content">
+                        <dl class="govuk-summary-list">
+                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Cross-team correspondence</dt>
+                                <dd                                 class="govuk-summary-list__value">No documents</dd>
+                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/3/internal-correspondence/cross-team/upload-documents/10"
+                                        data-cy="add-cross-team-correspondence">Add<span class="govuk-visually-hidden"> Cross-team correspondence</span></a>
+                                    </dd>
+                            </div>
+                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Inspector correspondence</dt>
+                                <dd                                 class="govuk-summary-list__value">No documents</dd>
+                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/3/internal-correspondence/inspector/upload-documents/11"
+                                        data-cy="add-inspector-correspondence">Add<span class="govuk-visually-hidden"> Inspector correspondence</span></a>
+                                    </dd>
+                            </div>
+                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Main party correspondence</dt>
+                                <dd                                 class="govuk-summary-list__value">No documents</dd>
+                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/3/internal-correspondence/main-party/upload-documents/22"
+                                        data-cy="add-main-party-correspondence">Add<span class="govuk-visually-hidden"> Main party correspondence</span></a>
+                                    </dd>
+                            </div>
+                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Case history</dt>
+                                <dd class="govuk-summary-list__value"></dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/3/audit" data-cy="view-case-history">View<span class="govuk-visually-hidden"> Case history</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Appeal withdrawal</dt>
+                                <dd class="govuk-summary-list__value"></dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/3/withdrawal/start"
+                                    data-cy="start-appeal-withdrawal">Start<span class="govuk-visually-hidden"> Appeal withdrawal</span></a>
+                                </dd>
+                            </div>
+                        </dl>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div id="case-details-cancel-section">
+        <h3 class="govuk-heading-m">Cancel appeal</h3>
+        <div>
+            <p><a id="cancelCase" class="govuk-body govuk-link" href="/appeals-service/appeal-details/3/cancel">Cancel appeal</a>
+            </p>
+        </div>
+    </div>
+</main>"
+`;
+
+exports[`appeal-details GET /:appealId Linked appeals should render the received appeal details for a valid appealId with no linked/other appeals 1`] = `
+"<main class="govuk-main-wrapper" id="main-content">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Appeal 351062</span>
+            <h1 class="govuk-heading-xl govuk-!-margin-bottom-3">Case details</h1>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full"><strong class="govuk-tag govuk-tag--grey pins-status-tag--full-width">Received appeal</strong>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
+            <dl class="govuk-summary-list pins-summary-list--no-border">
+                <div class="govuk-summary-list__row appeal-case-officer"><dt class="govuk-summary-list__key"> Case officer</dt>
+                    <dd class="govuk-summary-list__value">
+                        <p class="govuk-body">Not assigned</p>
+                    </dd>
+                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/assign-case-officer/search-case-officer"
+                        data-cy="assign-case-officer-name">Assign<span class="govuk-visually-hidden"> Case officer</span></a>
+                    </dd>
+                </div>
+                <div class="govuk-summary-list__row appeal-site-address"><dt class="govuk-summary-list__key"> Site address</dt>
+                    <dd class="govuk-summary-list__value">21 The Pavement, Wandsworth, SW4 0HY</dd>
+                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-address/change/1?backUrl=%2Fappeals-service%2Fappeal-details%2F1"
+                        data-cy="change-site-address">Change<span class="govuk-visually-hidden"> Site address</span></a>
+                    </dd>
+                </div>
+                <div class="govuk-summary-list__row appeal-local-planning-authority"><dt class="govuk-summary-list__key"> LPA</dt>
+                    <dd class="govuk-summary-list__value">Wiltshire Council</dd>
+                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/change-appeal-details/local-planning-authority"
+                        data-cy="change-local-planning-authority">Change<span class="govuk-visually-hidden"> LPA</span></a>
+                    </dd>
+                </div>
+            </dl>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
+            <p class="govuk-body govuk-!-margin-bottom-6" id="download-case-files"
+            data-cy="download-case-files"><a class="govuk-link" href="/documents/1/bulk-download/case-APP/Q9999/D/21/351062.zip">Download case</a>
+            </p>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
+            <details class="govuk-details">
+                <summary class="govuk-details__summary"><span class="govuk-details__summary-text"> 2 case notes</span>
+                </summary>
+                <div class="govuk-details__text">
+                    <form method="POST" novalidate="novalidate">
+                        <div class="govuk-grid-row">
+                            <div class="govuk-grid-column-two-thirds">
+                                <div class="govuk-form-group govuk-character-count" data-module="govuk-character-count"
+                                data-maxlength="500">
+                                    <textarea class="govuk-textarea govuk-js-character-count" id="comment"
+                                    name="comment" rows="5" aria-describedby="comment-info"></textarea>
+                                    <div id="comment-info" class="govuk-hint govuk-character-count__message">You can enter up to 500 characters</div>
+                                </div>
+                            </div>
+                        </div>
+                        <button type="submit" data-prevent-double-click="true" class="govuk-button govuk-button--secondary govuk-!-margin-bottom-1"
+                        data-module="govuk-button">Add case note</button>
+                    </form>
+                    <div>
+                        <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+                        <section>
+                            <p class="govuk-body govuk-!-margin-bottom-1">A case note you should see.</p>
+                            <p class="govuk-hint govuk-!-margin-bottom-6">11:00am on Tuesday 1 October 2024 by John.Smith</p>
+                            <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+                        </section>
+                        <section>
+                            <p class="govuk-body govuk-!-margin-bottom-1">A case note you should see.</p>
+                            <p class="govuk-hint govuk-!-margin-bottom-6">11:00am on Tuesday 1 October 2024 by John.Smith</p>
+                            <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+                        </section>
+                    </div>
+                </div>
+            </details>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
+            <div class="govuk-accordion" data-module="govuk-accordion" id="accordion-default1">
+                <div class="govuk-accordion__section">
+                    <div class="govuk-accordion__section-header">
+                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-1"> Overview</span></h2>
+                    </div>
+                    <div id="accordion-default1-content-1" class="govuk-accordion__section-content">
+                        <dl class="govuk-summary-list">
+                            <div class="govuk-summary-list__row govuk-summary-list__row--no-actions appeal-lpa-reference"><dt class="govuk-summary-list__key"> Planning application reference</dt>
+                                <dd                                 class="govuk-summary-list__value">48269/APP/2021/1482</dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-appeal-type"><dt class="govuk-summary-list__key"> Appeal type</dt>
+                                <dd class="govuk-summary-list__value">Householder</dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/change-appeal-type/appeal-type"
+                                    data-cy="change-appeal-type">Change<span class="govuk-visually-hidden"> Appeal type</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row govuk-summary-list__row--no-actions appeal-case-procedure"><dt class="govuk-summary-list__key"> Appeal procedure</dt>
+                                <dd class="govuk-summary-list__value">Written</dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-allocation-details"><dt class="govuk-summary-list__key"> Allocation level</dt>
+                                <dd class="govuk-summary-list__value">
+                                    <ul class="govuk-!-margin-0">
+                                        <li>Level: A</li>
+                                        <li>Historic heritage</li>
+                                        <li>Architecture design</li>
+                                    </ul>
+                                </dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/allocation-details/allocation-level"
+                                    data-cy="change-allocation-details">Change<span class="govuk-visually-hidden"> Allocation level</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-linked-appeals"><dt class="govuk-summary-list__key"> Linked appeals</dt>
+                                <dd class="govuk-summary-list__value"><span>No linked appeals</span>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-other-appeals"><dt class="govuk-summary-list__key"> Related appeals</dt>
+                                <dd class="govuk-summary-list__value"><span>No</span>
+                                </dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/other-appeals/add"
+                                    data-cy="add-related-appeals">Add<span class="govuk-visually-hidden"> Related appeals</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-decision"><dt class="govuk-summary-list__key"> Decision</dt>
+                                <dd class="govuk-summary-list__value">Dismissed</dd>
+                            </div>
+                        </dl>
+                    </div>
+                </div>
+                <div class="govuk-accordion__section">
+                    <div class="govuk-accordion__section-header">
+                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-2"> Site</span></h2>
+                    </div>
+                    <div id="accordion-default1-content-2" class="govuk-accordion__section-content">
+                        <dl class="govuk-summary-list">
+                            <div class="govuk-summary-list__row appeal-visit-type"><dt class="govuk-summary-list__key"> Visit type</dt>
+                                <dd class="govuk-summary-list__value">Accompanied</dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/visit-booked?backUrl=%2Fappeals-service%2Fappeal-details%2F1"
+                                    data-cy="change-set-visit-type">Change<span class="govuk-visually-hidden"> Visit type</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Date</dt>
+                                <dd class="govuk-summary-list__value">9 October 2023</dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/visit-booked"
+                                    data-cy="change-site-visit-date">Change<span class="govuk-visually-hidden"> Date</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Start time</dt>
+                                <dd class="govuk-summary-list__value">9:38am</dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/visit-booked"
+                                    data-cy="change-site-visit-start-time">Change<span class="govuk-visually-hidden"> Start time</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> End time</dt>
+                                <dd class="govuk-summary-list__value">10:00am</dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/visit-booked"
+                                    data-cy="change-site-visit-end-time">Change<span class="govuk-visually-hidden"> End time</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-neighbouring-sites-inspector"><dt class="govuk-summary-list__key"> Interested party and neighbour addresses</dt>
+                                <dd                                 class="govuk-summary-list__value">
+                                    <ul class="govuk-list govuk-list--bullet">
+                                        <li>2 Grove Cottage, Shotesham Road, Woodton, Devon, NR35 2ND</li>
+                                    </ul>
+                                    </dd>
+                                    <dd class="govuk-summary-list__actions">
+                                        <ul class="govuk-summary-list__actions-list">
+                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/neighbouring-sites/manage"
+                                                data-cy="manage-neighbouring-sites-inspector">Manage<span class="govuk-visually-hidden"> Interested party and neighbour addresses</span></a>
+                                            </li>
+                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/neighbouring-sites/add/back-office"
+                                                data-cy="add-neighbouring-sites-inspector">Add<span class="govuk-visually-hidden"> Interested party and neighbour addresses</span></a>
+                                            </li>
+                                        </ul>
+                                    </dd>
+                            </div>
+                        </dl>
+                    </div>
+                </div>
+                <div class="govuk-accordion__section">
+                    <div class="govuk-accordion__section-header">
+                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-3"> Timetable</span></h2>
+                    </div>
+                    <div id="accordion-default1-content-3" class="govuk-accordion__section-content">
+                        <dl class="govuk-summary-list appeal-case-timetable">
+                            <div class="govuk-summary-list__row appeal-valid-date"><dt class="govuk-summary-list__key"> Valid date</dt>
+                                <dd class="govuk-summary-list__value">23 May 2023</dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/valid/date"
+                                    data-cy="-valid-date"><span class="govuk-visually-hidden"> Valid date</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-start-date"><dt class="govuk-summary-list__key"> Start date</dt>
+                                <dd class="govuk-summary-list__value">23 May 2023</dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/start-case/change"
+                                    data-cy="change-start-case-date">Change<span class="govuk-visually-hidden"> Start date</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-lpa-questionnaire-due-date"><dt class="govuk-summary-list__key"> LPA questionnaire due</dt>
+                                <dd class="govuk-summary-list__value">11 October 2023</dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-site-visit"><dt class="govuk-summary-list__key"> Site visit</dt>
+                                <dd class="govuk-summary-list__value">
+                                    <ul class="govuk-list govuk-!-margin-top-0 govuk-!-padding-left-0">
+                                        <li>9 October 2023</li>
+                                        <li>9:38am - 10:00am</li>
+                                    </ul>
+                                </dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/manage-visit?backUrl=%2Fappeals-service%2Fappeal-details%2F1"
+                                    data-cy="change-schedule-visit">Change<span class="govuk-visually-hidden"> Site visit</span></a>
+                                </dd>
+                            </div>
+                        </dl>
+                    </div>
+                </div>
+                <div class="govuk-accordion__section">
+                    <div class="govuk-accordion__section-header">
+                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-4"> Documentation</span></h2>
+                    </div>
+                    <div id="accordion-default1-content-4" class="govuk-accordion__section-content">
+                        <table class="govuk-table">
+                            <thead class="govuk-table__head">
+                                <tr class="govuk-table__row">
+                                    <th scope="col" class="govuk-table__header">Documentation</th>
+                                    <th scope="col" class="govuk-table__header">Status</th>
+                                    <th scope="col" class="govuk-table__header">Received</th>
+                                    <th scope="col" class="govuk-table__header govuk-!-text-align-right">Action</th>
+                                </tr>
+                            </thead>
+                            <tbody class="govuk-table__body">
+                                <tr class="govuk-table__row">
+                                    <th scope="row" class="govuk-table__header">Appeal</th>
+                                    <td class="govuk-table__cell">Ready to review</td>
+                                    <td class="govuk-table__cell">2 August 2024</td>
+                                    <td class="govuk-table__cell govuk-!-text-align-right"><a href="/appeals-service/appeal-details/1/appellant-case?backUrl=%2Fappeals-service%2Fappeal-details%2F1"
+                                        data-cy="review-appellant-case" class="govuk-link">Review<span class="govuk-visually-hidden"> appellant case</span></a>
+                                    </td>
+                                </tr>
+                                <tr class="govuk-table__row">
+                                    <th scope="row" class="govuk-table__header">LPA questionnaire</th>
+                                    <td class="govuk-table__cell">Overdue</td>
+                                    <td class="govuk-table__cell">Due by 11 October 2023</td>
+                                    <td class="govuk-table__cell govuk-!-text-align-right"></td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
+                <div class="govuk-accordion__section">
+                    <div class="govuk-accordion__section-header">
+                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-5"> Costs</span></h2>
+                    </div>
+                    <div id="accordion-default1-content-5" class="govuk-accordion__section-content">
+                        <table class="govuk-table">
+                            <thead class="govuk-table__head">
+                                <tr class="govuk-table__row">
+                                    <th scope="col" class="govuk-table__header">Documentation</th>
+                                    <th scope="col" class="govuk-table__header">Status</th>
+                                    <th scope="col" class="govuk-table__header govuk-!-text-align-right">Action</th>
+                                </tr>
+                            </thead>
+                            <tbody class="govuk-table__body">
+                                <tr class="govuk-table__row">
+                                    <th scope="row" class="govuk-table__header appeal-costs-appellant-application-documentation">Appellant application</th>
+                                    <td class="govuk-table__cell appeal-costs-appellant-application-status">No documents available</td>
+                                    <td class="govuk-table__cell appeal-costs-appellant-application-actions govuk-!-text-align-right">
+                                        <ul class="govuk-summary-list__actions-list">
+                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-appellant-application" href="/appeals-service/appeal-details/1/costs/appellant/application/upload-documents/1">Add<span class="govuk-visually-hidden"> Appellant application</span></a>
+                                            </li>
+                                        </ul>
+                                    </td>
+                                </tr>
+                                <tr class="govuk-table__row">
+                                    <th scope="row" class="govuk-table__header appeal-costs-appellant-withdrawal-documentation">Appellant withdrawal</th>
+                                    <td class="govuk-table__cell appeal-costs-appellant-withdrawal-status">No documents available</td>
+                                    <td class="govuk-table__cell appeal-costs-appellant-withdrawal-actions govuk-!-text-align-right">
+                                        <ul class="govuk-summary-list__actions-list">
+                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-appellant-withdrawal" href="/appeals-service/appeal-details/1/costs/appellant/withdrawal/upload-documents/2">Add<span class="govuk-visually-hidden"> Appellant withdrawal</span></a>
+                                            </li>
+                                        </ul>
+                                    </td>
+                                </tr>
+                                <tr class="govuk-table__row">
+                                    <th scope="row" class="govuk-table__header appeal-costs-appellant-correspondence-documentation">Appellant correspondence</th>
+                                    <td class="govuk-table__cell appeal-costs-appellant-correspondence-status">No documents available</td>
+                                    <td class="govuk-table__cell appeal-costs-appellant-correspondence-actions govuk-!-text-align-right">
+                                        <ul class="govuk-summary-list__actions-list">
+                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-appellant-correspondence" href="/appeals-service/appeal-details/1/costs/appellant/correspondence/upload-documents/3">Add<span class="govuk-visually-hidden"> Appellant correspondence</span></a>
+                                            </li>
+                                        </ul>
+                                    </td>
+                                </tr>
+                                <tr class="govuk-table__row">
+                                    <th scope="row" class="govuk-table__header appeal-costs-lpa-application-documentation">LPA application</th>
+                                    <td class="govuk-table__cell appeal-costs-lpa-application-status">No documents available</td>
+                                    <td class="govuk-table__cell appeal-costs-lpa-application-actions govuk-!-text-align-right">
+                                        <ul class="govuk-summary-list__actions-list">
+                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-lpa-application" href="/appeals-service/appeal-details/1/costs/lpa/application/upload-documents/4">Add<span class="govuk-visually-hidden"> LPA application</span></a>
+                                            </li>
+                                        </ul>
+                                    </td>
+                                </tr>
+                                <tr class="govuk-table__row">
+                                    <th scope="row" class="govuk-table__header appeal-costs-lpa-withdrawal-documentation">LPA withdrawal</th>
+                                    <td class="govuk-table__cell appeal-costs-lpa-withdrawal-status">No documents available</td>
+                                    <td class="govuk-table__cell appeal-costs-lpa-withdrawal-actions govuk-!-text-align-right">
+                                        <ul class="govuk-summary-list__actions-list">
+                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-lpa-withdrawal" href="/appeals-service/appeal-details/1/costs/lpa/withdrawal/upload-documents/5">Add<span class="govuk-visually-hidden"> LPA withdrawal</span></a>
+                                            </li>
+                                        </ul>
+                                    </td>
+                                </tr>
+                                <tr class="govuk-table__row">
+                                    <th scope="row" class="govuk-table__header appeal-costs-lpa-correspondence-documentation">LPA correspondence</th>
+                                    <td class="govuk-table__cell appeal-costs-lpa-correspondence-status">No documents available</td>
+                                    <td class="govuk-table__cell appeal-costs-lpa-correspondence-actions govuk-!-text-align-right">
+                                        <ul class="govuk-summary-list__actions-list">
+                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-lpa-correspondence" href="/appeals-service/appeal-details/1/costs/lpa/correspondence/upload-documents/6">Add<span class="govuk-visually-hidden"> LPA correspondence</span></a>
+                                            </li>
+                                        </ul>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
+                <div class="govuk-accordion__section">
+                    <div class="govuk-accordion__section-header">
+                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-6"> Contacts</span></h2>
+                    </div>
+                    <div id="accordion-default1-content-6" class="govuk-accordion__section-content">
+                        <dl class="govuk-summary-list">
+                            <div class="govuk-summary-list__row appeal-appellant"><dt class="govuk-summary-list__key"> Appellant</dt>
+                                <dd class="govuk-summary-list__value">
+                                    <ul class="govuk-list">
+                                        <li>Roger Simmons</li>
+                                        <li>test3@example.com</li>
+                                    </ul>
+                                </dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/service-user/change/appellant"
+                                    data-cy="change-appellant">Change<span class="govuk-visually-hidden"> Appellant</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-agent"><dt class="govuk-summary-list__key"> Agent</dt>
+                                <dd class="govuk-summary-list__value">
+                                    <ul class="govuk-list">
+                                        <li>Fiona Shell</li>
+                                        <li>test2@example.com</li>
+                                    </ul>
+                                </dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/service-user/change/agent"
+                                    data-cy="change-agent">Change<span class="govuk-visually-hidden"> Agent</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-lpa-contact-details"><dt class="govuk-summary-list__key"> LPA</dt>
+                                <dd class="govuk-summary-list__value">
+                                    <ul class="govuk-list">
+                                        <li>Wiltshire Council</li>
+                                        <li>wilt@lpa-email.gov.uk</li>
+                                    </ul>
+                                </dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/change-appeal-details/local-planning-authority"
+                                    data-cy="change-lpa-contact-details">Change<span class="govuk-visually-hidden"> Local planning authority (LPA)</span></a>
+                                </dd>
+                            </div>
+                        </dl>
+                    </div>
+                </div>
+                <div class="govuk-accordion__section">
+                    <div class="govuk-accordion__section-header">
+                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-7"> Team</span></h2>
+                    </div>
+                    <div id="accordion-default1-content-7" class="govuk-accordion__section-content">
+                        <dl class="govuk-summary-list">
+                            <div class="govuk-summary-list__row appeal-case-officer"><dt class="govuk-summary-list__key"> Case officer</dt>
+                                <dd class="govuk-summary-list__value">
+                                    <p class="govuk-body">Not assigned</p>
+                                </dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/assign-case-officer/search-case-officer"
+                                    data-cy="assign-case-officer">Assign<span class="govuk-visually-hidden"> Case officer</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-inspector"><dt class="govuk-summary-list__key"> Inspector</dt>
+                                <dd class="govuk-summary-list__value">
+                                    <p class="govuk-body">Not assigned</p>
+                                </dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/assign-inspector/search-inspector"
+                                    data-cy="assign-inspector">Assign<span class="govuk-visually-hidden"> Inspector</span></a>
+                                </dd>
+                            </div>
+                        </dl>
+                    </div>
+                </div>
+                <div class="govuk-accordion__section">
+                    <div class="govuk-accordion__section-header">
+                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-8"> Case management</span></h2>
+                    </div>
+                    <div id="accordion-default1-content-8" class="govuk-accordion__section-content">
+                        <dl class="govuk-summary-list">
+                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Cross-team correspondence</dt>
+                                <dd                                 class="govuk-summary-list__value">No documents</dd>
+                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/internal-correspondence/cross-team/upload-documents/10"
+                                        data-cy="add-cross-team-correspondence">Add<span class="govuk-visually-hidden"> Cross-team correspondence</span></a>
+                                    </dd>
+                            </div>
+                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Inspector correspondence</dt>
+                                <dd                                 class="govuk-summary-list__value">No documents</dd>
+                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/internal-correspondence/inspector/upload-documents/11"
+                                        data-cy="add-inspector-correspondence">Add<span class="govuk-visually-hidden"> Inspector correspondence</span></a>
+                                    </dd>
+                            </div>
+                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Main party correspondence</dt>
+                                <dd                                 class="govuk-summary-list__value">No documents</dd>
+                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/internal-correspondence/main-party/upload-documents/22"
+                                        data-cy="add-main-party-correspondence">Add<span class="govuk-visually-hidden"> Main party correspondence</span></a>
+                                    </dd>
+                            </div>
+                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Case history</dt>
+                                <dd class="govuk-summary-list__value"></dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/audit" data-cy="view-case-history">View<span class="govuk-visually-hidden"> Case history</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Appeal withdrawal</dt>
+                                <dd class="govuk-summary-list__value"></dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/withdrawal/start"
+                                    data-cy="start-appeal-withdrawal">Start<span class="govuk-visually-hidden"> Appeal withdrawal</span></a>
+                                </dd>
+                            </div>
+                        </dl>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div id="case-details-cancel-section">
+        <h3 class="govuk-heading-m">Cancel appeal</h3>
+        <div>
+            <p><a id="cancelCase" class="govuk-body govuk-link" href="/appeals-service/appeal-details/1/cancel">Cancel appeal</a>
+            </p>
+        </div>
+    </div>
+</main>"
+`;
+
+exports[`appeal-details GET /:appealId Linked appeals should render the received appeal details for a valid appealId with single linked/other appeals 1`] = `
+"<main class="govuk-main-wrapper" id="main-content">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Appeal 351062</span>
+            <h1 class="govuk-heading-xl govuk-!-margin-bottom-3">Case details</h1>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full"><strong class="govuk-tag govuk-tag--grey pins-status-tag--full-width">Received appeal</strong>
+            <strong             class="govuk-tag govuk-tag--grey govuk-!-margin-left-1 govuk-!-margin-bottom-4"></strong>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
+            <dl class="govuk-summary-list pins-summary-list--no-border">
+                <div class="govuk-summary-list__row appeal-case-officer"><dt class="govuk-summary-list__key"> Case officer</dt>
+                    <dd class="govuk-summary-list__value">
+                        <p class="govuk-body">Not assigned</p>
+                    </dd>
+                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/assign-case-officer/search-case-officer"
+                        data-cy="assign-case-officer-name">Assign<span class="govuk-visually-hidden"> Case officer</span></a>
+                    </dd>
+                </div>
+                <div class="govuk-summary-list__row appeal-site-address"><dt class="govuk-summary-list__key"> Site address</dt>
+                    <dd class="govuk-summary-list__value">21 The Pavement, Wandsworth, SW4 0HY</dd>
+                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/site-address/change/1?backUrl=%2Fappeals-service%2Fappeal-details%2F2"
+                        data-cy="change-site-address">Change<span class="govuk-visually-hidden"> Site address</span></a>
+                    </dd>
+                </div>
+                <div class="govuk-summary-list__row appeal-local-planning-authority"><dt class="govuk-summary-list__key"> LPA</dt>
+                    <dd class="govuk-summary-list__value">Wiltshire Council</dd>
+                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/change-appeal-details/local-planning-authority"
+                        data-cy="change-local-planning-authority">Change<span class="govuk-visually-hidden"> LPA</span></a>
+                    </dd>
+                </div>
+            </dl>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
+            <p class="govuk-body govuk-!-margin-bottom-6" id="download-case-files"
+            data-cy="download-case-files"><a class="govuk-link" href="/documents/2/bulk-download/case-APP/Q9999/D/21/351062.zip">Download case</a>
+            </p>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
+            <details class="govuk-details">
+                <summary class="govuk-details__summary"><span class="govuk-details__summary-text"> 2 case notes</span>
+                </summary>
+                <div class="govuk-details__text">
+                    <form method="POST" novalidate="novalidate">
+                        <div class="govuk-grid-row">
+                            <div class="govuk-grid-column-two-thirds">
+                                <div class="govuk-form-group govuk-character-count" data-module="govuk-character-count"
+                                data-maxlength="500">
+                                    <textarea class="govuk-textarea govuk-js-character-count" id="comment"
+                                    name="comment" rows="5" aria-describedby="comment-info"></textarea>
+                                    <div id="comment-info" class="govuk-hint govuk-character-count__message">You can enter up to 500 characters</div>
+                                </div>
+                            </div>
+                        </div>
+                        <button type="submit" data-prevent-double-click="true" class="govuk-button govuk-button--secondary govuk-!-margin-bottom-1"
+                        data-module="govuk-button">Add case note</button>
+                    </form>
+                    <div>
+                        <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+                        <section>
+                            <p class="govuk-body govuk-!-margin-bottom-1">A case note you should see.</p>
+                            <p class="govuk-hint govuk-!-margin-bottom-6">11:00am on Tuesday 1 October 2024 by John.Smith</p>
+                            <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+                        </section>
+                        <section>
+                            <p class="govuk-body govuk-!-margin-bottom-1">A case note you should see.</p>
+                            <p class="govuk-hint govuk-!-margin-bottom-6">11:00am on Tuesday 1 October 2024 by John.Smith</p>
+                            <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+                        </section>
+                    </div>
+                </div>
+            </details>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
+            <div class="govuk-accordion" data-module="govuk-accordion" id="accordion-default2">
+                <div class="govuk-accordion__section">
+                    <div class="govuk-accordion__section-header">
+                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default2-heading-1"> Overview</span></h2>
+                    </div>
+                    <div id="accordion-default2-content-1" class="govuk-accordion__section-content">
+                        <dl class="govuk-summary-list">
+                            <div class="govuk-summary-list__row govuk-summary-list__row--no-actions appeal-lpa-reference"><dt class="govuk-summary-list__key"> Planning application reference</dt>
+                                <dd                                 class="govuk-summary-list__value">48269/APP/2021/1482</dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-appeal-type"><dt class="govuk-summary-list__key"> Appeal type</dt>
+                                <dd class="govuk-summary-list__value">Householder</dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/change-appeal-type/appeal-type"
+                                    data-cy="change-appeal-type">Change<span class="govuk-visually-hidden"> Appeal type</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row govuk-summary-list__row--no-actions appeal-case-procedure"><dt class="govuk-summary-list__key"> Appeal procedure</dt>
+                                <dd class="govuk-summary-list__value">Written</dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-allocation-details"><dt class="govuk-summary-list__key"> Allocation level</dt>
+                                <dd class="govuk-summary-list__value">
+                                    <ul class="govuk-!-margin-0">
+                                        <li>Level: A</li>
+                                        <li>Historic heritage</li>
+                                        <li>Architecture design</li>
+                                    </ul>
+                                </dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/allocation-details/allocation-level"
+                                    data-cy="change-allocation-details">Change<span class="govuk-visually-hidden"> Allocation level</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-linked-appeals"><dt class="govuk-summary-list__key"> Linked appeals</dt>
+                                <dd class="govuk-summary-list__value"><a href="/appeals-service/appeal-details/1" class="govuk-link" data-cy="linked-appeal-725284"
+                                    aria-label="Appeal 7 2 5 2 8 4">725284</a>
+                                </dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/linked-appeals/manage"
+                                    data-cy="manage-linked-appeals">Manage<span class="govuk-visually-hidden"> Linked appeals</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-other-appeals"><dt class="govuk-summary-list__key"> Related appeals</dt>
+                                <dd class="govuk-summary-list__value">
+                                    <ul class="govuk-list govuk-list--bullet">
+                                        <li><a href="/appeals-service/appeal-details/3" class="govuk-link" data-cy="related-appeal-765413"
+                                            aria-label="Appeal 7 6 5 4 1 3">765413</a>
+                                        </li>
+                                    </ul>
+                                </dd>
+                                <dd class="govuk-summary-list__actions">
+                                    <ul class="govuk-summary-list__actions-list">
+                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/2/other-appeals/manage"
+                                            data-cy="manage-related-appeals">Manage<span class="govuk-visually-hidden"> Related appeals</span></a>
+                                        </li>
+                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/2/other-appeals/add"
+                                            data-cy="add-related-appeals">Add<span class="govuk-visually-hidden"> Related appeals</span></a>
+                                        </li>
+                                    </ul>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-decision"><dt class="govuk-summary-list__key"> Decision</dt>
+                                <dd class="govuk-summary-list__value">Dismissed</dd>
+                            </div>
+                        </dl>
+                    </div>
+                </div>
+                <div class="govuk-accordion__section">
+                    <div class="govuk-accordion__section-header">
+                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default2-heading-2"> Site</span></h2>
+                    </div>
+                    <div id="accordion-default2-content-2" class="govuk-accordion__section-content">
+                        <dl class="govuk-summary-list">
+                            <div class="govuk-summary-list__row appeal-visit-type"><dt class="govuk-summary-list__key"> Visit type</dt>
+                                <dd class="govuk-summary-list__value">Accompanied</dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/site-visit/visit-booked?backUrl=%2Fappeals-service%2Fappeal-details%2F2"
+                                    data-cy="change-set-visit-type">Change<span class="govuk-visually-hidden"> Visit type</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Date</dt>
+                                <dd class="govuk-summary-list__value">9 October 2023</dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/site-visit/visit-booked"
+                                    data-cy="change-site-visit-date">Change<span class="govuk-visually-hidden"> Date</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Start time</dt>
+                                <dd class="govuk-summary-list__value">9:38am</dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/site-visit/visit-booked"
+                                    data-cy="change-site-visit-start-time">Change<span class="govuk-visually-hidden"> Start time</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> End time</dt>
+                                <dd class="govuk-summary-list__value">10:00am</dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/site-visit/visit-booked"
+                                    data-cy="change-site-visit-end-time">Change<span class="govuk-visually-hidden"> End time</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-neighbouring-sites-inspector"><dt class="govuk-summary-list__key"> Interested party and neighbour addresses</dt>
+                                <dd                                 class="govuk-summary-list__value">
+                                    <ul class="govuk-list govuk-list--bullet">
+                                        <li>2 Grove Cottage, Shotesham Road, Woodton, Devon, NR35 2ND</li>
+                                    </ul>
+                                    </dd>
+                                    <dd class="govuk-summary-list__actions">
+                                        <ul class="govuk-summary-list__actions-list">
+                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/2/neighbouring-sites/manage"
+                                                data-cy="manage-neighbouring-sites-inspector">Manage<span class="govuk-visually-hidden"> Interested party and neighbour addresses</span></a>
+                                            </li>
+                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/2/neighbouring-sites/add/back-office"
+                                                data-cy="add-neighbouring-sites-inspector">Add<span class="govuk-visually-hidden"> Interested party and neighbour addresses</span></a>
+                                            </li>
+                                        </ul>
+                                    </dd>
+                            </div>
+                        </dl>
+                    </div>
+                </div>
+                <div class="govuk-accordion__section">
+                    <div class="govuk-accordion__section-header">
+                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default2-heading-3"> Timetable</span></h2>
+                    </div>
+                    <div id="accordion-default2-content-3" class="govuk-accordion__section-content">
+                        <dl class="govuk-summary-list appeal-case-timetable">
+                            <div class="govuk-summary-list__row appeal-valid-date"><dt class="govuk-summary-list__key"> Valid date</dt>
+                                <dd class="govuk-summary-list__value">23 May 2023</dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/appellant-case/valid/date"
+                                    data-cy="-valid-date"><span class="govuk-visually-hidden"> Valid date</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-start-date"><dt class="govuk-summary-list__key"> Start date</dt>
+                                <dd class="govuk-summary-list__value">23 May 2023</dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/start-case/change"
+                                    data-cy="change-start-case-date">Change<span class="govuk-visually-hidden"> Start date</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-lpa-questionnaire-due-date"><dt class="govuk-summary-list__key"> LPA questionnaire due</dt>
+                                <dd class="govuk-summary-list__value">11 October 2023</dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-site-visit"><dt class="govuk-summary-list__key"> Site visit</dt>
+                                <dd class="govuk-summary-list__value">
+                                    <ul class="govuk-list govuk-!-margin-top-0 govuk-!-padding-left-0">
+                                        <li>9 October 2023</li>
+                                        <li>9:38am - 10:00am</li>
+                                    </ul>
+                                </dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/site-visit/manage-visit?backUrl=%2Fappeals-service%2Fappeal-details%2F2"
+                                    data-cy="change-schedule-visit">Change<span class="govuk-visually-hidden"> Site visit</span></a>
+                                </dd>
+                            </div>
+                        </dl>
+                    </div>
+                </div>
+                <div class="govuk-accordion__section">
+                    <div class="govuk-accordion__section-header">
+                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default2-heading-4"> Documentation</span></h2>
+                    </div>
+                    <div id="accordion-default2-content-4" class="govuk-accordion__section-content">
+                        <table class="govuk-table">
+                            <thead class="govuk-table__head">
+                                <tr class="govuk-table__row">
+                                    <th scope="col" class="govuk-table__header">Documentation</th>
+                                    <th scope="col" class="govuk-table__header">Status</th>
+                                    <th scope="col" class="govuk-table__header">Received</th>
+                                    <th scope="col" class="govuk-table__header govuk-!-text-align-right">Action</th>
+                                </tr>
+                            </thead>
+                            <tbody class="govuk-table__body">
+                                <tr class="govuk-table__row">
+                                    <th scope="row" class="govuk-table__header">Appeal</th>
+                                    <td class="govuk-table__cell">Ready to review</td>
+                                    <td class="govuk-table__cell">2 August 2024</td>
+                                    <td class="govuk-table__cell govuk-!-text-align-right"><a href="/appeals-service/appeal-details/2/appellant-case?backUrl=%2Fappeals-service%2Fappeal-details%2F2"
+                                        data-cy="review-appellant-case" class="govuk-link">Review<span class="govuk-visually-hidden"> appellant case</span></a>
+                                    </td>
+                                </tr>
+                                <tr class="govuk-table__row">
+                                    <th scope="row" class="govuk-table__header">LPA questionnaire</th>
+                                    <td class="govuk-table__cell">Overdue</td>
+                                    <td class="govuk-table__cell">Due by 11 October 2023</td>
+                                    <td class="govuk-table__cell govuk-!-text-align-right"></td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
+                <div class="govuk-accordion__section">
+                    <div class="govuk-accordion__section-header">
+                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default2-heading-5"> Costs</span></h2>
+                    </div>
+                    <div id="accordion-default2-content-5" class="govuk-accordion__section-content">
+                        <table class="govuk-table">
+                            <thead class="govuk-table__head">
+                                <tr class="govuk-table__row">
+                                    <th scope="col" class="govuk-table__header">Documentation</th>
+                                    <th scope="col" class="govuk-table__header">Status</th>
+                                    <th scope="col" class="govuk-table__header govuk-!-text-align-right">Action</th>
+                                </tr>
+                            </thead>
+                            <tbody class="govuk-table__body">
+                                <tr class="govuk-table__row">
+                                    <th scope="row" class="govuk-table__header appeal-costs-appellant-application-documentation">Appellant application</th>
+                                    <td class="govuk-table__cell appeal-costs-appellant-application-status">No documents available</td>
+                                    <td class="govuk-table__cell appeal-costs-appellant-application-actions govuk-!-text-align-right">
+                                        <ul class="govuk-summary-list__actions-list">
+                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-appellant-application" href="/appeals-service/appeal-details/2/costs/appellant/application/upload-documents/1">Add<span class="govuk-visually-hidden"> Appellant application</span></a>
+                                            </li>
+                                        </ul>
+                                    </td>
+                                </tr>
+                                <tr class="govuk-table__row">
+                                    <th scope="row" class="govuk-table__header appeal-costs-appellant-withdrawal-documentation">Appellant withdrawal</th>
+                                    <td class="govuk-table__cell appeal-costs-appellant-withdrawal-status">No documents available</td>
+                                    <td class="govuk-table__cell appeal-costs-appellant-withdrawal-actions govuk-!-text-align-right">
+                                        <ul class="govuk-summary-list__actions-list">
+                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-appellant-withdrawal" href="/appeals-service/appeal-details/2/costs/appellant/withdrawal/upload-documents/2">Add<span class="govuk-visually-hidden"> Appellant withdrawal</span></a>
+                                            </li>
+                                        </ul>
+                                    </td>
+                                </tr>
+                                <tr class="govuk-table__row">
+                                    <th scope="row" class="govuk-table__header appeal-costs-appellant-correspondence-documentation">Appellant correspondence</th>
+                                    <td class="govuk-table__cell appeal-costs-appellant-correspondence-status">No documents available</td>
+                                    <td class="govuk-table__cell appeal-costs-appellant-correspondence-actions govuk-!-text-align-right">
+                                        <ul class="govuk-summary-list__actions-list">
+                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-appellant-correspondence" href="/appeals-service/appeal-details/2/costs/appellant/correspondence/upload-documents/3">Add<span class="govuk-visually-hidden"> Appellant correspondence</span></a>
+                                            </li>
+                                        </ul>
+                                    </td>
+                                </tr>
+                                <tr class="govuk-table__row">
+                                    <th scope="row" class="govuk-table__header appeal-costs-lpa-application-documentation">LPA application</th>
+                                    <td class="govuk-table__cell appeal-costs-lpa-application-status">No documents available</td>
+                                    <td class="govuk-table__cell appeal-costs-lpa-application-actions govuk-!-text-align-right">
+                                        <ul class="govuk-summary-list__actions-list">
+                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-lpa-application" href="/appeals-service/appeal-details/2/costs/lpa/application/upload-documents/4">Add<span class="govuk-visually-hidden"> LPA application</span></a>
+                                            </li>
+                                        </ul>
+                                    </td>
+                                </tr>
+                                <tr class="govuk-table__row">
+                                    <th scope="row" class="govuk-table__header appeal-costs-lpa-withdrawal-documentation">LPA withdrawal</th>
+                                    <td class="govuk-table__cell appeal-costs-lpa-withdrawal-status">No documents available</td>
+                                    <td class="govuk-table__cell appeal-costs-lpa-withdrawal-actions govuk-!-text-align-right">
+                                        <ul class="govuk-summary-list__actions-list">
+                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-lpa-withdrawal" href="/appeals-service/appeal-details/2/costs/lpa/withdrawal/upload-documents/5">Add<span class="govuk-visually-hidden"> LPA withdrawal</span></a>
+                                            </li>
+                                        </ul>
+                                    </td>
+                                </tr>
+                                <tr class="govuk-table__row">
+                                    <th scope="row" class="govuk-table__header appeal-costs-lpa-correspondence-documentation">LPA correspondence</th>
+                                    <td class="govuk-table__cell appeal-costs-lpa-correspondence-status">No documents available</td>
+                                    <td class="govuk-table__cell appeal-costs-lpa-correspondence-actions govuk-!-text-align-right">
+                                        <ul class="govuk-summary-list__actions-list">
+                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-lpa-correspondence" href="/appeals-service/appeal-details/2/costs/lpa/correspondence/upload-documents/6">Add<span class="govuk-visually-hidden"> LPA correspondence</span></a>
+                                            </li>
+                                        </ul>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
+                <div class="govuk-accordion__section">
+                    <div class="govuk-accordion__section-header">
+                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default2-heading-6"> Contacts</span></h2>
+                    </div>
+                    <div id="accordion-default2-content-6" class="govuk-accordion__section-content">
+                        <dl class="govuk-summary-list">
+                            <div class="govuk-summary-list__row appeal-appellant"><dt class="govuk-summary-list__key"> Appellant</dt>
+                                <dd class="govuk-summary-list__value">
+                                    <ul class="govuk-list">
+                                        <li>Roger Simmons</li>
+                                        <li>test3@example.com</li>
+                                    </ul>
+                                </dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/service-user/change/appellant"
+                                    data-cy="change-appellant">Change<span class="govuk-visually-hidden"> Appellant</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-agent"><dt class="govuk-summary-list__key"> Agent</dt>
+                                <dd class="govuk-summary-list__value">
+                                    <ul class="govuk-list">
+                                        <li>Fiona Shell</li>
+                                        <li>test2@example.com</li>
+                                    </ul>
+                                </dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/service-user/change/agent"
+                                    data-cy="change-agent">Change<span class="govuk-visually-hidden"> Agent</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-lpa-contact-details"><dt class="govuk-summary-list__key"> LPA</dt>
+                                <dd class="govuk-summary-list__value">
+                                    <ul class="govuk-list">
+                                        <li>Wiltshire Council</li>
+                                        <li>wilt@lpa-email.gov.uk</li>
+                                    </ul>
+                                </dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/change-appeal-details/local-planning-authority"
+                                    data-cy="change-lpa-contact-details">Change<span class="govuk-visually-hidden"> Local planning authority (LPA)</span></a>
+                                </dd>
+                            </div>
+                        </dl>
+                    </div>
+                </div>
+                <div class="govuk-accordion__section">
+                    <div class="govuk-accordion__section-header">
+                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default2-heading-7"> Team</span></h2>
+                    </div>
+                    <div id="accordion-default2-content-7" class="govuk-accordion__section-content">
+                        <dl class="govuk-summary-list">
+                            <div class="govuk-summary-list__row appeal-case-officer"><dt class="govuk-summary-list__key"> Case officer</dt>
+                                <dd class="govuk-summary-list__value">
+                                    <p class="govuk-body">Not assigned</p>
+                                </dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/assign-case-officer/search-case-officer"
+                                    data-cy="assign-case-officer">Assign<span class="govuk-visually-hidden"> Case officer</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-inspector"><dt class="govuk-summary-list__key"> Inspector</dt>
+                                <dd class="govuk-summary-list__value">
+                                    <p class="govuk-body">Not assigned</p>
+                                </dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/assign-inspector/search-inspector"
+                                    data-cy="assign-inspector">Assign<span class="govuk-visually-hidden"> Inspector</span></a>
+                                </dd>
+                            </div>
+                        </dl>
+                    </div>
+                </div>
+                <div class="govuk-accordion__section">
+                    <div class="govuk-accordion__section-header">
+                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default2-heading-8"> Case management</span></h2>
+                    </div>
+                    <div id="accordion-default2-content-8" class="govuk-accordion__section-content">
+                        <dl class="govuk-summary-list">
+                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Cross-team correspondence</dt>
+                                <dd                                 class="govuk-summary-list__value">No documents</dd>
+                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/internal-correspondence/cross-team/upload-documents/10"
+                                        data-cy="add-cross-team-correspondence">Add<span class="govuk-visually-hidden"> Cross-team correspondence</span></a>
+                                    </dd>
+                            </div>
+                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Inspector correspondence</dt>
+                                <dd                                 class="govuk-summary-list__value">No documents</dd>
+                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/internal-correspondence/inspector/upload-documents/11"
+                                        data-cy="add-inspector-correspondence">Add<span class="govuk-visually-hidden"> Inspector correspondence</span></a>
+                                    </dd>
+                            </div>
+                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Main party correspondence</dt>
+                                <dd                                 class="govuk-summary-list__value">No documents</dd>
+                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/internal-correspondence/main-party/upload-documents/22"
+                                        data-cy="add-main-party-correspondence">Add<span class="govuk-visually-hidden"> Main party correspondence</span></a>
+                                    </dd>
+                            </div>
+                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Case history</dt>
+                                <dd class="govuk-summary-list__value"></dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/audit" data-cy="view-case-history">View<span class="govuk-visually-hidden"> Case history</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Appeal withdrawal</dt>
+                                <dd class="govuk-summary-list__value"></dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/withdrawal/start"
+                                    data-cy="start-appeal-withdrawal">Start<span class="govuk-visually-hidden"> Appeal withdrawal</span></a>
+                                </dd>
+                            </div>
+                        </dl>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div id="case-details-cancel-section">
+        <h3 class="govuk-heading-m">Cancel appeal</h3>
+        <div>
+            <p><a id="cancelCase" class="govuk-body govuk-link" href="/appeals-service/appeal-details/2/cancel">Cancel appeal</a>
+            </p>
+        </div>
+    </div>
+</main>"
+`;
+
 exports[`appeal-details GET /:appealId Notification banners Important banners residential units banner should render a "Add number of residential units" important notification banner a link to add residential units when numberOfResidencesNetChange has not been added 1`] = `
 "<div class="govuk-notification-banner govuk-!-margin-bottom-5" role="region"
 aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner"
@@ -1001,6 +5974,13 @@ exports[`appeal-details GET /:appealId Notification banners Important banners sh
             </div>
         </div>
     </div>
+    <div id="case-details-cancel-section">
+        <h3 class="govuk-heading-m">Cancel appeal</h3>
+        <div>
+            <p><a id="cancelCase" class="govuk-body govuk-link" href="/appeals-service/appeal-details/2/cancel">Cancel appeal</a>
+            </p>
+        </div>
+    </div>
 </main>"
 `;
 
@@ -1523,840 +6503,6 @@ exports[`appeal-details GET /:appealId Timetable for a child appeal should not c
 </dl>"
 `;
 
-exports[`appeal-details GET /:appealId should not render a "Appeal valid" notification banner when status is "READY_TO_START" and appeal is a linked child appeal 1`] = `
-"<main class="govuk-main-wrapper" id="main-content">
-    <div class="govuk-grid-row">
-        <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Appeal 351062</span>
-            <h1 class="govuk-heading-xl govuk-!-margin-bottom-3">Case details</h1>
-        </div>
-    </div>
-    <div class="govuk-grid-row">
-        <div class="govuk-grid-column-full"><strong class="govuk-tag govuk-tag--green pins-status-tag--full-width">Ready to start</strong>
-        </div>
-    </div>
-    <div class="govuk-grid-row">
-        <div class="govuk-grid-column-full">
-            <dl class="govuk-summary-list pins-summary-list--no-border">
-                <div class="govuk-summary-list__row appeal-case-officer"><dt class="govuk-summary-list__key"> Case officer</dt>
-                    <dd class="govuk-summary-list__value">
-                        <p class="govuk-body">Not assigned</p>
-                    </dd>
-                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/assign-case-officer/search-case-officer"
-                        data-cy="assign-case-officer-name">Assign<span class="govuk-visually-hidden"> Case officer</span></a>
-                    </dd>
-                </div>
-                <div class="govuk-summary-list__row appeal-site-address"><dt class="govuk-summary-list__key"> Site address</dt>
-                    <dd class="govuk-summary-list__value">21 The Pavement, Wandsworth, SW4 0HY</dd>
-                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/site-address/change/1?backUrl=%2Fappeals-service%2Fappeal-details%2F2"
-                        data-cy="change-site-address">Change<span class="govuk-visually-hidden"> Site address</span></a>
-                    </dd>
-                </div>
-                <div class="govuk-summary-list__row appeal-local-planning-authority"><dt class="govuk-summary-list__key"> LPA</dt>
-                    <dd class="govuk-summary-list__value">Wiltshire Council</dd>
-                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/change-appeal-details/local-planning-authority"
-                        data-cy="change-local-planning-authority">Change<span class="govuk-visually-hidden"> LPA</span></a>
-                    </dd>
-                </div>
-            </dl>
-        </div>
-    </div>
-    <div class="govuk-grid-row">
-        <div class="govuk-grid-column-full">
-            <p class="govuk-body govuk-!-margin-bottom-6" id="download-case-files"
-            data-cy="download-case-files"><a class="govuk-link" href="/documents/2/bulk-download/case-APP/Q9999/D/21/351062.zip">Download case</a>
-            </p>
-        </div>
-    </div>
-    <div class="govuk-grid-row">
-        <div class="govuk-grid-column-full">
-            <details class="govuk-details">
-                <summary class="govuk-details__summary"><span class="govuk-details__summary-text"> 2 case notes</span>
-                </summary>
-                <div class="govuk-details__text">
-                    <form method="POST" novalidate="novalidate">
-                        <div class="govuk-grid-row">
-                            <div class="govuk-grid-column-two-thirds">
-                                <div class="govuk-form-group govuk-character-count" data-module="govuk-character-count"
-                                data-maxlength="500">
-                                    <textarea class="govuk-textarea govuk-js-character-count" id="comment"
-                                    name="comment" rows="5" aria-describedby="comment-info"></textarea>
-                                    <div id="comment-info" class="govuk-hint govuk-character-count__message">You can enter up to 500 characters</div>
-                                </div>
-                            </div>
-                        </div>
-                        <button type="submit" data-prevent-double-click="true" class="govuk-button govuk-button--secondary govuk-!-margin-bottom-1"
-                        data-module="govuk-button">Add case note</button>
-                    </form>
-                    <div>
-                        <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
-                        <section>
-                            <p class="govuk-body govuk-!-margin-bottom-1">A case note you should see.</p>
-                            <p class="govuk-hint govuk-!-margin-bottom-6">11:00am on Tuesday 1 October 2024 by John.Smith</p>
-                            <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
-                        </section>
-                        <section>
-                            <p class="govuk-body govuk-!-margin-bottom-1">A case note you should see.</p>
-                            <p class="govuk-hint govuk-!-margin-bottom-6">11:00am on Tuesday 1 October 2024 by John.Smith</p>
-                            <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
-                        </section>
-                    </div>
-                </div>
-            </details>
-        </div>
-    </div>
-    <div class="govuk-grid-row">
-        <div class="govuk-grid-column-full">
-            <div class="govuk-accordion" data-module="govuk-accordion" id="accordion-default2">
-                <div class="govuk-accordion__section">
-                    <div class="govuk-accordion__section-header">
-                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default2-heading-1"> Overview</span></h2>
-                    </div>
-                    <div id="accordion-default2-content-1" class="govuk-accordion__section-content">
-                        <dl class="govuk-summary-list">
-                            <div class="govuk-summary-list__row govuk-summary-list__row--no-actions appeal-lpa-reference"><dt class="govuk-summary-list__key"> Planning application reference</dt>
-                                <dd                                 class="govuk-summary-list__value">48269/APP/2021/1482</dd>
-                            </div>
-                            <div class="govuk-summary-list__row appeal-appeal-type"><dt class="govuk-summary-list__key"> Appeal type</dt>
-                                <dd class="govuk-summary-list__value">Householder</dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/change-appeal-type/appeal-type"
-                                    data-cy="change-appeal-type">Change<span class="govuk-visually-hidden"> Appeal type</span></a>
-                                </dd>
-                            </div>
-                            <div class="govuk-summary-list__row govuk-summary-list__row--no-actions appeal-case-procedure"><dt class="govuk-summary-list__key"> Appeal procedure</dt>
-                                <dd class="govuk-summary-list__value">Written</dd>
-                            </div>
-                            <div class="govuk-summary-list__row appeal-allocation-details"><dt class="govuk-summary-list__key"> Allocation level</dt>
-                                <dd class="govuk-summary-list__value">
-                                    <ul class="govuk-!-margin-0">
-                                        <li>Level: A</li>
-                                        <li>Historic heritage</li>
-                                        <li>Architecture design</li>
-                                    </ul>
-                                </dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/allocation-details/allocation-level"
-                                    data-cy="change-allocation-details">Change<span class="govuk-visually-hidden"> Allocation level</span></a>
-                                </dd>
-                            </div>
-                            <div class="govuk-summary-list__row appeal-linked-appeals"><dt class="govuk-summary-list__key"> Linked appeals</dt>
-                                <dd class="govuk-summary-list__value"><span>No linked appeals</span>
-                                </dd>
-                            </div>
-                            <div class="govuk-summary-list__row appeal-other-appeals"><dt class="govuk-summary-list__key"> Related appeals</dt>
-                                <dd class="govuk-summary-list__value"><span>No</span>
-                                </dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/other-appeals/add"
-                                    data-cy="add-related-appeals">Add<span class="govuk-visually-hidden"> Related appeals</span></a>
-                                </dd>
-                            </div>
-                            <div class="govuk-summary-list__row appeal-decision"><dt class="govuk-summary-list__key"> Decision</dt>
-                                <dd class="govuk-summary-list__value">Dismissed</dd>
-                            </div>
-                        </dl>
-                    </div>
-                </div>
-                <div class="govuk-accordion__section">
-                    <div class="govuk-accordion__section-header">
-                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default2-heading-2"> Timetable</span></h2>
-                    </div>
-                    <div id="accordion-default2-content-2" class="govuk-accordion__section-content">
-                        <dl class="govuk-summary-list appeal-case-timetable">
-                            <div class="govuk-summary-list__row appeal-valid-date"><dt class="govuk-summary-list__key"> Valid date</dt>
-                                <dd class="govuk-summary-list__value">23 May 2023</dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/appellant-case/valid/date"
-                                    data-cy="-valid-date"><span class="govuk-visually-hidden"> Valid date</span></a>
-                                </dd>
-                            </div>
-                            <div class="govuk-summary-list__row appeal-start-date"><dt class="govuk-summary-list__key"> Start date</dt>
-                                <dd class="govuk-summary-list__value">23 May 2023</dd>
-                            </div>
-                            <div class="govuk-summary-list__row appeal-lpa-questionnaire-due-date"><dt class="govuk-summary-list__key"> LPA questionnaire due</dt>
-                                <dd class="govuk-summary-list__value">11 October 2023</dd>
-                            </div>
-                            <div class="govuk-summary-list__row appeal-site-visit"><dt class="govuk-summary-list__key"> Site visit</dt>
-                                <dd class="govuk-summary-list__value">
-                                    <ul class="govuk-list govuk-!-margin-top-0 govuk-!-padding-left-0">
-                                        <li>9 October 2023</li>
-                                        <li>9:38am - 10:00am</li>
-                                    </ul>
-                                </dd>
-                            </div>
-                        </dl>
-                    </div>
-                </div>
-                <div class="govuk-accordion__section">
-                    <div class="govuk-accordion__section-header">
-                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default2-heading-3"> Documentation</span></h2>
-                    </div>
-                    <div id="accordion-default2-content-3" class="govuk-accordion__section-content">
-                        <table class="govuk-table">
-                            <thead class="govuk-table__head">
-                                <tr class="govuk-table__row">
-                                    <th scope="col" class="govuk-table__header">Documentation</th>
-                                    <th scope="col" class="govuk-table__header">Status</th>
-                                    <th scope="col" class="govuk-table__header">Received</th>
-                                    <th scope="col" class="govuk-table__header govuk-!-text-align-right">Action</th>
-                                </tr>
-                            </thead>
-                            <tbody class="govuk-table__body">
-                                <tr class="govuk-table__row">
-                                    <th scope="row" class="govuk-table__header">Appeal</th>
-                                    <td class="govuk-table__cell">Ready to review</td>
-                                    <td class="govuk-table__cell">2 August 2024</td>
-                                    <td class="govuk-table__cell govuk-!-text-align-right"><a href="/appeals-service/appeal-details/2/appellant-case?backUrl=%2Fappeals-service%2Fappeal-details%2F2"
-                                        data-cy="review-appellant-case" class="govuk-link">Review<span class="govuk-visually-hidden"> appellant case</span></a>
-                                    </td>
-                                </tr>
-                                <tr class="govuk-table__row">
-                                    <th scope="row" class="govuk-table__header">LPA questionnaire</th>
-                                    <td class="govuk-table__cell">Overdue</td>
-                                    <td class="govuk-table__cell">Due by 11 October 2023</td>
-                                    <td class="govuk-table__cell govuk-!-text-align-right"></td>
-                                </tr>
-                            </tbody>
-                        </table>
-                    </div>
-                </div>
-                <div class="govuk-accordion__section">
-                    <div class="govuk-accordion__section-header">
-                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default2-heading-4"> Costs</span></h2>
-                    </div>
-                    <div id="accordion-default2-content-4" class="govuk-accordion__section-content">
-                        <table class="govuk-table">
-                            <thead class="govuk-table__head">
-                                <tr class="govuk-table__row">
-                                    <th scope="col" class="govuk-table__header">Documentation</th>
-                                    <th scope="col" class="govuk-table__header">Status</th>
-                                    <th scope="col" class="govuk-table__header govuk-!-text-align-right">Action</th>
-                                </tr>
-                            </thead>
-                            <tbody class="govuk-table__body">
-                                <tr class="govuk-table__row">
-                                    <th scope="row" class="govuk-table__header appeal-costs-appellant-application-documentation">Appellant application</th>
-                                    <td class="govuk-table__cell appeal-costs-appellant-application-status">No documents available</td>
-                                    <td class="govuk-table__cell appeal-costs-appellant-application-actions govuk-!-text-align-right">
-                                        <ul class="govuk-summary-list__actions-list">
-                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-appellant-application" href="/appeals-service/appeal-details/2/costs/appellant/application/upload-documents/1">Add<span class="govuk-visually-hidden"> Appellant application</span></a>
-                                            </li>
-                                        </ul>
-                                    </td>
-                                </tr>
-                                <tr class="govuk-table__row">
-                                    <th scope="row" class="govuk-table__header appeal-costs-appellant-withdrawal-documentation">Appellant withdrawal</th>
-                                    <td class="govuk-table__cell appeal-costs-appellant-withdrawal-status">No documents available</td>
-                                    <td class="govuk-table__cell appeal-costs-appellant-withdrawal-actions govuk-!-text-align-right">
-                                        <ul class="govuk-summary-list__actions-list">
-                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-appellant-withdrawal" href="/appeals-service/appeal-details/2/costs/appellant/withdrawal/upload-documents/2">Add<span class="govuk-visually-hidden"> Appellant withdrawal</span></a>
-                                            </li>
-                                        </ul>
-                                    </td>
-                                </tr>
-                                <tr class="govuk-table__row">
-                                    <th scope="row" class="govuk-table__header appeal-costs-appellant-correspondence-documentation">Appellant correspondence</th>
-                                    <td class="govuk-table__cell appeal-costs-appellant-correspondence-status">No documents available</td>
-                                    <td class="govuk-table__cell appeal-costs-appellant-correspondence-actions govuk-!-text-align-right">
-                                        <ul class="govuk-summary-list__actions-list">
-                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-appellant-correspondence" href="/appeals-service/appeal-details/2/costs/appellant/correspondence/upload-documents/3">Add<span class="govuk-visually-hidden"> Appellant correspondence</span></a>
-                                            </li>
-                                        </ul>
-                                    </td>
-                                </tr>
-                                <tr class="govuk-table__row">
-                                    <th scope="row" class="govuk-table__header appeal-costs-lpa-application-documentation">LPA application</th>
-                                    <td class="govuk-table__cell appeal-costs-lpa-application-status">No documents available</td>
-                                    <td class="govuk-table__cell appeal-costs-lpa-application-actions govuk-!-text-align-right">
-                                        <ul class="govuk-summary-list__actions-list">
-                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-lpa-application" href="/appeals-service/appeal-details/2/costs/lpa/application/upload-documents/4">Add<span class="govuk-visually-hidden"> LPA application</span></a>
-                                            </li>
-                                        </ul>
-                                    </td>
-                                </tr>
-                                <tr class="govuk-table__row">
-                                    <th scope="row" class="govuk-table__header appeal-costs-lpa-withdrawal-documentation">LPA withdrawal</th>
-                                    <td class="govuk-table__cell appeal-costs-lpa-withdrawal-status">No documents available</td>
-                                    <td class="govuk-table__cell appeal-costs-lpa-withdrawal-actions govuk-!-text-align-right">
-                                        <ul class="govuk-summary-list__actions-list">
-                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-lpa-withdrawal" href="/appeals-service/appeal-details/2/costs/lpa/withdrawal/upload-documents/5">Add<span class="govuk-visually-hidden"> LPA withdrawal</span></a>
-                                            </li>
-                                        </ul>
-                                    </td>
-                                </tr>
-                                <tr class="govuk-table__row">
-                                    <th scope="row" class="govuk-table__header appeal-costs-lpa-correspondence-documentation">LPA correspondence</th>
-                                    <td class="govuk-table__cell appeal-costs-lpa-correspondence-status">No documents available</td>
-                                    <td class="govuk-table__cell appeal-costs-lpa-correspondence-actions govuk-!-text-align-right">
-                                        <ul class="govuk-summary-list__actions-list">
-                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-lpa-correspondence" href="/appeals-service/appeal-details/2/costs/lpa/correspondence/upload-documents/6">Add<span class="govuk-visually-hidden"> LPA correspondence</span></a>
-                                            </li>
-                                        </ul>
-                                    </td>
-                                </tr>
-                            </tbody>
-                        </table>
-                    </div>
-                </div>
-                <div class="govuk-accordion__section">
-                    <div class="govuk-accordion__section-header">
-                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default2-heading-5"> Contacts</span></h2>
-                    </div>
-                    <div id="accordion-default2-content-5" class="govuk-accordion__section-content">
-                        <dl class="govuk-summary-list">
-                            <div class="govuk-summary-list__row appeal-appellant"><dt class="govuk-summary-list__key"> Appellant</dt>
-                                <dd class="govuk-summary-list__value">
-                                    <ul class="govuk-list">
-                                        <li>Roger Simmons</li>
-                                        <li>test3@example.com</li>
-                                    </ul>
-                                </dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/service-user/change/appellant"
-                                    data-cy="change-appellant">Change<span class="govuk-visually-hidden"> Appellant</span></a>
-                                </dd>
-                            </div>
-                            <div class="govuk-summary-list__row appeal-agent"><dt class="govuk-summary-list__key"> Agent</dt>
-                                <dd class="govuk-summary-list__value">
-                                    <ul class="govuk-list">
-                                        <li>Fiona Shell</li>
-                                        <li>test2@example.com</li>
-                                    </ul>
-                                </dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/service-user/change/agent"
-                                    data-cy="change-agent">Change<span class="govuk-visually-hidden"> Agent</span></a>
-                                </dd>
-                            </div>
-                            <div class="govuk-summary-list__row appeal-lpa-contact-details"><dt class="govuk-summary-list__key"> LPA</dt>
-                                <dd class="govuk-summary-list__value">
-                                    <ul class="govuk-list">
-                                        <li>Wiltshire Council</li>
-                                        <li>wilt@lpa-email.gov.uk</li>
-                                    </ul>
-                                </dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/change-appeal-details/local-planning-authority"
-                                    data-cy="change-lpa-contact-details">Change<span class="govuk-visually-hidden"> Local planning authority (LPA)</span></a>
-                                </dd>
-                            </div>
-                        </dl>
-                    </div>
-                </div>
-                <div class="govuk-accordion__section">
-                    <div class="govuk-accordion__section-header">
-                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default2-heading-6"> Team</span></h2>
-                    </div>
-                    <div id="accordion-default2-content-6" class="govuk-accordion__section-content">
-                        <dl class="govuk-summary-list">
-                            <div class="govuk-summary-list__row appeal-case-officer"><dt class="govuk-summary-list__key"> Case officer</dt>
-                                <dd class="govuk-summary-list__value">
-                                    <p class="govuk-body">Not assigned</p>
-                                </dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/assign-case-officer/search-case-officer"
-                                    data-cy="assign-case-officer">Assign<span class="govuk-visually-hidden"> Case officer</span></a>
-                                </dd>
-                            </div>
-                            <div class="govuk-summary-list__row appeal-inspector"><dt class="govuk-summary-list__key"> Inspector</dt>
-                                <dd class="govuk-summary-list__value">
-                                    <p class="govuk-body">Not assigned</p>
-                                </dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/assign-inspector/search-inspector"
-                                    data-cy="assign-inspector">Assign<span class="govuk-visually-hidden"> Inspector</span></a>
-                                </dd>
-                            </div>
-                        </dl>
-                    </div>
-                </div>
-                <div class="govuk-accordion__section">
-                    <div class="govuk-accordion__section-header">
-                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default2-heading-7"> Case management</span></h2>
-                    </div>
-                    <div id="accordion-default2-content-7" class="govuk-accordion__section-content">
-                        <dl class="govuk-summary-list">
-                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Cross-team correspondence</dt>
-                                <dd                                 class="govuk-summary-list__value">No documents</dd>
-                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/internal-correspondence/cross-team/upload-documents/10"
-                                        data-cy="add-cross-team-correspondence">Add<span class="govuk-visually-hidden"> Cross-team correspondence</span></a>
-                                    </dd>
-                            </div>
-                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Inspector correspondence</dt>
-                                <dd                                 class="govuk-summary-list__value">No documents</dd>
-                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/internal-correspondence/inspector/upload-documents/11"
-                                        data-cy="add-inspector-correspondence">Add<span class="govuk-visually-hidden"> Inspector correspondence</span></a>
-                                    </dd>
-                            </div>
-                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Main party correspondence</dt>
-                                <dd                                 class="govuk-summary-list__value">No documents</dd>
-                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/internal-correspondence/main-party/upload-documents/22"
-                                        data-cy="add-main-party-correspondence">Add<span class="govuk-visually-hidden"> Main party correspondence</span></a>
-                                    </dd>
-                            </div>
-                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Case history</dt>
-                                <dd class="govuk-summary-list__value"></dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/audit" data-cy="view-case-history">View<span class="govuk-visually-hidden"> Case history</span></a>
-                                </dd>
-                            </div>
-                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Appeal withdrawal</dt>
-                                <dd class="govuk-summary-list__value"></dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/withdrawal/start"
-                                    data-cy="start-appeal-withdrawal">Start<span class="govuk-visually-hidden"> Appeal withdrawal</span></a>
-                                </dd>
-                            </div>
-                        </dl>
-                    </div>
-                </div>
-            </div>
-        </div>
-    </div>
-</main>"
-`;
-
-exports[`appeal-details GET /:appealId should not render action links to the manage linked appeals page or the add linked appeal page in the linked appeals row, if the appeal is linked as a child of an external lead appeal 1`] = `
-"<main class="govuk-main-wrapper" id="main-content">
-    <div class="govuk-grid-row">
-        <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Appeal 351062</span>
-            <h1 class="govuk-heading-xl govuk-!-margin-bottom-3">Case details</h1>
-        </div>
-    </div>
-    <div class="govuk-grid-row">
-        <div class="govuk-grid-column-full"><strong class="govuk-tag govuk-tag--grey pins-status-tag--full-width">Received appeal</strong>
-            <strong             class="govuk-tag govuk-tag--grey govuk-!-margin-left-1 govuk-!-margin-bottom-4"></strong>
-        </div>
-    </div>
-    <div class="govuk-grid-row">
-        <div class="govuk-grid-column-full">
-            <dl class="govuk-summary-list pins-summary-list--no-border">
-                <div class="govuk-summary-list__row appeal-case-officer"><dt class="govuk-summary-list__key"> Case officer</dt>
-                    <dd class="govuk-summary-list__value">
-                        <p class="govuk-body">Not assigned</p>
-                    </dd>
-                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/assign-case-officer/search-case-officer"
-                        data-cy="assign-case-officer-name">Assign<span class="govuk-visually-hidden"> Case officer</span></a>
-                    </dd>
-                </div>
-                <div class="govuk-summary-list__row appeal-site-address"><dt class="govuk-summary-list__key"> Site address</dt>
-                    <dd class="govuk-summary-list__value">21 The Pavement, Wandsworth, SW4 0HY</dd>
-                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-address/change/1?backUrl=%2Fappeals-service%2Fappeal-details%2F1"
-                        data-cy="change-site-address">Change<span class="govuk-visually-hidden"> Site address</span></a>
-                    </dd>
-                </div>
-                <div class="govuk-summary-list__row appeal-local-planning-authority"><dt class="govuk-summary-list__key"> LPA</dt>
-                    <dd class="govuk-summary-list__value">Wiltshire Council</dd>
-                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/change-appeal-details/local-planning-authority"
-                        data-cy="change-local-planning-authority">Change<span class="govuk-visually-hidden"> LPA</span></a>
-                    </dd>
-                </div>
-            </dl>
-        </div>
-    </div>
-    <div class="govuk-grid-row">
-        <div class="govuk-grid-column-full">
-            <p class="govuk-body govuk-!-margin-bottom-6" id="download-case-files"
-            data-cy="download-case-files"><a class="govuk-link" href="/documents/1/bulk-download/case-APP/Q9999/D/21/351062.zip">Download case</a>
-            </p>
-        </div>
-    </div>
-    <div class="govuk-grid-row">
-        <div class="govuk-grid-column-full">
-            <details class="govuk-details">
-                <summary class="govuk-details__summary"><span class="govuk-details__summary-text"> 2 case notes</span>
-                </summary>
-                <div class="govuk-details__text">
-                    <form method="POST" novalidate="novalidate">
-                        <div class="govuk-grid-row">
-                            <div class="govuk-grid-column-two-thirds">
-                                <div class="govuk-form-group govuk-character-count" data-module="govuk-character-count"
-                                data-maxlength="500">
-                                    <textarea class="govuk-textarea govuk-js-character-count" id="comment"
-                                    name="comment" rows="5" aria-describedby="comment-info"></textarea>
-                                    <div id="comment-info" class="govuk-hint govuk-character-count__message">You can enter up to 500 characters</div>
-                                </div>
-                            </div>
-                        </div>
-                        <button type="submit" data-prevent-double-click="true" class="govuk-button govuk-button--secondary govuk-!-margin-bottom-1"
-                        data-module="govuk-button">Add case note</button>
-                    </form>
-                    <div>
-                        <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
-                        <section>
-                            <p class="govuk-body govuk-!-margin-bottom-1">A case note you should see.</p>
-                            <p class="govuk-hint govuk-!-margin-bottom-6">11:00am on Tuesday 1 October 2024 by John.Smith</p>
-                            <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
-                        </section>
-                        <section>
-                            <p class="govuk-body govuk-!-margin-bottom-1">A case note you should see.</p>
-                            <p class="govuk-hint govuk-!-margin-bottom-6">11:00am on Tuesday 1 October 2024 by John.Smith</p>
-                            <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
-                        </section>
-                    </div>
-                </div>
-            </details>
-        </div>
-    </div>
-    <div class="govuk-grid-row">
-        <div class="govuk-grid-column-full">
-            <div class="govuk-accordion" data-module="govuk-accordion" id="accordion-default1">
-                <div class="govuk-accordion__section">
-                    <div class="govuk-accordion__section-header">
-                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-1"> Overview</span></h2>
-                    </div>
-                    <div id="accordion-default1-content-1" class="govuk-accordion__section-content">
-                        <dl class="govuk-summary-list">
-                            <div class="govuk-summary-list__row govuk-summary-list__row--no-actions appeal-lpa-reference"><dt class="govuk-summary-list__key"> Planning application reference</dt>
-                                <dd                                 class="govuk-summary-list__value">48269/APP/2021/1482</dd>
-                            </div>
-                            <div class="govuk-summary-list__row appeal-appeal-type"><dt class="govuk-summary-list__key"> Appeal type</dt>
-                                <dd class="govuk-summary-list__value">Householder</dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/change-appeal-type/appeal-type"
-                                    data-cy="change-appeal-type">Change<span class="govuk-visually-hidden"> Appeal type</span></a>
-                                </dd>
-                            </div>
-                            <div class="govuk-summary-list__row govuk-summary-list__row--no-actions appeal-case-procedure"><dt class="govuk-summary-list__key"> Appeal procedure</dt>
-                                <dd class="govuk-summary-list__value">Written</dd>
-                            </div>
-                            <div class="govuk-summary-list__row appeal-allocation-details"><dt class="govuk-summary-list__key"> Allocation level</dt>
-                                <dd class="govuk-summary-list__value">
-                                    <ul class="govuk-!-margin-0">
-                                        <li>Level: A</li>
-                                        <li>Historic heritage</li>
-                                        <li>Architecture design</li>
-                                    </ul>
-                                </dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/allocation-details/allocation-level"
-                                    data-cy="change-allocation-details">Change<span class="govuk-visually-hidden"> Allocation level</span></a>
-                                </dd>
-                            </div>
-                            <div class="govuk-summary-list__row appeal-linked-appeals"><dt class="govuk-summary-list__key"> Linked appeals</dt>
-                                <dd class="govuk-summary-list__value">
-                                    <ul class="govuk-list govuk-list--bullet">
-                                        <li><a href="/appeals-service/appeal-details/5449" class="govuk-link" data-cy="linked-appeal-784706"
-                                            aria-label="Appeal 7 8 4 7 0 6">784706</a>
-                                        </li>
-                                        <li><span class="govuk-body">87326527</span>
-                                        </li>
-                                        <li><a href="/appeals-service/appeal-details/5464" class="govuk-link" data-cy="linked-appeal-140079"
-                                            aria-label="Appeal 1 4 0 0 7 9">140079</a> (lead)</li>
-                                        <li><a href="/appeals-service/appeal-details/5451" class="govuk-link" data-cy="linked-appeal-721086"
-                                            aria-label="Appeal 7 2 1 0 8 6">721086</a>
-                                        </li>
-                                        <li><span class="govuk-body">76215416</span> (lead)</li>
-                                    </ul>
-                                </dd>
-                            </div>
-                            <div class="govuk-summary-list__row appeal-other-appeals"><dt class="govuk-summary-list__key"> Related appeals</dt>
-                                <dd class="govuk-summary-list__value"><span>No</span>
-                                </dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/other-appeals/add"
-                                    data-cy="add-related-appeals">Add<span class="govuk-visually-hidden"> Related appeals</span></a>
-                                </dd>
-                            </div>
-                            <div class="govuk-summary-list__row appeal-decision"><dt class="govuk-summary-list__key"> Decision</dt>
-                                <dd class="govuk-summary-list__value">Dismissed</dd>
-                            </div>
-                        </dl>
-                    </div>
-                </div>
-                <div class="govuk-accordion__section">
-                    <div class="govuk-accordion__section-header">
-                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-2"> Site</span></h2>
-                    </div>
-                    <div id="accordion-default1-content-2" class="govuk-accordion__section-content">
-                        <dl class="govuk-summary-list">
-                            <div class="govuk-summary-list__row appeal-visit-type"><dt class="govuk-summary-list__key"> Visit type</dt>
-                                <dd class="govuk-summary-list__value">Accompanied</dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/visit-booked?backUrl=%2Fappeals-service%2Fappeal-details%2F1"
-                                    data-cy="change-set-visit-type">Change<span class="govuk-visually-hidden"> Visit type</span></a>
-                                </dd>
-                            </div>
-                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Date</dt>
-                                <dd class="govuk-summary-list__value">9 October 2023</dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/visit-booked"
-                                    data-cy="change-site-visit-date">Change<span class="govuk-visually-hidden"> Date</span></a>
-                                </dd>
-                            </div>
-                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Start time</dt>
-                                <dd class="govuk-summary-list__value">9:38am</dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/visit-booked"
-                                    data-cy="change-site-visit-start-time">Change<span class="govuk-visually-hidden"> Start time</span></a>
-                                </dd>
-                            </div>
-                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> End time</dt>
-                                <dd class="govuk-summary-list__value">10:00am</dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/visit-booked"
-                                    data-cy="change-site-visit-end-time">Change<span class="govuk-visually-hidden"> End time</span></a>
-                                </dd>
-                            </div>
-                            <div class="govuk-summary-list__row appeal-neighbouring-sites-inspector"><dt class="govuk-summary-list__key"> Interested party and neighbour addresses</dt>
-                                <dd                                 class="govuk-summary-list__value">
-                                    <ul class="govuk-list govuk-list--bullet">
-                                        <li>2 Grove Cottage, Shotesham Road, Woodton, Devon, NR35 2ND</li>
-                                    </ul>
-                                    </dd>
-                                    <dd class="govuk-summary-list__actions">
-                                        <ul class="govuk-summary-list__actions-list">
-                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/neighbouring-sites/manage"
-                                                data-cy="manage-neighbouring-sites-inspector">Manage<span class="govuk-visually-hidden"> Interested party and neighbour addresses</span></a>
-                                            </li>
-                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/neighbouring-sites/add/back-office"
-                                                data-cy="add-neighbouring-sites-inspector">Add<span class="govuk-visually-hidden"> Interested party and neighbour addresses</span></a>
-                                            </li>
-                                        </ul>
-                                    </dd>
-                            </div>
-                        </dl>
-                    </div>
-                </div>
-                <div class="govuk-accordion__section">
-                    <div class="govuk-accordion__section-header">
-                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-3"> Timetable</span></h2>
-                    </div>
-                    <div id="accordion-default1-content-3" class="govuk-accordion__section-content">
-                        <dl class="govuk-summary-list appeal-case-timetable">
-                            <div class="govuk-summary-list__row appeal-valid-date"><dt class="govuk-summary-list__key"> Valid date</dt>
-                                <dd class="govuk-summary-list__value">23 May 2023</dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/valid/date"
-                                    data-cy="-valid-date"><span class="govuk-visually-hidden"> Valid date</span></a>
-                                </dd>
-                            </div>
-                            <div class="govuk-summary-list__row appeal-start-date"><dt class="govuk-summary-list__key"> Start date</dt>
-                                <dd class="govuk-summary-list__value">23 May 2023</dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/start-case/change"
-                                    data-cy="change-start-case-date">Change<span class="govuk-visually-hidden"> Start date</span></a>
-                                </dd>
-                            </div>
-                            <div class="govuk-summary-list__row appeal-lpa-questionnaire-due-date"><dt class="govuk-summary-list__key"> LPA questionnaire due</dt>
-                                <dd class="govuk-summary-list__value">11 October 2023</dd>
-                            </div>
-                            <div class="govuk-summary-list__row appeal-site-visit"><dt class="govuk-summary-list__key"> Site visit</dt>
-                                <dd class="govuk-summary-list__value">
-                                    <ul class="govuk-list govuk-!-margin-top-0 govuk-!-padding-left-0">
-                                        <li>9 October 2023</li>
-                                        <li>9:38am - 10:00am</li>
-                                    </ul>
-                                </dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/manage-visit?backUrl=%2Fappeals-service%2Fappeal-details%2F1"
-                                    data-cy="change-schedule-visit">Change<span class="govuk-visually-hidden"> Site visit</span></a>
-                                </dd>
-                            </div>
-                        </dl>
-                    </div>
-                </div>
-                <div class="govuk-accordion__section">
-                    <div class="govuk-accordion__section-header">
-                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-4"> Documentation</span></h2>
-                    </div>
-                    <div id="accordion-default1-content-4" class="govuk-accordion__section-content">
-                        <table class="govuk-table">
-                            <thead class="govuk-table__head">
-                                <tr class="govuk-table__row">
-                                    <th scope="col" class="govuk-table__header">Documentation</th>
-                                    <th scope="col" class="govuk-table__header">Status</th>
-                                    <th scope="col" class="govuk-table__header">Received</th>
-                                    <th scope="col" class="govuk-table__header govuk-!-text-align-right">Action</th>
-                                </tr>
-                            </thead>
-                            <tbody class="govuk-table__body">
-                                <tr class="govuk-table__row">
-                                    <th scope="row" class="govuk-table__header">Appeal</th>
-                                    <td class="govuk-table__cell">Ready to review</td>
-                                    <td class="govuk-table__cell">2 August 2024</td>
-                                    <td class="govuk-table__cell govuk-!-text-align-right"><a href="/appeals-service/appeal-details/1/appellant-case?backUrl=%2Fappeals-service%2Fappeal-details%2F1"
-                                        data-cy="review-appellant-case" class="govuk-link">Review<span class="govuk-visually-hidden"> appellant case</span></a>
-                                    </td>
-                                </tr>
-                                <tr class="govuk-table__row">
-                                    <th scope="row" class="govuk-table__header">LPA questionnaire</th>
-                                    <td class="govuk-table__cell">Overdue</td>
-                                    <td class="govuk-table__cell">Due by 11 October 2023</td>
-                                    <td class="govuk-table__cell govuk-!-text-align-right"></td>
-                                </tr>
-                            </tbody>
-                        </table>
-                    </div>
-                </div>
-                <div class="govuk-accordion__section">
-                    <div class="govuk-accordion__section-header">
-                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-5"> Costs</span></h2>
-                    </div>
-                    <div id="accordion-default1-content-5" class="govuk-accordion__section-content">
-                        <table class="govuk-table">
-                            <thead class="govuk-table__head">
-                                <tr class="govuk-table__row">
-                                    <th scope="col" class="govuk-table__header">Documentation</th>
-                                    <th scope="col" class="govuk-table__header">Status</th>
-                                    <th scope="col" class="govuk-table__header govuk-!-text-align-right">Action</th>
-                                </tr>
-                            </thead>
-                            <tbody class="govuk-table__body">
-                                <tr class="govuk-table__row">
-                                    <th scope="row" class="govuk-table__header appeal-costs-appellant-application-documentation">Appellant application</th>
-                                    <td class="govuk-table__cell appeal-costs-appellant-application-status">No documents available</td>
-                                    <td class="govuk-table__cell appeal-costs-appellant-application-actions govuk-!-text-align-right">
-                                        <ul class="govuk-summary-list__actions-list">
-                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-appellant-application" href="/appeals-service/appeal-details/1/costs/appellant/application/upload-documents/1">Add<span class="govuk-visually-hidden"> Appellant application</span></a>
-                                            </li>
-                                        </ul>
-                                    </td>
-                                </tr>
-                                <tr class="govuk-table__row">
-                                    <th scope="row" class="govuk-table__header appeal-costs-appellant-withdrawal-documentation">Appellant withdrawal</th>
-                                    <td class="govuk-table__cell appeal-costs-appellant-withdrawal-status">No documents available</td>
-                                    <td class="govuk-table__cell appeal-costs-appellant-withdrawal-actions govuk-!-text-align-right">
-                                        <ul class="govuk-summary-list__actions-list">
-                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-appellant-withdrawal" href="/appeals-service/appeal-details/1/costs/appellant/withdrawal/upload-documents/2">Add<span class="govuk-visually-hidden"> Appellant withdrawal</span></a>
-                                            </li>
-                                        </ul>
-                                    </td>
-                                </tr>
-                                <tr class="govuk-table__row">
-                                    <th scope="row" class="govuk-table__header appeal-costs-appellant-correspondence-documentation">Appellant correspondence</th>
-                                    <td class="govuk-table__cell appeal-costs-appellant-correspondence-status">No documents available</td>
-                                    <td class="govuk-table__cell appeal-costs-appellant-correspondence-actions govuk-!-text-align-right">
-                                        <ul class="govuk-summary-list__actions-list">
-                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-appellant-correspondence" href="/appeals-service/appeal-details/1/costs/appellant/correspondence/upload-documents/3">Add<span class="govuk-visually-hidden"> Appellant correspondence</span></a>
-                                            </li>
-                                        </ul>
-                                    </td>
-                                </tr>
-                                <tr class="govuk-table__row">
-                                    <th scope="row" class="govuk-table__header appeal-costs-lpa-application-documentation">LPA application</th>
-                                    <td class="govuk-table__cell appeal-costs-lpa-application-status">No documents available</td>
-                                    <td class="govuk-table__cell appeal-costs-lpa-application-actions govuk-!-text-align-right">
-                                        <ul class="govuk-summary-list__actions-list">
-                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-lpa-application" href="/appeals-service/appeal-details/1/costs/lpa/application/upload-documents/4">Add<span class="govuk-visually-hidden"> LPA application</span></a>
-                                            </li>
-                                        </ul>
-                                    </td>
-                                </tr>
-                                <tr class="govuk-table__row">
-                                    <th scope="row" class="govuk-table__header appeal-costs-lpa-withdrawal-documentation">LPA withdrawal</th>
-                                    <td class="govuk-table__cell appeal-costs-lpa-withdrawal-status">No documents available</td>
-                                    <td class="govuk-table__cell appeal-costs-lpa-withdrawal-actions govuk-!-text-align-right">
-                                        <ul class="govuk-summary-list__actions-list">
-                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-lpa-withdrawal" href="/appeals-service/appeal-details/1/costs/lpa/withdrawal/upload-documents/5">Add<span class="govuk-visually-hidden"> LPA withdrawal</span></a>
-                                            </li>
-                                        </ul>
-                                    </td>
-                                </tr>
-                                <tr class="govuk-table__row">
-                                    <th scope="row" class="govuk-table__header appeal-costs-lpa-correspondence-documentation">LPA correspondence</th>
-                                    <td class="govuk-table__cell appeal-costs-lpa-correspondence-status">No documents available</td>
-                                    <td class="govuk-table__cell appeal-costs-lpa-correspondence-actions govuk-!-text-align-right">
-                                        <ul class="govuk-summary-list__actions-list">
-                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-lpa-correspondence" href="/appeals-service/appeal-details/1/costs/lpa/correspondence/upload-documents/6">Add<span class="govuk-visually-hidden"> LPA correspondence</span></a>
-                                            </li>
-                                        </ul>
-                                    </td>
-                                </tr>
-                            </tbody>
-                        </table>
-                    </div>
-                </div>
-                <div class="govuk-accordion__section">
-                    <div class="govuk-accordion__section-header">
-                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-6"> Contacts</span></h2>
-                    </div>
-                    <div id="accordion-default1-content-6" class="govuk-accordion__section-content">
-                        <dl class="govuk-summary-list">
-                            <div class="govuk-summary-list__row appeal-appellant"><dt class="govuk-summary-list__key"> Appellant</dt>
-                                <dd class="govuk-summary-list__value">
-                                    <ul class="govuk-list">
-                                        <li>Roger Simmons</li>
-                                        <li>test3@example.com</li>
-                                    </ul>
-                                </dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/service-user/change/appellant"
-                                    data-cy="change-appellant">Change<span class="govuk-visually-hidden"> Appellant</span></a>
-                                </dd>
-                            </div>
-                            <div class="govuk-summary-list__row appeal-agent"><dt class="govuk-summary-list__key"> Agent</dt>
-                                <dd class="govuk-summary-list__value">
-                                    <ul class="govuk-list">
-                                        <li>Fiona Shell</li>
-                                        <li>test2@example.com</li>
-                                    </ul>
-                                </dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/service-user/change/agent"
-                                    data-cy="change-agent">Change<span class="govuk-visually-hidden"> Agent</span></a>
-                                </dd>
-                            </div>
-                            <div class="govuk-summary-list__row appeal-lpa-contact-details"><dt class="govuk-summary-list__key"> LPA</dt>
-                                <dd class="govuk-summary-list__value">
-                                    <ul class="govuk-list">
-                                        <li>Wiltshire Council</li>
-                                        <li>wilt@lpa-email.gov.uk</li>
-                                    </ul>
-                                </dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/change-appeal-details/local-planning-authority"
-                                    data-cy="change-lpa-contact-details">Change<span class="govuk-visually-hidden"> Local planning authority (LPA)</span></a>
-                                </dd>
-                            </div>
-                        </dl>
-                    </div>
-                </div>
-                <div class="govuk-accordion__section">
-                    <div class="govuk-accordion__section-header">
-                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-7"> Team</span></h2>
-                    </div>
-                    <div id="accordion-default1-content-7" class="govuk-accordion__section-content">
-                        <dl class="govuk-summary-list">
-                            <div class="govuk-summary-list__row appeal-case-officer"><dt class="govuk-summary-list__key"> Case officer</dt>
-                                <dd class="govuk-summary-list__value">
-                                    <p class="govuk-body">Not assigned</p>
-                                </dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/assign-case-officer/search-case-officer"
-                                    data-cy="assign-case-officer">Assign<span class="govuk-visually-hidden"> Case officer</span></a>
-                                </dd>
-                            </div>
-                            <div class="govuk-summary-list__row appeal-inspector"><dt class="govuk-summary-list__key"> Inspector</dt>
-                                <dd class="govuk-summary-list__value">
-                                    <p class="govuk-body">Not assigned</p>
-                                </dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/assign-inspector/search-inspector"
-                                    data-cy="assign-inspector">Assign<span class="govuk-visually-hidden"> Inspector</span></a>
-                                </dd>
-                            </div>
-                        </dl>
-                    </div>
-                </div>
-                <div class="govuk-accordion__section">
-                    <div class="govuk-accordion__section-header">
-                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-8"> Case management</span></h2>
-                    </div>
-                    <div id="accordion-default1-content-8" class="govuk-accordion__section-content">
-                        <dl class="govuk-summary-list">
-                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Cross-team correspondence</dt>
-                                <dd                                 class="govuk-summary-list__value">No documents</dd>
-                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/internal-correspondence/cross-team/upload-documents/10"
-                                        data-cy="add-cross-team-correspondence">Add<span class="govuk-visually-hidden"> Cross-team correspondence</span></a>
-                                    </dd>
-                            </div>
-                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Inspector correspondence</dt>
-                                <dd                                 class="govuk-summary-list__value">No documents</dd>
-                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/internal-correspondence/inspector/upload-documents/11"
-                                        data-cy="add-inspector-correspondence">Add<span class="govuk-visually-hidden"> Inspector correspondence</span></a>
-                                    </dd>
-                            </div>
-                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Main party correspondence</dt>
-                                <dd                                 class="govuk-summary-list__value">No documents</dd>
-                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/internal-correspondence/main-party/upload-documents/22"
-                                        data-cy="add-main-party-correspondence">Add<span class="govuk-visually-hidden"> Main party correspondence</span></a>
-                                    </dd>
-                            </div>
-                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Case history</dt>
-                                <dd class="govuk-summary-list__value"></dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/audit" data-cy="view-case-history">View<span class="govuk-visually-hidden"> Case history</span></a>
-                                </dd>
-                            </div>
-                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Appeal withdrawal</dt>
-                                <dd class="govuk-summary-list__value"></dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/withdrawal/start"
-                                    data-cy="start-appeal-withdrawal">Start<span class="govuk-visually-hidden"> Appeal withdrawal</span></a>
-                                </dd>
-                            </div>
-                        </dl>
-                    </div>
-                </div>
-            </div>
-        </div>
-    </div>
-</main>"
-`;
-
 exports[`appeal-details GET /:appealId should render a "Appeal valid" notification banner with a link to start case when status is "READY_TO_START" 1`] = `
 "<div class="govuk-notification-banner govuk-!-margin-bottom-5" role="region"
 aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner"
@@ -2818,6 +6964,13 @@ exports[`appeal-details GET /:appealId should render a Decision inset panel when
             </div>
         </div>
     </div>
+    <div id="case-details-cancel-section">
+        <h3 class="govuk-heading-m">Cancel appeal</h3>
+        <div>
+            <p><a id="cancelCase" class="govuk-body govuk-link" href="/appeals-service/appeal-details/2/cancel">Cancel appeal</a>
+            </p>
+        </div>
+    </div>
 </main>"
 `;
 
@@ -3265,6 +7418,13 @@ exports[`appeal-details GET /:appealId should render a Decision inset panel when
                     </div>
                 </div>
             </div>
+        </div>
+    </div>
+    <div id="case-details-cancel-section">
+        <h3 class="govuk-heading-m">Cancel appeal</h3>
+        <div>
+            <p><a id="cancelCase" class="govuk-body govuk-link" href="/appeals-service/appeal-details/2/cancel">Cancel appeal</a>
+            </p>
         </div>
     </div>
 </main>"
@@ -3716,838 +7876,6 @@ exports[`appeal-details GET /:appealId should render a Decision inset panel when
 </main>"
 `;
 
-exports[`appeal-details GET /:appealId should render a child tag next to the appeal status tag if the appeal is a child 1`] = `
-"<main class="govuk-main-wrapper" id="main-content">
-    <div class="govuk-grid-row">
-        <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Appeal 351062</span>
-            <h1 class="govuk-heading-xl govuk-!-margin-bottom-3">Case details</h1>
-        </div>
-    </div>
-    <div class="govuk-grid-row">
-        <div class="govuk-grid-column-full"><strong class="govuk-tag govuk-tag--grey pins-status-tag--full-width">Received appeal</strong>
-            <strong             class="govuk-tag govuk-tag--grey govuk-!-margin-left-1 govuk-!-margin-bottom-4">Child</strong>
-        </div>
-    </div>
-    <div class="govuk-grid-row">
-        <div class="govuk-grid-column-full">
-            <dl class="govuk-summary-list pins-summary-list--no-border">
-                <div class="govuk-summary-list__row appeal-case-officer"><dt class="govuk-summary-list__key"> Case officer</dt>
-                    <dd class="govuk-summary-list__value">
-                        <p class="govuk-body">Not assigned</p>
-                    </dd>
-                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/assign-case-officer/search-case-officer"
-                        data-cy="assign-case-officer-name">Assign<span class="govuk-visually-hidden"> Case officer</span></a>
-                    </dd>
-                </div>
-                <div class="govuk-summary-list__row appeal-site-address"><dt class="govuk-summary-list__key"> Site address</dt>
-                    <dd class="govuk-summary-list__value">21 The Pavement, Wandsworth, SW4 0HY</dd>
-                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-address/change/1?backUrl=%2Fappeals-service%2Fappeal-details%2F1"
-                        data-cy="change-site-address">Change<span class="govuk-visually-hidden"> Site address</span></a>
-                    </dd>
-                </div>
-                <div class="govuk-summary-list__row appeal-local-planning-authority"><dt class="govuk-summary-list__key"> LPA</dt>
-                    <dd class="govuk-summary-list__value">Wiltshire Council</dd>
-                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/change-appeal-details/local-planning-authority"
-                        data-cy="change-local-planning-authority">Change<span class="govuk-visually-hidden"> LPA</span></a>
-                    </dd>
-                </div>
-            </dl>
-        </div>
-    </div>
-    <div class="govuk-grid-row">
-        <div class="govuk-grid-column-full">
-            <p class="govuk-body govuk-!-margin-bottom-6" id="download-case-files"
-            data-cy="download-case-files"><a class="govuk-link" href="/documents/1/bulk-download/case-APP/Q9999/D/21/351062.zip">Download case</a>
-            </p>
-        </div>
-    </div>
-    <div class="govuk-grid-row">
-        <div class="govuk-grid-column-full">
-            <details class="govuk-details">
-                <summary class="govuk-details__summary"><span class="govuk-details__summary-text"> 2 case notes</span>
-                </summary>
-                <div class="govuk-details__text">
-                    <form method="POST" novalidate="novalidate">
-                        <div class="govuk-grid-row">
-                            <div class="govuk-grid-column-two-thirds">
-                                <div class="govuk-form-group govuk-character-count" data-module="govuk-character-count"
-                                data-maxlength="500">
-                                    <textarea class="govuk-textarea govuk-js-character-count" id="comment"
-                                    name="comment" rows="5" aria-describedby="comment-info"></textarea>
-                                    <div id="comment-info" class="govuk-hint govuk-character-count__message">You can enter up to 500 characters</div>
-                                </div>
-                            </div>
-                        </div>
-                        <button type="submit" data-prevent-double-click="true" class="govuk-button govuk-button--secondary govuk-!-margin-bottom-1"
-                        data-module="govuk-button">Add case note</button>
-                    </form>
-                    <div>
-                        <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
-                        <section>
-                            <p class="govuk-body govuk-!-margin-bottom-1">A case note you should see.</p>
-                            <p class="govuk-hint govuk-!-margin-bottom-6">11:00am on Tuesday 1 October 2024 by John.Smith</p>
-                            <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
-                        </section>
-                        <section>
-                            <p class="govuk-body govuk-!-margin-bottom-1">A case note you should see.</p>
-                            <p class="govuk-hint govuk-!-margin-bottom-6">11:00am on Tuesday 1 October 2024 by John.Smith</p>
-                            <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
-                        </section>
-                    </div>
-                </div>
-            </details>
-        </div>
-    </div>
-    <div class="govuk-grid-row">
-        <div class="govuk-grid-column-full">
-            <div class="govuk-accordion" data-module="govuk-accordion" id="accordion-default1">
-                <div class="govuk-accordion__section">
-                    <div class="govuk-accordion__section-header">
-                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-1"> Overview</span></h2>
-                    </div>
-                    <div id="accordion-default1-content-1" class="govuk-accordion__section-content">
-                        <dl class="govuk-summary-list">
-                            <div class="govuk-summary-list__row govuk-summary-list__row--no-actions appeal-lpa-reference"><dt class="govuk-summary-list__key"> Planning application reference</dt>
-                                <dd                                 class="govuk-summary-list__value">48269/APP/2021/1482</dd>
-                            </div>
-                            <div class="govuk-summary-list__row appeal-appeal-type"><dt class="govuk-summary-list__key"> Appeal type</dt>
-                                <dd class="govuk-summary-list__value">Householder</dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/change-appeal-type/appeal-type"
-                                    data-cy="change-appeal-type">Change<span class="govuk-visually-hidden"> Appeal type</span></a>
-                                </dd>
-                            </div>
-                            <div class="govuk-summary-list__row govuk-summary-list__row--no-actions appeal-case-procedure"><dt class="govuk-summary-list__key"> Appeal procedure</dt>
-                                <dd class="govuk-summary-list__value">Written</dd>
-                            </div>
-                            <div class="govuk-summary-list__row appeal-allocation-details"><dt class="govuk-summary-list__key"> Allocation level</dt>
-                                <dd class="govuk-summary-list__value">
-                                    <ul class="govuk-!-margin-0">
-                                        <li>Level: A</li>
-                                        <li>Historic heritage</li>
-                                        <li>Architecture design</li>
-                                    </ul>
-                                </dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/allocation-details/allocation-level"
-                                    data-cy="change-allocation-details">Change<span class="govuk-visually-hidden"> Allocation level</span></a>
-                                </dd>
-                            </div>
-                            <div class="govuk-summary-list__row appeal-linked-appeals"><dt class="govuk-summary-list__key"> Linked appeals</dt>
-                                <dd class="govuk-summary-list__value"><a href="/appeals-service/appeal-details/5464" class="govuk-link" data-cy="linked-appeal-140079"
-                                    aria-label="Appeal 1 4 0 0 7 9">140079</a> (lead)</dd>
-                            </div>
-                            <div class="govuk-summary-list__row appeal-other-appeals"><dt class="govuk-summary-list__key"> Related appeals</dt>
-                                <dd class="govuk-summary-list__value"><span>No</span>
-                                </dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/other-appeals/add"
-                                    data-cy="add-related-appeals">Add<span class="govuk-visually-hidden"> Related appeals</span></a>
-                                </dd>
-                            </div>
-                            <div class="govuk-summary-list__row appeal-decision"><dt class="govuk-summary-list__key"> Decision</dt>
-                                <dd class="govuk-summary-list__value">Dismissed</dd>
-                            </div>
-                        </dl>
-                    </div>
-                </div>
-                <div class="govuk-accordion__section">
-                    <div class="govuk-accordion__section-header">
-                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-2"> Timetable</span></h2>
-                    </div>
-                    <div id="accordion-default1-content-2" class="govuk-accordion__section-content">
-                        <dl class="govuk-summary-list appeal-case-timetable">
-                            <div class="govuk-summary-list__row appeal-valid-date"><dt class="govuk-summary-list__key"> Valid date</dt>
-                                <dd class="govuk-summary-list__value">23 May 2023</dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/valid/date"
-                                    data-cy="-valid-date"><span class="govuk-visually-hidden"> Valid date</span></a>
-                                </dd>
-                            </div>
-                            <div class="govuk-summary-list__row appeal-start-date"><dt class="govuk-summary-list__key"> Start date</dt>
-                                <dd class="govuk-summary-list__value">23 May 2023</dd>
-                            </div>
-                            <div class="govuk-summary-list__row appeal-lpa-questionnaire-due-date"><dt class="govuk-summary-list__key"> LPA questionnaire due</dt>
-                                <dd class="govuk-summary-list__value">11 October 2023</dd>
-                            </div>
-                            <div class="govuk-summary-list__row appeal-site-visit"><dt class="govuk-summary-list__key"> Site visit</dt>
-                                <dd class="govuk-summary-list__value">
-                                    <ul class="govuk-list govuk-!-margin-top-0 govuk-!-padding-left-0">
-                                        <li>9 October 2023</li>
-                                        <li>9:38am - 10:00am</li>
-                                    </ul>
-                                </dd>
-                            </div>
-                        </dl>
-                    </div>
-                </div>
-                <div class="govuk-accordion__section">
-                    <div class="govuk-accordion__section-header">
-                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-3"> Documentation</span></h2>
-                    </div>
-                    <div id="accordion-default1-content-3" class="govuk-accordion__section-content">
-                        <table class="govuk-table">
-                            <thead class="govuk-table__head">
-                                <tr class="govuk-table__row">
-                                    <th scope="col" class="govuk-table__header">Documentation</th>
-                                    <th scope="col" class="govuk-table__header">Status</th>
-                                    <th scope="col" class="govuk-table__header">Received</th>
-                                    <th scope="col" class="govuk-table__header govuk-!-text-align-right">Action</th>
-                                </tr>
-                            </thead>
-                            <tbody class="govuk-table__body">
-                                <tr class="govuk-table__row">
-                                    <th scope="row" class="govuk-table__header">Appeal</th>
-                                    <td class="govuk-table__cell">Ready to review</td>
-                                    <td class="govuk-table__cell">2 August 2024</td>
-                                    <td class="govuk-table__cell govuk-!-text-align-right"><a href="/appeals-service/appeal-details/1/appellant-case?backUrl=%2Fappeals-service%2Fappeal-details%2F1"
-                                        data-cy="review-appellant-case" class="govuk-link">Review<span class="govuk-visually-hidden"> appellant case</span></a>
-                                    </td>
-                                </tr>
-                                <tr class="govuk-table__row">
-                                    <th scope="row" class="govuk-table__header">LPA questionnaire</th>
-                                    <td class="govuk-table__cell">Overdue</td>
-                                    <td class="govuk-table__cell">Due by 11 October 2023</td>
-                                    <td class="govuk-table__cell govuk-!-text-align-right"></td>
-                                </tr>
-                            </tbody>
-                        </table>
-                    </div>
-                </div>
-                <div class="govuk-accordion__section">
-                    <div class="govuk-accordion__section-header">
-                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-4"> Costs</span></h2>
-                    </div>
-                    <div id="accordion-default1-content-4" class="govuk-accordion__section-content">
-                        <table class="govuk-table">
-                            <thead class="govuk-table__head">
-                                <tr class="govuk-table__row">
-                                    <th scope="col" class="govuk-table__header">Documentation</th>
-                                    <th scope="col" class="govuk-table__header">Status</th>
-                                    <th scope="col" class="govuk-table__header govuk-!-text-align-right">Action</th>
-                                </tr>
-                            </thead>
-                            <tbody class="govuk-table__body">
-                                <tr class="govuk-table__row">
-                                    <th scope="row" class="govuk-table__header appeal-costs-appellant-application-documentation">Appellant application</th>
-                                    <td class="govuk-table__cell appeal-costs-appellant-application-status">No documents available</td>
-                                    <td class="govuk-table__cell appeal-costs-appellant-application-actions govuk-!-text-align-right">
-                                        <ul class="govuk-summary-list__actions-list">
-                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-appellant-application" href="/appeals-service/appeal-details/1/costs/appellant/application/upload-documents/1">Add<span class="govuk-visually-hidden"> Appellant application</span></a>
-                                            </li>
-                                        </ul>
-                                    </td>
-                                </tr>
-                                <tr class="govuk-table__row">
-                                    <th scope="row" class="govuk-table__header appeal-costs-appellant-withdrawal-documentation">Appellant withdrawal</th>
-                                    <td class="govuk-table__cell appeal-costs-appellant-withdrawal-status">No documents available</td>
-                                    <td class="govuk-table__cell appeal-costs-appellant-withdrawal-actions govuk-!-text-align-right">
-                                        <ul class="govuk-summary-list__actions-list">
-                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-appellant-withdrawal" href="/appeals-service/appeal-details/1/costs/appellant/withdrawal/upload-documents/2">Add<span class="govuk-visually-hidden"> Appellant withdrawal</span></a>
-                                            </li>
-                                        </ul>
-                                    </td>
-                                </tr>
-                                <tr class="govuk-table__row">
-                                    <th scope="row" class="govuk-table__header appeal-costs-appellant-correspondence-documentation">Appellant correspondence</th>
-                                    <td class="govuk-table__cell appeal-costs-appellant-correspondence-status">No documents available</td>
-                                    <td class="govuk-table__cell appeal-costs-appellant-correspondence-actions govuk-!-text-align-right">
-                                        <ul class="govuk-summary-list__actions-list">
-                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-appellant-correspondence" href="/appeals-service/appeal-details/1/costs/appellant/correspondence/upload-documents/3">Add<span class="govuk-visually-hidden"> Appellant correspondence</span></a>
-                                            </li>
-                                        </ul>
-                                    </td>
-                                </tr>
-                                <tr class="govuk-table__row">
-                                    <th scope="row" class="govuk-table__header appeal-costs-lpa-application-documentation">LPA application</th>
-                                    <td class="govuk-table__cell appeal-costs-lpa-application-status">No documents available</td>
-                                    <td class="govuk-table__cell appeal-costs-lpa-application-actions govuk-!-text-align-right">
-                                        <ul class="govuk-summary-list__actions-list">
-                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-lpa-application" href="/appeals-service/appeal-details/1/costs/lpa/application/upload-documents/4">Add<span class="govuk-visually-hidden"> LPA application</span></a>
-                                            </li>
-                                        </ul>
-                                    </td>
-                                </tr>
-                                <tr class="govuk-table__row">
-                                    <th scope="row" class="govuk-table__header appeal-costs-lpa-withdrawal-documentation">LPA withdrawal</th>
-                                    <td class="govuk-table__cell appeal-costs-lpa-withdrawal-status">No documents available</td>
-                                    <td class="govuk-table__cell appeal-costs-lpa-withdrawal-actions govuk-!-text-align-right">
-                                        <ul class="govuk-summary-list__actions-list">
-                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-lpa-withdrawal" href="/appeals-service/appeal-details/1/costs/lpa/withdrawal/upload-documents/5">Add<span class="govuk-visually-hidden"> LPA withdrawal</span></a>
-                                            </li>
-                                        </ul>
-                                    </td>
-                                </tr>
-                                <tr class="govuk-table__row">
-                                    <th scope="row" class="govuk-table__header appeal-costs-lpa-correspondence-documentation">LPA correspondence</th>
-                                    <td class="govuk-table__cell appeal-costs-lpa-correspondence-status">No documents available</td>
-                                    <td class="govuk-table__cell appeal-costs-lpa-correspondence-actions govuk-!-text-align-right">
-                                        <ul class="govuk-summary-list__actions-list">
-                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-lpa-correspondence" href="/appeals-service/appeal-details/1/costs/lpa/correspondence/upload-documents/6">Add<span class="govuk-visually-hidden"> LPA correspondence</span></a>
-                                            </li>
-                                        </ul>
-                                    </td>
-                                </tr>
-                            </tbody>
-                        </table>
-                    </div>
-                </div>
-                <div class="govuk-accordion__section">
-                    <div class="govuk-accordion__section-header">
-                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-5"> Contacts</span></h2>
-                    </div>
-                    <div id="accordion-default1-content-5" class="govuk-accordion__section-content">
-                        <dl class="govuk-summary-list">
-                            <div class="govuk-summary-list__row appeal-appellant"><dt class="govuk-summary-list__key"> Appellant</dt>
-                                <dd class="govuk-summary-list__value">
-                                    <ul class="govuk-list">
-                                        <li>Roger Simmons</li>
-                                        <li>test3@example.com</li>
-                                    </ul>
-                                </dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/service-user/change/appellant"
-                                    data-cy="change-appellant">Change<span class="govuk-visually-hidden"> Appellant</span></a>
-                                </dd>
-                            </div>
-                            <div class="govuk-summary-list__row appeal-agent"><dt class="govuk-summary-list__key"> Agent</dt>
-                                <dd class="govuk-summary-list__value">
-                                    <ul class="govuk-list">
-                                        <li>Fiona Shell</li>
-                                        <li>test2@example.com</li>
-                                    </ul>
-                                </dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/service-user/change/agent"
-                                    data-cy="change-agent">Change<span class="govuk-visually-hidden"> Agent</span></a>
-                                </dd>
-                            </div>
-                            <div class="govuk-summary-list__row appeal-lpa-contact-details"><dt class="govuk-summary-list__key"> LPA</dt>
-                                <dd class="govuk-summary-list__value">
-                                    <ul class="govuk-list">
-                                        <li>Wiltshire Council</li>
-                                        <li>wilt@lpa-email.gov.uk</li>
-                                    </ul>
-                                </dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/change-appeal-details/local-planning-authority"
-                                    data-cy="change-lpa-contact-details">Change<span class="govuk-visually-hidden"> Local planning authority (LPA)</span></a>
-                                </dd>
-                            </div>
-                        </dl>
-                    </div>
-                </div>
-                <div class="govuk-accordion__section">
-                    <div class="govuk-accordion__section-header">
-                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-6"> Team</span></h2>
-                    </div>
-                    <div id="accordion-default1-content-6" class="govuk-accordion__section-content">
-                        <dl class="govuk-summary-list">
-                            <div class="govuk-summary-list__row appeal-case-officer"><dt class="govuk-summary-list__key"> Case officer</dt>
-                                <dd class="govuk-summary-list__value">
-                                    <p class="govuk-body">Not assigned</p>
-                                </dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/assign-case-officer/search-case-officer"
-                                    data-cy="assign-case-officer">Assign<span class="govuk-visually-hidden"> Case officer</span></a>
-                                </dd>
-                            </div>
-                            <div class="govuk-summary-list__row appeal-inspector"><dt class="govuk-summary-list__key"> Inspector</dt>
-                                <dd class="govuk-summary-list__value">
-                                    <p class="govuk-body">Not assigned</p>
-                                </dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/assign-inspector/search-inspector"
-                                    data-cy="assign-inspector">Assign<span class="govuk-visually-hidden"> Inspector</span></a>
-                                </dd>
-                            </div>
-                        </dl>
-                    </div>
-                </div>
-                <div class="govuk-accordion__section">
-                    <div class="govuk-accordion__section-header">
-                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-7"> Case management</span></h2>
-                    </div>
-                    <div id="accordion-default1-content-7" class="govuk-accordion__section-content">
-                        <dl class="govuk-summary-list">
-                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Cross-team correspondence</dt>
-                                <dd                                 class="govuk-summary-list__value">No documents</dd>
-                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/internal-correspondence/cross-team/upload-documents/10"
-                                        data-cy="add-cross-team-correspondence">Add<span class="govuk-visually-hidden"> Cross-team correspondence</span></a>
-                                    </dd>
-                            </div>
-                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Inspector correspondence</dt>
-                                <dd                                 class="govuk-summary-list__value">No documents</dd>
-                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/internal-correspondence/inspector/upload-documents/11"
-                                        data-cy="add-inspector-correspondence">Add<span class="govuk-visually-hidden"> Inspector correspondence</span></a>
-                                    </dd>
-                            </div>
-                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Main party correspondence</dt>
-                                <dd                                 class="govuk-summary-list__value">No documents</dd>
-                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/internal-correspondence/main-party/upload-documents/22"
-                                        data-cy="add-main-party-correspondence">Add<span class="govuk-visually-hidden"> Main party correspondence</span></a>
-                                    </dd>
-                            </div>
-                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Case history</dt>
-                                <dd class="govuk-summary-list__value"></dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/audit" data-cy="view-case-history">View<span class="govuk-visually-hidden"> Case history</span></a>
-                                </dd>
-                            </div>
-                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Appeal withdrawal</dt>
-                                <dd class="govuk-summary-list__value"></dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/withdrawal/start"
-                                    data-cy="start-appeal-withdrawal">Start<span class="govuk-visually-hidden"> Appeal withdrawal</span></a>
-                                </dd>
-                            </div>
-                        </dl>
-                    </div>
-                </div>
-            </div>
-        </div>
-    </div>
-</main>"
-`;
-
-exports[`appeal-details GET /:appealId should render a lead tag next to the appeal status tag if the appeal is a parent 1`] = `
-"<main class="govuk-main-wrapper" id="main-content">
-    <div class="govuk-grid-row">
-        <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Appeal 351062</span>
-            <h1 class="govuk-heading-xl govuk-!-margin-bottom-3">Case details</h1>
-        </div>
-    </div>
-    <div class="govuk-grid-row">
-        <div class="govuk-grid-column-full"><strong class="govuk-tag govuk-tag--grey pins-status-tag--full-width">Received appeal</strong>
-            <strong             class="govuk-tag govuk-tag--grey govuk-!-margin-left-1 govuk-!-margin-bottom-4">Lead</strong>
-        </div>
-    </div>
-    <div class="govuk-grid-row">
-        <div class="govuk-grid-column-full">
-            <dl class="govuk-summary-list pins-summary-list--no-border">
-                <div class="govuk-summary-list__row appeal-case-officer"><dt class="govuk-summary-list__key"> Case officer</dt>
-                    <dd class="govuk-summary-list__value">
-                        <p class="govuk-body">Not assigned</p>
-                    </dd>
-                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/assign-case-officer/search-case-officer"
-                        data-cy="assign-case-officer-name">Assign<span class="govuk-visually-hidden"> Case officer</span></a>
-                    </dd>
-                </div>
-                <div class="govuk-summary-list__row appeal-site-address"><dt class="govuk-summary-list__key"> Site address</dt>
-                    <dd class="govuk-summary-list__value">21 The Pavement, Wandsworth, SW4 0HY</dd>
-                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-address/change/1?backUrl=%2Fappeals-service%2Fappeal-details%2F1"
-                        data-cy="change-site-address">Change<span class="govuk-visually-hidden"> Site address</span></a>
-                    </dd>
-                </div>
-                <div class="govuk-summary-list__row appeal-local-planning-authority"><dt class="govuk-summary-list__key"> LPA</dt>
-                    <dd class="govuk-summary-list__value">Wiltshire Council</dd>
-                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/change-appeal-details/local-planning-authority"
-                        data-cy="change-local-planning-authority">Change<span class="govuk-visually-hidden"> LPA</span></a>
-                    </dd>
-                </div>
-            </dl>
-        </div>
-    </div>
-    <div class="govuk-grid-row">
-        <div class="govuk-grid-column-full">
-            <p class="govuk-body govuk-!-margin-bottom-6" id="download-case-files"
-            data-cy="download-case-files"><a class="govuk-link" href="/documents/1/bulk-download/case-APP/Q9999/D/21/351062.zip">Download case</a>
-            </p>
-        </div>
-    </div>
-    <div class="govuk-grid-row">
-        <div class="govuk-grid-column-full">
-            <details class="govuk-details">
-                <summary class="govuk-details__summary"><span class="govuk-details__summary-text"> 2 case notes</span>
-                </summary>
-                <div class="govuk-details__text">
-                    <form method="POST" novalidate="novalidate">
-                        <div class="govuk-grid-row">
-                            <div class="govuk-grid-column-two-thirds">
-                                <div class="govuk-form-group govuk-character-count" data-module="govuk-character-count"
-                                data-maxlength="500">
-                                    <textarea class="govuk-textarea govuk-js-character-count" id="comment"
-                                    name="comment" rows="5" aria-describedby="comment-info"></textarea>
-                                    <div id="comment-info" class="govuk-hint govuk-character-count__message">You can enter up to 500 characters</div>
-                                </div>
-                            </div>
-                        </div>
-                        <button type="submit" data-prevent-double-click="true" class="govuk-button govuk-button--secondary govuk-!-margin-bottom-1"
-                        data-module="govuk-button">Add case note</button>
-                    </form>
-                    <div>
-                        <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
-                        <section>
-                            <p class="govuk-body govuk-!-margin-bottom-1">A case note you should see.</p>
-                            <p class="govuk-hint govuk-!-margin-bottom-6">11:00am on Tuesday 1 October 2024 by John.Smith</p>
-                            <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
-                        </section>
-                        <section>
-                            <p class="govuk-body govuk-!-margin-bottom-1">A case note you should see.</p>
-                            <p class="govuk-hint govuk-!-margin-bottom-6">11:00am on Tuesday 1 October 2024 by John.Smith</p>
-                            <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
-                        </section>
-                    </div>
-                </div>
-            </details>
-        </div>
-    </div>
-    <div class="govuk-grid-row">
-        <div class="govuk-grid-column-full">
-            <div class="govuk-accordion" data-module="govuk-accordion" id="accordion-default1">
-                <div class="govuk-accordion__section">
-                    <div class="govuk-accordion__section-header">
-                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-1"> Overview</span></h2>
-                    </div>
-                    <div id="accordion-default1-content-1" class="govuk-accordion__section-content">
-                        <dl class="govuk-summary-list">
-                            <div class="govuk-summary-list__row govuk-summary-list__row--no-actions appeal-lpa-reference"><dt class="govuk-summary-list__key"> Planning application reference</dt>
-                                <dd                                 class="govuk-summary-list__value">48269/APP/2021/1482</dd>
-                            </div>
-                            <div class="govuk-summary-list__row appeal-appeal-type"><dt class="govuk-summary-list__key"> Appeal type</dt>
-                                <dd class="govuk-summary-list__value">Householder</dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/change-appeal-type/appeal-type"
-                                    data-cy="change-appeal-type">Change<span class="govuk-visually-hidden"> Appeal type</span></a>
-                                </dd>
-                            </div>
-                            <div class="govuk-summary-list__row govuk-summary-list__row--no-actions appeal-case-procedure"><dt class="govuk-summary-list__key"> Appeal procedure</dt>
-                                <dd class="govuk-summary-list__value">Written</dd>
-                            </div>
-                            <div class="govuk-summary-list__row appeal-allocation-details"><dt class="govuk-summary-list__key"> Allocation level</dt>
-                                <dd class="govuk-summary-list__value">
-                                    <ul class="govuk-!-margin-0">
-                                        <li>Level: A</li>
-                                        <li>Historic heritage</li>
-                                        <li>Architecture design</li>
-                                    </ul>
-                                </dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/allocation-details/allocation-level"
-                                    data-cy="change-allocation-details">Change<span class="govuk-visually-hidden"> Allocation level</span></a>
-                                </dd>
-                            </div>
-                            <div class="govuk-summary-list__row appeal-linked-appeals"><dt class="govuk-summary-list__key"> Linked appeals</dt>
-                                <dd class="govuk-summary-list__value">
-                                    <ul class="govuk-list govuk-list--bullet">
-                                        <li><a href="/appeals-service/appeal-details/5449" class="govuk-link" data-cy="linked-appeal-784706"
-                                            aria-label="Appeal 7 8 4 7 0 6">784706</a>
-                                        </li>
-                                        <li><span class="govuk-body">87326527</span>
-                                        </li>
-                                        <li><a href="/appeals-service/appeal-details/5451" class="govuk-link" data-cy="linked-appeal-721086"
-                                            aria-label="Appeal 7 2 1 0 8 6">721086</a>
-                                        </li>
-                                    </ul>
-                                </dd>
-                            </div>
-                            <div class="govuk-summary-list__row appeal-other-appeals"><dt class="govuk-summary-list__key"> Related appeals</dt>
-                                <dd class="govuk-summary-list__value"><span>No</span>
-                                </dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/other-appeals/add"
-                                    data-cy="add-related-appeals">Add<span class="govuk-visually-hidden"> Related appeals</span></a>
-                                </dd>
-                            </div>
-                            <div class="govuk-summary-list__row appeal-decision"><dt class="govuk-summary-list__key"> Decision</dt>
-                                <dd class="govuk-summary-list__value">Dismissed</dd>
-                            </div>
-                        </dl>
-                    </div>
-                </div>
-                <div class="govuk-accordion__section">
-                    <div class="govuk-accordion__section-header">
-                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-2"> Site</span></h2>
-                    </div>
-                    <div id="accordion-default1-content-2" class="govuk-accordion__section-content">
-                        <dl class="govuk-summary-list">
-                            <div class="govuk-summary-list__row appeal-visit-type"><dt class="govuk-summary-list__key"> Visit type</dt>
-                                <dd class="govuk-summary-list__value">Accompanied</dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/visit-booked?backUrl=%2Fappeals-service%2Fappeal-details%2F1"
-                                    data-cy="change-set-visit-type">Change<span class="govuk-visually-hidden"> Visit type</span></a>
-                                </dd>
-                            </div>
-                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Date</dt>
-                                <dd class="govuk-summary-list__value">9 October 2023</dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/visit-booked"
-                                    data-cy="change-site-visit-date">Change<span class="govuk-visually-hidden"> Date</span></a>
-                                </dd>
-                            </div>
-                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Start time</dt>
-                                <dd class="govuk-summary-list__value">9:38am</dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/visit-booked"
-                                    data-cy="change-site-visit-start-time">Change<span class="govuk-visually-hidden"> Start time</span></a>
-                                </dd>
-                            </div>
-                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> End time</dt>
-                                <dd class="govuk-summary-list__value">10:00am</dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/visit-booked"
-                                    data-cy="change-site-visit-end-time">Change<span class="govuk-visually-hidden"> End time</span></a>
-                                </dd>
-                            </div>
-                            <div class="govuk-summary-list__row appeal-neighbouring-sites-inspector"><dt class="govuk-summary-list__key"> Interested party and neighbour addresses</dt>
-                                <dd                                 class="govuk-summary-list__value">
-                                    <ul class="govuk-list govuk-list--bullet">
-                                        <li>2 Grove Cottage, Shotesham Road, Woodton, Devon, NR35 2ND</li>
-                                    </ul>
-                                    </dd>
-                                    <dd class="govuk-summary-list__actions">
-                                        <ul class="govuk-summary-list__actions-list">
-                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/neighbouring-sites/manage"
-                                                data-cy="manage-neighbouring-sites-inspector">Manage<span class="govuk-visually-hidden"> Interested party and neighbour addresses</span></a>
-                                            </li>
-                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/neighbouring-sites/add/back-office"
-                                                data-cy="add-neighbouring-sites-inspector">Add<span class="govuk-visually-hidden"> Interested party and neighbour addresses</span></a>
-                                            </li>
-                                        </ul>
-                                    </dd>
-                            </div>
-                        </dl>
-                    </div>
-                </div>
-                <div class="govuk-accordion__section">
-                    <div class="govuk-accordion__section-header">
-                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-3"> Timetable</span></h2>
-                    </div>
-                    <div id="accordion-default1-content-3" class="govuk-accordion__section-content">
-                        <dl class="govuk-summary-list appeal-case-timetable">
-                            <div class="govuk-summary-list__row appeal-valid-date"><dt class="govuk-summary-list__key"> Valid date</dt>
-                                <dd class="govuk-summary-list__value">23 May 2023</dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/valid/date"
-                                    data-cy="-valid-date"><span class="govuk-visually-hidden"> Valid date</span></a>
-                                </dd>
-                            </div>
-                            <div class="govuk-summary-list__row appeal-start-date"><dt class="govuk-summary-list__key"> Start date</dt>
-                                <dd class="govuk-summary-list__value">23 May 2023</dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/start-case/change"
-                                    data-cy="change-start-case-date">Change<span class="govuk-visually-hidden"> Start date</span></a>
-                                </dd>
-                            </div>
-                            <div class="govuk-summary-list__row appeal-lpa-questionnaire-due-date"><dt class="govuk-summary-list__key"> LPA questionnaire due</dt>
-                                <dd class="govuk-summary-list__value">11 October 2023</dd>
-                            </div>
-                            <div class="govuk-summary-list__row appeal-site-visit"><dt class="govuk-summary-list__key"> Site visit</dt>
-                                <dd class="govuk-summary-list__value">
-                                    <ul class="govuk-list govuk-!-margin-top-0 govuk-!-padding-left-0">
-                                        <li>9 October 2023</li>
-                                        <li>9:38am - 10:00am</li>
-                                    </ul>
-                                </dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/manage-visit?backUrl=%2Fappeals-service%2Fappeal-details%2F1"
-                                    data-cy="change-schedule-visit">Change<span class="govuk-visually-hidden"> Site visit</span></a>
-                                </dd>
-                            </div>
-                        </dl>
-                    </div>
-                </div>
-                <div class="govuk-accordion__section">
-                    <div class="govuk-accordion__section-header">
-                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-4"> Documentation</span></h2>
-                    </div>
-                    <div id="accordion-default1-content-4" class="govuk-accordion__section-content">
-                        <table class="govuk-table">
-                            <thead class="govuk-table__head">
-                                <tr class="govuk-table__row">
-                                    <th scope="col" class="govuk-table__header">Documentation</th>
-                                    <th scope="col" class="govuk-table__header">Status</th>
-                                    <th scope="col" class="govuk-table__header">Received</th>
-                                    <th scope="col" class="govuk-table__header govuk-!-text-align-right">Action</th>
-                                </tr>
-                            </thead>
-                            <tbody class="govuk-table__body">
-                                <tr class="govuk-table__row">
-                                    <th scope="row" class="govuk-table__header">Appeal</th>
-                                    <td class="govuk-table__cell">Ready to review</td>
-                                    <td class="govuk-table__cell">2 August 2024</td>
-                                    <td class="govuk-table__cell govuk-!-text-align-right"><a href="/appeals-service/appeal-details/1/appellant-case?backUrl=%2Fappeals-service%2Fappeal-details%2F1"
-                                        data-cy="review-appellant-case" class="govuk-link">Review<span class="govuk-visually-hidden"> appellant case</span></a>
-                                    </td>
-                                </tr>
-                                <tr class="govuk-table__row">
-                                    <th scope="row" class="govuk-table__header">LPA questionnaire</th>
-                                    <td class="govuk-table__cell">Overdue</td>
-                                    <td class="govuk-table__cell">Due by 11 October 2023</td>
-                                    <td class="govuk-table__cell govuk-!-text-align-right"></td>
-                                </tr>
-                            </tbody>
-                        </table>
-                    </div>
-                </div>
-                <div class="govuk-accordion__section">
-                    <div class="govuk-accordion__section-header">
-                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-5"> Costs</span></h2>
-                    </div>
-                    <div id="accordion-default1-content-5" class="govuk-accordion__section-content">
-                        <table class="govuk-table">
-                            <thead class="govuk-table__head">
-                                <tr class="govuk-table__row">
-                                    <th scope="col" class="govuk-table__header">Documentation</th>
-                                    <th scope="col" class="govuk-table__header">Status</th>
-                                    <th scope="col" class="govuk-table__header govuk-!-text-align-right">Action</th>
-                                </tr>
-                            </thead>
-                            <tbody class="govuk-table__body">
-                                <tr class="govuk-table__row">
-                                    <th scope="row" class="govuk-table__header appeal-costs-appellant-application-documentation">Appellant application</th>
-                                    <td class="govuk-table__cell appeal-costs-appellant-application-status">No documents available</td>
-                                    <td class="govuk-table__cell appeal-costs-appellant-application-actions govuk-!-text-align-right">
-                                        <ul class="govuk-summary-list__actions-list">
-                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-appellant-application" href="/appeals-service/appeal-details/1/costs/appellant/application/upload-documents/1">Add<span class="govuk-visually-hidden"> Appellant application</span></a>
-                                            </li>
-                                        </ul>
-                                    </td>
-                                </tr>
-                                <tr class="govuk-table__row">
-                                    <th scope="row" class="govuk-table__header appeal-costs-appellant-withdrawal-documentation">Appellant withdrawal</th>
-                                    <td class="govuk-table__cell appeal-costs-appellant-withdrawal-status">No documents available</td>
-                                    <td class="govuk-table__cell appeal-costs-appellant-withdrawal-actions govuk-!-text-align-right">
-                                        <ul class="govuk-summary-list__actions-list">
-                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-appellant-withdrawal" href="/appeals-service/appeal-details/1/costs/appellant/withdrawal/upload-documents/2">Add<span class="govuk-visually-hidden"> Appellant withdrawal</span></a>
-                                            </li>
-                                        </ul>
-                                    </td>
-                                </tr>
-                                <tr class="govuk-table__row">
-                                    <th scope="row" class="govuk-table__header appeal-costs-appellant-correspondence-documentation">Appellant correspondence</th>
-                                    <td class="govuk-table__cell appeal-costs-appellant-correspondence-status">No documents available</td>
-                                    <td class="govuk-table__cell appeal-costs-appellant-correspondence-actions govuk-!-text-align-right">
-                                        <ul class="govuk-summary-list__actions-list">
-                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-appellant-correspondence" href="/appeals-service/appeal-details/1/costs/appellant/correspondence/upload-documents/3">Add<span class="govuk-visually-hidden"> Appellant correspondence</span></a>
-                                            </li>
-                                        </ul>
-                                    </td>
-                                </tr>
-                                <tr class="govuk-table__row">
-                                    <th scope="row" class="govuk-table__header appeal-costs-lpa-application-documentation">LPA application</th>
-                                    <td class="govuk-table__cell appeal-costs-lpa-application-status">No documents available</td>
-                                    <td class="govuk-table__cell appeal-costs-lpa-application-actions govuk-!-text-align-right">
-                                        <ul class="govuk-summary-list__actions-list">
-                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-lpa-application" href="/appeals-service/appeal-details/1/costs/lpa/application/upload-documents/4">Add<span class="govuk-visually-hidden"> LPA application</span></a>
-                                            </li>
-                                        </ul>
-                                    </td>
-                                </tr>
-                                <tr class="govuk-table__row">
-                                    <th scope="row" class="govuk-table__header appeal-costs-lpa-withdrawal-documentation">LPA withdrawal</th>
-                                    <td class="govuk-table__cell appeal-costs-lpa-withdrawal-status">No documents available</td>
-                                    <td class="govuk-table__cell appeal-costs-lpa-withdrawal-actions govuk-!-text-align-right">
-                                        <ul class="govuk-summary-list__actions-list">
-                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-lpa-withdrawal" href="/appeals-service/appeal-details/1/costs/lpa/withdrawal/upload-documents/5">Add<span class="govuk-visually-hidden"> LPA withdrawal</span></a>
-                                            </li>
-                                        </ul>
-                                    </td>
-                                </tr>
-                                <tr class="govuk-table__row">
-                                    <th scope="row" class="govuk-table__header appeal-costs-lpa-correspondence-documentation">LPA correspondence</th>
-                                    <td class="govuk-table__cell appeal-costs-lpa-correspondence-status">No documents available</td>
-                                    <td class="govuk-table__cell appeal-costs-lpa-correspondence-actions govuk-!-text-align-right">
-                                        <ul class="govuk-summary-list__actions-list">
-                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-lpa-correspondence" href="/appeals-service/appeal-details/1/costs/lpa/correspondence/upload-documents/6">Add<span class="govuk-visually-hidden"> LPA correspondence</span></a>
-                                            </li>
-                                        </ul>
-                                    </td>
-                                </tr>
-                            </tbody>
-                        </table>
-                    </div>
-                </div>
-                <div class="govuk-accordion__section">
-                    <div class="govuk-accordion__section-header">
-                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-6"> Contacts</span></h2>
-                    </div>
-                    <div id="accordion-default1-content-6" class="govuk-accordion__section-content">
-                        <dl class="govuk-summary-list">
-                            <div class="govuk-summary-list__row appeal-appellant"><dt class="govuk-summary-list__key"> Appellant</dt>
-                                <dd class="govuk-summary-list__value">
-                                    <ul class="govuk-list">
-                                        <li>Roger Simmons</li>
-                                        <li>test3@example.com</li>
-                                    </ul>
-                                </dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/service-user/change/appellant"
-                                    data-cy="change-appellant">Change<span class="govuk-visually-hidden"> Appellant</span></a>
-                                </dd>
-                            </div>
-                            <div class="govuk-summary-list__row appeal-agent"><dt class="govuk-summary-list__key"> Agent</dt>
-                                <dd class="govuk-summary-list__value">
-                                    <ul class="govuk-list">
-                                        <li>Fiona Shell</li>
-                                        <li>test2@example.com</li>
-                                    </ul>
-                                </dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/service-user/change/agent"
-                                    data-cy="change-agent">Change<span class="govuk-visually-hidden"> Agent</span></a>
-                                </dd>
-                            </div>
-                            <div class="govuk-summary-list__row appeal-lpa-contact-details"><dt class="govuk-summary-list__key"> LPA</dt>
-                                <dd class="govuk-summary-list__value">
-                                    <ul class="govuk-list">
-                                        <li>Wiltshire Council</li>
-                                        <li>wilt@lpa-email.gov.uk</li>
-                                    </ul>
-                                </dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/change-appeal-details/local-planning-authority"
-                                    data-cy="change-lpa-contact-details">Change<span class="govuk-visually-hidden"> Local planning authority (LPA)</span></a>
-                                </dd>
-                            </div>
-                        </dl>
-                    </div>
-                </div>
-                <div class="govuk-accordion__section">
-                    <div class="govuk-accordion__section-header">
-                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-7"> Team</span></h2>
-                    </div>
-                    <div id="accordion-default1-content-7" class="govuk-accordion__section-content">
-                        <dl class="govuk-summary-list">
-                            <div class="govuk-summary-list__row appeal-case-officer"><dt class="govuk-summary-list__key"> Case officer</dt>
-                                <dd class="govuk-summary-list__value">
-                                    <p class="govuk-body">Not assigned</p>
-                                </dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/assign-case-officer/search-case-officer"
-                                    data-cy="assign-case-officer">Assign<span class="govuk-visually-hidden"> Case officer</span></a>
-                                </dd>
-                            </div>
-                            <div class="govuk-summary-list__row appeal-inspector"><dt class="govuk-summary-list__key"> Inspector</dt>
-                                <dd class="govuk-summary-list__value">
-                                    <p class="govuk-body">Not assigned</p>
-                                </dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/assign-inspector/search-inspector"
-                                    data-cy="assign-inspector">Assign<span class="govuk-visually-hidden"> Inspector</span></a>
-                                </dd>
-                            </div>
-                        </dl>
-                    </div>
-                </div>
-                <div class="govuk-accordion__section">
-                    <div class="govuk-accordion__section-header">
-                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-8"> Case management</span></h2>
-                    </div>
-                    <div id="accordion-default1-content-8" class="govuk-accordion__section-content">
-                        <dl class="govuk-summary-list">
-                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Cross-team correspondence</dt>
-                                <dd                                 class="govuk-summary-list__value">No documents</dd>
-                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/internal-correspondence/cross-team/upload-documents/10"
-                                        data-cy="add-cross-team-correspondence">Add<span class="govuk-visually-hidden"> Cross-team correspondence</span></a>
-                                    </dd>
-                            </div>
-                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Inspector correspondence</dt>
-                                <dd                                 class="govuk-summary-list__value">No documents</dd>
-                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/internal-correspondence/inspector/upload-documents/11"
-                                        data-cy="add-inspector-correspondence">Add<span class="govuk-visually-hidden"> Inspector correspondence</span></a>
-                                    </dd>
-                            </div>
-                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Main party correspondence</dt>
-                                <dd                                 class="govuk-summary-list__value">No documents</dd>
-                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/internal-correspondence/main-party/upload-documents/22"
-                                        data-cy="add-main-party-correspondence">Add<span class="govuk-visually-hidden"> Main party correspondence</span></a>
-                                    </dd>
-                            </div>
-                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Case history</dt>
-                                <dd class="govuk-summary-list__value"></dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/audit" data-cy="view-case-history">View<span class="govuk-visually-hidden"> Case history</span></a>
-                                </dd>
-                            </div>
-                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Appeal withdrawal</dt>
-                                <dd class="govuk-summary-list__value"></dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/withdrawal/start"
-                                    data-cy="start-appeal-withdrawal">Start<span class="govuk-visually-hidden"> Appeal withdrawal</span></a>
-                                </dd>
-                            </div>
-                        </dl>
-                    </div>
-                </div>
-            </div>
-        </div>
-    </div>
-</main>"
-`;
-
 exports[`appeal-details GET /:appealId should render a page not found when the appealId is not valid/does not exist 1`] = `
 "<main class="govuk-main-wrapper" id="main-content">
     <div class="govuk-grid-row">
@@ -4561,926 +7889,6 @@ exports[`appeal-details GET /:appealId should render a page not found when the a
             <p class="govuk-body">If you pasted the web address, check you copied the entire address.</p>
             <p             class="govuk-body"><a href="https://has-appeal.herokuapp.com/help/contact" class="govuk-link">Contact the Planning Inspectorate Customer Support</a> if
                 the problem persists</p>
-        </div>
-    </div>
-</main>"
-`;
-
-exports[`appeal-details GET /:appealId should render an action link to the add linked appeals page, if the appeal is a lead appeal in a state before STATEMENTS 1`] = `
-"<main class="govuk-main-wrapper" id="main-content">
-    <div class="govuk-grid-row">
-        <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Appeal 351062</span>
-            <h1 class="govuk-heading-xl govuk-!-margin-bottom-3">Case details</h1>
-        </div>
-    </div>
-    <div class="govuk-grid-row">
-        <div class="govuk-grid-column-full"><strong class="govuk-tag govuk-tag--green pins-status-tag--full-width">LPA questionnaire</strong>
-            <strong             class="govuk-tag govuk-tag--grey govuk-!-margin-left-1 govuk-!-margin-bottom-4">Lead</strong>
-        </div>
-    </div>
-    <div class="govuk-grid-row">
-        <div class="govuk-grid-column-full">
-            <dl class="govuk-summary-list pins-summary-list--no-border">
-                <div class="govuk-summary-list__row appeal-case-officer"><dt class="govuk-summary-list__key"> Case officer</dt>
-                    <dd class="govuk-summary-list__value">
-                        <p class="govuk-body">Not assigned</p>
-                    </dd>
-                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/assign-case-officer/search-case-officer"
-                        data-cy="assign-case-officer-name">Assign<span class="govuk-visually-hidden"> Case officer</span></a>
-                    </dd>
-                </div>
-                <div class="govuk-summary-list__row appeal-site-address"><dt class="govuk-summary-list__key"> Site address</dt>
-                    <dd class="govuk-summary-list__value">21 The Pavement, Wandsworth, SW4 0HY</dd>
-                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-address/change/1?backUrl=%2Fappeals-service%2Fappeal-details%2F1"
-                        data-cy="change-site-address">Change<span class="govuk-visually-hidden"> Site address</span></a>
-                    </dd>
-                </div>
-                <div class="govuk-summary-list__row appeal-local-planning-authority"><dt class="govuk-summary-list__key"> LPA</dt>
-                    <dd class="govuk-summary-list__value">Wiltshire Council</dd>
-                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/change-appeal-details/local-planning-authority"
-                        data-cy="change-local-planning-authority">Change<span class="govuk-visually-hidden"> LPA</span></a>
-                    </dd>
-                </div>
-            </dl>
-        </div>
-    </div>
-    <div class="govuk-grid-row">
-        <div class="govuk-grid-column-full">
-            <p class="govuk-body govuk-!-margin-bottom-6" id="download-case-files"
-            data-cy="download-case-files"><a class="govuk-link" href="/documents/1/bulk-download/case-APP/Q9999/D/21/351062.zip">Download case</a>
-            </p>
-        </div>
-    </div>
-    <div class="govuk-grid-row">
-        <div class="govuk-grid-column-full">
-            <details class="govuk-details">
-                <summary class="govuk-details__summary"><span class="govuk-details__summary-text"> 2 case notes</span>
-                </summary>
-                <div class="govuk-details__text">
-                    <form method="POST" novalidate="novalidate">
-                        <div class="govuk-grid-row">
-                            <div class="govuk-grid-column-two-thirds">
-                                <div class="govuk-form-group govuk-character-count" data-module="govuk-character-count"
-                                data-maxlength="500">
-                                    <textarea class="govuk-textarea govuk-js-character-count" id="comment"
-                                    name="comment" rows="5" aria-describedby="comment-info"></textarea>
-                                    <div id="comment-info" class="govuk-hint govuk-character-count__message">You can enter up to 500 characters</div>
-                                </div>
-                            </div>
-                        </div>
-                        <button type="submit" data-prevent-double-click="true" class="govuk-button govuk-button--secondary govuk-!-margin-bottom-1"
-                        data-module="govuk-button">Add case note</button>
-                    </form>
-                    <div>
-                        <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
-                        <section>
-                            <p class="govuk-body govuk-!-margin-bottom-1">A case note you should see.</p>
-                            <p class="govuk-hint govuk-!-margin-bottom-6">11:00am on Tuesday 1 October 2024 by John.Smith</p>
-                            <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
-                        </section>
-                        <section>
-                            <p class="govuk-body govuk-!-margin-bottom-1">A case note you should see.</p>
-                            <p class="govuk-hint govuk-!-margin-bottom-6">11:00am on Tuesday 1 October 2024 by John.Smith</p>
-                            <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
-                        </section>
-                    </div>
-                </div>
-            </details>
-        </div>
-    </div>
-    <div class="govuk-grid-row">
-        <div class="govuk-grid-column-full">
-            <div class="govuk-accordion" data-module="govuk-accordion" id="accordion-default1">
-                <div class="govuk-accordion__section">
-                    <div class="govuk-accordion__section-header">
-                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-1"> Overview</span></h2>
-                    </div>
-                    <div id="accordion-default1-content-1" class="govuk-accordion__section-content">
-                        <dl class="govuk-summary-list">
-                            <div class="govuk-summary-list__row govuk-summary-list__row--no-actions appeal-lpa-reference"><dt class="govuk-summary-list__key"> Planning application reference</dt>
-                                <dd                                 class="govuk-summary-list__value">48269/APP/2021/1482</dd>
-                            </div>
-                            <div class="govuk-summary-list__row appeal-appeal-type"><dt class="govuk-summary-list__key"> Appeal type</dt>
-                                <dd class="govuk-summary-list__value">Householder</dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/change-appeal-type/appeal-type"
-                                    data-cy="change-appeal-type">Change<span class="govuk-visually-hidden"> Appeal type</span></a>
-                                </dd>
-                            </div>
-                            <div class="govuk-summary-list__row govuk-summary-list__row--no-actions appeal-case-procedure"><dt class="govuk-summary-list__key"> Appeal procedure</dt>
-                                <dd class="govuk-summary-list__value">Written</dd>
-                            </div>
-                            <div class="govuk-summary-list__row appeal-allocation-details"><dt class="govuk-summary-list__key"> Allocation level</dt>
-                                <dd class="govuk-summary-list__value">
-                                    <ul class="govuk-!-margin-0">
-                                        <li>Level: A</li>
-                                        <li>Historic heritage</li>
-                                        <li>Architecture design</li>
-                                    </ul>
-                                </dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/allocation-details/allocation-level"
-                                    data-cy="change-allocation-details">Change<span class="govuk-visually-hidden"> Allocation level</span></a>
-                                </dd>
-                            </div>
-                            <div class="govuk-summary-list__row appeal-linked-appeals"><dt class="govuk-summary-list__key"> Linked appeals</dt>
-                                <dd class="govuk-summary-list__value">
-                                    <ul class="govuk-list govuk-list--bullet">
-                                        <li><a href="/appeals-service/appeal-details/5449" class="govuk-link" data-cy="linked-appeal-784706"
-                                            aria-label="Appeal 7 8 4 7 0 6">784706</a>
-                                        </li>
-                                        <li><a href="/appeals-service/appeal-details/5451" class="govuk-link" data-cy="linked-appeal-721086"
-                                            aria-label="Appeal 7 2 1 0 8 6">721086</a>
-                                        </li>
-                                    </ul>
-                                </dd>
-                                <dd class="govuk-summary-list__actions">
-                                    <ul class="govuk-summary-list__actions-list">
-                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/linked-appeals/manage"
-                                            data-cy="manage-linked-appeals">Manage<span class="govuk-visually-hidden"> Linked appeals</span></a>
-                                        </li>
-                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/linked-appeals/add"
-                                            data-cy="add-linked-appeal">Add<span class="govuk-visually-hidden"> Linked appeals</span></a>
-                                        </li>
-                                    </ul>
-                                </dd>
-                            </div>
-                            <div class="govuk-summary-list__row appeal-other-appeals"><dt class="govuk-summary-list__key"> Related appeals</dt>
-                                <dd class="govuk-summary-list__value"><span>No</span>
-                                </dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/other-appeals/add"
-                                    data-cy="add-related-appeals">Add<span class="govuk-visually-hidden"> Related appeals</span></a>
-                                </dd>
-                            </div>
-                            <div class="govuk-summary-list__row appeal-decision"><dt class="govuk-summary-list__key"> Decision</dt>
-                                <dd class="govuk-summary-list__value">Dismissed</dd>
-                            </div>
-                        </dl>
-                    </div>
-                </div>
-                <div class="govuk-accordion__section">
-                    <div class="govuk-accordion__section-header">
-                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-2"> Site</span></h2>
-                    </div>
-                    <div id="accordion-default1-content-2" class="govuk-accordion__section-content">
-                        <dl class="govuk-summary-list">
-                            <div class="govuk-summary-list__row appeal-visit-type"><dt class="govuk-summary-list__key"> Visit type</dt>
-                                <dd class="govuk-summary-list__value">Accompanied</dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/visit-booked?backUrl=%2Fappeals-service%2Fappeal-details%2F1"
-                                    data-cy="change-set-visit-type">Change<span class="govuk-visually-hidden"> Visit type</span></a>
-                                </dd>
-                            </div>
-                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Date</dt>
-                                <dd class="govuk-summary-list__value">9 October 2023</dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/visit-booked"
-                                    data-cy="change-site-visit-date">Change<span class="govuk-visually-hidden"> Date</span></a>
-                                </dd>
-                            </div>
-                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Start time</dt>
-                                <dd class="govuk-summary-list__value">9:38am</dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/visit-booked"
-                                    data-cy="change-site-visit-start-time">Change<span class="govuk-visually-hidden"> Start time</span></a>
-                                </dd>
-                            </div>
-                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> End time</dt>
-                                <dd class="govuk-summary-list__value">10:00am</dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/visit-booked"
-                                    data-cy="change-site-visit-end-time">Change<span class="govuk-visually-hidden"> End time</span></a>
-                                </dd>
-                            </div>
-                            <div class="govuk-summary-list__row appeal-neighbouring-sites-inspector"><dt class="govuk-summary-list__key"> Interested party and neighbour addresses</dt>
-                                <dd                                 class="govuk-summary-list__value">
-                                    <ul class="govuk-list govuk-list--bullet">
-                                        <li>2 Grove Cottage, Shotesham Road, Woodton, Devon, NR35 2ND</li>
-                                    </ul>
-                                    </dd>
-                                    <dd class="govuk-summary-list__actions">
-                                        <ul class="govuk-summary-list__actions-list">
-                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/neighbouring-sites/manage"
-                                                data-cy="manage-neighbouring-sites-inspector">Manage<span class="govuk-visually-hidden"> Interested party and neighbour addresses</span></a>
-                                            </li>
-                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/neighbouring-sites/add/back-office"
-                                                data-cy="add-neighbouring-sites-inspector">Add<span class="govuk-visually-hidden"> Interested party and neighbour addresses</span></a>
-                                            </li>
-                                        </ul>
-                                    </dd>
-                            </div>
-                        </dl>
-                    </div>
-                </div>
-                <div class="govuk-accordion__section">
-                    <div class="govuk-accordion__section-header">
-                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-3"> Timetable</span></h2>
-                    </div>
-                    <div id="accordion-default1-content-3" class="govuk-accordion__section-content">
-                        <dl class="govuk-summary-list appeal-case-timetable">
-                            <div class="govuk-summary-list__row appeal-valid-date"><dt class="govuk-summary-list__key"> Valid date</dt>
-                                <dd class="govuk-summary-list__value">23 May 2023</dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/valid/date"
-                                    data-cy="-valid-date"><span class="govuk-visually-hidden"> Valid date</span></a>
-                                </dd>
-                            </div>
-                            <div class="govuk-summary-list__row appeal-start-date"><dt class="govuk-summary-list__key"> Start date</dt>
-                                <dd class="govuk-summary-list__value">23 May 2023</dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/start-case/change"
-                                    data-cy="change-start-case-date">Change<span class="govuk-visually-hidden"> Start date</span></a>
-                                </dd>
-                            </div>
-                            <div class="govuk-summary-list__row appeal-lpa-questionnaire-due-date"><dt class="govuk-summary-list__key"> LPA questionnaire due</dt>
-                                <dd class="govuk-summary-list__value">11 October 2023</dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/timetable/edit"
-                                    data-cy="change-lpa-questionnaire-due-date">Change<span class="govuk-visually-hidden"> LPA questionnaire due</span></a>
-                                </dd>
-                            </div>
-                            <div class="govuk-summary-list__row appeal-site-visit"><dt class="govuk-summary-list__key"> Site visit</dt>
-                                <dd class="govuk-summary-list__value">
-                                    <ul class="govuk-list govuk-!-margin-top-0 govuk-!-padding-left-0">
-                                        <li>9 October 2023</li>
-                                        <li>9:38am - 10:00am</li>
-                                    </ul>
-                                </dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/manage-visit?backUrl=%2Fappeals-service%2Fappeal-details%2F1"
-                                    data-cy="change-schedule-visit">Change<span class="govuk-visually-hidden"> Site visit</span></a>
-                                </dd>
-                            </div>
-                        </dl>
-                    </div>
-                </div>
-                <div class="govuk-accordion__section">
-                    <div class="govuk-accordion__section-header">
-                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-4"> Documentation</span></h2>
-                    </div>
-                    <div id="accordion-default1-content-4" class="govuk-accordion__section-content">
-                        <table class="govuk-table">
-                            <thead class="govuk-table__head">
-                                <tr class="govuk-table__row">
-                                    <th scope="col" class="govuk-table__header">Documentation</th>
-                                    <th scope="col" class="govuk-table__header">Status</th>
-                                    <th scope="col" class="govuk-table__header">Received</th>
-                                    <th scope="col" class="govuk-table__header govuk-!-text-align-right">Action</th>
-                                </tr>
-                            </thead>
-                            <tbody class="govuk-table__body">
-                                <tr class="govuk-table__row">
-                                    <th scope="row" class="govuk-table__header">Appeal</th>
-                                    <td class="govuk-table__cell">Ready to review</td>
-                                    <td class="govuk-table__cell">2 August 2024</td>
-                                    <td class="govuk-table__cell govuk-!-text-align-right"><a href="/appeals-service/appeal-details/1/appellant-case?backUrl=%2Fappeals-service%2Fappeal-details%2F1"
-                                        data-cy="review-appellant-case" class="govuk-link">Review<span class="govuk-visually-hidden"> appellant case</span></a>
-                                    </td>
-                                </tr>
-                                <tr class="govuk-table__row">
-                                    <th scope="row" class="govuk-table__header">LPA questionnaire</th>
-                                    <td class="govuk-table__cell">Overdue</td>
-                                    <td class="govuk-table__cell">Due by 11 October 2023</td>
-                                    <td class="govuk-table__cell govuk-!-text-align-right"></td>
-                                </tr>
-                            </tbody>
-                        </table>
-                    </div>
-                </div>
-                <div class="govuk-accordion__section">
-                    <div class="govuk-accordion__section-header">
-                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-5"> Costs</span></h2>
-                    </div>
-                    <div id="accordion-default1-content-5" class="govuk-accordion__section-content">
-                        <table class="govuk-table">
-                            <thead class="govuk-table__head">
-                                <tr class="govuk-table__row">
-                                    <th scope="col" class="govuk-table__header">Documentation</th>
-                                    <th scope="col" class="govuk-table__header">Status</th>
-                                    <th scope="col" class="govuk-table__header govuk-!-text-align-right">Action</th>
-                                </tr>
-                            </thead>
-                            <tbody class="govuk-table__body">
-                                <tr class="govuk-table__row">
-                                    <th scope="row" class="govuk-table__header appeal-costs-appellant-application-documentation">Appellant application</th>
-                                    <td class="govuk-table__cell appeal-costs-appellant-application-status">No documents available</td>
-                                    <td class="govuk-table__cell appeal-costs-appellant-application-actions govuk-!-text-align-right">
-                                        <ul class="govuk-summary-list__actions-list">
-                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-appellant-application" href="/appeals-service/appeal-details/1/costs/appellant/application/upload-documents/1">Add<span class="govuk-visually-hidden"> Appellant application</span></a>
-                                            </li>
-                                        </ul>
-                                    </td>
-                                </tr>
-                                <tr class="govuk-table__row">
-                                    <th scope="row" class="govuk-table__header appeal-costs-appellant-withdrawal-documentation">Appellant withdrawal</th>
-                                    <td class="govuk-table__cell appeal-costs-appellant-withdrawal-status">No documents available</td>
-                                    <td class="govuk-table__cell appeal-costs-appellant-withdrawal-actions govuk-!-text-align-right">
-                                        <ul class="govuk-summary-list__actions-list">
-                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-appellant-withdrawal" href="/appeals-service/appeal-details/1/costs/appellant/withdrawal/upload-documents/2">Add<span class="govuk-visually-hidden"> Appellant withdrawal</span></a>
-                                            </li>
-                                        </ul>
-                                    </td>
-                                </tr>
-                                <tr class="govuk-table__row">
-                                    <th scope="row" class="govuk-table__header appeal-costs-appellant-correspondence-documentation">Appellant correspondence</th>
-                                    <td class="govuk-table__cell appeal-costs-appellant-correspondence-status">No documents available</td>
-                                    <td class="govuk-table__cell appeal-costs-appellant-correspondence-actions govuk-!-text-align-right">
-                                        <ul class="govuk-summary-list__actions-list">
-                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-appellant-correspondence" href="/appeals-service/appeal-details/1/costs/appellant/correspondence/upload-documents/3">Add<span class="govuk-visually-hidden"> Appellant correspondence</span></a>
-                                            </li>
-                                        </ul>
-                                    </td>
-                                </tr>
-                                <tr class="govuk-table__row">
-                                    <th scope="row" class="govuk-table__header appeal-costs-lpa-application-documentation">LPA application</th>
-                                    <td class="govuk-table__cell appeal-costs-lpa-application-status">No documents available</td>
-                                    <td class="govuk-table__cell appeal-costs-lpa-application-actions govuk-!-text-align-right">
-                                        <ul class="govuk-summary-list__actions-list">
-                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-lpa-application" href="/appeals-service/appeal-details/1/costs/lpa/application/upload-documents/4">Add<span class="govuk-visually-hidden"> LPA application</span></a>
-                                            </li>
-                                        </ul>
-                                    </td>
-                                </tr>
-                                <tr class="govuk-table__row">
-                                    <th scope="row" class="govuk-table__header appeal-costs-lpa-withdrawal-documentation">LPA withdrawal</th>
-                                    <td class="govuk-table__cell appeal-costs-lpa-withdrawal-status">No documents available</td>
-                                    <td class="govuk-table__cell appeal-costs-lpa-withdrawal-actions govuk-!-text-align-right">
-                                        <ul class="govuk-summary-list__actions-list">
-                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-lpa-withdrawal" href="/appeals-service/appeal-details/1/costs/lpa/withdrawal/upload-documents/5">Add<span class="govuk-visually-hidden"> LPA withdrawal</span></a>
-                                            </li>
-                                        </ul>
-                                    </td>
-                                </tr>
-                                <tr class="govuk-table__row">
-                                    <th scope="row" class="govuk-table__header appeal-costs-lpa-correspondence-documentation">LPA correspondence</th>
-                                    <td class="govuk-table__cell appeal-costs-lpa-correspondence-status">No documents available</td>
-                                    <td class="govuk-table__cell appeal-costs-lpa-correspondence-actions govuk-!-text-align-right">
-                                        <ul class="govuk-summary-list__actions-list">
-                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-lpa-correspondence" href="/appeals-service/appeal-details/1/costs/lpa/correspondence/upload-documents/6">Add<span class="govuk-visually-hidden"> LPA correspondence</span></a>
-                                            </li>
-                                        </ul>
-                                    </td>
-                                </tr>
-                            </tbody>
-                        </table>
-                    </div>
-                </div>
-                <div class="govuk-accordion__section">
-                    <div class="govuk-accordion__section-header">
-                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-6"> Contacts</span></h2>
-                    </div>
-                    <div id="accordion-default1-content-6" class="govuk-accordion__section-content">
-                        <dl class="govuk-summary-list">
-                            <div class="govuk-summary-list__row appeal-appellant"><dt class="govuk-summary-list__key"> Appellant</dt>
-                                <dd class="govuk-summary-list__value">
-                                    <ul class="govuk-list">
-                                        <li>Roger Simmons</li>
-                                        <li>test3@example.com</li>
-                                    </ul>
-                                </dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/service-user/change/appellant"
-                                    data-cy="change-appellant">Change<span class="govuk-visually-hidden"> Appellant</span></a>
-                                </dd>
-                            </div>
-                            <div class="govuk-summary-list__row appeal-agent"><dt class="govuk-summary-list__key"> Agent</dt>
-                                <dd class="govuk-summary-list__value">
-                                    <ul class="govuk-list">
-                                        <li>Fiona Shell</li>
-                                        <li>test2@example.com</li>
-                                    </ul>
-                                </dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/service-user/change/agent"
-                                    data-cy="change-agent">Change<span class="govuk-visually-hidden"> Agent</span></a>
-                                </dd>
-                            </div>
-                            <div class="govuk-summary-list__row appeal-lpa-contact-details"><dt class="govuk-summary-list__key"> LPA</dt>
-                                <dd class="govuk-summary-list__value">
-                                    <ul class="govuk-list">
-                                        <li>Wiltshire Council</li>
-                                        <li>wilt@lpa-email.gov.uk</li>
-                                    </ul>
-                                </dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/change-appeal-details/local-planning-authority"
-                                    data-cy="change-lpa-contact-details">Change<span class="govuk-visually-hidden"> Local planning authority (LPA)</span></a>
-                                </dd>
-                            </div>
-                        </dl>
-                    </div>
-                </div>
-                <div class="govuk-accordion__section">
-                    <div class="govuk-accordion__section-header">
-                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-7"> Team</span></h2>
-                    </div>
-                    <div id="accordion-default1-content-7" class="govuk-accordion__section-content">
-                        <dl class="govuk-summary-list">
-                            <div class="govuk-summary-list__row appeal-case-officer"><dt class="govuk-summary-list__key"> Case officer</dt>
-                                <dd class="govuk-summary-list__value">
-                                    <p class="govuk-body">Not assigned</p>
-                                </dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/assign-case-officer/search-case-officer"
-                                    data-cy="assign-case-officer">Assign<span class="govuk-visually-hidden"> Case officer</span></a>
-                                </dd>
-                            </div>
-                            <div class="govuk-summary-list__row appeal-inspector"><dt class="govuk-summary-list__key"> Inspector</dt>
-                                <dd class="govuk-summary-list__value">
-                                    <p class="govuk-body">Not assigned</p>
-                                </dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/assign-inspector/search-inspector"
-                                    data-cy="assign-inspector">Assign<span class="govuk-visually-hidden"> Inspector</span></a>
-                                </dd>
-                            </div>
-                        </dl>
-                    </div>
-                </div>
-                <div class="govuk-accordion__section">
-                    <div class="govuk-accordion__section-header">
-                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-8"> Case management</span></h2>
-                    </div>
-                    <div id="accordion-default1-content-8" class="govuk-accordion__section-content">
-                        <dl class="govuk-summary-list">
-                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Cross-team correspondence</dt>
-                                <dd                                 class="govuk-summary-list__value">No documents</dd>
-                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/internal-correspondence/cross-team/upload-documents/10"
-                                        data-cy="add-cross-team-correspondence">Add<span class="govuk-visually-hidden"> Cross-team correspondence</span></a>
-                                    </dd>
-                            </div>
-                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Inspector correspondence</dt>
-                                <dd                                 class="govuk-summary-list__value">No documents</dd>
-                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/internal-correspondence/inspector/upload-documents/11"
-                                        data-cy="add-inspector-correspondence">Add<span class="govuk-visually-hidden"> Inspector correspondence</span></a>
-                                    </dd>
-                            </div>
-                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Main party correspondence</dt>
-                                <dd                                 class="govuk-summary-list__value">No documents</dd>
-                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/internal-correspondence/main-party/upload-documents/22"
-                                        data-cy="add-main-party-correspondence">Add<span class="govuk-visually-hidden"> Main party correspondence</span></a>
-                                    </dd>
-                            </div>
-                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Case history</dt>
-                                <dd class="govuk-summary-list__value"></dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/audit" data-cy="view-case-history">View<span class="govuk-visually-hidden"> Case history</span></a>
-                                </dd>
-                            </div>
-                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Appeal withdrawal</dt>
-                                <dd class="govuk-summary-list__value"></dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/withdrawal/start"
-                                    data-cy="start-appeal-withdrawal">Start<span class="govuk-visually-hidden"> Appeal withdrawal</span></a>
-                                </dd>
-                            </div>
-                        </dl>
-                    </div>
-                </div>
-            </div>
-        </div>
-    </div>
-</main>"
-`;
-
-exports[`appeal-details GET /:appealId should render an action link to the manage linked appeals page, if there are linked appeals, the status is not past LPA Questionnaire, all the linked appeals are children and internal 1`] = `
-"<main class="govuk-main-wrapper" id="main-content">
-    <div class="govuk-grid-row">
-        <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Appeal 351062</span>
-            <h1 class="govuk-heading-xl govuk-!-margin-bottom-3">Case details</h1>
-        </div>
-    </div>
-    <div class="govuk-grid-row">
-        <div class="govuk-grid-column-full"><strong class="govuk-tag govuk-tag--green pins-status-tag--full-width">LPA questionnaire</strong>
-            <strong             class="govuk-tag govuk-tag--grey govuk-!-margin-left-1 govuk-!-margin-bottom-4"></strong>
-        </div>
-    </div>
-    <div class="govuk-grid-row">
-        <div class="govuk-grid-column-full">
-            <dl class="govuk-summary-list pins-summary-list--no-border">
-                <div class="govuk-summary-list__row appeal-case-officer"><dt class="govuk-summary-list__key"> Case officer</dt>
-                    <dd class="govuk-summary-list__value">
-                        <p class="govuk-body">Not assigned</p>
-                    </dd>
-                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/assign-case-officer/search-case-officer"
-                        data-cy="assign-case-officer-name">Assign<span class="govuk-visually-hidden"> Case officer</span></a>
-                    </dd>
-                </div>
-                <div class="govuk-summary-list__row appeal-site-address"><dt class="govuk-summary-list__key"> Site address</dt>
-                    <dd class="govuk-summary-list__value">21 The Pavement, Wandsworth, SW4 0HY</dd>
-                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-address/change/1?backUrl=%2Fappeals-service%2Fappeal-details%2F1"
-                        data-cy="change-site-address">Change<span class="govuk-visually-hidden"> Site address</span></a>
-                    </dd>
-                </div>
-                <div class="govuk-summary-list__row appeal-local-planning-authority"><dt class="govuk-summary-list__key"> LPA</dt>
-                    <dd class="govuk-summary-list__value">Wiltshire Council</dd>
-                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/change-appeal-details/local-planning-authority"
-                        data-cy="change-local-planning-authority">Change<span class="govuk-visually-hidden"> LPA</span></a>
-                    </dd>
-                </div>
-            </dl>
-        </div>
-    </div>
-    <div class="govuk-grid-row">
-        <div class="govuk-grid-column-full">
-            <p class="govuk-body govuk-!-margin-bottom-6" id="download-case-files"
-            data-cy="download-case-files"><a class="govuk-link" href="/documents/1/bulk-download/case-APP/Q9999/D/21/351062.zip">Download case</a>
-            </p>
-        </div>
-    </div>
-    <div class="govuk-grid-row">
-        <div class="govuk-grid-column-full">
-            <details class="govuk-details">
-                <summary class="govuk-details__summary"><span class="govuk-details__summary-text"> 2 case notes</span>
-                </summary>
-                <div class="govuk-details__text">
-                    <form method="POST" novalidate="novalidate">
-                        <div class="govuk-grid-row">
-                            <div class="govuk-grid-column-two-thirds">
-                                <div class="govuk-form-group govuk-character-count" data-module="govuk-character-count"
-                                data-maxlength="500">
-                                    <textarea class="govuk-textarea govuk-js-character-count" id="comment"
-                                    name="comment" rows="5" aria-describedby="comment-info"></textarea>
-                                    <div id="comment-info" class="govuk-hint govuk-character-count__message">You can enter up to 500 characters</div>
-                                </div>
-                            </div>
-                        </div>
-                        <button type="submit" data-prevent-double-click="true" class="govuk-button govuk-button--secondary govuk-!-margin-bottom-1"
-                        data-module="govuk-button">Add case note</button>
-                    </form>
-                    <div>
-                        <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
-                        <section>
-                            <p class="govuk-body govuk-!-margin-bottom-1">A case note you should see.</p>
-                            <p class="govuk-hint govuk-!-margin-bottom-6">11:00am on Tuesday 1 October 2024 by John.Smith</p>
-                            <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
-                        </section>
-                        <section>
-                            <p class="govuk-body govuk-!-margin-bottom-1">A case note you should see.</p>
-                            <p class="govuk-hint govuk-!-margin-bottom-6">11:00am on Tuesday 1 October 2024 by John.Smith</p>
-                            <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
-                        </section>
-                    </div>
-                </div>
-            </details>
-        </div>
-    </div>
-    <div class="govuk-grid-row">
-        <div class="govuk-grid-column-full">
-            <div class="govuk-accordion" data-module="govuk-accordion" id="accordion-default1">
-                <div class="govuk-accordion__section">
-                    <div class="govuk-accordion__section-header">
-                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-1"> Overview</span></h2>
-                    </div>
-                    <div id="accordion-default1-content-1" class="govuk-accordion__section-content">
-                        <dl class="govuk-summary-list">
-                            <div class="govuk-summary-list__row govuk-summary-list__row--no-actions appeal-lpa-reference"><dt class="govuk-summary-list__key"> Planning application reference</dt>
-                                <dd                                 class="govuk-summary-list__value">48269/APP/2021/1482</dd>
-                            </div>
-                            <div class="govuk-summary-list__row appeal-appeal-type"><dt class="govuk-summary-list__key"> Appeal type</dt>
-                                <dd class="govuk-summary-list__value">Householder</dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/change-appeal-type/appeal-type"
-                                    data-cy="change-appeal-type">Change<span class="govuk-visually-hidden"> Appeal type</span></a>
-                                </dd>
-                            </div>
-                            <div class="govuk-summary-list__row govuk-summary-list__row--no-actions appeal-case-procedure"><dt class="govuk-summary-list__key"> Appeal procedure</dt>
-                                <dd class="govuk-summary-list__value">Written</dd>
-                            </div>
-                            <div class="govuk-summary-list__row appeal-allocation-details"><dt class="govuk-summary-list__key"> Allocation level</dt>
-                                <dd class="govuk-summary-list__value">
-                                    <ul class="govuk-!-margin-0">
-                                        <li>Level: A</li>
-                                        <li>Historic heritage</li>
-                                        <li>Architecture design</li>
-                                    </ul>
-                                </dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/allocation-details/allocation-level"
-                                    data-cy="change-allocation-details">Change<span class="govuk-visually-hidden"> Allocation level</span></a>
-                                </dd>
-                            </div>
-                            <div class="govuk-summary-list__row appeal-linked-appeals"><dt class="govuk-summary-list__key"> Linked appeals</dt>
-                                <dd class="govuk-summary-list__value">
-                                    <ul class="govuk-list govuk-list--bullet">
-                                        <li><a href="/appeals-service/appeal-details/5449" class="govuk-link" data-cy="linked-appeal-784706"
-                                            aria-label="Appeal 7 8 4 7 0 6">784706</a>
-                                        </li>
-                                        <li><a href="/appeals-service/appeal-details/5451" class="govuk-link" data-cy="linked-appeal-721086"
-                                            aria-label="Appeal 7 2 1 0 8 6">721086</a>
-                                        </li>
-                                    </ul>
-                                </dd>
-                                <dd class="govuk-summary-list__actions">
-                                    <ul class="govuk-summary-list__actions-list">
-                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/linked-appeals/manage"
-                                            data-cy="manage-linked-appeals">Manage<span class="govuk-visually-hidden"> Linked appeals</span></a>
-                                        </li>
-                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/linked-appeals/add"
-                                            data-cy="add-linked-appeal">Add<span class="govuk-visually-hidden"> Linked appeals</span></a>
-                                        </li>
-                                    </ul>
-                                </dd>
-                            </div>
-                            <div class="govuk-summary-list__row appeal-other-appeals"><dt class="govuk-summary-list__key"> Related appeals</dt>
-                                <dd class="govuk-summary-list__value"><span>No</span>
-                                </dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/other-appeals/add"
-                                    data-cy="add-related-appeals">Add<span class="govuk-visually-hidden"> Related appeals</span></a>
-                                </dd>
-                            </div>
-                            <div class="govuk-summary-list__row appeal-decision"><dt class="govuk-summary-list__key"> Decision</dt>
-                                <dd class="govuk-summary-list__value">Dismissed</dd>
-                            </div>
-                        </dl>
-                    </div>
-                </div>
-                <div class="govuk-accordion__section">
-                    <div class="govuk-accordion__section-header">
-                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-2"> Site</span></h2>
-                    </div>
-                    <div id="accordion-default1-content-2" class="govuk-accordion__section-content">
-                        <dl class="govuk-summary-list">
-                            <div class="govuk-summary-list__row appeal-visit-type"><dt class="govuk-summary-list__key"> Visit type</dt>
-                                <dd class="govuk-summary-list__value">Accompanied</dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/visit-booked?backUrl=%2Fappeals-service%2Fappeal-details%2F1"
-                                    data-cy="change-set-visit-type">Change<span class="govuk-visually-hidden"> Visit type</span></a>
-                                </dd>
-                            </div>
-                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Date</dt>
-                                <dd class="govuk-summary-list__value">9 October 2023</dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/visit-booked"
-                                    data-cy="change-site-visit-date">Change<span class="govuk-visually-hidden"> Date</span></a>
-                                </dd>
-                            </div>
-                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Start time</dt>
-                                <dd class="govuk-summary-list__value">9:38am</dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/visit-booked"
-                                    data-cy="change-site-visit-start-time">Change<span class="govuk-visually-hidden"> Start time</span></a>
-                                </dd>
-                            </div>
-                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> End time</dt>
-                                <dd class="govuk-summary-list__value">10:00am</dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/visit-booked"
-                                    data-cy="change-site-visit-end-time">Change<span class="govuk-visually-hidden"> End time</span></a>
-                                </dd>
-                            </div>
-                            <div class="govuk-summary-list__row appeal-neighbouring-sites-inspector"><dt class="govuk-summary-list__key"> Interested party and neighbour addresses</dt>
-                                <dd                                 class="govuk-summary-list__value">
-                                    <ul class="govuk-list govuk-list--bullet">
-                                        <li>2 Grove Cottage, Shotesham Road, Woodton, Devon, NR35 2ND</li>
-                                    </ul>
-                                    </dd>
-                                    <dd class="govuk-summary-list__actions">
-                                        <ul class="govuk-summary-list__actions-list">
-                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/neighbouring-sites/manage"
-                                                data-cy="manage-neighbouring-sites-inspector">Manage<span class="govuk-visually-hidden"> Interested party and neighbour addresses</span></a>
-                                            </li>
-                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/neighbouring-sites/add/back-office"
-                                                data-cy="add-neighbouring-sites-inspector">Add<span class="govuk-visually-hidden"> Interested party and neighbour addresses</span></a>
-                                            </li>
-                                        </ul>
-                                    </dd>
-                            </div>
-                        </dl>
-                    </div>
-                </div>
-                <div class="govuk-accordion__section">
-                    <div class="govuk-accordion__section-header">
-                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-3"> Timetable</span></h2>
-                    </div>
-                    <div id="accordion-default1-content-3" class="govuk-accordion__section-content">
-                        <dl class="govuk-summary-list appeal-case-timetable">
-                            <div class="govuk-summary-list__row appeal-valid-date"><dt class="govuk-summary-list__key"> Valid date</dt>
-                                <dd class="govuk-summary-list__value">23 May 2023</dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/valid/date"
-                                    data-cy="-valid-date"><span class="govuk-visually-hidden"> Valid date</span></a>
-                                </dd>
-                            </div>
-                            <div class="govuk-summary-list__row appeal-start-date"><dt class="govuk-summary-list__key"> Start date</dt>
-                                <dd class="govuk-summary-list__value">23 May 2023</dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/start-case/change"
-                                    data-cy="change-start-case-date">Change<span class="govuk-visually-hidden"> Start date</span></a>
-                                </dd>
-                            </div>
-                            <div class="govuk-summary-list__row appeal-lpa-questionnaire-due-date"><dt class="govuk-summary-list__key"> LPA questionnaire due</dt>
-                                <dd class="govuk-summary-list__value">11 October 2023</dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/timetable/edit"
-                                    data-cy="change-lpa-questionnaire-due-date">Change<span class="govuk-visually-hidden"> LPA questionnaire due</span></a>
-                                </dd>
-                            </div>
-                            <div class="govuk-summary-list__row appeal-site-visit"><dt class="govuk-summary-list__key"> Site visit</dt>
-                                <dd class="govuk-summary-list__value">
-                                    <ul class="govuk-list govuk-!-margin-top-0 govuk-!-padding-left-0">
-                                        <li>9 October 2023</li>
-                                        <li>9:38am - 10:00am</li>
-                                    </ul>
-                                </dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/manage-visit?backUrl=%2Fappeals-service%2Fappeal-details%2F1"
-                                    data-cy="change-schedule-visit">Change<span class="govuk-visually-hidden"> Site visit</span></a>
-                                </dd>
-                            </div>
-                        </dl>
-                    </div>
-                </div>
-                <div class="govuk-accordion__section">
-                    <div class="govuk-accordion__section-header">
-                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-4"> Documentation</span></h2>
-                    </div>
-                    <div id="accordion-default1-content-4" class="govuk-accordion__section-content">
-                        <table class="govuk-table">
-                            <thead class="govuk-table__head">
-                                <tr class="govuk-table__row">
-                                    <th scope="col" class="govuk-table__header">Documentation</th>
-                                    <th scope="col" class="govuk-table__header">Status</th>
-                                    <th scope="col" class="govuk-table__header">Received</th>
-                                    <th scope="col" class="govuk-table__header govuk-!-text-align-right">Action</th>
-                                </tr>
-                            </thead>
-                            <tbody class="govuk-table__body">
-                                <tr class="govuk-table__row">
-                                    <th scope="row" class="govuk-table__header">Appeal</th>
-                                    <td class="govuk-table__cell">Ready to review</td>
-                                    <td class="govuk-table__cell">2 August 2024</td>
-                                    <td class="govuk-table__cell govuk-!-text-align-right"><a href="/appeals-service/appeal-details/1/appellant-case?backUrl=%2Fappeals-service%2Fappeal-details%2F1"
-                                        data-cy="review-appellant-case" class="govuk-link">Review<span class="govuk-visually-hidden"> appellant case</span></a>
-                                    </td>
-                                </tr>
-                                <tr class="govuk-table__row">
-                                    <th scope="row" class="govuk-table__header">LPA questionnaire</th>
-                                    <td class="govuk-table__cell">Overdue</td>
-                                    <td class="govuk-table__cell">Due by 11 October 2023</td>
-                                    <td class="govuk-table__cell govuk-!-text-align-right"></td>
-                                </tr>
-                            </tbody>
-                        </table>
-                    </div>
-                </div>
-                <div class="govuk-accordion__section">
-                    <div class="govuk-accordion__section-header">
-                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-5"> Costs</span></h2>
-                    </div>
-                    <div id="accordion-default1-content-5" class="govuk-accordion__section-content">
-                        <table class="govuk-table">
-                            <thead class="govuk-table__head">
-                                <tr class="govuk-table__row">
-                                    <th scope="col" class="govuk-table__header">Documentation</th>
-                                    <th scope="col" class="govuk-table__header">Status</th>
-                                    <th scope="col" class="govuk-table__header govuk-!-text-align-right">Action</th>
-                                </tr>
-                            </thead>
-                            <tbody class="govuk-table__body">
-                                <tr class="govuk-table__row">
-                                    <th scope="row" class="govuk-table__header appeal-costs-appellant-application-documentation">Appellant application</th>
-                                    <td class="govuk-table__cell appeal-costs-appellant-application-status">No documents available</td>
-                                    <td class="govuk-table__cell appeal-costs-appellant-application-actions govuk-!-text-align-right">
-                                        <ul class="govuk-summary-list__actions-list">
-                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-appellant-application" href="/appeals-service/appeal-details/1/costs/appellant/application/upload-documents/1">Add<span class="govuk-visually-hidden"> Appellant application</span></a>
-                                            </li>
-                                        </ul>
-                                    </td>
-                                </tr>
-                                <tr class="govuk-table__row">
-                                    <th scope="row" class="govuk-table__header appeal-costs-appellant-withdrawal-documentation">Appellant withdrawal</th>
-                                    <td class="govuk-table__cell appeal-costs-appellant-withdrawal-status">No documents available</td>
-                                    <td class="govuk-table__cell appeal-costs-appellant-withdrawal-actions govuk-!-text-align-right">
-                                        <ul class="govuk-summary-list__actions-list">
-                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-appellant-withdrawal" href="/appeals-service/appeal-details/1/costs/appellant/withdrawal/upload-documents/2">Add<span class="govuk-visually-hidden"> Appellant withdrawal</span></a>
-                                            </li>
-                                        </ul>
-                                    </td>
-                                </tr>
-                                <tr class="govuk-table__row">
-                                    <th scope="row" class="govuk-table__header appeal-costs-appellant-correspondence-documentation">Appellant correspondence</th>
-                                    <td class="govuk-table__cell appeal-costs-appellant-correspondence-status">No documents available</td>
-                                    <td class="govuk-table__cell appeal-costs-appellant-correspondence-actions govuk-!-text-align-right">
-                                        <ul class="govuk-summary-list__actions-list">
-                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-appellant-correspondence" href="/appeals-service/appeal-details/1/costs/appellant/correspondence/upload-documents/3">Add<span class="govuk-visually-hidden"> Appellant correspondence</span></a>
-                                            </li>
-                                        </ul>
-                                    </td>
-                                </tr>
-                                <tr class="govuk-table__row">
-                                    <th scope="row" class="govuk-table__header appeal-costs-lpa-application-documentation">LPA application</th>
-                                    <td class="govuk-table__cell appeal-costs-lpa-application-status">No documents available</td>
-                                    <td class="govuk-table__cell appeal-costs-lpa-application-actions govuk-!-text-align-right">
-                                        <ul class="govuk-summary-list__actions-list">
-                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-lpa-application" href="/appeals-service/appeal-details/1/costs/lpa/application/upload-documents/4">Add<span class="govuk-visually-hidden"> LPA application</span></a>
-                                            </li>
-                                        </ul>
-                                    </td>
-                                </tr>
-                                <tr class="govuk-table__row">
-                                    <th scope="row" class="govuk-table__header appeal-costs-lpa-withdrawal-documentation">LPA withdrawal</th>
-                                    <td class="govuk-table__cell appeal-costs-lpa-withdrawal-status">No documents available</td>
-                                    <td class="govuk-table__cell appeal-costs-lpa-withdrawal-actions govuk-!-text-align-right">
-                                        <ul class="govuk-summary-list__actions-list">
-                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-lpa-withdrawal" href="/appeals-service/appeal-details/1/costs/lpa/withdrawal/upload-documents/5">Add<span class="govuk-visually-hidden"> LPA withdrawal</span></a>
-                                            </li>
-                                        </ul>
-                                    </td>
-                                </tr>
-                                <tr class="govuk-table__row">
-                                    <th scope="row" class="govuk-table__header appeal-costs-lpa-correspondence-documentation">LPA correspondence</th>
-                                    <td class="govuk-table__cell appeal-costs-lpa-correspondence-status">No documents available</td>
-                                    <td class="govuk-table__cell appeal-costs-lpa-correspondence-actions govuk-!-text-align-right">
-                                        <ul class="govuk-summary-list__actions-list">
-                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-lpa-correspondence" href="/appeals-service/appeal-details/1/costs/lpa/correspondence/upload-documents/6">Add<span class="govuk-visually-hidden"> LPA correspondence</span></a>
-                                            </li>
-                                        </ul>
-                                    </td>
-                                </tr>
-                            </tbody>
-                        </table>
-                    </div>
-                </div>
-                <div class="govuk-accordion__section">
-                    <div class="govuk-accordion__section-header">
-                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-6"> Contacts</span></h2>
-                    </div>
-                    <div id="accordion-default1-content-6" class="govuk-accordion__section-content">
-                        <dl class="govuk-summary-list">
-                            <div class="govuk-summary-list__row appeal-appellant"><dt class="govuk-summary-list__key"> Appellant</dt>
-                                <dd class="govuk-summary-list__value">
-                                    <ul class="govuk-list">
-                                        <li>Roger Simmons</li>
-                                        <li>test3@example.com</li>
-                                    </ul>
-                                </dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/service-user/change/appellant"
-                                    data-cy="change-appellant">Change<span class="govuk-visually-hidden"> Appellant</span></a>
-                                </dd>
-                            </div>
-                            <div class="govuk-summary-list__row appeal-agent"><dt class="govuk-summary-list__key"> Agent</dt>
-                                <dd class="govuk-summary-list__value">
-                                    <ul class="govuk-list">
-                                        <li>Fiona Shell</li>
-                                        <li>test2@example.com</li>
-                                    </ul>
-                                </dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/service-user/change/agent"
-                                    data-cy="change-agent">Change<span class="govuk-visually-hidden"> Agent</span></a>
-                                </dd>
-                            </div>
-                            <div class="govuk-summary-list__row appeal-lpa-contact-details"><dt class="govuk-summary-list__key"> LPA</dt>
-                                <dd class="govuk-summary-list__value">
-                                    <ul class="govuk-list">
-                                        <li>Wiltshire Council</li>
-                                        <li>wilt@lpa-email.gov.uk</li>
-                                    </ul>
-                                </dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/change-appeal-details/local-planning-authority"
-                                    data-cy="change-lpa-contact-details">Change<span class="govuk-visually-hidden"> Local planning authority (LPA)</span></a>
-                                </dd>
-                            </div>
-                        </dl>
-                    </div>
-                </div>
-                <div class="govuk-accordion__section">
-                    <div class="govuk-accordion__section-header">
-                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-7"> Team</span></h2>
-                    </div>
-                    <div id="accordion-default1-content-7" class="govuk-accordion__section-content">
-                        <dl class="govuk-summary-list">
-                            <div class="govuk-summary-list__row appeal-case-officer"><dt class="govuk-summary-list__key"> Case officer</dt>
-                                <dd class="govuk-summary-list__value">
-                                    <p class="govuk-body">Not assigned</p>
-                                </dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/assign-case-officer/search-case-officer"
-                                    data-cy="assign-case-officer">Assign<span class="govuk-visually-hidden"> Case officer</span></a>
-                                </dd>
-                            </div>
-                            <div class="govuk-summary-list__row appeal-inspector"><dt class="govuk-summary-list__key"> Inspector</dt>
-                                <dd class="govuk-summary-list__value">
-                                    <p class="govuk-body">Not assigned</p>
-                                </dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/assign-inspector/search-inspector"
-                                    data-cy="assign-inspector">Assign<span class="govuk-visually-hidden"> Inspector</span></a>
-                                </dd>
-                            </div>
-                        </dl>
-                    </div>
-                </div>
-                <div class="govuk-accordion__section">
-                    <div class="govuk-accordion__section-header">
-                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-8"> Case management</span></h2>
-                    </div>
-                    <div id="accordion-default1-content-8" class="govuk-accordion__section-content">
-                        <dl class="govuk-summary-list">
-                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Cross-team correspondence</dt>
-                                <dd                                 class="govuk-summary-list__value">No documents</dd>
-                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/internal-correspondence/cross-team/upload-documents/10"
-                                        data-cy="add-cross-team-correspondence">Add<span class="govuk-visually-hidden"> Cross-team correspondence</span></a>
-                                    </dd>
-                            </div>
-                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Inspector correspondence</dt>
-                                <dd                                 class="govuk-summary-list__value">No documents</dd>
-                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/internal-correspondence/inspector/upload-documents/11"
-                                        data-cy="add-inspector-correspondence">Add<span class="govuk-visually-hidden"> Inspector correspondence</span></a>
-                                    </dd>
-                            </div>
-                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Main party correspondence</dt>
-                                <dd                                 class="govuk-summary-list__value">No documents</dd>
-                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/internal-correspondence/main-party/upload-documents/22"
-                                        data-cy="add-main-party-correspondence">Add<span class="govuk-visually-hidden"> Main party correspondence</span></a>
-                                    </dd>
-                            </div>
-                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Case history</dt>
-                                <dd class="govuk-summary-list__value"></dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/audit" data-cy="view-case-history">View<span class="govuk-visually-hidden"> Case history</span></a>
-                                </dd>
-                            </div>
-                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Appeal withdrawal</dt>
-                                <dd class="govuk-summary-list__value"></dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/withdrawal/start"
-                                    data-cy="start-appeal-withdrawal">Start<span class="govuk-visually-hidden"> Appeal withdrawal</span></a>
-                                </dd>
-                            </div>
-                        </dl>
-                    </div>
-                </div>
-            </div>
         </div>
     </div>
 </main>"
@@ -5924,6 +8332,13 @@ exports[`appeal-details GET /:appealId should render the appellant case status a
             </div>
         </div>
     </div>
+    <div id="case-details-cancel-section">
+        <h3 class="govuk-heading-m">Cancel appeal</h3>
+        <div>
+            <p><a id="cancelCase" class="govuk-body govuk-link" href="/appeals-service/appeal-details/2/cancel">Cancel appeal</a>
+            </p>
+        </div>
+    </div>
 </main>"
 `;
 
@@ -6365,455 +8780,11 @@ exports[`appeal-details GET /:appealId should render the appellant case status a
             </div>
         </div>
     </div>
-</main>"
-`;
-
-exports[`appeal-details GET /:appealId should render the case reference for each linked appeal in the linked appeals row, with each internal linked appeal item linking to the respective case details page, if there are linked appeals 1`] = `
-"<main class="govuk-main-wrapper" id="main-content">
-    <div class="govuk-grid-row">
-        <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Appeal 351062</span>
-            <h1 class="govuk-heading-xl govuk-!-margin-bottom-3">Case details</h1>
-        </div>
-    </div>
-    <div class="govuk-grid-row">
-        <div class="govuk-grid-column-full"><strong class="govuk-tag govuk-tag--grey pins-status-tag--full-width">Received appeal</strong>
-            <strong             class="govuk-tag govuk-tag--grey govuk-!-margin-left-1 govuk-!-margin-bottom-4"></strong>
-        </div>
-    </div>
-    <div class="govuk-grid-row">
-        <div class="govuk-grid-column-full">
-            <dl class="govuk-summary-list pins-summary-list--no-border">
-                <div class="govuk-summary-list__row appeal-case-officer"><dt class="govuk-summary-list__key"> Case officer</dt>
-                    <dd class="govuk-summary-list__value">
-                        <p class="govuk-body">Not assigned</p>
-                    </dd>
-                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/assign-case-officer/search-case-officer"
-                        data-cy="assign-case-officer-name">Assign<span class="govuk-visually-hidden"> Case officer</span></a>
-                    </dd>
-                </div>
-                <div class="govuk-summary-list__row appeal-site-address"><dt class="govuk-summary-list__key"> Site address</dt>
-                    <dd class="govuk-summary-list__value">21 The Pavement, Wandsworth, SW4 0HY</dd>
-                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-address/change/1?backUrl=%2Fappeals-service%2Fappeal-details%2F1"
-                        data-cy="change-site-address">Change<span class="govuk-visually-hidden"> Site address</span></a>
-                    </dd>
-                </div>
-                <div class="govuk-summary-list__row appeal-local-planning-authority"><dt class="govuk-summary-list__key"> LPA</dt>
-                    <dd class="govuk-summary-list__value">Wiltshire Council</dd>
-                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/change-appeal-details/local-planning-authority"
-                        data-cy="change-local-planning-authority">Change<span class="govuk-visually-hidden"> LPA</span></a>
-                    </dd>
-                </div>
-            </dl>
-        </div>
-    </div>
-    <div class="govuk-grid-row">
-        <div class="govuk-grid-column-full">
-            <p class="govuk-body govuk-!-margin-bottom-6" id="download-case-files"
-            data-cy="download-case-files"><a class="govuk-link" href="/documents/1/bulk-download/case-APP/Q9999/D/21/351062.zip">Download case</a>
+    <div id="case-details-cancel-section">
+        <h3 class="govuk-heading-m">Cancel appeal</h3>
+        <div>
+            <p><a id="cancelCase" class="govuk-body govuk-link" href="/appeals-service/appeal-details/2/cancel">Cancel appeal</a>
             </p>
-        </div>
-    </div>
-    <div class="govuk-grid-row">
-        <div class="govuk-grid-column-full">
-            <details class="govuk-details">
-                <summary class="govuk-details__summary"><span class="govuk-details__summary-text"> 2 case notes</span>
-                </summary>
-                <div class="govuk-details__text">
-                    <form method="POST" novalidate="novalidate">
-                        <div class="govuk-grid-row">
-                            <div class="govuk-grid-column-two-thirds">
-                                <div class="govuk-form-group govuk-character-count" data-module="govuk-character-count"
-                                data-maxlength="500">
-                                    <textarea class="govuk-textarea govuk-js-character-count" id="comment"
-                                    name="comment" rows="5" aria-describedby="comment-info"></textarea>
-                                    <div id="comment-info" class="govuk-hint govuk-character-count__message">You can enter up to 500 characters</div>
-                                </div>
-                            </div>
-                        </div>
-                        <button type="submit" data-prevent-double-click="true" class="govuk-button govuk-button--secondary govuk-!-margin-bottom-1"
-                        data-module="govuk-button">Add case note</button>
-                    </form>
-                    <div>
-                        <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
-                        <section>
-                            <p class="govuk-body govuk-!-margin-bottom-1">A case note you should see.</p>
-                            <p class="govuk-hint govuk-!-margin-bottom-6">11:00am on Tuesday 1 October 2024 by John.Smith</p>
-                            <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
-                        </section>
-                        <section>
-                            <p class="govuk-body govuk-!-margin-bottom-1">A case note you should see.</p>
-                            <p class="govuk-hint govuk-!-margin-bottom-6">11:00am on Tuesday 1 October 2024 by John.Smith</p>
-                            <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
-                        </section>
-                    </div>
-                </div>
-            </details>
-        </div>
-    </div>
-    <div class="govuk-grid-row">
-        <div class="govuk-grid-column-full">
-            <div class="govuk-accordion" data-module="govuk-accordion" id="accordion-default1">
-                <div class="govuk-accordion__section">
-                    <div class="govuk-accordion__section-header">
-                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-1"> Overview</span></h2>
-                    </div>
-                    <div id="accordion-default1-content-1" class="govuk-accordion__section-content">
-                        <dl class="govuk-summary-list">
-                            <div class="govuk-summary-list__row govuk-summary-list__row--no-actions appeal-lpa-reference"><dt class="govuk-summary-list__key"> Planning application reference</dt>
-                                <dd                                 class="govuk-summary-list__value">48269/APP/2021/1482</dd>
-                            </div>
-                            <div class="govuk-summary-list__row appeal-appeal-type"><dt class="govuk-summary-list__key"> Appeal type</dt>
-                                <dd class="govuk-summary-list__value">Householder</dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/change-appeal-type/appeal-type"
-                                    data-cy="change-appeal-type">Change<span class="govuk-visually-hidden"> Appeal type</span></a>
-                                </dd>
-                            </div>
-                            <div class="govuk-summary-list__row govuk-summary-list__row--no-actions appeal-case-procedure"><dt class="govuk-summary-list__key"> Appeal procedure</dt>
-                                <dd class="govuk-summary-list__value">Written</dd>
-                            </div>
-                            <div class="govuk-summary-list__row appeal-allocation-details"><dt class="govuk-summary-list__key"> Allocation level</dt>
-                                <dd class="govuk-summary-list__value">
-                                    <ul class="govuk-!-margin-0">
-                                        <li>Level: A</li>
-                                        <li>Historic heritage</li>
-                                        <li>Architecture design</li>
-                                    </ul>
-                                </dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/allocation-details/allocation-level"
-                                    data-cy="change-allocation-details">Change<span class="govuk-visually-hidden"> Allocation level</span></a>
-                                </dd>
-                            </div>
-                            <div class="govuk-summary-list__row appeal-linked-appeals"><dt class="govuk-summary-list__key"> Linked appeals</dt>
-                                <dd class="govuk-summary-list__value">
-                                    <ul class="govuk-list govuk-list--bullet">
-                                        <li><a href="/appeals-service/appeal-details/5449" class="govuk-link" data-cy="linked-appeal-784706"
-                                            aria-label="Appeal 7 8 4 7 0 6">784706</a>
-                                        </li>
-                                        <li><span class="govuk-body">87326527</span>
-                                        </li>
-                                        <li><a href="/appeals-service/appeal-details/5464" class="govuk-link" data-cy="linked-appeal-140079"
-                                            aria-label="Appeal 1 4 0 0 7 9">140079</a> (lead)</li>
-                                        <li><a href="/appeals-service/appeal-details/5451" class="govuk-link" data-cy="linked-appeal-721086"
-                                            aria-label="Appeal 7 2 1 0 8 6">721086</a>
-                                        </li>
-                                    </ul>
-                                </dd>
-                            </div>
-                            <div class="govuk-summary-list__row appeal-other-appeals"><dt class="govuk-summary-list__key"> Related appeals</dt>
-                                <dd class="govuk-summary-list__value"><span>No</span>
-                                </dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/other-appeals/add"
-                                    data-cy="add-related-appeals">Add<span class="govuk-visually-hidden"> Related appeals</span></a>
-                                </dd>
-                            </div>
-                            <div class="govuk-summary-list__row appeal-decision"><dt class="govuk-summary-list__key"> Decision</dt>
-                                <dd class="govuk-summary-list__value">Dismissed</dd>
-                            </div>
-                        </dl>
-                    </div>
-                </div>
-                <div class="govuk-accordion__section">
-                    <div class="govuk-accordion__section-header">
-                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-2"> Site</span></h2>
-                    </div>
-                    <div id="accordion-default1-content-2" class="govuk-accordion__section-content">
-                        <dl class="govuk-summary-list">
-                            <div class="govuk-summary-list__row appeal-visit-type"><dt class="govuk-summary-list__key"> Visit type</dt>
-                                <dd class="govuk-summary-list__value">Accompanied</dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/visit-booked?backUrl=%2Fappeals-service%2Fappeal-details%2F1"
-                                    data-cy="change-set-visit-type">Change<span class="govuk-visually-hidden"> Visit type</span></a>
-                                </dd>
-                            </div>
-                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Date</dt>
-                                <dd class="govuk-summary-list__value">9 October 2023</dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/visit-booked"
-                                    data-cy="change-site-visit-date">Change<span class="govuk-visually-hidden"> Date</span></a>
-                                </dd>
-                            </div>
-                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Start time</dt>
-                                <dd class="govuk-summary-list__value">9:38am</dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/visit-booked"
-                                    data-cy="change-site-visit-start-time">Change<span class="govuk-visually-hidden"> Start time</span></a>
-                                </dd>
-                            </div>
-                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> End time</dt>
-                                <dd class="govuk-summary-list__value">10:00am</dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/visit-booked"
-                                    data-cy="change-site-visit-end-time">Change<span class="govuk-visually-hidden"> End time</span></a>
-                                </dd>
-                            </div>
-                            <div class="govuk-summary-list__row appeal-neighbouring-sites-inspector"><dt class="govuk-summary-list__key"> Interested party and neighbour addresses</dt>
-                                <dd                                 class="govuk-summary-list__value">
-                                    <ul class="govuk-list govuk-list--bullet">
-                                        <li>2 Grove Cottage, Shotesham Road, Woodton, Devon, NR35 2ND</li>
-                                    </ul>
-                                    </dd>
-                                    <dd class="govuk-summary-list__actions">
-                                        <ul class="govuk-summary-list__actions-list">
-                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/neighbouring-sites/manage"
-                                                data-cy="manage-neighbouring-sites-inspector">Manage<span class="govuk-visually-hidden"> Interested party and neighbour addresses</span></a>
-                                            </li>
-                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/neighbouring-sites/add/back-office"
-                                                data-cy="add-neighbouring-sites-inspector">Add<span class="govuk-visually-hidden"> Interested party and neighbour addresses</span></a>
-                                            </li>
-                                        </ul>
-                                    </dd>
-                            </div>
-                        </dl>
-                    </div>
-                </div>
-                <div class="govuk-accordion__section">
-                    <div class="govuk-accordion__section-header">
-                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-3"> Timetable</span></h2>
-                    </div>
-                    <div id="accordion-default1-content-3" class="govuk-accordion__section-content">
-                        <dl class="govuk-summary-list appeal-case-timetable">
-                            <div class="govuk-summary-list__row appeal-valid-date"><dt class="govuk-summary-list__key"> Valid date</dt>
-                                <dd class="govuk-summary-list__value">23 May 2023</dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/valid/date"
-                                    data-cy="-valid-date"><span class="govuk-visually-hidden"> Valid date</span></a>
-                                </dd>
-                            </div>
-                            <div class="govuk-summary-list__row appeal-start-date"><dt class="govuk-summary-list__key"> Start date</dt>
-                                <dd class="govuk-summary-list__value">23 May 2023</dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/start-case/change"
-                                    data-cy="change-start-case-date">Change<span class="govuk-visually-hidden"> Start date</span></a>
-                                </dd>
-                            </div>
-                            <div class="govuk-summary-list__row appeal-lpa-questionnaire-due-date"><dt class="govuk-summary-list__key"> LPA questionnaire due</dt>
-                                <dd class="govuk-summary-list__value">11 October 2023</dd>
-                            </div>
-                            <div class="govuk-summary-list__row appeal-site-visit"><dt class="govuk-summary-list__key"> Site visit</dt>
-                                <dd class="govuk-summary-list__value">
-                                    <ul class="govuk-list govuk-!-margin-top-0 govuk-!-padding-left-0">
-                                        <li>9 October 2023</li>
-                                        <li>9:38am - 10:00am</li>
-                                    </ul>
-                                </dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/manage-visit?backUrl=%2Fappeals-service%2Fappeal-details%2F1"
-                                    data-cy="change-schedule-visit">Change<span class="govuk-visually-hidden"> Site visit</span></a>
-                                </dd>
-                            </div>
-                        </dl>
-                    </div>
-                </div>
-                <div class="govuk-accordion__section">
-                    <div class="govuk-accordion__section-header">
-                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-4"> Documentation</span></h2>
-                    </div>
-                    <div id="accordion-default1-content-4" class="govuk-accordion__section-content">
-                        <table class="govuk-table">
-                            <thead class="govuk-table__head">
-                                <tr class="govuk-table__row">
-                                    <th scope="col" class="govuk-table__header">Documentation</th>
-                                    <th scope="col" class="govuk-table__header">Status</th>
-                                    <th scope="col" class="govuk-table__header">Received</th>
-                                    <th scope="col" class="govuk-table__header govuk-!-text-align-right">Action</th>
-                                </tr>
-                            </thead>
-                            <tbody class="govuk-table__body">
-                                <tr class="govuk-table__row">
-                                    <th scope="row" class="govuk-table__header">Appeal</th>
-                                    <td class="govuk-table__cell">Ready to review</td>
-                                    <td class="govuk-table__cell">2 August 2024</td>
-                                    <td class="govuk-table__cell govuk-!-text-align-right"><a href="/appeals-service/appeal-details/1/appellant-case?backUrl=%2Fappeals-service%2Fappeal-details%2F1"
-                                        data-cy="review-appellant-case" class="govuk-link">Review<span class="govuk-visually-hidden"> appellant case</span></a>
-                                    </td>
-                                </tr>
-                                <tr class="govuk-table__row">
-                                    <th scope="row" class="govuk-table__header">LPA questionnaire</th>
-                                    <td class="govuk-table__cell">Overdue</td>
-                                    <td class="govuk-table__cell">Due by 11 October 2023</td>
-                                    <td class="govuk-table__cell govuk-!-text-align-right"></td>
-                                </tr>
-                            </tbody>
-                        </table>
-                    </div>
-                </div>
-                <div class="govuk-accordion__section">
-                    <div class="govuk-accordion__section-header">
-                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-5"> Costs</span></h2>
-                    </div>
-                    <div id="accordion-default1-content-5" class="govuk-accordion__section-content">
-                        <table class="govuk-table">
-                            <thead class="govuk-table__head">
-                                <tr class="govuk-table__row">
-                                    <th scope="col" class="govuk-table__header">Documentation</th>
-                                    <th scope="col" class="govuk-table__header">Status</th>
-                                    <th scope="col" class="govuk-table__header govuk-!-text-align-right">Action</th>
-                                </tr>
-                            </thead>
-                            <tbody class="govuk-table__body">
-                                <tr class="govuk-table__row">
-                                    <th scope="row" class="govuk-table__header appeal-costs-appellant-application-documentation">Appellant application</th>
-                                    <td class="govuk-table__cell appeal-costs-appellant-application-status">No documents available</td>
-                                    <td class="govuk-table__cell appeal-costs-appellant-application-actions govuk-!-text-align-right">
-                                        <ul class="govuk-summary-list__actions-list">
-                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-appellant-application" href="/appeals-service/appeal-details/1/costs/appellant/application/upload-documents/1">Add<span class="govuk-visually-hidden"> Appellant application</span></a>
-                                            </li>
-                                        </ul>
-                                    </td>
-                                </tr>
-                                <tr class="govuk-table__row">
-                                    <th scope="row" class="govuk-table__header appeal-costs-appellant-withdrawal-documentation">Appellant withdrawal</th>
-                                    <td class="govuk-table__cell appeal-costs-appellant-withdrawal-status">No documents available</td>
-                                    <td class="govuk-table__cell appeal-costs-appellant-withdrawal-actions govuk-!-text-align-right">
-                                        <ul class="govuk-summary-list__actions-list">
-                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-appellant-withdrawal" href="/appeals-service/appeal-details/1/costs/appellant/withdrawal/upload-documents/2">Add<span class="govuk-visually-hidden"> Appellant withdrawal</span></a>
-                                            </li>
-                                        </ul>
-                                    </td>
-                                </tr>
-                                <tr class="govuk-table__row">
-                                    <th scope="row" class="govuk-table__header appeal-costs-appellant-correspondence-documentation">Appellant correspondence</th>
-                                    <td class="govuk-table__cell appeal-costs-appellant-correspondence-status">No documents available</td>
-                                    <td class="govuk-table__cell appeal-costs-appellant-correspondence-actions govuk-!-text-align-right">
-                                        <ul class="govuk-summary-list__actions-list">
-                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-appellant-correspondence" href="/appeals-service/appeal-details/1/costs/appellant/correspondence/upload-documents/3">Add<span class="govuk-visually-hidden"> Appellant correspondence</span></a>
-                                            </li>
-                                        </ul>
-                                    </td>
-                                </tr>
-                                <tr class="govuk-table__row">
-                                    <th scope="row" class="govuk-table__header appeal-costs-lpa-application-documentation">LPA application</th>
-                                    <td class="govuk-table__cell appeal-costs-lpa-application-status">No documents available</td>
-                                    <td class="govuk-table__cell appeal-costs-lpa-application-actions govuk-!-text-align-right">
-                                        <ul class="govuk-summary-list__actions-list">
-                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-lpa-application" href="/appeals-service/appeal-details/1/costs/lpa/application/upload-documents/4">Add<span class="govuk-visually-hidden"> LPA application</span></a>
-                                            </li>
-                                        </ul>
-                                    </td>
-                                </tr>
-                                <tr class="govuk-table__row">
-                                    <th scope="row" class="govuk-table__header appeal-costs-lpa-withdrawal-documentation">LPA withdrawal</th>
-                                    <td class="govuk-table__cell appeal-costs-lpa-withdrawal-status">No documents available</td>
-                                    <td class="govuk-table__cell appeal-costs-lpa-withdrawal-actions govuk-!-text-align-right">
-                                        <ul class="govuk-summary-list__actions-list">
-                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-lpa-withdrawal" href="/appeals-service/appeal-details/1/costs/lpa/withdrawal/upload-documents/5">Add<span class="govuk-visually-hidden"> LPA withdrawal</span></a>
-                                            </li>
-                                        </ul>
-                                    </td>
-                                </tr>
-                                <tr class="govuk-table__row">
-                                    <th scope="row" class="govuk-table__header appeal-costs-lpa-correspondence-documentation">LPA correspondence</th>
-                                    <td class="govuk-table__cell appeal-costs-lpa-correspondence-status">No documents available</td>
-                                    <td class="govuk-table__cell appeal-costs-lpa-correspondence-actions govuk-!-text-align-right">
-                                        <ul class="govuk-summary-list__actions-list">
-                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-lpa-correspondence" href="/appeals-service/appeal-details/1/costs/lpa/correspondence/upload-documents/6">Add<span class="govuk-visually-hidden"> LPA correspondence</span></a>
-                                            </li>
-                                        </ul>
-                                    </td>
-                                </tr>
-                            </tbody>
-                        </table>
-                    </div>
-                </div>
-                <div class="govuk-accordion__section">
-                    <div class="govuk-accordion__section-header">
-                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-6"> Contacts</span></h2>
-                    </div>
-                    <div id="accordion-default1-content-6" class="govuk-accordion__section-content">
-                        <dl class="govuk-summary-list">
-                            <div class="govuk-summary-list__row appeal-appellant"><dt class="govuk-summary-list__key"> Appellant</dt>
-                                <dd class="govuk-summary-list__value">
-                                    <ul class="govuk-list">
-                                        <li>Roger Simmons</li>
-                                        <li>test3@example.com</li>
-                                    </ul>
-                                </dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/service-user/change/appellant"
-                                    data-cy="change-appellant">Change<span class="govuk-visually-hidden"> Appellant</span></a>
-                                </dd>
-                            </div>
-                            <div class="govuk-summary-list__row appeal-agent"><dt class="govuk-summary-list__key"> Agent</dt>
-                                <dd class="govuk-summary-list__value">
-                                    <ul class="govuk-list">
-                                        <li>Fiona Shell</li>
-                                        <li>test2@example.com</li>
-                                    </ul>
-                                </dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/service-user/change/agent"
-                                    data-cy="change-agent">Change<span class="govuk-visually-hidden"> Agent</span></a>
-                                </dd>
-                            </div>
-                            <div class="govuk-summary-list__row appeal-lpa-contact-details"><dt class="govuk-summary-list__key"> LPA</dt>
-                                <dd class="govuk-summary-list__value">
-                                    <ul class="govuk-list">
-                                        <li>Wiltshire Council</li>
-                                        <li>wilt@lpa-email.gov.uk</li>
-                                    </ul>
-                                </dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/change-appeal-details/local-planning-authority"
-                                    data-cy="change-lpa-contact-details">Change<span class="govuk-visually-hidden"> Local planning authority (LPA)</span></a>
-                                </dd>
-                            </div>
-                        </dl>
-                    </div>
-                </div>
-                <div class="govuk-accordion__section">
-                    <div class="govuk-accordion__section-header">
-                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-7"> Team</span></h2>
-                    </div>
-                    <div id="accordion-default1-content-7" class="govuk-accordion__section-content">
-                        <dl class="govuk-summary-list">
-                            <div class="govuk-summary-list__row appeal-case-officer"><dt class="govuk-summary-list__key"> Case officer</dt>
-                                <dd class="govuk-summary-list__value">
-                                    <p class="govuk-body">Not assigned</p>
-                                </dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/assign-case-officer/search-case-officer"
-                                    data-cy="assign-case-officer">Assign<span class="govuk-visually-hidden"> Case officer</span></a>
-                                </dd>
-                            </div>
-                            <div class="govuk-summary-list__row appeal-inspector"><dt class="govuk-summary-list__key"> Inspector</dt>
-                                <dd class="govuk-summary-list__value">
-                                    <p class="govuk-body">Not assigned</p>
-                                </dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/assign-inspector/search-inspector"
-                                    data-cy="assign-inspector">Assign<span class="govuk-visually-hidden"> Inspector</span></a>
-                                </dd>
-                            </div>
-                        </dl>
-                    </div>
-                </div>
-                <div class="govuk-accordion__section">
-                    <div class="govuk-accordion__section-header">
-                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-8"> Case management</span></h2>
-                    </div>
-                    <div id="accordion-default1-content-8" class="govuk-accordion__section-content">
-                        <dl class="govuk-summary-list">
-                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Cross-team correspondence</dt>
-                                <dd                                 class="govuk-summary-list__value">No documents</dd>
-                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/internal-correspondence/cross-team/upload-documents/10"
-                                        data-cy="add-cross-team-correspondence">Add<span class="govuk-visually-hidden"> Cross-team correspondence</span></a>
-                                    </dd>
-                            </div>
-                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Inspector correspondence</dt>
-                                <dd                                 class="govuk-summary-list__value">No documents</dd>
-                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/internal-correspondence/inspector/upload-documents/11"
-                                        data-cy="add-inspector-correspondence">Add<span class="govuk-visually-hidden"> Inspector correspondence</span></a>
-                                    </dd>
-                            </div>
-                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Main party correspondence</dt>
-                                <dd                                 class="govuk-summary-list__value">No documents</dd>
-                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/internal-correspondence/main-party/upload-documents/22"
-                                        data-cy="add-main-party-correspondence">Add<span class="govuk-visually-hidden"> Main party correspondence</span></a>
-                                    </dd>
-                            </div>
-                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Case history</dt>
-                                <dd class="govuk-summary-list__value"></dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/audit" data-cy="view-case-history">View<span class="govuk-visually-hidden"> Case history</span></a>
-                                </dd>
-                            </div>
-                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Appeal withdrawal</dt>
-                                <dd class="govuk-summary-list__value"></dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/withdrawal/start"
-                                    data-cy="start-appeal-withdrawal">Start<span class="govuk-visually-hidden"> Appeal withdrawal</span></a>
-                                </dd>
-                            </div>
-                        </dl>
-                    </div>
-                </div>
-            </div>
         </div>
     </div>
 </main>"
@@ -6845,1815 +8816,6 @@ role="banner" data-module="govuk-header">
         </div>
     </div>
 </header>"
-`;
-
-exports[`appeal-details GET /:appealId should render the lead or child status after the case reference link of each linked appeal in the linked appeals row, if there are linked appeals 1`] = `
-"<main class="govuk-main-wrapper" id="main-content">
-    <div class="govuk-grid-row">
-        <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Appeal 351062</span>
-            <h1 class="govuk-heading-xl govuk-!-margin-bottom-3">Case details</h1>
-        </div>
-    </div>
-    <div class="govuk-grid-row">
-        <div class="govuk-grid-column-full"><strong class="govuk-tag govuk-tag--grey pins-status-tag--full-width">Received appeal</strong>
-            <strong             class="govuk-tag govuk-tag--grey govuk-!-margin-left-1 govuk-!-margin-bottom-4"></strong>
-        </div>
-    </div>
-    <div class="govuk-grid-row">
-        <div class="govuk-grid-column-full">
-            <dl class="govuk-summary-list pins-summary-list--no-border">
-                <div class="govuk-summary-list__row appeal-case-officer"><dt class="govuk-summary-list__key"> Case officer</dt>
-                    <dd class="govuk-summary-list__value">
-                        <p class="govuk-body">Not assigned</p>
-                    </dd>
-                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/assign-case-officer/search-case-officer"
-                        data-cy="assign-case-officer-name">Assign<span class="govuk-visually-hidden"> Case officer</span></a>
-                    </dd>
-                </div>
-                <div class="govuk-summary-list__row appeal-site-address"><dt class="govuk-summary-list__key"> Site address</dt>
-                    <dd class="govuk-summary-list__value">21 The Pavement, Wandsworth, SW4 0HY</dd>
-                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-address/change/1?backUrl=%2Fappeals-service%2Fappeal-details%2F1"
-                        data-cy="change-site-address">Change<span class="govuk-visually-hidden"> Site address</span></a>
-                    </dd>
-                </div>
-                <div class="govuk-summary-list__row appeal-local-planning-authority"><dt class="govuk-summary-list__key"> LPA</dt>
-                    <dd class="govuk-summary-list__value">Wiltshire Council</dd>
-                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/change-appeal-details/local-planning-authority"
-                        data-cy="change-local-planning-authority">Change<span class="govuk-visually-hidden"> LPA</span></a>
-                    </dd>
-                </div>
-            </dl>
-        </div>
-    </div>
-    <div class="govuk-grid-row">
-        <div class="govuk-grid-column-full">
-            <p class="govuk-body govuk-!-margin-bottom-6" id="download-case-files"
-            data-cy="download-case-files"><a class="govuk-link" href="/documents/1/bulk-download/case-APP/Q9999/D/21/351062.zip">Download case</a>
-            </p>
-        </div>
-    </div>
-    <div class="govuk-grid-row">
-        <div class="govuk-grid-column-full">
-            <details class="govuk-details">
-                <summary class="govuk-details__summary"><span class="govuk-details__summary-text"> 2 case notes</span>
-                </summary>
-                <div class="govuk-details__text">
-                    <form method="POST" novalidate="novalidate">
-                        <div class="govuk-grid-row">
-                            <div class="govuk-grid-column-two-thirds">
-                                <div class="govuk-form-group govuk-character-count" data-module="govuk-character-count"
-                                data-maxlength="500">
-                                    <textarea class="govuk-textarea govuk-js-character-count" id="comment"
-                                    name="comment" rows="5" aria-describedby="comment-info"></textarea>
-                                    <div id="comment-info" class="govuk-hint govuk-character-count__message">You can enter up to 500 characters</div>
-                                </div>
-                            </div>
-                        </div>
-                        <button type="submit" data-prevent-double-click="true" class="govuk-button govuk-button--secondary govuk-!-margin-bottom-1"
-                        data-module="govuk-button">Add case note</button>
-                    </form>
-                    <div>
-                        <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
-                        <section>
-                            <p class="govuk-body govuk-!-margin-bottom-1">A case note you should see.</p>
-                            <p class="govuk-hint govuk-!-margin-bottom-6">11:00am on Tuesday 1 October 2024 by John.Smith</p>
-                            <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
-                        </section>
-                        <section>
-                            <p class="govuk-body govuk-!-margin-bottom-1">A case note you should see.</p>
-                            <p class="govuk-hint govuk-!-margin-bottom-6">11:00am on Tuesday 1 October 2024 by John.Smith</p>
-                            <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
-                        </section>
-                    </div>
-                </div>
-            </details>
-        </div>
-    </div>
-    <div class="govuk-grid-row">
-        <div class="govuk-grid-column-full">
-            <div class="govuk-accordion" data-module="govuk-accordion" id="accordion-default1">
-                <div class="govuk-accordion__section">
-                    <div class="govuk-accordion__section-header">
-                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-1"> Overview</span></h2>
-                    </div>
-                    <div id="accordion-default1-content-1" class="govuk-accordion__section-content">
-                        <dl class="govuk-summary-list">
-                            <div class="govuk-summary-list__row govuk-summary-list__row--no-actions appeal-lpa-reference"><dt class="govuk-summary-list__key"> Planning application reference</dt>
-                                <dd                                 class="govuk-summary-list__value">48269/APP/2021/1482</dd>
-                            </div>
-                            <div class="govuk-summary-list__row appeal-appeal-type"><dt class="govuk-summary-list__key"> Appeal type</dt>
-                                <dd class="govuk-summary-list__value">Householder</dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/change-appeal-type/appeal-type"
-                                    data-cy="change-appeal-type">Change<span class="govuk-visually-hidden"> Appeal type</span></a>
-                                </dd>
-                            </div>
-                            <div class="govuk-summary-list__row govuk-summary-list__row--no-actions appeal-case-procedure"><dt class="govuk-summary-list__key"> Appeal procedure</dt>
-                                <dd class="govuk-summary-list__value">Written</dd>
-                            </div>
-                            <div class="govuk-summary-list__row appeal-allocation-details"><dt class="govuk-summary-list__key"> Allocation level</dt>
-                                <dd class="govuk-summary-list__value">
-                                    <ul class="govuk-!-margin-0">
-                                        <li>Level: A</li>
-                                        <li>Historic heritage</li>
-                                        <li>Architecture design</li>
-                                    </ul>
-                                </dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/allocation-details/allocation-level"
-                                    data-cy="change-allocation-details">Change<span class="govuk-visually-hidden"> Allocation level</span></a>
-                                </dd>
-                            </div>
-                            <div class="govuk-summary-list__row appeal-linked-appeals"><dt class="govuk-summary-list__key"> Linked appeals</dt>
-                                <dd class="govuk-summary-list__value">
-                                    <ul class="govuk-list govuk-list--bullet">
-                                        <li><a href="/appeals-service/appeal-details/5449" class="govuk-link" data-cy="linked-appeal-784706"
-                                            aria-label="Appeal 7 8 4 7 0 6">784706</a>
-                                        </li>
-                                        <li><span class="govuk-body">87326527</span>
-                                        </li>
-                                        <li><a href="/appeals-service/appeal-details/5464" class="govuk-link" data-cy="linked-appeal-140079"
-                                            aria-label="Appeal 1 4 0 0 7 9">140079</a> (lead)</li>
-                                        <li><a href="/appeals-service/appeal-details/5451" class="govuk-link" data-cy="linked-appeal-721086"
-                                            aria-label="Appeal 7 2 1 0 8 6">721086</a>
-                                        </li>
-                                    </ul>
-                                </dd>
-                            </div>
-                            <div class="govuk-summary-list__row appeal-other-appeals"><dt class="govuk-summary-list__key"> Related appeals</dt>
-                                <dd class="govuk-summary-list__value"><span>No</span>
-                                </dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/other-appeals/add"
-                                    data-cy="add-related-appeals">Add<span class="govuk-visually-hidden"> Related appeals</span></a>
-                                </dd>
-                            </div>
-                            <div class="govuk-summary-list__row appeal-decision"><dt class="govuk-summary-list__key"> Decision</dt>
-                                <dd class="govuk-summary-list__value">Dismissed</dd>
-                            </div>
-                        </dl>
-                    </div>
-                </div>
-                <div class="govuk-accordion__section">
-                    <div class="govuk-accordion__section-header">
-                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-2"> Site</span></h2>
-                    </div>
-                    <div id="accordion-default1-content-2" class="govuk-accordion__section-content">
-                        <dl class="govuk-summary-list">
-                            <div class="govuk-summary-list__row appeal-visit-type"><dt class="govuk-summary-list__key"> Visit type</dt>
-                                <dd class="govuk-summary-list__value">Accompanied</dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/visit-booked?backUrl=%2Fappeals-service%2Fappeal-details%2F1"
-                                    data-cy="change-set-visit-type">Change<span class="govuk-visually-hidden"> Visit type</span></a>
-                                </dd>
-                            </div>
-                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Date</dt>
-                                <dd class="govuk-summary-list__value">9 October 2023</dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/visit-booked"
-                                    data-cy="change-site-visit-date">Change<span class="govuk-visually-hidden"> Date</span></a>
-                                </dd>
-                            </div>
-                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Start time</dt>
-                                <dd class="govuk-summary-list__value">9:38am</dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/visit-booked"
-                                    data-cy="change-site-visit-start-time">Change<span class="govuk-visually-hidden"> Start time</span></a>
-                                </dd>
-                            </div>
-                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> End time</dt>
-                                <dd class="govuk-summary-list__value">10:00am</dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/visit-booked"
-                                    data-cy="change-site-visit-end-time">Change<span class="govuk-visually-hidden"> End time</span></a>
-                                </dd>
-                            </div>
-                            <div class="govuk-summary-list__row appeal-neighbouring-sites-inspector"><dt class="govuk-summary-list__key"> Interested party and neighbour addresses</dt>
-                                <dd                                 class="govuk-summary-list__value">
-                                    <ul class="govuk-list govuk-list--bullet">
-                                        <li>2 Grove Cottage, Shotesham Road, Woodton, Devon, NR35 2ND</li>
-                                    </ul>
-                                    </dd>
-                                    <dd class="govuk-summary-list__actions">
-                                        <ul class="govuk-summary-list__actions-list">
-                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/neighbouring-sites/manage"
-                                                data-cy="manage-neighbouring-sites-inspector">Manage<span class="govuk-visually-hidden"> Interested party and neighbour addresses</span></a>
-                                            </li>
-                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/neighbouring-sites/add/back-office"
-                                                data-cy="add-neighbouring-sites-inspector">Add<span class="govuk-visually-hidden"> Interested party and neighbour addresses</span></a>
-                                            </li>
-                                        </ul>
-                                    </dd>
-                            </div>
-                        </dl>
-                    </div>
-                </div>
-                <div class="govuk-accordion__section">
-                    <div class="govuk-accordion__section-header">
-                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-3"> Timetable</span></h2>
-                    </div>
-                    <div id="accordion-default1-content-3" class="govuk-accordion__section-content">
-                        <dl class="govuk-summary-list appeal-case-timetable">
-                            <div class="govuk-summary-list__row appeal-valid-date"><dt class="govuk-summary-list__key"> Valid date</dt>
-                                <dd class="govuk-summary-list__value">23 May 2023</dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/valid/date"
-                                    data-cy="-valid-date"><span class="govuk-visually-hidden"> Valid date</span></a>
-                                </dd>
-                            </div>
-                            <div class="govuk-summary-list__row appeal-start-date"><dt class="govuk-summary-list__key"> Start date</dt>
-                                <dd class="govuk-summary-list__value">23 May 2023</dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/start-case/change"
-                                    data-cy="change-start-case-date">Change<span class="govuk-visually-hidden"> Start date</span></a>
-                                </dd>
-                            </div>
-                            <div class="govuk-summary-list__row appeal-lpa-questionnaire-due-date"><dt class="govuk-summary-list__key"> LPA questionnaire due</dt>
-                                <dd class="govuk-summary-list__value">11 October 2023</dd>
-                            </div>
-                            <div class="govuk-summary-list__row appeal-site-visit"><dt class="govuk-summary-list__key"> Site visit</dt>
-                                <dd class="govuk-summary-list__value">
-                                    <ul class="govuk-list govuk-!-margin-top-0 govuk-!-padding-left-0">
-                                        <li>9 October 2023</li>
-                                        <li>9:38am - 10:00am</li>
-                                    </ul>
-                                </dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/manage-visit?backUrl=%2Fappeals-service%2Fappeal-details%2F1"
-                                    data-cy="change-schedule-visit">Change<span class="govuk-visually-hidden"> Site visit</span></a>
-                                </dd>
-                            </div>
-                        </dl>
-                    </div>
-                </div>
-                <div class="govuk-accordion__section">
-                    <div class="govuk-accordion__section-header">
-                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-4"> Documentation</span></h2>
-                    </div>
-                    <div id="accordion-default1-content-4" class="govuk-accordion__section-content">
-                        <table class="govuk-table">
-                            <thead class="govuk-table__head">
-                                <tr class="govuk-table__row">
-                                    <th scope="col" class="govuk-table__header">Documentation</th>
-                                    <th scope="col" class="govuk-table__header">Status</th>
-                                    <th scope="col" class="govuk-table__header">Received</th>
-                                    <th scope="col" class="govuk-table__header govuk-!-text-align-right">Action</th>
-                                </tr>
-                            </thead>
-                            <tbody class="govuk-table__body">
-                                <tr class="govuk-table__row">
-                                    <th scope="row" class="govuk-table__header">Appeal</th>
-                                    <td class="govuk-table__cell">Ready to review</td>
-                                    <td class="govuk-table__cell">2 August 2024</td>
-                                    <td class="govuk-table__cell govuk-!-text-align-right"><a href="/appeals-service/appeal-details/1/appellant-case?backUrl=%2Fappeals-service%2Fappeal-details%2F1"
-                                        data-cy="review-appellant-case" class="govuk-link">Review<span class="govuk-visually-hidden"> appellant case</span></a>
-                                    </td>
-                                </tr>
-                                <tr class="govuk-table__row">
-                                    <th scope="row" class="govuk-table__header">LPA questionnaire</th>
-                                    <td class="govuk-table__cell">Overdue</td>
-                                    <td class="govuk-table__cell">Due by 11 October 2023</td>
-                                    <td class="govuk-table__cell govuk-!-text-align-right"></td>
-                                </tr>
-                            </tbody>
-                        </table>
-                    </div>
-                </div>
-                <div class="govuk-accordion__section">
-                    <div class="govuk-accordion__section-header">
-                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-5"> Costs</span></h2>
-                    </div>
-                    <div id="accordion-default1-content-5" class="govuk-accordion__section-content">
-                        <table class="govuk-table">
-                            <thead class="govuk-table__head">
-                                <tr class="govuk-table__row">
-                                    <th scope="col" class="govuk-table__header">Documentation</th>
-                                    <th scope="col" class="govuk-table__header">Status</th>
-                                    <th scope="col" class="govuk-table__header govuk-!-text-align-right">Action</th>
-                                </tr>
-                            </thead>
-                            <tbody class="govuk-table__body">
-                                <tr class="govuk-table__row">
-                                    <th scope="row" class="govuk-table__header appeal-costs-appellant-application-documentation">Appellant application</th>
-                                    <td class="govuk-table__cell appeal-costs-appellant-application-status">No documents available</td>
-                                    <td class="govuk-table__cell appeal-costs-appellant-application-actions govuk-!-text-align-right">
-                                        <ul class="govuk-summary-list__actions-list">
-                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-appellant-application" href="/appeals-service/appeal-details/1/costs/appellant/application/upload-documents/1">Add<span class="govuk-visually-hidden"> Appellant application</span></a>
-                                            </li>
-                                        </ul>
-                                    </td>
-                                </tr>
-                                <tr class="govuk-table__row">
-                                    <th scope="row" class="govuk-table__header appeal-costs-appellant-withdrawal-documentation">Appellant withdrawal</th>
-                                    <td class="govuk-table__cell appeal-costs-appellant-withdrawal-status">No documents available</td>
-                                    <td class="govuk-table__cell appeal-costs-appellant-withdrawal-actions govuk-!-text-align-right">
-                                        <ul class="govuk-summary-list__actions-list">
-                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-appellant-withdrawal" href="/appeals-service/appeal-details/1/costs/appellant/withdrawal/upload-documents/2">Add<span class="govuk-visually-hidden"> Appellant withdrawal</span></a>
-                                            </li>
-                                        </ul>
-                                    </td>
-                                </tr>
-                                <tr class="govuk-table__row">
-                                    <th scope="row" class="govuk-table__header appeal-costs-appellant-correspondence-documentation">Appellant correspondence</th>
-                                    <td class="govuk-table__cell appeal-costs-appellant-correspondence-status">No documents available</td>
-                                    <td class="govuk-table__cell appeal-costs-appellant-correspondence-actions govuk-!-text-align-right">
-                                        <ul class="govuk-summary-list__actions-list">
-                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-appellant-correspondence" href="/appeals-service/appeal-details/1/costs/appellant/correspondence/upload-documents/3">Add<span class="govuk-visually-hidden"> Appellant correspondence</span></a>
-                                            </li>
-                                        </ul>
-                                    </td>
-                                </tr>
-                                <tr class="govuk-table__row">
-                                    <th scope="row" class="govuk-table__header appeal-costs-lpa-application-documentation">LPA application</th>
-                                    <td class="govuk-table__cell appeal-costs-lpa-application-status">No documents available</td>
-                                    <td class="govuk-table__cell appeal-costs-lpa-application-actions govuk-!-text-align-right">
-                                        <ul class="govuk-summary-list__actions-list">
-                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-lpa-application" href="/appeals-service/appeal-details/1/costs/lpa/application/upload-documents/4">Add<span class="govuk-visually-hidden"> LPA application</span></a>
-                                            </li>
-                                        </ul>
-                                    </td>
-                                </tr>
-                                <tr class="govuk-table__row">
-                                    <th scope="row" class="govuk-table__header appeal-costs-lpa-withdrawal-documentation">LPA withdrawal</th>
-                                    <td class="govuk-table__cell appeal-costs-lpa-withdrawal-status">No documents available</td>
-                                    <td class="govuk-table__cell appeal-costs-lpa-withdrawal-actions govuk-!-text-align-right">
-                                        <ul class="govuk-summary-list__actions-list">
-                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-lpa-withdrawal" href="/appeals-service/appeal-details/1/costs/lpa/withdrawal/upload-documents/5">Add<span class="govuk-visually-hidden"> LPA withdrawal</span></a>
-                                            </li>
-                                        </ul>
-                                    </td>
-                                </tr>
-                                <tr class="govuk-table__row">
-                                    <th scope="row" class="govuk-table__header appeal-costs-lpa-correspondence-documentation">LPA correspondence</th>
-                                    <td class="govuk-table__cell appeal-costs-lpa-correspondence-status">No documents available</td>
-                                    <td class="govuk-table__cell appeal-costs-lpa-correspondence-actions govuk-!-text-align-right">
-                                        <ul class="govuk-summary-list__actions-list">
-                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-lpa-correspondence" href="/appeals-service/appeal-details/1/costs/lpa/correspondence/upload-documents/6">Add<span class="govuk-visually-hidden"> LPA correspondence</span></a>
-                                            </li>
-                                        </ul>
-                                    </td>
-                                </tr>
-                            </tbody>
-                        </table>
-                    </div>
-                </div>
-                <div class="govuk-accordion__section">
-                    <div class="govuk-accordion__section-header">
-                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-6"> Contacts</span></h2>
-                    </div>
-                    <div id="accordion-default1-content-6" class="govuk-accordion__section-content">
-                        <dl class="govuk-summary-list">
-                            <div class="govuk-summary-list__row appeal-appellant"><dt class="govuk-summary-list__key"> Appellant</dt>
-                                <dd class="govuk-summary-list__value">
-                                    <ul class="govuk-list">
-                                        <li>Roger Simmons</li>
-                                        <li>test3@example.com</li>
-                                    </ul>
-                                </dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/service-user/change/appellant"
-                                    data-cy="change-appellant">Change<span class="govuk-visually-hidden"> Appellant</span></a>
-                                </dd>
-                            </div>
-                            <div class="govuk-summary-list__row appeal-agent"><dt class="govuk-summary-list__key"> Agent</dt>
-                                <dd class="govuk-summary-list__value">
-                                    <ul class="govuk-list">
-                                        <li>Fiona Shell</li>
-                                        <li>test2@example.com</li>
-                                    </ul>
-                                </dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/service-user/change/agent"
-                                    data-cy="change-agent">Change<span class="govuk-visually-hidden"> Agent</span></a>
-                                </dd>
-                            </div>
-                            <div class="govuk-summary-list__row appeal-lpa-contact-details"><dt class="govuk-summary-list__key"> LPA</dt>
-                                <dd class="govuk-summary-list__value">
-                                    <ul class="govuk-list">
-                                        <li>Wiltshire Council</li>
-                                        <li>wilt@lpa-email.gov.uk</li>
-                                    </ul>
-                                </dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/change-appeal-details/local-planning-authority"
-                                    data-cy="change-lpa-contact-details">Change<span class="govuk-visually-hidden"> Local planning authority (LPA)</span></a>
-                                </dd>
-                            </div>
-                        </dl>
-                    </div>
-                </div>
-                <div class="govuk-accordion__section">
-                    <div class="govuk-accordion__section-header">
-                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-7"> Team</span></h2>
-                    </div>
-                    <div id="accordion-default1-content-7" class="govuk-accordion__section-content">
-                        <dl class="govuk-summary-list">
-                            <div class="govuk-summary-list__row appeal-case-officer"><dt class="govuk-summary-list__key"> Case officer</dt>
-                                <dd class="govuk-summary-list__value">
-                                    <p class="govuk-body">Not assigned</p>
-                                </dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/assign-case-officer/search-case-officer"
-                                    data-cy="assign-case-officer">Assign<span class="govuk-visually-hidden"> Case officer</span></a>
-                                </dd>
-                            </div>
-                            <div class="govuk-summary-list__row appeal-inspector"><dt class="govuk-summary-list__key"> Inspector</dt>
-                                <dd class="govuk-summary-list__value">
-                                    <p class="govuk-body">Not assigned</p>
-                                </dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/assign-inspector/search-inspector"
-                                    data-cy="assign-inspector">Assign<span class="govuk-visually-hidden"> Inspector</span></a>
-                                </dd>
-                            </div>
-                        </dl>
-                    </div>
-                </div>
-                <div class="govuk-accordion__section">
-                    <div class="govuk-accordion__section-header">
-                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-8"> Case management</span></h2>
-                    </div>
-                    <div id="accordion-default1-content-8" class="govuk-accordion__section-content">
-                        <dl class="govuk-summary-list">
-                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Cross-team correspondence</dt>
-                                <dd                                 class="govuk-summary-list__value">No documents</dd>
-                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/internal-correspondence/cross-team/upload-documents/10"
-                                        data-cy="add-cross-team-correspondence">Add<span class="govuk-visually-hidden"> Cross-team correspondence</span></a>
-                                    </dd>
-                            </div>
-                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Inspector correspondence</dt>
-                                <dd                                 class="govuk-summary-list__value">No documents</dd>
-                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/internal-correspondence/inspector/upload-documents/11"
-                                        data-cy="add-inspector-correspondence">Add<span class="govuk-visually-hidden"> Inspector correspondence</span></a>
-                                    </dd>
-                            </div>
-                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Main party correspondence</dt>
-                                <dd                                 class="govuk-summary-list__value">No documents</dd>
-                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/internal-correspondence/main-party/upload-documents/22"
-                                        data-cy="add-main-party-correspondence">Add<span class="govuk-visually-hidden"> Main party correspondence</span></a>
-                                    </dd>
-                            </div>
-                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Case history</dt>
-                                <dd class="govuk-summary-list__value"></dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/audit" data-cy="view-case-history">View<span class="govuk-visually-hidden"> Case history</span></a>
-                                </dd>
-                            </div>
-                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Appeal withdrawal</dt>
-                                <dd class="govuk-summary-list__value"></dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/withdrawal/start"
-                                    data-cy="start-appeal-withdrawal">Start<span class="govuk-visually-hidden"> Appeal withdrawal</span></a>
-                                </dd>
-                            </div>
-                        </dl>
-                    </div>
-                </div>
-            </div>
-        </div>
-    </div>
-</main>"
-`;
-
-exports[`appeal-details GET /:appealId should render the received appeal details for a valid appealId with multiple linked/other appeals 1`] = `
-"<main class="govuk-main-wrapper" id="main-content">
-    <div class="govuk-grid-row">
-        <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Appeal 351062</span>
-            <h1 class="govuk-heading-xl govuk-!-margin-bottom-3">Case details</h1>
-        </div>
-    </div>
-    <div class="govuk-grid-row">
-        <div class="govuk-grid-column-full"><strong class="govuk-tag govuk-tag--grey pins-status-tag--full-width">Received appeal</strong>
-            <strong             class="govuk-tag govuk-tag--grey govuk-!-margin-left-1 govuk-!-margin-bottom-4"></strong>
-        </div>
-    </div>
-    <div class="govuk-grid-row">
-        <div class="govuk-grid-column-full">
-            <dl class="govuk-summary-list pins-summary-list--no-border">
-                <div class="govuk-summary-list__row appeal-case-officer"><dt class="govuk-summary-list__key"> Case officer</dt>
-                    <dd class="govuk-summary-list__value">
-                        <p class="govuk-body">Not assigned</p>
-                    </dd>
-                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/3/assign-case-officer/search-case-officer"
-                        data-cy="assign-case-officer-name">Assign<span class="govuk-visually-hidden"> Case officer</span></a>
-                    </dd>
-                </div>
-                <div class="govuk-summary-list__row appeal-site-address"><dt class="govuk-summary-list__key"> Site address</dt>
-                    <dd class="govuk-summary-list__value">21 The Pavement, Wandsworth, SW4 0HY</dd>
-                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/3/site-address/change/1?backUrl=%2Fappeals-service%2Fappeal-details%2F3"
-                        data-cy="change-site-address">Change<span class="govuk-visually-hidden"> Site address</span></a>
-                    </dd>
-                </div>
-                <div class="govuk-summary-list__row appeal-local-planning-authority"><dt class="govuk-summary-list__key"> LPA</dt>
-                    <dd class="govuk-summary-list__value">Wiltshire Council</dd>
-                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/3/change-appeal-details/local-planning-authority"
-                        data-cy="change-local-planning-authority">Change<span class="govuk-visually-hidden"> LPA</span></a>
-                    </dd>
-                </div>
-            </dl>
-        </div>
-    </div>
-    <div class="govuk-grid-row">
-        <div class="govuk-grid-column-full">
-            <p class="govuk-body govuk-!-margin-bottom-6" id="download-case-files"
-            data-cy="download-case-files"><a class="govuk-link" href="/documents/3/bulk-download/case-APP/Q9999/D/21/351062.zip">Download case</a>
-            </p>
-        </div>
-    </div>
-    <div class="govuk-grid-row">
-        <div class="govuk-grid-column-full">
-            <details class="govuk-details">
-                <summary class="govuk-details__summary"><span class="govuk-details__summary-text"> 2 case notes</span>
-                </summary>
-                <div class="govuk-details__text">
-                    <form method="POST" novalidate="novalidate">
-                        <div class="govuk-grid-row">
-                            <div class="govuk-grid-column-two-thirds">
-                                <div class="govuk-form-group govuk-character-count" data-module="govuk-character-count"
-                                data-maxlength="500">
-                                    <textarea class="govuk-textarea govuk-js-character-count" id="comment"
-                                    name="comment" rows="5" aria-describedby="comment-info"></textarea>
-                                    <div id="comment-info" class="govuk-hint govuk-character-count__message">You can enter up to 500 characters</div>
-                                </div>
-                            </div>
-                        </div>
-                        <button type="submit" data-prevent-double-click="true" class="govuk-button govuk-button--secondary govuk-!-margin-bottom-1"
-                        data-module="govuk-button">Add case note</button>
-                    </form>
-                    <div>
-                        <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
-                        <section>
-                            <p class="govuk-body govuk-!-margin-bottom-1">A case note you should see.</p>
-                            <p class="govuk-hint govuk-!-margin-bottom-6">11:00am on Tuesday 1 October 2024 by John.Smith</p>
-                            <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
-                        </section>
-                        <section>
-                            <p class="govuk-body govuk-!-margin-bottom-1">A case note you should see.</p>
-                            <p class="govuk-hint govuk-!-margin-bottom-6">11:00am on Tuesday 1 October 2024 by John.Smith</p>
-                            <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
-                        </section>
-                    </div>
-                </div>
-            </details>
-        </div>
-    </div>
-    <div class="govuk-grid-row">
-        <div class="govuk-grid-column-full">
-            <div class="govuk-accordion" data-module="govuk-accordion" id="accordion-default3">
-                <div class="govuk-accordion__section">
-                    <div class="govuk-accordion__section-header">
-                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default3-heading-1"> Overview</span></h2>
-                    </div>
-                    <div id="accordion-default3-content-1" class="govuk-accordion__section-content">
-                        <dl class="govuk-summary-list">
-                            <div class="govuk-summary-list__row govuk-summary-list__row--no-actions appeal-lpa-reference"><dt class="govuk-summary-list__key"> Planning application reference</dt>
-                                <dd                                 class="govuk-summary-list__value">48269/APP/2021/1482</dd>
-                            </div>
-                            <div class="govuk-summary-list__row appeal-appeal-type"><dt class="govuk-summary-list__key"> Appeal type</dt>
-                                <dd class="govuk-summary-list__value">Householder</dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/3/change-appeal-type/appeal-type"
-                                    data-cy="change-appeal-type">Change<span class="govuk-visually-hidden"> Appeal type</span></a>
-                                </dd>
-                            </div>
-                            <div class="govuk-summary-list__row govuk-summary-list__row--no-actions appeal-case-procedure"><dt class="govuk-summary-list__key"> Appeal procedure</dt>
-                                <dd class="govuk-summary-list__value">Written</dd>
-                            </div>
-                            <div class="govuk-summary-list__row appeal-allocation-details"><dt class="govuk-summary-list__key"> Allocation level</dt>
-                                <dd class="govuk-summary-list__value">
-                                    <ul class="govuk-!-margin-0">
-                                        <li>Level: A</li>
-                                        <li>Historic heritage</li>
-                                        <li>Architecture design</li>
-                                    </ul>
-                                </dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/3/allocation-details/allocation-level"
-                                    data-cy="change-allocation-details">Change<span class="govuk-visually-hidden"> Allocation level</span></a>
-                                </dd>
-                            </div>
-                            <div class="govuk-summary-list__row appeal-linked-appeals"><dt class="govuk-summary-list__key"> Linked appeals</dt>
-                                <dd class="govuk-summary-list__value">
-                                    <ul class="govuk-list govuk-list--bullet">
-                                        <li><a href="/appeals-service/appeal-details/4" class="govuk-link" data-cy="linked-appeal-725284"
-                                            aria-label="Appeal 7 2 5 2 8 4">725284</a>
-                                        </li>
-                                        <li><a href="/appeals-service/appeal-details/5" class="govuk-link" data-cy="linked-appeal-725285"
-                                            aria-label="Appeal 7 2 5 2 8 5">725285</a>
-                                        </li>
-                                    </ul>
-                                </dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/3/linked-appeals/manage"
-                                    data-cy="manage-linked-appeals">Manage<span class="govuk-visually-hidden"> Linked appeals</span></a>
-                                </dd>
-                            </div>
-                            <div class="govuk-summary-list__row appeal-other-appeals"><dt class="govuk-summary-list__key"> Related appeals</dt>
-                                <dd class="govuk-summary-list__value">
-                                    <ul class="govuk-list govuk-list--bullet">
-                                        <li><a href="/appeals-service/appeal-details/6" class="govuk-link" data-cy="related-appeal-765413"
-                                            aria-label="Appeal 7 6 5 4 1 3">765413</a>
-                                        </li>
-                                        <li><a href="/appeals-service/appeal-details/7" class="govuk-link" data-cy="related-appeal-765414"
-                                            aria-label="Appeal 7 6 5 4 1 4">765414</a>
-                                        </li>
-                                    </ul>
-                                </dd>
-                                <dd class="govuk-summary-list__actions">
-                                    <ul class="govuk-summary-list__actions-list">
-                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/3/other-appeals/manage"
-                                            data-cy="manage-related-appeals">Manage<span class="govuk-visually-hidden"> Related appeals</span></a>
-                                        </li>
-                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/3/other-appeals/add"
-                                            data-cy="add-related-appeals">Add<span class="govuk-visually-hidden"> Related appeals</span></a>
-                                        </li>
-                                    </ul>
-                                </dd>
-                            </div>
-                            <div class="govuk-summary-list__row appeal-decision"><dt class="govuk-summary-list__key"> Decision</dt>
-                                <dd class="govuk-summary-list__value">Dismissed</dd>
-                            </div>
-                        </dl>
-                    </div>
-                </div>
-                <div class="govuk-accordion__section">
-                    <div class="govuk-accordion__section-header">
-                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default3-heading-2"> Site</span></h2>
-                    </div>
-                    <div id="accordion-default3-content-2" class="govuk-accordion__section-content">
-                        <dl class="govuk-summary-list">
-                            <div class="govuk-summary-list__row appeal-visit-type"><dt class="govuk-summary-list__key"> Visit type</dt>
-                                <dd class="govuk-summary-list__value">Accompanied</dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/3/site-visit/visit-booked?backUrl=%2Fappeals-service%2Fappeal-details%2F3"
-                                    data-cy="change-set-visit-type">Change<span class="govuk-visually-hidden"> Visit type</span></a>
-                                </dd>
-                            </div>
-                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Date</dt>
-                                <dd class="govuk-summary-list__value">9 October 2023</dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/3/site-visit/visit-booked"
-                                    data-cy="change-site-visit-date">Change<span class="govuk-visually-hidden"> Date</span></a>
-                                </dd>
-                            </div>
-                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Start time</dt>
-                                <dd class="govuk-summary-list__value">9:38am</dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/3/site-visit/visit-booked"
-                                    data-cy="change-site-visit-start-time">Change<span class="govuk-visually-hidden"> Start time</span></a>
-                                </dd>
-                            </div>
-                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> End time</dt>
-                                <dd class="govuk-summary-list__value">10:00am</dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/3/site-visit/visit-booked"
-                                    data-cy="change-site-visit-end-time">Change<span class="govuk-visually-hidden"> End time</span></a>
-                                </dd>
-                            </div>
-                            <div class="govuk-summary-list__row appeal-neighbouring-sites-inspector"><dt class="govuk-summary-list__key"> Interested party and neighbour addresses</dt>
-                                <dd                                 class="govuk-summary-list__value">
-                                    <ul class="govuk-list govuk-list--bullet">
-                                        <li>2 Grove Cottage, Shotesham Road, Woodton, Devon, NR35 2ND</li>
-                                    </ul>
-                                    </dd>
-                                    <dd class="govuk-summary-list__actions">
-                                        <ul class="govuk-summary-list__actions-list">
-                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/3/neighbouring-sites/manage"
-                                                data-cy="manage-neighbouring-sites-inspector">Manage<span class="govuk-visually-hidden"> Interested party and neighbour addresses</span></a>
-                                            </li>
-                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/3/neighbouring-sites/add/back-office"
-                                                data-cy="add-neighbouring-sites-inspector">Add<span class="govuk-visually-hidden"> Interested party and neighbour addresses</span></a>
-                                            </li>
-                                        </ul>
-                                    </dd>
-                            </div>
-                        </dl>
-                    </div>
-                </div>
-                <div class="govuk-accordion__section">
-                    <div class="govuk-accordion__section-header">
-                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default3-heading-3"> Timetable</span></h2>
-                    </div>
-                    <div id="accordion-default3-content-3" class="govuk-accordion__section-content">
-                        <dl class="govuk-summary-list appeal-case-timetable">
-                            <div class="govuk-summary-list__row appeal-valid-date"><dt class="govuk-summary-list__key"> Valid date</dt>
-                                <dd class="govuk-summary-list__value">23 May 2023</dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/3/appellant-case/valid/date"
-                                    data-cy="-valid-date"><span class="govuk-visually-hidden"> Valid date</span></a>
-                                </dd>
-                            </div>
-                            <div class="govuk-summary-list__row appeal-start-date"><dt class="govuk-summary-list__key"> Start date</dt>
-                                <dd class="govuk-summary-list__value">23 May 2023</dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/3/start-case/change"
-                                    data-cy="change-start-case-date">Change<span class="govuk-visually-hidden"> Start date</span></a>
-                                </dd>
-                            </div>
-                            <div class="govuk-summary-list__row appeal-lpa-questionnaire-due-date"><dt class="govuk-summary-list__key"> LPA questionnaire due</dt>
-                                <dd class="govuk-summary-list__value">11 October 2023</dd>
-                            </div>
-                            <div class="govuk-summary-list__row appeal-site-visit"><dt class="govuk-summary-list__key"> Site visit</dt>
-                                <dd class="govuk-summary-list__value">
-                                    <ul class="govuk-list govuk-!-margin-top-0 govuk-!-padding-left-0">
-                                        <li>9 October 2023</li>
-                                        <li>9:38am - 10:00am</li>
-                                    </ul>
-                                </dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/3/site-visit/manage-visit?backUrl=%2Fappeals-service%2Fappeal-details%2F3"
-                                    data-cy="change-schedule-visit">Change<span class="govuk-visually-hidden"> Site visit</span></a>
-                                </dd>
-                            </div>
-                        </dl>
-                    </div>
-                </div>
-                <div class="govuk-accordion__section">
-                    <div class="govuk-accordion__section-header">
-                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default3-heading-4"> Documentation</span></h2>
-                    </div>
-                    <div id="accordion-default3-content-4" class="govuk-accordion__section-content">
-                        <table class="govuk-table">
-                            <thead class="govuk-table__head">
-                                <tr class="govuk-table__row">
-                                    <th scope="col" class="govuk-table__header">Documentation</th>
-                                    <th scope="col" class="govuk-table__header">Status</th>
-                                    <th scope="col" class="govuk-table__header">Received</th>
-                                    <th scope="col" class="govuk-table__header govuk-!-text-align-right">Action</th>
-                                </tr>
-                            </thead>
-                            <tbody class="govuk-table__body">
-                                <tr class="govuk-table__row">
-                                    <th scope="row" class="govuk-table__header">Appeal</th>
-                                    <td class="govuk-table__cell">Ready to review</td>
-                                    <td class="govuk-table__cell">2 August 2024</td>
-                                    <td class="govuk-table__cell govuk-!-text-align-right"><a href="/appeals-service/appeal-details/3/appellant-case?backUrl=%2Fappeals-service%2Fappeal-details%2F3"
-                                        data-cy="review-appellant-case" class="govuk-link">Review<span class="govuk-visually-hidden"> appellant case</span></a>
-                                    </td>
-                                </tr>
-                                <tr class="govuk-table__row">
-                                    <th scope="row" class="govuk-table__header">LPA questionnaire</th>
-                                    <td class="govuk-table__cell">Overdue</td>
-                                    <td class="govuk-table__cell">Due by 11 October 2023</td>
-                                    <td class="govuk-table__cell govuk-!-text-align-right"></td>
-                                </tr>
-                            </tbody>
-                        </table>
-                    </div>
-                </div>
-                <div class="govuk-accordion__section">
-                    <div class="govuk-accordion__section-header">
-                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default3-heading-5"> Costs</span></h2>
-                    </div>
-                    <div id="accordion-default3-content-5" class="govuk-accordion__section-content">
-                        <table class="govuk-table">
-                            <thead class="govuk-table__head">
-                                <tr class="govuk-table__row">
-                                    <th scope="col" class="govuk-table__header">Documentation</th>
-                                    <th scope="col" class="govuk-table__header">Status</th>
-                                    <th scope="col" class="govuk-table__header govuk-!-text-align-right">Action</th>
-                                </tr>
-                            </thead>
-                            <tbody class="govuk-table__body">
-                                <tr class="govuk-table__row">
-                                    <th scope="row" class="govuk-table__header appeal-costs-appellant-application-documentation">Appellant application</th>
-                                    <td class="govuk-table__cell appeal-costs-appellant-application-status">No documents available</td>
-                                    <td class="govuk-table__cell appeal-costs-appellant-application-actions govuk-!-text-align-right">
-                                        <ul class="govuk-summary-list__actions-list">
-                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-appellant-application" href="/appeals-service/appeal-details/3/costs/appellant/application/upload-documents/1">Add<span class="govuk-visually-hidden"> Appellant application</span></a>
-                                            </li>
-                                        </ul>
-                                    </td>
-                                </tr>
-                                <tr class="govuk-table__row">
-                                    <th scope="row" class="govuk-table__header appeal-costs-appellant-withdrawal-documentation">Appellant withdrawal</th>
-                                    <td class="govuk-table__cell appeal-costs-appellant-withdrawal-status">No documents available</td>
-                                    <td class="govuk-table__cell appeal-costs-appellant-withdrawal-actions govuk-!-text-align-right">
-                                        <ul class="govuk-summary-list__actions-list">
-                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-appellant-withdrawal" href="/appeals-service/appeal-details/3/costs/appellant/withdrawal/upload-documents/2">Add<span class="govuk-visually-hidden"> Appellant withdrawal</span></a>
-                                            </li>
-                                        </ul>
-                                    </td>
-                                </tr>
-                                <tr class="govuk-table__row">
-                                    <th scope="row" class="govuk-table__header appeal-costs-appellant-correspondence-documentation">Appellant correspondence</th>
-                                    <td class="govuk-table__cell appeal-costs-appellant-correspondence-status">No documents available</td>
-                                    <td class="govuk-table__cell appeal-costs-appellant-correspondence-actions govuk-!-text-align-right">
-                                        <ul class="govuk-summary-list__actions-list">
-                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-appellant-correspondence" href="/appeals-service/appeal-details/3/costs/appellant/correspondence/upload-documents/3">Add<span class="govuk-visually-hidden"> Appellant correspondence</span></a>
-                                            </li>
-                                        </ul>
-                                    </td>
-                                </tr>
-                                <tr class="govuk-table__row">
-                                    <th scope="row" class="govuk-table__header appeal-costs-lpa-application-documentation">LPA application</th>
-                                    <td class="govuk-table__cell appeal-costs-lpa-application-status">No documents available</td>
-                                    <td class="govuk-table__cell appeal-costs-lpa-application-actions govuk-!-text-align-right">
-                                        <ul class="govuk-summary-list__actions-list">
-                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-lpa-application" href="/appeals-service/appeal-details/3/costs/lpa/application/upload-documents/4">Add<span class="govuk-visually-hidden"> LPA application</span></a>
-                                            </li>
-                                        </ul>
-                                    </td>
-                                </tr>
-                                <tr class="govuk-table__row">
-                                    <th scope="row" class="govuk-table__header appeal-costs-lpa-withdrawal-documentation">LPA withdrawal</th>
-                                    <td class="govuk-table__cell appeal-costs-lpa-withdrawal-status">No documents available</td>
-                                    <td class="govuk-table__cell appeal-costs-lpa-withdrawal-actions govuk-!-text-align-right">
-                                        <ul class="govuk-summary-list__actions-list">
-                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-lpa-withdrawal" href="/appeals-service/appeal-details/3/costs/lpa/withdrawal/upload-documents/5">Add<span class="govuk-visually-hidden"> LPA withdrawal</span></a>
-                                            </li>
-                                        </ul>
-                                    </td>
-                                </tr>
-                                <tr class="govuk-table__row">
-                                    <th scope="row" class="govuk-table__header appeal-costs-lpa-correspondence-documentation">LPA correspondence</th>
-                                    <td class="govuk-table__cell appeal-costs-lpa-correspondence-status">No documents available</td>
-                                    <td class="govuk-table__cell appeal-costs-lpa-correspondence-actions govuk-!-text-align-right">
-                                        <ul class="govuk-summary-list__actions-list">
-                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-lpa-correspondence" href="/appeals-service/appeal-details/3/costs/lpa/correspondence/upload-documents/6">Add<span class="govuk-visually-hidden"> LPA correspondence</span></a>
-                                            </li>
-                                        </ul>
-                                    </td>
-                                </tr>
-                            </tbody>
-                        </table>
-                    </div>
-                </div>
-                <div class="govuk-accordion__section">
-                    <div class="govuk-accordion__section-header">
-                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default3-heading-6"> Contacts</span></h2>
-                    </div>
-                    <div id="accordion-default3-content-6" class="govuk-accordion__section-content">
-                        <dl class="govuk-summary-list">
-                            <div class="govuk-summary-list__row appeal-appellant"><dt class="govuk-summary-list__key"> Appellant</dt>
-                                <dd class="govuk-summary-list__value">
-                                    <ul class="govuk-list">
-                                        <li>Roger Simmons</li>
-                                        <li>test3@example.com</li>
-                                    </ul>
-                                </dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/3/service-user/change/appellant"
-                                    data-cy="change-appellant">Change<span class="govuk-visually-hidden"> Appellant</span></a>
-                                </dd>
-                            </div>
-                            <div class="govuk-summary-list__row appeal-agent"><dt class="govuk-summary-list__key"> Agent</dt>
-                                <dd class="govuk-summary-list__value">
-                                    <ul class="govuk-list">
-                                        <li>Fiona Shell</li>
-                                        <li>test2@example.com</li>
-                                    </ul>
-                                </dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/3/service-user/change/agent"
-                                    data-cy="change-agent">Change<span class="govuk-visually-hidden"> Agent</span></a>
-                                </dd>
-                            </div>
-                            <div class="govuk-summary-list__row appeal-lpa-contact-details"><dt class="govuk-summary-list__key"> LPA</dt>
-                                <dd class="govuk-summary-list__value">
-                                    <ul class="govuk-list">
-                                        <li>Wiltshire Council</li>
-                                        <li>wilt@lpa-email.gov.uk</li>
-                                    </ul>
-                                </dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/3/change-appeal-details/local-planning-authority"
-                                    data-cy="change-lpa-contact-details">Change<span class="govuk-visually-hidden"> Local planning authority (LPA)</span></a>
-                                </dd>
-                            </div>
-                        </dl>
-                    </div>
-                </div>
-                <div class="govuk-accordion__section">
-                    <div class="govuk-accordion__section-header">
-                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default3-heading-7"> Team</span></h2>
-                    </div>
-                    <div id="accordion-default3-content-7" class="govuk-accordion__section-content">
-                        <dl class="govuk-summary-list">
-                            <div class="govuk-summary-list__row appeal-case-officer"><dt class="govuk-summary-list__key"> Case officer</dt>
-                                <dd class="govuk-summary-list__value">
-                                    <p class="govuk-body">Not assigned</p>
-                                </dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/3/assign-case-officer/search-case-officer"
-                                    data-cy="assign-case-officer">Assign<span class="govuk-visually-hidden"> Case officer</span></a>
-                                </dd>
-                            </div>
-                            <div class="govuk-summary-list__row appeal-inspector"><dt class="govuk-summary-list__key"> Inspector</dt>
-                                <dd class="govuk-summary-list__value">
-                                    <p class="govuk-body">Not assigned</p>
-                                </dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/3/assign-inspector/search-inspector"
-                                    data-cy="assign-inspector">Assign<span class="govuk-visually-hidden"> Inspector</span></a>
-                                </dd>
-                            </div>
-                        </dl>
-                    </div>
-                </div>
-                <div class="govuk-accordion__section">
-                    <div class="govuk-accordion__section-header">
-                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default3-heading-8"> Case management</span></h2>
-                    </div>
-                    <div id="accordion-default3-content-8" class="govuk-accordion__section-content">
-                        <dl class="govuk-summary-list">
-                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Cross-team correspondence</dt>
-                                <dd                                 class="govuk-summary-list__value">No documents</dd>
-                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/3/internal-correspondence/cross-team/upload-documents/10"
-                                        data-cy="add-cross-team-correspondence">Add<span class="govuk-visually-hidden"> Cross-team correspondence</span></a>
-                                    </dd>
-                            </div>
-                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Inspector correspondence</dt>
-                                <dd                                 class="govuk-summary-list__value">No documents</dd>
-                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/3/internal-correspondence/inspector/upload-documents/11"
-                                        data-cy="add-inspector-correspondence">Add<span class="govuk-visually-hidden"> Inspector correspondence</span></a>
-                                    </dd>
-                            </div>
-                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Main party correspondence</dt>
-                                <dd                                 class="govuk-summary-list__value">No documents</dd>
-                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/3/internal-correspondence/main-party/upload-documents/22"
-                                        data-cy="add-main-party-correspondence">Add<span class="govuk-visually-hidden"> Main party correspondence</span></a>
-                                    </dd>
-                            </div>
-                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Case history</dt>
-                                <dd class="govuk-summary-list__value"></dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/3/audit" data-cy="view-case-history">View<span class="govuk-visually-hidden"> Case history</span></a>
-                                </dd>
-                            </div>
-                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Appeal withdrawal</dt>
-                                <dd class="govuk-summary-list__value"></dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/3/withdrawal/start"
-                                    data-cy="start-appeal-withdrawal">Start<span class="govuk-visually-hidden"> Appeal withdrawal</span></a>
-                                </dd>
-                            </div>
-                        </dl>
-                    </div>
-                </div>
-            </div>
-        </div>
-    </div>
-</main>"
-`;
-
-exports[`appeal-details GET /:appealId should render the received appeal details for a valid appealId with no linked/other appeals 1`] = `
-"<main class="govuk-main-wrapper" id="main-content">
-    <div class="govuk-grid-row">
-        <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Appeal 351062</span>
-            <h1 class="govuk-heading-xl govuk-!-margin-bottom-3">Case details</h1>
-        </div>
-    </div>
-    <div class="govuk-grid-row">
-        <div class="govuk-grid-column-full"><strong class="govuk-tag govuk-tag--grey pins-status-tag--full-width">Received appeal</strong>
-        </div>
-    </div>
-    <div class="govuk-grid-row">
-        <div class="govuk-grid-column-full">
-            <dl class="govuk-summary-list pins-summary-list--no-border">
-                <div class="govuk-summary-list__row appeal-case-officer"><dt class="govuk-summary-list__key"> Case officer</dt>
-                    <dd class="govuk-summary-list__value">
-                        <p class="govuk-body">Not assigned</p>
-                    </dd>
-                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/assign-case-officer/search-case-officer"
-                        data-cy="assign-case-officer-name">Assign<span class="govuk-visually-hidden"> Case officer</span></a>
-                    </dd>
-                </div>
-                <div class="govuk-summary-list__row appeal-site-address"><dt class="govuk-summary-list__key"> Site address</dt>
-                    <dd class="govuk-summary-list__value">21 The Pavement, Wandsworth, SW4 0HY</dd>
-                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-address/change/1?backUrl=%2Fappeals-service%2Fappeal-details%2F1"
-                        data-cy="change-site-address">Change<span class="govuk-visually-hidden"> Site address</span></a>
-                    </dd>
-                </div>
-                <div class="govuk-summary-list__row appeal-local-planning-authority"><dt class="govuk-summary-list__key"> LPA</dt>
-                    <dd class="govuk-summary-list__value">Wiltshire Council</dd>
-                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/change-appeal-details/local-planning-authority"
-                        data-cy="change-local-planning-authority">Change<span class="govuk-visually-hidden"> LPA</span></a>
-                    </dd>
-                </div>
-            </dl>
-        </div>
-    </div>
-    <div class="govuk-grid-row">
-        <div class="govuk-grid-column-full">
-            <p class="govuk-body govuk-!-margin-bottom-6" id="download-case-files"
-            data-cy="download-case-files"><a class="govuk-link" href="/documents/1/bulk-download/case-APP/Q9999/D/21/351062.zip">Download case</a>
-            </p>
-        </div>
-    </div>
-    <div class="govuk-grid-row">
-        <div class="govuk-grid-column-full">
-            <details class="govuk-details">
-                <summary class="govuk-details__summary"><span class="govuk-details__summary-text"> 2 case notes</span>
-                </summary>
-                <div class="govuk-details__text">
-                    <form method="POST" novalidate="novalidate">
-                        <div class="govuk-grid-row">
-                            <div class="govuk-grid-column-two-thirds">
-                                <div class="govuk-form-group govuk-character-count" data-module="govuk-character-count"
-                                data-maxlength="500">
-                                    <textarea class="govuk-textarea govuk-js-character-count" id="comment"
-                                    name="comment" rows="5" aria-describedby="comment-info"></textarea>
-                                    <div id="comment-info" class="govuk-hint govuk-character-count__message">You can enter up to 500 characters</div>
-                                </div>
-                            </div>
-                        </div>
-                        <button type="submit" data-prevent-double-click="true" class="govuk-button govuk-button--secondary govuk-!-margin-bottom-1"
-                        data-module="govuk-button">Add case note</button>
-                    </form>
-                    <div>
-                        <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
-                        <section>
-                            <p class="govuk-body govuk-!-margin-bottom-1">A case note you should see.</p>
-                            <p class="govuk-hint govuk-!-margin-bottom-6">11:00am on Tuesday 1 October 2024 by John.Smith</p>
-                            <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
-                        </section>
-                        <section>
-                            <p class="govuk-body govuk-!-margin-bottom-1">A case note you should see.</p>
-                            <p class="govuk-hint govuk-!-margin-bottom-6">11:00am on Tuesday 1 October 2024 by John.Smith</p>
-                            <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
-                        </section>
-                    </div>
-                </div>
-            </details>
-        </div>
-    </div>
-    <div class="govuk-grid-row">
-        <div class="govuk-grid-column-full">
-            <div class="govuk-accordion" data-module="govuk-accordion" id="accordion-default1">
-                <div class="govuk-accordion__section">
-                    <div class="govuk-accordion__section-header">
-                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-1"> Overview</span></h2>
-                    </div>
-                    <div id="accordion-default1-content-1" class="govuk-accordion__section-content">
-                        <dl class="govuk-summary-list">
-                            <div class="govuk-summary-list__row govuk-summary-list__row--no-actions appeal-lpa-reference"><dt class="govuk-summary-list__key"> Planning application reference</dt>
-                                <dd                                 class="govuk-summary-list__value">48269/APP/2021/1482</dd>
-                            </div>
-                            <div class="govuk-summary-list__row appeal-appeal-type"><dt class="govuk-summary-list__key"> Appeal type</dt>
-                                <dd class="govuk-summary-list__value">Householder</dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/change-appeal-type/appeal-type"
-                                    data-cy="change-appeal-type">Change<span class="govuk-visually-hidden"> Appeal type</span></a>
-                                </dd>
-                            </div>
-                            <div class="govuk-summary-list__row govuk-summary-list__row--no-actions appeal-case-procedure"><dt class="govuk-summary-list__key"> Appeal procedure</dt>
-                                <dd class="govuk-summary-list__value">Written</dd>
-                            </div>
-                            <div class="govuk-summary-list__row appeal-allocation-details"><dt class="govuk-summary-list__key"> Allocation level</dt>
-                                <dd class="govuk-summary-list__value">
-                                    <ul class="govuk-!-margin-0">
-                                        <li>Level: A</li>
-                                        <li>Historic heritage</li>
-                                        <li>Architecture design</li>
-                                    </ul>
-                                </dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/allocation-details/allocation-level"
-                                    data-cy="change-allocation-details">Change<span class="govuk-visually-hidden"> Allocation level</span></a>
-                                </dd>
-                            </div>
-                            <div class="govuk-summary-list__row appeal-linked-appeals"><dt class="govuk-summary-list__key"> Linked appeals</dt>
-                                <dd class="govuk-summary-list__value"><span>No linked appeals</span>
-                                </dd>
-                            </div>
-                            <div class="govuk-summary-list__row appeal-other-appeals"><dt class="govuk-summary-list__key"> Related appeals</dt>
-                                <dd class="govuk-summary-list__value"><span>No</span>
-                                </dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/other-appeals/add"
-                                    data-cy="add-related-appeals">Add<span class="govuk-visually-hidden"> Related appeals</span></a>
-                                </dd>
-                            </div>
-                            <div class="govuk-summary-list__row appeal-decision"><dt class="govuk-summary-list__key"> Decision</dt>
-                                <dd class="govuk-summary-list__value">Dismissed</dd>
-                            </div>
-                        </dl>
-                    </div>
-                </div>
-                <div class="govuk-accordion__section">
-                    <div class="govuk-accordion__section-header">
-                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-2"> Site</span></h2>
-                    </div>
-                    <div id="accordion-default1-content-2" class="govuk-accordion__section-content">
-                        <dl class="govuk-summary-list">
-                            <div class="govuk-summary-list__row appeal-visit-type"><dt class="govuk-summary-list__key"> Visit type</dt>
-                                <dd class="govuk-summary-list__value">Accompanied</dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/visit-booked?backUrl=%2Fappeals-service%2Fappeal-details%2F1"
-                                    data-cy="change-set-visit-type">Change<span class="govuk-visually-hidden"> Visit type</span></a>
-                                </dd>
-                            </div>
-                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Date</dt>
-                                <dd class="govuk-summary-list__value">9 October 2023</dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/visit-booked"
-                                    data-cy="change-site-visit-date">Change<span class="govuk-visually-hidden"> Date</span></a>
-                                </dd>
-                            </div>
-                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Start time</dt>
-                                <dd class="govuk-summary-list__value">9:38am</dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/visit-booked"
-                                    data-cy="change-site-visit-start-time">Change<span class="govuk-visually-hidden"> Start time</span></a>
-                                </dd>
-                            </div>
-                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> End time</dt>
-                                <dd class="govuk-summary-list__value">10:00am</dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/visit-booked"
-                                    data-cy="change-site-visit-end-time">Change<span class="govuk-visually-hidden"> End time</span></a>
-                                </dd>
-                            </div>
-                            <div class="govuk-summary-list__row appeal-neighbouring-sites-inspector"><dt class="govuk-summary-list__key"> Interested party and neighbour addresses</dt>
-                                <dd                                 class="govuk-summary-list__value">
-                                    <ul class="govuk-list govuk-list--bullet">
-                                        <li>2 Grove Cottage, Shotesham Road, Woodton, Devon, NR35 2ND</li>
-                                    </ul>
-                                    </dd>
-                                    <dd class="govuk-summary-list__actions">
-                                        <ul class="govuk-summary-list__actions-list">
-                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/neighbouring-sites/manage"
-                                                data-cy="manage-neighbouring-sites-inspector">Manage<span class="govuk-visually-hidden"> Interested party and neighbour addresses</span></a>
-                                            </li>
-                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/neighbouring-sites/add/back-office"
-                                                data-cy="add-neighbouring-sites-inspector">Add<span class="govuk-visually-hidden"> Interested party and neighbour addresses</span></a>
-                                            </li>
-                                        </ul>
-                                    </dd>
-                            </div>
-                        </dl>
-                    </div>
-                </div>
-                <div class="govuk-accordion__section">
-                    <div class="govuk-accordion__section-header">
-                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-3"> Timetable</span></h2>
-                    </div>
-                    <div id="accordion-default1-content-3" class="govuk-accordion__section-content">
-                        <dl class="govuk-summary-list appeal-case-timetable">
-                            <div class="govuk-summary-list__row appeal-valid-date"><dt class="govuk-summary-list__key"> Valid date</dt>
-                                <dd class="govuk-summary-list__value">23 May 2023</dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/valid/date"
-                                    data-cy="-valid-date"><span class="govuk-visually-hidden"> Valid date</span></a>
-                                </dd>
-                            </div>
-                            <div class="govuk-summary-list__row appeal-start-date"><dt class="govuk-summary-list__key"> Start date</dt>
-                                <dd class="govuk-summary-list__value">23 May 2023</dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/start-case/change"
-                                    data-cy="change-start-case-date">Change<span class="govuk-visually-hidden"> Start date</span></a>
-                                </dd>
-                            </div>
-                            <div class="govuk-summary-list__row appeal-lpa-questionnaire-due-date"><dt class="govuk-summary-list__key"> LPA questionnaire due</dt>
-                                <dd class="govuk-summary-list__value">11 October 2023</dd>
-                            </div>
-                            <div class="govuk-summary-list__row appeal-site-visit"><dt class="govuk-summary-list__key"> Site visit</dt>
-                                <dd class="govuk-summary-list__value">
-                                    <ul class="govuk-list govuk-!-margin-top-0 govuk-!-padding-left-0">
-                                        <li>9 October 2023</li>
-                                        <li>9:38am - 10:00am</li>
-                                    </ul>
-                                </dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/manage-visit?backUrl=%2Fappeals-service%2Fappeal-details%2F1"
-                                    data-cy="change-schedule-visit">Change<span class="govuk-visually-hidden"> Site visit</span></a>
-                                </dd>
-                            </div>
-                        </dl>
-                    </div>
-                </div>
-                <div class="govuk-accordion__section">
-                    <div class="govuk-accordion__section-header">
-                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-4"> Documentation</span></h2>
-                    </div>
-                    <div id="accordion-default1-content-4" class="govuk-accordion__section-content">
-                        <table class="govuk-table">
-                            <thead class="govuk-table__head">
-                                <tr class="govuk-table__row">
-                                    <th scope="col" class="govuk-table__header">Documentation</th>
-                                    <th scope="col" class="govuk-table__header">Status</th>
-                                    <th scope="col" class="govuk-table__header">Received</th>
-                                    <th scope="col" class="govuk-table__header govuk-!-text-align-right">Action</th>
-                                </tr>
-                            </thead>
-                            <tbody class="govuk-table__body">
-                                <tr class="govuk-table__row">
-                                    <th scope="row" class="govuk-table__header">Appeal</th>
-                                    <td class="govuk-table__cell">Ready to review</td>
-                                    <td class="govuk-table__cell">2 August 2024</td>
-                                    <td class="govuk-table__cell govuk-!-text-align-right"><a href="/appeals-service/appeal-details/1/appellant-case?backUrl=%2Fappeals-service%2Fappeal-details%2F1"
-                                        data-cy="review-appellant-case" class="govuk-link">Review<span class="govuk-visually-hidden"> appellant case</span></a>
-                                    </td>
-                                </tr>
-                                <tr class="govuk-table__row">
-                                    <th scope="row" class="govuk-table__header">LPA questionnaire</th>
-                                    <td class="govuk-table__cell">Overdue</td>
-                                    <td class="govuk-table__cell">Due by 11 October 2023</td>
-                                    <td class="govuk-table__cell govuk-!-text-align-right"></td>
-                                </tr>
-                            </tbody>
-                        </table>
-                    </div>
-                </div>
-                <div class="govuk-accordion__section">
-                    <div class="govuk-accordion__section-header">
-                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-5"> Costs</span></h2>
-                    </div>
-                    <div id="accordion-default1-content-5" class="govuk-accordion__section-content">
-                        <table class="govuk-table">
-                            <thead class="govuk-table__head">
-                                <tr class="govuk-table__row">
-                                    <th scope="col" class="govuk-table__header">Documentation</th>
-                                    <th scope="col" class="govuk-table__header">Status</th>
-                                    <th scope="col" class="govuk-table__header govuk-!-text-align-right">Action</th>
-                                </tr>
-                            </thead>
-                            <tbody class="govuk-table__body">
-                                <tr class="govuk-table__row">
-                                    <th scope="row" class="govuk-table__header appeal-costs-appellant-application-documentation">Appellant application</th>
-                                    <td class="govuk-table__cell appeal-costs-appellant-application-status">No documents available</td>
-                                    <td class="govuk-table__cell appeal-costs-appellant-application-actions govuk-!-text-align-right">
-                                        <ul class="govuk-summary-list__actions-list">
-                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-appellant-application" href="/appeals-service/appeal-details/1/costs/appellant/application/upload-documents/1">Add<span class="govuk-visually-hidden"> Appellant application</span></a>
-                                            </li>
-                                        </ul>
-                                    </td>
-                                </tr>
-                                <tr class="govuk-table__row">
-                                    <th scope="row" class="govuk-table__header appeal-costs-appellant-withdrawal-documentation">Appellant withdrawal</th>
-                                    <td class="govuk-table__cell appeal-costs-appellant-withdrawal-status">No documents available</td>
-                                    <td class="govuk-table__cell appeal-costs-appellant-withdrawal-actions govuk-!-text-align-right">
-                                        <ul class="govuk-summary-list__actions-list">
-                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-appellant-withdrawal" href="/appeals-service/appeal-details/1/costs/appellant/withdrawal/upload-documents/2">Add<span class="govuk-visually-hidden"> Appellant withdrawal</span></a>
-                                            </li>
-                                        </ul>
-                                    </td>
-                                </tr>
-                                <tr class="govuk-table__row">
-                                    <th scope="row" class="govuk-table__header appeal-costs-appellant-correspondence-documentation">Appellant correspondence</th>
-                                    <td class="govuk-table__cell appeal-costs-appellant-correspondence-status">No documents available</td>
-                                    <td class="govuk-table__cell appeal-costs-appellant-correspondence-actions govuk-!-text-align-right">
-                                        <ul class="govuk-summary-list__actions-list">
-                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-appellant-correspondence" href="/appeals-service/appeal-details/1/costs/appellant/correspondence/upload-documents/3">Add<span class="govuk-visually-hidden"> Appellant correspondence</span></a>
-                                            </li>
-                                        </ul>
-                                    </td>
-                                </tr>
-                                <tr class="govuk-table__row">
-                                    <th scope="row" class="govuk-table__header appeal-costs-lpa-application-documentation">LPA application</th>
-                                    <td class="govuk-table__cell appeal-costs-lpa-application-status">No documents available</td>
-                                    <td class="govuk-table__cell appeal-costs-lpa-application-actions govuk-!-text-align-right">
-                                        <ul class="govuk-summary-list__actions-list">
-                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-lpa-application" href="/appeals-service/appeal-details/1/costs/lpa/application/upload-documents/4">Add<span class="govuk-visually-hidden"> LPA application</span></a>
-                                            </li>
-                                        </ul>
-                                    </td>
-                                </tr>
-                                <tr class="govuk-table__row">
-                                    <th scope="row" class="govuk-table__header appeal-costs-lpa-withdrawal-documentation">LPA withdrawal</th>
-                                    <td class="govuk-table__cell appeal-costs-lpa-withdrawal-status">No documents available</td>
-                                    <td class="govuk-table__cell appeal-costs-lpa-withdrawal-actions govuk-!-text-align-right">
-                                        <ul class="govuk-summary-list__actions-list">
-                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-lpa-withdrawal" href="/appeals-service/appeal-details/1/costs/lpa/withdrawal/upload-documents/5">Add<span class="govuk-visually-hidden"> LPA withdrawal</span></a>
-                                            </li>
-                                        </ul>
-                                    </td>
-                                </tr>
-                                <tr class="govuk-table__row">
-                                    <th scope="row" class="govuk-table__header appeal-costs-lpa-correspondence-documentation">LPA correspondence</th>
-                                    <td class="govuk-table__cell appeal-costs-lpa-correspondence-status">No documents available</td>
-                                    <td class="govuk-table__cell appeal-costs-lpa-correspondence-actions govuk-!-text-align-right">
-                                        <ul class="govuk-summary-list__actions-list">
-                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-lpa-correspondence" href="/appeals-service/appeal-details/1/costs/lpa/correspondence/upload-documents/6">Add<span class="govuk-visually-hidden"> LPA correspondence</span></a>
-                                            </li>
-                                        </ul>
-                                    </td>
-                                </tr>
-                            </tbody>
-                        </table>
-                    </div>
-                </div>
-                <div class="govuk-accordion__section">
-                    <div class="govuk-accordion__section-header">
-                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-6"> Contacts</span></h2>
-                    </div>
-                    <div id="accordion-default1-content-6" class="govuk-accordion__section-content">
-                        <dl class="govuk-summary-list">
-                            <div class="govuk-summary-list__row appeal-appellant"><dt class="govuk-summary-list__key"> Appellant</dt>
-                                <dd class="govuk-summary-list__value">
-                                    <ul class="govuk-list">
-                                        <li>Roger Simmons</li>
-                                        <li>test3@example.com</li>
-                                    </ul>
-                                </dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/service-user/change/appellant"
-                                    data-cy="change-appellant">Change<span class="govuk-visually-hidden"> Appellant</span></a>
-                                </dd>
-                            </div>
-                            <div class="govuk-summary-list__row appeal-agent"><dt class="govuk-summary-list__key"> Agent</dt>
-                                <dd class="govuk-summary-list__value">
-                                    <ul class="govuk-list">
-                                        <li>Fiona Shell</li>
-                                        <li>test2@example.com</li>
-                                    </ul>
-                                </dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/service-user/change/agent"
-                                    data-cy="change-agent">Change<span class="govuk-visually-hidden"> Agent</span></a>
-                                </dd>
-                            </div>
-                            <div class="govuk-summary-list__row appeal-lpa-contact-details"><dt class="govuk-summary-list__key"> LPA</dt>
-                                <dd class="govuk-summary-list__value">
-                                    <ul class="govuk-list">
-                                        <li>Wiltshire Council</li>
-                                        <li>wilt@lpa-email.gov.uk</li>
-                                    </ul>
-                                </dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/change-appeal-details/local-planning-authority"
-                                    data-cy="change-lpa-contact-details">Change<span class="govuk-visually-hidden"> Local planning authority (LPA)</span></a>
-                                </dd>
-                            </div>
-                        </dl>
-                    </div>
-                </div>
-                <div class="govuk-accordion__section">
-                    <div class="govuk-accordion__section-header">
-                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-7"> Team</span></h2>
-                    </div>
-                    <div id="accordion-default1-content-7" class="govuk-accordion__section-content">
-                        <dl class="govuk-summary-list">
-                            <div class="govuk-summary-list__row appeal-case-officer"><dt class="govuk-summary-list__key"> Case officer</dt>
-                                <dd class="govuk-summary-list__value">
-                                    <p class="govuk-body">Not assigned</p>
-                                </dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/assign-case-officer/search-case-officer"
-                                    data-cy="assign-case-officer">Assign<span class="govuk-visually-hidden"> Case officer</span></a>
-                                </dd>
-                            </div>
-                            <div class="govuk-summary-list__row appeal-inspector"><dt class="govuk-summary-list__key"> Inspector</dt>
-                                <dd class="govuk-summary-list__value">
-                                    <p class="govuk-body">Not assigned</p>
-                                </dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/assign-inspector/search-inspector"
-                                    data-cy="assign-inspector">Assign<span class="govuk-visually-hidden"> Inspector</span></a>
-                                </dd>
-                            </div>
-                        </dl>
-                    </div>
-                </div>
-                <div class="govuk-accordion__section">
-                    <div class="govuk-accordion__section-header">
-                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-8"> Case management</span></h2>
-                    </div>
-                    <div id="accordion-default1-content-8" class="govuk-accordion__section-content">
-                        <dl class="govuk-summary-list">
-                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Cross-team correspondence</dt>
-                                <dd                                 class="govuk-summary-list__value">No documents</dd>
-                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/internal-correspondence/cross-team/upload-documents/10"
-                                        data-cy="add-cross-team-correspondence">Add<span class="govuk-visually-hidden"> Cross-team correspondence</span></a>
-                                    </dd>
-                            </div>
-                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Inspector correspondence</dt>
-                                <dd                                 class="govuk-summary-list__value">No documents</dd>
-                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/internal-correspondence/inspector/upload-documents/11"
-                                        data-cy="add-inspector-correspondence">Add<span class="govuk-visually-hidden"> Inspector correspondence</span></a>
-                                    </dd>
-                            </div>
-                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Main party correspondence</dt>
-                                <dd                                 class="govuk-summary-list__value">No documents</dd>
-                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/internal-correspondence/main-party/upload-documents/22"
-                                        data-cy="add-main-party-correspondence">Add<span class="govuk-visually-hidden"> Main party correspondence</span></a>
-                                    </dd>
-                            </div>
-                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Case history</dt>
-                                <dd class="govuk-summary-list__value"></dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/audit" data-cy="view-case-history">View<span class="govuk-visually-hidden"> Case history</span></a>
-                                </dd>
-                            </div>
-                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Appeal withdrawal</dt>
-                                <dd class="govuk-summary-list__value"></dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/withdrawal/start"
-                                    data-cy="start-appeal-withdrawal">Start<span class="govuk-visually-hidden"> Appeal withdrawal</span></a>
-                                </dd>
-                            </div>
-                        </dl>
-                    </div>
-                </div>
-            </div>
-        </div>
-    </div>
-</main>"
-`;
-
-exports[`appeal-details GET /:appealId should render the received appeal details for a valid appealId with single linked/other appeals 1`] = `
-"<main class="govuk-main-wrapper" id="main-content">
-    <div class="govuk-grid-row">
-        <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Appeal 351062</span>
-            <h1 class="govuk-heading-xl govuk-!-margin-bottom-3">Case details</h1>
-        </div>
-    </div>
-    <div class="govuk-grid-row">
-        <div class="govuk-grid-column-full"><strong class="govuk-tag govuk-tag--grey pins-status-tag--full-width">Received appeal</strong>
-            <strong             class="govuk-tag govuk-tag--grey govuk-!-margin-left-1 govuk-!-margin-bottom-4"></strong>
-        </div>
-    </div>
-    <div class="govuk-grid-row">
-        <div class="govuk-grid-column-full">
-            <dl class="govuk-summary-list pins-summary-list--no-border">
-                <div class="govuk-summary-list__row appeal-case-officer"><dt class="govuk-summary-list__key"> Case officer</dt>
-                    <dd class="govuk-summary-list__value">
-                        <p class="govuk-body">Not assigned</p>
-                    </dd>
-                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/assign-case-officer/search-case-officer"
-                        data-cy="assign-case-officer-name">Assign<span class="govuk-visually-hidden"> Case officer</span></a>
-                    </dd>
-                </div>
-                <div class="govuk-summary-list__row appeal-site-address"><dt class="govuk-summary-list__key"> Site address</dt>
-                    <dd class="govuk-summary-list__value">21 The Pavement, Wandsworth, SW4 0HY</dd>
-                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/site-address/change/1?backUrl=%2Fappeals-service%2Fappeal-details%2F2"
-                        data-cy="change-site-address">Change<span class="govuk-visually-hidden"> Site address</span></a>
-                    </dd>
-                </div>
-                <div class="govuk-summary-list__row appeal-local-planning-authority"><dt class="govuk-summary-list__key"> LPA</dt>
-                    <dd class="govuk-summary-list__value">Wiltshire Council</dd>
-                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/change-appeal-details/local-planning-authority"
-                        data-cy="change-local-planning-authority">Change<span class="govuk-visually-hidden"> LPA</span></a>
-                    </dd>
-                </div>
-            </dl>
-        </div>
-    </div>
-    <div class="govuk-grid-row">
-        <div class="govuk-grid-column-full">
-            <p class="govuk-body govuk-!-margin-bottom-6" id="download-case-files"
-            data-cy="download-case-files"><a class="govuk-link" href="/documents/2/bulk-download/case-APP/Q9999/D/21/351062.zip">Download case</a>
-            </p>
-        </div>
-    </div>
-    <div class="govuk-grid-row">
-        <div class="govuk-grid-column-full">
-            <details class="govuk-details">
-                <summary class="govuk-details__summary"><span class="govuk-details__summary-text"> 2 case notes</span>
-                </summary>
-                <div class="govuk-details__text">
-                    <form method="POST" novalidate="novalidate">
-                        <div class="govuk-grid-row">
-                            <div class="govuk-grid-column-two-thirds">
-                                <div class="govuk-form-group govuk-character-count" data-module="govuk-character-count"
-                                data-maxlength="500">
-                                    <textarea class="govuk-textarea govuk-js-character-count" id="comment"
-                                    name="comment" rows="5" aria-describedby="comment-info"></textarea>
-                                    <div id="comment-info" class="govuk-hint govuk-character-count__message">You can enter up to 500 characters</div>
-                                </div>
-                            </div>
-                        </div>
-                        <button type="submit" data-prevent-double-click="true" class="govuk-button govuk-button--secondary govuk-!-margin-bottom-1"
-                        data-module="govuk-button">Add case note</button>
-                    </form>
-                    <div>
-                        <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
-                        <section>
-                            <p class="govuk-body govuk-!-margin-bottom-1">A case note you should see.</p>
-                            <p class="govuk-hint govuk-!-margin-bottom-6">11:00am on Tuesday 1 October 2024 by John.Smith</p>
-                            <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
-                        </section>
-                        <section>
-                            <p class="govuk-body govuk-!-margin-bottom-1">A case note you should see.</p>
-                            <p class="govuk-hint govuk-!-margin-bottom-6">11:00am on Tuesday 1 October 2024 by John.Smith</p>
-                            <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
-                        </section>
-                    </div>
-                </div>
-            </details>
-        </div>
-    </div>
-    <div class="govuk-grid-row">
-        <div class="govuk-grid-column-full">
-            <div class="govuk-accordion" data-module="govuk-accordion" id="accordion-default2">
-                <div class="govuk-accordion__section">
-                    <div class="govuk-accordion__section-header">
-                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default2-heading-1"> Overview</span></h2>
-                    </div>
-                    <div id="accordion-default2-content-1" class="govuk-accordion__section-content">
-                        <dl class="govuk-summary-list">
-                            <div class="govuk-summary-list__row govuk-summary-list__row--no-actions appeal-lpa-reference"><dt class="govuk-summary-list__key"> Planning application reference</dt>
-                                <dd                                 class="govuk-summary-list__value">48269/APP/2021/1482</dd>
-                            </div>
-                            <div class="govuk-summary-list__row appeal-appeal-type"><dt class="govuk-summary-list__key"> Appeal type</dt>
-                                <dd class="govuk-summary-list__value">Householder</dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/change-appeal-type/appeal-type"
-                                    data-cy="change-appeal-type">Change<span class="govuk-visually-hidden"> Appeal type</span></a>
-                                </dd>
-                            </div>
-                            <div class="govuk-summary-list__row govuk-summary-list__row--no-actions appeal-case-procedure"><dt class="govuk-summary-list__key"> Appeal procedure</dt>
-                                <dd class="govuk-summary-list__value">Written</dd>
-                            </div>
-                            <div class="govuk-summary-list__row appeal-allocation-details"><dt class="govuk-summary-list__key"> Allocation level</dt>
-                                <dd class="govuk-summary-list__value">
-                                    <ul class="govuk-!-margin-0">
-                                        <li>Level: A</li>
-                                        <li>Historic heritage</li>
-                                        <li>Architecture design</li>
-                                    </ul>
-                                </dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/allocation-details/allocation-level"
-                                    data-cy="change-allocation-details">Change<span class="govuk-visually-hidden"> Allocation level</span></a>
-                                </dd>
-                            </div>
-                            <div class="govuk-summary-list__row appeal-linked-appeals"><dt class="govuk-summary-list__key"> Linked appeals</dt>
-                                <dd class="govuk-summary-list__value"><a href="/appeals-service/appeal-details/1" class="govuk-link" data-cy="linked-appeal-725284"
-                                    aria-label="Appeal 7 2 5 2 8 4">725284</a>
-                                </dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/linked-appeals/manage"
-                                    data-cy="manage-linked-appeals">Manage<span class="govuk-visually-hidden"> Linked appeals</span></a>
-                                </dd>
-                            </div>
-                            <div class="govuk-summary-list__row appeal-other-appeals"><dt class="govuk-summary-list__key"> Related appeals</dt>
-                                <dd class="govuk-summary-list__value">
-                                    <ul class="govuk-list govuk-list--bullet">
-                                        <li><a href="/appeals-service/appeal-details/3" class="govuk-link" data-cy="related-appeal-765413"
-                                            aria-label="Appeal 7 6 5 4 1 3">765413</a>
-                                        </li>
-                                    </ul>
-                                </dd>
-                                <dd class="govuk-summary-list__actions">
-                                    <ul class="govuk-summary-list__actions-list">
-                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/2/other-appeals/manage"
-                                            data-cy="manage-related-appeals">Manage<span class="govuk-visually-hidden"> Related appeals</span></a>
-                                        </li>
-                                        <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/2/other-appeals/add"
-                                            data-cy="add-related-appeals">Add<span class="govuk-visually-hidden"> Related appeals</span></a>
-                                        </li>
-                                    </ul>
-                                </dd>
-                            </div>
-                            <div class="govuk-summary-list__row appeal-decision"><dt class="govuk-summary-list__key"> Decision</dt>
-                                <dd class="govuk-summary-list__value">Dismissed</dd>
-                            </div>
-                        </dl>
-                    </div>
-                </div>
-                <div class="govuk-accordion__section">
-                    <div class="govuk-accordion__section-header">
-                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default2-heading-2"> Site</span></h2>
-                    </div>
-                    <div id="accordion-default2-content-2" class="govuk-accordion__section-content">
-                        <dl class="govuk-summary-list">
-                            <div class="govuk-summary-list__row appeal-visit-type"><dt class="govuk-summary-list__key"> Visit type</dt>
-                                <dd class="govuk-summary-list__value">Accompanied</dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/site-visit/visit-booked?backUrl=%2Fappeals-service%2Fappeal-details%2F2"
-                                    data-cy="change-set-visit-type">Change<span class="govuk-visually-hidden"> Visit type</span></a>
-                                </dd>
-                            </div>
-                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Date</dt>
-                                <dd class="govuk-summary-list__value">9 October 2023</dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/site-visit/visit-booked"
-                                    data-cy="change-site-visit-date">Change<span class="govuk-visually-hidden"> Date</span></a>
-                                </dd>
-                            </div>
-                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Start time</dt>
-                                <dd class="govuk-summary-list__value">9:38am</dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/site-visit/visit-booked"
-                                    data-cy="change-site-visit-start-time">Change<span class="govuk-visually-hidden"> Start time</span></a>
-                                </dd>
-                            </div>
-                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> End time</dt>
-                                <dd class="govuk-summary-list__value">10:00am</dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/site-visit/visit-booked"
-                                    data-cy="change-site-visit-end-time">Change<span class="govuk-visually-hidden"> End time</span></a>
-                                </dd>
-                            </div>
-                            <div class="govuk-summary-list__row appeal-neighbouring-sites-inspector"><dt class="govuk-summary-list__key"> Interested party and neighbour addresses</dt>
-                                <dd                                 class="govuk-summary-list__value">
-                                    <ul class="govuk-list govuk-list--bullet">
-                                        <li>2 Grove Cottage, Shotesham Road, Woodton, Devon, NR35 2ND</li>
-                                    </ul>
-                                    </dd>
-                                    <dd class="govuk-summary-list__actions">
-                                        <ul class="govuk-summary-list__actions-list">
-                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/2/neighbouring-sites/manage"
-                                                data-cy="manage-neighbouring-sites-inspector">Manage<span class="govuk-visually-hidden"> Interested party and neighbour addresses</span></a>
-                                            </li>
-                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/2/neighbouring-sites/add/back-office"
-                                                data-cy="add-neighbouring-sites-inspector">Add<span class="govuk-visually-hidden"> Interested party and neighbour addresses</span></a>
-                                            </li>
-                                        </ul>
-                                    </dd>
-                            </div>
-                        </dl>
-                    </div>
-                </div>
-                <div class="govuk-accordion__section">
-                    <div class="govuk-accordion__section-header">
-                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default2-heading-3"> Timetable</span></h2>
-                    </div>
-                    <div id="accordion-default2-content-3" class="govuk-accordion__section-content">
-                        <dl class="govuk-summary-list appeal-case-timetable">
-                            <div class="govuk-summary-list__row appeal-valid-date"><dt class="govuk-summary-list__key"> Valid date</dt>
-                                <dd class="govuk-summary-list__value">23 May 2023</dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/appellant-case/valid/date"
-                                    data-cy="-valid-date"><span class="govuk-visually-hidden"> Valid date</span></a>
-                                </dd>
-                            </div>
-                            <div class="govuk-summary-list__row appeal-start-date"><dt class="govuk-summary-list__key"> Start date</dt>
-                                <dd class="govuk-summary-list__value">23 May 2023</dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/start-case/change"
-                                    data-cy="change-start-case-date">Change<span class="govuk-visually-hidden"> Start date</span></a>
-                                </dd>
-                            </div>
-                            <div class="govuk-summary-list__row appeal-lpa-questionnaire-due-date"><dt class="govuk-summary-list__key"> LPA questionnaire due</dt>
-                                <dd class="govuk-summary-list__value">11 October 2023</dd>
-                            </div>
-                            <div class="govuk-summary-list__row appeal-site-visit"><dt class="govuk-summary-list__key"> Site visit</dt>
-                                <dd class="govuk-summary-list__value">
-                                    <ul class="govuk-list govuk-!-margin-top-0 govuk-!-padding-left-0">
-                                        <li>9 October 2023</li>
-                                        <li>9:38am - 10:00am</li>
-                                    </ul>
-                                </dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/site-visit/manage-visit?backUrl=%2Fappeals-service%2Fappeal-details%2F2"
-                                    data-cy="change-schedule-visit">Change<span class="govuk-visually-hidden"> Site visit</span></a>
-                                </dd>
-                            </div>
-                        </dl>
-                    </div>
-                </div>
-                <div class="govuk-accordion__section">
-                    <div class="govuk-accordion__section-header">
-                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default2-heading-4"> Documentation</span></h2>
-                    </div>
-                    <div id="accordion-default2-content-4" class="govuk-accordion__section-content">
-                        <table class="govuk-table">
-                            <thead class="govuk-table__head">
-                                <tr class="govuk-table__row">
-                                    <th scope="col" class="govuk-table__header">Documentation</th>
-                                    <th scope="col" class="govuk-table__header">Status</th>
-                                    <th scope="col" class="govuk-table__header">Received</th>
-                                    <th scope="col" class="govuk-table__header govuk-!-text-align-right">Action</th>
-                                </tr>
-                            </thead>
-                            <tbody class="govuk-table__body">
-                                <tr class="govuk-table__row">
-                                    <th scope="row" class="govuk-table__header">Appeal</th>
-                                    <td class="govuk-table__cell">Ready to review</td>
-                                    <td class="govuk-table__cell">2 August 2024</td>
-                                    <td class="govuk-table__cell govuk-!-text-align-right"><a href="/appeals-service/appeal-details/2/appellant-case?backUrl=%2Fappeals-service%2Fappeal-details%2F2"
-                                        data-cy="review-appellant-case" class="govuk-link">Review<span class="govuk-visually-hidden"> appellant case</span></a>
-                                    </td>
-                                </tr>
-                                <tr class="govuk-table__row">
-                                    <th scope="row" class="govuk-table__header">LPA questionnaire</th>
-                                    <td class="govuk-table__cell">Overdue</td>
-                                    <td class="govuk-table__cell">Due by 11 October 2023</td>
-                                    <td class="govuk-table__cell govuk-!-text-align-right"></td>
-                                </tr>
-                            </tbody>
-                        </table>
-                    </div>
-                </div>
-                <div class="govuk-accordion__section">
-                    <div class="govuk-accordion__section-header">
-                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default2-heading-5"> Costs</span></h2>
-                    </div>
-                    <div id="accordion-default2-content-5" class="govuk-accordion__section-content">
-                        <table class="govuk-table">
-                            <thead class="govuk-table__head">
-                                <tr class="govuk-table__row">
-                                    <th scope="col" class="govuk-table__header">Documentation</th>
-                                    <th scope="col" class="govuk-table__header">Status</th>
-                                    <th scope="col" class="govuk-table__header govuk-!-text-align-right">Action</th>
-                                </tr>
-                            </thead>
-                            <tbody class="govuk-table__body">
-                                <tr class="govuk-table__row">
-                                    <th scope="row" class="govuk-table__header appeal-costs-appellant-application-documentation">Appellant application</th>
-                                    <td class="govuk-table__cell appeal-costs-appellant-application-status">No documents available</td>
-                                    <td class="govuk-table__cell appeal-costs-appellant-application-actions govuk-!-text-align-right">
-                                        <ul class="govuk-summary-list__actions-list">
-                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-appellant-application" href="/appeals-service/appeal-details/2/costs/appellant/application/upload-documents/1">Add<span class="govuk-visually-hidden"> Appellant application</span></a>
-                                            </li>
-                                        </ul>
-                                    </td>
-                                </tr>
-                                <tr class="govuk-table__row">
-                                    <th scope="row" class="govuk-table__header appeal-costs-appellant-withdrawal-documentation">Appellant withdrawal</th>
-                                    <td class="govuk-table__cell appeal-costs-appellant-withdrawal-status">No documents available</td>
-                                    <td class="govuk-table__cell appeal-costs-appellant-withdrawal-actions govuk-!-text-align-right">
-                                        <ul class="govuk-summary-list__actions-list">
-                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-appellant-withdrawal" href="/appeals-service/appeal-details/2/costs/appellant/withdrawal/upload-documents/2">Add<span class="govuk-visually-hidden"> Appellant withdrawal</span></a>
-                                            </li>
-                                        </ul>
-                                    </td>
-                                </tr>
-                                <tr class="govuk-table__row">
-                                    <th scope="row" class="govuk-table__header appeal-costs-appellant-correspondence-documentation">Appellant correspondence</th>
-                                    <td class="govuk-table__cell appeal-costs-appellant-correspondence-status">No documents available</td>
-                                    <td class="govuk-table__cell appeal-costs-appellant-correspondence-actions govuk-!-text-align-right">
-                                        <ul class="govuk-summary-list__actions-list">
-                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-appellant-correspondence" href="/appeals-service/appeal-details/2/costs/appellant/correspondence/upload-documents/3">Add<span class="govuk-visually-hidden"> Appellant correspondence</span></a>
-                                            </li>
-                                        </ul>
-                                    </td>
-                                </tr>
-                                <tr class="govuk-table__row">
-                                    <th scope="row" class="govuk-table__header appeal-costs-lpa-application-documentation">LPA application</th>
-                                    <td class="govuk-table__cell appeal-costs-lpa-application-status">No documents available</td>
-                                    <td class="govuk-table__cell appeal-costs-lpa-application-actions govuk-!-text-align-right">
-                                        <ul class="govuk-summary-list__actions-list">
-                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-lpa-application" href="/appeals-service/appeal-details/2/costs/lpa/application/upload-documents/4">Add<span class="govuk-visually-hidden"> LPA application</span></a>
-                                            </li>
-                                        </ul>
-                                    </td>
-                                </tr>
-                                <tr class="govuk-table__row">
-                                    <th scope="row" class="govuk-table__header appeal-costs-lpa-withdrawal-documentation">LPA withdrawal</th>
-                                    <td class="govuk-table__cell appeal-costs-lpa-withdrawal-status">No documents available</td>
-                                    <td class="govuk-table__cell appeal-costs-lpa-withdrawal-actions govuk-!-text-align-right">
-                                        <ul class="govuk-summary-list__actions-list">
-                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-lpa-withdrawal" href="/appeals-service/appeal-details/2/costs/lpa/withdrawal/upload-documents/5">Add<span class="govuk-visually-hidden"> LPA withdrawal</span></a>
-                                            </li>
-                                        </ul>
-                                    </td>
-                                </tr>
-                                <tr class="govuk-table__row">
-                                    <th scope="row" class="govuk-table__header appeal-costs-lpa-correspondence-documentation">LPA correspondence</th>
-                                    <td class="govuk-table__cell appeal-costs-lpa-correspondence-status">No documents available</td>
-                                    <td class="govuk-table__cell appeal-costs-lpa-correspondence-actions govuk-!-text-align-right">
-                                        <ul class="govuk-summary-list__actions-list">
-                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-lpa-correspondence" href="/appeals-service/appeal-details/2/costs/lpa/correspondence/upload-documents/6">Add<span class="govuk-visually-hidden"> LPA correspondence</span></a>
-                                            </li>
-                                        </ul>
-                                    </td>
-                                </tr>
-                            </tbody>
-                        </table>
-                    </div>
-                </div>
-                <div class="govuk-accordion__section">
-                    <div class="govuk-accordion__section-header">
-                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default2-heading-6"> Contacts</span></h2>
-                    </div>
-                    <div id="accordion-default2-content-6" class="govuk-accordion__section-content">
-                        <dl class="govuk-summary-list">
-                            <div class="govuk-summary-list__row appeal-appellant"><dt class="govuk-summary-list__key"> Appellant</dt>
-                                <dd class="govuk-summary-list__value">
-                                    <ul class="govuk-list">
-                                        <li>Roger Simmons</li>
-                                        <li>test3@example.com</li>
-                                    </ul>
-                                </dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/service-user/change/appellant"
-                                    data-cy="change-appellant">Change<span class="govuk-visually-hidden"> Appellant</span></a>
-                                </dd>
-                            </div>
-                            <div class="govuk-summary-list__row appeal-agent"><dt class="govuk-summary-list__key"> Agent</dt>
-                                <dd class="govuk-summary-list__value">
-                                    <ul class="govuk-list">
-                                        <li>Fiona Shell</li>
-                                        <li>test2@example.com</li>
-                                    </ul>
-                                </dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/service-user/change/agent"
-                                    data-cy="change-agent">Change<span class="govuk-visually-hidden"> Agent</span></a>
-                                </dd>
-                            </div>
-                            <div class="govuk-summary-list__row appeal-lpa-contact-details"><dt class="govuk-summary-list__key"> LPA</dt>
-                                <dd class="govuk-summary-list__value">
-                                    <ul class="govuk-list">
-                                        <li>Wiltshire Council</li>
-                                        <li>wilt@lpa-email.gov.uk</li>
-                                    </ul>
-                                </dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/change-appeal-details/local-planning-authority"
-                                    data-cy="change-lpa-contact-details">Change<span class="govuk-visually-hidden"> Local planning authority (LPA)</span></a>
-                                </dd>
-                            </div>
-                        </dl>
-                    </div>
-                </div>
-                <div class="govuk-accordion__section">
-                    <div class="govuk-accordion__section-header">
-                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default2-heading-7"> Team</span></h2>
-                    </div>
-                    <div id="accordion-default2-content-7" class="govuk-accordion__section-content">
-                        <dl class="govuk-summary-list">
-                            <div class="govuk-summary-list__row appeal-case-officer"><dt class="govuk-summary-list__key"> Case officer</dt>
-                                <dd class="govuk-summary-list__value">
-                                    <p class="govuk-body">Not assigned</p>
-                                </dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/assign-case-officer/search-case-officer"
-                                    data-cy="assign-case-officer">Assign<span class="govuk-visually-hidden"> Case officer</span></a>
-                                </dd>
-                            </div>
-                            <div class="govuk-summary-list__row appeal-inspector"><dt class="govuk-summary-list__key"> Inspector</dt>
-                                <dd class="govuk-summary-list__value">
-                                    <p class="govuk-body">Not assigned</p>
-                                </dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/assign-inspector/search-inspector"
-                                    data-cy="assign-inspector">Assign<span class="govuk-visually-hidden"> Inspector</span></a>
-                                </dd>
-                            </div>
-                        </dl>
-                    </div>
-                </div>
-                <div class="govuk-accordion__section">
-                    <div class="govuk-accordion__section-header">
-                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default2-heading-8"> Case management</span></h2>
-                    </div>
-                    <div id="accordion-default2-content-8" class="govuk-accordion__section-content">
-                        <dl class="govuk-summary-list">
-                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Cross-team correspondence</dt>
-                                <dd                                 class="govuk-summary-list__value">No documents</dd>
-                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/internal-correspondence/cross-team/upload-documents/10"
-                                        data-cy="add-cross-team-correspondence">Add<span class="govuk-visually-hidden"> Cross-team correspondence</span></a>
-                                    </dd>
-                            </div>
-                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Inspector correspondence</dt>
-                                <dd                                 class="govuk-summary-list__value">No documents</dd>
-                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/internal-correspondence/inspector/upload-documents/11"
-                                        data-cy="add-inspector-correspondence">Add<span class="govuk-visually-hidden"> Inspector correspondence</span></a>
-                                    </dd>
-                            </div>
-                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Main party correspondence</dt>
-                                <dd                                 class="govuk-summary-list__value">No documents</dd>
-                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/internal-correspondence/main-party/upload-documents/22"
-                                        data-cy="add-main-party-correspondence">Add<span class="govuk-visually-hidden"> Main party correspondence</span></a>
-                                    </dd>
-                            </div>
-                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Case history</dt>
-                                <dd class="govuk-summary-list__value"></dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/audit" data-cy="view-case-history">View<span class="govuk-visually-hidden"> Case history</span></a>
-                                </dd>
-                            </div>
-                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Appeal withdrawal</dt>
-                                <dd class="govuk-summary-list__value"></dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/withdrawal/start"
-                                    data-cy="start-appeal-withdrawal">Start<span class="govuk-visually-hidden"> Appeal withdrawal</span></a>
-                                </dd>
-                            </div>
-                        </dl>
-                    </div>
-                </div>
-            </div>
-        </div>
-    </div>
-</main>"
 `;
 
 exports[`appeal-details GET /:appealId should render the received appeal details for a valid appealId without start date 1`] = `
@@ -9075,6 +9237,13 @@ exports[`appeal-details GET /:appealId should render the received appeal details
                     </div>
                 </div>
             </div>
+        </div>
+    </div>
+    <div id="case-details-cancel-section">
+        <h3 class="govuk-heading-m">Cancel appeal</h3>
+        <div>
+            <p><a id="cancelCase" class="govuk-body govuk-link" href="/appeals-service/appeal-details/2/cancel">Cancel appeal</a>
+            </p>
         </div>
     </div>
 </main>"
@@ -9549,6 +9718,13 @@ exports[`appeal-details should not render a back button 1`] = `
                                 </div>
                             </div>
                         </div>
+                    </div>
+                </div>
+                <div id="case-details-cancel-section">
+                    <h3 class="govuk-heading-m">Cancel appeal</h3>
+                    <div>
+                        <p><a id="cancelCase" class="govuk-body govuk-link" href="/appeals-service/appeal-details/2/cancel">Cancel appeal</a>
+                        </p>
                     </div>
                 </div>
             </main>

--- a/appeals/web/src/server/appeals/appeal-details/__tests__/__snapshots__/appeal-details.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/__tests__/__snapshots__/appeal-details.test.js.snap
@@ -596,59 +596,9 @@ exports[`appeal-details GET /:appealId Linked appeals should not render a "Appea
                 </div>
                 <div class="govuk-accordion__section">
                     <div class="govuk-accordion__section-header">
-                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default2-heading-2"> Site</span></h2>
+                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default2-heading-2"> Timetable</span></h2>
                     </div>
                     <div id="accordion-default2-content-2" class="govuk-accordion__section-content">
-                        <dl class="govuk-summary-list">
-                            <div class="govuk-summary-list__row appeal-visit-type"><dt class="govuk-summary-list__key"> Visit type</dt>
-                                <dd class="govuk-summary-list__value">Accompanied</dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/site-visit/visit-booked?backUrl=%2Fappeals-service%2Fappeal-details%2F2"
-                                    data-cy="change-set-visit-type">Change<span class="govuk-visually-hidden"> Visit type</span></a>
-                                </dd>
-                            </div>
-                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Date</dt>
-                                <dd class="govuk-summary-list__value">9 October 2023</dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/site-visit/visit-booked"
-                                    data-cy="change-site-visit-date">Change<span class="govuk-visually-hidden"> Date</span></a>
-                                </dd>
-                            </div>
-                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Start time</dt>
-                                <dd class="govuk-summary-list__value">9:38am</dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/site-visit/visit-booked"
-                                    data-cy="change-site-visit-start-time">Change<span class="govuk-visually-hidden"> Start time</span></a>
-                                </dd>
-                            </div>
-                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> End time</dt>
-                                <dd class="govuk-summary-list__value">10:00am</dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/site-visit/visit-booked"
-                                    data-cy="change-site-visit-end-time">Change<span class="govuk-visually-hidden"> End time</span></a>
-                                </dd>
-                            </div>
-                            <div class="govuk-summary-list__row appeal-neighbouring-sites-inspector"><dt class="govuk-summary-list__key"> Interested party and neighbour addresses</dt>
-                                <dd                                 class="govuk-summary-list__value">
-                                    <ul class="govuk-list govuk-list--bullet">
-                                        <li>2 Grove Cottage, Shotesham Road, Woodton, Devon, NR35 2ND</li>
-                                    </ul>
-                                    </dd>
-                                    <dd class="govuk-summary-list__actions">
-                                        <ul class="govuk-summary-list__actions-list">
-                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/2/neighbouring-sites/manage"
-                                                data-cy="manage-neighbouring-sites-inspector">Manage<span class="govuk-visually-hidden"> Interested party and neighbour addresses</span></a>
-                                            </li>
-                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/2/neighbouring-sites/add/back-office"
-                                                data-cy="add-neighbouring-sites-inspector">Add<span class="govuk-visually-hidden"> Interested party and neighbour addresses</span></a>
-                                            </li>
-                                        </ul>
-                                    </dd>
-                            </div>
-                        </dl>
-                    </div>
-                </div>
-                <div class="govuk-accordion__section">
-                    <div class="govuk-accordion__section-header">
-                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default2-heading-3"> Timetable</span></h2>
-                    </div>
-                    <div id="accordion-default2-content-3" class="govuk-accordion__section-content">
                         <dl class="govuk-summary-list appeal-case-timetable">
                             <div class="govuk-summary-list__row appeal-valid-date"><dt class="govuk-summary-list__key"> Valid date</dt>
                                 <dd class="govuk-summary-list__value">23 May 2023</dd>
@@ -675,9 +625,9 @@ exports[`appeal-details GET /:appealId Linked appeals should not render a "Appea
                 </div>
                 <div class="govuk-accordion__section">
                     <div class="govuk-accordion__section-header">
-                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default2-heading-4"> Documentation</span></h2>
+                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default2-heading-3"> Documentation</span></h2>
                     </div>
-                    <div id="accordion-default2-content-4" class="govuk-accordion__section-content">
+                    <div id="accordion-default2-content-3" class="govuk-accordion__section-content">
                         <table class="govuk-table">
                             <thead class="govuk-table__head">
                                 <tr class="govuk-table__row">
@@ -708,9 +658,9 @@ exports[`appeal-details GET /:appealId Linked appeals should not render a "Appea
                 </div>
                 <div class="govuk-accordion__section">
                     <div class="govuk-accordion__section-header">
-                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default2-heading-5"> Costs</span></h2>
+                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default2-heading-4"> Costs</span></h2>
                     </div>
-                    <div id="accordion-default2-content-5" class="govuk-accordion__section-content">
+                    <div id="accordion-default2-content-4" class="govuk-accordion__section-content">
                         <table class="govuk-table">
                             <thead class="govuk-table__head">
                                 <tr class="govuk-table__row">
@@ -786,9 +736,9 @@ exports[`appeal-details GET /:appealId Linked appeals should not render a "Appea
                 </div>
                 <div class="govuk-accordion__section">
                     <div class="govuk-accordion__section-header">
-                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default2-heading-6"> Contacts</span></h2>
+                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default2-heading-5"> Contacts</span></h2>
                     </div>
-                    <div id="accordion-default2-content-6" class="govuk-accordion__section-content">
+                    <div id="accordion-default2-content-5" class="govuk-accordion__section-content">
                         <dl class="govuk-summary-list">
                             <div class="govuk-summary-list__row appeal-appellant"><dt class="govuk-summary-list__key"> Appellant</dt>
                                 <dd class="govuk-summary-list__value">
@@ -828,9 +778,9 @@ exports[`appeal-details GET /:appealId Linked appeals should not render a "Appea
                 </div>
                 <div class="govuk-accordion__section">
                     <div class="govuk-accordion__section-header">
-                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default2-heading-7"> Team</span></h2>
+                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default2-heading-6"> Team</span></h2>
                     </div>
-                    <div id="accordion-default2-content-7" class="govuk-accordion__section-content">
+                    <div id="accordion-default2-content-6" class="govuk-accordion__section-content">
                         <dl class="govuk-summary-list">
                             <div class="govuk-summary-list__row appeal-case-officer"><dt class="govuk-summary-list__key"> Case officer</dt>
                                 <dd class="govuk-summary-list__value">
@@ -853,9 +803,9 @@ exports[`appeal-details GET /:appealId Linked appeals should not render a "Appea
                 </div>
                 <div class="govuk-accordion__section">
                     <div class="govuk-accordion__section-header">
-                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default2-heading-8"> Case management</span></h2>
+                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default2-heading-7"> Case management</span></h2>
                     </div>
-                    <div id="accordion-default2-content-8" class="govuk-accordion__section-content">
+                    <div id="accordion-default2-content-7" class="govuk-accordion__section-content">
                         <dl class="govuk-summary-list">
                             <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Cross-team correspondence</dt>
                                 <dd                                 class="govuk-summary-list__value">No documents</dd>
@@ -878,12 +828,6 @@ exports[`appeal-details GET /:appealId Linked appeals should not render a "Appea
                             <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Case history</dt>
                                 <dd class="govuk-summary-list__value"></dd>
                                 <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/audit" data-cy="view-case-history">View<span class="govuk-visually-hidden"> Case history</span></a>
-                                </dd>
-                            </div>
-                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Appeal withdrawal</dt>
-                                <dd class="govuk-summary-list__value"></dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/withdrawal/start"
-                                    data-cy="start-appeal-withdrawal">Start<span class="govuk-visually-hidden"> Appeal withdrawal</span></a>
                                 </dd>
                             </div>
                         </dl>
@@ -1339,12 +1283,6 @@ exports[`appeal-details GET /:appealId Linked appeals should not render action l
                                 <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/audit" data-cy="view-case-history">View<span class="govuk-visually-hidden"> Case history</span></a>
                                 </dd>
                             </div>
-                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Appeal withdrawal</dt>
-                                <dd class="govuk-summary-list__value"></dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/withdrawal/start"
-                                    data-cy="start-appeal-withdrawal">Start<span class="govuk-visually-hidden"> Appeal withdrawal</span></a>
-                                </dd>
-                            </div>
                         </dl>
                     </div>
                 </div>
@@ -1495,59 +1433,9 @@ exports[`appeal-details GET /:appealId Linked appeals should render a child tag 
                 </div>
                 <div class="govuk-accordion__section">
                     <div class="govuk-accordion__section-header">
-                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-2"> Site</span></h2>
+                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-2"> Timetable</span></h2>
                     </div>
                     <div id="accordion-default1-content-2" class="govuk-accordion__section-content">
-                        <dl class="govuk-summary-list">
-                            <div class="govuk-summary-list__row appeal-visit-type"><dt class="govuk-summary-list__key"> Visit type</dt>
-                                <dd class="govuk-summary-list__value">Accompanied</dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/visit-booked?backUrl=%2Fappeals-service%2Fappeal-details%2F1"
-                                    data-cy="change-set-visit-type">Change<span class="govuk-visually-hidden"> Visit type</span></a>
-                                </dd>
-                            </div>
-                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Date</dt>
-                                <dd class="govuk-summary-list__value">9 October 2023</dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/visit-booked"
-                                    data-cy="change-site-visit-date">Change<span class="govuk-visually-hidden"> Date</span></a>
-                                </dd>
-                            </div>
-                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Start time</dt>
-                                <dd class="govuk-summary-list__value">9:38am</dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/visit-booked"
-                                    data-cy="change-site-visit-start-time">Change<span class="govuk-visually-hidden"> Start time</span></a>
-                                </dd>
-                            </div>
-                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> End time</dt>
-                                <dd class="govuk-summary-list__value">10:00am</dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/visit-booked"
-                                    data-cy="change-site-visit-end-time">Change<span class="govuk-visually-hidden"> End time</span></a>
-                                </dd>
-                            </div>
-                            <div class="govuk-summary-list__row appeal-neighbouring-sites-inspector"><dt class="govuk-summary-list__key"> Interested party and neighbour addresses</dt>
-                                <dd                                 class="govuk-summary-list__value">
-                                    <ul class="govuk-list govuk-list--bullet">
-                                        <li>2 Grove Cottage, Shotesham Road, Woodton, Devon, NR35 2ND</li>
-                                    </ul>
-                                    </dd>
-                                    <dd class="govuk-summary-list__actions">
-                                        <ul class="govuk-summary-list__actions-list">
-                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/neighbouring-sites/manage"
-                                                data-cy="manage-neighbouring-sites-inspector">Manage<span class="govuk-visually-hidden"> Interested party and neighbour addresses</span></a>
-                                            </li>
-                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/neighbouring-sites/add/back-office"
-                                                data-cy="add-neighbouring-sites-inspector">Add<span class="govuk-visually-hidden"> Interested party and neighbour addresses</span></a>
-                                            </li>
-                                        </ul>
-                                    </dd>
-                            </div>
-                        </dl>
-                    </div>
-                </div>
-                <div class="govuk-accordion__section">
-                    <div class="govuk-accordion__section-header">
-                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-3"> Timetable</span></h2>
-                    </div>
-                    <div id="accordion-default1-content-3" class="govuk-accordion__section-content">
                         <dl class="govuk-summary-list appeal-case-timetable">
                             <div class="govuk-summary-list__row appeal-valid-date"><dt class="govuk-summary-list__key"> Valid date</dt>
                                 <dd class="govuk-summary-list__value">23 May 2023</dd>
@@ -1574,9 +1462,9 @@ exports[`appeal-details GET /:appealId Linked appeals should render a child tag 
                 </div>
                 <div class="govuk-accordion__section">
                     <div class="govuk-accordion__section-header">
-                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-4"> Documentation</span></h2>
+                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-3"> Documentation</span></h2>
                     </div>
-                    <div id="accordion-default1-content-4" class="govuk-accordion__section-content">
+                    <div id="accordion-default1-content-3" class="govuk-accordion__section-content">
                         <table class="govuk-table">
                             <thead class="govuk-table__head">
                                 <tr class="govuk-table__row">
@@ -1607,9 +1495,9 @@ exports[`appeal-details GET /:appealId Linked appeals should render a child tag 
                 </div>
                 <div class="govuk-accordion__section">
                     <div class="govuk-accordion__section-header">
-                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-5"> Costs</span></h2>
+                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-4"> Costs</span></h2>
                     </div>
-                    <div id="accordion-default1-content-5" class="govuk-accordion__section-content">
+                    <div id="accordion-default1-content-4" class="govuk-accordion__section-content">
                         <table class="govuk-table">
                             <thead class="govuk-table__head">
                                 <tr class="govuk-table__row">
@@ -1685,9 +1573,9 @@ exports[`appeal-details GET /:appealId Linked appeals should render a child tag 
                 </div>
                 <div class="govuk-accordion__section">
                     <div class="govuk-accordion__section-header">
-                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-6"> Contacts</span></h2>
+                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-5"> Contacts</span></h2>
                     </div>
-                    <div id="accordion-default1-content-6" class="govuk-accordion__section-content">
+                    <div id="accordion-default1-content-5" class="govuk-accordion__section-content">
                         <dl class="govuk-summary-list">
                             <div class="govuk-summary-list__row appeal-appellant"><dt class="govuk-summary-list__key"> Appellant</dt>
                                 <dd class="govuk-summary-list__value">
@@ -1727,9 +1615,9 @@ exports[`appeal-details GET /:appealId Linked appeals should render a child tag 
                 </div>
                 <div class="govuk-accordion__section">
                     <div class="govuk-accordion__section-header">
-                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-7"> Team</span></h2>
+                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-6"> Team</span></h2>
                     </div>
-                    <div id="accordion-default1-content-7" class="govuk-accordion__section-content">
+                    <div id="accordion-default1-content-6" class="govuk-accordion__section-content">
                         <dl class="govuk-summary-list">
                             <div class="govuk-summary-list__row appeal-case-officer"><dt class="govuk-summary-list__key"> Case officer</dt>
                                 <dd class="govuk-summary-list__value">
@@ -1752,9 +1640,9 @@ exports[`appeal-details GET /:appealId Linked appeals should render a child tag 
                 </div>
                 <div class="govuk-accordion__section">
                     <div class="govuk-accordion__section-header">
-                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-8"> Case management</span></h2>
+                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-7"> Case management</span></h2>
                     </div>
-                    <div id="accordion-default1-content-8" class="govuk-accordion__section-content">
+                    <div id="accordion-default1-content-7" class="govuk-accordion__section-content">
                         <dl class="govuk-summary-list">
                             <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Cross-team correspondence</dt>
                                 <dd                                 class="govuk-summary-list__value">No documents</dd>
@@ -1777,12 +1665,6 @@ exports[`appeal-details GET /:appealId Linked appeals should render a child tag 
                             <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Case history</dt>
                                 <dd class="govuk-summary-list__value"></dd>
                                 <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/audit" data-cy="view-case-history">View<span class="govuk-visually-hidden"> Case history</span></a>
-                                </dd>
-                            </div>
-                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Appeal withdrawal</dt>
-                                <dd class="govuk-summary-list__value"></dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/withdrawal/start"
-                                    data-cy="start-appeal-withdrawal">Start<span class="govuk-visually-hidden"> Appeal withdrawal</span></a>
                                 </dd>
                             </div>
                         </dl>
@@ -2233,12 +2115,6 @@ exports[`appeal-details GET /:appealId Linked appeals should render a lead tag n
                             <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Case history</dt>
                                 <dd class="govuk-summary-list__value"></dd>
                                 <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/audit" data-cy="view-case-history">View<span class="govuk-visually-hidden"> Case history</span></a>
-                                </dd>
-                            </div>
-                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Appeal withdrawal</dt>
-                                <dd class="govuk-summary-list__value"></dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/withdrawal/start"
-                                    data-cy="start-appeal-withdrawal">Start<span class="govuk-visually-hidden"> Appeal withdrawal</span></a>
                                 </dd>
                             </div>
                         </dl>
@@ -2702,12 +2578,6 @@ exports[`appeal-details GET /:appealId Linked appeals should render an action li
                                 <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/audit" data-cy="view-case-history">View<span class="govuk-visually-hidden"> Case history</span></a>
                                 </dd>
                             </div>
-                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Appeal withdrawal</dt>
-                                <dd class="govuk-summary-list__value"></dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/withdrawal/start"
-                                    data-cy="start-appeal-withdrawal">Start<span class="govuk-visually-hidden"> Appeal withdrawal</span></a>
-                                </dd>
-                            </div>
                         </dl>
                     </div>
                 </div>
@@ -3169,12 +3039,6 @@ exports[`appeal-details GET /:appealId Linked appeals should render an action li
                                 <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/audit" data-cy="view-case-history">View<span class="govuk-visually-hidden"> Case history</span></a>
                                 </dd>
                             </div>
-                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Appeal withdrawal</dt>
-                                <dd class="govuk-summary-list__value"></dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/withdrawal/start"
-                                    data-cy="start-appeal-withdrawal">Start<span class="govuk-visually-hidden"> Appeal withdrawal</span></a>
-                                </dd>
-                            </div>
                         </dl>
                     </div>
                 </div>
@@ -3337,9 +3201,59 @@ exports[`appeal-details GET /:appealId Linked appeals should render the case ref
                 </div>
                 <div class="govuk-accordion__section">
                     <div class="govuk-accordion__section-header">
-                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-2"> Timetable</span></h2>
+                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-2"> Site</span></h2>
                     </div>
                     <div id="accordion-default1-content-2" class="govuk-accordion__section-content">
+                        <dl class="govuk-summary-list">
+                            <div class="govuk-summary-list__row appeal-visit-type"><dt class="govuk-summary-list__key"> Visit type</dt>
+                                <dd class="govuk-summary-list__value">Accompanied</dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/visit-booked?backUrl=%2Fappeals-service%2Fappeal-details%2F1"
+                                    data-cy="change-set-visit-type">Change<span class="govuk-visually-hidden"> Visit type</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Date</dt>
+                                <dd class="govuk-summary-list__value">9 October 2023</dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/visit-booked"
+                                    data-cy="change-site-visit-date">Change<span class="govuk-visually-hidden"> Date</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Start time</dt>
+                                <dd class="govuk-summary-list__value">9:38am</dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/visit-booked"
+                                    data-cy="change-site-visit-start-time">Change<span class="govuk-visually-hidden"> Start time</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> End time</dt>
+                                <dd class="govuk-summary-list__value">10:00am</dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/visit-booked"
+                                    data-cy="change-site-visit-end-time">Change<span class="govuk-visually-hidden"> End time</span></a>
+                                </dd>
+                            </div>
+                            <div class="govuk-summary-list__row appeal-neighbouring-sites-inspector"><dt class="govuk-summary-list__key"> Interested party and neighbour addresses</dt>
+                                <dd                                 class="govuk-summary-list__value">
+                                    <ul class="govuk-list govuk-list--bullet">
+                                        <li>2 Grove Cottage, Shotesham Road, Woodton, Devon, NR35 2ND</li>
+                                    </ul>
+                                    </dd>
+                                    <dd class="govuk-summary-list__actions">
+                                        <ul class="govuk-summary-list__actions-list">
+                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/neighbouring-sites/manage"
+                                                data-cy="manage-neighbouring-sites-inspector">Manage<span class="govuk-visually-hidden"> Interested party and neighbour addresses</span></a>
+                                            </li>
+                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/1/neighbouring-sites/add/back-office"
+                                                data-cy="add-neighbouring-sites-inspector">Add<span class="govuk-visually-hidden"> Interested party and neighbour addresses</span></a>
+                                            </li>
+                                        </ul>
+                                    </dd>
+                            </div>
+                        </dl>
+                    </div>
+                </div>
+                <div class="govuk-accordion__section">
+                    <div class="govuk-accordion__section-header">
+                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-3"> Timetable</span></h2>
+                    </div>
+                    <div id="accordion-default1-content-3" class="govuk-accordion__section-content">
                         <dl class="govuk-summary-list appeal-case-timetable">
                             <div class="govuk-summary-list__row appeal-valid-date"><dt class="govuk-summary-list__key"> Valid date</dt>
                                 <dd class="govuk-summary-list__value">23 May 2023</dd>
@@ -3372,9 +3286,9 @@ exports[`appeal-details GET /:appealId Linked appeals should render the case ref
                 </div>
                 <div class="govuk-accordion__section">
                     <div class="govuk-accordion__section-header">
-                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-3"> Documentation</span></h2>
+                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-4"> Documentation</span></h2>
                     </div>
-                    <div id="accordion-default1-content-3" class="govuk-accordion__section-content">
+                    <div id="accordion-default1-content-4" class="govuk-accordion__section-content">
                         <table class="govuk-table">
                             <thead class="govuk-table__head">
                                 <tr class="govuk-table__row">
@@ -3405,9 +3319,9 @@ exports[`appeal-details GET /:appealId Linked appeals should render the case ref
                 </div>
                 <div class="govuk-accordion__section">
                     <div class="govuk-accordion__section-header">
-                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-4"> Costs</span></h2>
+                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-5"> Costs</span></h2>
                     </div>
-                    <div id="accordion-default1-content-4" class="govuk-accordion__section-content">
+                    <div id="accordion-default1-content-5" class="govuk-accordion__section-content">
                         <table class="govuk-table">
                             <thead class="govuk-table__head">
                                 <tr class="govuk-table__row">
@@ -3483,9 +3397,9 @@ exports[`appeal-details GET /:appealId Linked appeals should render the case ref
                 </div>
                 <div class="govuk-accordion__section">
                     <div class="govuk-accordion__section-header">
-                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-5"> Contacts</span></h2>
+                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-6"> Contacts</span></h2>
                     </div>
-                    <div id="accordion-default1-content-5" class="govuk-accordion__section-content">
+                    <div id="accordion-default1-content-6" class="govuk-accordion__section-content">
                         <dl class="govuk-summary-list">
                             <div class="govuk-summary-list__row appeal-appellant"><dt class="govuk-summary-list__key"> Appellant</dt>
                                 <dd class="govuk-summary-list__value">
@@ -3525,9 +3439,9 @@ exports[`appeal-details GET /:appealId Linked appeals should render the case ref
                 </div>
                 <div class="govuk-accordion__section">
                     <div class="govuk-accordion__section-header">
-                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-6"> Team</span></h2>
+                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-7"> Team</span></h2>
                     </div>
-                    <div id="accordion-default1-content-6" class="govuk-accordion__section-content">
+                    <div id="accordion-default1-content-7" class="govuk-accordion__section-content">
                         <dl class="govuk-summary-list">
                             <div class="govuk-summary-list__row appeal-case-officer"><dt class="govuk-summary-list__key"> Case officer</dt>
                                 <dd class="govuk-summary-list__value">
@@ -3550,9 +3464,9 @@ exports[`appeal-details GET /:appealId Linked appeals should render the case ref
                 </div>
                 <div class="govuk-accordion__section">
                     <div class="govuk-accordion__section-header">
-                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-7"> Case management</span></h2>
+                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-8"> Case management</span></h2>
                     </div>
-                    <div id="accordion-default1-content-7" class="govuk-accordion__section-content">
+                    <div id="accordion-default1-content-8" class="govuk-accordion__section-content">
                         <dl class="govuk-summary-list">
                             <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Cross-team correspondence</dt>
                                 <dd                                 class="govuk-summary-list__value">No documents</dd>
@@ -3575,12 +3489,6 @@ exports[`appeal-details GET /:appealId Linked appeals should render the case ref
                             <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Case history</dt>
                                 <dd class="govuk-summary-list__value"></dd>
                                 <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/audit" data-cy="view-case-history">View<span class="govuk-visually-hidden"> Case history</span></a>
-                                </dd>
-                            </div>
-                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Appeal withdrawal</dt>
-                                <dd class="govuk-summary-list__value"></dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/withdrawal/start"
-                                    data-cy="start-appeal-withdrawal">Start<span class="govuk-visually-hidden"> Appeal withdrawal</span></a>
                                 </dd>
                             </div>
                         </dl>
@@ -4033,12 +3941,6 @@ exports[`appeal-details GET /:appealId Linked appeals should render the lead or 
                             <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Case history</dt>
                                 <dd class="govuk-summary-list__value"></dd>
                                 <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/audit" data-cy="view-case-history">View<span class="govuk-visually-hidden"> Case history</span></a>
-                                </dd>
-                            </div>
-                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Appeal withdrawal</dt>
-                                <dd class="govuk-summary-list__value"></dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/withdrawal/start"
-                                    data-cy="start-appeal-withdrawal">Start<span class="govuk-visually-hidden"> Appeal withdrawal</span></a>
                                 </dd>
                             </div>
                         </dl>
@@ -4507,12 +4409,6 @@ exports[`appeal-details GET /:appealId Linked appeals should render the received
                                 <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/3/audit" data-cy="view-case-history">View<span class="govuk-visually-hidden"> Case history</span></a>
                                 </dd>
                             </div>
-                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Appeal withdrawal</dt>
-                                <dd class="govuk-summary-list__value"></dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/3/withdrawal/start"
-                                    data-cy="start-appeal-withdrawal">Start<span class="govuk-visually-hidden"> Appeal withdrawal</span></a>
-                                </dd>
-                            </div>
                         </dl>
                     </div>
                 </div>
@@ -4950,12 +4846,6 @@ exports[`appeal-details GET /:appealId Linked appeals should render the received
                             <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Case history</dt>
                                 <dd class="govuk-summary-list__value"></dd>
                                 <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/audit" data-cy="view-case-history">View<span class="govuk-visually-hidden"> Case history</span></a>
-                                </dd>
-                            </div>
-                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Appeal withdrawal</dt>
-                                <dd class="govuk-summary-list__value"></dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/withdrawal/start"
-                                    data-cy="start-appeal-withdrawal">Start<span class="govuk-visually-hidden"> Appeal withdrawal</span></a>
                                 </dd>
                             </div>
                         </dl>
@@ -5412,12 +5302,6 @@ exports[`appeal-details GET /:appealId Linked appeals should render the received
                             <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Case history</dt>
                                 <dd class="govuk-summary-list__value"></dd>
                                 <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/audit" data-cy="view-case-history">View<span class="govuk-visually-hidden"> Case history</span></a>
-                                </dd>
-                            </div>
-                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Appeal withdrawal</dt>
-                                <dd class="govuk-summary-list__value"></dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/withdrawal/start"
-                                    data-cy="start-appeal-withdrawal">Start<span class="govuk-visually-hidden"> Appeal withdrawal</span></a>
                                 </dd>
                             </div>
                         </dl>
@@ -5960,12 +5844,6 @@ exports[`appeal-details GET /:appealId Notification banners Important banners sh
                             <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Case history</dt>
                                 <dd class="govuk-summary-list__value"></dd>
                                 <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/audit" data-cy="view-case-history">View<span class="govuk-visually-hidden"> Case history</span></a>
-                                </dd>
-                            </div>
-                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Appeal withdrawal</dt>
-                                <dd class="govuk-summary-list__value"></dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/withdrawal/start"
-                                    data-cy="start-appeal-withdrawal">Start<span class="govuk-visually-hidden"> Appeal withdrawal</span></a>
                                 </dd>
                             </div>
                         </dl>
@@ -6952,12 +6830,6 @@ exports[`appeal-details GET /:appealId should render a Decision inset panel when
                                 <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/audit" data-cy="view-case-history">View<span class="govuk-visually-hidden"> Case history</span></a>
                                 </dd>
                             </div>
-                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Appeal withdrawal</dt>
-                                <dd class="govuk-summary-list__value"></dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/withdrawal/start"
-                                    data-cy="start-appeal-withdrawal">Start<span class="govuk-visually-hidden"> Appeal withdrawal</span></a>
-                                </dd>
-                            </div>
                         </dl>
                     </div>
                 </div>
@@ -7408,12 +7280,6 @@ exports[`appeal-details GET /:appealId should render a Decision inset panel when
                                 <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/audit" data-cy="view-case-history">View<span class="govuk-visually-hidden"> Case history</span></a>
                                 </dd>
                             </div>
-                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Appeal withdrawal</dt>
-                                <dd class="govuk-summary-list__value"></dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/withdrawal/start"
-                                    data-cy="start-appeal-withdrawal">Start<span class="govuk-visually-hidden"> Appeal withdrawal</span></a>
-                                </dd>
-                            </div>
                         </dl>
                     </div>
                 </div>
@@ -7859,12 +7725,6 @@ exports[`appeal-details GET /:appealId should render a Decision inset panel when
                             <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Case history</dt>
                                 <dd class="govuk-summary-list__value"></dd>
                                 <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/audit" data-cy="view-case-history">View<span class="govuk-visually-hidden"> Case history</span></a>
-                                </dd>
-                            </div>
-                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Appeal withdrawal</dt>
-                                <dd class="govuk-summary-list__value"></dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/withdrawal/start"
-                                    data-cy="start-appeal-withdrawal">Start<span class="govuk-visually-hidden"> Appeal withdrawal</span></a>
                                 </dd>
                             </div>
                         </dl>
@@ -8320,12 +8180,6 @@ exports[`appeal-details GET /:appealId should render the appellant case status a
                                 <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/audit" data-cy="view-case-history">View<span class="govuk-visually-hidden"> Case history</span></a>
                                 </dd>
                             </div>
-                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Appeal withdrawal</dt>
-                                <dd class="govuk-summary-list__value"></dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/withdrawal/start"
-                                    data-cy="start-appeal-withdrawal">Start<span class="govuk-visually-hidden"> Appeal withdrawal</span></a>
-                                </dd>
-                            </div>
                         </dl>
                     </div>
                 </div>
@@ -8766,12 +8620,6 @@ exports[`appeal-details GET /:appealId should render the appellant case status a
                             <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Case history</dt>
                                 <dd class="govuk-summary-list__value"></dd>
                                 <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/audit" data-cy="view-case-history">View<span class="govuk-visually-hidden"> Case history</span></a>
-                                </dd>
-                            </div>
-                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Appeal withdrawal</dt>
-                                <dd class="govuk-summary-list__value"></dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/withdrawal/start"
-                                    data-cy="start-appeal-withdrawal">Start<span class="govuk-visually-hidden"> Appeal withdrawal</span></a>
                                 </dd>
                             </div>
                         </dl>
@@ -9225,12 +9073,6 @@ exports[`appeal-details GET /:appealId should render the received appeal details
                             <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Case history</dt>
                                 <dd class="govuk-summary-list__value"></dd>
                                 <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/audit" data-cy="view-case-history">View<span class="govuk-visually-hidden"> Case history</span></a>
-                                </dd>
-                            </div>
-                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Appeal withdrawal</dt>
-                                <dd class="govuk-summary-list__value"></dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/withdrawal/start"
-                                    data-cy="start-appeal-withdrawal">Start<span class="govuk-visually-hidden"> Appeal withdrawal</span></a>
                                 </dd>
                             </div>
                         </dl>
@@ -9706,12 +9548,6 @@ exports[`appeal-details should not render a back button 1`] = `
                                         <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Case history</dt>
                                             <dd class="govuk-summary-list__value"></dd>
                                             <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/audit" data-cy="view-case-history">View<span class="govuk-visually-hidden"> Case history</span></a>
-                                            </dd>
-                                        </div>
-                                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Appeal withdrawal</dt>
-                                            <dd class="govuk-summary-list__value"></dd>
-                                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/withdrawal/start"
-                                                data-cy="start-appeal-withdrawal">Start<span class="govuk-visually-hidden"> Appeal withdrawal</span></a>
                                             </dd>
                                         </div>
                                     </dl>

--- a/appeals/web/src/server/appeals/appeal-details/__tests__/appeal-details.test.js
+++ b/appeals/web/src/server/appeals/appeal-details/__tests__/appeal-details.test.js
@@ -28,7 +28,7 @@ import {
 } from '#testing/app/fixtures/referencedata.js';
 import { createTestEnvironment } from '#testing/index.js';
 import usersService from '#appeals/appeal-users/users-service.js';
-import { APPEAL_CASE_PROCEDURE } from '@planning-inspectorate/data-model';
+import { APPEAL_CASE_PROCEDURE, APPEAL_CASE_STATUS } from '@planning-inspectorate/data-model';
 import { dateISOStringToDisplayTime12hr } from '#lib/dates.js';
 import { textInputCharacterLimits } from '#appeals/appeal.constants.js';
 
@@ -1824,27 +1824,6 @@ describe('appeal-details', () => {
 			});
 		});
 
-		it('should redirect to 500 page if it fails to post', async () => {
-			nock.cleanAll();
-			const appealId = appealData.appealId;
-			const comment = 'This is a new comment';
-			nock('http://test/').get(`/appeals/${appealId}`).reply(200, appealData).persist();
-			nock('http://test/').get(`/appeals/${appealId}/case-notes`).reply(200, caseNotes);
-
-			nock('http://test/')
-				.get(`/appeals/${appealId}/reps?type=appellant_final_comment`)
-				.reply(200, appellantFinalCommentsAwaitingReview);
-			nock('http://test/')
-				.get(`/appeals/${appealId}/reps?type=lpa_final_comment`)
-				.reply(200, lpaFinalCommentsAwaitingReview);
-
-			const submitRequest = nock('http://test/').post(`/appeals/${appealId}/case-notes`).reply(500);
-			await request.get(`${baseUrl}/${appealId}`);
-
-			const response = await request.post(`${baseUrl}/${appealId}`).send({ comment: comment });
-			expect(response.statusCode).toBe(500);
-			expect(submitRequest.isDone()).toBe(true);
-		});
 		describe('Case download', () => {
 			it('should render the case download link', async () => {
 				const appealId = appealData.appealId.toString();
@@ -1859,6 +1838,7 @@ describe('appeal-details', () => {
 				expect(element).toContain('Download case');
 			});
 		});
+
 		describe('Status tags', () => {
 			const testCases = [
 				{
@@ -1957,35 +1937,431 @@ describe('appeal-details', () => {
 			}
 		});
 
-		it('should render the received appeal details for a valid appealId with no linked/other appeals', async () => {
-			const appealId = appealData.appealId.toString();
+		describe('Linked appeals', () => {
+			it('should render the received appeal details for a valid appealId with no linked/other appeals', async () => {
+				const appealId = appealData.appealId.toString();
 
-			nock('http://test/').get(`/appeals/${appealId}`).reply(200, undefined);
+				nock('http://test/').get(`/appeals/${appealId}`).reply(200, undefined);
+				nock('http://test/').get(`/appeals/${appealId}/case-notes`).reply(200, caseNotes);
+				const response = await request.get(`${baseUrl}/${appealId}`);
+				const element = parseHtml(response.text);
+
+				expect(element.innerHTML).toMatchSnapshot();
+
+				const unprettifiedElement = parseHtml(response.text, { skipPrettyPrint: true });
+
+				expect(unprettifiedElement.innerHTML).toContain('Case details</h1>');
+				expect(unprettifiedElement.innerHTML).toContain(
+					'Linked appeals</dt><dd class="govuk-summary-list__value"><span>No linked appeals</span>'
+				);
+				expect(unprettifiedElement.innerHTML).toContain(
+					'Linked appeals</dt><dd class="govuk-summary-list__value"><span>No linked appeals</span>'
+				);
+
+				expect(unprettifiedElement.innerHTML).not.toContain(
+					`href="/appeals-service/appeal-details/${appealId}/inspector-access/change/lpa"`
+				);
+				expect(unprettifiedElement.innerHTML).not.toContain(
+					`href="/appeals-service/appeal-details/${appealId}/neighbouring-sites/change/affected"`
+				);
+				expect(unprettifiedElement.innerHTML).not.toContain(
+					`href="/appeals-service/appeal-details/${appealId}/safety-risks/change/lpa"`
+				);
+			});
+
+			it('should render an action link to the manage linked appeals page, if there are linked appeals, the status is not past LPA Questionnaire, all the linked appeals are children and internal', async () => {
+				nock.cleanAll();
+				nock('http://test/')
+					.get(`/appeals/${appealData.appealId}`)
+					.reply(200, {
+						...appealData,
+						appealStatus: 'lpa_questionnaire',
+						linkedAppeals: linkedAppealsAreAllInternalAndNotALead
+					});
+				nock('http://test/')
+					.get(`/appeals/${appealData.appealId}/case-notes`)
+					.reply(200, caseNotes);
+				nock('http://test/')
+					.get(`/appeals/${appealData.appealId}/reps?type=appellant_final_comment`)
+					.reply(200, appellantFinalCommentsAwaitingReview);
+				nock('http://test/')
+					.get(`/appeals/${appealData.appealId}/reps?type=lpa_final_comment`)
+					.reply(200, lpaFinalCommentsAwaitingReview);
+				nock('http://test/')
+					.get(/appeals\/\d+\/appellant-cases\/\d+/)
+					.reply(200, { planningObligation: { hasObligation: false } });
+
+				const response = await request.get(`${baseUrl}/${appealData.appealId}`);
+				const element = parseHtml(response.text);
+
+				expect(element.innerHTML).toMatchSnapshot();
+
+				const linkedAppealsRowElement = parseHtml(response.text, {
+					rootElement: '.appeal-linked-appeals',
+					skipPrettyPrint: true
+				});
+
+				expect(linkedAppealsRowElement.innerHTML).toContain(
+					'href="/appeals-service/appeal-details/1/linked-appeals/manage" data-cy="manage-linked-appeals">Manage<span class="govuk-visually-hidden"> Linked appeals</span></a>'
+				);
+			});
+
+			it('should render an action link to the add linked appeals page, if the appeal is a lead appeal in a state before STATEMENTS', async () => {
+				nock.cleanAll();
+				nock('http://test/')
+					.get(`/appeals/${appealData.appealId}`)
+					.reply(200, {
+						...appealData,
+						isParentAppeal: true,
+						appealStatus: 'lpa_questionnaire',
+						linkedAppeals: linkedAppealsAreAllInternalAndNotALead
+					});
+				nock('http://test/')
+					.get(`/appeals/${appealData.appealId}/case-notes`)
+					.reply(200, caseNotes);
+				nock('http://test/')
+					.get(`/appeals/${appealData.appealId}/reps?type=appellant_final_comment`)
+					.reply(200, appellantFinalCommentsAwaitingReview);
+				nock('http://test/')
+					.get(`/appeals/${appealData.appealId}/reps?type=lpa_final_comment`)
+					.reply(200, lpaFinalCommentsAwaitingReview);
+				nock('http://test/')
+					.get(/appeals\/\d+\/appellant-cases\/\d+/)
+					.reply(200, { planningObligation: { hasObligation: false } });
+
+				const response = await request.get(`${baseUrl}/${appealData.appealId}`);
+				const element = parseHtml(response.text);
+
+				expect(element.innerHTML).toMatchSnapshot();
+
+				const linkedAppealsRowElement = parseHtml(response.text, {
+					rootElement: '.appeal-linked-appeals',
+					skipPrettyPrint: true
+				});
+
+				expect(linkedAppealsRowElement.innerHTML).toContain(
+					'href="/appeals-service/appeal-details/1/linked-appeals/add" data-cy="add-linked-appeal">Add<span class="govuk-visually-hidden"> Linked appeals</span></a>'
+				);
+			});
+
+			it('should not render action links to the manage linked appeals page or the add linked appeal page in the linked appeals row, if the appeal is linked as a child of an external lead appeal', async () => {
+				nock.cleanAll();
+				nock('http://test/')
+					.get(`/appeals/${appealData.appealId}`)
+					.reply(200, {
+						...appealData,
+						isParentAppeal: false,
+						linkedAppeals: linkedAppealsWithExternalLead
+					});
+				nock('http://test/')
+					.get(`/appeals/${appealData.appealId}/case-notes`)
+					.reply(200, caseNotes);
+				nock('http://test/')
+					.get(`/appeals/${appealData.appealId}/reps?type=appellant_final_comment`)
+					.reply(200, appellantFinalCommentsAwaitingReview);
+				nock('http://test/')
+					.get(`/appeals/${appealData.appealId}/reps?type=lpa_final_comment`)
+					.reply(200, lpaFinalCommentsAwaitingReview);
+				nock('http://test/')
+					.get(/appeals\/\d+\/appellant-cases\/\d+/)
+					.reply(200, { planningObligation: { hasObligation: false } });
+
+				const response = await request.get(`${baseUrl}/${appealData.appealId}`);
+				const element = parseHtml(response.text);
+
+				expect(element.innerHTML).toMatchSnapshot();
+
+				const unprettifiedElement = parseHtml(response.text, {
+					rootElement: '.appeal-linked-appeals',
+					skipPrettyPrint: true
+				});
+
+				expect(unprettifiedElement.innerHTML).toContain('Linked appeals</dt>');
+				expect(unprettifiedElement.innerHTML).not.toContain(
+					'href="/appeals-service/appeal-details/1/linked-appeals/add"'
+				);
+				expect(unprettifiedElement.innerHTML).not.toContain(
+					'href="/appeals-service/appeal-details/1/linked-appeals/manage"'
+				);
+			});
+
+			it('should render the case reference for each linked appeal in the linked appeals row, with each internal linked appeal item linking to the respective case details page, if there are linked appeals', async () => {
+				nock.cleanAll();
+				nock('http://test/')
+					.get(`/appeals/${appealData.appealId}`)
+					.reply(200, {
+						...appealData,
+						linkedAppeals
+					});
+				nock('http://test/')
+					.get(`/appeals/${appealData.appealId}/case-notes`)
+					.reply(200, caseNotes);
+				nock('http://test/')
+					.get(`/appeals/${appealData.appealId}/reps?type=appellant_final_comment`)
+					.reply(200, appellantFinalCommentsAwaitingReview);
+				nock('http://test/')
+					.get(`/appeals/${appealData.appealId}/reps?type=lpa_final_comment`)
+					.reply(200, lpaFinalCommentsAwaitingReview);
+				nock('http://test/')
+					.get(/appeals\/\d+\/appellant-cases\/\d+/)
+					.reply(200, { planningObligation: { hasObligation: false } });
+
+				const response = await request.get(`${baseUrl}/${appealData.appealId}`);
+				const element = parseHtml(response.text);
+
+				expect(element.innerHTML).toMatchSnapshot();
+
+				const linkedAppealsRowElement = parseHtml(response.text, {
+					rootElement: '.appeal-linked-appeals',
+					skipPrettyPrint: true
+				});
+
+				expect(linkedAppealsRowElement.innerHTML).toContain(
+					'<a href="/appeals-service/appeal-details/5449"'
+				);
+				expect(linkedAppealsRowElement.innerHTML).toContain(
+					'aria-label="Appeal 7 8 4 7 0 6">784706</a>'
+				);
+				expect(linkedAppealsRowElement.innerHTML).toContain(
+					'<span class="govuk-body">87326527</span>'
+				);
+				expect(linkedAppealsRowElement.innerHTML).toContain(
+					'<a href="/appeals-service/appeal-details/5464"'
+				);
+				expect(linkedAppealsRowElement.innerHTML).toContain(
+					'aria-label="Appeal 1 4 0 0 7 9">140079</a>'
+				);
+				expect(linkedAppealsRowElement.innerHTML).toContain(
+					'<a href="/appeals-service/appeal-details/5451"'
+				);
+				expect(linkedAppealsRowElement.innerHTML).toContain(
+					'aria-label="Appeal 7 2 1 0 8 6">721086</a>'
+				);
+			});
+
+			it('should render the received appeal details for a valid appealId with single linked/other appeals', async () => {
+				const appealId = '2';
+
+				nock('http://test/')
+					.get(`/appeals/${appealId}`)
+					.reply(200, {
+						...appealData,
+						appealId,
+						linkedAppeals: [
+							{
+								appealId: 1,
+								appealReference: 'APP/Q9999/D/21/725284'
+							}
+						],
+						otherAppeals: [
+							{
+								appealId: 3,
+								appealReference: 'APP/Q9999/D/21/765413'
+							}
+						]
+					});
+				nock('http://test/').get(`/appeals/${appealId}/case-notes`).reply(200, caseNotes);
+				const response = await request.get(`${baseUrl}/${appealId}`);
+				const element = parseHtml(response.text);
+
+				expect(element.innerHTML).toMatchSnapshot();
+
+				const unprettifiedElement = parseHtml(response.text, { skipPrettyPrint: true });
+
+				expect(unprettifiedElement.innerHTML).toContain(
+					'Linked appeals</dt><dd class="govuk-summary-list__value"><a href="/appeals-service/appeal-details/1" class="govuk-link" data-cy="linked-appeal-725284" aria-label="Appeal 7 2 5 2 8 4">725284</a>'
+				);
+				expect(unprettifiedElement.innerHTML).toContain(
+					'Related appeals</dt><dd class="govuk-summary-list__value"><ul class="govuk-list govuk-list--bullet"><li><a href="/appeals-service/appeal-details/3" class="govuk-link" data-cy="related-appeal-765413" aria-label="Appeal 7 6 5 4 1 3">765413</a>'
+				);
+			});
+
+			it('should render the received appeal details for a valid appealId with multiple linked/other appeals', async () => {
+				const appealId = '3';
+
+				nock('http://test/')
+					.get(`/appeals/${appealId}`)
+					.reply(200, {
+						...appealData,
+						appealId,
+						linkedAppeals: [
+							{
+								appealId: 4,
+								appealReference: 'APP/Q9999/D/21/725284'
+							},
+							{
+								appealId: 5,
+								appealReference: 'APP/Q9999/D/21/725285'
+							}
+						],
+						otherAppeals: [
+							{
+								appealId: 6,
+								appealReference: 'APP/Q9999/D/21/765413'
+							},
+							{
+								appealId: 7,
+								appealReference: 'APP/Q9999/D/21/765414'
+							}
+						]
+					});
+				nock('http://test/').get(`/appeals/${appealId}/case-notes`).reply(200, caseNotes);
+				const response = await request.get(`${baseUrl}/${appealId}`);
+				const element = parseHtml(response.text);
+
+				expect(element.innerHTML).toMatchSnapshot();
+
+				const unprettifiedElement = parseHtml(response.text, { skipPrettyPrint: true });
+
+				expect(unprettifiedElement.innerHTML).toContain(
+					'Linked appeals</dt><dd class="govuk-summary-list__value"><ul class="govuk-list govuk-list--bullet"><li><a href="/appeals-service/appeal-details/4" class="govuk-link" data-cy="linked-appeal-725284" aria-label="Appeal 7 2 5 2 8 4">725284</a></li><li><a href="/appeals-service/appeal-details/5" class="govuk-link" data-cy="linked-appeal-725285" aria-label="Appeal 7 2 5 2 8 5">725285</a></li></ul>'
+				);
+				expect(unprettifiedElement.innerHTML).toContain(
+					'Related appeals</dt><dd class="govuk-summary-list__value"><ul class="govuk-list govuk-list--bullet"><li><a href="/appeals-service/appeal-details/6" class="govuk-link" data-cy="related-appeal-765413" aria-label="Appeal 7 6 5 4 1 3">765413</a></li><li><a href="/appeals-service/appeal-details/7" class="govuk-link" data-cy="related-appeal-765414" aria-label="Appeal 7 6 5 4 1 4">765414</a></li></ul>'
+				);
+			});
+
+			it('should render the lead or child status after the case reference link of each linked appeal in the linked appeals row, if there are linked appeals', async () => {
+				nock.cleanAll();
+				nock('http://test/')
+					.get(`/appeals/${appealData.appealId}`)
+					.reply(200, {
+						...appealData,
+						linkedAppeals
+					});
+				nock('http://test/')
+					.get(`/appeals/${appealData.appealId}/case-notes`)
+					.reply(200, caseNotes);
+				nock('http://test/')
+					.get(`/appeals/${appealData.appealId}/reps?type=appellant_final_comment`)
+					.reply(200, appellantFinalCommentsAwaitingReview);
+				nock('http://test/')
+					.get(`/appeals/${appealData.appealId}/reps?type=lpa_final_comment`)
+					.reply(200, lpaFinalCommentsAwaitingReview);
+				nock('http://test/')
+					.get(/appeals\/\d+\/appellant-cases\/\d+/)
+					.reply(200, { planningObligation: { hasObligation: false } });
+
+				const response = await request.get(`${baseUrl}/${appealData.appealId}`);
+
+				const element = parseHtml(response.text);
+
+				expect(element.innerHTML).toMatchSnapshot();
+
+				const linkedAppealsRowElement = parseHtml(response.text, {
+					rootElement: '.appeal-linked-appeals',
+					skipPrettyPrint: true
+				});
+
+				expect(linkedAppealsRowElement.innerHTML).toContain('(lead)</li>');
+			});
+
+			it('should render a lead tag next to the appeal status tag if the appeal is a parent', async () => {
+				nock.cleanAll();
+				nock('http://test/')
+					.get(`/appeals/${appealData.appealId}`)
+					.reply(200, {
+						...appealData,
+						isParentAppeal: true,
+						isChildAppeal: false,
+						linkedAppeals: linkedAppeals.filter(
+							(linkedAppeal) => linkedAppeal.isParentAppeal === false
+						)
+					});
+				nock('http://test/')
+					.get(`/appeals/${appealData.appealId}/case-notes`)
+					.reply(200, caseNotes);
+				nock('http://test/')
+					.get(`/appeals/${appealData.appealId}/reps?type=appellant_final_comment`)
+					.reply(200, appellantFinalCommentsAwaitingReview);
+				nock('http://test/')
+					.get(`/appeals/${appealData.appealId}/reps?type=lpa_final_comment`)
+					.reply(200, lpaFinalCommentsAwaitingReview);
+				nock('http://test/')
+					.get(/appeals\/\d+\/appellant-cases\/\d+/)
+					.reply(200, { planningObligation: { hasObligation: false } });
+
+				const response = await request.get(`${baseUrl}/${appealData.appealId}`);
+				const element = parseHtml(response.text);
+
+				expect(element.innerHTML).toMatchSnapshot();
+				expect(element.innerHTML).toContain('Lead</strong>');
+			});
+
+			it('should render a child tag next to the appeal status tag if the appeal is a child', async () => {
+				nock.cleanAll();
+				nock('http://test/')
+					.get(`/appeals/${appealData.appealId}`)
+					.reply(200, {
+						...appealData,
+						isParentAppeal: false,
+						isChildAppeal: true,
+						linkedAppeals: linkedAppeals.filter(
+							(linkedAppeal) => linkedAppeal.isParentAppeal === true
+						)
+					})
+					.persist();
+				nock('http://test/')
+					.get(`/appeals/${appealData.appealId}/case-notes`)
+					.reply(200, caseNotes);
+				nock('http://test/')
+					.get(`/appeals/${appealData.appealId}/reps?type=appellant_final_comment`)
+					.reply(200, appellantFinalCommentsAwaitingReview);
+				nock('http://test/')
+					.get(`/appeals/${appealData.appealId}/reps?type=lpa_final_comment`)
+					.reply(200, lpaFinalCommentsAwaitingReview);
+				nock('http://test/')
+					.get(/appeals\/\d+\/appellant-cases\/\d+/)
+					.reply(200, { planningObligation: { hasObligation: false } });
+
+				const response = await request.get(`${baseUrl}/${appealData.appealId}`);
+				const element = parseHtml(response.text);
+
+				expect(element.innerHTML).toMatchSnapshot();
+				expect(element.innerHTML).toContain('Child</strong>');
+			});
+
+			it('should not render a "Appeal valid" notification banner when status is "READY_TO_START" and appeal is a linked child appeal', async () => {
+				const appealId = 2;
+				nock('http://test/')
+					.get(`/appeals/${appealId}`)
+					.reply(200, {
+						...appealData,
+						appealId,
+						appealStatus: 'ready_to_start',
+						isChildAppeal: true
+					});
+				nock('http://test/').get(`/appeals/${appealId}/case-notes`).reply(200, caseNotes);
+				const response = await request.get(`${baseUrl}/${appealId}`);
+
+				expect(response.statusCode).toBe(200);
+				const element = parseHtml(response.text, { rootElement: '.govuk-main-wrapper' });
+
+				expect(element.innerHTML).toMatchSnapshot();
+				expect(element.innerHTML).not.toContain('govuk-notification-banner');
+			});
+		});
+
+		it('should redirect to 500 page if it fails to post', async () => {
+			nock.cleanAll();
+			const appealId = appealData.appealId;
+			const comment = 'This is a new comment';
+			nock('http://test/').get(`/appeals/${appealId}`).reply(200, appealData).persist();
 			nock('http://test/').get(`/appeals/${appealId}/case-notes`).reply(200, caseNotes);
-			const response = await request.get(`${baseUrl}/${appealId}`);
-			const element = parseHtml(response.text);
 
-			expect(element.innerHTML).toMatchSnapshot();
+			nock('http://test/')
+				.get(`/appeals/${appealId}/reps?type=appellant_final_comment`)
+				.reply(200, appellantFinalCommentsAwaitingReview);
+			nock('http://test/')
+				.get(`/appeals/${appealId}/reps?type=lpa_final_comment`)
+				.reply(200, lpaFinalCommentsAwaitingReview);
 
-			const unprettifiedElement = parseHtml(response.text, { skipPrettyPrint: true });
+			const submitRequest = nock('http://test/').post(`/appeals/${appealId}/case-notes`).reply(500);
+			await request.get(`${baseUrl}/${appealId}`);
 
-			expect(unprettifiedElement.innerHTML).toContain('Case details</h1>');
-			expect(unprettifiedElement.innerHTML).toContain(
-				'Linked appeals</dt><dd class="govuk-summary-list__value"><span>No linked appeals</span>'
-			);
-			expect(unprettifiedElement.innerHTML).toContain(
-				'Linked appeals</dt><dd class="govuk-summary-list__value"><span>No linked appeals</span>'
-			);
-
-			expect(unprettifiedElement.innerHTML).not.toContain(
-				`href="/appeals-service/appeal-details/${appealId}/inspector-access/change/lpa"`
-			);
-			expect(unprettifiedElement.innerHTML).not.toContain(
-				`href="/appeals-service/appeal-details/${appealId}/neighbouring-sites/change/affected"`
-			);
-			expect(unprettifiedElement.innerHTML).not.toContain(
-				`href="/appeals-service/appeal-details/${appealId}/safety-risks/change/lpa"`
-			);
+			const response = await request.post(`${baseUrl}/${appealId}`).send({ comment: comment });
+			expect(response.statusCode).toBe(500);
+			expect(submitRequest.isDone()).toBe(true);
 		});
 
 		it('should render the header with navigation containing links to the personal list, national list, and sign out route, without any active modifier classes', async () => {
@@ -2005,88 +2381,6 @@ describe('appeal-details', () => {
 			);
 			expect(element.innerHTML).toContain(
 				'<a class="govuk-header__link" href="/auth/signout">Sign out</a>'
-			);
-		});
-
-		it('should render the received appeal details for a valid appealId with single linked/other appeals', async () => {
-			const appealId = '2';
-
-			nock('http://test/')
-				.get(`/appeals/${appealId}`)
-				.reply(200, {
-					...appealData,
-					appealId,
-					linkedAppeals: [
-						{
-							appealId: 1,
-							appealReference: 'APP/Q9999/D/21/725284'
-						}
-					],
-					otherAppeals: [
-						{
-							appealId: 3,
-							appealReference: 'APP/Q9999/D/21/765413'
-						}
-					]
-				});
-			nock('http://test/').get(`/appeals/${appealId}/case-notes`).reply(200, caseNotes);
-			const response = await request.get(`${baseUrl}/${appealId}`);
-			const element = parseHtml(response.text);
-
-			expect(element.innerHTML).toMatchSnapshot();
-
-			const unprettifiedElement = parseHtml(response.text, { skipPrettyPrint: true });
-
-			expect(unprettifiedElement.innerHTML).toContain(
-				'Linked appeals</dt><dd class="govuk-summary-list__value"><a href="/appeals-service/appeal-details/1" class="govuk-link" data-cy="linked-appeal-725284" aria-label="Appeal 7 2 5 2 8 4">725284</a>'
-			);
-			expect(unprettifiedElement.innerHTML).toContain(
-				'Related appeals</dt><dd class="govuk-summary-list__value"><ul class="govuk-list govuk-list--bullet"><li><a href="/appeals-service/appeal-details/3" class="govuk-link" data-cy="related-appeal-765413" aria-label="Appeal 7 6 5 4 1 3">765413</a>'
-			);
-		});
-
-		it('should render the received appeal details for a valid appealId with multiple linked/other appeals', async () => {
-			const appealId = '3';
-
-			nock('http://test/')
-				.get(`/appeals/${appealId}`)
-				.reply(200, {
-					...appealData,
-					appealId,
-					linkedAppeals: [
-						{
-							appealId: 4,
-							appealReference: 'APP/Q9999/D/21/725284'
-						},
-						{
-							appealId: 5,
-							appealReference: 'APP/Q9999/D/21/725285'
-						}
-					],
-					otherAppeals: [
-						{
-							appealId: 6,
-							appealReference: 'APP/Q9999/D/21/765413'
-						},
-						{
-							appealId: 7,
-							appealReference: 'APP/Q9999/D/21/765414'
-						}
-					]
-				});
-			nock('http://test/').get(`/appeals/${appealId}/case-notes`).reply(200, caseNotes);
-			const response = await request.get(`${baseUrl}/${appealId}`);
-			const element = parseHtml(response.text);
-
-			expect(element.innerHTML).toMatchSnapshot();
-
-			const unprettifiedElement = parseHtml(response.text, { skipPrettyPrint: true });
-
-			expect(unprettifiedElement.innerHTML).toContain(
-				'Linked appeals</dt><dd class="govuk-summary-list__value"><ul class="govuk-list govuk-list--bullet"><li><a href="/appeals-service/appeal-details/4" class="govuk-link" data-cy="linked-appeal-725284" aria-label="Appeal 7 2 5 2 8 4">725284</a></li><li><a href="/appeals-service/appeal-details/5" class="govuk-link" data-cy="linked-appeal-725285" aria-label="Appeal 7 2 5 2 8 5">725285</a></li></ul>'
-			);
-			expect(unprettifiedElement.innerHTML).toContain(
-				'Related appeals</dt><dd class="govuk-summary-list__value"><ul class="govuk-list govuk-list--bullet"><li><a href="/appeals-service/appeal-details/6" class="govuk-link" data-cy="related-appeal-765413" aria-label="Appeal 7 6 5 4 1 3">765413</a></li><li><a href="/appeals-service/appeal-details/7" class="govuk-link" data-cy="related-appeal-765414" aria-label="Appeal 7 6 5 4 1 4">765414</a></li></ul>'
 			);
 		});
 
@@ -2284,262 +2578,6 @@ describe('appeal-details', () => {
 			);
 		});
 
-		it('should render an action link to the manage linked appeals page, if there are linked appeals, the status is not past LPA Questionnaire, all the linked appeals are children and internal', async () => {
-			nock.cleanAll();
-			nock('http://test/')
-				.get(`/appeals/${appealData.appealId}`)
-				.reply(200, {
-					...appealData,
-					appealStatus: 'lpa_questionnaire',
-					linkedAppeals: linkedAppealsAreAllInternalAndNotALead
-				});
-			nock('http://test/').get(`/appeals/${appealData.appealId}/case-notes`).reply(200, caseNotes);
-			nock('http://test/')
-				.get(`/appeals/${appealData.appealId}/reps?type=appellant_final_comment`)
-				.reply(200, appellantFinalCommentsAwaitingReview);
-			nock('http://test/')
-				.get(`/appeals/${appealData.appealId}/reps?type=lpa_final_comment`)
-				.reply(200, lpaFinalCommentsAwaitingReview);
-			nock('http://test/')
-				.get(/appeals\/\d+\/appellant-cases\/\d+/)
-				.reply(200, { planningObligation: { hasObligation: false } });
-
-			const response = await request.get(`${baseUrl}/${appealData.appealId}`);
-			const element = parseHtml(response.text);
-
-			expect(element.innerHTML).toMatchSnapshot();
-
-			const linkedAppealsRowElement = parseHtml(response.text, {
-				rootElement: '.appeal-linked-appeals',
-				skipPrettyPrint: true
-			});
-
-			expect(linkedAppealsRowElement.innerHTML).toContain(
-				'href="/appeals-service/appeal-details/1/linked-appeals/manage" data-cy="manage-linked-appeals">Manage<span class="govuk-visually-hidden"> Linked appeals</span></a>'
-			);
-		});
-
-		it('should render an action link to the add linked appeals page, if the appeal is a lead appeal in a state before STATEMENTS', async () => {
-			nock.cleanAll();
-			nock('http://test/')
-				.get(`/appeals/${appealData.appealId}`)
-				.reply(200, {
-					...appealData,
-					isParentAppeal: true,
-					appealStatus: 'lpa_questionnaire',
-					linkedAppeals: linkedAppealsAreAllInternalAndNotALead
-				});
-			nock('http://test/').get(`/appeals/${appealData.appealId}/case-notes`).reply(200, caseNotes);
-			nock('http://test/')
-				.get(`/appeals/${appealData.appealId}/reps?type=appellant_final_comment`)
-				.reply(200, appellantFinalCommentsAwaitingReview);
-			nock('http://test/')
-				.get(`/appeals/${appealData.appealId}/reps?type=lpa_final_comment`)
-				.reply(200, lpaFinalCommentsAwaitingReview);
-			nock('http://test/')
-				.get(/appeals\/\d+\/appellant-cases\/\d+/)
-				.reply(200, { planningObligation: { hasObligation: false } });
-
-			const response = await request.get(`${baseUrl}/${appealData.appealId}`);
-			const element = parseHtml(response.text);
-
-			expect(element.innerHTML).toMatchSnapshot();
-
-			const linkedAppealsRowElement = parseHtml(response.text, {
-				rootElement: '.appeal-linked-appeals',
-				skipPrettyPrint: true
-			});
-
-			expect(linkedAppealsRowElement.innerHTML).toContain(
-				'href="/appeals-service/appeal-details/1/linked-appeals/add" data-cy="add-linked-appeal">Add<span class="govuk-visually-hidden"> Linked appeals</span></a>'
-			);
-		});
-
-		it('should not render action links to the manage linked appeals page or the add linked appeal page in the linked appeals row, if the appeal is linked as a child of an external lead appeal', async () => {
-			nock.cleanAll();
-			nock('http://test/')
-				.get(`/appeals/${appealData.appealId}`)
-				.reply(200, {
-					...appealData,
-					isParentAppeal: false,
-					linkedAppeals: linkedAppealsWithExternalLead
-				});
-			nock('http://test/').get(`/appeals/${appealData.appealId}/case-notes`).reply(200, caseNotes);
-			nock('http://test/')
-				.get(`/appeals/${appealData.appealId}/reps?type=appellant_final_comment`)
-				.reply(200, appellantFinalCommentsAwaitingReview);
-			nock('http://test/')
-				.get(`/appeals/${appealData.appealId}/reps?type=lpa_final_comment`)
-				.reply(200, lpaFinalCommentsAwaitingReview);
-			nock('http://test/')
-				.get(/appeals\/\d+\/appellant-cases\/\d+/)
-				.reply(200, { planningObligation: { hasObligation: false } });
-
-			const response = await request.get(`${baseUrl}/${appealData.appealId}`);
-			const element = parseHtml(response.text);
-
-			expect(element.innerHTML).toMatchSnapshot();
-
-			const unprettifiedElement = parseHtml(response.text, {
-				rootElement: '.appeal-linked-appeals',
-				skipPrettyPrint: true
-			});
-
-			expect(unprettifiedElement.innerHTML).toContain('Linked appeals</dt>');
-			expect(unprettifiedElement.innerHTML).not.toContain(
-				'href="/appeals-service/appeal-details/1/linked-appeals/add"'
-			);
-			expect(unprettifiedElement.innerHTML).not.toContain(
-				'href="/appeals-service/appeal-details/1/linked-appeals/manage"'
-			);
-		});
-
-		it('should render the case reference for each linked appeal in the linked appeals row, with each internal linked appeal item linking to the respective case details page, if there are linked appeals', async () => {
-			nock.cleanAll();
-			nock('http://test/')
-				.get(`/appeals/${appealData.appealId}`)
-				.reply(200, {
-					...appealData,
-					linkedAppeals
-				});
-			nock('http://test/').get(`/appeals/${appealData.appealId}/case-notes`).reply(200, caseNotes);
-			nock('http://test/')
-				.get(`/appeals/${appealData.appealId}/reps?type=appellant_final_comment`)
-				.reply(200, appellantFinalCommentsAwaitingReview);
-			nock('http://test/')
-				.get(`/appeals/${appealData.appealId}/reps?type=lpa_final_comment`)
-				.reply(200, lpaFinalCommentsAwaitingReview);
-			nock('http://test/')
-				.get(/appeals\/\d+\/appellant-cases\/\d+/)
-				.reply(200, { planningObligation: { hasObligation: false } });
-
-			const response = await request.get(`${baseUrl}/${appealData.appealId}`);
-			const element = parseHtml(response.text);
-
-			expect(element.innerHTML).toMatchSnapshot();
-
-			const linkedAppealsRowElement = parseHtml(response.text, {
-				rootElement: '.appeal-linked-appeals',
-				skipPrettyPrint: true
-			});
-
-			expect(linkedAppealsRowElement.innerHTML).toContain(
-				'<a href="/appeals-service/appeal-details/5449"'
-			);
-			expect(linkedAppealsRowElement.innerHTML).toContain(
-				'aria-label="Appeal 7 8 4 7 0 6">784706</a>'
-			);
-			expect(linkedAppealsRowElement.innerHTML).toContain(
-				'<span class="govuk-body">87326527</span>'
-			);
-			expect(linkedAppealsRowElement.innerHTML).toContain(
-				'<a href="/appeals-service/appeal-details/5464"'
-			);
-			expect(linkedAppealsRowElement.innerHTML).toContain(
-				'aria-label="Appeal 1 4 0 0 7 9">140079</a>'
-			);
-			expect(linkedAppealsRowElement.innerHTML).toContain(
-				'<a href="/appeals-service/appeal-details/5451"'
-			);
-			expect(linkedAppealsRowElement.innerHTML).toContain(
-				'aria-label="Appeal 7 2 1 0 8 6">721086</a>'
-			);
-		});
-
-		it('should render the lead or child status after the case reference link of each linked appeal in the linked appeals row, if there are linked appeals', async () => {
-			nock.cleanAll();
-			nock('http://test/')
-				.get(`/appeals/${appealData.appealId}`)
-				.reply(200, {
-					...appealData,
-					linkedAppeals
-				});
-			nock('http://test/').get(`/appeals/${appealData.appealId}/case-notes`).reply(200, caseNotes);
-			nock('http://test/')
-				.get(`/appeals/${appealData.appealId}/reps?type=appellant_final_comment`)
-				.reply(200, appellantFinalCommentsAwaitingReview);
-			nock('http://test/')
-				.get(`/appeals/${appealData.appealId}/reps?type=lpa_final_comment`)
-				.reply(200, lpaFinalCommentsAwaitingReview);
-			nock('http://test/')
-				.get(/appeals\/\d+\/appellant-cases\/\d+/)
-				.reply(200, { planningObligation: { hasObligation: false } });
-
-			const response = await request.get(`${baseUrl}/${appealData.appealId}`);
-
-			const element = parseHtml(response.text);
-
-			expect(element.innerHTML).toMatchSnapshot();
-
-			const linkedAppealsRowElement = parseHtml(response.text, {
-				rootElement: '.appeal-linked-appeals',
-				skipPrettyPrint: true
-			});
-
-			expect(linkedAppealsRowElement.innerHTML).toContain('(lead)</li>');
-		});
-
-		it('should render a lead tag next to the appeal status tag if the appeal is a parent', async () => {
-			nock.cleanAll();
-			nock('http://test/')
-				.get(`/appeals/${appealData.appealId}`)
-				.reply(200, {
-					...appealData,
-					isParentAppeal: true,
-					isChildAppeal: false,
-					linkedAppeals: linkedAppeals.filter(
-						(linkedAppeal) => linkedAppeal.isParentAppeal === false
-					)
-				});
-			nock('http://test/').get(`/appeals/${appealData.appealId}/case-notes`).reply(200, caseNotes);
-			nock('http://test/')
-				.get(`/appeals/${appealData.appealId}/reps?type=appellant_final_comment`)
-				.reply(200, appellantFinalCommentsAwaitingReview);
-			nock('http://test/')
-				.get(`/appeals/${appealData.appealId}/reps?type=lpa_final_comment`)
-				.reply(200, lpaFinalCommentsAwaitingReview);
-			nock('http://test/')
-				.get(/appeals\/\d+\/appellant-cases\/\d+/)
-				.reply(200, { planningObligation: { hasObligation: false } });
-
-			const response = await request.get(`${baseUrl}/${appealData.appealId}`);
-			const element = parseHtml(response.text);
-
-			expect(element.innerHTML).toMatchSnapshot();
-			expect(element.innerHTML).toContain('Lead</strong>');
-		});
-
-		it('should render a child tag next to the appeal status tag if the appeal is a child', async () => {
-			nock.cleanAll();
-			nock('http://test/')
-				.get(`/appeals/${appealData.appealId}`)
-				.reply(200, {
-					...appealData,
-					isParentAppeal: false,
-					isChildAppeal: true,
-					linkedAppeals: linkedAppeals.filter(
-						(linkedAppeal) => linkedAppeal.isParentAppeal === true
-					)
-				})
-				.persist();
-			nock('http://test/').get(`/appeals/${appealData.appealId}/case-notes`).reply(200, caseNotes);
-			nock('http://test/')
-				.get(`/appeals/${appealData.appealId}/reps?type=appellant_final_comment`)
-				.reply(200, appellantFinalCommentsAwaitingReview);
-			nock('http://test/')
-				.get(`/appeals/${appealData.appealId}/reps?type=lpa_final_comment`)
-				.reply(200, lpaFinalCommentsAwaitingReview);
-			nock('http://test/')
-				.get(/appeals\/\d+\/appellant-cases\/\d+/)
-				.reply(200, { planningObligation: { hasObligation: false } });
-
-			const response = await request.get(`${baseUrl}/${appealData.appealId}`);
-			const element = parseHtml(response.text);
-
-			expect(element.innerHTML).toMatchSnapshot();
-			expect(element.innerHTML).toContain('Child</strong>');
-		});
-
 		it('should render a "Appeal valid" notification banner with a link to start case when status is "READY_TO_START"', async () => {
 			const appealId = 2;
 			nock('http://test/')
@@ -2557,26 +2595,6 @@ describe('appeal-details', () => {
 			expect(element.innerHTML).toContain(
 				`href="/appeals-service/appeal-details/2/start-case/add?backUrl=%2Fappeals-service%2Fappeal-details%2F${appealId}">Start case</a>`
 			);
-		});
-
-		it('should not render a "Appeal valid" notification banner when status is "READY_TO_START" and appeal is a linked child appeal', async () => {
-			const appealId = 2;
-			nock('http://test/')
-				.get(`/appeals/${appealId}`)
-				.reply(200, {
-					...appealData,
-					appealId,
-					appealStatus: 'ready_to_start',
-					isChildAppeal: true
-				});
-			nock('http://test/').get(`/appeals/${appealId}/case-notes`).reply(200, caseNotes);
-			const response = await request.get(`${baseUrl}/${appealId}`);
-
-			expect(response.statusCode).toBe(200);
-			const element = parseHtml(response.text, { rootElement: '.govuk-main-wrapper' });
-
-			expect(element.innerHTML).toMatchSnapshot();
-			expect(element.innerHTML).not.toContain('govuk-notification-banner');
 		});
 
 		describe('"Progress case" important banners', () => {
@@ -5522,6 +5540,66 @@ describe('appeal-details', () => {
 				expect(unprettifiedInquirySectionHtml).toContain(
 					`<dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/${appealId}/inquiry/estimates/change"`
 				);
+			});
+		});
+
+		describe('Cancel appeal', () => {
+			const appealId = appealData.appealId.toString();
+
+			beforeEach(() => {
+				nock.cleanAll();
+				nock('http://test/').get(`/appeals/${appealId}/case-notes`).reply(200, caseNotes);
+				nock('http://test/')
+					.get(`/appeals/${appealId}/reps?type=appellant_final_comment`)
+					.reply(200, appellantFinalCommentsAwaitingReview);
+				nock('http://test/')
+					.get(`/appeals/${appealId}/reps?type=lpa_final_comment`)
+					.reply(200, lpaFinalCommentsAwaitingReview);
+				nock('http://test/')
+					.get(/appeals\/\d+\/appellant-cases\/\d+/)
+					.reply(200, { planningObligation: { hasObligation: false } });
+			});
+
+			it('should render the cancel appeal section if appeal status is not withdrawn or invalid', async () => {
+				nock('http://test/')
+					.get(`/appeals/${appealId}`)
+					.reply(200, { ...appealData, appealStatus: APPEAL_CASE_STATUS.VALIDATION });
+				const response = await request.get(`${baseUrl}/${appealId}`);
+
+				const cancelSection = parseHtml(response.text, {
+					skipPrettyPrint: true,
+					rootElement: '#case-details-cancel-section'
+				}).innerHTML;
+				expect(cancelSection).toContain('Cancel appeal</h3>');
+				expect(cancelSection).toContain(
+					`href="/appeals-service/appeal-details/${appealId}/cancel">Cancel appeal`
+				);
+			});
+
+			it('should not render the cancel appeal section if appeal status is withdrawn', async () => {
+				const appealId = appealData.appealId.toString();
+				nock('http://test/')
+					.get(`/appeals/${appealId}`)
+					.reply(200, { ...appealData, appealStatus: APPEAL_CASE_STATUS.WITHDRAWN });
+				const response = await request.get(`${baseUrl}/${appealId}`);
+
+				const element = parseHtml(response.text);
+				const cancelSection = element?.querySelector('#case-details-cancel-section');
+
+				expect(cancelSection).toBeNull();
+			});
+
+			it('should not render the cancel appeal section if appeal status is invalid', async () => {
+				const appealId = appealData.appealId.toString();
+				nock('http://test/')
+					.get(`/appeals/${appealId}`)
+					.reply(200, { ...appealData, appealStatus: APPEAL_CASE_STATUS.INVALID });
+				const response = await request.get(`${baseUrl}/${appealId}`);
+
+				const element = parseHtml(response.text);
+				const cancelSection = element?.querySelector('#case-details-cancel-section');
+
+				expect(cancelSection).toBeNull();
 			});
 		});
 	});

--- a/appeals/web/src/server/appeals/appeal-details/accordions/common/case-management.js
+++ b/appeals/web/src/server/appeals/appeal-details/accordions/common/case-management.js
@@ -1,3 +1,5 @@
+import { isDefined } from '#lib/ts-utilities.js';
+
 /**
  * @param {{appeal: MappedInstructions}} mappedData
  * @returns {PageComponent}
@@ -11,6 +13,6 @@ export const getCaseManagement = (mappedData) => ({
 			mappedData.appeal.mainPartyCorrespondence.display.summaryListItem,
 			mappedData.appeal.caseHistory.display.summaryListItem,
 			mappedData.appeal.appealWithdrawal.display.summaryListItem
-		]
+		].filter(isDefined)
 	}
 });

--- a/appeals/web/src/server/appeals/appeal-details/appeal-details.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/appeal-details.mapper.js
@@ -7,6 +7,7 @@ import { generateCaseNotes } from './case-notes/case-notes.mapper.js';
 import { generateStatusTags } from './status-tags/status-tags.mapper.js';
 import { mapStatusDependentNotifications } from '#lib/mappers/utils/map-status-dependent-notifications.js';
 import { formatCaseOfficerDetailsForCaseSummary } from '#lib/mappers/utils/format-case-officer-details-for-case-summary.js';
+import { getCancelAppealSection } from './cancel/cancel-appeal-section.js';
 
 export const pageHeading = 'Case details';
 
@@ -87,13 +88,16 @@ export async function appealDetailsPage(
 		...mapNotificationBannersFromSession(session, 'appealDetails', appealDetails.appealId)
 	]);
 
+	const caseCancel = getCancelAppealSection(appealDetails, currentRoute);
+
 	const pageComponents = [
 		...notificationBanners,
 		...(await generateStatusTags(mappedData, appealDetails, request)),
 		caseSummary,
 		...caseDownload,
 		caseNotes,
-		accordion
+		accordion,
+		...(caseCancel ?? [])
 	];
 
 	preRenderPageComponents(pageComponents);

--- a/appeals/web/src/server/appeals/appeal-details/cancel/__tests__/__snapshots__/cancel.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/cancel/__tests__/__snapshots__/cancel.test.js.snap
@@ -24,7 +24,7 @@ exports[`cancel GET /new should render the cancel appeal page with radio compone
                                     </div>
                                     <div class="govuk-radios__item">
                                         <input class="govuk-radios__input" id="cancel-reason-radio-2" name="cancelReasonRadio"
-                                        type="radio" value="withdraw">
+                                        type="radio" value="withdrawal">
                                         <label class="govuk-label govuk-radios__label" for="cancel-reason-radio-2">Request to withdraw appeal</label>
                                     </div>
                                 </div>
@@ -98,7 +98,7 @@ exports[`cancel POST /new should render cancel appeal page with errors if cancel
                                     </div>
                                     <div class="govuk-radios__item">
                                         <input class="govuk-radios__input" id="cancel-reason-radio-2" name="cancelReasonRadio"
-                                        type="radio" value="withdraw">
+                                        type="radio" value="withdrawal">
                                         <label class="govuk-label govuk-radios__label" for="cancel-reason-radio-2">Request to withdraw appeal</label>
                                     </div>
                                 </div>

--- a/appeals/web/src/server/appeals/appeal-details/cancel/cancel-appeal-section.js
+++ b/appeals/web/src/server/appeals/appeal-details/cancel/cancel-appeal-section.js
@@ -1,0 +1,39 @@
+import config from '#environment/config.js';
+import { wrapComponents } from '#lib/mappers/index.js';
+import { APPEAL_CASE_STATUS } from '@planning-inspectorate/data-model';
+
+/**
+ * @param {import('#appeals/appeal-details/appeal-details.types.js').WebAppeal} appealDetails
+ * @param {string} currentRoute
+ * @returns {PageComponent[]|undefined}
+ */
+export const getCancelAppealSection = (appealDetails, currentRoute) => {
+	if (
+		!config.featureFlags.featureFlagCancelCase ||
+		appealDetails.appealStatus === APPEAL_CASE_STATUS.WITHDRAWN ||
+		appealDetails.appealStatus === APPEAL_CASE_STATUS.INVALID
+	) {
+		return;
+	}
+
+	/** @type {PageComponent} */
+	const cancelAppealHeading = {
+		type: 'html',
+		parameters: { html: '<h3 class="govuk-heading-m">Cancel appeal</h3>' }
+	};
+
+	/** @type {PageComponent} */
+	const cancelAppealComponent = {
+		type: 'html',
+		parameters: {
+			html: `<div><p><a id="cancelCase" class="govuk-body govuk-link" href="${currentRoute}/cancel">Cancel appeal</a></p></div>`
+		}
+	};
+
+	return [
+		wrapComponents([cancelAppealHeading, cancelAppealComponent], {
+			opening: '<div id="case-details-cancel-section">',
+			closing: '</div>'
+		})
+	];
+};

--- a/appeals/web/src/server/appeals/appeal-details/cancel/cancel.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/cancel/cancel.mapper.js
@@ -32,7 +32,7 @@ export function mapCancelAppealPage(appealData, errorMessage) {
 							text: 'Appeal invalid'
 						},
 						{
-							value: 'withdraw',
+							value: 'withdrawal',
 							text: 'Request to withdraw appeal'
 						}
 					],

--- a/appeals/web/src/server/lib/mappers/data/appeal/submappers/appeal-withdrawal.mapper.js
+++ b/appeals/web/src/server/lib/mappers/data/appeal/submappers/appeal-withdrawal.mapper.js
@@ -1,3 +1,4 @@
+import config from '#environment/config.js';
 import { textSummaryListItem } from '#lib/mappers/index.js';
 import { APPEAL_CASE_STATUS } from '@planning-inspectorate/data-model';
 
@@ -7,6 +8,11 @@ export const mapAppealWithdrawal = ({
 	currentRoute,
 	userHasUpdateCasePermission
 }) => {
+	const id = 'appeal-withdrawal';
+	if (config.featureFlags.featureFlagCancelCase) {
+		return { id, display: {} };
+	}
+
 	const appealHasWithdrawalDocuments =
 		appealDetails?.withdrawal?.withdrawalFolder?.documents?.filter(
 			(document) => document.latestDocumentVersion?.isDeleted === false
@@ -14,14 +20,14 @@ export const mapAppealWithdrawal = ({
 
 	return appealDetails.appealStatus === APPEAL_CASE_STATUS.WITHDRAWN && appealHasWithdrawalDocuments
 		? textSummaryListItem({
-				id: 'appeal-withdrawal',
+				id,
 				text: 'Appeal withdrawal',
 				link: `${currentRoute}/withdrawal/view`,
 				editable: true,
 				actionText: 'View'
 		  })
 		: textSummaryListItem({
-				id: 'appeal-withdrawal',
+				id,
 				text: 'Appeal withdrawal',
 				link: `${currentRoute}/withdrawal/start`,
 				editable: userHasUpdateCasePermission,


### PR DESCRIPTION
## Describe your changes

### WEB
- Added a new cancel appeal section to the appeal-details page (not part of the accordion)
- Cancel appeal section displays conditionally depending on FF and whether appeal is invalid/withdrawn
- Added FF conditional to existing withdraw row

### Tests
- Added unit tests for new cancel appeal section & updated snapshots
- Added new describe container for appeal-details unit tests for linked appeals for better organisation
- Manual testing in browser with Feature flag ON and OFF
<img width="1107" height="210" alt="Screenshot 2025-08-06 at 16 45 13" src="https://github.com/user-attachments/assets/1e04a098-a8ef-474c-9d2e-d14d0d6869e2" />

<!--
    Please include a summary of the change along with any relevant context.
    List any dependencies that are required for this change.
-->

## Issue ticket number and link

[Ticket](https://pins-ds.atlassian.net.mcas.ms/browse/A2-3840)
