### PR TITLE
fix(appeals): add hyperlinks to reject ip comment notify

### DIFF
--- a/appeals/api/src/server/notify/templates/__tests__/notify-ip-comment-rejected-deadline-extended.test.js
+++ b/appeals/api/src/server/notify/templates/__tests__/notify-ip-comment-rejected-deadline-extended.test.js
@@ -47,7 +47,7 @@ describe('ip-comment-rejected-deadline-extended.md', () => {
 			'You can [submit a different comment](/mock-front-office-url/comment-planning-appeal/enter-appeal-reference) by 01 January 2021.',
 			'',
 			'The Planning Inspectorate',
-			'caseofficers@planninginspectorate.gov.uk'
+			'[enquiries@planninginspectorate.gov.uk](mailto:enquiries@planninginspectorate.gov.uk)'
 		].join('\n');
 
 		await notifySend(notifySendData);
@@ -92,10 +92,10 @@ describe('ip-comment-rejected-deadline-extended.md', () => {
 			'',
 			'# What happens next',
 			'',
-			'You can send a different comment to caseofficers@planninginspectorate.gov.uk by 01 January 2021.',
+			'You can send a different comment to [caseofficers@planninginspectorate.gov.uk](mailto:caseofficers@planninginspectorate.gov.uk) by 01 January 2021.',
 			'',
 			'The Planning Inspectorate',
-			'caseofficers@planninginspectorate.gov.uk'
+			'[enquiries@planninginspectorate.gov.uk](mailto:enquiries@planninginspectorate.gov.uk)'
 		].join('\n');
 
 		await notifySend(notifySendData);

--- a/appeals/api/src/server/notify/templates/ip-comment-rejected-deadline-extended.content.md
+++ b/appeals/api/src/server/notify/templates/ip-comment-rejected-deadline-extended.content.md
@@ -15,10 +15,9 @@ We rejected your comment because:
     You can [submit a different comment]({{front_office_url}}/comment-planning-appeal/enter-appeal-reference) by {{deadline_date}}.
 
 {% else -%}
-    You can send a different comment to caseofficers@planninginspectorate.gov.uk by {{deadline_date}}.
+    You can send a different comment to [caseofficers@planninginspectorate.gov.uk](mailto:caseofficers@planninginspectorate.gov.uk) by {{deadline_date}}.
 
 {% endif -%}
 
 The Planning Inspectorate
-caseofficers@planninginspectorate.gov.uk
-
+[enquiries@planninginspectorate.gov.uk](mailto:enquiries@planninginspectorate.gov.uk)


### PR DESCRIPTION
## Describe your changes

Adding missing hyperlinks for email addresses in notify for IP comment rejected.

## Issue ticket number and link

[Ticket](https://pins-ds.atlassian.net/browse/A2-3920)
