### PR TITLE
Feat(A2-3841): Adding the invalid appeal reasons why page for cancel flow

### DIFF
--- a/appeals/api/src/database/seed/data-static.js
+++ b/appeals/api/src/database/seed/data-static.js
@@ -314,11 +314,11 @@ export const appellantCaseInvalidReasons = [
 		hasText: false
 	},
 	{
-		name: "The appellant doesn't have the right to appeal",
+		name: 'The appellant does not have the right to appeal',
 		hasText: false
 	},
 	{
-		name: 'Other',
+		name: 'Other reason',
 		hasText: true
 	}
 ];

--- a/appeals/web/src/server/appeals/appeal-details/appeal-details.router.js
+++ b/appeals/web/src/server/appeals/appeal-details/appeal-details.router.js
@@ -46,6 +46,7 @@ import inquiryRouter from './inquiry/inquiry.router.js';
 import assignUserRouter from './assign-user/assign-user.router.js';
 import netResidenceRouter from './net-residence/net-residence.router.js';
 import cancelAppealRouter from './cancel/cancel.router.js';
+import invalidAppealRouter from './invalid-appeal/invalid-appeal.router.js';
 import changeAppealTypeMiddleware from './change-appeal-type.middleware.js';
 const router = createRouter();
 
@@ -242,6 +243,12 @@ router.use(
 	validateAppeal,
 	assertUserHasPermission(permissionNames.updateCase),
 	cancelAppealRouter
+);
+router.use(
+	'/:appealId/invalid',
+	validateAppeal,
+	assertUserHasPermission(permissionNames.updateCase),
+	invalidAppealRouter
 );
 
 router.use('/:appealId', validateAppeal, representationsRouter);

--- a/appeals/web/src/server/appeals/appeal-details/appellant-case/__tests__/__snapshots__/appellant-case.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/appellant-case/__tests__/__snapshots__/appellant-case.test.js.snap
@@ -3544,8 +3544,8 @@ exports[`appellant-case GET /appellant-case/check-your-answers should render the
                         <div class="pins-show-more" data-label="Read more" data-mode="html">
                             <ul class="govuk-list govuk-!-margin-top-0 govuk-!-margin-bottom-0 govuk-list--bullet">
                                 <li>Documents have not been submitted on time: test reason text 1</li>
-                                <li>Other: test reason text 1</li>
-                                <li>Other: test reason text 2</li>
+                                <li>Other reason: test reason text 1</li>
+                                <li>Other reason: test reason text 2</li>
                             </ul>
                         </div>
                     </dd>
@@ -3822,7 +3822,7 @@ exports[`appellant-case GET /appellant-case/incomplete/date should render the up
 exports[`appellant-case GET /appellant-case/invalid should render the invalid reason page 1`] = `
 "<main class="govuk-main-wrapper" id="main-content">
     <div class="govuk-grid-row">
-        <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Appeal 351062</span>
+        <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Appeal 351062 - mark as invalid</span>
         </div>
     </div>
     <div class="govuk-grid-row">
@@ -3850,7 +3850,7 @@ exports[`appellant-case GET /appellant-case/invalid should render the invalid re
                                     <div class="pins-add-another__item govuk-!-margin-top-6">
                                         <div class="govuk-grid-row">
                                             <div class="govuk-grid-column-full flex-row space-between">
-                                                <label for="invalid-reason-22-1" class="govuk-label govuk-!-margin-bottom-4">Which part is incorrect or incomplete?</label>
+                                                <label for="invalid-reason-22-1" class="govuk-label govuk-!-margin-bottom-4">Enter a reason</label>
                                                 <div class="pins-add-another__remove-button-container"></div>
                                             </div>
                                         </div>
@@ -3870,12 +3870,12 @@ exports[`appellant-case GET /appellant-case/invalid should render the invalid re
                             <div class="govuk-checkboxes__item">
                                 <input class="govuk-checkboxes__input" id="invalid-reason-3" name="invalidReason"
                                 type="checkbox" value="23">
-                                <label class="govuk-label govuk-checkboxes__label" for="invalid-reason-3">The appellant doesn&#39;t have the right to appeal</label>
+                                <label class="govuk-label govuk-checkboxes__label" for="invalid-reason-3">The appellant does not have the right to appeal</label>
                             </div>
                             <div class="govuk-checkboxes__item">
                                 <input class="govuk-checkboxes__input" id="invalid-reason-4" name="invalidReason"
                                 type="checkbox" value="24" data-aria-controls="conditional-invalid-reason-4">
-                                <label class="govuk-label govuk-checkboxes__label" for="invalid-reason-4">Other</label>
+                                <label class="govuk-label govuk-checkboxes__label" for="invalid-reason-4">Other reason</label>
                             </div>
                             <div class="govuk-checkboxes__conditional govuk-checkboxes__conditional--hidden"
                             id="conditional-invalid-reason-4">
@@ -3883,7 +3883,7 @@ exports[`appellant-case GET /appellant-case/invalid should render the invalid re
                                     <div class="pins-add-another__item govuk-!-margin-top-6">
                                         <div class="govuk-grid-row">
                                             <div class="govuk-grid-column-full flex-row space-between">
-                                                <label for="invalid-reason-24-1" class="govuk-label govuk-!-margin-bottom-4">Which part is incorrect or incomplete?</label>
+                                                <label for="invalid-reason-24-1" class="govuk-label govuk-!-margin-bottom-4">Enter a reason</label>
                                                 <div class="pins-add-another__remove-button-container"></div>
                                             </div>
                                         </div>
@@ -5330,7 +5330,7 @@ exports[`appellant-case POST /appellant-case/incomplete should re-render the inc
                     <h2 class="govuk-error-summary__title"> There is a problem</h2>
                     <div class="govuk-error-summary__body">
                         <ul class="govuk-list govuk-error-summary__list">
-                            <li><a href="#incomplete-reason-2026-1">Text in text fields cannot exceed 1000 characters</a>
+                            <li><a href="#incomplete-reason-2026-1">Reason must be 1000 characters or less</a>
                             </li>
                         </ul>
                     </div>
@@ -6218,7 +6218,7 @@ exports[`appellant-case POST /appellant-case/incomplete should re-render the inc
                     <h2 class="govuk-error-summary__title"> There is a problem</h2>
                     <div class="govuk-error-summary__body">
                         <ul class="govuk-list govuk-error-summary__list">
-                            <li><a href="#incomplete-reason-2026-1">Text in text fields cannot exceed 1000 characters</a>
+                            <li><a href="#incomplete-reason-2026-1">Reason must be 1000 characters or less</a>
                             </li>
                         </ul>
                     </div>
@@ -7264,7 +7264,7 @@ exports[`appellant-case POST /appellant-case/invalid should re-render the invali
                     <h2 class="govuk-error-summary__title"> There is a problem</h2>
                     <div class="govuk-error-summary__body">
                         <ul class="govuk-list govuk-error-summary__list">
-                            <li><a href="#invalid-reason-22-1">Text in text fields cannot exceed 1000 characters</a>
+                            <li><a href="#invalid-reason-22-1">Reason must be 1000 characters or less</a>
                             </li>
                         </ul>
                     </div>
@@ -7273,7 +7273,7 @@ exports[`appellant-case POST /appellant-case/invalid should re-render the invali
         </div>
     </div>
     <div class="govuk-grid-row">
-        <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Appeal 351062</span>
+        <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Appeal 351062 - mark as invalid</span>
         </div>
     </div>
     <div class="govuk-grid-row">
@@ -7300,7 +7300,7 @@ exports[`appellant-case POST /appellant-case/invalid should re-render the invali
                                     <div class="pins-add-another__item govuk-!-margin-top-6">
                                         <div class="govuk-grid-row">
                                             <div class="govuk-grid-column-full flex-row space-between">
-                                                <label for="invalid-reason-22-1" class="govuk-label govuk-!-margin-bottom-4">Which part is incorrect or incomplete?</label>
+                                                <label for="invalid-reason-22-1" class="govuk-label govuk-!-margin-bottom-4">Enter a reason</label>
                                                 <div class="pins-add-another__remove-button-container"></div>
                                             </div>
                                         </div>
@@ -7320,12 +7320,12 @@ exports[`appellant-case POST /appellant-case/invalid should re-render the invali
                             <div class="govuk-checkboxes__item">
                                 <input class="govuk-checkboxes__input" id="invalid-reason-3" name="invalidReason"
                                 type="checkbox" value="23">
-                                <label class="govuk-label govuk-checkboxes__label" for="invalid-reason-3">The appellant doesn&#39;t have the right to appeal</label>
+                                <label class="govuk-label govuk-checkboxes__label" for="invalid-reason-3">The appellant does not have the right to appeal</label>
                             </div>
                             <div class="govuk-checkboxes__item">
                                 <input class="govuk-checkboxes__input" id="invalid-reason-4" name="invalidReason"
                                 type="checkbox" value="24" data-aria-controls="conditional-invalid-reason-4">
-                                <label class="govuk-label govuk-checkboxes__label" for="invalid-reason-4">Other</label>
+                                <label class="govuk-label govuk-checkboxes__label" for="invalid-reason-4">Other reason</label>
                             </div>
                             <div class="govuk-checkboxes__conditional govuk-checkboxes__conditional--hidden"
                             id="conditional-invalid-reason-4">
@@ -7333,7 +7333,7 @@ exports[`appellant-case POST /appellant-case/invalid should re-render the invali
                                     <div class="pins-add-another__item govuk-!-margin-top-6">
                                         <div class="govuk-grid-row">
                                             <div class="govuk-grid-column-full flex-row space-between">
-                                                <label for="invalid-reason-24-1" class="govuk-label govuk-!-margin-bottom-4">Which part is incorrect or incomplete?</label>
+                                                <label for="invalid-reason-24-1" class="govuk-label govuk-!-margin-bottom-4">Enter a reason</label>
                                                 <div class="pins-add-another__remove-button-container"></div>
                                             </div>
                                         </div>
@@ -7378,7 +7378,7 @@ exports[`appellant-case POST /appellant-case/invalid should re-render the invali
         </div>
     </div>
     <div class="govuk-grid-row">
-        <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Appeal 351062</span>
+        <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Appeal 351062 - mark as invalid</span>
         </div>
     </div>
     <div class="govuk-grid-row">
@@ -7405,7 +7405,7 @@ exports[`appellant-case POST /appellant-case/invalid should re-render the invali
                                     <div class="pins-add-another__item govuk-!-margin-top-6">
                                         <div class="govuk-grid-row">
                                             <div class="govuk-grid-column-full flex-row space-between">
-                                                <label for="invalid-reason-22-1" class="govuk-label govuk-!-margin-bottom-4">Which part is incorrect or incomplete?</label>
+                                                <label for="invalid-reason-22-1" class="govuk-label govuk-!-margin-bottom-4">Enter a reason</label>
                                                 <div class="pins-add-another__remove-button-container"></div>
                                             </div>
                                         </div>
@@ -7425,12 +7425,12 @@ exports[`appellant-case POST /appellant-case/invalid should re-render the invali
                             <div class="govuk-checkboxes__item">
                                 <input class="govuk-checkboxes__input" id="invalid-reason-3" name="invalidReason"
                                 type="checkbox" value="23">
-                                <label class="govuk-label govuk-checkboxes__label" for="invalid-reason-3">The appellant doesn&#39;t have the right to appeal</label>
+                                <label class="govuk-label govuk-checkboxes__label" for="invalid-reason-3">The appellant does not have the right to appeal</label>
                             </div>
                             <div class="govuk-checkboxes__item">
                                 <input class="govuk-checkboxes__input" id="invalid-reason-4" name="invalidReason"
                                 type="checkbox" value="24" data-aria-controls="conditional-invalid-reason-4">
-                                <label class="govuk-label govuk-checkboxes__label" for="invalid-reason-4">Other</label>
+                                <label class="govuk-label govuk-checkboxes__label" for="invalid-reason-4">Other reason</label>
                             </div>
                             <div class="govuk-checkboxes__conditional govuk-checkboxes__conditional--hidden"
                             id="conditional-invalid-reason-4">
@@ -7438,7 +7438,7 @@ exports[`appellant-case POST /appellant-case/invalid should re-render the invali
                                     <div class="pins-add-another__item govuk-!-margin-top-6">
                                         <div class="govuk-grid-row">
                                             <div class="govuk-grid-column-full flex-row space-between">
-                                                <label for="invalid-reason-24-1" class="govuk-label govuk-!-margin-bottom-4">Which part is incorrect or incomplete?</label>
+                                                <label for="invalid-reason-24-1" class="govuk-label govuk-!-margin-bottom-4">Enter a reason</label>
                                                 <div class="pins-add-another__remove-button-container"></div>
                                             </div>
                                         </div>
@@ -7483,7 +7483,7 @@ exports[`appellant-case POST /appellant-case/invalid should re-render the invali
         </div>
     </div>
     <div class="govuk-grid-row">
-        <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Appeal 351062</span>
+        <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Appeal 351062 - mark as invalid</span>
         </div>
     </div>
     <div class="govuk-grid-row">
@@ -7510,7 +7510,7 @@ exports[`appellant-case POST /appellant-case/invalid should re-render the invali
                                     <div class="pins-add-another__item govuk-!-margin-top-6">
                                         <div class="govuk-grid-row">
                                             <div class="govuk-grid-column-full flex-row space-between">
-                                                <label for="invalid-reason-22-1" class="govuk-label govuk-!-margin-bottom-4">Which part is incorrect or incomplete?</label>
+                                                <label for="invalid-reason-22-1" class="govuk-label govuk-!-margin-bottom-4">Enter a reason</label>
                                                 <div class="pins-add-another__remove-button-container"></div>
                                             </div>
                                         </div>
@@ -7530,12 +7530,12 @@ exports[`appellant-case POST /appellant-case/invalid should re-render the invali
                             <div class="govuk-checkboxes__item">
                                 <input class="govuk-checkboxes__input" id="invalid-reason-3" name="invalidReason"
                                 type="checkbox" value="23">
-                                <label class="govuk-label govuk-checkboxes__label" for="invalid-reason-3">The appellant doesn&#39;t have the right to appeal</label>
+                                <label class="govuk-label govuk-checkboxes__label" for="invalid-reason-3">The appellant does not have the right to appeal</label>
                             </div>
                             <div class="govuk-checkboxes__item">
                                 <input class="govuk-checkboxes__input" id="invalid-reason-4" name="invalidReason"
                                 type="checkbox" value="24" data-aria-controls="conditional-invalid-reason-4">
-                                <label class="govuk-label govuk-checkboxes__label" for="invalid-reason-4">Other</label>
+                                <label class="govuk-label govuk-checkboxes__label" for="invalid-reason-4">Other reason</label>
                             </div>
                             <div class="govuk-checkboxes__conditional govuk-checkboxes__conditional--hidden"
                             id="conditional-invalid-reason-4">
@@ -7543,7 +7543,7 @@ exports[`appellant-case POST /appellant-case/invalid should re-render the invali
                                     <div class="pins-add-another__item govuk-!-margin-top-6">
                                         <div class="govuk-grid-row">
                                             <div class="govuk-grid-column-full flex-row space-between">
-                                                <label for="invalid-reason-24-1" class="govuk-label govuk-!-margin-bottom-4">Which part is incorrect or incomplete?</label>
+                                                <label for="invalid-reason-24-1" class="govuk-label govuk-!-margin-bottom-4">Enter a reason</label>
                                                 <div class="pins-add-another__remove-button-container"></div>
                                             </div>
                                         </div>
@@ -7588,7 +7588,7 @@ exports[`appellant-case POST /appellant-case/invalid should re-render the invali
         </div>
     </div>
     <div class="govuk-grid-row">
-        <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Appeal 351062</span>
+        <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Appeal 351062 - mark as invalid</span>
         </div>
     </div>
     <div class="govuk-grid-row">
@@ -7615,7 +7615,7 @@ exports[`appellant-case POST /appellant-case/invalid should re-render the invali
                                     <div class="pins-add-another__item govuk-!-margin-top-6">
                                         <div class="govuk-grid-row">
                                             <div class="govuk-grid-column-full flex-row space-between">
-                                                <label for="invalid-reason-22-1" class="govuk-label govuk-!-margin-bottom-4">Which part is incorrect or incomplete?</label>
+                                                <label for="invalid-reason-22-1" class="govuk-label govuk-!-margin-bottom-4">Enter a reason</label>
                                                 <div class="pins-add-another__remove-button-container"></div>
                                             </div>
                                         </div>
@@ -7635,19 +7635,19 @@ exports[`appellant-case POST /appellant-case/invalid should re-render the invali
                             <div class="govuk-checkboxes__item">
                                 <input class="govuk-checkboxes__input" id="invalid-reason-3" name="invalidReason"
                                 type="checkbox" value="23">
-                                <label class="govuk-label govuk-checkboxes__label" for="invalid-reason-3">The appellant doesn&#39;t have the right to appeal</label>
+                                <label class="govuk-label govuk-checkboxes__label" for="invalid-reason-3">The appellant does not have the right to appeal</label>
                             </div>
                             <div class="govuk-checkboxes__item">
                                 <input class="govuk-checkboxes__input" id="invalid-reason-4" name="invalidReason"
                                 type="checkbox" value="24" checked data-aria-controls="conditional-invalid-reason-4">
-                                <label class="govuk-label govuk-checkboxes__label" for="invalid-reason-4">Other</label>
+                                <label class="govuk-label govuk-checkboxes__label" for="invalid-reason-4">Other reason</label>
                             </div>
                             <div class="govuk-checkboxes__conditional" id="conditional-invalid-reason-4">
                                 <div class="pins-add-another" aria-live="polite" data-max-item-count="10">
                                     <div class="pins-add-another__item govuk-!-margin-top-6">
                                         <div class="govuk-grid-row">
                                             <div class="govuk-grid-column-full flex-row space-between">
-                                                <label for="invalid-reason-24-1" class="govuk-label govuk-!-margin-bottom-4">Which part is incorrect or incomplete?</label>
+                                                <label for="invalid-reason-24-1" class="govuk-label govuk-!-margin-bottom-4">Enter a reason</label>
                                                 <div class="pins-add-another__remove-button-container"></div>
                                             </div>
                                         </div>
@@ -7692,7 +7692,7 @@ exports[`appellant-case POST /appellant-case/invalid should re-render the invali
         </div>
     </div>
     <div class="govuk-grid-row">
-        <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Appeal 351062</span>
+        <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Appeal 351062 - mark as invalid</span>
         </div>
     </div>
     <div class="govuk-grid-row">
@@ -7719,7 +7719,7 @@ exports[`appellant-case POST /appellant-case/invalid should re-render the invali
                                     <div class="pins-add-another__item govuk-!-margin-top-6">
                                         <div class="govuk-grid-row">
                                             <div class="govuk-grid-column-full flex-row space-between">
-                                                <label for="invalid-reason-22-1" class="govuk-label govuk-!-margin-bottom-4">Which part is incorrect or incomplete?</label>
+                                                <label for="invalid-reason-22-1" class="govuk-label govuk-!-margin-bottom-4">Enter a reason</label>
                                                 <div class="pins-add-another__remove-button-container"></div>
                                             </div>
                                         </div>
@@ -7739,19 +7739,19 @@ exports[`appellant-case POST /appellant-case/invalid should re-render the invali
                             <div class="govuk-checkboxes__item">
                                 <input class="govuk-checkboxes__input" id="invalid-reason-3" name="invalidReason"
                                 type="checkbox" value="23">
-                                <label class="govuk-label govuk-checkboxes__label" for="invalid-reason-3">The appellant doesn&#39;t have the right to appeal</label>
+                                <label class="govuk-label govuk-checkboxes__label" for="invalid-reason-3">The appellant does not have the right to appeal</label>
                             </div>
                             <div class="govuk-checkboxes__item">
                                 <input class="govuk-checkboxes__input" id="invalid-reason-4" name="invalidReason"
                                 type="checkbox" value="24" checked data-aria-controls="conditional-invalid-reason-4">
-                                <label class="govuk-label govuk-checkboxes__label" for="invalid-reason-4">Other</label>
+                                <label class="govuk-label govuk-checkboxes__label" for="invalid-reason-4">Other reason</label>
                             </div>
                             <div class="govuk-checkboxes__conditional" id="conditional-invalid-reason-4">
                                 <div class="pins-add-another" aria-live="polite" data-max-item-count="10">
                                     <div class="pins-add-another__item govuk-!-margin-top-6">
                                         <div class="govuk-grid-row">
                                             <div class="govuk-grid-column-full flex-row space-between">
-                                                <label for="invalid-reason-24-1" class="govuk-label govuk-!-margin-bottom-4">Which part is incorrect or incomplete?</label>
+                                                <label for="invalid-reason-24-1" class="govuk-label govuk-!-margin-bottom-4">Enter a reason</label>
                                                 <div class="pins-add-another__remove-button-container"></div>
                                             </div>
                                         </div>
@@ -7787,7 +7787,7 @@ exports[`appellant-case POST /appellant-case/invalid should re-render the invali
                     <h2 class="govuk-error-summary__title"> There is a problem</h2>
                     <div class="govuk-error-summary__body">
                         <ul class="govuk-list govuk-error-summary__list">
-                            <li><a href="#invalid-reason-22-1">Text in text fields cannot exceed 1000 characters</a>
+                            <li><a href="#invalid-reason-22-1">Reason must be 1000 characters or less</a>
                             </li>
                         </ul>
                     </div>
@@ -7796,7 +7796,7 @@ exports[`appellant-case POST /appellant-case/invalid should re-render the invali
         </div>
     </div>
     <div class="govuk-grid-row">
-        <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Appeal 351062</span>
+        <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Appeal 351062 - mark as invalid</span>
         </div>
     </div>
     <div class="govuk-grid-row">
@@ -7823,7 +7823,7 @@ exports[`appellant-case POST /appellant-case/invalid should re-render the invali
                                     <div class="pins-add-another__item govuk-!-margin-top-6">
                                         <div class="govuk-grid-row">
                                             <div class="govuk-grid-column-full flex-row space-between">
-                                                <label for="invalid-reason-22-1" class="govuk-label govuk-!-margin-bottom-4">Which part is incorrect or incomplete?</label>
+                                                <label for="invalid-reason-22-1" class="govuk-label govuk-!-margin-bottom-4">Enter a reason</label>
                                                 <div class="pins-add-another__remove-button-container"></div>
                                             </div>
                                         </div>
@@ -7843,19 +7843,19 @@ exports[`appellant-case POST /appellant-case/invalid should re-render the invali
                             <div class="govuk-checkboxes__item">
                                 <input class="govuk-checkboxes__input" id="invalid-reason-3" name="invalidReason"
                                 type="checkbox" value="23">
-                                <label class="govuk-label govuk-checkboxes__label" for="invalid-reason-3">The appellant doesn&#39;t have the right to appeal</label>
+                                <label class="govuk-label govuk-checkboxes__label" for="invalid-reason-3">The appellant does not have the right to appeal</label>
                             </div>
                             <div class="govuk-checkboxes__item">
                                 <input class="govuk-checkboxes__input" id="invalid-reason-4" name="invalidReason"
                                 type="checkbox" value="24" checked data-aria-controls="conditional-invalid-reason-4">
-                                <label class="govuk-label govuk-checkboxes__label" for="invalid-reason-4">Other</label>
+                                <label class="govuk-label govuk-checkboxes__label" for="invalid-reason-4">Other reason</label>
                             </div>
                             <div class="govuk-checkboxes__conditional" id="conditional-invalid-reason-4">
                                 <div class="pins-add-another" aria-live="polite" data-max-item-count="10">
                                     <div class="pins-add-another__item govuk-!-margin-top-6">
                                         <div class="govuk-grid-row">
                                             <div class="govuk-grid-column-full flex-row space-between">
-                                                <label for="invalid-reason-24-1" class="govuk-label govuk-!-margin-bottom-4">Which part is incorrect or incomplete?</label>
+                                                <label for="invalid-reason-24-1" class="govuk-label govuk-!-margin-bottom-4">Enter a reason</label>
                                                 <div class="pins-add-another__remove-button-container"></div>
                                             </div>
                                         </div>
@@ -7900,7 +7900,7 @@ exports[`appellant-case POST /appellant-case/invalid should re-render the invali
         </div>
     </div>
     <div class="govuk-grid-row">
-        <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Appeal 351062</span>
+        <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Appeal 351062 - mark as invalid</span>
         </div>
     </div>
     <div class="govuk-grid-row">
@@ -7930,7 +7930,7 @@ exports[`appellant-case POST /appellant-case/invalid should re-render the invali
                                     <div class="pins-add-another__item govuk-!-margin-top-6">
                                         <div class="govuk-grid-row">
                                             <div class="govuk-grid-column-full flex-row space-between">
-                                                <label for="invalid-reason-22-1" class="govuk-label govuk-!-margin-bottom-4">Which part is incorrect or incomplete?</label>
+                                                <label for="invalid-reason-22-1" class="govuk-label govuk-!-margin-bottom-4">Enter a reason</label>
                                                 <div class="pins-add-another__remove-button-container"></div>
                                             </div>
                                         </div>
@@ -7950,12 +7950,12 @@ exports[`appellant-case POST /appellant-case/invalid should re-render the invali
                             <div class="govuk-checkboxes__item">
                                 <input class="govuk-checkboxes__input" id="invalid-reason-3" name="invalidReason"
                                 type="checkbox" value="23">
-                                <label class="govuk-label govuk-checkboxes__label" for="invalid-reason-3">The appellant doesn&#39;t have the right to appeal</label>
+                                <label class="govuk-label govuk-checkboxes__label" for="invalid-reason-3">The appellant does not have the right to appeal</label>
                             </div>
                             <div class="govuk-checkboxes__item">
                                 <input class="govuk-checkboxes__input" id="invalid-reason-4" name="invalidReason"
                                 type="checkbox" value="24" data-aria-controls="conditional-invalid-reason-4">
-                                <label class="govuk-label govuk-checkboxes__label" for="invalid-reason-4">Other</label>
+                                <label class="govuk-label govuk-checkboxes__label" for="invalid-reason-4">Other reason</label>
                             </div>
                             <div class="govuk-checkboxes__conditional govuk-checkboxes__conditional--hidden"
                             id="conditional-invalid-reason-4">
@@ -7963,7 +7963,7 @@ exports[`appellant-case POST /appellant-case/invalid should re-render the invali
                                     <div class="pins-add-another__item govuk-!-margin-top-6">
                                         <div class="govuk-grid-row">
                                             <div class="govuk-grid-column-full flex-row space-between">
-                                                <label for="invalid-reason-24-1" class="govuk-label govuk-!-margin-bottom-4">Which part is incorrect or incomplete?</label>
+                                                <label for="invalid-reason-24-1" class="govuk-label govuk-!-margin-bottom-4">Enter a reason</label>
                                                 <div class="pins-add-another__remove-button-container"></div>
                                             </div>
                                         </div>

--- a/appeals/web/src/server/appeals/appeal-details/appellant-case/__tests__/appellant-case.test.js
+++ b/appeals/web/src/server/appeals/appeal-details/appellant-case/__tests__/appellant-case.test.js
@@ -1583,7 +1583,7 @@ describe('appellant-case', () => {
 			}).innerHTML;
 			expect(unprettifiedErrorSummaryHtml).toContain('There is a problem</h2>');
 			expect(unprettifiedErrorSummaryHtml).toContain(
-				`Text in text fields cannot exceed ${textInputCharacterLimits.checkboxTextItemsLength} characters</a>`
+				`Reason must be ${textInputCharacterLimits.checkboxTextItemsLength} characters or less</a>`
 			);
 		});
 
@@ -1607,7 +1607,7 @@ describe('appellant-case', () => {
 			}).innerHTML;
 			expect(unprettifiedErrorSummaryHtml).toContain('There is a problem</h2>');
 			expect(unprettifiedErrorSummaryHtml).toContain(
-				`Text in text fields cannot exceed ${textInputCharacterLimits.checkboxTextItemsLength} characters</a>`
+				`Reason must be ${textInputCharacterLimits.checkboxTextItemsLength} characters or less</a>`
 			);
 		});
 
@@ -1828,7 +1828,7 @@ describe('appellant-case', () => {
 			}).innerHTML;
 			expect(unprettifiedErrorSummaryHtml).toContain('There is a problem</h2>');
 			expect(unprettifiedErrorSummaryHtml).toContain(
-				`Text in text fields cannot exceed ${textInputCharacterLimits.checkboxTextItemsLength} characters</a>`
+				`Reason must be ${textInputCharacterLimits.checkboxTextItemsLength} characters or less</a>`
 			);
 		});
 
@@ -1852,7 +1852,7 @@ describe('appellant-case', () => {
 			}).innerHTML;
 			expect(unprettifiedErrorSummaryHtml).toContain('There is a problem</h2>');
 			expect(unprettifiedErrorSummaryHtml).toContain(
-				`Text in text fields cannot exceed ${textInputCharacterLimits.checkboxTextItemsLength} characters</a>`
+				`Reason must be ${textInputCharacterLimits.checkboxTextItemsLength} characters or less</a>`
 			);
 		});
 

--- a/appeals/web/src/server/appeals/appeal-details/appellant-case/appellant-case.router.js
+++ b/appeals/web/src/server/appeals/appeal-details/appellant-case/appellant-case.router.js
@@ -4,7 +4,7 @@ import * as controller from './appellant-case.controller.js';
 import * as validators from './appellant-case.validators.js';
 import * as documentsValidators from '../../appeal-documents/appeal-documents.validators.js';
 import outcomeValidRouter from './outcome-valid/outcome-valid.router.js';
-import outcomeInvalidRouter from './outcome-invalid/outcome-invalid.router.js';
+import outcomeInvalidRouter from '../invalid-appeal/invalid-appeal.router.js';
 import outcomeIncompleteRouter from './outcome-incomplete/outcome-incomplete.router.js';
 import { assertUserHasPermission } from '#app/auth/auth.guards.js';
 import { validateAppeal } from '../appeal-details.middleware.js';

--- a/appeals/web/src/server/appeals/appeal-details/invalid-appeal/__tests__/__snapshots__/invalid-appeal.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/invalid-appeal/__tests__/__snapshots__/invalid-appeal.test.js.snap
@@ -1,0 +1,827 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`invalid-appeal GET / , /new should render the invalid reason page 1`] = `
+"<main class="govuk-main-wrapper" id="main-content">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Appeal 351062 - mark as invalid</span>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
+            <form action="" method="POST" novalidate>
+                <div class="govuk-form-group">
+                    <fieldset class="govuk-fieldset">
+                        <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+                            <h1 class="govuk-fieldset__heading"> Why is the appeal invalid?</h1>
+                        </legend>
+                        <div class="govuk-checkboxes" data-module="govuk-checkboxes">
+                            <div class="govuk-checkboxes__item">
+                                <input class="govuk-checkboxes__input" id="invalid-reason" name="invalidReason"
+                                type="checkbox" value="21">
+                                <label class="govuk-label govuk-checkboxes__label" for="invalid-reason">Appeal has not been submitted on time</label>
+                            </div>
+                            <div class="govuk-checkboxes__item">
+                                <input class="govuk-checkboxes__input" id="invalid-reason-2" name="invalidReason"
+                                type="checkbox" value="22" data-aria-controls="conditional-invalid-reason-2">
+                                <label class="govuk-label govuk-checkboxes__label" for="invalid-reason-2">Documents have not been submitted on time</label>
+                            </div>
+                            <div class="govuk-checkboxes__conditional govuk-checkboxes__conditional--hidden"
+                            id="conditional-invalid-reason-2">
+                                <div class="pins-add-another" aria-live="polite" data-max-item-count="10">
+                                    <div class="pins-add-another__item govuk-!-margin-top-6">
+                                        <div class="govuk-grid-row">
+                                            <div class="govuk-grid-column-full flex-row space-between">
+                                                <label for="invalid-reason-22-1" class="govuk-label govuk-!-margin-bottom-4">Enter a reason</label>
+                                                <div class="pins-add-another__remove-button-container"></div>
+                                            </div>
+                                        </div>
+                                        <div class="govuk-grid-row">
+                                            <div class="govuk-grid-column-full">
+                                                <div class="govuk-form-group">
+                                                    <input class="govuk-input pins-add-another__item-input govuk-!-margin-0"
+                                                    id="invalid-reason-22-1" name="invalidReason-22" type="text" value="">
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                    <button type="button" class="govuk-button pins-add-another__add-button govuk-button--secondary govuk-!-margin-top-4 govuk-!-margin-bottom-0"
+                                    data-module="govuk-button">Add another</button>
+                                </div>
+                            </div>
+                            <div class="govuk-checkboxes__item">
+                                <input class="govuk-checkboxes__input" id="invalid-reason-3" name="invalidReason"
+                                type="checkbox" value="23">
+                                <label class="govuk-label govuk-checkboxes__label" for="invalid-reason-3">The appellant does not have the right to appeal</label>
+                            </div>
+                            <div class="govuk-checkboxes__item">
+                                <input class="govuk-checkboxes__input" id="invalid-reason-4" name="invalidReason"
+                                type="checkbox" value="24" data-aria-controls="conditional-invalid-reason-4">
+                                <label class="govuk-label govuk-checkboxes__label" for="invalid-reason-4">Other reason</label>
+                            </div>
+                            <div class="govuk-checkboxes__conditional govuk-checkboxes__conditional--hidden"
+                            id="conditional-invalid-reason-4">
+                                <div class="pins-add-another" aria-live="polite" data-max-item-count="10">
+                                    <div class="pins-add-another__item govuk-!-margin-top-6">
+                                        <div class="govuk-grid-row">
+                                            <div class="govuk-grid-column-full flex-row space-between">
+                                                <label for="invalid-reason-24-1" class="govuk-label govuk-!-margin-bottom-4">Enter a reason</label>
+                                                <div class="pins-add-another__remove-button-container"></div>
+                                            </div>
+                                        </div>
+                                        <div class="govuk-grid-row">
+                                            <div class="govuk-grid-column-full">
+                                                <div class="govuk-form-group">
+                                                    <input class="govuk-input pins-add-another__item-input govuk-!-margin-0"
+                                                    id="invalid-reason-24-1" name="invalidReason-24" type="text" value="">
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                    <button type="button" class="govuk-button pins-add-another__add-button govuk-button--secondary govuk-!-margin-top-4 govuk-!-margin-bottom-0"
+                                    data-module="govuk-button">Add another</button>
+                                </div>
+                            </div>
+                        </div>
+                    </fieldset>
+                </div>
+                <button type="submit" class="govuk-button" data-module="govuk-button">Continue</button>
+            </form>
+        </div>
+    </div>
+</main>"
+`;
+
+exports[`invalid-appeal POST  / , /new should re-render the invalid reason page with the expected error message if a single invalid reason with text was provided but the matching text property exceeds the character limit 1`] = `
+"<main class="govuk-main-wrapper" id="main-content">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <div class="govuk-error-summary" data-module="govuk-error-summary">
+                <div role="alert">
+                    <h2 class="govuk-error-summary__title"> There is a problem</h2>
+                    <div class="govuk-error-summary__body">
+                        <ul class="govuk-list govuk-error-summary__list">
+                            <li><a href="#invalid-reason-22-1">Reason must be 1000 characters or less</a>
+                            </li>
+                        </ul>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Appeal 351062 - mark as invalid</span>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
+            <form action="" method="POST" novalidate>
+                <div class="govuk-form-group">
+                    <fieldset class="govuk-fieldset">
+                        <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+                            <h1 class="govuk-fieldset__heading"> Why is the appeal invalid?</h1>
+                        </legend>
+                        <div class="govuk-checkboxes" data-module="govuk-checkboxes">
+                            <div class="govuk-checkboxes__item">
+                                <input class="govuk-checkboxes__input" id="invalid-reason" name="invalidReason"
+                                type="checkbox" value="21">
+                                <label class="govuk-label govuk-checkboxes__label" for="invalid-reason">Appeal has not been submitted on time</label>
+                            </div>
+                            <div class="govuk-checkboxes__item">
+                                <input class="govuk-checkboxes__input" id="invalid-reason-2" name="invalidReason"
+                                type="checkbox" value="22" checked data-aria-controls="conditional-invalid-reason-2">
+                                <label class="govuk-label govuk-checkboxes__label" for="invalid-reason-2">Documents have not been submitted on time</label>
+                            </div>
+                            <div class="govuk-checkboxes__conditional" id="conditional-invalid-reason-2">
+                                <div class="pins-add-another" aria-live="polite" data-max-item-count="10">
+                                    <div class="pins-add-another__item govuk-!-margin-top-6">
+                                        <div class="govuk-grid-row">
+                                            <div class="govuk-grid-column-full flex-row space-between">
+                                                <label for="invalid-reason-22-1" class="govuk-label govuk-!-margin-bottom-4">Enter a reason</label>
+                                                <div class="pins-add-another__remove-button-container"></div>
+                                            </div>
+                                        </div>
+                                        <div class="govuk-grid-row">
+                                            <div class="govuk-grid-column-full">
+                                                <div class="govuk-form-group">
+                                                    <input class="govuk-input pins-add-another__item-input govuk-!-margin-0"
+                                                    id="invalid-reason-22-1" name="invalidReason-22" type="text" value="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa">
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                    <button type="button" class="govuk-button pins-add-another__add-button govuk-button--secondary govuk-!-margin-top-4 govuk-!-margin-bottom-0"
+                                    data-module="govuk-button">Add another</button>
+                                </div>
+                            </div>
+                            <div class="govuk-checkboxes__item">
+                                <input class="govuk-checkboxes__input" id="invalid-reason-3" name="invalidReason"
+                                type="checkbox" value="23">
+                                <label class="govuk-label govuk-checkboxes__label" for="invalid-reason-3">The appellant does not have the right to appeal</label>
+                            </div>
+                            <div class="govuk-checkboxes__item">
+                                <input class="govuk-checkboxes__input" id="invalid-reason-4" name="invalidReason"
+                                type="checkbox" value="24" data-aria-controls="conditional-invalid-reason-4">
+                                <label class="govuk-label govuk-checkboxes__label" for="invalid-reason-4">Other reason</label>
+                            </div>
+                            <div class="govuk-checkboxes__conditional govuk-checkboxes__conditional--hidden"
+                            id="conditional-invalid-reason-4">
+                                <div class="pins-add-another" aria-live="polite" data-max-item-count="10">
+                                    <div class="pins-add-another__item govuk-!-margin-top-6">
+                                        <div class="govuk-grid-row">
+                                            <div class="govuk-grid-column-full flex-row space-between">
+                                                <label for="invalid-reason-24-1" class="govuk-label govuk-!-margin-bottom-4">Enter a reason</label>
+                                                <div class="pins-add-another__remove-button-container"></div>
+                                            </div>
+                                        </div>
+                                        <div class="govuk-grid-row">
+                                            <div class="govuk-grid-column-full">
+                                                <div class="govuk-form-group">
+                                                    <input class="govuk-input pins-add-another__item-input govuk-!-margin-0"
+                                                    id="invalid-reason-24-1" name="invalidReason-24" type="text" value="">
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                    <button type="button" class="govuk-button pins-add-another__add-button govuk-button--secondary govuk-!-margin-top-4 govuk-!-margin-bottom-0"
+                                    data-module="govuk-button">Add another</button>
+                                </div>
+                            </div>
+                        </div>
+                    </fieldset>
+                </div>
+                <button type="submit" class="govuk-button" data-module="govuk-button">Continue</button>
+            </form>
+        </div>
+    </div>
+</main>"
+`;
+
+exports[`invalid-appeal POST  / , /new should re-render the invalid reason page with the expected error message if a single invalid reason with text was provided but the matching text property is an empty array 1`] = `
+"<main class="govuk-main-wrapper" id="main-content">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <div class="govuk-error-summary" data-module="govuk-error-summary">
+                <div role="alert">
+                    <h2 class="govuk-error-summary__title"> There is a problem</h2>
+                    <div class="govuk-error-summary__body">
+                        <ul class="govuk-list govuk-error-summary__list">
+                            <li><a href="#invalid-reason-22">Enter a reason</a>
+                            </li>
+                        </ul>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Appeal 351062 - mark as invalid</span>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
+            <form action="" method="POST" novalidate>
+                <div class="govuk-form-group">
+                    <fieldset class="govuk-fieldset">
+                        <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+                            <h1 class="govuk-fieldset__heading"> Why is the appeal invalid?</h1>
+                        </legend>
+                        <div class="govuk-checkboxes" data-module="govuk-checkboxes">
+                            <div class="govuk-checkboxes__item">
+                                <input class="govuk-checkboxes__input" id="invalid-reason" name="invalidReason"
+                                type="checkbox" value="21">
+                                <label class="govuk-label govuk-checkboxes__label" for="invalid-reason">Appeal has not been submitted on time</label>
+                            </div>
+                            <div class="govuk-checkboxes__item">
+                                <input class="govuk-checkboxes__input" id="invalid-reason-2" name="invalidReason"
+                                type="checkbox" value="22" checked data-aria-controls="conditional-invalid-reason-2">
+                                <label class="govuk-label govuk-checkboxes__label" for="invalid-reason-2">Documents have not been submitted on time</label>
+                            </div>
+                            <div class="govuk-checkboxes__conditional" id="conditional-invalid-reason-2">
+                                <div class="pins-add-another" aria-live="polite" data-max-item-count="10">
+                                    <div class="pins-add-another__item govuk-!-margin-top-6">
+                                        <div class="govuk-grid-row">
+                                            <div class="govuk-grid-column-full flex-row space-between">
+                                                <label for="invalid-reason-22-1" class="govuk-label govuk-!-margin-bottom-4">Enter a reason</label>
+                                                <div class="pins-add-another__remove-button-container"></div>
+                                            </div>
+                                        </div>
+                                        <div class="govuk-grid-row">
+                                            <div class="govuk-grid-column-full">
+                                                <div class="govuk-form-group">
+                                                    <input class="govuk-input pins-add-another__item-input govuk-!-margin-0"
+                                                    id="invalid-reason-22-1" name="invalidReason-22" type="text" value="">
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                    <button type="button" class="govuk-button pins-add-another__add-button govuk-button--secondary govuk-!-margin-top-4 govuk-!-margin-bottom-0"
+                                    data-module="govuk-button">Add another</button>
+                                </div>
+                            </div>
+                            <div class="govuk-checkboxes__item">
+                                <input class="govuk-checkboxes__input" id="invalid-reason-3" name="invalidReason"
+                                type="checkbox" value="23">
+                                <label class="govuk-label govuk-checkboxes__label" for="invalid-reason-3">The appellant does not have the right to appeal</label>
+                            </div>
+                            <div class="govuk-checkboxes__item">
+                                <input class="govuk-checkboxes__input" id="invalid-reason-4" name="invalidReason"
+                                type="checkbox" value="24" data-aria-controls="conditional-invalid-reason-4">
+                                <label class="govuk-label govuk-checkboxes__label" for="invalid-reason-4">Other reason</label>
+                            </div>
+                            <div class="govuk-checkboxes__conditional govuk-checkboxes__conditional--hidden"
+                            id="conditional-invalid-reason-4">
+                                <div class="pins-add-another" aria-live="polite" data-max-item-count="10">
+                                    <div class="pins-add-another__item govuk-!-margin-top-6">
+                                        <div class="govuk-grid-row">
+                                            <div class="govuk-grid-column-full flex-row space-between">
+                                                <label for="invalid-reason-24-1" class="govuk-label govuk-!-margin-bottom-4">Enter a reason</label>
+                                                <div class="pins-add-another__remove-button-container"></div>
+                                            </div>
+                                        </div>
+                                        <div class="govuk-grid-row">
+                                            <div class="govuk-grid-column-full">
+                                                <div class="govuk-form-group">
+                                                    <input class="govuk-input pins-add-another__item-input govuk-!-margin-0"
+                                                    id="invalid-reason-24-1" name="invalidReason-24" type="text" value="">
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                    <button type="button" class="govuk-button pins-add-another__add-button govuk-button--secondary govuk-!-margin-top-4 govuk-!-margin-bottom-0"
+                                    data-module="govuk-button">Add another</button>
+                                </div>
+                            </div>
+                        </div>
+                    </fieldset>
+                </div>
+                <button type="submit" class="govuk-button" data-module="govuk-button">Continue</button>
+            </form>
+        </div>
+    </div>
+</main>"
+`;
+
+exports[`invalid-appeal POST  / , /new should re-render the invalid reason page with the expected error message if a single invalid reason with text was provided but the matching text property is an empty string 1`] = `
+"<main class="govuk-main-wrapper" id="main-content">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <div class="govuk-error-summary" data-module="govuk-error-summary">
+                <div role="alert">
+                    <h2 class="govuk-error-summary__title"> There is a problem</h2>
+                    <div class="govuk-error-summary__body">
+                        <ul class="govuk-list govuk-error-summary__list">
+                            <li><a href="#invalid-reason-22-1">Enter a reason</a>
+                            </li>
+                        </ul>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Appeal 351062 - mark as invalid</span>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
+            <form action="" method="POST" novalidate>
+                <div class="govuk-form-group">
+                    <fieldset class="govuk-fieldset">
+                        <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+                            <h1 class="govuk-fieldset__heading"> Why is the appeal invalid?</h1>
+                        </legend>
+                        <div class="govuk-checkboxes" data-module="govuk-checkboxes">
+                            <div class="govuk-checkboxes__item">
+                                <input class="govuk-checkboxes__input" id="invalid-reason" name="invalidReason"
+                                type="checkbox" value="21">
+                                <label class="govuk-label govuk-checkboxes__label" for="invalid-reason">Appeal has not been submitted on time</label>
+                            </div>
+                            <div class="govuk-checkboxes__item">
+                                <input class="govuk-checkboxes__input" id="invalid-reason-2" name="invalidReason"
+                                type="checkbox" value="22" checked data-aria-controls="conditional-invalid-reason-2">
+                                <label class="govuk-label govuk-checkboxes__label" for="invalid-reason-2">Documents have not been submitted on time</label>
+                            </div>
+                            <div class="govuk-checkboxes__conditional" id="conditional-invalid-reason-2">
+                                <div class="pins-add-another" aria-live="polite" data-max-item-count="10">
+                                    <div class="pins-add-another__item govuk-!-margin-top-6">
+                                        <div class="govuk-grid-row">
+                                            <div class="govuk-grid-column-full flex-row space-between">
+                                                <label for="invalid-reason-22-1" class="govuk-label govuk-!-margin-bottom-4">Enter a reason</label>
+                                                <div class="pins-add-another__remove-button-container"></div>
+                                            </div>
+                                        </div>
+                                        <div class="govuk-grid-row">
+                                            <div class="govuk-grid-column-full">
+                                                <div class="govuk-form-group">
+                                                    <input class="govuk-input pins-add-another__item-input govuk-!-margin-0"
+                                                    id="invalid-reason-22-1" name="invalidReason-22" type="text" value="">
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                    <button type="button" class="govuk-button pins-add-another__add-button govuk-button--secondary govuk-!-margin-top-4 govuk-!-margin-bottom-0"
+                                    data-module="govuk-button">Add another</button>
+                                </div>
+                            </div>
+                            <div class="govuk-checkboxes__item">
+                                <input class="govuk-checkboxes__input" id="invalid-reason-3" name="invalidReason"
+                                type="checkbox" value="23">
+                                <label class="govuk-label govuk-checkboxes__label" for="invalid-reason-3">The appellant does not have the right to appeal</label>
+                            </div>
+                            <div class="govuk-checkboxes__item">
+                                <input class="govuk-checkboxes__input" id="invalid-reason-4" name="invalidReason"
+                                type="checkbox" value="24" data-aria-controls="conditional-invalid-reason-4">
+                                <label class="govuk-label govuk-checkboxes__label" for="invalid-reason-4">Other reason</label>
+                            </div>
+                            <div class="govuk-checkboxes__conditional govuk-checkboxes__conditional--hidden"
+                            id="conditional-invalid-reason-4">
+                                <div class="pins-add-another" aria-live="polite" data-max-item-count="10">
+                                    <div class="pins-add-another__item govuk-!-margin-top-6">
+                                        <div class="govuk-grid-row">
+                                            <div class="govuk-grid-column-full flex-row space-between">
+                                                <label for="invalid-reason-24-1" class="govuk-label govuk-!-margin-bottom-4">Enter a reason</label>
+                                                <div class="pins-add-another__remove-button-container"></div>
+                                            </div>
+                                        </div>
+                                        <div class="govuk-grid-row">
+                                            <div class="govuk-grid-column-full">
+                                                <div class="govuk-form-group">
+                                                    <input class="govuk-input pins-add-another__item-input govuk-!-margin-0"
+                                                    id="invalid-reason-24-1" name="invalidReason-24" type="text" value="">
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                    <button type="button" class="govuk-button pins-add-another__add-button govuk-button--secondary govuk-!-margin-top-4 govuk-!-margin-bottom-0"
+                                    data-module="govuk-button">Add another</button>
+                                </div>
+                            </div>
+                        </div>
+                    </fieldset>
+                </div>
+                <button type="submit" class="govuk-button" data-module="govuk-button">Continue</button>
+            </form>
+        </div>
+    </div>
+</main>"
+`;
+
+exports[`invalid-appeal POST  / , /new should re-render the invalid reason page with the expected error message if multiple invalid reasons with text were provided but any of the matching text properties are empty arays 1`] = `
+"<main class="govuk-main-wrapper" id="main-content">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <div class="govuk-error-summary" data-module="govuk-error-summary">
+                <div role="alert">
+                    <h2 class="govuk-error-summary__title"> There is a problem</h2>
+                    <div class="govuk-error-summary__body">
+                        <ul class="govuk-list govuk-error-summary__list">
+                            <li><a href="#invalid-reason-22">Enter a reason</a>
+                            </li>
+                        </ul>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Appeal 351062 - mark as invalid</span>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
+            <form action="" method="POST" novalidate>
+                <div class="govuk-form-group">
+                    <fieldset class="govuk-fieldset">
+                        <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+                            <h1 class="govuk-fieldset__heading"> Why is the appeal invalid?</h1>
+                        </legend>
+                        <div class="govuk-checkboxes" data-module="govuk-checkboxes">
+                            <div class="govuk-checkboxes__item">
+                                <input class="govuk-checkboxes__input" id="invalid-reason" name="invalidReason"
+                                type="checkbox" value="21">
+                                <label class="govuk-label govuk-checkboxes__label" for="invalid-reason">Appeal has not been submitted on time</label>
+                            </div>
+                            <div class="govuk-checkboxes__item">
+                                <input class="govuk-checkboxes__input" id="invalid-reason-2" name="invalidReason"
+                                type="checkbox" value="22" checked data-aria-controls="conditional-invalid-reason-2">
+                                <label class="govuk-label govuk-checkboxes__label" for="invalid-reason-2">Documents have not been submitted on time</label>
+                            </div>
+                            <div class="govuk-checkboxes__conditional" id="conditional-invalid-reason-2">
+                                <div class="pins-add-another" aria-live="polite" data-max-item-count="10">
+                                    <div class="pins-add-another__item govuk-!-margin-top-6">
+                                        <div class="govuk-grid-row">
+                                            <div class="govuk-grid-column-full flex-row space-between">
+                                                <label for="invalid-reason-22-1" class="govuk-label govuk-!-margin-bottom-4">Enter a reason</label>
+                                                <div class="pins-add-another__remove-button-container"></div>
+                                            </div>
+                                        </div>
+                                        <div class="govuk-grid-row">
+                                            <div class="govuk-grid-column-full">
+                                                <div class="govuk-form-group">
+                                                    <input class="govuk-input pins-add-another__item-input govuk-!-margin-0"
+                                                    id="invalid-reason-22-1" name="invalidReason-22" type="text" value="">
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                    <button type="button" class="govuk-button pins-add-another__add-button govuk-button--secondary govuk-!-margin-top-4 govuk-!-margin-bottom-0"
+                                    data-module="govuk-button">Add another</button>
+                                </div>
+                            </div>
+                            <div class="govuk-checkboxes__item">
+                                <input class="govuk-checkboxes__input" id="invalid-reason-3" name="invalidReason"
+                                type="checkbox" value="23">
+                                <label class="govuk-label govuk-checkboxes__label" for="invalid-reason-3">The appellant does not have the right to appeal</label>
+                            </div>
+                            <div class="govuk-checkboxes__item">
+                                <input class="govuk-checkboxes__input" id="invalid-reason-4" name="invalidReason"
+                                type="checkbox" value="24" checked data-aria-controls="conditional-invalid-reason-4">
+                                <label class="govuk-label govuk-checkboxes__label" for="invalid-reason-4">Other reason</label>
+                            </div>
+                            <div class="govuk-checkboxes__conditional" id="conditional-invalid-reason-4">
+                                <div class="pins-add-another" aria-live="polite" data-max-item-count="10">
+                                    <div class="pins-add-another__item govuk-!-margin-top-6">
+                                        <div class="govuk-grid-row">
+                                            <div class="govuk-grid-column-full flex-row space-between">
+                                                <label for="invalid-reason-24-1" class="govuk-label govuk-!-margin-bottom-4">Enter a reason</label>
+                                                <div class="pins-add-another__remove-button-container"></div>
+                                            </div>
+                                        </div>
+                                        <div class="govuk-grid-row">
+                                            <div class="govuk-grid-column-full">
+                                                <div class="govuk-form-group">
+                                                    <input class="govuk-input pins-add-another__item-input govuk-!-margin-0"
+                                                    id="invalid-reason-24-1" name="invalidReason-24" type="text" value="">
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                    <button type="button" class="govuk-button pins-add-another__add-button govuk-button--secondary govuk-!-margin-top-4 govuk-!-margin-bottom-0"
+                                    data-module="govuk-button">Add another</button>
+                                </div>
+                            </div>
+                        </div>
+                    </fieldset>
+                </div>
+                <button type="submit" class="govuk-button" data-module="govuk-button">Continue</button>
+            </form>
+        </div>
+    </div>
+</main>"
+`;
+
+exports[`invalid-appeal POST  / , /new should re-render the invalid reason page with the expected error message if multiple invalid reasons with text were provided but any of the matching text properties are empty strings 1`] = `
+"<main class="govuk-main-wrapper" id="main-content">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <div class="govuk-error-summary" data-module="govuk-error-summary">
+                <div role="alert">
+                    <h2 class="govuk-error-summary__title"> There is a problem</h2>
+                    <div class="govuk-error-summary__body">
+                        <ul class="govuk-list govuk-error-summary__list">
+                            <li><a href="#invalid-reason-22-1">Enter a reason</a>
+                            </li>
+                        </ul>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Appeal 351062 - mark as invalid</span>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
+            <form action="" method="POST" novalidate>
+                <div class="govuk-form-group">
+                    <fieldset class="govuk-fieldset">
+                        <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+                            <h1 class="govuk-fieldset__heading"> Why is the appeal invalid?</h1>
+                        </legend>
+                        <div class="govuk-checkboxes" data-module="govuk-checkboxes">
+                            <div class="govuk-checkboxes__item">
+                                <input class="govuk-checkboxes__input" id="invalid-reason" name="invalidReason"
+                                type="checkbox" value="21">
+                                <label class="govuk-label govuk-checkboxes__label" for="invalid-reason">Appeal has not been submitted on time</label>
+                            </div>
+                            <div class="govuk-checkboxes__item">
+                                <input class="govuk-checkboxes__input" id="invalid-reason-2" name="invalidReason"
+                                type="checkbox" value="22" checked data-aria-controls="conditional-invalid-reason-2">
+                                <label class="govuk-label govuk-checkboxes__label" for="invalid-reason-2">Documents have not been submitted on time</label>
+                            </div>
+                            <div class="govuk-checkboxes__conditional" id="conditional-invalid-reason-2">
+                                <div class="pins-add-another" aria-live="polite" data-max-item-count="10">
+                                    <div class="pins-add-another__item govuk-!-margin-top-6">
+                                        <div class="govuk-grid-row">
+                                            <div class="govuk-grid-column-full flex-row space-between">
+                                                <label for="invalid-reason-22-1" class="govuk-label govuk-!-margin-bottom-4">Enter a reason</label>
+                                                <div class="pins-add-another__remove-button-container"></div>
+                                            </div>
+                                        </div>
+                                        <div class="govuk-grid-row">
+                                            <div class="govuk-grid-column-full">
+                                                <div class="govuk-form-group">
+                                                    <input class="govuk-input pins-add-another__item-input govuk-!-margin-0"
+                                                    id="invalid-reason-22-1" name="invalidReason-22" type="text" value="">
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                    <button type="button" class="govuk-button pins-add-another__add-button govuk-button--secondary govuk-!-margin-top-4 govuk-!-margin-bottom-0"
+                                    data-module="govuk-button">Add another</button>
+                                </div>
+                            </div>
+                            <div class="govuk-checkboxes__item">
+                                <input class="govuk-checkboxes__input" id="invalid-reason-3" name="invalidReason"
+                                type="checkbox" value="23">
+                                <label class="govuk-label govuk-checkboxes__label" for="invalid-reason-3">The appellant does not have the right to appeal</label>
+                            </div>
+                            <div class="govuk-checkboxes__item">
+                                <input class="govuk-checkboxes__input" id="invalid-reason-4" name="invalidReason"
+                                type="checkbox" value="24" checked data-aria-controls="conditional-invalid-reason-4">
+                                <label class="govuk-label govuk-checkboxes__label" for="invalid-reason-4">Other reason</label>
+                            </div>
+                            <div class="govuk-checkboxes__conditional" id="conditional-invalid-reason-4">
+                                <div class="pins-add-another" aria-live="polite" data-max-item-count="10">
+                                    <div class="pins-add-another__item govuk-!-margin-top-6">
+                                        <div class="govuk-grid-row">
+                                            <div class="govuk-grid-column-full flex-row space-between">
+                                                <label for="invalid-reason-24-1" class="govuk-label govuk-!-margin-bottom-4">Enter a reason</label>
+                                                <div class="pins-add-another__remove-button-container"></div>
+                                            </div>
+                                        </div>
+                                        <div class="govuk-grid-row">
+                                            <div class="govuk-grid-column-full">
+                                                <div class="govuk-form-group">
+                                                    <input class="govuk-input pins-add-another__item-input govuk-!-margin-0"
+                                                    id="invalid-reason-24-1" name="invalidReason-24" type="text" value="">
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                    <button type="button" class="govuk-button pins-add-another__add-button govuk-button--secondary govuk-!-margin-top-4 govuk-!-margin-bottom-0"
+                                    data-module="govuk-button">Add another</button>
+                                </div>
+                            </div>
+                        </div>
+                    </fieldset>
+                </div>
+                <button type="submit" class="govuk-button" data-module="govuk-button">Continue</button>
+            </form>
+        </div>
+    </div>
+</main>"
+`;
+
+exports[`invalid-appeal POST  / , /new should re-render the invalid reason page with the expected error message if multiple invalid reasons with text were provided but any of the matching text properties exceed the character limit 1`] = `
+"<main class="govuk-main-wrapper" id="main-content">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <div class="govuk-error-summary" data-module="govuk-error-summary">
+                <div role="alert">
+                    <h2 class="govuk-error-summary__title"> There is a problem</h2>
+                    <div class="govuk-error-summary__body">
+                        <ul class="govuk-list govuk-error-summary__list">
+                            <li><a href="#invalid-reason-22-1">Reason must be 1000 characters or less</a>
+                            </li>
+                        </ul>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Appeal 351062 - mark as invalid</span>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
+            <form action="" method="POST" novalidate>
+                <div class="govuk-form-group">
+                    <fieldset class="govuk-fieldset">
+                        <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+                            <h1 class="govuk-fieldset__heading"> Why is the appeal invalid?</h1>
+                        </legend>
+                        <div class="govuk-checkboxes" data-module="govuk-checkboxes">
+                            <div class="govuk-checkboxes__item">
+                                <input class="govuk-checkboxes__input" id="invalid-reason" name="invalidReason"
+                                type="checkbox" value="21">
+                                <label class="govuk-label govuk-checkboxes__label" for="invalid-reason">Appeal has not been submitted on time</label>
+                            </div>
+                            <div class="govuk-checkboxes__item">
+                                <input class="govuk-checkboxes__input" id="invalid-reason-2" name="invalidReason"
+                                type="checkbox" value="22" checked data-aria-controls="conditional-invalid-reason-2">
+                                <label class="govuk-label govuk-checkboxes__label" for="invalid-reason-2">Documents have not been submitted on time</label>
+                            </div>
+                            <div class="govuk-checkboxes__conditional" id="conditional-invalid-reason-2">
+                                <div class="pins-add-another" aria-live="polite" data-max-item-count="10">
+                                    <div class="pins-add-another__item govuk-!-margin-top-6">
+                                        <div class="govuk-grid-row">
+                                            <div class="govuk-grid-column-full flex-row space-between">
+                                                <label for="invalid-reason-22-1" class="govuk-label govuk-!-margin-bottom-4">Enter a reason</label>
+                                                <div class="pins-add-another__remove-button-container"></div>
+                                            </div>
+                                        </div>
+                                        <div class="govuk-grid-row">
+                                            <div class="govuk-grid-column-full">
+                                                <div class="govuk-form-group">
+                                                    <input class="govuk-input pins-add-another__item-input govuk-!-margin-0"
+                                                    id="invalid-reason-22-1" name="invalidReason-22" type="text" value="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa">
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                    <button type="button" class="govuk-button pins-add-another__add-button govuk-button--secondary govuk-!-margin-top-4 govuk-!-margin-bottom-0"
+                                    data-module="govuk-button">Add another</button>
+                                </div>
+                            </div>
+                            <div class="govuk-checkboxes__item">
+                                <input class="govuk-checkboxes__input" id="invalid-reason-3" name="invalidReason"
+                                type="checkbox" value="23">
+                                <label class="govuk-label govuk-checkboxes__label" for="invalid-reason-3">The appellant does not have the right to appeal</label>
+                            </div>
+                            <div class="govuk-checkboxes__item">
+                                <input class="govuk-checkboxes__input" id="invalid-reason-4" name="invalidReason"
+                                type="checkbox" value="24" checked data-aria-controls="conditional-invalid-reason-4">
+                                <label class="govuk-label govuk-checkboxes__label" for="invalid-reason-4">Other reason</label>
+                            </div>
+                            <div class="govuk-checkboxes__conditional" id="conditional-invalid-reason-4">
+                                <div class="pins-add-another" aria-live="polite" data-max-item-count="10">
+                                    <div class="pins-add-another__item govuk-!-margin-top-6">
+                                        <div class="govuk-grid-row">
+                                            <div class="govuk-grid-column-full flex-row space-between">
+                                                <label for="invalid-reason-24-1" class="govuk-label govuk-!-margin-bottom-4">Enter a reason</label>
+                                                <div class="pins-add-another__remove-button-container"></div>
+                                            </div>
+                                        </div>
+                                        <div class="govuk-grid-row">
+                                            <div class="govuk-grid-column-full">
+                                                <div class="govuk-form-group">
+                                                    <input class="govuk-input pins-add-another__item-input govuk-!-margin-0"
+                                                    id="invalid-reason-24-1" name="invalidReason-24" type="text" value="">
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                    <button type="button" class="govuk-button pins-add-another__add-button govuk-button--secondary govuk-!-margin-top-4 govuk-!-margin-bottom-0"
+                                    data-module="govuk-button">Add another</button>
+                                </div>
+                            </div>
+                        </div>
+                    </fieldset>
+                </div>
+                <button type="submit" class="govuk-button" data-module="govuk-button">Continue</button>
+            </form>
+        </div>
+    </div>
+</main>"
+`;
+
+exports[`invalid-appeal POST  / , /new should re-render the invalid reason page with the expected error message if no invalid reason was provided 1`] = `
+"<main class="govuk-main-wrapper" id="main-content">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <div class="govuk-error-summary" data-module="govuk-error-summary">
+                <div role="alert">
+                    <h2 class="govuk-error-summary__title"> There is a problem</h2>
+                    <div class="govuk-error-summary__body">
+                        <ul class="govuk-list govuk-error-summary__list">
+                            <li><a href="#invalid-reason">Select why the appeal is invalid</a>
+                            </li>
+                        </ul>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Appeal 351062 - mark as invalid</span>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
+            <form action="" method="POST" novalidate>
+                <div class="govuk-form-group govuk-form-group--error">
+                    <fieldset class="govuk-fieldset" aria-describedby="invalid-reason-error">
+                        <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+                            <h1 class="govuk-fieldset__heading"> Why is the appeal invalid?</h1>
+                        </legend>
+                        <p id="invalid-reason-error" class="govuk-error-message"><span class="govuk-visually-hidden">Error:</span> Select why the appeal
+                            is invalid</p>
+                        <div class="govuk-checkboxes" data-module="govuk-checkboxes">
+                            <div class="govuk-checkboxes__item">
+                                <input class="govuk-checkboxes__input" id="invalid-reason" name="invalidReason"
+                                type="checkbox" value="21">
+                                <label class="govuk-label govuk-checkboxes__label" for="invalid-reason">Appeal has not been submitted on time</label>
+                            </div>
+                            <div class="govuk-checkboxes__item">
+                                <input class="govuk-checkboxes__input" id="invalid-reason-2" name="invalidReason"
+                                type="checkbox" value="22" data-aria-controls="conditional-invalid-reason-2">
+                                <label class="govuk-label govuk-checkboxes__label" for="invalid-reason-2">Documents have not been submitted on time</label>
+                            </div>
+                            <div class="govuk-checkboxes__conditional govuk-checkboxes__conditional--hidden"
+                            id="conditional-invalid-reason-2">
+                                <div class="pins-add-another" aria-live="polite" data-max-item-count="10">
+                                    <div class="pins-add-another__item govuk-!-margin-top-6">
+                                        <div class="govuk-grid-row">
+                                            <div class="govuk-grid-column-full flex-row space-between">
+                                                <label for="invalid-reason-22-1" class="govuk-label govuk-!-margin-bottom-4">Enter a reason</label>
+                                                <div class="pins-add-another__remove-button-container"></div>
+                                            </div>
+                                        </div>
+                                        <div class="govuk-grid-row">
+                                            <div class="govuk-grid-column-full">
+                                                <div class="govuk-form-group">
+                                                    <input class="govuk-input pins-add-another__item-input govuk-!-margin-0"
+                                                    id="invalid-reason-22-1" name="invalidReason-22" type="text" value="">
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                    <button type="button" class="govuk-button pins-add-another__add-button govuk-button--secondary govuk-!-margin-top-4 govuk-!-margin-bottom-0"
+                                    data-module="govuk-button">Add another</button>
+                                </div>
+                            </div>
+                            <div class="govuk-checkboxes__item">
+                                <input class="govuk-checkboxes__input" id="invalid-reason-3" name="invalidReason"
+                                type="checkbox" value="23">
+                                <label class="govuk-label govuk-checkboxes__label" for="invalid-reason-3">The appellant does not have the right to appeal</label>
+                            </div>
+                            <div class="govuk-checkboxes__item">
+                                <input class="govuk-checkboxes__input" id="invalid-reason-4" name="invalidReason"
+                                type="checkbox" value="24" data-aria-controls="conditional-invalid-reason-4">
+                                <label class="govuk-label govuk-checkboxes__label" for="invalid-reason-4">Other reason</label>
+                            </div>
+                            <div class="govuk-checkboxes__conditional govuk-checkboxes__conditional--hidden"
+                            id="conditional-invalid-reason-4">
+                                <div class="pins-add-another" aria-live="polite" data-max-item-count="10">
+                                    <div class="pins-add-another__item govuk-!-margin-top-6">
+                                        <div class="govuk-grid-row">
+                                            <div class="govuk-grid-column-full flex-row space-between">
+                                                <label for="invalid-reason-24-1" class="govuk-label govuk-!-margin-bottom-4">Enter a reason</label>
+                                                <div class="pins-add-another__remove-button-container"></div>
+                                            </div>
+                                        </div>
+                                        <div class="govuk-grid-row">
+                                            <div class="govuk-grid-column-full">
+                                                <div class="govuk-form-group">
+                                                    <input class="govuk-input pins-add-another__item-input govuk-!-margin-0"
+                                                    id="invalid-reason-24-1" name="invalidReason-24" type="text" value="">
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                    <button type="button" class="govuk-button pins-add-another__add-button govuk-button--secondary govuk-!-margin-top-4 govuk-!-margin-bottom-0"
+                                    data-module="govuk-button">Add another</button>
+                                </div>
+                            </div>
+                        </div>
+                    </fieldset>
+                </div>
+                <button type="submit" class="govuk-button" data-module="govuk-button">Continue</button>
+            </form>
+        </div>
+    </div>
+</main>"
+`;

--- a/appeals/web/src/server/appeals/appeal-details/invalid-appeal/__tests__/invalid-appeal.test.js
+++ b/appeals/web/src/server/appeals/appeal-details/invalid-appeal/__tests__/invalid-appeal.test.js
@@ -1,0 +1,261 @@
+import { parseHtml } from '@pins/platform';
+import supertest from 'supertest';
+import {
+	appealData,
+	appellantCaseDataNotValidated,
+	appellantCaseInvalidReasons
+} from '#testing/app/fixtures/referencedata.js';
+import { createTestEnvironment } from '#testing/index.js';
+import nock from 'nock';
+import { textInputCharacterLimits } from '#appeals/appeal.constants.js';
+
+const { app, installMockApi, teardown } = createTestEnvironment();
+const request = supertest(app);
+const appealId = appealData.appealId;
+const baseUrl = `/appeals-service/appeal-details/${appealId}`;
+
+const invalidReasonsWithoutText = appellantCaseInvalidReasons.filter(
+	(reason) => reason.hasText === false
+);
+const invalidReasonsWithText = appellantCaseInvalidReasons.filter(
+	(reason) => reason.hasText === true
+);
+
+const invalidReasonsWithoutTextIds = invalidReasonsWithoutText.map((reason) => reason.id);
+const invalidReasonsWithTextIds = invalidReasonsWithText.map((reason) => reason.id);
+
+describe('invalid-appeal', () => {
+	beforeEach(installMockApi);
+	afterEach(teardown);
+
+	describe('GET / , /new', () => {
+		beforeEach(() => {
+			nock('http://test/')
+				.get('/appeals/1/appellant-cases/0')
+				.reply(200, appellantCaseDataNotValidated);
+			nock('http://test/')
+				.get('/appeals/appellant-case-invalid-reasons')
+				.reply(200, appellantCaseInvalidReasons);
+		});
+
+		afterEach(() => {
+			nock.cleanAll();
+		});
+
+		it('should render the invalid reason page', async () => {
+			const response = await request.get(`${baseUrl}/invalid/new`);
+			const element = parseHtml(response.text);
+
+			expect(element.innerHTML).toMatchSnapshot();
+			expect(element.innerHTML).toContain('Why is the appeal invalid?</h1>');
+			expect(element.innerHTML).toContain('data-module="govuk-checkboxes">');
+			expect(element.innerHTML).toContain(
+				'for="invalid-reason">Appeal has not been submitted on time'
+			);
+			expect(element.innerHTML).toContain(
+				'for="invalid-reason-2">Documents have not been submitted on time'
+			);
+			expect(element.innerHTML).toContain(
+				'for="invalid-reason-3">The appellant does not have the right to appeal'
+			);
+			expect(element.innerHTML).toContain('for="invalid-reason-4">Other reason');
+			expect(element.innerHTML).toContain('Continue</button>');
+		});
+	});
+
+	describe('POST  / , /new', () => {
+		beforeEach(async () => {
+			nock('http://test/')
+				.get('/appeals/1/appellant-cases/0')
+				.reply(200, appellantCaseDataNotValidated);
+			nock('http://test/')
+				.get('/appeals/appellant-case-invalid-reasons')
+				.reply(200, appellantCaseInvalidReasons);
+		});
+
+		afterEach(() => {
+			nock.cleanAll();
+		});
+
+		it('should re-render the invalid reason page with the expected error message if no invalid reason was provided', async () => {
+			const response = await request.post(`${baseUrl}/invalid/new`).send({});
+
+			const element = parseHtml(response.text);
+			expect(element.innerHTML).toMatchSnapshot();
+
+			const unprettifiedErrorSummaryHtml = parseHtml(response.text, {
+				rootElement: '.govuk-error-summary',
+				skipPrettyPrint: true
+			}).innerHTML;
+			expect(unprettifiedErrorSummaryHtml).toContain('There is a problem</h2>');
+			expect(unprettifiedErrorSummaryHtml).toContain('Select why the appeal is invalid</a>');
+		});
+
+		it('should re-render the invalid reason page with the expected error message if a single invalid reason with text was provided but the matching text property is an empty string', async () => {
+			const response = await request.post(`${baseUrl}/invalid/new`).send({
+				invalidReason: invalidReasonsWithTextIds[0],
+				[`invalidReason-${invalidReasonsWithTextIds[0]}`]: ''
+			});
+
+			const element = parseHtml(response.text);
+			expect(element.innerHTML).toMatchSnapshot();
+
+			const unprettifiedErrorSummaryHtml = parseHtml(response.text, {
+				rootElement: '.govuk-error-summary',
+				skipPrettyPrint: true
+			}).innerHTML;
+			expect(unprettifiedErrorSummaryHtml).toContain('There is a problem</h2>');
+			expect(unprettifiedErrorSummaryHtml).toContain('Enter a reason</a>');
+		});
+
+		it('should re-render the invalid reason page with the expected error message if a single invalid reason with text was provided but the matching text property is an empty array', async () => {
+			const response = await request.post(`${baseUrl}/invalid/new`).send({
+				invalidReason: invalidReasonsWithTextIds[0],
+				[`invalidReason-${invalidReasonsWithTextIds[0]}`]: []
+			});
+
+			const element = parseHtml(response.text);
+			expect(element.innerHTML).toMatchSnapshot();
+
+			const unprettifiedErrorSummaryHtml = parseHtml(response.text, {
+				rootElement: '.govuk-error-summary',
+				skipPrettyPrint: true
+			}).innerHTML;
+			expect(unprettifiedErrorSummaryHtml).toContain('There is a problem</h2>');
+			expect(unprettifiedErrorSummaryHtml).toContain('Enter a reason</a>');
+		});
+
+		it('should re-render the invalid reason page with the expected error message if multiple invalid reasons with text were provided but any of the matching text properties are empty strings', async () => {
+			const response = await request.post(`${baseUrl}/invalid/new`).send({
+				invalidReason: [invalidReasonsWithTextIds[0], invalidReasonsWithTextIds[1]],
+				[`invalidReason-${invalidReasonsWithTextIds[0]}`]: 'test reason text 1',
+				[`invalidReason-${invalidReasonsWithTextIds[0]}`]: ''
+			});
+
+			const element = parseHtml(response.text);
+			expect(element.innerHTML).toMatchSnapshot();
+
+			const unprettifiedErrorSummaryHtml = parseHtml(response.text, {
+				rootElement: '.govuk-error-summary',
+				skipPrettyPrint: true
+			}).innerHTML;
+			expect(unprettifiedErrorSummaryHtml).toContain('There is a problem</h2>');
+			expect(unprettifiedErrorSummaryHtml).toContain('Enter a reason</a>');
+		});
+
+		it('should re-render the invalid reason page with the expected error message if multiple invalid reasons with text were provided but any of the matching text properties are empty arays', async () => {
+			const response = await request.post(`${baseUrl}/invalid/new`).send({
+				invalidReason: [invalidReasonsWithTextIds[0], invalidReasonsWithTextIds[1]],
+				[`invalidReason-${invalidReasonsWithTextIds[0]}`]: 'test reason text 1',
+				[`invalidReason-${invalidReasonsWithTextIds[0]}`]: []
+			});
+
+			const element = parseHtml(response.text);
+			expect(element.innerHTML).toMatchSnapshot();
+
+			const unprettifiedErrorSummaryHtml = parseHtml(response.text, {
+				rootElement: '.govuk-error-summary',
+				skipPrettyPrint: true
+			}).innerHTML;
+			expect(unprettifiedErrorSummaryHtml).toContain('There is a problem</h2>');
+			expect(unprettifiedErrorSummaryHtml).toContain('Enter a reason</a>');
+		});
+
+		it('should re-render the invalid reason page with the expected error message if a single invalid reason with text was provided but the matching text property exceeds the character limit', async () => {
+			const response = await request.post(`${baseUrl}/invalid/new`).send({
+				invalidReason: invalidReasonsWithTextIds[0],
+				[`invalidReason-${invalidReasonsWithTextIds[0]}`]: 'a'.repeat(
+					textInputCharacterLimits.checkboxTextItemsLength + 1
+				)
+			});
+
+			const element = parseHtml(response.text);
+			expect(element.innerHTML).toMatchSnapshot();
+
+			const unprettifiedErrorSummaryHtml = parseHtml(response.text, {
+				rootElement: '.govuk-error-summary',
+				skipPrettyPrint: true
+			}).innerHTML;
+			expect(unprettifiedErrorSummaryHtml).toContain('There is a problem</h2>');
+			expect(unprettifiedErrorSummaryHtml).toContain(
+				`Reason must be ${textInputCharacterLimits.checkboxTextItemsLength} characters or less</a>`
+			);
+		});
+
+		it('should re-render the invalid reason page with the expected error message if multiple invalid reasons with text were provided but any of the matching text properties exceed the character limit', async () => {
+			const response = await request.post(`${baseUrl}/invalid/new`).send({
+				invalidReason: [invalidReasonsWithTextIds[0], invalidReasonsWithTextIds[1]],
+				[`invalidReason-${invalidReasonsWithTextIds[0]}`]: 'test reason text 1',
+				[`invalidReason-${invalidReasonsWithTextIds[0]}`]: 'a'.repeat(
+					textInputCharacterLimits.checkboxTextItemsLength + 1
+				)
+			});
+
+			const element = parseHtml(response.text);
+			expect(element.innerHTML).toMatchSnapshot();
+
+			const unprettifiedErrorSummaryHtml = parseHtml(response.text, {
+				rootElement: '.govuk-error-summary',
+				skipPrettyPrint: true
+			}).innerHTML;
+			expect(unprettifiedErrorSummaryHtml).toContain('There is a problem</h2>');
+			expect(unprettifiedErrorSummaryHtml).toContain(
+				`Reason must be ${textInputCharacterLimits.checkboxTextItemsLength} characters or less</a>`
+			);
+		});
+
+		it('should redirect to the check and confirm page if a single invalid reason without text was provided', async () => {
+			const response = await request.post(`${baseUrl}/invalid/new`).send({
+				invalidReason: invalidReasonsWithoutTextIds[0]
+			});
+
+			expect(response.statusCode).toBe(302);
+			expect(response.text).toBe(
+				'Found. Redirecting to /appeals-service/appeal-details/1/invalid/check'
+			);
+		});
+
+		it('should redirect to the CYA page if a single invalid reason with text within the character limit was provided', async () => {
+			const response = await request.post(`${baseUrl}/invalid/new`).send({
+				invalidReason: invalidReasonsWithTextIds[0],
+				[`invalidReason-${invalidReasonsWithTextIds[0]}`]: [
+					'a'.repeat(textInputCharacterLimits.checkboxTextItemsLength)
+				]
+			});
+
+			expect(response.statusCode).toBe(302);
+			expect(response.text).toBe(
+				'Found. Redirecting to /appeals-service/appeal-details/1/invalid/check'
+			);
+		});
+
+		it('should redirect to the check and confirm page if multiple invalid reasons without text were provided', async () => {
+			const response = await request.post(`${baseUrl}/invalid/new`).send({
+				invalidReason: invalidReasonsWithoutTextIds
+			});
+
+			expect(response.statusCode).toBe(302);
+			expect(response.text).toBe(
+				'Found. Redirecting to /appeals-service/appeal-details/1/invalid/check'
+			);
+		});
+
+		it('should redirect to the check and confirm page if multiple invalid reasons with text within the character limit were provided', async () => {
+			const response = await request.post(`${baseUrl}/invalid/new`).send({
+				invalidReason: [invalidReasonsWithTextIds[0], invalidReasonsWithTextIds[1]],
+				[`invalidReason-${invalidReasonsWithTextIds[0]}`]: [
+					'a'.repeat(textInputCharacterLimits.checkboxTextItemsLength)
+				],
+				[`invalidReason-${invalidReasonsWithTextIds[1]}`]: [
+					'a'.repeat(textInputCharacterLimits.checkboxTextItemsLength),
+					'a'.repeat(textInputCharacterLimits.checkboxTextItemsLength)
+				]
+			});
+
+			expect(response.statusCode).toBe(302);
+			expect(response.text).toBe(
+				'Found. Redirecting to /appeals-service/appeal-details/1/invalid/check'
+			);
+		});
+	});
+});

--- a/appeals/web/src/server/appeals/appeal-details/invalid-appeal/invalid-appeal.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/invalid-appeal/invalid-appeal.mapper.js
@@ -43,21 +43,25 @@ export function decisionInvalidConfirmationPage(appealId, appealReference) {
  * @param {string} appealReference
  * @param {import('#appeals/appeals.types.js').CheckboxItemParameter[]} mappedInvalidReasonOptions
  * @param {string | undefined} errorMessage
+ * @param {boolean} sourceIsAppellantCase
  * @returns {PageContent}
  */
 export const mapInvalidReasonPage = (
 	appealId,
 	appealReference,
 	mappedInvalidReasonOptions,
-	errorMessage = undefined
+	errorMessage = undefined,
+	sourceIsAppellantCase
 ) => {
 	const shortAppealReference = appealShortReference(appealReference);
 
 	/** @type {PageContent} */
 	const pageContent = {
 		title: `Why is the appeal invalid?`,
-		backLinkUrl: `/appeals-service/appeal-details/${appealId}/appellant-case`,
-		preHeading: `Appeal ${shortAppealReference}`,
+		backLinkUrl: `/appeals-service/appeal-details/${appealId}/${
+			sourceIsAppellantCase ? 'appellant-case' : ''
+		}`,
+		preHeading: `Appeal ${shortAppealReference} - mark as invalid`,
 		pageComponents: [
 			{
 				type: 'checkboxes',
@@ -86,7 +90,7 @@ export const mapInvalidReasonPage = (
 				option,
 				'invalidReason-',
 				'invalid-reason-',
-				'Which part is incorrect or incomplete?'
+				'Enter a reason'
 			)
 		);
 	return pageContent;

--- a/appeals/web/src/server/appeals/appeal-details/invalid-appeal/invalid-appeal.router.js
+++ b/appeals/web/src/server/appeals/appeal-details/invalid-appeal/invalid-appeal.router.js
@@ -1,11 +1,11 @@
 import { Router as createRouter } from 'express';
-import * as controller from './outcome-invalid.controller.js';
-import * as validators from './outcome-invalid.validators.js';
+import * as controller from './invalid-appeal.controller.js';
+import * as validators from './invalid-appeal.validators.js';
 
 const router = createRouter({ mergeParams: true });
 
 router
-	.route('/')
+	.route(['/', '/new'])
 	.get(controller.getInvalidReason)
 	.post(
 		validators.validateInvalidReason,

--- a/appeals/web/src/server/appeals/appeal-details/invalid-appeal/invalid-appeal.validators.js
+++ b/appeals/web/src/server/appeals/appeal-details/invalid-appeal/invalid-appeal.validators.js
@@ -1,6 +1,7 @@
 import { createValidator } from '@pins/express';
 import { body } from 'express-validator';
 import { createCheckboxTextItemsValidator } from '#lib/validators/checkbox-text-items.validator.js';
+import { LENGTH_1000 } from '@pins/appeals/constants/support.js';
 
 export const validateInvalidReason = createValidator(
 	body('invalidReason')
@@ -9,6 +10,9 @@ export const validateInvalidReason = createValidator(
 		.bail()
 		.notEmpty()
 		.withMessage('Select why the appeal is invalid')
+		.bail()
+		.isLength({ max: LENGTH_1000 })
+		.withMessage(`Reason must be ${LENGTH_1000} characters or less`)
 );
 
 export const validateInvalidReasonTextItems = createCheckboxTextItemsValidator('invalidReason');

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/__tests__/__snapshots__/lpa-questionnaire.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/__tests__/__snapshots__/lpa-questionnaire.test.js.snap
@@ -4745,7 +4745,7 @@ exports[`LPA Questionnaire review POST /appeals-service/appeal-details/1/lpa-que
                     <h2 class="govuk-error-summary__title"> There is a problem</h2>
                     <div class="govuk-error-summary__body">
                         <ul class="govuk-list govuk-error-summary__list">
-                            <li><a href="#incomplete-reason-1-1">Text in text fields cannot exceed 1000 characters</a>
+                            <li><a href="#incomplete-reason-1-1">Reason must be 1000 characters or less</a>
                             </li>
                         </ul>
                     </div>
@@ -5628,7 +5628,7 @@ exports[`LPA Questionnaire review POST /appeals-service/appeal-details/1/lpa-que
                     <h2 class="govuk-error-summary__title"> There is a problem</h2>
                     <div class="govuk-error-summary__body">
                         <ul class="govuk-list govuk-error-summary__list">
-                            <li><a href="#incomplete-reason-2-1">Text in text fields cannot exceed 1000 characters</a>
+                            <li><a href="#incomplete-reason-2-1">Reason must be 1000 characters or less</a>
                             </li>
                         </ul>
                     </div>

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/__tests__/lpa-questionnaire.test.js
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/__tests__/lpa-questionnaire.test.js
@@ -1533,7 +1533,7 @@ describe('LPA Questionnaire review', () => {
 
 			expect(errorSummaryHtml).toContain('There is a problem</h2>');
 			expect(errorSummaryHtml).toContain(
-				`Text in text fields cannot exceed ${textInputCharacterLimits.checkboxTextItemsLength} characters</a>`
+				`>Reason must be ${textInputCharacterLimits.checkboxTextItemsLength} characters or less</a>`
 			);
 		});
 
@@ -1557,7 +1557,7 @@ describe('LPA Questionnaire review', () => {
 
 			expect(errorSummaryHtml).toContain('There is a problem</h2>');
 			expect(errorSummaryHtml).toContain(
-				`Text in text fields cannot exceed ${textInputCharacterLimits.checkboxTextItemsLength} characters</a>`
+				`>Reason must be ${textInputCharacterLimits.checkboxTextItemsLength} characters or less</a>`
 			);
 		});
 

--- a/appeals/web/src/server/lib/__tests__/libraries.test.js
+++ b/appeals/web/src/server/lib/__tests__/libraries.test.js
@@ -507,12 +507,12 @@ describe('Libraries', () => {
 					},
 					{
 						value: '23',
-						text: "The appellant doesn't have the right to appeal",
+						text: 'The appellant does not have the right to appeal',
 						checked: false
 					},
 					{
 						value: '24',
-						text: 'Other',
+						text: 'Other reason',
 						checked: false,
 						addAnother: { textItems: [''] }
 					}
@@ -545,12 +545,12 @@ describe('Libraries', () => {
 					},
 					{
 						value: '23',
-						text: "The appellant doesn't have the right to appeal",
+						text: 'The appellant does not have the right to appeal',
 						checked: false
 					},
 					{
 						value: '24',
-						text: 'Other',
+						text: 'Other reason',
 						checked: false,
 						addAnother: { textItems: [''] }
 					}
@@ -576,7 +576,7 @@ describe('Libraries', () => {
 					},
 					{
 						value: '23',
-						text: "The appellant doesn't have the right to appeal",
+						text: 'The appellant does not have the right to appeal',
 						checked: false
 					}
 				];
@@ -601,7 +601,7 @@ describe('Libraries', () => {
 					},
 					{
 						value: '23',
-						text: "The appellant doesn't have the right to appeal",
+						text: 'The appellant does not have the right to appeal',
 						checked: true
 					}
 				];
@@ -656,12 +656,12 @@ describe('Libraries', () => {
 					},
 					{
 						value: '23',
-						text: "The appellant doesn't have the right to appeal",
+						text: 'The appellant does not have the right to appeal',
 						checked: true
 					},
 					{
 						value: '24',
-						text: 'Other',
+						text: 'Other reason',
 						checked: false,
 						addAnother: { textItems: [''] }
 					}
@@ -708,12 +708,12 @@ describe('Libraries', () => {
 					},
 					{
 						value: '23',
-						text: "The appellant doesn't have the right to appeal",
+						text: 'The appellant does not have the right to appeal',
 						checked: true
 					},
 					{
 						value: '24',
-						text: 'Other',
+						text: 'Other reason',
 						checked: false,
 						addAnother: { textItems: [''] }
 					}
@@ -756,12 +756,12 @@ describe('Libraries', () => {
 					},
 					{
 						value: '23',
-						text: "The appellant doesn't have the right to appeal",
+						text: 'The appellant does not have the right to appeal',
 						checked: true
 					},
 					{
 						value: '24',
-						text: 'Other',
+						text: 'Other reason',
 						checked: false,
 						addAnother: { textItems: [''] }
 					}
@@ -821,12 +821,12 @@ describe('Libraries', () => {
 					},
 					{
 						value: '23',
-						text: "The appellant doesn't have the right to appeal",
+						text: 'The appellant does not have the right to appeal',
 						checked: true
 					},
 					{
 						value: '24',
-						text: 'Other',
+						text: 'Other reason',
 						checked: false,
 						addAnother: { textItems: [''] }
 					}
@@ -890,12 +890,12 @@ describe('Libraries', () => {
 					},
 					{
 						value: '23',
-						text: "The appellant doesn't have the right to appeal",
+						text: 'The appellant does not have the right to appeal',
 						checked: true
 					},
 					{
 						value: '24',
-						text: 'Other',
+						text: 'Other reason',
 						checked: false,
 						addAnother: { textItems: [''] }
 					}
@@ -930,7 +930,7 @@ describe('Libraries', () => {
 				);
 
 				expect(result).toEqual(
-					'<ul class="govuk-list govuk-!-margin-top-0 govuk-!-margin-bottom-0 govuk-list--bullet"><li>Documents have not been submitted on time</li><li>The appellant doesn\'t have the right to appeal</li></ul>'
+					'<ul class="govuk-list govuk-!-margin-top-0 govuk-!-margin-bottom-0 govuk-list--bullet"><li>Documents have not been submitted on time</li><li>The appellant does not have the right to appeal</li></ul>'
 				);
 			});
 
@@ -938,7 +938,7 @@ describe('Libraries', () => {
 				const result = mapReasonsToReasonsListHtml(appellantCaseInvalidReasons, ['22', '23'], {});
 
 				expect(result).toEqual(
-					'<ul class="govuk-list govuk-!-margin-top-0 govuk-!-margin-bottom-0 govuk-list--bullet"><li>Documents have not been submitted on time</li><li>The appellant doesn\'t have the right to appeal</li></ul>'
+					'<ul class="govuk-list govuk-!-margin-top-0 govuk-!-margin-bottom-0 govuk-list--bullet"><li>Documents have not been submitted on time</li><li>The appellant does not have the right to appeal</li></ul>'
 				);
 			});
 
@@ -948,7 +948,7 @@ describe('Libraries', () => {
 				});
 
 				expect(result).toEqual(
-					'<ul class="govuk-list govuk-!-margin-top-0 govuk-!-margin-bottom-0 govuk-list--bullet"><li>Documents have not been submitted on time: test reason text 1</li><li>Documents have not been submitted on time: test reason text 2</li><li>The appellant doesn\'t have the right to appeal</li></ul>'
+					'<ul class="govuk-list govuk-!-margin-top-0 govuk-!-margin-bottom-0 govuk-list--bullet"><li>Documents have not been submitted on time: test reason text 1</li><li>Documents have not been submitted on time: test reason text 2</li><li>The appellant does not have the right to appeal</li></ul>'
 				);
 			});
 		});

--- a/appeals/web/src/server/lib/validators/checkbox-text-items.validator.js
+++ b/appeals/web/src/server/lib/validators/checkbox-text-items.validator.js
@@ -60,7 +60,12 @@ const textItemCustomValidator = (textItem) => {
 	}
 	if (textItem.length > textInputCharacterLimits.checkboxTextItemsLength) {
 		throw new Error(
-			`Text in text fields cannot exceed ${textInputCharacterLimits.checkboxTextItemsLength} characters`
+			`Reason must be ${textInputCharacterLimits.checkboxTextItemsLength} characters or less`
+		);
+	}
+	if (!textItem.match(/^[A-Za-z0-9 .,'!&-]+$/)) {
+		throw new Error(
+			'Reason must only include letters a to z, numbers 0 to 9, and special characters such as hyphens, spaces and apostrophes'
 		);
 	}
 	return true;

--- a/appeals/web/testing/app/fixtures/referencedata.js
+++ b/appeals/web/testing/app/fixtures/referencedata.js
@@ -1467,12 +1467,12 @@ export const appellantCaseInvalidReasons = [
 	},
 	{
 		id: 23,
-		name: "The appellant doesn't have the right to appeal",
+		name: 'The appellant does not have the right to appeal',
 		hasText: false
 	},
 	{
 		id: 24,
-		name: 'Other',
+		name: 'Other reason',
 		hasText: true
 	}
 ];


### PR DESCRIPTION
## Describe your changes

### Web
- Moved & renamed the existing outcome-invalid directory to make it common and used for both appeal-details in cancel flow and within appellant case (with different routes).
- Made copy updates by updating seed data for invalid reasons table
- Updated the error message for entering a reason characters exceeded
- Added new regex validator to add another components

### Test
- Tested feature inside the browser 
- Tested feature with feature flag OFF
- Tested that all features for appellant-case entry point and journey still

<!--
    Please include a summary of the change along with any relevant context.
    List any dependencies that are required for this change.
-->

## Issue ticket number and link

[Ticket](https://pins-ds.atlassian.net/browse/A2-3841)
