### PR TITLE
fix(web): updating mapStatusTag to display awaiting site visit for s20 appeals (A2-4102)

### DIFF
--- a/appeals/web/src/server/lib/__tests__/libraries.test.js
+++ b/appeals/web/src/server/lib/__tests__/libraries.test.js
@@ -1775,9 +1775,24 @@ describe('appeal-status', () => {
 			);
 		});
 
+		it(`should return 'site_visit_ready_to_set_up' if appealStatus is 'event' appeal type is S20 and appealProcedureType is undefined`, () => {
+			expect(
+				mapStatusText(APPEAL_CASE_STATUS.EVENT, APPEAL_TYPE.PLANNED_LISTED_BUILDING, undefined)
+			).toBe('site_visit_ready_to_set_up');
+		});
+
 		it(`should return 'site_visit_ready_to_set_up' if appealStatus is 'event' and appealProcedureType is 'written'`, () => {
 			expect(
 				mapStatusText(APPEAL_CASE_STATUS.EVENT, APPEAL_TYPE.S78, APPEAL_CASE_PROCEDURE.WRITTEN)
+			).toBe('site_visit_ready_to_set_up');
+		});
+		it(`should return 'site_visit_ready_to_set_up' if appealStatus is 'event', appeal type is S20 and appealProcedureType is 'written'`, () => {
+			expect(
+				mapStatusText(
+					APPEAL_CASE_STATUS.EVENT,
+					APPEAL_TYPE.PLANNED_LISTED_BUILDING,
+					APPEAL_CASE_PROCEDURE.WRITTEN
+				)
 			).toBe('site_visit_ready_to_set_up');
 		});
 
@@ -1799,11 +1814,30 @@ describe('appeal-status', () => {
 			);
 		});
 
+		it(`should return 'awaiting_site_visit' if appealStatus is 'awaiting_event, event type is S20and appealProcedureType is undefined`, () => {
+			expect(
+				mapStatusText(
+					APPEAL_CASE_STATUS.AWAITING_EVENT,
+					APPEAL_TYPE.PLANNED_LISTED_BUILDING,
+					undefined
+				)
+			).toBe('awaiting_site_visit');
+		});
+
 		it(`should return 'awaiting_site_visit' if appealStatus is 'awaiting_event' and appealProcedureType is 'written'`, () => {
 			expect(
 				mapStatusText(
 					APPEAL_CASE_STATUS.AWAITING_EVENT,
 					APPEAL_TYPE.S78,
+					APPEAL_CASE_PROCEDURE.WRITTEN
+				)
+			).toBe('awaiting_site_visit');
+		});
+		it(`should return 'awaiting_site_visit' if appealStatus is 'awaiting_event', appeal type is S20 and appealProcedureType is 'written'`, () => {
+			expect(
+				mapStatusText(
+					APPEAL_CASE_STATUS.AWAITING_EVENT,
+					APPEAL_TYPE.PLANNED_LISTED_BUILDING,
 					APPEAL_CASE_PROCEDURE.WRITTEN
 				)
 			).toBe('awaiting_site_visit');

--- a/appeals/web/src/server/lib/appeal-status.js
+++ b/appeals/web/src/server/lib/appeal-status.js
@@ -10,7 +10,11 @@ import { capitalizeFirstLetter } from '#lib/string-utilities.js';
  * @returns {string}
  * */
 export function mapStatusText(appealStatus, appealType, appealProcedureType) {
-	if (![APPEAL_TYPE.HOUSEHOLDER, APPEAL_TYPE.S78].includes(appealType)) {
+	if (
+		![APPEAL_TYPE.HOUSEHOLDER, APPEAL_TYPE.S78, APPEAL_TYPE.PLANNED_LISTED_BUILDING].includes(
+			appealType
+		)
+	) {
 		return appealStatus;
 	}
 
@@ -66,9 +70,7 @@ export function mapStatusFilterLabel(appealStatus) {
 		appealStatus
 			.replace('issue_determination', 'issue_decision')
 			.replace('lpa_', 'LPA_')
-			.replace('awaiting_event', 'awaiting_EVENT')
-			.replace('event', 'EVENT_ready_to_set_up')
-			.replace('EVENT', 'event')
+			.replace(/^event$/, 'event_ready_to_set_up')
 			.replaceAll('_', ' ')
 	);
 }


### PR DESCRIPTION
## Describe your changes

### WEB

- updated status tag mapper so that 'Site visit is ready to set up ' and 'Awaiting site visit' is displayed when status is 'Event' and 'Awaiting event' respectively

### TEST

- manually tested within browser
- added new unit tests 

## Issue ticket number and link

[Ticket](https://pins-ds.atlassian.net.mcas.ms/browse/A2-4102
