### PR TITLE
feat(A2-3647): adding docs reader role assignment to read_only user group 

### DIFF
--- a/infrastructure/document-storage.tf
+++ b/infrastructure/document-storage.tf
@@ -130,3 +130,9 @@ resource "azurerm_role_assignment" "api_document_validation" {
   role_definition_name = "Storage Blob Data Reader"
   principal_id         = module.app_api.principal_id
 }
+
+resource "azurerm_role_assignment" "read_only_documents_access" {
+  scope                = azurerm_storage_container.appeal_documents.resource_manager_id
+  role_definition_name = "Storage Blob Data Reader"
+  principal_id         = var.apps_config.auth.group_ids.read_only
+}


### PR DESCRIPTION
## Describe your changes
- Should allow read only users to view and download documents that we store in blob storage
<!--
    Please include a summary of the change along with any relevant context.
    List any dependencies that are required for this change.
-->

## Issue ticket number and link

[Ticket](https://pins-ds.atlassian.net/browse/A2-3647)
