### PR TITLE
fix(api): roll back status transitions properly

### DIFF
--- a/appeals/api/setup-tests.js
+++ b/appeals/api/setup-tests.js
@@ -22,6 +22,9 @@ const mocklPAQuestionnaireUpdate = jest.fn().mockResolvedValue({});
 const mockAppealStatusFindMany = jest.fn().mockResolvedValue([]);
 const mockAppealStatusUpdateMany = jest.fn().mockResolvedValue({});
 const mockAppealStatusCreate = jest.fn().mockResolvedValue({});
+const mockAppealStatusFindFirst = jest.fn().mockResolvedValue({});
+const mockAppealStatusDeleteMany = jest.fn().mockResolvedValue({});
+const mockAppealStatusUpdate = jest.fn().mockResolvedValue({});
 const mockAppealUpdate = jest.fn().mockResolvedValue({});
 const mockAppealStatusCreateMany = jest.fn().mockResolvedValue({});
 const mockAppealFindMany = jest.fn().mockResolvedValue({});
@@ -209,7 +212,10 @@ class MockPrismaClient {
 			updateMany: mockAppealStatusUpdateMany,
 			create: mockAppealStatusCreate,
 			createMany: mockAppealStatusCreateMany,
-			findMany: mockAppealStatusFindMany
+			findMany: mockAppealStatusFindMany,
+			findFirst: mockAppealStatusFindFirst,
+			deleteMany: mockAppealStatusDeleteMany,
+			update: mockAppealStatusUpdate
 		};
 	}
 

--- a/appeals/api/src/server/endpoints/hearings/__tests__/hearing.test.js
+++ b/appeals/api/src/server/endpoints/hearings/__tests__/hearing.test.js
@@ -387,6 +387,13 @@ describe('hearing routes', () => {
 					]
 				});
 				databaseConnector.hearing.update.mockResolvedValue({ ...hearing, address: null });
+				databaseConnector.appealStatus.findFirst.mockResolvedValue({
+					id: 592,
+					appealId: fullPlanningAppeal.id,
+					status: APPEAL_CASE_STATUS.EVENT,
+					valid: false,
+					createdAt: new Date('2999-01-01T12:00:00.000Z')
+				});
 
 				const response = await request
 					.patch(`/appeals/${fullPlanningAppeal.id}/hearing/${hearing.id}`)
@@ -414,13 +421,16 @@ describe('hearing routes', () => {
 					}
 				});
 
-				expect(databaseConnector.appealStatus.create).toHaveBeenCalledWith({
-					data: {
-						appealId: fullPlanningAppeal.id,
-						createdAt: expect.any(Date),
-						status: 'event',
-						valid: true
+				expect(databaseConnector.appealStatus.deleteMany).toHaveBeenCalledWith({
+					where: {
+						createdAt: {
+							gt: new Date('2999-01-01T12:00:00.000Z')
+						}
 					}
+				});
+				expect(databaseConnector.appealStatus.update).toHaveBeenCalledWith({
+					where: { id: 592 },
+					data: { valid: true }
 				});
 
 				expect(mockNotifySend).not.toHaveBeenCalled();

--- a/appeals/api/src/server/mappers/mapper-factory.js
+++ b/appeals/api/src/server/mappers/mapper-factory.js
@@ -17,7 +17,7 @@ import mergeMaps from '#utils/merge-maps.js';
 /** @typedef {import('@planning-inspectorate/data-model').Schemas.AppealS78Case} AppealS78Case */
 /** @typedef {AppealDTO|AppellantCaseDto|LpaQuestionnaireDTO|AppealHASCase|AppealS78Case} MapResult */
 /** @typedef {import('@pins/appeals.api').Api.Folder} Folder */
-/** @typedef {{ appeal: Appeal, appealTypes?: AppealType[]|undefined, linkedAppeals?: *[]|undefined, context: keyof contextEnum|undefined }} MappingRequest */
+/** @typedef {{ appeal: Appeal, appealTypes?: AppealType[]|undefined, linkedAppeals?: *[]|undefined, context?: keyof contextEnum }} MappingRequest */
 
 /**
  *

--- a/appeals/api/src/server/repositories/appeal-status.repository.js
+++ b/appeals/api/src/server/repositories/appeal-status.repository.js
@@ -21,4 +21,33 @@ const updateAppealStatusByAppealId = (appealId, status) =>
 		})
 	]);
 
-export default { updateAppealStatusByAppealId };
+/**
+ * @param {number} appealId
+ * @param {string} status
+ * @returns {Promise<object>}
+ */
+const rollBackAppealStatusTo = (appealId, status) =>
+	databaseConnector.$transaction(async (tx) => {
+		const prevStatus = await tx.appealStatus.findFirst({
+			where: { appealId, status }
+		});
+
+		if (!prevStatus) {
+			throw new Error(`Appeal status ${status} not found for appeal ${appealId}`);
+		}
+
+		await tx.appealStatus.deleteMany({
+			where: {
+				createdAt: {
+					gt: prevStatus.createdAt
+				}
+			}
+		});
+
+		return await tx.appealStatus.update({
+			where: { id: prevStatus.id },
+			data: { valid: true }
+		});
+	});
+
+export default { updateAppealStatusByAppealId, rollBackAppealStatusTo };


### PR DESCRIPTION
## Describe your changes

We need to keep a linear history of appeal status transitions. There are some situations where an appeal might have to transition back to a state that it has had previously. In this case we need to find that old status, set it to valid, and delete any ones that were created after that.

## Issue ticket number and link

[A2-4126](https://pins-ds.atlassian.net/browse/A2-4126)


[A2-4126]: https://pins-ds.atlassian.net/browse/A2-4126?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ