### PR TITLE
fix(api): remove hyperlinks from notify templates

### DIFF
--- a/appeals/api/src/server/notify/templates/__tests__/notify-appellant-costs-decision-appellant.test.js
+++ b/appeals/api/src/server/notify/templates/__tests__/notify-appellant-costs-decision-appellant.test.js
@@ -38,7 +38,7 @@ describe('appellant-costs-decision-appellant.md', () => {
 			'We welcome your feedback on our appeals service. Tell us on this short [feedback form](https://mcas-proxyweb.mcas.ms/certificate-checker?login=false&originalUrl=https%3A%2F%2Fforms.office.com.mcas.ms%2Fpages%2Fresponsepage.aspx%3Fid%3DmN94WIhvq0iTIpmM5VcIjfMZj__F6D9LmMUUyoUrZDZUOERYMEFBN0NCOFdNU1BGWEhHUFQxWVhUUy4u%26McasTsid%3D20596&McasCSRF=06374e6dbbae2e7c7f24c4fc332cd4cbc0b467358e647ded92d4f539754b8ff7).',
 			'',
 			'The Planning Inspectorate  ',
-			'[enquiries@planninginspectorate.gov.uk](mailto:enquiries@planninginspectorate.gov.uk)'
+			'enquiries@planninginspectorate.gov.uk'
 		].join('\n');
 
 		await notifySend(notifySendData);

--- a/appeals/api/src/server/notify/templates/__tests__/notify-appellant-costs-decision-lpa.test.js
+++ b/appeals/api/src/server/notify/templates/__tests__/notify-appellant-costs-decision-lpa.test.js
@@ -38,7 +38,7 @@ describe('appellant-costs-decision-lpa.md', () => {
 			'We welcome your feedback on our appeals service. Tell us on this short [feedback form](https://mcas-proxyweb.mcas.ms/certificate-checker?login=false&originalUrl=https%3A%2F%2Fforms.office.com.mcas.ms%2Fpages%2Fresponsepage.aspx%3Fid%3DmN94WIhvq0iTIpmM5VcIjfMZj__F6D9LmMUUyoUrZDZUOERYMEFBN0NCOFdNU1BGWEhHUFQxWVhUUy4u%26McasTsid%3D20596&McasCSRF=06374e6dbbae2e7c7f24c4fc332cd4cbc0b467358e647ded92d4f539754b8ff7).',
 			'',
 			'The Planning Inspectorate  ',
-			'[enquiries@planninginspectorate.gov.uk](mailto:enquiries@planninginspectorate.gov.uk)'
+			'enquiries@planninginspectorate.gov.uk'
 		].join('\n');
 
 		await notifySend(notifySendData);

--- a/appeals/api/src/server/notify/templates/__tests__/notify-decision-is-allowed-split-dismissed-lpa.test.js
+++ b/appeals/api/src/server/notify/templates/__tests__/notify-decision-is-allowed-split-dismissed-lpa.test.js
@@ -44,7 +44,7 @@ describe('decision-is-allowed-split-dismissed-lpa.md', () => {
 			'We welcome your feedback on our appeals service. Tell us on this short [feedback form](https://forms.office.com/pages/responsepage.aspx?id=mN94WIhvq0iTIpmM5VcIjfMZj__F6D9LmMUUyoUrZDZUOERYMEFBN0NCOFdNU1BGWEhHUFQxWVhUUy4u).',
 			'',
 			'The Planning Inspectorate',
-			'[enquiries@planninginspectorate.gov.uk](mailto:enquiries@planninginspectorate.gov.uk)'
+			'enquiries@planninginspectorate.gov.uk'
 		].join('\n');
 
 		await notifySend(notifySendData);

--- a/appeals/api/src/server/notify/templates/__tests__/notify-ip-comment-rejected-deadline-extended.test.js
+++ b/appeals/api/src/server/notify/templates/__tests__/notify-ip-comment-rejected-deadline-extended.test.js
@@ -47,7 +47,7 @@ describe('ip-comment-rejected-deadline-extended.md', () => {
 			'You can [submit a different comment](/mock-front-office-url/comment-planning-appeal/enter-appeal-reference) by 01 January 2021.',
 			'',
 			'The Planning Inspectorate',
-			'[enquiries@planninginspectorate.gov.uk](mailto:enquiries@planninginspectorate.gov.uk)'
+			'enquiries@planninginspectorate.gov.uk'
 		].join('\n');
 
 		await notifySend(notifySendData);
@@ -92,10 +92,10 @@ describe('ip-comment-rejected-deadline-extended.md', () => {
 			'',
 			'# What happens next',
 			'',
-			'You can send a different comment to [caseofficers@planninginspectorate.gov.uk](mailto:caseofficers@planninginspectorate.gov.uk) by 01 January 2021.',
+			'You can send a different comment to caseofficers@planninginspectorate.gov.uk by 01 January 2021.',
 			'',
 			'The Planning Inspectorate',
-			'[enquiries@planninginspectorate.gov.uk](mailto:enquiries@planninginspectorate.gov.uk)'
+			'enquiries@planninginspectorate.gov.uk'
 		].join('\n');
 
 		await notifySend(notifySendData);

--- a/appeals/api/src/server/notify/templates/__tests__/notify-lpa-costs-decision-appellant.test.js
+++ b/appeals/api/src/server/notify/templates/__tests__/notify-lpa-costs-decision-appellant.test.js
@@ -38,7 +38,7 @@ describe('lpa-costs-decision-lpa.md', () => {
 			'We welcome your feedback on our appeals service. Tell us on this short [feedback form](https://mcas-proxyweb.mcas.ms/certificate-checker?login=false&originalUrl=https%3A%2F%2Fforms.office.com.mcas.ms%2Fpages%2Fresponsepage.aspx%3Fid%3DmN94WIhvq0iTIpmM5VcIjfMZj__F6D9LmMUUyoUrZDZUOERYMEFBN0NCOFdNU1BGWEhHUFQxWVhUUy4u%26McasTsid%3D20596&McasCSRF=06374e6dbbae2e7c7f24c4fc332cd4cbc0b467358e647ded92d4f539754b8ff7).',
 			'',
 			'The Planning Inspectorate  ',
-			'[enquiries@planninginspectorate.gov.uk](mailto:enquiries@planninginspectorate.gov.uk)'
+			'enquiries@planninginspectorate.gov.uk'
 		].join('\n');
 
 		await notifySend(notifySendData);

--- a/appeals/api/src/server/notify/templates/__tests__/notify-lpa-costs-decision-lpa.test.js
+++ b/appeals/api/src/server/notify/templates/__tests__/notify-lpa-costs-decision-lpa.test.js
@@ -38,7 +38,7 @@ describe('lpa-costs-decision-appellant.md', () => {
 			'We welcome your feedback on our appeals service. Tell us on this short [feedback form](https://mcas-proxyweb.mcas.ms/certificate-checker?login=false&originalUrl=https%3A%2F%2Fforms.office.com.mcas.ms%2Fpages%2Fresponsepage.aspx%3Fid%3DmN94WIhvq0iTIpmM5VcIjfMZj__F6D9LmMUUyoUrZDZUOERYMEFBN0NCOFdNU1BGWEhHUFQxWVhUUy4u%26McasTsid%3D20596&McasCSRF=06374e6dbbae2e7c7f24c4fc332cd4cbc0b467358e647ded92d4f539754b8ff7).',
 			'',
 			'The Planning Inspectorate  ',
-			'[enquiries@planninginspectorate.gov.uk](mailto:enquiries@planninginspectorate.gov.uk)'
+			'enquiries@planninginspectorate.gov.uk'
 		].join('\n');
 
 		await notifySend(notifySendData);

--- a/appeals/api/src/server/notify/templates/decision-is-allowed-split-dismissed-lpa.content.md
+++ b/appeals/api/src/server/notify/templates/decision-is-allowed-split-dismissed-lpa.content.md
@@ -17,4 +17,4 @@ The Planning Inspectorate cannot change or revoke the decision. You can [challen
 We welcome your feedback on our appeals service. Tell us on this short [feedback form](https://forms.office.com/pages/responsepage.aspx?id=mN94WIhvq0iTIpmM5VcIjfMZj__F6D9LmMUUyoUrZDZUOERYMEFBN0NCOFdNU1BGWEhHUFQxWVhUUy4u).
 
 The Planning Inspectorate
-[enquiries@planninginspectorate.gov.uk](mailto:enquiries@planninginspectorate.gov.uk)
+enquiries@planninginspectorate.gov.uk

--- a/appeals/api/src/server/notify/templates/ip-comment-rejected-deadline-extended.content.md
+++ b/appeals/api/src/server/notify/templates/ip-comment-rejected-deadline-extended.content.md
@@ -15,9 +15,9 @@ We rejected your comment because:
     You can [submit a different comment]({{front_office_url}}/comment-planning-appeal/enter-appeal-reference) by {{deadline_date}}.
 
 {% else -%}
-    You can send a different comment to [caseofficers@planninginspectorate.gov.uk](mailto:caseofficers@planninginspectorate.gov.uk) by {{deadline_date}}.
+    You can send a different comment to caseofficers@planninginspectorate.gov.uk by {{deadline_date}}.
 
 {% endif -%}
 
 The Planning Inspectorate
-[enquiries@planninginspectorate.gov.uk](mailto:enquiries@planninginspectorate.gov.uk)
+enquiries@planninginspectorate.gov.uk

--- a/appeals/api/src/server/notify/templates/parts/feedback.md
+++ b/appeals/api/src/server/notify/templates/parts/feedback.md
@@ -3,4 +3,4 @@
 We welcome your feedback on our appeals service. Tell us on this short [feedback form](https://mcas-proxyweb.mcas.ms/certificate-checker?login=false&originalUrl=https%3A%2F%2Fforms.office.com.mcas.ms%2Fpages%2Fresponsepage.aspx%3Fid%3DmN94WIhvq0iTIpmM5VcIjfMZj__F6D9LmMUUyoUrZDZUOERYMEFBN0NCOFdNU1BGWEhHUFQxWVhUUy4u%26McasTsid%3D20596&McasCSRF=06374e6dbbae2e7c7f24c4fc332cd4cbc0b467358e647ded92d4f539754b8ff7).
 
 The Planning Inspectorate  
-[enquiries@planninginspectorate.gov.uk](mailto:enquiries@planninginspectorate.gov.uk)
+enquiries@planninginspectorate.gov.uk


### PR DESCRIPTION
## Describe your changes

Removing hyperlinks for emails from notify templates as per design requirements

## Issue ticket number and link

[Ticket](https://pins-ds.atlassian.net/browse/A2-4125)
