### PR TITLE
feat(web): use session to save backUrl for IP comments flow

### DIFF
--- a/appeals/web/src/server/appeals/appeal-details/representations/interested-party-comments/add-ip-comment/add-ip-comment.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/representations/interested-party-comments/add-ip-comment/add-ip-comment.mapper.js
@@ -14,7 +14,7 @@ import {
 	getTodaysISOString,
 	dayMonthYearHourMinuteToISOString
 } from '#lib/dates.js';
-import { getBackLinkUrlFromQuery } from '#lib/url-utilities.js';
+import { getSavedBackUrl } from '#lib/middleware/save-back-url.js';
 
 /** @typedef {import("../../../appeal-details.types.js").WebAppeal} Appeal */
 /** @typedef {import('#appeals/appeal-details/representations/types.js').interestedPartyComment} IpComment */
@@ -33,7 +33,7 @@ import { getBackLinkUrlFromQuery } from '#lib/url-utilities.js';
 export const ipDetailsPage = (appealDetails, values, request, errors) => ({
 	title: "Interested party's details",
 	backLinkUrl:
-		getBackLinkUrlFromQuery(request) ||
+		getSavedBackUrl(request, 'addIpComment') ||
 		`/appeals-service/appeal-details/${appealDetails.appealId}/interested-party-comments`,
 	preHeading: `Appeal ${appealShortReference(appealDetails.appealReference)}`,
 	heading: "Interested party's details",

--- a/appeals/web/src/server/appeals/appeal-details/representations/interested-party-comments/add-ip-comment/add-ip-comment.router.js
+++ b/appeals/web/src/server/appeals/appeal-details/representations/interested-party-comments/add-ip-comment/add-ip-comment.router.js
@@ -14,12 +14,13 @@ import {
 } from './add-ip-comment.validators.js';
 import { validateInterestedPartyAddress } from '../common/validators.js';
 import { validateRedactionStatus } from '../../representations.validators.js';
+import { saveBackUrl } from '#lib/middleware/save-back-url.js';
 
 const router = createRouter({ mergeParams: true });
 
 router
 	.route('/ip-details')
-	.get(asyncHandler(controller.renderIpDetails))
+	.get(saveBackUrl('addIpComment'), asyncHandler(controller.renderIpDetails))
 	.post(
 		validateInterestedPartyDetails,
 		saveBodyToSession('addIpComment'),

--- a/appeals/web/src/server/appeals/appeal-details/representations/interested-party-comments/interested-party-comments.controller.js
+++ b/appeals/web/src/server/appeals/appeal-details/representations/interested-party-comments/interested-party-comments.controller.js
@@ -3,7 +3,7 @@ import {
 	sharedIpCommentsPage
 } from './interested-party-comments.mapper.js';
 import * as interestedPartyCommentsService from './interested-party-comments.service.js';
-import { getBackLinkUrlFromQuery } from '#lib/url-utilities.js';
+import { getSavedBackUrl } from '#lib/middleware/save-back-url.js';
 
 /**
  *
@@ -61,7 +61,7 @@ export async function renderInterestedPartyComments(request, response) {
 		validComments,
 		invalidComments,
 		session,
-		getBackLinkUrlFromQuery(request)
+		getSavedBackUrl(request, 'manageIpComments')
 	);
 
 	return response.status(200).render('appeals/appeal/interested-party-comments.njk', {
@@ -84,7 +84,11 @@ export async function renderSharedInterestedPartyComments(request, response) {
 		'published'
 	);
 
-	const pageContent = sharedIpCommentsPage(currentAppeal, comments.items);
+	const pageContent = sharedIpCommentsPage(
+		currentAppeal,
+		comments.items,
+		getSavedBackUrl(request, 'manageIpComments')
+	);
 
 	return response.status(200).render('patterns/display-page.pattern.njk', {
 		errors,

--- a/appeals/web/src/server/appeals/appeal-details/representations/interested-party-comments/interested-party-comments.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/representations/interested-party-comments/interested-party-comments.mapper.js
@@ -113,9 +113,10 @@ function generateTableRows(items, isReview = false) {
 /**
  * @param {Appeal} appealDetails
  * @param {Representation[]} comments
+ * @param {string} [backUrl]
  * @returns {PageContent}
  * */
-export function sharedIpCommentsPage(appealDetails, comments) {
+export function sharedIpCommentsPage(appealDetails, comments, backUrl) {
 	const shortReference = appealShortReference(appealDetails.appealReference);
 
 	/** @type {PageComponent} */
@@ -202,7 +203,7 @@ export function sharedIpCommentsPage(appealDetails, comments) {
 
 	return {
 		title: 'Interested party comments',
-		backLinkUrl: `/appeals-service/appeal-details/${appealDetails.appealId}`,
+		backLinkUrl: backUrl || `/appeals-service/appeal-details/${appealDetails.appealId}`,
 		preHeading: `Appeal ${shortReference}`,
 		heading: 'Interested party comments',
 		pageComponents: pageComponents

--- a/appeals/web/src/server/appeals/appeal-details/representations/interested-party-comments/interested-party-comments.router.js
+++ b/appeals/web/src/server/appeals/appeal-details/representations/interested-party-comments/interested-party-comments.router.js
@@ -8,6 +8,7 @@ import redactIpCommentRouter from './redact/redact.router.js';
 import * as controller from './interested-party-comments.controller.js';
 import { validateComment } from './interested-party-comments.middleware.js';
 import { clearUncommittedFilesFromSession } from '#appeals/appeal-documents/appeal-documents.middleware.js';
+import { saveBackUrl } from '#lib/middleware/save-back-url.js';
 
 const router = createRouter({ mergeParams: true });
 
@@ -29,6 +30,7 @@ router
 	.get(
 		validateAppeal,
 		clearUncommittedFilesFromSession,
+		saveBackUrl('manageIpComments', { invalidateKeys: ['addIpComment'] }),
 		asyncHandler(controller.handleInterestedPartyComments)
 	);
 

--- a/appeals/web/src/server/lib/middleware/__tests__/save-back-url.test.js
+++ b/appeals/web/src/server/lib/middleware/__tests__/save-back-url.test.js
@@ -1,0 +1,93 @@
+// @ts-nocheck
+import { jest } from '@jest/globals';
+import { saveBackUrl } from '../save-back-url.js';
+
+describe('saveBackUrl', () => {
+	it('should save the backUrl to the session', async () => {
+		const req = {
+			params: {
+				appealId: '123'
+			},
+			query: {
+				backUrl: '/appeals-service/personal-list'
+			},
+			session: {}
+		};
+
+		saveBackUrl('manageIpComments')(req, {}, jest.fn());
+		expect(req.session['backUrl/manageIpComments']['123']).toBe('/appeals-service/personal-list');
+	});
+
+	it('should not save the backUrl to the session if it is not present', async () => {
+		const req = {
+			params: {
+				appealId: '123'
+			},
+			session: {}
+		};
+
+		saveBackUrl('manageIpComments')(req, {}, jest.fn());
+		expect(req.session['backUrl/manageIpComments']).toBeUndefined();
+	});
+
+	it('should keep the existing backUrl if no query param is present', async () => {
+		const req = {
+			params: {
+				appealId: '123'
+			},
+			session: {
+				'backUrl/manageIpComments': {
+					123: '/appeals-service/personal-list'
+				}
+			}
+		};
+
+		saveBackUrl('manageIpComments')(req, {}, jest.fn());
+		expect(req.session['backUrl/manageIpComments']['123']).toBe('/appeals-service/personal-list');
+	});
+
+	it('should invalidate other specified session keys', async () => {
+		const req = {
+			params: {
+				appealId: '123'
+			},
+			query: {
+				backUrl: '/appeals-service/personal-list'
+			},
+			session: {
+				'backUrl/manageIpComments': {
+					123: '/appeals-service/personal-list'
+				},
+				'backUrl/addIpComment': {
+					123: '/appeals-service/add-ip-comment'
+				}
+			}
+		};
+
+		saveBackUrl('manageIpComments', { invalidateKeys: ['addIpComment'] })(req, {}, jest.fn());
+
+		expect(req.session['backUrl/manageIpComments']['123']).toBe('/appeals-service/personal-list');
+		expect(req.session['backUrl/addIpComment']).toBeUndefined();
+	});
+
+	it('should not invalidate other specified session keys if no backUrl is present', async () => {
+		const req = {
+			params: {
+				appealId: '123'
+			},
+			session: {
+				'backUrl/manageIpComments': {
+					123: '/appeals-service/personal-list'
+				},
+				'backUrl/addIpComment': {
+					123: '/appeals-service/add-ip-comment'
+				}
+			}
+		};
+
+		saveBackUrl('manageIpComments', { invalidateKeys: ['addIpComment'] })(req, {}, jest.fn());
+
+		expect(req.session['backUrl/manageIpComments']['123']).toBe('/appeals-service/personal-list');
+		expect(req.session['backUrl/addIpComment']).toEqual({ 123: '/appeals-service/add-ip-comment' });
+	});
+});

--- a/appeals/web/src/server/lib/middleware/save-back-url.js
+++ b/appeals/web/src/server/lib/middleware/save-back-url.js
@@ -1,0 +1,55 @@
+/**
+ * Store the backUrl query param the session, scoped using a specific
+ * session key (to represent the flow the user is currently entering),
+ * and the ID of the current appeal.
+ *
+ * If the `invalidateKeys` option is provided, the backUrl will be
+ * cleared for the specified keys. For example if we are entering at
+ * the start of a flow, but the entrypoint may also be a later step in
+ * the flow, we want to clear that one if it already exists so that if
+ * we click back from that step it doesn't go straight back from there
+ * to another backUrl that was previously saved against that key.
+ *
+ * @param {string} sessionKey
+ * @param {{ invalidateKeys?: string[] }} [options]
+ * @returns {import('@pins/express').RequestHandler<{}>}
+ */
+export const saveBackUrl = (sessionKey, options) => (request, _, next) => {
+	const { params, query, session } = request;
+	const { appealId } = params;
+	const backUrl = query?.backUrl;
+
+	if (!backUrl) {
+		return next();
+	}
+
+	const key = `backUrl/${sessionKey}`;
+	if (!session[key]) {
+		session[key] = {};
+	}
+	session[key][appealId] = backUrl;
+
+	if (options?.invalidateKeys) {
+		options.invalidateKeys.forEach((invalidateKey) => {
+			delete session[`backUrl/${invalidateKey}`];
+		});
+	}
+
+	next();
+};
+
+/**
+ * Get the backUrl from the session, scoped using a specific session
+ * key (to represent the flow the user is currently entering), and the
+ * ID of the current appeal.
+ * @param {import('express').Request} request
+ * @param {string} sessionKey
+ * @returns {string | undefined}
+ */
+export const getSavedBackUrl = (request, sessionKey) => {
+	const { params, session } = request;
+	const { appealId } = params;
+	const key = `backUrl/${sessionKey}`;
+
+	return session[key]?.[appealId];
+};


### PR DESCRIPTION
## Describe your changes

Use the session to save the backUrl when entering the IP comments flow. This means that we don't need to carry forward the backUrl query string on every single link that the user follows within this flow, which would be very error-prone because if we forgot to add it to any of the links or added new links without preserving the query string then it would forget where to go back to at the end. Also this session-based approach requires far less work and touches fewer files, so it will be easier to roll out to other flows. I have scoped the session key by flow and appeal ID to avoid any interference if the user is doing different things in multiple tabs.

## Issue ticket number and link

[A2-3053](https://pins-ds.atlassian.net/browse/A2-3053)


[A2-3053]: https://pins-ds.atlassian.net/browse/A2-3053?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ