### PR TITLE
fix(appeals): prevent linking a lead appeal to another lead appeal (a2-3917)

### DIFF
--- a/appeals/e2e/cypress/e2e/back-office-appeals/linkAppeals.spec.js
+++ b/appeals/e2e/cypress/e2e/back-office-appeals/linkAppeals.spec.js
@@ -6,7 +6,6 @@ import { CaseDetailsPage } from '../../page_objects/caseDetailsPage.js';
 import { urlPaths } from '../../support/urlPaths';
 import { tag } from '../../support/tag';
 import { happyPathHelper } from '../../support/happyPathHelper.js';
-import { horizonTestAppeals } from '../../support/horizonTestAppeals.js';
 
 const caseDetailsPage = new CaseDetailsPage();
 
@@ -150,10 +149,6 @@ describe('link appeals', () => {
 					caseDetailsPage.fillInput(childCase2);
 					caseDetailsPage.clickButtonByText('Continue');
 
-					//select lead appeal
-					caseDetailsPage.selectRadioButtonByValue(leadCase);
-					caseDetailsPage.clickButtonByText('Continue');
-
 					//CYA
 					caseDetailsPage.clickButtonByText('Add linked appeal');
 
@@ -204,7 +199,7 @@ describe('link appeals', () => {
 		});
 	});
 
-	it.skip('As a lead appeal, I am unable to link to another lead appeal', () => {
+	it('As a lead appeal, I am unable to link to another lead appeal', () => {
 		cy.createCase().then((leadCase1) => {
 			cy.createCase().then((leadCase2) => {
 				cy.createCase().then((childCase1) => {
@@ -254,7 +249,7 @@ describe('link appeals', () => {
 						caseDetailsPage.clickButtonByText('Continue');
 
 						//exit page
-						caseDetailsPage.checkHeading(`You have already linked appeal ${leadCase2}`);
+						caseDetailsPage.checkHeading(`You have already linked appeal ${leadCase1}`);
 					});
 				});
 			});

--- a/appeals/web/src/server/appeals/appeal-details/linked-appeals/__tests__/linked-appeals.test.js
+++ b/appeals/web/src/server/appeals/appeal-details/linked-appeals/__tests__/linked-appeals.test.js
@@ -276,6 +276,23 @@ describe('linked-appeals', () => {
 			expect(response.text).toEqual(`Found. Redirecting to ${linkedAppealsAddUrl}/already-linked`);
 		});
 
+		it('should redirect to a drop out page if both appeals are already linked as lead appeals', async () => {
+			nock.cleanAll();
+			nock('http://test/')
+				.get('/appeals/1')
+				.reply(200, { ...appealData, isParentAppeal: true });
+			nock('http://test/')
+				.get(`/appeals/linkable-appeal/${testValidLinkableAppealReference}/linked`)
+				.reply(200, { ...linkableAppealSummaryBackOffice, childAppeals: [{ appealId: 2 }] });
+
+			const response = await request.post(linkedAppealsAddUrl).send({
+				'appeal-reference': testValidLinkableAppealReference
+			});
+
+			expect(response.statusCode).toBe(302);
+			expect(response.text).toEqual(`Found. Redirecting to ${linkedAppealsAddUrl}/already-linked`);
+		});
+
 		it('should redirect to a drop out page if the appeal cannot be linked due to an invalid case status', async () => {
 			nock.cleanAll();
 			nock('http://test/').get('/appeals/1').reply(200, appealData);

--- a/appeals/web/src/server/appeals/appeal-details/linked-appeals/add/add.controller.js
+++ b/appeals/web/src/server/appeals/appeal-details/linked-appeals/add/add.controller.js
@@ -72,10 +72,21 @@ export const postAddLinkedAppeal = (request, response) => {
 		});
 	}
 
+	const proposedLinkableAppealIsLead = Boolean(
+		session.linkableAppeal.linkableAppealSummary?.childAppeals?.length
+	);
+
+	if (proposedLinkableAppealIsLead && currentAppeal.isParentAppeal) {
+		// cannot link two parent appeals
+		return response.redirect(
+			`/appeals-service/appeal-details/${appealId}/linked-appeals/add/already-linked`
+		);
+	}
+
 	if (currentAppeal.isParentAppeal) {
 		// The current appeal is a lead already, so make it the lead of this relationship
 		session.linkableAppeal.leadAppeal = currentAppeal.appealReference;
-	} else if (session.linkableAppeal.linkableAppealSummary?.childAppeals?.length) {
+	} else if (proposedLinkableAppealIsLead) {
 		// The chosen appeal is a lead already as it has child appeals, so make it the lead of this relationship
 		session.linkableAppeal.leadAppeal =
 			session.linkableAppeal.linkableAppealSummary.appealReference;


### PR DESCRIPTION
## Describe your changes
#### Prevent linking a lead appeal to another lead appeal (a2-3917)

### WEB:
- Redirect to the link appeal conflict page if both appeals are a linked lead appeal

### E2E:
- Fixed e2e tests for linked appeals

### TEST:
- Added unit tests to test the functionality
- Made sure all unit tests pass
- Manually tested within browser

## Issue ticket number and link:
- [(A2-3917) Remove 'Which is the lead appeal?' screen when linking additional child appeals and slightly amend CYA screen](https://pins-ds.atlassian.net/browse/A2-3917)

