### PR TITLE
fix(api): resolve clearing the test data failing

### DIFF
--- a/appeals/api/src/database/seed/seed-clear-test-data.js
+++ b/appeals/api/src/database/seed/seed-clear-test-data.js
@@ -428,9 +428,9 @@ const deleteAppealData = async (
 		deleteRepsAttachments,
 		deleteHearingEstimate,
 		deleteHearing,
-		deleteAppeals,
 		deleteInquiry,
-		deleteInquiryEstimate
+		deleteInquiryEstimate,
+		deleteAppeals
 	]);
 };
 


### PR DESCRIPTION
## Describe your changes

Clearing the test data failed for inquiries due to a foreign key constraint.

I changed the ordering, so the inquiry rows are deleted before the appeal.
