### PR TITLE
A2-3259 - fixing issue with inquiry tests

### DIFF
--- a/appeals/e2e/cypress/page_objects/caseDetails/inquirySectionPage.js
+++ b/appeals/e2e/cypress/page_objects/caseDetails/inquirySectionPage.js
@@ -16,7 +16,7 @@ export class InquirySectionPage extends CaseDetailsPage {
 	}
 
 	setUpInquiry(day, month, year, hour, minute) {
-		dateTimeSection.enterInquiryDate(day, month, year);
+		dateTimeSection.setInquiryDate(day, month, year);
 		dateTimeSection.enterInquiryTime(hour, minute);
 		this.clickButtonByText('Continue');
 	}

--- a/appeals/e2e/cypress/page_objects/dateTimeSection.js
+++ b/appeals/e2e/cypress/page_objects/dateTimeSection.js
@@ -97,7 +97,7 @@ export class DateTimeSection extends Page {
 		this.#setAllDateFields(this.selectorPrefix.inquiryDate, date);
 	}
 
-	enterInquiryDate(day, month, year) {
+	setInquiryDate(day, month, year) {
 		this.#setDateFields(this.selectorPrefix.inquiryDate, day, month, year);
 	}
 


### PR DESCRIPTION
## Describe your changes

As part of https://github.com.mcas.ms/Planning-Inspectorate/appeals-back-office/pull/1830 a new version of `enterInquiryDate` function was added to the `dateTimeSection` so that could pass in year, month and day 

However, because javascript does not support overloading this new method was also being used in the `inquiry` tests, instead of the version which accepts a date object! 

To fix this I've changed the name of the new function to `setDateTime`, as seems easiest and cleanest solution 

## Issue ticket number and link

https://pins-ds.atlassian.net.mcas.ms/browse/A2-3259 
