### PR TITLE
fix(web): add document button fix for manage folder page (A2-4007)

### DIFF
--- a/appeals/web/src/server/appeals/appeal-details/appellant-case/__tests__/__snapshots__/appellant-case.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/appellant-case/__tests__/__snapshots__/appellant-case.test.js.snap
@@ -3983,7 +3983,9 @@ exports[`appellant-case GET /appellant-case/manage-documents/:folderId/ should r
         <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Manage folder</span>
             <h1 class="govuk-heading-l">Changed description documents</h1>
         </div>
-    </div>
+    </div><a href="/appeals-service/appeal-details/1/appellant-case/add-documents/2864"
+    role="button" draggable="false" class="govuk-button govuk-button--secondary"
+    data-module="govuk-button"> Add document</a>
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-full">
             <table class="govuk-table" id="documents-table">
@@ -4062,8 +4064,7 @@ exports[`appellant-case GET /appellant-case/manage-documents/:folderId/ should r
                 </tbody>
             </table>
         </div>
-    </div><a href="/appeals-service/appeal-details/1/appellant-case/add-documents/2864"
-    role="button" draggable="false" class="govuk-button" data-module="govuk-button"> Add documents</a>
+    </div>
 </main>"
 `;
 
@@ -4102,7 +4103,9 @@ exports[`appellant-case GET /appellant-case/manage-documents/:folderId/ should r
         <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Manage folder</span>
             <h1 class="govuk-heading-l">Additional documents</h1>
         </div>
-    </div>
+    </div><a href="/appeals-service/appeal-details/1/appellant-case/add-documents/2865"
+    role="button" draggable="false" class="govuk-button govuk-button--secondary"
+    data-module="govuk-button"> Add document</a>
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-full">
             <table class="govuk-table" id="documents-table">
@@ -4189,8 +4192,7 @@ exports[`appellant-case GET /appellant-case/manage-documents/:folderId/ should r
                 </tbody>
             </table>
         </div>
-    </div><a href="/appeals-service/appeal-details/1/appellant-case/add-documents/2865"
-    role="button" draggable="false" class="govuk-button" data-module="govuk-button"> Add documents</a>
+    </div>
 </main>"
 `;
 

--- a/appeals/web/src/server/appeals/appeal-details/appellant-case/__tests__/appellant-case.test.js
+++ b/appeals/web/src/server/appeals/appeal-details/appellant-case/__tests__/appellant-case.test.js
@@ -5100,7 +5100,7 @@ describe('appellant-case', () => {
 			expect(unprettifiedElement.innerHTML).toContain('ph0-documentFolderInfo.jpeg</span>');
 			expect(unprettifiedElement.innerHTML).toContain('ph1-documentFolderInfo.jpeg</a>');
 			expect(unprettifiedElement.innerHTML).toContain(
-				`<a href="/appeals-service/appeal-details/1/appellant-case/add-documents/${documentFolderInfo.folderId}" role="button" draggable="false" class="govuk-button" data-module="govuk-button"> Add documents</a>`
+				`<a href="/appeals-service/appeal-details/1/appellant-case/add-documents/${documentFolderInfo.folderId}" role="button" draggable="false" class="govuk-button govuk-button--secondary" data-module="govuk-button"> Add document</a>`
 			);
 		});
 

--- a/appeals/web/src/server/appeals/appeal-details/costs/__tests__/__snapshots__/costs.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/costs/__tests__/__snapshots__/costs.test.js.snap
@@ -696,7 +696,9 @@ exports[`costs application, withdrawal and correspondence GET /costs/:costsCateg
         <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Manage folder</span>
             <h1 class="govuk-heading-l">Appellant costs application documents</h1>
         </div>
-    </div>
+    </div><a href="/appeals-service/appeal-details/1/costs/appellant/application/upload-documents/1"
+    role="button" draggable="false" class="govuk-button govuk-button--secondary"
+    data-module="govuk-button"> Add document</a>
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-full">
             <table class="govuk-table" id="documents-table">
@@ -742,8 +744,7 @@ exports[`costs application, withdrawal and correspondence GET /costs/:costsCateg
                 </tbody>
             </table>
         </div>
-    </div><a href="/appeals-service/appeal-details/1/costs/appellant/application/upload-documents/1"
-    role="button" draggable="false" class="govuk-button" data-module="govuk-button"> Add document</a>
+    </div>
 </main>"
 `;
 
@@ -753,7 +754,9 @@ exports[`costs application, withdrawal and correspondence GET /costs/:costsCateg
         <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Manage folder</span>
             <h1 class="govuk-heading-l">Appellant costs correspondence documents</h1>
         </div>
-    </div>
+    </div><a href="/appeals-service/appeal-details/1/costs/appellant/correspondence/upload-documents/3"
+    role="button" draggable="false" class="govuk-button govuk-button--secondary"
+    data-module="govuk-button"> Add document</a>
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-full">
             <table class="govuk-table" id="documents-table">
@@ -799,8 +802,7 @@ exports[`costs application, withdrawal and correspondence GET /costs/:costsCateg
                 </tbody>
             </table>
         </div>
-    </div><a href="/appeals-service/appeal-details/1/costs/appellant/correspondence/upload-documents/3"
-    role="button" draggable="false" class="govuk-button" data-module="govuk-button"> Add document</a>
+    </div>
 </main>"
 `;
 
@@ -810,7 +812,9 @@ exports[`costs application, withdrawal and correspondence GET /costs/:costsCateg
         <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Manage folder</span>
             <h1 class="govuk-heading-l">Appellant costs withdrawal documents</h1>
         </div>
-    </div>
+    </div><a href="/appeals-service/appeal-details/1/costs/appellant/withdrawal/upload-documents/2"
+    role="button" draggable="false" class="govuk-button govuk-button--secondary"
+    data-module="govuk-button"> Add document</a>
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-full">
             <table class="govuk-table" id="documents-table">
@@ -856,8 +860,7 @@ exports[`costs application, withdrawal and correspondence GET /costs/:costsCateg
                 </tbody>
             </table>
         </div>
-    </div><a href="/appeals-service/appeal-details/1/costs/appellant/withdrawal/upload-documents/2"
-    role="button" draggable="false" class="govuk-button" data-module="govuk-button"> Add document</a>
+    </div>
 </main>"
 `;
 
@@ -867,7 +870,9 @@ exports[`costs application, withdrawal and correspondence GET /costs/:costsCateg
         <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Manage folder</span>
             <h1 class="govuk-heading-l">LPA costs application documents</h1>
         </div>
-    </div>
+    </div><a href="/appeals-service/appeal-details/1/costs/lpa/application/upload-documents/4"
+    role="button" draggable="false" class="govuk-button govuk-button--secondary"
+    data-module="govuk-button"> Add document</a>
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-full">
             <table class="govuk-table" id="documents-table">
@@ -913,8 +918,7 @@ exports[`costs application, withdrawal and correspondence GET /costs/:costsCateg
                 </tbody>
             </table>
         </div>
-    </div><a href="/appeals-service/appeal-details/1/costs/lpa/application/upload-documents/4"
-    role="button" draggable="false" class="govuk-button" data-module="govuk-button"> Add document</a>
+    </div>
 </main>"
 `;
 
@@ -924,7 +928,9 @@ exports[`costs application, withdrawal and correspondence GET /costs/:costsCateg
         <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Manage folder</span>
             <h1 class="govuk-heading-l">LPA costs correspondence documents</h1>
         </div>
-    </div>
+    </div><a href="/appeals-service/appeal-details/1/costs/lpa/correspondence/upload-documents/6"
+    role="button" draggable="false" class="govuk-button govuk-button--secondary"
+    data-module="govuk-button"> Add document</a>
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-full">
             <table class="govuk-table" id="documents-table">
@@ -970,8 +976,7 @@ exports[`costs application, withdrawal and correspondence GET /costs/:costsCateg
                 </tbody>
             </table>
         </div>
-    </div><a href="/appeals-service/appeal-details/1/costs/lpa/correspondence/upload-documents/6"
-    role="button" draggable="false" class="govuk-button" data-module="govuk-button"> Add document</a>
+    </div>
 </main>"
 `;
 
@@ -981,7 +986,9 @@ exports[`costs application, withdrawal and correspondence GET /costs/:costsCateg
         <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Manage folder</span>
             <h1 class="govuk-heading-l">LPA costs withdrawal documents</h1>
         </div>
-    </div>
+    </div><a href="/appeals-service/appeal-details/1/costs/lpa/withdrawal/upload-documents/5"
+    role="button" draggable="false" class="govuk-button govuk-button--secondary"
+    data-module="govuk-button"> Add document</a>
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-full">
             <table class="govuk-table" id="documents-table">
@@ -1027,8 +1034,7 @@ exports[`costs application, withdrawal and correspondence GET /costs/:costsCateg
                 </tbody>
             </table>
         </div>
-    </div><a href="/appeals-service/appeal-details/1/costs/lpa/withdrawal/upload-documents/5"
-    role="button" draggable="false" class="govuk-button" data-module="govuk-button"> Add document</a>
+    </div>
 </main>"
 `;
 
@@ -5740,7 +5746,9 @@ exports[`costs decision GET /costs/decision/manage-documents/:folderId should re
         <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Manage folder</span>
             <h1 class="govuk-heading-l">Costs decision documents</h1>
         </div>
-    </div>
+    </div><a href="/appeals-service/appeal-details/1/costs/decision/upload-documents/7"
+    role="button" draggable="false" class="govuk-button govuk-button--secondary"
+    data-module="govuk-button"> Add documents</a>
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-full">
             <table class="govuk-table" id="documents-table">
@@ -5786,8 +5794,7 @@ exports[`costs decision GET /costs/decision/manage-documents/:folderId should re
                 </tbody>
             </table>
         </div>
-    </div><a href="/appeals-service/appeal-details/1/costs/decision/upload-documents/7"
-    role="button" draggable="false" class="govuk-button" data-module="govuk-button"> Add documents</a>
+    </div>
 </main>"
 `;
 

--- a/appeals/web/src/server/appeals/appeal-details/costs/__tests__/costs.test.js
+++ b/appeals/web/src/server/appeals/appeal-details/costs/__tests__/costs.test.js
@@ -1464,7 +1464,7 @@ describe('costs', () => {
 							} costs ${costsDocumentType} documents</h1>`
 						);
 						expect(unprettifiedElement.innerHTML).toContain(
-							`<a href="/appeals-service/appeal-details/1/costs/${costsCategory}/${costsDocumentType}/upload-documents/${costsFolder.folderId}" role="button" draggable="false" class="govuk-button" data-module="govuk-button"> Add document</a>`
+							`<a href="/appeals-service/appeal-details/1/costs/${costsCategory}/${costsDocumentType}/upload-documents/${costsFolder.folderId}" role="button" draggable="false" class="govuk-button govuk-button--secondary" data-module="govuk-button"> Add document</a>`
 						);
 					});
 				}
@@ -2867,7 +2867,7 @@ describe('costs', () => {
 				expect(unprettifiedElement.innerHTML).toContain('Manage folder</span><h1');
 				expect(unprettifiedElement.innerHTML).toContain(`Costs decision documents</h1>`);
 				expect(unprettifiedElement.innerHTML).toContain(
-					`<a href="/appeals-service/appeal-details/1/costs/decision/upload-documents/${costsFolder?.folderId}" role="button" draggable="false" class="govuk-button" data-module="govuk-button"> Add documents</a>`
+					`<a href="/appeals-service/appeal-details/1/costs/decision/upload-documents/7" role="button" draggable="false" class="govuk-button govuk-button--secondary" data-module="govuk-button"> Add documents</a>`
 				);
 			});
 		});

--- a/appeals/web/src/server/appeals/appeal-details/environmental-assessment/__tests__/__snapshots__/environmental-assessment.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/environmental-assessment/__tests__/__snapshots__/environmental-assessment.test.js.snap
@@ -35,7 +35,9 @@ exports[`environmental-assessment GET /environmental-assessment/manage-documents
         <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Manage folder</span>
             <h1 class="govuk-heading-l">Environmental assessment documents</h1>
         </div>
-    </div>
+    </div><a href="/appeals-service/appeal-details/1/environmental-assessment/upload-documents/2864"
+    role="button" draggable="false" class="govuk-button govuk-button--secondary"
+    data-module="govuk-button"> Add document</a>
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-full">
             <table class="govuk-table" id="documents-table">
@@ -114,8 +116,7 @@ exports[`environmental-assessment GET /environmental-assessment/manage-documents
                 </tbody>
             </table>
         </div>
-    </div><a href="/appeals-service/appeal-details/1/environmental-assessment/upload-documents/2864"
-    role="button" draggable="false" class="govuk-button" data-module="govuk-button"> Add documents</a>
+    </div>
 </main>"
 `;
 

--- a/appeals/web/src/server/appeals/appeal-details/environmental-assessment/__tests__/environmental-assessment.test.js
+++ b/appeals/web/src/server/appeals/appeal-details/environmental-assessment/__tests__/environmental-assessment.test.js
@@ -199,7 +199,7 @@ describe('environmental-assessment', () => {
 
 			const unprettifiedHtml = parseHtml(response.text, { skipPrettyPrint: true });
 			expect(unprettifiedHtml.innerHTML).toContain(
-				`<a href="/appeals-service/appeal-details/${appealId}/environmental-assessment/upload-documents/${folderId}" role="button" draggable="false" class="govuk-button" data-module="govuk-button"> Add documents</a>`
+				`<a href="/appeals-service/appeal-details/${appealId}/environmental-assessment/upload-documents/${folderId}" role="button" draggable="false" class="govuk-button govuk-button--secondary" data-module="govuk-button"> Add document</a>`
 			);
 		});
 	});

--- a/appeals/web/src/server/appeals/appeal-details/internal-correspondence/__tests__/__snapshots__/internal-correspondence.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/internal-correspondence/__tests__/__snapshots__/internal-correspondence.test.js.snap
@@ -585,7 +585,9 @@ exports[`internal correspondence GET /internal-correspondence/:correspondenceCat
         <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Manage folder</span>
             <h1 class="govuk-heading-l">Cross-team correspondence documents</h1>
         </div>
-    </div>
+    </div><a href="/appeals-service/appeal-details/1/internal-correspondence/cross-team/upload-documents/10"
+    role="button" draggable="false" class="govuk-button govuk-button--secondary"
+    data-module="govuk-button"> Add document</a>
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-full">
             <table class="govuk-table" id="documents-table">
@@ -631,8 +633,7 @@ exports[`internal correspondence GET /internal-correspondence/:correspondenceCat
                 </tbody>
             </table>
         </div>
-    </div><a href="/appeals-service/appeal-details/1/internal-correspondence/cross-team/upload-documents/10"
-    role="button" draggable="false" class="govuk-button" data-module="govuk-button"> Add documents</a>
+    </div>
 </main>"
 `;
 
@@ -642,7 +643,9 @@ exports[`internal correspondence GET /internal-correspondence/:correspondenceCat
         <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Manage folder</span>
             <h1 class="govuk-heading-l">Inspector correspondence documents</h1>
         </div>
-    </div>
+    </div><a href="/appeals-service/appeal-details/1/internal-correspondence/inspector/upload-documents/11"
+    role="button" draggable="false" class="govuk-button govuk-button--secondary"
+    data-module="govuk-button"> Add document</a>
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-full">
             <table class="govuk-table" id="documents-table">
@@ -688,8 +691,7 @@ exports[`internal correspondence GET /internal-correspondence/:correspondenceCat
                 </tbody>
             </table>
         </div>
-    </div><a href="/appeals-service/appeal-details/1/internal-correspondence/inspector/upload-documents/11"
-    role="button" draggable="false" class="govuk-button" data-module="govuk-button"> Add documents</a>
+    </div>
 </main>"
 `;
 
@@ -699,7 +701,9 @@ exports[`internal correspondence GET /internal-correspondence/:correspondenceCat
         <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Manage folder</span>
             <h1 class="govuk-heading-l">Main party correspondence documents</h1>
         </div>
-    </div>
+    </div><a href="/appeals-service/appeal-details/1/internal-correspondence/main-party/upload-documents/22"
+    role="button" draggable="false" class="govuk-button govuk-button--secondary"
+    data-module="govuk-button"> Add document</a>
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-full">
             <table class="govuk-table" id="documents-table">
@@ -745,8 +749,7 @@ exports[`internal correspondence GET /internal-correspondence/:correspondenceCat
                 </tbody>
             </table>
         </div>
-    </div><a href="/appeals-service/appeal-details/1/internal-correspondence/main-party/upload-documents/22"
-    role="button" draggable="false" class="govuk-button" data-module="govuk-button"> Add documents</a>
+    </div>
 </main>"
 `;
 

--- a/appeals/web/src/server/appeals/appeal-details/internal-correspondence/__tests__/internal-correspondence.test.js
+++ b/appeals/web/src/server/appeals/appeal-details/internal-correspondence/__tests__/internal-correspondence.test.js
@@ -1618,7 +1618,7 @@ describe('internal correspondence', () => {
 					`${convertToTitle(correspondenceCategory)} correspondence documents</h1>`
 				);
 				expect(unprettifiedElement.innerHTML).toContain(
-					`<a href="/appeals-service/appeal-details/1/internal-correspondence/${correspondenceCategory}/upload-documents/${folder.folderId}" role="button" draggable="false" class="govuk-button" data-module="govuk-button"> Add documents</a>`
+					`<a href="/appeals-service/appeal-details/1/internal-correspondence/${correspondenceCategory}/upload-documents/${folder.folderId}" role="button" draggable="false" class="govuk-button govuk-button--secondary" data-module="govuk-button"> Add document</a>`
 				);
 			});
 		}

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/__tests__/__snapshots__/lpa-questionnaire.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/__tests__/__snapshots__/lpa-questionnaire.test.js.snap
@@ -3199,7 +3199,9 @@ exports[`LPA Questionnaire review GET /lpa-questionnaire/1/manage-documents/:fol
         <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Manage folder</span>
             <h1 class="govuk-heading-l">Changed description documents</h1>
         </div>
-    </div>
+    </div><a href="/appeals-service/appeal-details/1/lpa-questionnaire/2/add-documents/2864"
+    role="button" draggable="false" class="govuk-button govuk-button--secondary"
+    data-module="govuk-button"> Add document</a>
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-full">
             <table class="govuk-table" id="documents-table">
@@ -3278,8 +3280,7 @@ exports[`LPA Questionnaire review GET /lpa-questionnaire/1/manage-documents/:fol
                 </tbody>
             </table>
         </div>
-    </div><a href="/appeals-service/appeal-details/1/lpa-questionnaire/2/add-documents/2864"
-    role="button" draggable="false" class="govuk-button" data-module="govuk-button"> Add documents</a>
+    </div>
 </main>"
 `;
 
@@ -3318,7 +3319,9 @@ exports[`LPA Questionnaire review GET /lpa-questionnaire/1/manage-documents/:fol
         <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Manage folder</span>
             <h1 class="govuk-heading-l">Additional documents</h1>
         </div>
-    </div>
+    </div><a href="/appeals-service/appeal-details/1/lpa-questionnaire/2/add-documents/2865"
+    role="button" draggable="false" class="govuk-button govuk-button--secondary"
+    data-module="govuk-button"> Add document</a>
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-full">
             <table class="govuk-table" id="documents-table">
@@ -3405,8 +3408,7 @@ exports[`LPA Questionnaire review GET /lpa-questionnaire/1/manage-documents/:fol
                 </tbody>
             </table>
         </div>
-    </div><a href="/appeals-service/appeal-details/1/lpa-questionnaire/2/add-documents/2865"
-    role="button" draggable="false" class="govuk-button" data-module="govuk-button"> Add documents</a>
+    </div>
 </main>"
 `;
 

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/__tests__/lpa-questionnaire.test.js
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/__tests__/lpa-questionnaire.test.js
@@ -3567,7 +3567,7 @@ describe('LPA Questionnaire review', () => {
 			expect(unprettifiedElement.innerHTML).toContain('ph0-documentFolderInfo.jpeg</span>');
 			expect(unprettifiedElement.innerHTML).toContain('ph1-documentFolderInfo.jpeg</a>');
 			expect(unprettifiedElement.innerHTML).toContain(
-				`<a href="/appeals-service/appeal-details/1/lpa-questionnaire/2/add-documents/${documentFolderInfo.folderId}" role="button" draggable="false" class="govuk-button" data-module="govuk-button"> Add documents</a>`
+				`<a href="/appeals-service/appeal-details/1/lpa-questionnaire/2/add-documents/${documentFolderInfo.folderId}" role="button" draggable="false" class="govuk-button govuk-button--secondary" data-module="govuk-button"> Add document</a>`
 			);
 		});
 

--- a/appeals/web/src/server/appeals/appeal-details/representations/final-comments/view-and-review/__tests__/__snapshots__/view-and-review.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/representations/final-comments/view-and-review/__tests__/__snapshots__/view-and-review.test.js.snap
@@ -75,7 +75,9 @@ exports[`final-comments GET /manage-documents/:folderId/ should render manage fo
         <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Manage folder</span>
             <h1 class="govuk-heading-l">Supporting documents</h1>
         </div>
-    </div>
+    </div><a href="/appeals-service/appeal-details/2/final-comments/lpa/add-document"
+    role="button" draggable="false" class="govuk-button govuk-button--secondary"
+    data-module="govuk-button"> Add document</a>
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-full">
             <table class="govuk-table" id="documents-table">
@@ -121,8 +123,7 @@ exports[`final-comments GET /manage-documents/:folderId/ should render manage fo
                 </tbody>
             </table>
         </div>
-    </div><a href="/appeals-service/appeal-details/2/final-comments/lpa/add-document"
-    role="button" draggable="false" class="govuk-button" data-module="govuk-button"> Add document</a>
+    </div>
 </main>"
 `;
 

--- a/appeals/web/src/server/appeals/appeal-details/representations/final-comments/view-and-review/__tests__/view-and-review.test.js
+++ b/appeals/web/src/server/appeals/appeal-details/representations/final-comments/view-and-review/__tests__/view-and-review.test.js
@@ -203,7 +203,7 @@ describe('final-comments', () => {
 			expect(unprettifiedElement.innerHTML).toContain('Actions</th>');
 			expect(unprettifiedElement.innerHTML).toContain('test-pdf-documentFolderInfo.pdf</span>');
 			expect(unprettifiedElement.innerHTML).toContain(
-				`<a href="/appeals-service/appeal-details/2/final-comments/lpa/add-document" role="button" draggable="false" class="govuk-button" data-module="govuk-button"> Add document</a>`
+				`<a href="/appeals-service/appeal-details/2/final-comments/lpa/add-document" role="button" draggable="false" class="govuk-button govuk-button--secondary" data-module="govuk-button"> Add document</a>`
 			);
 		});
 	});

--- a/appeals/web/src/server/appeals/appeal-details/representations/interested-party-comments/view-and-review/__tests__/__snapshots__/view-and-review.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/representations/interested-party-comments/view-and-review/__tests__/__snapshots__/view-and-review.test.js.snap
@@ -24,7 +24,9 @@ exports[`interested-party-comments GET /manage-documents/:folderId/ should rende
         <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Manage folder</span>
             <h1 class="govuk-heading-l">Supporting documents</h1>
         </div>
-    </div>
+    </div><a href="/appeals-service/appeal-details/2/interested-party-comments/5/add-document"
+    role="button" draggable="false" class="govuk-button govuk-button--secondary"
+    data-module="govuk-button"> Add document</a>
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-full">
             <table class="govuk-table" id="documents-table">
@@ -70,8 +72,7 @@ exports[`interested-party-comments GET /manage-documents/:folderId/ should rende
                 </tbody>
             </table>
         </div>
-    </div><a href="/appeals-service/appeal-details/2/interested-party-comments/5/add-document"
-    role="button" draggable="false" class="govuk-button" data-module="govuk-button"> Add document</a>
+    </div>
 </main>"
 `;
 

--- a/appeals/web/src/server/appeals/appeal-details/representations/interested-party-comments/view-and-review/__tests__/view-and-review.test.js
+++ b/appeals/web/src/server/appeals/appeal-details/representations/interested-party-comments/view-and-review/__tests__/view-and-review.test.js
@@ -319,7 +319,7 @@ describe('interested-party-comments', () => {
 			expect(unprettifiedElement.innerHTML).toContain('Actions</th>');
 			expect(unprettifiedElement.innerHTML).toContain('test-pdf-documentFolderInfo.pdf</span>');
 			expect(unprettifiedElement.innerHTML).toContain(
-				`<a href="/appeals-service/appeal-details/2/interested-party-comments/5/add-document" role="button" draggable="false" class="govuk-button" data-module="govuk-button"> Add document</a>`
+				`<a href="/appeals-service/appeal-details/2/interested-party-comments/5/add-document" role="button" draggable="false" class="govuk-button govuk-button--secondary" data-module="govuk-button"> Add document</a>`
 			);
 		});
 	});

--- a/appeals/web/src/server/appeals/appeal-details/representations/lpa-statement/__tests__/__snapshots__/lpa-statement.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/representations/lpa-statement/__tests__/__snapshots__/lpa-statement.test.js.snap
@@ -196,7 +196,9 @@ exports[`lpa-statements GET /manage-documents/:folderId/ should render manage fo
         <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Manage folder</span>
             <h1 class="govuk-heading-l">Supporting documents</h1>
         </div>
-    </div>
+    </div><a href="/appeals-service/appeal-details/2/lpa-statement/add-document"
+    role="button" draggable="false" class="govuk-button govuk-button--secondary"
+    data-module="govuk-button"> Add document</a>
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-full">
             <table class="govuk-table" id="documents-table">
@@ -242,8 +244,7 @@ exports[`lpa-statements GET /manage-documents/:folderId/ should render manage fo
                 </tbody>
             </table>
         </div>
-    </div><a href="/appeals-service/appeal-details/2/lpa-statement/add-document"
-    role="button" draggable="false" class="govuk-button" data-module="govuk-button"> Add document</a>
+    </div>
 </main>"
 `;
 

--- a/appeals/web/src/server/appeals/appeal-details/representations/lpa-statement/__tests__/lpa-statement.test.js
+++ b/appeals/web/src/server/appeals/appeal-details/representations/lpa-statement/__tests__/lpa-statement.test.js
@@ -491,7 +491,7 @@ describe('lpa-statements', () => {
 			expect(unprettifiedElement.innerHTML).toContain('Actions</th>');
 			expect(unprettifiedElement.innerHTML).toContain('test-pdf-documentFolderInfo.pdf</span>');
 			expect(unprettifiedElement.innerHTML).toContain(
-				`<a href="/appeals-service/appeal-details/2/lpa-statement/add-document" role="button" draggable="false" class="govuk-button" data-module="govuk-button"> Add document</a>`
+				`<a href="/appeals-service/appeal-details/2/lpa-statement/add-document" role="button" draggable="false" class="govuk-button govuk-button--secondary" data-module="govuk-button"> Add document</a>`
 			);
 		});
 	});

--- a/appeals/web/src/server/appeals/appeal-documents/appeal-documents.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-documents/appeal-documents.mapper.js
@@ -913,8 +913,9 @@ export function manageFolderPage({
 	const buttonComponent = {
 		type: 'button',
 		parameters: {
-			text: addButtonTextOverride || 'Add documents',
-			href: addButtonUrl?.replace('{{folderId}}', folder.folderId.toString())
+			text: addButtonTextOverride || 'Add document',
+			href: addButtonUrl?.replace('{{folderId}}', folder.folderId.toString()),
+			classes: 'govuk-button--secondary'
 		}
 	};
 
@@ -928,6 +929,7 @@ export function manageFolderPage({
 		pageComponents: [
 			...notificationBanners,
 			...errorSummaryPageComponents,
+			buttonComponent,
 			{
 				type: 'table',
 				wrapperHtml: {
@@ -991,8 +993,7 @@ export function manageFolderPage({
 						mapFolderDocumentActionsHtmlProperty(folder, document, viewAndEditUrl)
 					])
 				}
-			},
-			buttonComponent
+			}
 		]
 	};
 


### PR DESCRIPTION
## Describe your changes
### WEB

- moved add document button to top of manage folder page
- made it a secondary button
- changes text to 'Add document'

### TEST

- Updated unit tests
- updated snapshots
- manual testing in browser

## Issue ticket number and link

[Ticket](https://pins-ds.atlassian.net.mcas.ms/browse/A2-4007)
