### PR TITLE
feat(web): removing update decision letter from caption (A2-4114)

### DIFF
--- a/appeals/web/src/server/appeals/appeal-details/update-decision-letter/__tests__/__snapshots__/update-decision-letter.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/update-decision-letter/__tests__/__snapshots__/update-decision-letter.test.js.snap
@@ -55,8 +55,8 @@ exports[`update-decision-letter GET /decision-letter-upload should render the de
 exports[`update-decision-letter GET /issue-decision/check-your-decision should render the check your decision page 1`] = `
 "<main class="govuk-main-wrapper" id="main-content">
     <div class="govuk-grid-row">
-        <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Appeal 351062 - update decision letter</span>
-            <h1             class="govuk-heading-l">Check details and update decision letter</h1>
+        <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Appeal 351062</span>
+            <h1 class="govuk-heading-l">Check details and update decision letter</h1>
         </div>
     </div>
     <div class="govuk-grid-row">

--- a/appeals/web/src/server/appeals/appeal-details/update-decision-letter/__tests__/update-decision-letter.test.js
+++ b/appeals/web/src/server/appeals/appeal-details/update-decision-letter/__tests__/update-decision-letter.test.js
@@ -239,9 +239,7 @@ describe('update-decision-letter', () => {
 
 			const unprettifiedElement = parseHtml(response.text, { skipPrettyPrint: true });
 
-			expect(unprettifiedElement.innerHTML).toContain(
-				'Appeal 351062 - update decision letter</span>'
-			);
+			expect(unprettifiedElement.innerHTML).toContain('Appeal 351062</span>');
 			expect(unprettifiedElement.innerHTML).toContain('Check details and update decision letter');
 			expect(unprettifiedElement.innerHTML).toContain('Decision letter');
 			expect(unprettifiedElement.innerHTML).toContain('Correction notice');

--- a/appeals/web/src/server/appeals/appeal-details/update-decision-letter/update-decision-letter.controller.js
+++ b/appeals/web/src/server/appeals/appeal-details/update-decision-letter/update-decision-letter.controller.js
@@ -89,7 +89,7 @@ export const renderUpdateDocumentCheckDetails = async (request, response) => {
 		{
 			title: 'Check details and update decision letter',
 			heading: 'Check details and update decision letter',
-			preHeading: `Appeal ${appealShortReference(appealReference)} - update decision letter`,
+			preHeading: `Appeal ${appealShortReference(appealReference)}`,
 			backLinkUrl: `${baseUrl}/correction-notice`,
 			submitButtonText: 'Update decision letter',
 			responses: {


### PR DESCRIPTION
## Describe your changes

### WEB

- Removed 'update decision letter' from page caption
 
### Test 

- Updates unit tests and snapshots
- manual testing within browser 

## Issue ticket number and link

[Ticket](https://pins-ds.atlassian.net.mcas.ms/browse/A2-4114)
