### PR TITLE
A2-3981 - test(appeals): shared file & file uploader

### DIFF
--- a/appeals/e2e/cypress/page_objects/shared.js
+++ b/appeals/e2e/cypress/page_objects/shared.js
@@ -1,0 +1,59 @@
+// @ts-nocheck
+
+import { Page } from './basePage';
+
+export class FileUploader extends Page {
+	fixturesPath = 'cypress/fixtures/';
+
+	/************************ Locators **********************/
+
+	selectors = {
+		...this.elements,
+		uploadFile: 'upload-file-button',
+		uploadedFileHeading: '.govuk-heading-s',
+		uploadedFileRows: '.pins-file-upload__files-rows > li',
+		removeButton: 'button-remove-'
+	};
+
+	fileUploaderElements = {
+		uploadFile: () => cy.getByData(this.selectors.uploadFile),
+		uploadedFiles: () => cy.get(this.selectors.uploadedFileRows)
+	};
+
+	/************************ Actions ***********************/
+
+	//accepts a single file, or an array of files
+	uploadFiles(fileNames) {
+		const files = [].concat(fileNames);
+
+		files.forEach((fileName) => {
+			this.fileUploaderElements
+				.uploadFile()
+				.click()
+				.selectFile(this.fixturesPath + fileName, { action: 'drag-drop' }, { force: true });
+		});
+	}
+
+	//accepts a single file, or an array of files
+	removeFile(filesArray) {
+		const removeFiles = [].concat(filesArray);
+
+		removeFiles.forEach((fileName) => {
+			cy.get(this.selectors.uploadedFileHeading).contains(fileName).next().click();
+		});
+	}
+
+	/************************ Assertions ***********************/
+
+	//accepts a single file, or an array of files
+	verifyUploadedFiles(filesArray) {
+		const expectedFiles = [].concat(filesArray);
+
+		expectedFiles.forEach((fileName) => {
+			this.fileUploaderElements
+				.uploadedFiles()
+				.find(this.selectors.uploadedFileHeading)
+				.should('include.text', `File name: ${fileName}`);
+		});
+	}
+}


### PR DESCRIPTION
new location for functionality that spans multiple areas of the application. Makes sense to have a 'shared' location where functions can live that can be used in multiple areas of the application. I've started it off with a file uploader. I think it makes sense to have each 'component' to have it's own class in this file and they can be imported individually. Having each class extend off the basePage should lead to less bloat.

## Describe your changes

* New shared.js file
* File uploader class extends basepage. Includes functions for uploading, removing and verifying files

## Issue ticket number and link

[A2-3981](https://pins-ds.atlassian.net/browse/A2-3981)


[A2-3981]: https://pins-ds.atlassian.net/browse/A2-3981?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ