### PR TITLE
test(appeals): poc of multi environment config

### DIFF
--- a/appeals/e2e/cypress.config.dev.env.js
+++ b/appeals/e2e/cypress.config.dev.env.js
@@ -1,0 +1,23 @@
+// @ts-nocheck
+const { defineConfig } = require('cypress');
+const { azureSignIn } = require('./cypress/support/login');
+const baseConfig = require('./cypress.config');
+
+require('dotenv').config();
+
+const app = process.env.APP;
+
+const e2eOverride = {
+	baseUrl: 'https://back-office-appeals-dev.planninginspectorate.gov.uk/',
+	apiBaseUrl: 'https://pins-app-appeals-bo-api-dev.azurewebsites.net/'
+};
+
+module.exports = defineConfig({
+	e2e: {
+		...baseConfig.e2e,
+		...e2eOverride
+	},
+	env: {
+		...baseConfig.env
+	}
+});

--- a/appeals/e2e/cypress.config.js
+++ b/appeals/e2e/cypress.config.js
@@ -32,8 +32,8 @@ module.exports = defineConfig({
 			on('task', { ValidateDownloadedFile: validateDownloadedFile });
 			return config;
 		},
-		baseUrl: process.env.BASE_URL,
-		apiBaseUrl: process.env.API_BASE_URL,
+		baseUrl: '', //supplied by environment config,
+		apiBaseUrl: '', //supplied by environment config,
 		env: {
 			PASSWORD: process.env.USER_PASSWORD,
 			CASE_TEAM_EMAIL: process.env.CASE_TEAM_EMAIL,

--- a/appeals/e2e/cypress.config.local.env.js
+++ b/appeals/e2e/cypress.config.local.env.js
@@ -1,0 +1,23 @@
+// @ts-nocheck
+const { defineConfig } = require('cypress');
+const { azureSignIn } = require('./cypress/support/login');
+const baseConfig = require('./cypress.config');
+
+require('dotenv').config();
+
+const app = process.env.APP;
+
+const e2eOverride = {
+	baseUrl: 'https://localhost:8080/',
+	apiBaseUrl: 'http://localhost:3000/'
+};
+
+module.exports = defineConfig({
+	e2e: {
+		...baseConfig.e2e,
+		...e2eOverride
+	},
+	env: {
+		...baseConfig.env
+	}
+});

--- a/appeals/e2e/cypress.config.test.env.js
+++ b/appeals/e2e/cypress.config.test.env.js
@@ -1,0 +1,23 @@
+// @ts-nocheck
+const { defineConfig } = require('cypress');
+const { azureSignIn } = require('./cypress/support/login');
+const baseConfig = require('./cypress.config');
+
+require('dotenv').config();
+
+const app = process.env.APP;
+
+const e2eOverride = {
+	baseUrl: 'https://back-office-appeals-test.planninginspectorate.gov.uk/',
+	apiBaseUrl: 'https://pins-app-appeals-bo-api-test.azurewebsites.net/'
+};
+
+module.exports = defineConfig({
+	e2e: {
+		...baseConfig.e2e,
+		...e2eOverride
+	},
+	env: {
+		...baseConfig.env
+	}
+});

--- a/appeals/e2e/package.json
+++ b/appeals/e2e/package.json
@@ -4,8 +4,12 @@
 	"description": "E2E Tests for the Back Office Application",
 	"main": "index.js",
 	"scripts": {
-		"cy:open": "npx cypress open --browser chrome --e2e",
-		"cy:run": "npx cypress run",
+		"cy:open": "npx cypress open --browser chrome --e2e --config-file cypress.config.local.env.js",
+		"cy:open:dev": "npx cypress open --browser chrome --e2e --config-file cypress.config.dev.env.js",
+		"cy:open:test": "npx cypress open --browser chrome --e2e --config-file cypress.config.test.env.js",
+		"cy:run": "npx cypress run --config-file cypress.config.local.env.js", 
+		"cy:run:dev": "npx cypress run --config-file cypress.config.dev.env.js",
+		"cy:run:test": "npx cypress run --config-file cypress.config.test.env.js",
 		"cy:open-smoke": "npx cypress open --browser chrome --e2e --env grepTags='smoke'",
 		"cy:run-smoke": "npx cypress run --env grepTags='smoke'",
 		"cy:ci": "npx cypress run --env isCI=true"


### PR DESCRIPTION
## Describe your changes

This is a POC for having a multi-environment config for e2e tests! Is based on ideas in this post https://medium.com/@dingraham01/cypress-easy-multi-environment-configuration-c18ac94971d5 

This has following benefits 

- a clean and elegant way to manage environment specific values (e.g. urls) 
- allows for specific commands (scripts) so that can easily run against different environments (no having to manually update stuff!)  

As such the set of commands that can run are now 

```
// for test runner
"cy:open": "npx cypress open --browser chrome --e2e --config-file cypress.config.local.env.js", 
"cy:open:dev": "npx cypress open --browser chrome --e2e --config-file cypress.config.dev.env.js",
"cy:open:test": "npx cypress open --browser chrome --e2e --config-file cypress.config.test.env.js",

// for headless run 
"cy:run": "npx cypress run --config-file cypress.config.local.env.js", 
"cy:run:dev": "npx cypress run --config-file cypress.config.dev.env.js",
"cy:run:test": "npx cypress run --config-file cypress.config.test.env.js", 
```

Comments and suggestions welcome! 

## Issue ticket number and link

[Does not have ticket yet!](<!--Paste your ticket link here-->)
