### PR TITLE
A2-3480 - Implement zero delay on text input commands

### DIFF
--- a/appeals/e2e/cypress/support/commands.js
+++ b/appeals/e2e/cypress/support/commands.js
@@ -2,6 +2,16 @@
 import { BrowserAuthData } from '../fixtures/browser-auth-data';
 import { appealsApiClient } from './appealsApiClient';
 
+//OVERWRITE
+
+Cypress.Commands.overwrite('type', (originalFn, subject, text, options = {}) => {
+	options.delay = 0;
+
+	return originalFn(subject, text, options);
+});
+
+//ADD
+
 const cookiesToSet = ['domain', 'expiry', 'httpOnly', 'path', 'secure'];
 
 Cypress.Commands.add('clearCookiesFiles', () => {


### PR DESCRIPTION
## Describe your changes

Overwritten cypress `.type()` command to use {delay: 0} option. This should have a decent impact on suite runtime.

## Issue ticket number and link

[A2-3480](https://pins-ds.atlassian.net/browse/A2-3480)


[A2-3480]: https://pins-ds.atlassian.net/browse/A2-3480?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ