### PR TITLE
fix(appeals): amend cost decision email templates

### DIFF
--- a/appeals/api/src/server/endpoints/decision/__tests__/decision.test.js
+++ b/appeals/api/src/server/endpoints/decision/__tests__/decision.test.js
@@ -266,7 +266,7 @@ describe('decision routes', () => {
 					site_address: `${appeal.address.addressLine1}, ${appeal.address.addressLine2}, ${appeal.address.addressTown}, ${appeal.address.addressCounty}, ${appeal.address.postcode}, ${appeal.address.addressCountry}`,
 					front_office_url: `https://appeal-planning-decision.service.gov.uk/appeals/${appeal.reference}`
 				},
-				templateName: 'lpa-costs-decision-lpa',
+				templateName: 'lpa-costs-decision-appellant',
 				recipientEmail: appeal.agent.email
 			});
 
@@ -306,7 +306,7 @@ describe('decision routes', () => {
 					site_address: `${appeal.address.addressLine1}, ${appeal.address.addressLine2}, ${appeal.address.addressTown}, ${appeal.address.addressCounty}, ${appeal.address.postcode}, ${appeal.address.addressCountry}`,
 					front_office_url: `https://appeal-planning-decision.service.gov.uk/appeals/${appeal.reference}`
 				},
-				templateName: 'lpa-costs-decision-appellant',
+				templateName: 'lpa-costs-decision-lpa',
 				recipientEmail: appeal.lpa.email
 			});
 

--- a/appeals/api/src/server/endpoints/decision/decision.service.js
+++ b/appeals/api/src/server/endpoints/decision/decision.service.js
@@ -175,8 +175,8 @@ const getCostDecisionDetails = (decisionType) => {
 		}
 		case DECISION_TYPE_LPA_COSTS: {
 			return {
-				recipientEmailTemplate: 'lpa-costs-decision-lpa',
-				lpaEmailTemplate: 'lpa-costs-decision-appellant',
+				recipientEmailTemplate: 'lpa-costs-decision-appellant',
+				lpaEmailTemplate: 'lpa-costs-decision-lpa',
 				auditTrailDetails: AUDIT_TRAIL_LPA_COSTS_DECISION_ISSUED
 			};
 		}


### PR DESCRIPTION
## Describe your changes

Fixing which email templates are used for LPA cost decisions to LPA and agent

## Issue ticket number and link

[Ticket](https://pins-ds.atlassian.net/browse/A2-4178)
