### PR TITLE
feat(appeals): issuing a decision for linked appeals (a2-3075)

### DIFF
--- a/appeals/api/src/server/endpoints/appeals.d.ts
+++ b/appeals/api/src/server/endpoints/appeals.d.ts
@@ -455,6 +455,7 @@ interface LinkedAppeal {
 	externalSource: boolean;
 	externalAppealType?: string | null;
 	externalId?: string | null;
+	inspectorDecision?: string | null;
 }
 
 interface LinkableAppealSummary {
@@ -768,7 +769,7 @@ interface UpdateAppealRequest {
 
 interface SetAppealDecisionRequest {
 	documentDate: Date;
-	documentGuid: string;
+	documentGuid?: string;
 	version: number;
 	outcome: string;
 }

--- a/appeals/api/src/server/mappers/api/shared/map-appeal-relationships.js
+++ b/appeals/api/src/server/mappers/api/shared/map-appeal-relationships.js
@@ -81,7 +81,7 @@ export const mapAppealRelationships = (data) => {
  *
  * @param {{parent?: Appeal | null | undefined, child?: Appeal | null | undefined, linkingDate: Date, externalSource: boolean | null, externalAppealType: string | null, externalId: string | null}} relationship
  * @param {Boolean} isParentAppeal
- * @returns {Partial<AppealRelationship & {currentStatus: string, completedStateList: string[]}>}
+ * @returns {Partial<AppealRelationship & {currentStatus: string, completedStateList: string[], inspectorDecision: string}>}
  */
 const mapLinkedAppeal = (relationship, isParentAppeal) => {
 	const { linkingDate, externalSource, externalAppealType, externalId, parent, child } =
@@ -90,7 +90,8 @@ const mapLinkedAppeal = (relationship, isParentAppeal) => {
 		id: appealId,
 		appealStatus,
 		reference: appealReference,
-		appealType
+		appealType,
+		inspectorDecision
 	} = (isParentAppeal ? parent : child) || {};
 
 	const currentStatus =
@@ -109,6 +110,7 @@ const mapLinkedAppeal = (relationship, isParentAppeal) => {
 		externalId,
 		isParentAppeal,
 		currentStatus: currentStatus[0] ?? undefined,
-		completedStateList
+		completedStateList,
+		inspectorDecision: inspectorDecision?.outcome ?? undefined
 	};
 };

--- a/appeals/web/src/server/appeals/appeal-details/__tests__/__snapshots__/appeal-details.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/__tests__/__snapshots__/appeal-details.test.js.snap
@@ -6510,7 +6510,7 @@ exports[`appeal-details GET /:appealId should render a Decision inset panel when
         <ul class="govuk-list">
             <li>Decision: Dismissed</li>
             <li>Decision issued on 4 August 2023 (updated on 11 October 2023)</li>
-            <li><a class="govuk-link" href="/appeals-service/appeal-details/1/issue-decision/view-decision">View decision</a>
+            <li><a class="govuk-link" href="/appeals-service/appeal-details/1/issue-decision/view-decision?backUrl=%2Fappeals-service%2Fappeal-details%2F2">View decision</a>
             </li>
         </ul>
     </div>
@@ -6964,7 +6964,7 @@ exports[`appeal-details GET /:appealId should render a Decision inset panel when
         <ul class="govuk-list">
             <li>Decision: Dismissed</li>
             <li>Decision issued on 25 December 2023</li>
-            <li><a class="govuk-link" href="/appeals-service/appeal-details/1/issue-decision/view-decision">View decision</a>
+            <li><a class="govuk-link" href="/appeals-service/appeal-details/1/issue-decision/view-decision?backUrl=%2Fappeals-service%2Fappeal-details%2F2">View decision</a>
             </li>
         </ul>
     </div>
@@ -7418,7 +7418,7 @@ exports[`appeal-details GET /:appealId should render a Decision inset panel when
         <ul class="govuk-list">
             <li>Decision: Invalid</li>
             <li>Decision issued on 25 December 2023</li>
-            <li><a class="govuk-link" href="/appeals-service/appeal-details/1/issue-decision/view-decision">View decision</a>
+            <li><a class="govuk-link" href="/appeals-service/appeal-details/1/issue-decision/view-decision?backUrl=%2Fappeals-service%2Fappeal-details%2F2">View decision</a>
             </li>
         </ul>
     </div>

--- a/appeals/web/src/server/appeals/appeal-details/__tests__/appeal-details.test.js
+++ b/appeals/web/src/server/appeals/appeal-details/__tests__/appeal-details.test.js
@@ -2493,7 +2493,7 @@ describe('appeal-details', () => {
 				'<li>Decision issued on 4 August 2023 (updated on 11 October 2023)</li>'
 			);
 			expect(insetTextElementHTML).toContain(
-				'<li><a class="govuk-link" href="/appeals-service/appeal-details/1/issue-decision/view-decision">View decision</a></li>'
+				'<li><a class="govuk-link" href="/appeals-service/appeal-details/1/issue-decision/view-decision?backUrl=%2Fappeals-service%2Fappeal-details%2F2">View decision</a></li>'
 			);
 		});
 
@@ -2550,7 +2550,7 @@ describe('appeal-details', () => {
 			expect(insetTextElementHTML).toContain('<li>Decision: Dismissed</li>');
 			expect(insetTextElementHTML).toContain('<li>Decision issued on 25 December 2023</li>');
 			expect(insetTextElementHTML).toContain(
-				'<li><a class="govuk-link" href="/appeals-service/appeal-details/1/issue-decision/view-decision">View decision</a></li>'
+				'<li><a class="govuk-link" href="/appeals-service/appeal-details/1/issue-decision/view-decision?backUrl=%2Fappeals-service%2Fappeal-details%2F2">View decision</a></li>'
 			);
 		});
 
@@ -2583,7 +2583,7 @@ describe('appeal-details', () => {
 			expect(insetTextElementHTML).toContain('<li>Decision: Invalid</li>');
 			expect(insetTextElementHTML).toContain('<li>Decision issued on 25 December 2023</li>');
 			expect(insetTextElementHTML).toContain(
-				'<li><a class="govuk-link" href="/appeals-service/appeal-details/1/issue-decision/view-decision">View decision</a></li>'
+				'<li><a class="govuk-link" href="/appeals-service/appeal-details/1/issue-decision/view-decision?backUrl=%2Fappeals-service%2Fappeal-details%2F2">View decision</a></li>'
 			);
 		});
 

--- a/appeals/web/src/server/appeals/appeal-details/issue-decision/__tests__/__snapshots__/issue-decision.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/issue-decision/__tests__/__snapshots__/issue-decision.test.js.snap
@@ -92,7 +92,121 @@ exports[`issue-decision GET /appellant-costs-decision-letter-upload should rende
 </main>"
 `;
 
-exports[`issue-decision GET /decision should render the 'what is the decision' page with the expected content 1`] = `
+exports[`issue-decision GET /decision Linked appeals Linked child appeal should render the 'decision' page for the child with the expected content 1`] = `
+"<main class="govuk-main-wrapper" id="main-content">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Appeal 351062 (lead) - issue decision</span>
+            <h1             class="govuk-heading-l">Decision for child appeal 351066</h1>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <div class="govuk-grid-row">
+                <div class="govuk-grid-column-full">
+                    <form method="POST" novalidate="novalidate">
+                        <dl class="govuk-summary-list">
+                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Appellant</dt>
+                                <dd class="govuk-summary-list__value">Roger Simmons</dd>
+                            </div>
+                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Site address</dt>
+                                <dd class="govuk-summary-list__value">21 The Pavement, Wandsworth, SW4 0HY</dd>
+                            </div>
+                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Appeal type</dt>
+                                <dd class="govuk-summary-list__value"></dd>
+                            </div>
+                        </dl>
+                        <div class="govuk-form-group">
+                            <fieldset class="govuk-fieldset">
+                                <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
+                                    <h1 class="govuk-fieldset__heading"> Decision for child appeal 351066</h1>
+                                </legend>
+                                <div class="govuk-radios" data-module="govuk-radios">
+                                    <div class="govuk-radios__item">
+                                        <input class="govuk-radios__input" id="decision" name="decision" type="radio"
+                                        value="allowed">
+                                        <label class="govuk-label govuk-radios__label" for="decision">Allowed</label>
+                                    </div>
+                                    <div class="govuk-radios__item">
+                                        <input class="govuk-radios__input" id="decision-2" name="decision" type="radio"
+                                        value="dismissed">
+                                        <label class="govuk-label govuk-radios__label" for="decision-2">Dismissed</label>
+                                    </div>
+                                    <div class="govuk-radios__item">
+                                        <input class="govuk-radios__input" id="decision-3" name="decision" type="radio"
+                                        value="split decision">
+                                        <label class="govuk-label govuk-radios__label" for="decision-3">Split decision</label>
+                                    </div>
+                                </div>
+                            </fieldset>
+                        </div>
+                        <button type="submit" data-prevent-double-click="true" class="govuk-button"
+                        data-module="govuk-button">Continue</button>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </div>
+</main>"
+`;
+
+exports[`issue-decision GET /decision Linked appeals Linked lead appeal should render the 'decision' page for the lead with the expected content 1`] = `
+"<main class="govuk-main-wrapper" id="main-content">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Appeal 351062 (lead) - issue decision</span>
+            <h1             class="govuk-heading-l">Decision for lead appeal 351062</h1>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <div class="govuk-grid-row">
+                <div class="govuk-grid-column-full">
+                    <form method="POST" novalidate="novalidate">
+                        <dl class="govuk-summary-list">
+                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Appellant</dt>
+                                <dd class="govuk-summary-list__value">Roger Simmons</dd>
+                            </div>
+                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Site address</dt>
+                                <dd class="govuk-summary-list__value">21 The Pavement, Wandsworth, SW4 0HY</dd>
+                            </div>
+                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Appeal type</dt>
+                                <dd class="govuk-summary-list__value">Householder</dd>
+                            </div>
+                        </dl>
+                        <div class="govuk-form-group">
+                            <fieldset class="govuk-fieldset">
+                                <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
+                                    <h1 class="govuk-fieldset__heading"> Decision for lead appeal 351062</h1>
+                                </legend>
+                                <div class="govuk-radios" data-module="govuk-radios">
+                                    <div class="govuk-radios__item">
+                                        <input class="govuk-radios__input" id="decision" name="decision" type="radio"
+                                        value="allowed">
+                                        <label class="govuk-label govuk-radios__label" for="decision">Allowed</label>
+                                    </div>
+                                    <div class="govuk-radios__item">
+                                        <input class="govuk-radios__input" id="decision-2" name="decision" type="radio"
+                                        value="dismissed">
+                                        <label class="govuk-label govuk-radios__label" for="decision-2">Dismissed</label>
+                                    </div>
+                                    <div class="govuk-radios__item">
+                                        <input class="govuk-radios__input" id="decision-3" name="decision" type="radio"
+                                        value="split decision">
+                                        <label class="govuk-label govuk-radios__label" for="decision-3">Split decision</label>
+                                    </div>
+                                </div>
+                            </fieldset>
+                        </div>
+                        <button type="submit" data-prevent-double-click="true" class="govuk-button"
+                        data-module="govuk-button">Continue</button>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </div>
+</main>"
+`;
+
+exports[`issue-decision GET /decision Single appeal should render the 'what is the decision' page with the expected content 1`] = `
 "<main class="govuk-main-wrapper" id="main-content">
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Appeal 351062 - issue decision</span>
@@ -117,28 +231,28 @@ exports[`issue-decision GET /decision should render the 'what is the decision' p
                         </dl>
                         <div class="govuk-form-group">
                             <fieldset class="govuk-fieldset">
-                                <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+                                <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
                                     <h1 class="govuk-fieldset__heading"> What is the decision?</h1>
                                 </legend>
                                 <div class="govuk-radios" data-module="govuk-radios">
                                     <div class="govuk-radios__item">
                                         <input class="govuk-radios__input" id="decision" name="decision" type="radio"
-                                        value="Allowed">
+                                        value="allowed">
                                         <label class="govuk-label govuk-radios__label" for="decision">Allowed</label>
                                     </div>
                                     <div class="govuk-radios__item">
                                         <input class="govuk-radios__input" id="decision-2" name="decision" type="radio"
-                                        value="Dismissed">
+                                        value="dismissed">
                                         <label class="govuk-label govuk-radios__label" for="decision-2">Dismissed</label>
                                     </div>
                                     <div class="govuk-radios__item">
                                         <input class="govuk-radios__input" id="decision-3" name="decision" type="radio"
-                                        value="Split">
-                                        <label class="govuk-label govuk-radios__label" for="decision-3">Split Decision</label>
+                                        value="split decision">
+                                        <label class="govuk-label govuk-radios__label" for="decision-3">Split decision</label>
                                     </div>
                                     <div class="govuk-radios__item">
                                         <input class="govuk-radios__input" id="decision-4" name="decision" type="radio"
-                                        value="Invalid" data-aria-controls="conditional-decision-4">
+                                        value="invalid" data-aria-controls="conditional-decision-4">
                                         <label class="govuk-label govuk-radios__label" for="decision-4">Invalid</label>
                                     </div>
                                     <div class="govuk-radios__conditional govuk-radios__conditional--hidden"
@@ -294,7 +408,68 @@ exports[`issue-decision GET /issue-decision/check-your-appellant-costs-decision 
 </main>"
 `;
 
-exports[`issue-decision GET /issue-decision/check-your-decision should render the check your decision page 1`] = `
+exports[`issue-decision GET /issue-decision/check-your-decision Linked appeals should render the check your decision page 1`] = `
+"<main class="govuk-main-wrapper" id="main-content">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Appeal 351062 (lead)</span>
+            <h1 class="govuk-heading-l">Check details and issue decision</h1>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <form method="POST" novalidate="novalidate">
+                <dl class="govuk-summary-list">
+                    <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Decision for lead appeal 351062</dt>
+                        <dd                         class="govuk-summary-list__value">Allowed</dd>
+                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/issue-decision/decision?backUrl=%2Fappeals-service%2Fappeal-details%2F1%2Fissue-decision%2F%2Fcheck-your-decision">Change<span class="govuk-visually-hidden"> decision for lead appeal 351062</span></a>
+                            </dd>
+                    </div>
+                    <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Decision for child appeal 351066</dt>
+                        <dd                         class="govuk-summary-list__value">Split decision</dd>
+                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/issue-decision/2/decision?backUrl=%2Fappeals-service%2Fappeal-details%2F1%2Fissue-decision%2F%2Fcheck-your-decision">Change<span class="govuk-visually-hidden"> decision for child appeal 351066</span></a>
+                            </dd>
+                    </div>
+                    <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Decision letter</dt>
+                        <dd class="govuk-summary-list__value"><a class="govuk-link" download href="/documents/APP/Q9999/D/21/351062/download-uncommitted/1/test-document.pdf"
+                            target="_blank">test-document.pdf</a>
+                        </dd>
+                        <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/issue-decision/decision-letter-upload?backUrl=%2Fappeals-service%2Fappeal-details%2F1%2Fissue-decision%2F%2Fcheck-your-decision">Change<span class="govuk-visually-hidden"> decision letter</span></a>
+                        </dd>
+                    </div>
+                    <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Do you want to issue the appellant&#39;s costs decision?</dt>
+                        <dd                         class="govuk-summary-list__value">Yes</dd>
+                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/issue-decision/appellant-costs-decision?backUrl=%2Fappeals-service%2Fappeal-details%2F1%2Fissue-decision%2F%2Fcheck-your-decision">Change<span class="govuk-visually-hidden"> appellant cost decision</span></a>
+                            </dd>
+                    </div>
+                    <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Appellant costs decision letter</dt>
+                        <dd                         class="govuk-summary-list__value"><a class="govuk-link" download href="/documents/APP/Q9999/D/21/351062/download-uncommitted/2/test-document-appellant.pdf"
+                            target="_blank">test-document-appellant.pdf</a>
+                            </dd>
+                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/issue-decision/appellant-costs-decision-letter-upload?backUrl=%2Fappeals-service%2Fappeal-details%2F1%2Fissue-decision%2F%2Fcheck-your-decision">Change<span class="govuk-visually-hidden"> appellant cost decision letter</span></a>
+                            </dd>
+                    </div>
+                    <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Do you want to issue the LPA&#39;s costs decision?</dt>
+                        <dd                         class="govuk-summary-list__value">Yes</dd>
+                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/issue-decision/lpa-costs-decision?backUrl=%2Fappeals-service%2Fappeal-details%2F1%2Fissue-decision%2F%2Fcheck-your-decision">Change<span class="govuk-visually-hidden"> lpa cost decision</span></a>
+                            </dd>
+                    </div>
+                    <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> LPA costs decision letter</dt>
+                        <dd                         class="govuk-summary-list__value"><a class="govuk-link" download href="/documents/APP/Q9999/D/21/351062/download-uncommitted/3/test-document-lpa.pdf"
+                            target="_blank">test-document-lpa.pdf</a>
+                            </dd>
+                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/issue-decision/lpa-costs-decision-letter-upload?backUrl=%2Fappeals-service%2Fappeal-details%2F1%2Fissue-decision%2F%2Fcheck-your-decision">Change<span class="govuk-visually-hidden"> lpa costs decision letter</span></a>
+                            </dd>
+                    </div>
+                </dl>
+                <p class="govuk-body">We'll send an email to the appellant and LPA to tell them about the decision.</p>
+                <button                 type="submit" class="govuk-button" data-module="govuk-button">Issue decision</button>
+            </form>
+        </div>
+    </div>
+</main>"
+`;
+
+exports[`issue-decision GET /issue-decision/check-your-decision Single appeal should render the check your decision page 1`] = `
 "<main class="govuk-main-wrapper" id="main-content">
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Appeal 351062</span>

--- a/appeals/web/src/server/appeals/appeal-details/issue-decision/issue-decision.middleware.js
+++ b/appeals/web/src/server/appeals/appeal-details/issue-decision/issue-decision.middleware.js
@@ -8,13 +8,15 @@ import { DECISION_TYPE_APPELLANT_COSTS } from '@pins/appeals/constants/support.j
  */
 export const clearIssueDecisionCache = async (request, response, next) => {
 	const appealId = request.params.appealId;
-	const { inspectorDecision, appellantCostsDecision, lpaCostsDecision } = request.session;
+	const { inspectorDecision, appellantCostsDecision, lpaCostsDecision, childDecisions } =
+		request.session;
 
 	// If the appealId in the session doesn't match the appealId in the request, clear the session data.
 	if (inspectorDecision?.appealId?.toString() !== appealId) request.session.inspectorDecision = {};
 	if (appellantCostsDecision?.appealId?.toString() !== appealId)
 		request.session.appellantCostsDecision = {};
 	if (lpaCostsDecision?.appealId?.toString() !== appealId) request.session.lpaCostsDecision = {};
+	if (childDecisions?.appealId?.toString() !== appealId) request.session.childDecisions = {};
 
 	next();
 };

--- a/appeals/web/src/server/appeals/appeal-details/issue-decision/issue-decision.router.js
+++ b/appeals/web/src/server/appeals/appeal-details/issue-decision/issue-decision.router.js
@@ -12,6 +12,7 @@ import {
 	DECISION_TYPE_APPELLANT_COSTS,
 	DECISION_TYPE_LPA_COSTS
 } from '@pins/appeals/constants/support.js';
+import { saveBackUrl } from '#lib/middleware/save-back-url.js';
 
 const router = createRouter({ mergeParams: true });
 
@@ -21,6 +22,7 @@ router
 	.route('/decision')
 	.get(
 		assertUserHasPermission(permissionNames.setCaseOutcome),
+		saveBackUrl('issueDecision'),
 		asyncHandler(controller.renderIssueDecision)
 	)
 	.post(
@@ -155,6 +157,19 @@ router
 	.get(
 		assertUserHasPermission(permissionNames.setCaseOutcome),
 		asyncHandler(controller.renderViewDecision)
+	);
+
+router
+	.route('/:childAppealId/decision')
+	.get(
+		assertUserHasPermission(permissionNames.setCaseOutcome),
+		asyncHandler(controller.renderIssueDecision)
+	)
+	.post(
+		validators.validateDecision,
+		validators.validateInvalidReason,
+		assertUserHasPermission(permissionNames.setCaseOutcome),
+		asyncHandler(controller.postIssueDecision)
 	);
 
 export default router;

--- a/appeals/web/src/server/lib/mappers/data/appeal/submappers/decision.mapper.js
+++ b/appeals/web/src/server/lib/mappers/data/appeal/submappers/decision.mapper.js
@@ -1,17 +1,16 @@
 import { APPEAL_CASE_STATUS } from '@planning-inspectorate/data-model';
-import { textSummaryListItem } from '#lib/mappers/index.js';
-import { userHasPermission } from '#lib/mappers/index.js';
+import { textSummaryListItem, userHasPermission } from '#lib/mappers/index.js';
 import { permissionNames } from '#environment/permissions.js';
 import { addBackLinkQueryToUrl } from '#lib/url-utilities.js';
 import { isStatePassed } from '#lib/appeal-status.js';
 import {
 	baseUrl,
-	generateIssueDecisionUrl,
-	mapDecisionOutcome
+	generateIssueDecisionUrl
 } from '#appeals/appeal-details/issue-decision/issue-decision.utils.js';
 import { mapDocumentDownloadUrl } from '#appeals/appeal-documents/appeal-documents.mapper.js';
 import config from '#environment/config.js';
 import { isChildAppeal } from '#lib/mappers/utils/is-linked-appeal.js';
+import { toSentenceCase } from '#lib/string-utilities.js';
 
 /** @type {import('../mapper.js').SubMapper} */
 export const mapDecision = ({ appealDetails, session, request }) => {
@@ -44,7 +43,7 @@ export const mapDecision = ({ appealDetails, session, request }) => {
 	return textSummaryListItem({
 		id: 'decision',
 		text: 'Decision',
-		value: mapDecisionOutcome(decision?.outcome || '') || 'Not issued',
+		value: toSentenceCase(decision?.outcome || '') || 'Not issued',
 		link,
 		editable,
 		actionText: canIssueDecision ? 'Issue' : 'View',

--- a/appeals/web/src/server/lib/string-utilities.js
+++ b/appeals/web/src/server/lib/string-utilities.js
@@ -69,3 +69,11 @@ export const toCamelCase = (str) => {
 		.map((word, idx) => (idx === 0 ? word : word.charAt(0).toUpperCase() + word.slice(1)))
 		.join('');
 };
+
+/**
+ * Converts a string to sentence case.
+ * @param {string} str - The string to convert.
+ * @returns {string} - The sentence case formatted string.
+ */
+export const toSentenceCase = (str) =>
+	capitalizeFirstLetter(camelCaseToWords(toCamelCase(str)).toLowerCase());


### PR DESCRIPTION
## Describe your changes
#### Issuing a decision for linked appeals (A2-3075)

This PR "appears" far bigger than it is.  Please don't let the detail below scare you when reviewing.

Please note that the upload page tickets (A2-4135, A2-4164, and A2-4169) and costs page tickets (A2-3046 and A2-4165) only amount to the preHeadingText including (lead) if the appeal is linked appeal.

Most of the specified changes below are for the tickets (A2-3075 and A2-4170)

### API:
- Add inspectorDecision to LinkedAppeal interface
- Create publishChildDecision in decision.service.js and call from decision.controller.js when child appeal.
- Include inspectorDecision when mapping relationships for linked appeals in map-appeal-relationships.js
- include inspectorDecision when retrieving linked appeals in appeal.repository.js
- Do not update the document version when creating a child issue decision (documentGuid will be null) in appeal.repository.js

### WEB:
- Determine next page url based on position in sequence of lead and child appeals if linked appeals when selecting decisions for each appeal.
- Save child appeals within the session under childDecisions
- Render issue decision pages based on whether the appeal is not linked, linked lead, or linked child
- Only include invalid as a decison for appeals that are not linked
- Create preHeadingText utility function to simplify injecting (lead) into the preHeading when linked appeals
- Use supplied decision constants CASE_OUTCOME_ALLOWED etc
- Create child decision route to allow child appeal id to be passed to the controller as well as the lead appeal id
- Remove unnecessary mapDecisionOutcome function as new toSentenceCase function will be used instead
- Update buildIssueDecisionLogicData function

### TEST:
- Added unit tests to test the functionality above
- Amend tests to test the functionality above
- Made sure all unit tests pass
- Manually tested within browser

## Issue ticket number and link:
- [(A2-3075) Issuing a decision for linked appeals (relates to all appeal types) - 'Decision outcome' screens - Part 1](https://pins-ds.atlassian.net/browse/A2-3075)
- [(A2-4135) Issuing a decision for linked appeals (relates to all appeal types) - 'Decision letter' screen - Part 2](https://pins-ds.atlassian.net/browse/A2-4135)
- [(A2-3046) Issuing a decision for linked appeals (relates to all appeal types) - 'Do you want to issue the appellant's costs decision?' screen - Part 3](https://pins-ds.atlassian.net/browse/A2-3046)
- [(A2-4164) Issuing a decision for linked appeals (relates to all appeal types) - 'Appellant costs decision letter' upload screen - Part 4](https://pins-ds.atlassian.net/browse/A2-4164)
- [(A2-4165) Issuing a decision for linked appeals (relates to all appeal types) - 'Do you want to issue the LPA's costs decision?' screen - Part 5](https://pins-ds.atlassian.net/browse/A2-4165)
- [(A2-4169) Issuing a decision for linked appeals (relates to all appeal types) - 'LPA costs decision letter' upload screen - Part 6](https://pins-ds.atlassian.net/browse/A2-4169)
- [(A2-4170) Issuing a decision for linked appeals (relates to all appeal types) - 'Check details and issue decision' screen - Part 7](https://pins-ds.atlassian.net/browse/A2-4170)

