### PR TITLE
feat(appeals): case details team section update (A2-3719)

### DIFF
--- a/appeals/api/setup-tests.js
+++ b/appeals/api/setup-tests.js
@@ -130,6 +130,8 @@ const mockRepresentationAttachmentCreateMany = jest.fn().mockResolvedValue({});
 const mockRepresentationCount = jest.fn().mockResolvedValue({});
 const mockLpaFindMany = jest.fn().mockResolvedValue({});
 const mockLpaFindUnique = jest.fn().mockResolvedValue({});
+const mockTeamFindUnique = jest.fn().mockResolvedValue({});
+const mockTeamFindFirst = jest.fn().mockResolvedValue({});
 
 const mockNotifySend = jest.fn().mockImplementation(async (params) => {
 	const { doNotMockNotifySend = false, ...options } = params || {};
@@ -525,6 +527,12 @@ class MockPrismaClient {
 		return {
 			findMany: mockLpaFindMany,
 			findUnique: mockLpaFindUnique
+		};
+	}
+	get team() {
+		return {
+			findUnique: mockTeamFindUnique,
+			findFirst: mockTeamFindFirst
 		};
 	}
 

--- a/appeals/api/src/database/schema.d.ts
+++ b/appeals/api/src/database/schema.d.ts
@@ -1,6 +1,7 @@
 import { RedactionStatus } from '#repositories/document-metadata.repository';
 import * as schema from '#utils/db-client';
 import { CaseOfficer, Inspector } from '@pins/appeals';
+import { AssignedTeam } from '@pins/appeals.api';
 
 export interface Appeal extends schema.Appeal {
 	parentAppeals?: AppealRelationship[];
@@ -19,6 +20,8 @@ export interface Appeal extends schema.Appeal {
 	lpaQuestionnaire?: LPAQuestionnaire | null;
 	appealTimetable?: AppealTimetable | null;
 	appellantCase?: AppellantCase | null;
+	assignedTeamId?: number | null;
+	assignedTeam?: AssignedTeam | null;
 	caseOfficer?: User | null;
 	inspector?: User | null;
 	siteVisit?: SiteVisit | null;

--- a/appeals/api/src/database/teams/dev.js
+++ b/appeals/api/src/database/teams/dev.js
@@ -1,7 +1,13 @@
 export const teamsToCreate = [
 	{ id: 1, name: 'Ops Test', email: 'opstest@planninginspectorate.co.uk' },
 	{ id: 2, name: 'DevTeam1', email: 'devteam1@planninginspectorate.gov.uk' },
-	{ id: 3, name: 'DevTeam2', email: 'devteam2@planninginspectorate.gov.uk' }
+	{ id: 3, name: 'DevTeam2', email: 'devteam2@planninginspectorate.gov.uk' },
+	{ id: 6, name: 'Major Casework Officer', email: 'majorcasework@planninginspectorate.gov.uk' },
+	{
+		id: 7,
+		name: 'Enforcement Appeals Officer',
+		email: 'enforcementappeals@planninginspectorate.gov.uk'
+	}
 ];
 
 /**

--- a/appeals/api/src/database/teams/prod.js
+++ b/appeals/api/src/database/teams/prod.js
@@ -3,7 +3,14 @@ export const teamsToCreate = [
 	{ id: 2, name: 'West2', email: 'west2@planninginspectorate.gov.uk' },
 	{ id: 3, name: 'West3', email: 'west3@planninginspectorate.gov.uk' },
 	{ id: 4, name: 'West4', email: 'west4@planninginspectorate.gov.uk' },
-	{ id: 5, name: 'East2', email: 'east2@planninginspectorate.gov.uk' }
+	{ id: 5, name: 'East2', email: 'east2@planninginspectorate.gov.uk' },
+	{ id: 6, name: 'East1', email: 'east1@planninginspectorate.gov.uk' },
+	{ id: 7, name: 'East3', email: 'east3@planninginspectorate.gov.uk' },
+	{ id: 8, name: 'East4', email: 'east4@planninginspectorate.gov.uk' },
+	{ id: 9, name: 'North1', email: 'north1@planninginspectorate.gov.uk' },
+	{ id: 10, name: 'North2', email: 'north2@planninginspectorate.gov.uk' },
+	{ id: 11, name: 'North3', email: 'north3@planninginspectorate.gov.uk' },
+	{ id: 12, name: 'North4', email: 'north4@planninginspectorate.gov.uk' }
 ];
 
 export const lpaTeamAssignments = {

--- a/appeals/api/src/server/endpoints/appeal-details/__tests__/appeals-details.test.js
+++ b/appeals/api/src/server/endpoints/appeal-details/__tests__/appeals-details.test.js
@@ -58,6 +58,10 @@ const householdAppealDto = {
 		caseResubmissionDueDate: null,
 		lpaQuestionnaireDueDate: householdAppeal.appealTimetable.lpaQuestionnaireDueDate.toISOString()
 	},
+	assignedTeam: {
+		email: 'temp@email.com',
+		name: 'temp'
+	},
 	appellantCaseId: householdAppeal.appellantCase.id,
 	awaitingLinkedAppeal: false,
 	caseOfficer: householdAppeal.caseOfficer.azureAdUserId,
@@ -158,6 +162,10 @@ const s78AppealDto = {
 	},
 	appealType: fullPlanningAppeal.appealType.type,
 	appellantCaseId: fullPlanningAppeal.appellantCase.id,
+	assignedTeam: {
+		email: 'temp@email.com',
+		name: 'temp'
+	},
 	awaitingLinkedAppeal: false,
 	caseOfficer: fullPlanningAppeal.caseOfficer.azureAdUserId,
 	costs: {},

--- a/appeals/api/src/server/endpoints/appeals.d.ts
+++ b/appeals/api/src/server/endpoints/appeals.d.ts
@@ -51,6 +51,11 @@ interface SingleAppealDetailsResponse {
 	appellantCaseId: number;
 	appellant?: ServiceUserResponse | null;
 	agent?: ServiceUserResponse | null;
+	assignedTeamId?: number | null;
+	assignedTeam?: {
+		name: string | null;
+		email: string | null;
+	};
 	caseOfficer?: string | null;
 	costs: {
 		appellantApplicationFolder?: FolderInfo | null;

--- a/appeals/api/src/server/endpoints/integrations/__tests__/integrations.test.js
+++ b/appeals/api/src/server/endpoints/integrations/__tests__/integrations.test.js
@@ -131,7 +131,8 @@ describe('/appeals/case-submission', () => {
 								status: APPEAL_CASE_STATUS.ASSIGN_CASE_OFFICER,
 								createdAt: expect.any(String)
 							}
-						}
+						},
+						assignedTeamId: 1
 					}
 				});
 
@@ -541,7 +542,8 @@ describe('/appeals/representation-submission', () => {
 });
 
 const createIntegrationMocks = (/** @type {*} */ appealIngestionInput) => {
-	const appealCreatedResult = { id: 100, reference: '6000100' };
+	const appealCreatedResult = { id: 100, reference: '6000100', assignedTeamId: 1 };
+
 	// @ts-ignore
 	databaseConnector.appealRelationship.findMany.mockResolvedValue([]);
 	// @ts-ignore
@@ -575,6 +577,21 @@ const createIntegrationMocks = (/** @type {*} */ appealIngestionInput) => {
 	]);
 	// @ts-ignore
 	databaseConnector.auditTrail.create.mockResolvedValue({});
+
+	// @ts-ignore
+	databaseConnector.team.findUnique.mockResolvedValue({
+		id: 1,
+		name: 'test',
+		email: 'test@email.com'
+	});
+	// @ts-ignore
+	databaseConnector.team.findFirst.mockResolvedValue({
+		id: 1
+	});
+	// @ts-ignore
+	databaseConnector.lPA.findUnique.mockResolvedValue({
+		teamId: 1
+	});
 	// @ts-ignore
 	databaseConnector.folder.findMany.mockResolvedValue(
 		appealIngestionInput.folders.create.map((/** @type {any} */ o, /** @type {number} */ ix) => {

--- a/appeals/api/src/server/mappers/api/definitions/appeal.js
+++ b/appeals/api/src/server/mappers/api/definitions/appeal.js
@@ -9,6 +9,7 @@ import { AppealDecision } from './appeal-decision.js';
 import { AppealRelationship } from './appeal-relationship.js';
 import { SiteAccess } from './site-access.js';
 import { SiteSafety } from './site-safety.js';
+import { AssignedTeam } from './assigned-team.js';
 
 const appeal = {
 	type: 'object',
@@ -16,6 +17,7 @@ const appeal = {
 	properties: {
 		...AppealSummary.properties,
 		...Team.properties,
+		...AssignedTeam.properties,
 		allocation: {
 			...Allocation,
 			nullable: true

--- a/appeals/api/src/server/mappers/api/definitions/assigned-team.js
+++ b/appeals/api/src/server/mappers/api/definitions/assigned-team.js
@@ -1,0 +1,17 @@
+const assignedTeam = {
+	type: 'object',
+	required: [],
+	properties: {
+		name: {
+			type: 'string',
+			nullable: true
+		},
+		email: {
+			type: 'string',
+			format: 'email',
+			nullable: true
+		}
+	}
+};
+
+export const AssignedTeam = assignedTeam;

--- a/appeals/api/src/server/mappers/api/definitions/index.js
+++ b/appeals/api/src/server/mappers/api/definitions/index.js
@@ -23,6 +23,7 @@ import { ListedBuilding } from './listed-building.js';
 import { DesignatedSiteName } from './designated-site-name.js';
 import { Notifications } from './notification.js';
 import { AuditNotifications } from './audit-notification.js';
+import { AssignedTeam } from './assigned-team.js';
 
 const partials = {
 	Address,
@@ -30,6 +31,7 @@ const partials = {
 	NeighbouringSite,
 	Timetable,
 	TransferStatus,
+	AssignedTeam,
 	Team,
 	AppealSummary,
 	DocumentationSummary,

--- a/appeals/api/src/server/mappers/api/shared/index.js
+++ b/appeals/api/src/server/mappers/api/shared/index.js
@@ -20,10 +20,12 @@ import { mapCompletedStateList } from '#mappers/api/shared/map-completed-state-l
 import { mapInquiry } from './map-inquiry.js';
 import { mapInquiryEstimate } from './map-inquiry-estimate.js';
 import { mapAppealCostsDecision } from '#mappers/api/shared/map-appeal-costs-decision.js';
+import { mapAssignedTeam } from './map-assigned-team.js';
 
 export const apiSharedMappers = {
 	appealSummary: mapAppealSummary,
 	appealStatus: mapAppealStatus,
+	assignedTeam: mapAssignedTeam,
 	team: mapAppealTeam,
 	siteVisit: mapSiteVisit,
 	hearing: mapHearing,

--- a/appeals/api/src/server/mappers/api/shared/map-assigned-team.js
+++ b/appeals/api/src/server/mappers/api/shared/map-assigned-team.js
@@ -1,0 +1,18 @@
+/** @typedef {import('@pins/appeals.api').Schema.Appeal} Appeal */
+/** @typedef {import('@pins/appeals.api').Api.Team} Team */
+/** @typedef {import('@pins/appeals.api').Api.AssignedTeam} AssignedTeam */
+/** @typedef {import('#mappers/mapper-factory.js').MappingRequest} MappingRequest */
+
+/**
+ *
+ * @param {MappingRequest} data
+ * @returns
+ */
+export const mapAssignedTeam = (data) => {
+	const { appeal } = data;
+
+	return {
+		name: appeal.assignedTeam?.name || null,
+		email: appeal.assignedTeam?.email || null
+	};
+};

--- a/appeals/api/src/server/mappers/mapper-factory.js
+++ b/appeals/api/src/server/mappers/mapper-factory.js
@@ -124,6 +124,7 @@ function createDataLayout(caseMap, mappingRequest) {
 
 	const {
 		appealSummary,
+		assignedTeam,
 		team,
 		appealRelationships,
 		appellantCase,
@@ -157,6 +158,7 @@ function createDataLayout(caseMap, mappingRequest) {
 		default: {
 			return {
 				...appealSummary,
+				assignedTeam,
 				...team,
 				...appealRelationships,
 				...appealDetails,

--- a/appeals/api/src/server/openapi-types.ts
+++ b/appeals/api/src/server/openapi-types.ts
@@ -2886,6 +2886,12 @@ export interface TransferStatus {
 	transferredAppealReference: string;
 }
 
+export interface AssignedTeam {
+	name?: string | null;
+	/** @format email */
+	email?: string | null;
+}
+
 export interface Team {
 	/** @format uuid */
 	caseOfficer?: string | null;
@@ -11586,6 +11592,9 @@ export interface Appeal {
 	caseOfficer?: string | null;
 	/** @format uuid */
 	inspector?: string | null;
+	name?: string | null;
+	/** @format email */
+	email?: string | null;
 	allocation?: {
 		level: string;
 		band: number;

--- a/appeals/api/src/server/openapi.json
+++ b/appeals/api/src/server/openapi.json
@@ -12182,6 +12182,21 @@
 					}
 				}
 			},
+			"AssignedTeam": {
+				"type": "object",
+				"required": [],
+				"properties": {
+					"name": {
+						"type": "string",
+						"nullable": true
+					},
+					"email": {
+						"type": "string",
+						"format": "email",
+						"nullable": true
+					}
+				}
+			},
 			"Team": {
 				"type": "object",
 				"required": [],
@@ -27679,6 +27694,15 @@
 					"inspector": {
 						"type": "string",
 						"format": "uuid",
+						"nullable": true
+					},
+					"name": {
+						"type": "string",
+						"nullable": true
+					},
+					"email": {
+						"type": "string",
+						"format": "email",
 						"nullable": true
 					},
 					"allocation": {

--- a/appeals/api/src/server/repositories/appeal.repository.js
+++ b/appeals/api/src/server/repositories/appeal.repository.js
@@ -80,6 +80,7 @@ const appealDetailsInclude = {
 	appealStatus: true,
 	appealTimetable: true,
 	appealType: true,
+	assignedTeam: true,
 	caseOfficer: true,
 	inspector: true,
 	inspectorDecision: true,

--- a/appeals/api/src/server/repositories/integrations.repository.js
+++ b/appeals/api/src/server/repositories/integrations.repository.js
@@ -22,7 +22,7 @@ export const createAppeal = async (data, documents, relatedReferences) => {
 	const transaction = await databaseConnector.$transaction(async (tx) => {
 		let appeal = await tx.appeal.create({ data });
 		const reference = createAppealReference(appeal.id).toString();
-		const team = await getTeamIdFromLpaCode(data.lpa.connect?.lpaCode || '');
+		const teamId = await getTeamIdFromLpaCode(data.lpa.connect?.lpaCode || '');
 		appeal = await tx.appeal.update({
 			where: { id: appeal.id },
 			data: {
@@ -33,7 +33,7 @@ export const createAppeal = async (data, documents, relatedReferences) => {
 						createdAt: new Date().toISOString()
 					}
 				},
-				assignedTeamId: team.id
+				assignedTeamId: teamId
 			}
 		});
 

--- a/appeals/api/src/server/repositories/integrations.repository.js
+++ b/appeals/api/src/server/repositories/integrations.repository.js
@@ -5,6 +5,7 @@ import config from '#config/config.js';
 import { APPEAL_CASE_STATUS, APPEAL_DOCUMENT_TYPE } from '@planning-inspectorate/data-model';
 import { getFolderIdFromDocumentType } from '#endpoints/integrations/integrations.utils.js';
 import { CASE_RELATIONSHIP_RELATED } from '@pins/appeals/constants/support.js';
+import { getTeamIdFromLpaCode } from './team.repository.js';
 
 /** @typedef {import('@pins/appeals.api').Schema.Appeal} Appeal */
 /** @typedef {import('@pins/appeals.api').Schema.Representation} Representation */
@@ -21,7 +22,7 @@ export const createAppeal = async (data, documents, relatedReferences) => {
 	const transaction = await databaseConnector.$transaction(async (tx) => {
 		let appeal = await tx.appeal.create({ data });
 		const reference = createAppealReference(appeal.id).toString();
-
+		const team = await getTeamIdFromLpaCode(data.lpa.connect?.lpaCode || '');
 		appeal = await tx.appeal.update({
 			where: { id: appeal.id },
 			data: {
@@ -31,7 +32,8 @@ export const createAppeal = async (data, documents, relatedReferences) => {
 						status: APPEAL_CASE_STATUS.ASSIGN_CASE_OFFICER,
 						createdAt: new Date().toISOString()
 					}
-				}
+				},
+				assignedTeamId: team.id
 			}
 		});
 

--- a/appeals/api/src/server/repositories/team.repository.js
+++ b/appeals/api/src/server/repositories/team.repository.js
@@ -3,7 +3,7 @@ import { databaseConnector } from '#utils/database-connector.js';
 /**
  *
  * @param {string} lpaCode
- * @returns {Promise<{id: number | null}>}
+ * @returns {Promise< number | null>}
  */
 export const getTeamIdFromLpaCode = async (lpaCode) => {
 	const team = await databaseConnector.lPA.findUnique({
@@ -12,12 +12,10 @@ export const getTeamIdFromLpaCode = async (lpaCode) => {
 	});
 
 	if (!team) {
-		return {
-			id: null
-		};
+		return null;
 	}
 
-	return { id: team.teamId };
+	return team.teamId;
 };
 /**
  *

--- a/appeals/api/src/server/repositories/team.repository.js
+++ b/appeals/api/src/server/repositories/team.repository.js
@@ -1,0 +1,35 @@
+import { databaseConnector } from '#utils/database-connector.js';
+
+/**
+ *
+ * @param {string} lpaCode
+ * @returns {Promise<{id: number | null}>}
+ */
+export const getTeamIdFromLpaCode = async (lpaCode) => {
+	const team = await databaseConnector.lPA.findUnique({
+		where: { lpaCode },
+		select: { teamId: true }
+	});
+
+	if (!team) {
+		return {
+			id: null
+		};
+	}
+
+	return { id: team.teamId };
+};
+/**
+ *
+ * @param {number} teamId
+ * @returns {Promise<{name: string|null, email: string|null}| null>}
+ */
+export const getAssignedTeam = (teamId) => {
+	return databaseConnector.team.findUnique({
+		where: { id: teamId },
+		select: {
+			name: true,
+			email: true
+		}
+	});
+};

--- a/appeals/api/src/server/tests/appeals/has.js
+++ b/appeals/api/src/server/tests/appeals/has.js
@@ -104,6 +104,10 @@ export default {
 		phoneNumber: null,
 		addressId: null
 	},
+	assignedTeam: {
+		email: 'temp@email.com',
+		name: 'temp'
+	},
 	agent: {
 		id: 2,
 		organisationName: null,

--- a/appeals/api/src/server/tests/appeals/s78.js
+++ b/appeals/api/src/server/tests/appeals/s78.js
@@ -107,6 +107,10 @@ export default {
 		phoneNumber: null,
 		addressId: null
 	},
+	assignedTeam: {
+		email: 'temp@email.com',
+		name: 'temp'
+	},
 	agent: null,
 	lpa: {
 		id: 2,

--- a/appeals/web/src/server/appeals/appeal-details/__tests__/__snapshots__/appeal-details.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/__tests__/__snapshots__/appeal-details.test.js.snap
@@ -755,6 +755,17 @@ exports[`appeal-details GET /:appealId Linked appeals should not render a "Appea
                     </div>
                     <div id="accordion-default2-content-6" class="govuk-accordion__section-content">
                         <dl class="govuk-summary-list">
+                            <div class="govuk-summary-list__row appeal-case-team"><dt class="govuk-summary-list__key"> Case team</dt>
+                                <dd class="govuk-summary-list__value">
+                                    <ul class="govuk-list">
+                                        <li>Test Team</li>
+                                        <li>test@emai.com</li>
+                                    </ul>
+                                </dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2//case-team"
+                                    data-cy="change-case-team">Change<span class="govuk-visually-hidden"> Case team</span></a>
+                                </dd>
+                            </div>
                             <div class="govuk-summary-list__row appeal-case-officer"><dt class="govuk-summary-list__key"> Case officer</dt>
                                 <dd class="govuk-summary-list__value">
                                     <p class="govuk-body">Not assigned</p>
@@ -1205,6 +1216,17 @@ exports[`appeal-details GET /:appealId Linked appeals should not render action l
                     </div>
                     <div id="accordion-default1-content-7" class="govuk-accordion__section-content">
                         <dl class="govuk-summary-list">
+                            <div class="govuk-summary-list__row appeal-case-team"><dt class="govuk-summary-list__key"> Case team</dt>
+                                <dd class="govuk-summary-list__value">
+                                    <ul class="govuk-list">
+                                        <li>Test Team</li>
+                                        <li>test@emai.com</li>
+                                    </ul>
+                                </dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1//case-team"
+                                    data-cy="change-case-team">Change<span class="govuk-visually-hidden"> Case team</span></a>
+                                </dd>
+                            </div>
                             <div class="govuk-summary-list__row appeal-case-officer"><dt class="govuk-summary-list__key"> Case officer</dt>
                                 <dd class="govuk-summary-list__value">
                                     <p class="govuk-body">Not assigned</p>
@@ -1586,6 +1608,17 @@ exports[`appeal-details GET /:appealId Linked appeals should render a child tag 
                     </div>
                     <div id="accordion-default1-content-6" class="govuk-accordion__section-content">
                         <dl class="govuk-summary-list">
+                            <div class="govuk-summary-list__row appeal-case-team"><dt class="govuk-summary-list__key"> Case team</dt>
+                                <dd class="govuk-summary-list__value">
+                                    <ul class="govuk-list">
+                                        <li>Test Team</li>
+                                        <li>test@emai.com</li>
+                                    </ul>
+                                </dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1//case-team"
+                                    data-cy="change-case-team">Change<span class="govuk-visually-hidden"> Case team</span></a>
+                                </dd>
+                            </div>
                             <div class="govuk-summary-list__row appeal-case-officer"><dt class="govuk-summary-list__key"> Case officer</dt>
                                 <dd class="govuk-summary-list__value">
                                     <p class="govuk-body">Not assigned</p>
@@ -2033,6 +2066,17 @@ exports[`appeal-details GET /:appealId Linked appeals should render a lead tag n
                     </div>
                     <div id="accordion-default1-content-7" class="govuk-accordion__section-content">
                         <dl class="govuk-summary-list">
+                            <div class="govuk-summary-list__row appeal-case-team"><dt class="govuk-summary-list__key"> Case team</dt>
+                                <dd class="govuk-summary-list__value">
+                                    <ul class="govuk-list">
+                                        <li>Test Team</li>
+                                        <li>test@emai.com</li>
+                                    </ul>
+                                </dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1//case-team"
+                                    data-cy="change-case-team">Change<span class="govuk-visually-hidden"> Case team</span></a>
+                                </dd>
+                            </div>
                             <div class="govuk-summary-list__row appeal-case-officer"><dt class="govuk-summary-list__key"> Case officer</dt>
                                 <dd class="govuk-summary-list__value">
                                     <p class="govuk-body">Not assigned</p>
@@ -2491,6 +2535,17 @@ exports[`appeal-details GET /:appealId Linked appeals should render an action li
                     </div>
                     <div id="accordion-default1-content-7" class="govuk-accordion__section-content">
                         <dl class="govuk-summary-list">
+                            <div class="govuk-summary-list__row appeal-case-team"><dt class="govuk-summary-list__key"> Case team</dt>
+                                <dd class="govuk-summary-list__value">
+                                    <ul class="govuk-list">
+                                        <li>Test Team</li>
+                                        <li>test@emai.com</li>
+                                    </ul>
+                                </dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1//case-team"
+                                    data-cy="change-case-team">Change<span class="govuk-visually-hidden"> Case team</span></a>
+                                </dd>
+                            </div>
                             <div class="govuk-summary-list__row appeal-case-officer"><dt class="govuk-summary-list__key"> Case officer</dt>
                                 <dd class="govuk-summary-list__value">
                                     <p class="govuk-body">Not assigned</p>
@@ -2949,6 +3004,17 @@ exports[`appeal-details GET /:appealId Linked appeals should render an action li
                     </div>
                     <div id="accordion-default1-content-7" class="govuk-accordion__section-content">
                         <dl class="govuk-summary-list">
+                            <div class="govuk-summary-list__row appeal-case-team"><dt class="govuk-summary-list__key"> Case team</dt>
+                                <dd class="govuk-summary-list__value">
+                                    <ul class="govuk-list">
+                                        <li>Test Team</li>
+                                        <li>test@emai.com</li>
+                                    </ul>
+                                </dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1//case-team"
+                                    data-cy="change-case-team">Change<span class="govuk-visually-hidden"> Case team</span></a>
+                                </dd>
+                            </div>
                             <div class="govuk-summary-list__row appeal-case-officer"><dt class="govuk-summary-list__key"> Case officer</dt>
                                 <dd class="govuk-summary-list__value">
                                     <p class="govuk-body">Not assigned</p>
@@ -3398,6 +3464,17 @@ exports[`appeal-details GET /:appealId Linked appeals should render the case ref
                     </div>
                     <div id="accordion-default1-content-7" class="govuk-accordion__section-content">
                         <dl class="govuk-summary-list">
+                            <div class="govuk-summary-list__row appeal-case-team"><dt class="govuk-summary-list__key"> Case team</dt>
+                                <dd class="govuk-summary-list__value">
+                                    <ul class="govuk-list">
+                                        <li>Test Team</li>
+                                        <li>test@emai.com</li>
+                                    </ul>
+                                </dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1//case-team"
+                                    data-cy="change-case-team">Change<span class="govuk-visually-hidden"> Case team</span></a>
+                                </dd>
+                            </div>
                             <div class="govuk-summary-list__row appeal-case-officer"><dt class="govuk-summary-list__key"> Case officer</dt>
                                 <dd class="govuk-summary-list__value">
                                     <p class="govuk-body">Not assigned</p>
@@ -3847,6 +3924,17 @@ exports[`appeal-details GET /:appealId Linked appeals should render the lead or 
                     </div>
                     <div id="accordion-default1-content-7" class="govuk-accordion__section-content">
                         <dl class="govuk-summary-list">
+                            <div class="govuk-summary-list__row appeal-case-team"><dt class="govuk-summary-list__key"> Case team</dt>
+                                <dd class="govuk-summary-list__value">
+                                    <ul class="govuk-list">
+                                        <li>Test Team</li>
+                                        <li>test@emai.com</li>
+                                    </ul>
+                                </dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1//case-team"
+                                    data-cy="change-case-team">Change<span class="govuk-visually-hidden"> Case team</span></a>
+                                </dd>
+                            </div>
                             <div class="govuk-summary-list__row appeal-case-officer"><dt class="govuk-summary-list__key"> Case officer</dt>
                                 <dd class="govuk-summary-list__value">
                                     <p class="govuk-body">Not assigned</p>
@@ -4310,6 +4398,17 @@ exports[`appeal-details GET /:appealId Linked appeals should render the received
                     </div>
                     <div id="accordion-default3-content-7" class="govuk-accordion__section-content">
                         <dl class="govuk-summary-list">
+                            <div class="govuk-summary-list__row appeal-case-team"><dt class="govuk-summary-list__key"> Case team</dt>
+                                <dd class="govuk-summary-list__value">
+                                    <ul class="govuk-list">
+                                        <li>Test Team</li>
+                                        <li>test@emai.com</li>
+                                    </ul>
+                                </dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/3//case-team"
+                                    data-cy="change-case-team">Change<span class="govuk-visually-hidden"> Case team</span></a>
+                                </dd>
+                            </div>
                             <div class="govuk-summary-list__row appeal-case-officer"><dt class="govuk-summary-list__key"> Case officer</dt>
                                 <dd class="govuk-summary-list__value">
                                     <p class="govuk-body">Not assigned</p>
@@ -4746,6 +4845,17 @@ exports[`appeal-details GET /:appealId Linked appeals should render the received
                     </div>
                     <div id="accordion-default1-content-7" class="govuk-accordion__section-content">
                         <dl class="govuk-summary-list">
+                            <div class="govuk-summary-list__row appeal-case-team"><dt class="govuk-summary-list__key"> Case team</dt>
+                                <dd class="govuk-summary-list__value">
+                                    <ul class="govuk-list">
+                                        <li>Test Team</li>
+                                        <li>test@emai.com</li>
+                                    </ul>
+                                </dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1//case-team"
+                                    data-cy="change-case-team">Change<span class="govuk-visually-hidden"> Case team</span></a>
+                                </dd>
+                            </div>
                             <div class="govuk-summary-list__row appeal-case-officer"><dt class="govuk-summary-list__key"> Case officer</dt>
                                 <dd class="govuk-summary-list__value">
                                     <p class="govuk-body">Not assigned</p>
@@ -5199,6 +5309,17 @@ exports[`appeal-details GET /:appealId Linked appeals should render the received
                     </div>
                     <div id="accordion-default2-content-7" class="govuk-accordion__section-content">
                         <dl class="govuk-summary-list">
+                            <div class="govuk-summary-list__row appeal-case-team"><dt class="govuk-summary-list__key"> Case team</dt>
+                                <dd class="govuk-summary-list__value">
+                                    <ul class="govuk-list">
+                                        <li>Test Team</li>
+                                        <li>test@emai.com</li>
+                                    </ul>
+                                </dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2//case-team"
+                                    data-cy="change-case-team">Change<span class="govuk-visually-hidden"> Case team</span></a>
+                                </dd>
+                            </div>
                             <div class="govuk-summary-list__row appeal-case-officer"><dt class="govuk-summary-list__key"> Case officer</dt>
                                 <dd class="govuk-summary-list__value">
                                     <p class="govuk-body">Not assigned</p>
@@ -5738,6 +5859,17 @@ exports[`appeal-details GET /:appealId Notification banners Important banners sh
                     </div>
                     <div id="accordion-default1-content-7" class="govuk-accordion__section-content">
                         <dl class="govuk-summary-list">
+                            <div class="govuk-summary-list__row appeal-case-team"><dt class="govuk-summary-list__key"> Case team</dt>
+                                <dd class="govuk-summary-list__value">
+                                    <ul class="govuk-list">
+                                        <li>Test Team</li>
+                                        <li>test@emai.com</li>
+                                    </ul>
+                                </dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2//case-team"
+                                    data-cy="change-case-team">Change<span class="govuk-visually-hidden"> Case team</span></a>
+                                </dd>
+                            </div>
                             <div class="govuk-summary-list__row appeal-case-officer"><dt class="govuk-summary-list__key"> Case officer</dt>
                                 <dd class="govuk-summary-list__value">
                                     <p class="govuk-body">Not assigned</p>
@@ -6185,6 +6317,33 @@ exports[`appeal-details GET /:appealId Status tags should render a status tag wi
 exports[`appeal-details GET /:appealId Status tags should render a status tag with the content "Validation" and a green modifier class if appeal status is validation 1`] = `"<strong class="govuk-tag govuk-tag--green pins-status-tag--full-width">Validation</strong>"`;
 
 exports[`appeal-details GET /:appealId Status tags should render a status tag with the content "Withdrawn" and a grey modifier class if appeal status is withdrawn 1`] = `"<strong class="govuk-tag govuk-tag--grey pins-status-tag--full-width">Withdrawn</strong>"`;
+
+exports[`appeal-details GET /:appealId Team section should render the case-team section for appeal with not assigned displayed when no team is assigned" 1`] = `
+"<div class="govuk-summary-list__row appeal-case-team"><dt class="govuk-summary-list__key"> Case team</dt>
+    <dd class="govuk-summary-list__value">
+        <ul class="govuk-list">
+            <li>Not assigned</li>
+        </ul>
+    </dd>
+    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2//case-team"
+        data-cy="change-case-team">Change<span class="govuk-visually-hidden"> Case team</span></a>
+    </dd>
+</div>"
+`;
+
+exports[`appeal-details GET /:appealId Team section should render the case-team section for appeal with team name and email displayed" 1`] = `
+"<div class="govuk-summary-list__row appeal-case-team"><dt class="govuk-summary-list__key"> Case team</dt>
+    <dd class="govuk-summary-list__value">
+        <ul class="govuk-list">
+            <li>Test Team</li>
+            <li>test@emai.com</li>
+        </ul>
+    </dd>
+    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2//case-team"
+        data-cy="change-case-team">Change<span class="govuk-visually-hidden"> Case team</span></a>
+    </dd>
+</div>"
+`;
 
 exports[`appeal-details GET /:appealId Timetable Valid date should render a "Timetable" with a Valid date row and a Start date row including no date and start action link 1`] = `
 "<dl class="govuk-summary-list appeal-case-timetable">
@@ -6722,6 +6881,17 @@ exports[`appeal-details GET /:appealId should render a Decision inset panel when
                     </div>
                     <div id="accordion-default1-content-7" class="govuk-accordion__section-content">
                         <dl class="govuk-summary-list">
+                            <div class="govuk-summary-list__row appeal-case-team"><dt class="govuk-summary-list__key"> Case team</dt>
+                                <dd class="govuk-summary-list__value">
+                                    <ul class="govuk-list">
+                                        <li>Test Team</li>
+                                        <li>test@emai.com</li>
+                                    </ul>
+                                </dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2//case-team"
+                                    data-cy="change-case-team">Change<span class="govuk-visually-hidden"> Case team</span></a>
+                                </dd>
+                            </div>
                             <div class="govuk-summary-list__row appeal-case-officer"><dt class="govuk-summary-list__key"> Case officer</dt>
                                 <dd class="govuk-summary-list__value">
                                     <p class="govuk-body">Not assigned</p>
@@ -7165,6 +7335,17 @@ exports[`appeal-details GET /:appealId should render a Decision inset panel when
                     </div>
                     <div id="accordion-default1-content-7" class="govuk-accordion__section-content">
                         <dl class="govuk-summary-list">
+                            <div class="govuk-summary-list__row appeal-case-team"><dt class="govuk-summary-list__key"> Case team</dt>
+                                <dd class="govuk-summary-list__value">
+                                    <ul class="govuk-list">
+                                        <li>Test Team</li>
+                                        <li>test@emai.com</li>
+                                    </ul>
+                                </dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2//case-team"
+                                    data-cy="change-case-team">Change<span class="govuk-visually-hidden"> Case team</span></a>
+                                </dd>
+                            </div>
                             <div class="govuk-summary-list__row appeal-case-officer"><dt class="govuk-summary-list__key"> Case officer</dt>
                                 <dd class="govuk-summary-list__value">
                                     <p class="govuk-body">Not assigned</p>
@@ -7602,6 +7783,17 @@ exports[`appeal-details GET /:appealId should render a Decision inset panel when
                     </div>
                     <div id="accordion-default1-content-7" class="govuk-accordion__section-content">
                         <dl class="govuk-summary-list">
+                            <div class="govuk-summary-list__row appeal-case-team"><dt class="govuk-summary-list__key"> Case team</dt>
+                                <dd class="govuk-summary-list__value">
+                                    <ul class="govuk-list">
+                                        <li>Test Team</li>
+                                        <li>test@emai.com</li>
+                                    </ul>
+                                </dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2//case-team"
+                                    data-cy="change-case-team">Change<span class="govuk-visually-hidden"> Case team</span></a>
+                                </dd>
+                            </div>
                             <div class="govuk-summary-list__row appeal-case-officer"><dt class="govuk-summary-list__key"> Case officer</dt>
                                 <dd class="govuk-summary-list__value">
                                     <p class="govuk-body">Not assigned</p>
@@ -8052,6 +8244,17 @@ exports[`appeal-details GET /:appealId should render the appellant case status a
                     </div>
                     <div id="accordion-default1-content-7" class="govuk-accordion__section-content">
                         <dl class="govuk-summary-list">
+                            <div class="govuk-summary-list__row appeal-case-team"><dt class="govuk-summary-list__key"> Case team</dt>
+                                <dd class="govuk-summary-list__value">
+                                    <ul class="govuk-list">
+                                        <li>Test Team</li>
+                                        <li>test@emai.com</li>
+                                    </ul>
+                                </dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2//case-team"
+                                    data-cy="change-case-team">Change<span class="govuk-visually-hidden"> Case team</span></a>
+                                </dd>
+                            </div>
                             <div class="govuk-summary-list__row appeal-case-officer"><dt class="govuk-summary-list__key"> Case officer</dt>
                                 <dd class="govuk-summary-list__value">
                                     <p class="govuk-body">Not assigned</p>
@@ -8491,6 +8694,17 @@ exports[`appeal-details GET /:appealId should render the appellant case status a
                     </div>
                     <div id="accordion-default1-content-7" class="govuk-accordion__section-content">
                         <dl class="govuk-summary-list">
+                            <div class="govuk-summary-list__row appeal-case-team"><dt class="govuk-summary-list__key"> Case team</dt>
+                                <dd class="govuk-summary-list__value">
+                                    <ul class="govuk-list">
+                                        <li>Test Team</li>
+                                        <li>test@emai.com</li>
+                                    </ul>
+                                </dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2//case-team"
+                                    data-cy="change-case-team">Change<span class="govuk-visually-hidden"> Case team</span></a>
+                                </dd>
+                            </div>
                             <div class="govuk-summary-list__row appeal-case-officer"><dt class="govuk-summary-list__key"> Case officer</dt>
                                 <dd class="govuk-summary-list__value">
                                     <p class="govuk-body">Not assigned</p>
@@ -8941,6 +9155,17 @@ exports[`appeal-details GET /:appealId should render the received appeal details
                     </div>
                     <div id="accordion-default1-content-7" class="govuk-accordion__section-content">
                         <dl class="govuk-summary-list">
+                            <div class="govuk-summary-list__row appeal-case-team"><dt class="govuk-summary-list__key"> Case team</dt>
+                                <dd class="govuk-summary-list__value">
+                                    <ul class="govuk-list">
+                                        <li>Test Team</li>
+                                        <li>test@emai.com</li>
+                                    </ul>
+                                </dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2//case-team"
+                                    data-cy="change-case-team">Change<span class="govuk-visually-hidden"> Case team</span></a>
+                                </dd>
+                            </div>
                             <div class="govuk-summary-list__row appeal-case-officer"><dt class="govuk-summary-list__key"> Case officer</dt>
                                 <dd class="govuk-summary-list__value">
                                     <p class="govuk-body">Not assigned</p>
@@ -9444,6 +9669,17 @@ exports[`appeal-details should not render a back button 1`] = `
                                 </div>
                                 <div id="accordion-default2-content-7" class="govuk-accordion__section-content">
                                     <dl class="govuk-summary-list">
+                                        <div class="govuk-summary-list__row appeal-case-team"><dt class="govuk-summary-list__key"> Case team</dt>
+                                            <dd class="govuk-summary-list__value">
+                                                <ul class="govuk-list">
+                                                    <li>Test Team</li>
+                                                    <li>test@emai.com</li>
+                                                </ul>
+                                            </dd>
+                                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2//case-team"
+                                                data-cy="change-case-team">Change<span class="govuk-visually-hidden"> Case team</span></a>
+                                            </dd>
+                                        </div>
                                         <div class="govuk-summary-list__row appeal-case-officer"><dt class="govuk-summary-list__key"> Case officer</dt>
                                             <dd class="govuk-summary-list__value">
                                                 <p class="govuk-body">Not assigned</p>

--- a/appeals/web/src/server/appeals/appeal-details/__tests__/appeal-details.test.js
+++ b/appeals/web/src/server/appeals/appeal-details/__tests__/appeal-details.test.js
@@ -112,6 +112,47 @@ describe('appeal-details', () => {
 	});
 
 	describe('GET /:appealId', () => {
+		describe('Team section', () => {
+			it('should render the case-team section for appeal with team name and email displayed"', async () => {
+				const appealId = 2;
+				nock('http://test/')
+					.get(`/appeals/${appealId}`)
+					.reply(200, {
+						...appealData,
+						appealId,
+						appealStatus: 'ready_to_start'
+					});
+				nock('http://test/').get(`/appeals/${appealId}/case-notes`).reply(200, caseNotes);
+				const response = await request.get(`${baseUrl}/${appealId}`);
+
+				expect(response.statusCode).toBe(200);
+				const element = parseHtml(response.text, { rootElement: '.appeal-case-team' });
+
+				expect(element.innerHTML).toMatchSnapshot();
+				expect(element.innerHTML).toContain('Test Team');
+				expect(element.innerHTML).toContain('test@emai.com');
+			});
+
+			it('should render the case-team section for appeal with not assigned displayed when no team is assigned"', async () => {
+				const appealId = 2;
+				nock('http://test/')
+					.get(`/appeals/${appealId}`)
+					.reply(200, {
+						...appealData,
+						appealId,
+						appealStatus: 'ready_to_start',
+						assignedTeam: {}
+					});
+				nock('http://test/').get(`/appeals/${appealId}/case-notes`).reply(200, caseNotes);
+				const response = await request.get(`${baseUrl}/${appealId}`);
+
+				expect(response.statusCode).toBe(200);
+				const element = parseHtml(response.text, { rootElement: '.appeal-case-team' });
+
+				expect(element.innerHTML).toMatchSnapshot();
+				expect(element.innerHTML).toContain('<li>Not assigned</li>');
+			});
+		});
 		describe('Notification banners', () => {
 			const notificationBannerElement = '.govuk-notification-banner';
 
@@ -156,7 +197,9 @@ describe('appeal-details', () => {
 							transferStatus: {
 								transferredAppealType: '(C) Enforcement notice appeal',
 								transferredAppealReference: '12345'
-							}
+							},
+							assignedTeamId: 1,
+							assignedTeam: {}
 						})
 						.persist();
 

--- a/appeals/web/src/server/appeals/appeal-details/accordions/common/case-team.js
+++ b/appeals/web/src/server/appeals/appeal-details/accordions/common/case-team.js
@@ -8,6 +8,7 @@ export const getCaseTeam = (mappedData) => ({
 	type: 'summary-list',
 	parameters: {
 		rows: [
+			mappedData.appeal.caseTeam.display.summaryListItem,
 			mappedData.appeal.caseOfficer.display.summaryListItem,
 			mappedData.appeal.inspector.display.summaryListItem
 		].filter(isDefined)

--- a/appeals/web/src/server/lib/mappers/data/appeal/has.js
+++ b/appeals/web/src/server/lib/mappers/data/appeal/has.js
@@ -48,6 +48,7 @@ import { mapVisitType } from './submappers/visit-type.mapper.js';
 import { mapLpaHealthAndSafety } from './submappers/lpa-health-and-safety.mapper.js';
 import { mapAppellantHealthAndSafety } from './submappers/appellant-health-and-safety.mapper.js';
 import { mapLpaNeighbouringSites } from './submappers/lpa-neighbouring-sites.mapper.js';
+import { mapCaseTeam } from './submappers/team.mapper.js';
 
 /** @type {Record<string, import('./mapper.js').SubMapper>} */
 export const submaps = {
@@ -76,6 +77,7 @@ export const submaps = {
 	siteVisitDate: mapSiteVisitDate,
 	siteVisitStartTime: mapSiteVisitStartTime,
 	siteVisitEndTime: mapSiteVisitEndTime,
+	caseTeam: mapCaseTeam,
 	caseOfficer: mapCaseOfficer,
 	inspector: mapInspector,
 	crossTeamCorrespondence: mapCrossTeamCorrespondence,

--- a/appeals/web/src/server/lib/mappers/data/appeal/submappers/team.mapper.js
+++ b/appeals/web/src/server/lib/mappers/data/appeal/submappers/team.mapper.js
@@ -1,0 +1,32 @@
+import { textSummaryListItem } from '#lib/mappers/index.js';
+
+/** @type {import('../mapper.js').SubMapper} */
+export const mapCaseTeam = ({ appealDetails, currentRoute, userHasUpdateCasePermission }) => {
+	const teamAssigned =
+		appealDetails.assignedTeam?.name === null || appealDetails.assignedTeam?.email === null
+			? false
+			: true;
+	const teamRowValue = `
+        <ul class="govuk-list">
+            ${
+							appealDetails.assignedTeam?.name && appealDetails.assignedTeam?.email
+								? `<li>${appealDetails.assignedTeam.name}</li><li>${appealDetails.assignedTeam.email}</li>`
+								: `<li>Not assigned</li>`
+						}
+        </ul>
+    `.trim();
+
+	const teamRoute = '/case-team';
+
+	return textSummaryListItem({
+		id: 'case-team',
+		text: 'Case team',
+		value: {
+			html: teamRowValue
+		},
+		link: `${currentRoute}/${teamRoute}`,
+		editable: userHasUpdateCasePermission,
+		classes: 'appeal-case-team',
+		actionText: teamAssigned ? 'Change' : 'Assign'
+	});
+};

--- a/appeals/web/testing/app/fixtures/referencedata.js
+++ b/appeals/web/testing/app/fixtures/referencedata.js
@@ -437,7 +437,9 @@ export const appealData = {
 		folderId: 17935,
 		path: 'appellant-case/environmentalAssessment',
 		documents: []
-	}
+	},
+	assignedTeamId: 1,
+	assignedTeam: { name: 'Test Team', email: 'test@emai.com' }
 };
 
 export const appealDataIssuedDecision = {

--- a/packages/appeals/constants/support.js
+++ b/packages/appeals/constants/support.js
@@ -180,6 +180,7 @@ export const AUDIT_TRAIL_LPAQ_REASON_FOR_NEIGHBOUR_VISITS_UPDATED =
 	'Inspector needs neighbouring site access changed';
 export const AUDIT_TRAIL_LPAQ_DESIGNATED_SITE_NAMES_UPDATED =
 	'In, near or likely to effect designated sites changed';
+export const AUDIT_TRAIL_TEAM_ASSIGNED = 'Case team {replacement0} assigned';
 
 export const AUDIT_TRAIL_LISTED_BUILDING_ADDED = 'A listed building was added';
 export const AUDIT_TRAIL_LISTED_BUILDING_UPDATED = 'A listed building was updated';


### PR DESCRIPTION
## Describe your changes

### API

- Added new seed data specified in ticket
- updated integrations endpoint to assign the teamId to an appeal
- updated definitions and mappers for an appeal to accommodate new assigned team fields
- new repository for for team queries
- updated appeals

### API TEST

- updated unit tests 
- added new test data
-  manually tested auto assignment in browser

### WEB
- added new submapper for team section to display assigned team
- added assigned team to appeal details page

### WEB TEST

- updated unit tests and snapshots for existing test
- updated test data to cover new fields
- manual testing within browser

## Issue ticket number and link

[Ticket](https://pins-ds.atlassian.net.mcas.ms/browse/A2-3719)
