### PR TITLE
feat(web): return to CYA back when clicking back from add docs page

### DIFF
--- a/appeals/web/src/server/appeals/appeal-details/representations/document-attachments/add-document.controller.js
+++ b/appeals/web/src/server/appeals/appeal-details/representations/document-attachments/add-document.controller.js
@@ -3,6 +3,7 @@ import {
 	renderDocumentUpload as renderDocumentUploadHelper
 } from '#appeals/appeal-documents/appeal-documents.controller.js';
 import { constructUrl } from '#lib/mappers/utils/url.mapper.js';
+import { preserveQueryString, stripQueryString } from '#lib/url-utilities.js';
 
 /** @type {import('@pins/express').RequestHandler<{}>}  */
 export const renderDocumentUpload = async (request, response) => {
@@ -11,9 +12,14 @@ export const renderDocumentUpload = async (request, response) => {
 	const baseUrl = request.baseUrl;
 	const representationBaseUrl = request.baseUrl.replace('/add-document', '');
 
-	const backButtonUrl = query.backUrl
-		? constructUrl(String(query.backUrl), currentAppeal.appealId)
-		: representationBaseUrl;
+	const backButtonUrl =
+		stripQueryString(String(request.query.editEntrypoint)) === stripQueryString(request.originalUrl)
+			? preserveQueryString(request, `${baseUrl}/check-your-answers`, {
+					exclude: ['editEntrypoint']
+			  })
+			: query.backUrl
+			? constructUrl(String(query.backUrl), currentAppeal.appealId)
+			: representationBaseUrl;
 
 	return renderDocumentUploadHelper({
 		request,

--- a/appeals/web/src/server/appeals/appeal-details/representations/document-attachments/controller/check-your-answers.js
+++ b/appeals/web/src/server/appeals/appeal-details/representations/document-attachments/controller/check-your-answers.js
@@ -12,9 +12,11 @@ import {
 } from '#appeals/appeal-details/representations/interested-party-comments/common/redaction-status.js';
 import { getDocumentRedactionStatuses } from '#appeals/appeal-documents/appeal.documents.service.js';
 import { patchRepresentationAttachments } from '../../final-comments/final-comments.service.js';
+import { clearEdits, editLink } from '#lib/edit-utilities.js';
 
 /**
- * @type {import('@pins/express').RenderHandler<{}>}
+ * @param {import('@pins/express').Request} request
+ * @param {import('express').Response} response
  */
 export const renderCheckYourAnswers = (request, response) => {
 	const {
@@ -33,6 +35,8 @@ export const renderCheckYourAnswers = (request, response) => {
 		throw new Error('Received invalid redaction status');
 	}
 
+	clearEdits(request, 'addDocument');
+
 	return renderCheckYourAnswersComponent(
 		{
 			title: 'Check details and add document',
@@ -45,7 +49,7 @@ export const renderCheckYourAnswers = (request, response) => {
 					html: `<a class="govuk-link" download href="${blobStoreUrl ?? ''}">${name ?? ''}</a>`,
 					actions: {
 						Change: {
-							href: `${baseUrl}`,
+							href: editLink(baseUrl),
 							visuallyHiddenText: 'supporting document'
 						}
 					}
@@ -54,7 +58,7 @@ export const renderCheckYourAnswers = (request, response) => {
 					value: statusFormatMap[redactionStatus],
 					actions: {
 						Change: {
-							href: `${baseUrl}/redaction-status`,
+							href: editLink(baseUrl, 'redaction-status'),
 							visuallyHiddenText: 'redaction status'
 						}
 					}
@@ -63,7 +67,7 @@ export const renderCheckYourAnswers = (request, response) => {
 					value: dayMonthYearHourMinuteToDisplayDate({ day, month, year }),
 					actions: {
 						Change: {
-							href: `${baseUrl}/date-submitted`,
+							href: editLink(baseUrl, 'date-submitted'),
 							visuallyHiddenText: 'date submitted'
 						}
 					}

--- a/appeals/web/src/server/appeals/appeal-details/representations/document-attachments/controller/date-submitted.js
+++ b/appeals/web/src/server/appeals/appeal-details/representations/document-attachments/controller/date-submitted.js
@@ -3,7 +3,11 @@
 /** @typedef {{ 'day': string, 'month': string, 'year': string }} RequestDate */
 /** @typedef {RequestDate} ReqBody */
 
+import { applyEdits } from '#lib/edit-utilities.js';
 import { dateSubmitted } from '../add-document.mapper.js';
+import { backLinkGenerator } from '#lib/middleware/save-back-url.js';
+
+const getBackLinkUrl = backLinkGenerator('addDocument');
 
 /**
  * @param {object} options
@@ -14,7 +18,11 @@ export const renderDateSubmittedFactory =
 	({ getValue }) =>
 	(request, response) => {
 		const baseUrl = request.baseUrl;
-		const backLinkUrl = `${baseUrl}/redaction-status`;
+		const backLinkUrl = getBackLinkUrl(
+			request,
+			`${baseUrl}/redaction-status`,
+			`${baseUrl}/check-your-answers`
+		);
 
 		const value = getValue(request);
 
@@ -40,6 +48,8 @@ export const postDateSubmittedFactory =
 			}
 			const baseUrl = request.baseUrl;
 			const redirectUrl = `${baseUrl}/check-your-answers`;
+
+			applyEdits(request, 'addDocument');
 
 			response.redirect(redirectUrl);
 		} catch (error) {

--- a/appeals/web/src/server/appeals/appeal-details/representations/document-attachments/controller/redaction-status.js
+++ b/appeals/web/src/server/appeals/appeal-details/representations/document-attachments/controller/redaction-status.js
@@ -1,10 +1,13 @@
 import { appealShortReference } from '#lib/appeals-formatter.js';
 import { radiosInput } from '#lib/mappers/index.js';
+import { backLinkGenerator } from '#lib/middleware/save-back-url.js';
 import { APPEAL_REDACTED_STATUS } from '@planning-inspectorate/data-model';
 
 /** @typedef {import("#appeals/appeal-details/appeal-details.types.js").WebAppeal} Appeal */
 /** @typedef {import('#appeals/appeal-details/representations/types.js').Representation} Representation */
 /** @typedef {{ 'redactionStatus': string }} ReqBody */
+
+const getBackLinkUrl = backLinkGenerator('addDocument');
 
 export const statusFormatMap = {
 	[APPEAL_REDACTED_STATUS.REDACTED]: 'Redacted',
@@ -51,7 +54,11 @@ const mapper = (appealDetails, errors, value, backLinkUrl) => ({
 export const renderRedactionStatusFactory =
 	({ getValue }) =>
 	(request, response) => {
-		const backLinkUrl = request.baseUrl;
+		const backLinkUrl = getBackLinkUrl(
+			request,
+			request.baseUrl,
+			`${request.baseUrl}/check-your-answers`
+		);
 		const value = getValue(request);
 
 		const pageContent = mapper(request.currentAppeal, request.errors, value, backLinkUrl);

--- a/appeals/web/src/server/appeals/appeal-details/representations/interested-party-comments/view-and-review/__tests__/__snapshots__/view-and-review.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/representations/interested-party-comments/view-and-review/__tests__/__snapshots__/view-and-review.test.js.snap
@@ -1,5 +1,154 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`interested-party-comments GET /add-document GET /add-document should render the add document details page 1`] = `
+"<main class="govuk-main-wrapper" id="main-content">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds top-errors-hook"></div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Appeal 351062</span>
+            <h1 class="govuk-heading-l">Upload supporting document</h1>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
+            <div class="govuk-grid-row pins-file-upload" data-next-page-url="/appeals-service/appeal-details/2/interested-party-comments/5/add-document/redaction-status"
+            data-form-id="1" data-case-id="2" data-case-reference="APP/Q9999/D/21/351062"
+            data-folder-id="1234" data-document-type="attachments" data-document-stage="representation"
+            data-blob-storage-host="https://127.0.0.1:10000/devstoreaccount1" data-blob-storage-container="document-service-uploads"
+            data-allowed-types="application/pdf,application/msword,application/vnd.openxmlformats-officedocument.wordprocessingml.document,application/vnd.ms-powerpoint,application/vnd.openxmlformats-officedocument.presentationml.presentation,application/vnd.ms-excel,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,application/vnd.ms-outlook,image/jpeg,image/jpeg,video/mpeg,audio/mpeg,video/mp4,video/quicktime,image/png,image/tiff,image/tiff"
+            data-formatted-allowed-types="PDF, DOC, DOCX, PPT, PPTX, XLS, XLSX, MSG, JPG, JPEG, MPEG, MP3, MP4, MOV, PNG, TIF or TIFF">
+                <form method="POST" novalidate="novalidate" class="govuk-grid-column-two-thirds"
+                data-filenames-in-folder="">
+                    <div class="pins-file-upload__container">
+                        <div class="govuk-body pins-file-upload__instructions"><span>The file must be a PDF, DOC, DOCX, PPT, PPTX, XLS, XLSX, MSG, JPG, JPEG, MPEG, MP3, MP4, MOV, PNG, TIF or TIFF.</span><span> The file must be smaller than 25MB.</span>
+                        </div>
+                        <div class="middle-errors-hook">
+                            <h2 class="pins-file-upload__container-title">Upload supporting document</h2>
+                            <div class="pins-file-upload__upload">
+                                <input class="display--none" id="upload-file-1" accept="application/pdf,application/msword,application/vnd.openxmlformats-officedocument.wordprocessingml.document,application/vnd.ms-powerpoint,application/vnd.openxmlformats-officedocument.presentationml.presentation,application/vnd.ms-excel,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,application/vnd.ms-outlook,image/jpeg,image/jpeg,video/mpeg,audio/mpeg,video/mp4,video/quicktime,image/png,image/tiff,image/tiff"
+                                type="file" name="files" value="Choose file" aria-controls="file-list-1">
+                                <div>
+                                    <button type='button' class="pins-file-upload__button govuk-button--secondary"
+                                    data-cy="upload-file-button" id="upload-file-button-1">Choose file</button><span class='govuk-body pins-file-upload__dropzone-text'>or drop file</span>
+                                </div>
+                            </div>
+                            <div id="file-list-1">
+                                <h2 class="display--sr-only" id="file-list-title-1">List of files to upload</h2>
+                                <ul class="pins-file-upload__files-rows" aria-describedby="file-list-title-1"
+                                aria-live="polite"></ul>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="display--flex">
+                        <button type="submit" class="govuk-button pins-file-upload__submit" data-module="govuk-button"
+                        id="submit-button-1">Continue</button>
+                        <div class="progress-hook"></div>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </div>
+</main>"
+`;
+
+exports[`interested-party-comments GET /add-document GET /add-document/date-submitted should render the date submitted page 1`] = `
+"<main class="govuk-main-wrapper" id="main-content">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Appeal 351062</span>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <div class="govuk-grid-row">
+                <div class="govuk-grid-column-full">
+                    <form method="POST" novalidate="novalidate">
+                        <div class="govuk-form-group">
+                            <fieldset class="govuk-fieldset" role="group" aria-describedby="date-hint">
+                                <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+                                    <h1 class="govuk-fieldset__heading"> When was the supporting document submitted?</h1>
+                                </legend>
+                                <div id="date-hint" class="govuk-hint">For example, 27 3 2024</div>
+                                <div class="govuk-date-input" id="date">
+                                    <div class="govuk-date-input__item">
+                                        <div class="govuk-form-group">
+                                            <label class="govuk-label govuk-date-input__label" for="day">Day</label>
+                                            <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
+                                            id="day" name="day" type="text" value="26" inputmode="numeric">
+                                        </div>
+                                    </div>
+                                    <div class="govuk-date-input__item">
+                                        <div class="govuk-form-group">
+                                            <label class="govuk-label govuk-date-input__label" for="month">Month</label>
+                                            <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input govuk-date-input__input"
+                                            id="month" name="month" type="text" value="8" inputmode="numeric">
+                                        </div>
+                                    </div>
+                                    <div class="govuk-date-input__item">
+                                        <div class="govuk-form-group">
+                                            <label class="govuk-label govuk-date-input__label" for="year">Year</label>
+                                            <input class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input govuk-date-input__input"
+                                            id="year" name="year" type="text" value="2025" inputmode="numeric">
+                                        </div>
+                                    </div>
+                                </div>
+                            </fieldset>
+                        </div>
+                        <button type="submit" data-prevent-double-click="true" class="govuk-button"
+                        data-module="govuk-button">Continue</button>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </div>
+</main>"
+`;
+
+exports[`interested-party-comments GET /add-document GET /add-document/redaction-status should render the redaction status page 1`] = `
+"<main class="govuk-main-wrapper" id="main-content">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Appeal 351062</span>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <div class="govuk-grid-row">
+                <div class="govuk-grid-column-full">
+                    <form method="POST" novalidate="novalidate">
+                        <div class="govuk-form-group">
+                            <fieldset class="govuk-fieldset">
+                                <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+                                    <h1 class="govuk-fieldset__heading"> Redaction status</h1>
+                                </legend>
+                                <div class="govuk-radios" data-module="govuk-radios">
+                                    <div class="govuk-radios__item">
+                                        <input class="govuk-radios__input" id="redactionStatus" name="redactionStatus"
+                                        type="radio" value="redacted">
+                                        <label class="govuk-label govuk-radios__label" for="redactionStatus">Redacted</label>
+                                    </div>
+                                    <div class="govuk-radios__item">
+                                        <input class="govuk-radios__input" id="redactionStatus-2" name="redactionStatus"
+                                        type="radio" value="not_redacted">
+                                        <label class="govuk-label govuk-radios__label" for="redactionStatus-2">Unredacted</label>
+                                    </div>
+                                    <div class="govuk-radios__item">
+                                        <input class="govuk-radios__input" id="redactionStatus-3" name="redactionStatus"
+                                        type="radio" value="no_redaction_required" checked>
+                                        <label class="govuk-label govuk-radios__label" for="redactionStatus-3">No redaction required</label>
+                                    </div>
+                                </div>
+                            </fieldset>
+                        </div>
+                        <button type="submit" data-prevent-double-click="true" class="govuk-button"
+                        data-module="govuk-button">Continue</button>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </div>
+</main>"
+`;
+
 exports[`interested-party-comments GET /manage-documents/:folderId/ should render a 404 error page if the folderId is invalid 1`] = `
 "<main class="govuk-main-wrapper" id="main-content">
     <div class="govuk-grid-row">

--- a/appeals/web/src/server/appeals/appeal-details/representations/interested-party-comments/view-and-review/__tests__/view-and-review.test.js
+++ b/appeals/web/src/server/appeals/appeal-details/representations/interested-party-comments/view-and-review/__tests__/view-and-review.test.js
@@ -44,6 +44,10 @@ describe('interested-party-comments', () => {
 			.get('/appeals/2/document-folders/1?repId=3670')
 			.reply(200, costsFolderInfoAppellantApplication)
 			.persist();
+
+		jest
+			.useFakeTimers({ doNotFake: ['nextTick', 'setImmediate'] })
+			.setSystemTime(new Date('2025-08-26'));
 	});
 
 	afterEach(teardown);
@@ -516,6 +520,151 @@ describe('interested-party-comments', () => {
 				'name="items[0][redactionStatus]" type="radio" value="no redaction required" checked>'
 			);
 			expect(unprettifiedElement.innerHTML).toContain('Confirm</button>');
+		});
+	});
+
+	describe('GET /add-document', () => {
+		beforeEach(() => {
+			nock('http://test/')
+				.get('/appeals/2')
+				.reply(200, {
+					...appealDataFullPlanning,
+					appealId: 2,
+					appealStatus: 'statements'
+				});
+			nock('http://test/')
+				.get('/appeals/2/reps/5')
+				.twice()
+				.reply(200, interestedPartyCommentForReview);
+			nock('http://test/')
+				.get('/appeals/2/document-folders?path=representation/representationAttachments')
+				.reply(200, [{ folderId: 1234, path: 'representation/attachments' }]);
+			nock('http://test/')
+				.get('/appeals/2/document-folders/1?repId=3670')
+				.reply(200, costsFolderInfoAppellantApplication)
+				.persist();
+		});
+
+		describe('GET /add-document', () => {
+			it('should render the add document details page', async () => {
+				const response = await request.get(`${baseUrl}/2/interested-party-comments/5/add-document`);
+
+				expect(response.statusCode).toBe(200);
+
+				const page = parseHtml(response.text);
+				expect(page.innerHTML).toMatchSnapshot();
+
+				expect(page.querySelector('h1')?.textContent?.trim()).toBe('Upload supporting document');
+			});
+
+			it('should have the correct back link', async () => {
+				const response = await request.get(`${baseUrl}/2/interested-party-comments/5/add-document`);
+
+				expect(response.statusCode).toBe(200);
+
+				const page = parseHtml(response.text, { rootElement: 'body' });
+				expect(page.querySelector('.govuk-back-link')?.getAttribute('href')?.trim()).toBe(
+					`${baseUrl}/2/interested-party-comments/5`
+				);
+			});
+
+			it('should have the correct back link when editing', async () => {
+				const response = await request.get(
+					`${baseUrl}/2/interested-party-comments/5/add-document` +
+						`?editEntrypoint=${baseUrl}/2/interested-party-comments/5/add-document`
+				);
+
+				expect(response.statusCode).toBe(200);
+
+				const page = parseHtml(response.text, { rootElement: 'body' });
+				expect(page.querySelector('.govuk-back-link')?.getAttribute('href')?.trim()).toBe(
+					`${baseUrl}/2/interested-party-comments/5/add-document/check-your-answers`
+				);
+			});
+		});
+
+		describe('GET /add-document/redaction-status', () => {
+			it('should render the redaction status page', async () => {
+				const response = await request.get(
+					`${baseUrl}/2/interested-party-comments/5/add-document/redaction-status`
+				);
+				expect(response.statusCode).toBe(200);
+
+				const page = parseHtml(response.text);
+				expect(page.innerHTML).toMatchSnapshot();
+
+				expect(page.querySelector('h1')?.textContent?.trim()).toBe('Redaction status');
+			});
+
+			it('should have the correct back link', async () => {
+				const response = await request.get(
+					`${baseUrl}/2/interested-party-comments/5/add-document/redaction-status`
+				);
+
+				expect(response.statusCode).toBe(200);
+
+				const page = parseHtml(response.text, { rootElement: 'body' });
+				expect(page.querySelector('.govuk-back-link')?.getAttribute('href')?.trim()).toBe(
+					`${baseUrl}/2/interested-party-comments/5/add-document`
+				);
+			});
+
+			it('should have the correct back link when editing', async () => {
+				const response = await request.get(
+					`${baseUrl}/2/interested-party-comments/5/add-document/redaction-status` +
+						`?editEntrypoint=${baseUrl}/2/interested-party-comments/5/add-document/redaction-status`
+				);
+
+				expect(response.statusCode).toBe(200);
+
+				const page = parseHtml(response.text, { rootElement: 'body' });
+				expect(page.querySelector('.govuk-back-link')?.getAttribute('href')?.trim()).toBe(
+					`${baseUrl}/2/interested-party-comments/5/add-document/check-your-answers`
+				);
+			});
+		});
+
+		describe('GET /add-document/date-submitted', () => {
+			it('should render the date submitted page', async () => {
+				const response = await request.get(
+					`${baseUrl}/2/interested-party-comments/5/add-document/date-submitted`
+				);
+				expect(response.statusCode).toBe(200);
+
+				const page = parseHtml(response.text);
+				expect(page.innerHTML).toMatchSnapshot();
+
+				expect(page.querySelector('h1')?.textContent?.trim()).toBe(
+					'When was the supporting document submitted?'
+				);
+			});
+
+			it('should have the correct back link', async () => {
+				const response = await request.get(
+					`${baseUrl}/2/interested-party-comments/5/add-document/date-submitted`
+				);
+
+				expect(response.statusCode).toBe(200);
+
+				const page = parseHtml(response.text, { rootElement: 'body' });
+				expect(page.querySelector('.govuk-back-link')?.getAttribute('href')?.trim()).toBe(
+					`${baseUrl}/2/interested-party-comments/5/add-document/redaction-status`
+				);
+			});
+
+			it('should have the correct back link when editing', async () => {
+				const response = await request.get(
+					`${baseUrl}/2/interested-party-comments/5/add-document/date-submitted` +
+						`?editEntrypoint=${baseUrl}/2/interested-party-comments/5/add-document/date-submitted`
+				);
+
+				expect(response.statusCode).toBe(200);
+
+				const page = parseHtml(response.text, { rootElement: 'body' });
+				expect(page.querySelector('.govuk-back-link')?.getAttribute('href')?.trim()).toBe(
+					`${baseUrl}/2/interested-party-comments/5/add-document/check-your-answers`
+				);
+			});
 		});
 	});
 });

--- a/appeals/web/src/server/lib/edit-utilities.js
+++ b/appeals/web/src/server/lib/edit-utilities.js
@@ -24,11 +24,11 @@ export const getSessionValues = (request, sessionKey) => {
  * Adds an editEntrypoint query param to the URL pointing to itself, indicating that the
  * user has started editing at that point.
  * @param {string} baseUrl - The base URL path
- * @param {string} slug - The last part of the URL path
+ * @param {string} [slug] - The last part of the URL path
  * @returns {string}
  */
 export const editLink = (baseUrl, slug) => {
-	const url = `${baseUrl}/${slug}`;
+	const url = slug ? `${baseUrl}/${slug}` : baseUrl;
 	return addQueryParamsToUrl(url, { editEntrypoint: url });
 };
 
@@ -51,7 +51,7 @@ export const applyEdits = (request, sessionKey) => {
 
 /**
  * Deletes the /edit session key without copying anything.
- * @param {import('@pins/express/types/express.js').Request} request
+ * @param {import('@pins/express').Request} request
  * @param {string} sessionKey
  */
 export const clearEdits = (request, sessionKey) => {


### PR DESCRIPTION
## Describe your changes

Documents can be added to an already submitted IP comment. After uploading the document and entering details the user is shown a CYA page and they can click "change" from that page. If they then click back, they will now be taken back to that CYA page.

## Issue ticket number and link

[A2-3053](https://pins-ds.atlassian.net/browse/A2-3053)


[A2-3053]: https://pins-ds.atlassian.net/browse/A2-3053?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ