### PR TITLE
fix(web): removing duplicate environmental services team review row (…

### DIFF
--- a/appeals/web/src/server/appeals/appeal-details/__tests__/appeal-details.test.js
+++ b/appeals/web/src/server/appeals/appeal-details/__tests__/appeal-details.test.js
@@ -3355,6 +3355,81 @@ describe('appeal-details', () => {
 					);
 				});
 			});
+
+			describe('Environmental services team review', () => {
+				const appealId = 3;
+				const testCase = [
+					{
+						name: 'LPA',
+						rowLabel: 'LPA final comments',
+						documentationSummaryKey: 'lpaFinalComments',
+						reviewPageRoute: 'final-comments/lpa',
+						cyAttribute: 'review-lpa-final-comments',
+						viewCyAttribute: 'view-lpa-final-comments',
+						actionLinkHiddenText: 'LPA final comments'
+					}
+				];
+
+				beforeEach(() => {
+					nock('http://test/').get(`/appeals/${appealId}/case-notes`).reply(200, caseNotes);
+				});
+
+				it('should not render an "Environmental services team review" row if the review is not required', async () => {
+					nock('http://test/')
+						.get(`/appeals/${appealId}`)
+						.reply(200, {
+							...appealDataFullPlanning,
+							appealId,
+							documentationSummary: {
+								...appealDataFullPlanning.documentationSummary,
+								[testCase.documentationSummaryKey]: {
+									status: 'received',
+									receivedAt: '2024-12-17T17:36:19.631Z',
+									representationStatus: 'valid'
+								}
+							},
+							eiaScreeningRequired: false
+						});
+
+					const response = await request.get(`${baseUrl}/${appealId}`);
+
+					expect(response.statusCode).toBe(200);
+
+					const unprettifiedHTML = parseHtml(response.text, { skipPrettyPrint: true }).innerHTML;
+
+					expect(unprettifiedHTML).toContain('Documentation</th>');
+					expect(unprettifiedHTML).not.toContain('Environmental services team review</th>');
+				});
+
+				it('should render exactly one "Environmental services team review" row if the review is required', async () => {
+					nock('http://test/')
+						.get(`/appeals/${appealId}`)
+						.reply(200, {
+							...appealDataFullPlanning,
+							appealId,
+							documentationSummary: {
+								...appealDataFullPlanning.documentationSummary,
+								[testCase.documentationSummaryKey]: {
+									status: 'received',
+									receivedAt: '2024-12-17T17:36:19.631Z',
+									representationStatus: 'valid'
+								}
+							},
+							eiaScreeningRequired: true
+						});
+
+					const response = await request.get(`${baseUrl}/${appealId}`);
+
+					expect(response.statusCode).toBe(200);
+
+					const unprettifiedHTML = parseHtml(response.text, { skipPrettyPrint: true }).innerHTML;
+
+					expect(unprettifiedHTML).toContain('Documentation</th>');
+					expect(
+						unprettifiedHTML.match(/Environmental services team review<\/th>/g) || []
+					).toHaveLength(1);
+				});
+			});
 		});
 
 		describe('Timetable', () => {

--- a/appeals/web/src/server/appeals/appeal-details/accordions/common/case-documentation.js
+++ b/appeals/web/src/server/appeals/appeal-details/accordions/common/case-documentation.js
@@ -25,7 +25,6 @@ export const getCaseDocumentation = (mappedData, appealDetails) => {
 							mappedData.appeal.ipComments.display.tableItem,
 							mappedData.appeal.appellantFinalComments.display.tableItem,
 							mappedData.appeal.lpaFinalComments.display.tableItem,
-							mappedData.appeal.environmentalAssessment.display.tableItem,
 							mappedData.appeal.appellantProofOfEvidence.display.tableItem,
 							mappedData.appeal.lpaProofOfEvidence.display.tableItem
 					  ]


### PR DESCRIPTION
…A2-4224)

## Describe your changes

- Removing the unneeded line (environmentalAssessment should show for all appeals, not just lead appeals)
<img width="1116" height="571" alt="image" src="https://github.com/user-attachments/assets/ed3a6e42-705e-4cef-b537-f26c54511596" />

- Adding tests to check the row is shown correctly (and shown only once when it is shown)

## Issue ticket number and link

[Ticket](https://pins-ds.atlassian.net/browse/A2-4224)
