### PR TITLE
feat(appeals): prevent awaiting linked appeal loop (a2-3630)

### DIFF
--- a/appeals/api/src/server/endpoints/lpa-questionnaires/lpa-questionnaires.service.js
+++ b/appeals/api/src/server/endpoints/lpa-questionnaires/lpa-questionnaires.service.js
@@ -97,7 +97,7 @@ const updateLPAQuestionnaireValidationOutcome = async (
 					linkedAppeals.map((appeal) => {
 						const validationOutcome = appeal.lpaQuestionnaire?.lpaQuestionnaireValidationOutcome;
 						if (validationOutcome) {
-							return transitionState(appeal.id, azureAdUserId, validationOutcome?.name);
+							return transitionState(appeal.id, azureAdUserId, validationOutcome.name);
 						}
 					})
 				);

--- a/appeals/api/src/server/mappers/api/shared/map-appeal-relationships.js
+++ b/appeals/api/src/server/mappers/api/shared/map-appeal-relationships.js
@@ -40,10 +40,15 @@ export const mapAppealRelationships = (data) => {
 
 	const linkedAppeals = [...parentAppeals, ...childAppeals];
 
-	const awaitingLinkedAppeal =
+	const awaitingLinkedAppeal = Boolean(
 		isFeatureActive(FEATURE_FLAG_NAMES.LINKED_APPEALS) &&
-		// @ts-ignore
-		isAwaitingLinkedAppeal(appeal, data.linkedAppeals);
+			data.linkedAppeals?.length &&
+			// @ts-ignore
+			isAwaitingLinkedAppeal(appeal, [
+				data.linkedAppeals[0].parent,
+				...data.linkedAppeals.map((linkedAppeal) => linkedAppeal.child)
+			])
+	);
 
 	const otherAppeals = appealRelationships.length
 		? appealRelationships

--- a/appeals/api/src/server/utils/__tests__/is-awaiting-linked-appeal.test.js
+++ b/appeals/api/src/server/utils/__tests__/is-awaiting-linked-appeal.test.js
@@ -1,0 +1,92 @@
+// @ts-nocheck
+import { isAwaitingLinkedAppeal } from '#utils/is-awaiting-linked-appeal.js';
+
+describe('isAwaitingLinkedAppeal', () => {
+	let appeal;
+
+	describe('when appeal status is validation', () => {
+		beforeEach(() => {
+			appeal = {
+				appellantCase: { appellantCaseValidationOutcome: { name: 'valid' } },
+				appealStatus: [{ status: 'validation', valid: true }]
+			};
+		});
+
+		test('returns true when appeal is awaiting linked appeal appellant case validation', () => {
+			expect(
+				isAwaitingLinkedAppeal(appeal, [
+					{
+						currentStatus: 'lpa_questionnaire',
+						completedStateList: ['validation'],
+						appellantCase: { appellantCaseValidationOutcome: { name: 'valid' } }
+					},
+					{
+						currentStatus: 'validation',
+						completedStateList: [],
+						appellantCase: { appellantCaseValidationOutcome: { name: '' } }
+					}
+				])
+			).toBe(true);
+		});
+
+		test('returns false when appeal is not awaiting linked appeal appellant case validation', () => {
+			expect(
+				isAwaitingLinkedAppeal(appeal, [
+					{
+						currentStatus: 'lpa_questionnaire',
+						completedStateList: ['validation'],
+						appellantCase: { appellantCaseValidationOutcome: { name: 'valid' } }
+					},
+					{
+						currentStatus: 'validation',
+						completedStateList: [],
+						appellantCase: { appellantCaseValidationOutcome: { name: 'valid' } }
+					}
+				])
+			).toBe(false);
+		});
+	});
+
+	describe('when appeal status is lpa_questionnaire', () => {
+		beforeEach(() => {
+			appeal = {
+				lpaQuestionnaire: { lpaQuestionnaireValidationOutcome: { name: 'complete' } },
+				appealStatus: [{ status: 'lpa_questionnaire', valid: true }]
+			};
+		});
+
+		test('returns true when appeal is awaiting linked appeal appellant case validation', () => {
+			expect(
+				isAwaitingLinkedAppeal(appeal, [
+					{
+						currentStatus: 'statements',
+						completedStateList: ['validation', 'lpa_questionnaire'],
+						lpaQuestionnaire: { lpaQuestionnaireValidationOutcome: { name: 'complete' } }
+					},
+					{
+						currentStatus: 'lpa_questionnaire',
+						completedStateList: ['validation'],
+						lpaQuestionnaire: { lpaQuestionnaireValidationOutcome: { name: '' } }
+					}
+				])
+			).toBe(true);
+		});
+
+		test('returns false when appeal is not awaiting linked appeal appellant case validation', () => {
+			expect(
+				isAwaitingLinkedAppeal(appeal, [
+					{
+						currentStatus: 'statements',
+						completedStateList: ['validation', 'lpa_questionnaire'],
+						lpaQuestionnaire: { lpaQuestionnaireValidationOutcome: { name: 'complete' } }
+					},
+					{
+						currentStatus: 'lpa_questionnaire',
+						completedStateList: ['validation'],
+						lpaQuestionnaire: { lpaQuestionnaireValidationOutcome: { name: 'complete' } }
+					}
+				])
+			).toBe(false);
+		});
+	});
+});


### PR DESCRIPTION
## Describe your changes
#### Prevent awaiting linked appeal loop to make sure all linked appeals roll on when they all complete their LPA Questionnaire.
#### Also make sure the broadcast of each appeal happens when all the LPA Questionnaire appeals transition

This is a bug fix for a previous ticket
 
### API:
- Fix the calculation for setting the awaitingLinkedAppeal property on the appeal get requests
- Make sure the broadcast of an appeal happens when all the LPA Questionnaire appeals transition

### Test:
- Add extra unit tests
- Make sure tests still pass
- Test within browser

## Issue ticket number and link

[A2-3630](https://pins-ds.atlassian.net/browse/A2-3630)

[A2-3630]: https://pins-ds.atlassian.net/browse/A2-3630?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ