### PR TITLE
fix(tooling): batch queries for clear test data pipeline

### DIFF
--- a/azure-pipelines-db-clear-test-data.yml
+++ b/azure-pipelines-db-clear-test-data.yml
@@ -64,6 +64,7 @@ jobs:
               parameters:
                 environmentVariables:
                   DATABASE_URL: $(appeals-bo-sql-admin-connection-string)
+                  QUERY_BATCH_SIZE: 2000
                 script: npm run db:seed:clear-test-data
                 workingDirectory: $(Build.Repository.LocalPath)/appeals/api
     workspace:


### PR DESCRIPTION
Batch queries for clear test data pipeline to stop it failing when there are > 2100 records

