### PR TITLE
feat(appeals): hide costs accordion when linked appeal (a2-4173)

### DIFF
--- a/appeals/api/setup-tests.js
+++ b/appeals/api/setup-tests.js
@@ -43,6 +43,7 @@ const mockDocumentFindMany = jest.fn().mockResolvedValue({});
 const mockDocumentCount = jest.fn().mockResolvedValue({});
 const mockDocumentFindFirst = jest.fn().mockResolvedValue({});
 const mockDocumentDelete = jest.fn().mockResolvedValue({});
+const mockDocumentCreate = jest.fn().mockResolvedValue({});
 const mockDocumentCreateMany = jest.fn().mockResolvedValue({});
 const mockDocumentVersionCreate = jest.fn().mockResolvedValue({});
 const mockDocumentVersionCreateMany = jest.fn().mockResolvedValue({});
@@ -133,6 +134,7 @@ const mockLpaFindUnique = jest.fn().mockResolvedValue({});
 const mockTeamFindUnique = jest.fn().mockResolvedValue({});
 const mockTeamFindFirst = jest.fn().mockResolvedValue({});
 const mockTeamFindMany = jest.fn().mockResolvedValue({});
+const mockBlobStorageCopyFile = jest.fn().mockResolvedValue({});
 
 const mockNotifySend = jest.fn().mockImplementation(async (params) => {
 	const { doNotMockNotifySend = false, ...options } = params || {};
@@ -245,7 +247,8 @@ class MockPrismaClient {
 			findMany: mockDocumentFindMany,
 			update: mockDocumentUpdate,
 			upsert: mockDocumentUpsert,
-			createMany: mockDocumentCreateMany
+			createMany: mockDocumentCreateMany,
+			create: mockDocumentCreate
 		};
 	}
 
@@ -572,6 +575,16 @@ jest.unstable_mockModule('./src/server/infrastructure/event-client.js', () => ({
 	eventClient: {
 		sendEvents: mockSendEvents
 	}
+}));
+
+jest.unstable_mockModule('@pins/blob-storage-client', () => ({
+	BlobStorageClient: { fromUrl: jest.fn().mockReturnValue({ copyFile: mockBlobStorageCopyFile }) }
+}));
+
+jest.unstable_mockModule('@azure/storage-blob', () => ({ BlobServiceClient: jest.fn() }));
+
+jest.unstable_mockModule('rhea', () => ({
+	default: { generate_uuid: jest.fn().mockReturnValue('mock-uuid') }
 }));
 
 const mockGotGet = jest.fn();

--- a/appeals/api/src/server/endpoints/documents/__tests__/documents.test.js
+++ b/appeals/api/src/server/endpoints/documents/__tests__/documents.test.js
@@ -22,6 +22,8 @@ import { request } from '../../../app-test.js';
 const { databaseConnector } = await import('#utils/database-connector.js');
 const { default: got } = await import('got');
 
+const savedDocument = savedFolder.documents[0];
+
 describe('/appeals/:appealId/document-folders/:folderId', () => {
 	beforeEach(() => {
 		// @ts-ignore
@@ -41,13 +43,14 @@ describe('/appeals/:appealId/document-folders/:folderId', () => {
 				.set('azureAdUserId', azureAdUserId);
 
 			expect(response.status).toEqual(200);
+
 			expect(response.body).toEqual({
 				folderId: savedFolder.id,
 				path: savedFolder.path,
 				caseId: savedFolder.caseId.toString(),
 				documents: [
 					{
-						id: savedFolder.documents[0].guid,
+						id: savedDocument.guid,
 						caseId: savedFolder.caseId,
 						folderId: savedFolder.id,
 						createdAt: expect.any(String),
@@ -55,11 +58,11 @@ describe('/appeals/:appealId/document-folders/:folderId', () => {
 						latestDocumentVersion: {
 							version: 1,
 							blobStorageContainer: '',
-							blobStoragePath: '',
+							blobStoragePath: savedDocument.latestDocumentVersion.blobStoragePath,
 							documentURI: '',
 							dateReceived: '',
-							size: '',
-							mime: '',
+							size: savedDocument.latestDocumentVersion.size.toString(),
+							mime: savedDocument.latestDocumentVersion.mime,
 							fileName: '',
 							originalFilename: '',
 							redactionStatus: '',
@@ -67,7 +70,7 @@ describe('/appeals/:appealId/document-folders/:folderId', () => {
 							stage: '',
 							virusCheckStatus: 'not_scanned'
 						},
-						name: savedFolder.documents[0].name,
+						name: savedDocument.name,
 						versionAudit: []
 					}
 				]
@@ -88,7 +91,7 @@ describe('/appeals/:appealId/documents/:documentId', () => {
 
 			expect(response.status).toEqual(200);
 			expect(response.body).toEqual({
-				id: savedFolder.documents[0].guid,
+				id: savedDocument.guid,
 				caseId: savedFolder.caseId,
 				folderId: savedFolder.id,
 				createdAt: expect.any(String),
@@ -96,11 +99,11 @@ describe('/appeals/:appealId/documents/:documentId', () => {
 				latestDocumentVersion: {
 					version: 1,
 					blobStorageContainer: '',
-					blobStoragePath: '',
+					blobStoragePath: savedDocument.latestDocumentVersion.blobStoragePath,
 					documentURI: '',
 					dateReceived: '',
-					size: '',
-					mime: '',
+					size: savedDocument.latestDocumentVersion.size.toString(),
+					mime: savedDocument.latestDocumentVersion.mime,
 					fileName: '',
 					originalFilename: '',
 					redactionStatus: '',

--- a/appeals/api/src/server/endpoints/documents/documents.service.js
+++ b/appeals/api/src/server/endpoints/documents/documents.service.js
@@ -220,9 +220,10 @@ export const getFoldersForStage = (path) => {
 /**
  * @param {AddDocumentsRequest} upload
  * @param {Appeal} appeal
+ * @param {boolean} [skipBlobValidation]
  * @returns {Promise<AddDocumentsResponse>}}
  */
-export const addDocumentsToAppeal = async (upload, appeal) => {
+export const addDocumentsToAppeal = async (upload, appeal, skipBlobValidation = false) => {
 	const { blobStorageHost, blobStorageContainer, documents } = upload;
 	const documentsToSendToDatabase = mapDocumentsForDatabase(
 		appeal.id,
@@ -231,13 +232,15 @@ export const addDocumentsToAppeal = async (upload, appeal) => {
 		documents
 	);
 
-	const blobValidation = await validateBlobContents(
-		appeal.reference,
-		documentsToSendToDatabase.map((doc) => doc.blobStoragePath ?? '')
-	);
+	if (!skipBlobValidation) {
+		const blobValidation = await validateBlobContents(
+			appeal.reference,
+			documentsToSendToDatabase.map((doc) => doc.blobStoragePath ?? '')
+		);
 
-	if (!blobValidation) {
-		throw new Error(`Invalid blobs submitted`);
+		if (!blobValidation) {
+			throw new Error(`Invalid blobs submitted`);
+		}
 	}
 
 	const documentsCreated = await addDocumentAndVersion(appeal, documentsToSendToDatabase);

--- a/appeals/api/src/server/endpoints/link-appeals/link-appeals.controller.js
+++ b/appeals/api/src/server/endpoints/link-appeals/link-appeals.controller.js
@@ -5,19 +5,22 @@ import {
 	AUDIT_TRAIL_APPEAL_LINK_ADDED,
 	AUDIT_TRAIL_APPEAL_LINK_REMOVED,
 	AUDIT_TRAIL_APPEAL_RELATION_ADDED,
-	AUDIT_TRAIL_APPEAL_RELATION_REMOVED
-} from '@pins/appeals/constants/support.js';
-import { canLinkAppeals, checkAppealsStatusBeforeLPAQ } from './link-appeals.service.js';
-import {
+	AUDIT_TRAIL_APPEAL_RELATION_REMOVED,
 	CASE_RELATIONSHIP_LINKED,
 	CASE_RELATIONSHIP_RELATED,
 	ERROR_LINKING_APPEALS
 } from '@pins/appeals/constants/support.js';
+import {
+	canLinkAppeals,
+	checkAppealsStatusBeforeLPAQ,
+	duplicateFiles
+} from './link-appeals.service.js';
 import { getAppealFromHorizon } from '#utils/horizon-gateway.js';
 import { formatHorizonGetCaseData } from '#utils/mapping/map-horizon.js';
 import stringTokenReplacement from '#utils/string-token-replacement.js';
 import { notifySend } from '#notify/notify-send.js';
 import { formatAddressSingleLine } from '#endpoints/addresses/addresses.formatter.js';
+import { APPEAL_CASE_STAGE } from '@planning-inspectorate/data-model';
 
 /** @typedef {import('express').Request} Request */
 /** @typedef {import('express').Response} Response */
@@ -55,25 +58,23 @@ export const linkAppeal = async (req, res) => {
 		});
 	}
 
-	const relationship = isCurrentAppealParent
-		? {
-				parentId: currentAppeal.id,
-				parentRef: currentAppeal.reference,
-				childId: linkedAppeal.id,
-				childRef: linkedAppeal.reference,
-				type: CASE_RELATIONSHIP_LINKED,
-				externalSource: false
-		  }
-		: {
-				parentId: linkedAppeal.id,
-				parentRef: linkedAppeal.reference,
-				childId: currentAppeal.id,
-				childRef: currentAppeal.reference,
-				type: CASE_RELATIONSHIP_LINKED,
-				externalSource: false
-		  };
+	const childAppeal = isCurrentAppealParent ? linkedAppeal : currentAppeal;
+	const parentAppeal = isCurrentAppealParent ? currentAppeal : linkedAppeal;
+
+	const relationship = {
+		parentId: parentAppeal.id,
+		parentRef: parentAppeal.reference,
+		childId: childAppeal.id,
+		childRef: childAppeal.reference,
+		type: CASE_RELATIONSHIP_LINKED,
+		externalSource: false
+	};
 
 	const result = await appealRepository.linkAppeal(relationship);
+
+	if (result) {
+		await duplicateFiles(childAppeal, parentAppeal, APPEAL_CASE_STAGE.COSTS);
+	}
 
 	const siteAddress = currentAppeal.address
 		? formatAddressSingleLine(currentAppeal.address)

--- a/appeals/api/src/server/repositories/document-metadata.repository.js
+++ b/appeals/api/src/server/repositories/document-metadata.repository.js
@@ -29,7 +29,7 @@ export const addDocument = async (metadata, context) => {
 
 		metadata.documentGuid = guid;
 		metadata.version = 1;
-		metadata.fileName = name;
+		metadata.fileName = name || metadata.originalFilename;
 		const scanStatus = await tx.documentVersionAvScan.findUnique({
 			where: {
 				documentGuid_version: {

--- a/appeals/api/src/server/tests/documents/mocks.js
+++ b/appeals/api/src/server/tests/documents/mocks.js
@@ -140,6 +140,11 @@ export const savedFolder = {
 				version: 1,
 				documentId: '27d0fda4-8a9a-4f5a-a158-68eaea676158',
 				documentType: 'appellantCostApplication',
+				blobStoragePath: 'appeal/6000001/27d0fda4-8a9a-4f5a-a158-68eaea676158/v1/mydoc.pdf',
+				mime: 'application/pdf',
+				size: 14699,
+				receivedDate: '2024-06-11T19:42:22.713Z',
+				redactionStatusId: 1,
 				avScan: []
 			}
 		}

--- a/appeals/api/src/server/utils/blob-copy.js
+++ b/appeals/api/src/server/utils/blob-copy.js
@@ -1,0 +1,35 @@
+import config from '#config/config.js';
+import { BlobStorageClient } from '@pins/blob-storage-client';
+import { BlobServiceClient } from '@azure/storage-blob';
+import logger from '#utils/logger.js';
+
+/**
+ * Copies blobs from one location to another
+ * @param {{ sourceBlobName: string|null|undefined, destinationBlobName: string }[]} copyList
+ * @returns {Promise<Promise<Awaited<unknown>[]> | Promise<{[p: string]: Awaited<*>, [p: number]: Awaited<*>, [p: symbol]: Awaited<*>}>>}
+ */
+export const copyBlobs = async (copyList) => {
+	const storageContainer = config.BO_BLOB_CONTAINER;
+	const storageClient = config.useBlobEmulator
+		? new BlobStorageClient(new BlobServiceClient(config.blobEmulatorSasUrl))
+		: BlobStorageClient.fromUrl(config.BO_BLOB_STORAGE_ACCOUNT);
+
+	return Promise.all(
+		// @ts-ignore
+		copyList.map(async (copyDetails) => {
+			const { sourceBlobName, destinationBlobName } = copyDetails;
+			let copyResult;
+			try {
+				copyResult = await storageClient.copyFile({
+					sourceContainerName: storageContainer,
+					destinationContainerName: storageContainer,
+					sourceBlobName: sourceBlobName ?? '',
+					destinationBlobName
+				});
+			} catch (error) {
+				logger.error(`Error copying blob ${sourceBlobName} to ${destinationBlobName}: ${error}`);
+			}
+			return copyResult;
+		})
+	);
+};

--- a/appeals/web/src/server/appeals/appeal-details/__tests__/__snapshots__/appeal-details.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/__tests__/__snapshots__/appeal-details.test.js.snap
@@ -631,87 +631,9 @@ exports[`appeal-details GET /:appealId Linked appeals should not render a "Appea
                 </div>
                 <div class="govuk-accordion__section">
                     <div class="govuk-accordion__section-header">
-                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default2-heading-4"> Costs</span></h2>
+                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default2-heading-4"> Contacts</span></h2>
                     </div>
                     <div id="accordion-default2-content-4" class="govuk-accordion__section-content">
-                        <table class="govuk-table">
-                            <thead class="govuk-table__head">
-                                <tr class="govuk-table__row">
-                                    <th scope="col" class="govuk-table__header">Documentation</th>
-                                    <th scope="col" class="govuk-table__header">Status</th>
-                                    <th scope="col" class="govuk-table__header govuk-!-text-align-right">Action</th>
-                                </tr>
-                            </thead>
-                            <tbody class="govuk-table__body">
-                                <tr class="govuk-table__row">
-                                    <th scope="row" class="govuk-table__header appeal-costs-appellant-application-documentation">Appellant application</th>
-                                    <td class="govuk-table__cell appeal-costs-appellant-application-status">No documents available</td>
-                                    <td class="govuk-table__cell appeal-costs-appellant-application-actions govuk-!-text-align-right">
-                                        <ul class="govuk-summary-list__actions-list">
-                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-appellant-application" href="/appeals-service/appeal-details/2/costs/appellant/application/upload-documents/1">Add<span class="govuk-visually-hidden"> Appellant application</span></a>
-                                            </li>
-                                        </ul>
-                                    </td>
-                                </tr>
-                                <tr class="govuk-table__row">
-                                    <th scope="row" class="govuk-table__header appeal-costs-appellant-withdrawal-documentation">Appellant withdrawal</th>
-                                    <td class="govuk-table__cell appeal-costs-appellant-withdrawal-status">No documents available</td>
-                                    <td class="govuk-table__cell appeal-costs-appellant-withdrawal-actions govuk-!-text-align-right">
-                                        <ul class="govuk-summary-list__actions-list">
-                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-appellant-withdrawal" href="/appeals-service/appeal-details/2/costs/appellant/withdrawal/upload-documents/2">Add<span class="govuk-visually-hidden"> Appellant withdrawal</span></a>
-                                            </li>
-                                        </ul>
-                                    </td>
-                                </tr>
-                                <tr class="govuk-table__row">
-                                    <th scope="row" class="govuk-table__header appeal-costs-appellant-correspondence-documentation">Appellant correspondence</th>
-                                    <td class="govuk-table__cell appeal-costs-appellant-correspondence-status">No documents available</td>
-                                    <td class="govuk-table__cell appeal-costs-appellant-correspondence-actions govuk-!-text-align-right">
-                                        <ul class="govuk-summary-list__actions-list">
-                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-appellant-correspondence" href="/appeals-service/appeal-details/2/costs/appellant/correspondence/upload-documents/3">Add<span class="govuk-visually-hidden"> Appellant correspondence</span></a>
-                                            </li>
-                                        </ul>
-                                    </td>
-                                </tr>
-                                <tr class="govuk-table__row">
-                                    <th scope="row" class="govuk-table__header appeal-costs-lpa-application-documentation">LPA application</th>
-                                    <td class="govuk-table__cell appeal-costs-lpa-application-status">No documents available</td>
-                                    <td class="govuk-table__cell appeal-costs-lpa-application-actions govuk-!-text-align-right">
-                                        <ul class="govuk-summary-list__actions-list">
-                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-lpa-application" href="/appeals-service/appeal-details/2/costs/lpa/application/upload-documents/4">Add<span class="govuk-visually-hidden"> LPA application</span></a>
-                                            </li>
-                                        </ul>
-                                    </td>
-                                </tr>
-                                <tr class="govuk-table__row">
-                                    <th scope="row" class="govuk-table__header appeal-costs-lpa-withdrawal-documentation">LPA withdrawal</th>
-                                    <td class="govuk-table__cell appeal-costs-lpa-withdrawal-status">No documents available</td>
-                                    <td class="govuk-table__cell appeal-costs-lpa-withdrawal-actions govuk-!-text-align-right">
-                                        <ul class="govuk-summary-list__actions-list">
-                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-lpa-withdrawal" href="/appeals-service/appeal-details/2/costs/lpa/withdrawal/upload-documents/5">Add<span class="govuk-visually-hidden"> LPA withdrawal</span></a>
-                                            </li>
-                                        </ul>
-                                    </td>
-                                </tr>
-                                <tr class="govuk-table__row">
-                                    <th scope="row" class="govuk-table__header appeal-costs-lpa-correspondence-documentation">LPA correspondence</th>
-                                    <td class="govuk-table__cell appeal-costs-lpa-correspondence-status">No documents available</td>
-                                    <td class="govuk-table__cell appeal-costs-lpa-correspondence-actions govuk-!-text-align-right">
-                                        <ul class="govuk-summary-list__actions-list">
-                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-lpa-correspondence" href="/appeals-service/appeal-details/2/costs/lpa/correspondence/upload-documents/6">Add<span class="govuk-visually-hidden"> LPA correspondence</span></a>
-                                            </li>
-                                        </ul>
-                                    </td>
-                                </tr>
-                            </tbody>
-                        </table>
-                    </div>
-                </div>
-                <div class="govuk-accordion__section">
-                    <div class="govuk-accordion__section-header">
-                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default2-heading-5"> Contacts</span></h2>
-                    </div>
-                    <div id="accordion-default2-content-5" class="govuk-accordion__section-content">
                         <dl class="govuk-summary-list">
                             <div class="govuk-summary-list__row appeal-appellant"><dt class="govuk-summary-list__key"> Appellant</dt>
                                 <dd class="govuk-summary-list__value">
@@ -751,9 +673,9 @@ exports[`appeal-details GET /:appealId Linked appeals should not render a "Appea
                 </div>
                 <div class="govuk-accordion__section">
                     <div class="govuk-accordion__section-header">
-                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default2-heading-6"> Team</span></h2>
+                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default2-heading-5"> Team</span></h2>
                     </div>
-                    <div id="accordion-default2-content-6" class="govuk-accordion__section-content">
+                    <div id="accordion-default2-content-5" class="govuk-accordion__section-content">
                         <dl class="govuk-summary-list">
                             <div class="govuk-summary-list__row appeal-case-team"><dt class="govuk-summary-list__key"> Case team</dt>
                                 <dd class="govuk-summary-list__value">
@@ -787,9 +709,9 @@ exports[`appeal-details GET /:appealId Linked appeals should not render a "Appea
                 </div>
                 <div class="govuk-accordion__section">
                     <div class="govuk-accordion__section-header">
-                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default2-heading-7"> Case management</span></h2>
+                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default2-heading-6"> Case management</span></h2>
                     </div>
-                    <div id="accordion-default2-content-7" class="govuk-accordion__section-content">
+                    <div id="accordion-default2-content-6" class="govuk-accordion__section-content">
                         <dl class="govuk-summary-list">
                             <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Cross-team correspondence</dt>
                                 <dd                                 class="govuk-summary-list__value">No documents</dd>
@@ -1484,87 +1406,9 @@ exports[`appeal-details GET /:appealId Linked appeals should render a child tag 
                 </div>
                 <div class="govuk-accordion__section">
                     <div class="govuk-accordion__section-header">
-                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-4"> Costs</span></h2>
+                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-4"> Contacts</span></h2>
                     </div>
                     <div id="accordion-default1-content-4" class="govuk-accordion__section-content">
-                        <table class="govuk-table">
-                            <thead class="govuk-table__head">
-                                <tr class="govuk-table__row">
-                                    <th scope="col" class="govuk-table__header">Documentation</th>
-                                    <th scope="col" class="govuk-table__header">Status</th>
-                                    <th scope="col" class="govuk-table__header govuk-!-text-align-right">Action</th>
-                                </tr>
-                            </thead>
-                            <tbody class="govuk-table__body">
-                                <tr class="govuk-table__row">
-                                    <th scope="row" class="govuk-table__header appeal-costs-appellant-application-documentation">Appellant application</th>
-                                    <td class="govuk-table__cell appeal-costs-appellant-application-status">No documents available</td>
-                                    <td class="govuk-table__cell appeal-costs-appellant-application-actions govuk-!-text-align-right">
-                                        <ul class="govuk-summary-list__actions-list">
-                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-appellant-application" href="/appeals-service/appeal-details/1/costs/appellant/application/upload-documents/1">Add<span class="govuk-visually-hidden"> Appellant application</span></a>
-                                            </li>
-                                        </ul>
-                                    </td>
-                                </tr>
-                                <tr class="govuk-table__row">
-                                    <th scope="row" class="govuk-table__header appeal-costs-appellant-withdrawal-documentation">Appellant withdrawal</th>
-                                    <td class="govuk-table__cell appeal-costs-appellant-withdrawal-status">No documents available</td>
-                                    <td class="govuk-table__cell appeal-costs-appellant-withdrawal-actions govuk-!-text-align-right">
-                                        <ul class="govuk-summary-list__actions-list">
-                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-appellant-withdrawal" href="/appeals-service/appeal-details/1/costs/appellant/withdrawal/upload-documents/2">Add<span class="govuk-visually-hidden"> Appellant withdrawal</span></a>
-                                            </li>
-                                        </ul>
-                                    </td>
-                                </tr>
-                                <tr class="govuk-table__row">
-                                    <th scope="row" class="govuk-table__header appeal-costs-appellant-correspondence-documentation">Appellant correspondence</th>
-                                    <td class="govuk-table__cell appeal-costs-appellant-correspondence-status">No documents available</td>
-                                    <td class="govuk-table__cell appeal-costs-appellant-correspondence-actions govuk-!-text-align-right">
-                                        <ul class="govuk-summary-list__actions-list">
-                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-appellant-correspondence" href="/appeals-service/appeal-details/1/costs/appellant/correspondence/upload-documents/3">Add<span class="govuk-visually-hidden"> Appellant correspondence</span></a>
-                                            </li>
-                                        </ul>
-                                    </td>
-                                </tr>
-                                <tr class="govuk-table__row">
-                                    <th scope="row" class="govuk-table__header appeal-costs-lpa-application-documentation">LPA application</th>
-                                    <td class="govuk-table__cell appeal-costs-lpa-application-status">No documents available</td>
-                                    <td class="govuk-table__cell appeal-costs-lpa-application-actions govuk-!-text-align-right">
-                                        <ul class="govuk-summary-list__actions-list">
-                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-lpa-application" href="/appeals-service/appeal-details/1/costs/lpa/application/upload-documents/4">Add<span class="govuk-visually-hidden"> LPA application</span></a>
-                                            </li>
-                                        </ul>
-                                    </td>
-                                </tr>
-                                <tr class="govuk-table__row">
-                                    <th scope="row" class="govuk-table__header appeal-costs-lpa-withdrawal-documentation">LPA withdrawal</th>
-                                    <td class="govuk-table__cell appeal-costs-lpa-withdrawal-status">No documents available</td>
-                                    <td class="govuk-table__cell appeal-costs-lpa-withdrawal-actions govuk-!-text-align-right">
-                                        <ul class="govuk-summary-list__actions-list">
-                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-lpa-withdrawal" href="/appeals-service/appeal-details/1/costs/lpa/withdrawal/upload-documents/5">Add<span class="govuk-visually-hidden"> LPA withdrawal</span></a>
-                                            </li>
-                                        </ul>
-                                    </td>
-                                </tr>
-                                <tr class="govuk-table__row">
-                                    <th scope="row" class="govuk-table__header appeal-costs-lpa-correspondence-documentation">LPA correspondence</th>
-                                    <td class="govuk-table__cell appeal-costs-lpa-correspondence-status">No documents available</td>
-                                    <td class="govuk-table__cell appeal-costs-lpa-correspondence-actions govuk-!-text-align-right">
-                                        <ul class="govuk-summary-list__actions-list">
-                                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" data-cy="add-costs-lpa-correspondence" href="/appeals-service/appeal-details/1/costs/lpa/correspondence/upload-documents/6">Add<span class="govuk-visually-hidden"> LPA correspondence</span></a>
-                                            </li>
-                                        </ul>
-                                    </td>
-                                </tr>
-                            </tbody>
-                        </table>
-                    </div>
-                </div>
-                <div class="govuk-accordion__section">
-                    <div class="govuk-accordion__section-header">
-                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-5"> Contacts</span></h2>
-                    </div>
-                    <div id="accordion-default1-content-5" class="govuk-accordion__section-content">
                         <dl class="govuk-summary-list">
                             <div class="govuk-summary-list__row appeal-appellant"><dt class="govuk-summary-list__key"> Appellant</dt>
                                 <dd class="govuk-summary-list__value">
@@ -1604,9 +1448,9 @@ exports[`appeal-details GET /:appealId Linked appeals should render a child tag 
                 </div>
                 <div class="govuk-accordion__section">
                     <div class="govuk-accordion__section-header">
-                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-6"> Team</span></h2>
+                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-5"> Team</span></h2>
                     </div>
-                    <div id="accordion-default1-content-6" class="govuk-accordion__section-content">
+                    <div id="accordion-default1-content-5" class="govuk-accordion__section-content">
                         <dl class="govuk-summary-list">
                             <div class="govuk-summary-list__row appeal-case-team"><dt class="govuk-summary-list__key"> Case team</dt>
                                 <dd class="govuk-summary-list__value">
@@ -1640,9 +1484,9 @@ exports[`appeal-details GET /:appealId Linked appeals should render a child tag 
                 </div>
                 <div class="govuk-accordion__section">
                     <div class="govuk-accordion__section-header">
-                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-7"> Case management</span></h2>
+                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-6"> Case management</span></h2>
                     </div>
-                    <div id="accordion-default1-content-7" class="govuk-accordion__section-content">
+                    <div id="accordion-default1-content-6" class="govuk-accordion__section-content">
                         <dl class="govuk-summary-list">
                             <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Cross-team correspondence</dt>
                                 <dd                                 class="govuk-summary-list__value">No documents</dd>

--- a/appeals/web/src/server/appeals/appeal-details/accordions/has.js
+++ b/appeals/web/src/server/appeals/appeal-details/accordions/has.js
@@ -70,7 +70,7 @@ export function generateAccordion(appealDetails, mappedData, session) {
 		}
 	};
 
-	const caseCosts = getCaseCosts(mappedData);
+	const caseCosts = !isChildAppeal(appealDetails) && getCaseCosts(mappedData);
 
 	const caseContacts = getCaseContacts(mappedData);
 
@@ -125,10 +125,14 @@ export function generateAccordion(appealDetails, mappedData, session) {
 					heading: { text: 'Documentation' },
 					content: { html: '', pageComponents: [caseDocumentation] }
 				},
-				{
-					heading: { text: 'Costs' },
-					content: { html: '', pageComponents: [caseCosts] }
-				},
+				...(caseCosts
+					? [
+							{
+								heading: { text: 'Costs' },
+								content: { html: '', pageComponents: [caseCosts] }
+							}
+					  ]
+					: []),
 				{
 					heading: { text: 'Contacts' },
 					content: { html: '', pageComponents: [caseContacts] }

--- a/appeals/web/src/server/appeals/appeal-details/accordions/s78.js
+++ b/appeals/web/src/server/appeals/appeal-details/accordions/s78.js
@@ -55,7 +55,7 @@ export function generateAccordion(appealDetails, mappedData, session) {
 
 	const caseDocumentation = getCaseDocumentation(mappedData, appealDetails);
 
-	const caseCosts = getCaseCosts(mappedData);
+	const caseCosts = !isChildAppeal(appealDetails) && getCaseCosts(mappedData);
 
 	const caseContacts = getCaseContacts(mappedData);
 
@@ -132,10 +132,14 @@ export function generateAccordion(appealDetails, mappedData, session) {
 					heading: { text: 'Documentation' },
 					content: { html: '', pageComponents: [caseDocumentation] }
 				},
-				{
-					heading: { text: 'Costs' },
-					content: { html: '', pageComponents: [caseCosts] }
-				},
+				...(caseCosts
+					? [
+							{
+								heading: { text: 'Costs' },
+								content: { html: '', pageComponents: [caseCosts] }
+							}
+					  ]
+					: []),
 				{
 					heading: { text: 'Contacts' },
 					content: { html: '', pageComponents: [caseContacts] }


### PR DESCRIPTION
## Describe your changes
#### Hide costs accordion when linked appeal (a2-1473)
##### This also implements a way of copying documents from one appeal to another which is required here as the child appeal cost documents need to be copied to the lead appeal when linking.

### WEB:
- Hide costs accordion on linked child appeal

### API:
- Create a function to copy blobs from one location to another
- Create a new generic duplicateFiles function to copy documents from a source appeal to a target appeal for a given stage (such as costs)

### TEST:
- Update unit tests where required
- Make sure they pass
- Tested within browser examining the blob emulator to make sure the blobs are copied correctly

## Issue ticket number and link

[A2-4173 - What happens to cost files/'Costs' accordion on child appeals when linking (relates to all appeal types)](https://pins-ds.atlassian.net/browse/A2-4173)
