### PR TITLE
fix(api): broadcast updated details for both child and lead linked appeals

### DIFF
--- a/appeals/api/src/server/endpoints/link-appeals/link-appeals.controller.js
+++ b/appeals/api/src/server/endpoints/link-appeals/link-appeals.controller.js
@@ -126,7 +126,9 @@ export const linkAppeal = async (req, res) => {
 		})
 	]);
 
-	await broadcasters.broadcastAppeal(currentAppeal.id);
+	await Promise.all(
+		[currentAppeal.id, linkedAppeal.id].map((id) => broadcasters.broadcastAppeal(id))
+	);
 	return res.status(201).send(result);
 };
 


### PR DESCRIPTION
When two appeals are linked, this change ensures that the updated details in respect of both linked appeals are broadcast.

## Issue ticket number and link

[Ticket]https://pins-ds.atlassian.net/browse/A2-3911
