### PR TITLE
FIX(3905): State transition from assign case officer to invalid

### DIFF
--- a/appeals/api/src/server/state/__tests__/state-machine.test.js
+++ b/appeals/api/src/server/state/__tests__/state-machine.test.js
@@ -86,6 +86,14 @@ describe('State Machine Transitions', () => {
 				APPEAL_CASE_STATUS.WITHDRAWN,
 				APPEAL_CASE_STATUS.WITHDRAWN,
 				APPEAL_CASE_STATUS.WITHDRAWN
+			],
+			[
+				APPEAL_CASE_STATUS.ASSIGN_CASE_OFFICER,
+				VALIDATION_OUTCOME_INVALID,
+				APPEAL_CASE_STATUS.INVALID,
+				APPEAL_CASE_STATUS.INVALID,
+				APPEAL_CASE_STATUS.INVALID,
+				APPEAL_CASE_STATUS.INVALID
 			]
 		])(
 			'correctly transitions from %s state on %s event to %s state',

--- a/appeals/api/src/server/state/create-state-machine.js
+++ b/appeals/api/src/server/state/create-state-machine.js
@@ -42,7 +42,8 @@ const createStateMachine = (appealType, procedureType, currentState, eventElapse
 					},
 					[APPEAL_CASE_STATUS.WITHDRAWN]: {
 						target: APPEAL_CASE_STATUS.WITHDRAWN
-					}
+					},
+					[VALIDATION_OUTCOME_INVALID]: { target: APPEAL_CASE_STATUS.INVALID }
 				},
 				meta: {
 					validAppealTypes: [APPEAL_TYPE_SHORTHAND_HAS, APPEAL_TYPE_SHORTHAND_FPA],


### PR DESCRIPTION
## Describe your changes
- Adding the missing state transition from assign case officer to invalid.
<!--
    Please include a summary of the change along with any relevant context.
    List any dependencies that are required for this change.
-->

## Issue ticket number and link

[Ticket](https://pins-ds.atlassian.net.mcas.ms/browse/A2-3905)
