### PR TITLE
fix(A2-4034): hiding redact and accept radio button when there's no rep to redact

### DIFF
--- a/appeals/web/src/server/appeals/appeal-details/representations/final-comments/view-and-review/__tests__/__snapshots__/view-and-review.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/representations/final-comments/view-and-review/__tests__/__snapshots__/view-and-review.test.js.snap
@@ -349,6 +349,56 @@ exports[`final-comments GET /review-comments with data should render review LPA 
 </main>"
 `;
 
+exports[`final-comments GET /review-comments with data should render review appellant final comments page with no redact & accept option when no representation text 1`] = `
+"<main class="govuk-main-wrapper" id="main-content">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Appeal 351062</span>
+            <h1 class="govuk-heading-l">Review appellant final comments</h1>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
+            <dl class="govuk-summary-list">
+                <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Final comments</dt>
+                    <dd class="govuk-summary-list__value">
+                        <div class="pins-show-more" data-label="Read more" data-mode="text"></div>
+                    </dd>
+                </div>
+                <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Supporting documents</dt>
+                    <dd class="govuk-summary-list__value">No documents</dd>
+                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/final-comments/lpa/add-document">Add<span class="govuk-visually-hidden"> supporting documents</span></a>
+                    </dd>
+                </div>
+            </dl>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
+            <form action="" method="POST" novalidate>
+                <div class="govuk-form-group">
+                    <fieldset class="govuk-fieldset">
+                        <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">Review decision</legend>
+                        <div class="govuk-radios" data-module="govuk-radios">
+                            <div class="govuk-radios__item">
+                                <input class="govuk-radios__input" id="status" name="status" type="radio"
+                                value="valid">
+                                <label class="govuk-label govuk-radios__label" for="status">Accept final comments</label>
+                            </div>
+                            <div class="govuk-radios__item">
+                                <input class="govuk-radios__input" id="status-3" name="status" type="radio"
+                                value="invalid">
+                                <label class="govuk-label govuk-radios__label" for="status-3">Reject final comments</label>
+                            </div>
+                        </div>
+                    </fieldset>
+                </div>
+                <button type="submit" class="govuk-button" data-module="govuk-button">Continue</button>
+            </form>
+        </div>
+    </div>
+</main>"
+`;
+
 exports[`final-comments GET /review-comments with data should render review appellant final comments page with the provided comments details 1`] = `
 "<main class="govuk-main-wrapper" id="main-content">
     <div class="govuk-grid-row">

--- a/appeals/web/src/server/appeals/appeal-details/representations/final-comments/view-and-review/__tests__/view-and-review.test.js
+++ b/appeals/web/src/server/appeals/appeal-details/representations/final-comments/view-and-review/__tests__/view-and-review.test.js
@@ -91,6 +91,23 @@ describe('final-comments', () => {
 			expect(partyKey?.textContent?.trim()).toBe('Final comments');
 			expect(finalCommentsValue?.textContent?.trim()).toBe('Awaiting final comments review');
 		});
+
+		it('should render review appellant final comments page with no redact & accept option when no representation text', async () => {
+			const testFinalComments = structuredClone(finalCommentsForReview);
+			testFinalComments.items[0].originalRepresentation = '';
+
+			nock('http://test/')
+				.get('/appeals/2/reps?type=appellant_final_comment')
+				.reply(200, testFinalComments);
+			const response = await request.get(`${baseUrl}/2/final-comments/appellant`);
+
+			expect(response.statusCode).toBe(200);
+
+			const dom = parseHtml(response.text);
+			const elementInnerHtml = dom.innerHTML;
+			expect(elementInnerHtml).toMatchSnapshot();
+			expect(elementInnerHtml).not.toContain('Redact and accept final comments');
+		});
 	});
 
 	describe('POST /review-comments with data', () => {

--- a/appeals/web/src/server/appeals/appeal-details/representations/final-comments/view-and-review/view-and-review.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/representations/final-comments/view-and-review/view-and-review.mapper.js
@@ -71,11 +71,13 @@ export function reviewFinalCommentsPage(
 						text: 'Accept final comments',
 						checked: comment?.status === COMMENT_STATUS.VALID
 					},
-					{
-						value: COMMENT_STATUS.VALID_REQUIRES_REDACTION,
-						text: 'Redact and accept final comments',
-						checked: false // This status isn't persisted so will always be unchecked
-					},
+					comment.originalRepresentation
+						? {
+								value: COMMENT_STATUS.VALID_REQUIRES_REDACTION,
+								text: 'Redact and accept final comments',
+								checked: false // This status isn't persisted so will always be unchecked
+						  }
+						: undefined,
 					{
 						value: COMMENT_STATUS.INVALID,
 						text: 'Reject final comments',

--- a/appeals/web/src/server/appeals/appeal-details/representations/interested-party-comments/view-and-review/__tests__/__snapshots__/view-and-review.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/representations/interested-party-comments/view-and-review/__tests__/__snapshots__/view-and-review.test.js.snap
@@ -530,6 +530,82 @@ exports[`interested-party-comments GET /review-comment with data should render r
                             </div>
                             <div class="govuk-radios__item">
                                 <input class="govuk-radios__input" id="status-2" name="status" type="radio"
+                                value="valid_requires_redaction">
+                                <label class="govuk-label govuk-radios__label" for="status-2">Redact and accept comment</label>
+                            </div>
+                            <div class="govuk-radios__item">
+                                <input class="govuk-radios__input" id="status-3" name="status" type="radio"
+                                value="invalid">
+                                <label class="govuk-label govuk-radios__label" for="status-3">Reject comment</label>
+                            </div>
+                        </div>
+                    </fieldset>
+                </div>
+                <button type="submit" class="govuk-button" data-module="govuk-button">Confirm</button>
+            </form>
+        </div>
+    </div>
+</main>"
+`;
+
+exports[`interested-party-comments GET /review-comment with data should render review comment page with redact and accept radio button hidden when no comment provided 1`] = `
+"<main class="govuk-main-wrapper" id="main-content">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Appeal 351062</span>
+            <h1 class="govuk-heading-l">Review comment</h1>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
+            <dl class="govuk-summary-list">
+                <div class="govuk-summary-list__row govuk-summary-list__row--no-actions"><dt class="govuk-summary-list__key"> Interested party</dt>
+                    <dd class="govuk-summary-list__value">Lee Thornton</dd>
+                </div>
+                <div class="govuk-summary-list__row govuk-summary-list__row--no-actions"><dt class="govuk-summary-list__key"> Email</dt>
+                    <dd class="govuk-summary-list__value">test1@example.com</dd>
+                </div>
+                <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Address</dt>
+                    <dd class="govuk-summary-list__value">Not provided</dd>
+                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/interested-party-comments/3670/edit/address?review=true&amp;editAddress=false">Add<span class="govuk-visually-hidden"> address</span></a>
+                    </dd>
+                </div>
+                <div class="govuk-summary-list__row govuk-summary-list__row--no-actions"><dt class="govuk-summary-list__key"> When did the interested party submit the comment?</dt>
+                    <dd                     class="govuk-summary-list__value">9 October 2024</dd>
+                </div>
+                <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Comment</dt>
+                    <dd class="govuk-summary-list__value"></dd>
+                </div>
+                <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Supporting documents</dt>
+                    <dd class="govuk-summary-list__value">No documents</dd>
+                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/interested-party-comments/3670/add-document">Add<span class="govuk-visually-hidden"> supporting documents</span></a>
+                    </dd>
+                </div>
+            </dl>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
+            <form action="" method="POST" novalidate>
+                <div class="govuk-form-group">
+                    <div class="govuk-checkboxes" data-module="govuk-checkboxes">
+                        <div class="govuk-checkboxes__item">
+                            <input class="govuk-checkboxes__input" id="site-visit-request" name="site-visit-request"
+                            type="checkbox" value="site-visit">
+                            <label class="govuk-label govuk-checkboxes__label" for="site-visit-request">Comment includes a site visit request</label>
+                        </div>
+                    </div>
+                </div>
+                <div class="govuk-form-group">
+                    <fieldset class="govuk-fieldset">
+                        <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">Review decision</legend>
+                        <div class="govuk-radios" data-module="govuk-radios">
+                            <div class="govuk-radios__item">
+                                <input class="govuk-radios__input" id="status" name="status" type="radio"
+                                value="valid">
+                                <label class="govuk-label govuk-radios__label" for="status">Accept comment</label>
+                            </div>
+                            <div class="govuk-radios__item">
+                                <input class="govuk-radios__input" id="status-2" name="status" type="radio"
                                 value="invalid">
                                 <label class="govuk-label govuk-radios__label" for="status-2">Reject comment</label>
                             </div>
@@ -601,8 +677,13 @@ exports[`interested-party-comments GET /review-comment with data should render r
                             </div>
                             <div class="govuk-radios__item">
                                 <input class="govuk-radios__input" id="status-2" name="status" type="radio"
+                                value="valid_requires_redaction">
+                                <label class="govuk-label govuk-radios__label" for="status-2">Redact and accept comment</label>
+                            </div>
+                            <div class="govuk-radios__item">
+                                <input class="govuk-radios__input" id="status-3" name="status" type="radio"
                                 value="invalid">
-                                <label class="govuk-label govuk-radios__label" for="status-2">Reject comment</label>
+                                <label class="govuk-label govuk-radios__label" for="status-3">Reject comment</label>
                             </div>
                         </div>
                     </fieldset>

--- a/appeals/web/src/server/appeals/appeal-details/representations/interested-party-comments/view-and-review/__tests__/view-and-review.test.js
+++ b/appeals/web/src/server/appeals/appeal-details/representations/interested-party-comments/view-and-review/__tests__/view-and-review.test.js
@@ -105,6 +105,32 @@ describe('interested-party-comments', () => {
 			expect(partyKey?.textContent?.trim()).toBe('Interested party');
 			expect(partyValue?.textContent?.trim()).toBe('Lee Thornton');
 		});
+
+		it('should render review comment page with redact and accept radio button hidden when no comment provided', async () => {
+			const testComment = structuredClone(interestedPartyCommentForReview);
+			testComment.originalRepresentation = '';
+
+			nock('http://test/').get('/appeals/2/reps/55').reply(200, testComment);
+			const response = await request.get(`${baseUrl}/2/interested-party-comments/55/review`);
+
+			expect(response.statusCode).toBe(200);
+
+			const dom = parseHtml(response.text);
+			const elementInnerHtml = dom.innerHTML;
+			expect(elementInnerHtml).toMatchSnapshot();
+			expect(elementInnerHtml).toContain('Review comment</h1>');
+
+			const interestedPartyRow = parseHtml(response.text, {
+				rootElement: '.govuk-summary-list__row:first-of-type'
+			});
+
+			expect(interestedPartyRow).not.toBeNull();
+			const partyKey = interestedPartyRow?.querySelector('.govuk-summary-list__key');
+			const partyValue = interestedPartyRow?.querySelector('.govuk-summary-list__value');
+			expect(partyKey?.textContent?.trim()).toBe('Interested party');
+			expect(partyValue?.textContent?.trim()).toBe('Lee Thornton');
+			expect(elementInnerHtml).not.toContain('Redact and accept comment');
+		});
 	});
 
 	describe('GET /review-comment with no data', () => {

--- a/appeals/web/src/server/appeals/appeal-details/representations/interested-party-comments/view-and-review/page-components/review.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/representations/interested-party-comments/view-and-review/page-components/review.mapper.js
@@ -59,7 +59,7 @@ export function reviewInterestedPartyCommentPage(appealDetails, comment, session
 					checked: comment?.status === COMMENT_STATUS.VALID
 				},
 				...[
-					comment.source === 'citizen'
+					comment.source === 'citizen' && comment.originalRepresentation
 						? {
 								value: COMMENT_STATUS.VALID_REQUIRES_REDACTION,
 								text: 'Redact and accept comment',

--- a/appeals/web/src/server/appeals/appeal-details/representations/lpa-statement/__tests__/__snapshots__/lpa-statement.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/representations/lpa-statement/__tests__/__snapshots__/lpa-statement.test.js.snap
@@ -1,5 +1,56 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`lpa-statements GET / should render the review LPA statement page with no valid_requires_redaction option if no text in lpa statement 1`] = `
+"<main class="govuk-main-wrapper" id="main-content">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Appeal 351062</span>
+            <h1 class="govuk-heading-l">Review LPA statement</h1>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
+            <dl class="govuk-summary-list">
+                <div class="govuk-summary-list__row govuk-summary-list__row--no-actions"><dt class="govuk-summary-list__key"> Statement</dt>
+                    <dd class="govuk-summary-list__value">
+                        <div class="pins-show-more" data-label="Statement" data-mode="text"></div>
+                    </dd>
+                </div>
+                <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Supporting documents</dt>
+                    <dd class="govuk-summary-list__value">No documents</dd>
+                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/3/lpa-statement/add-document">Add<span class="govuk-visually-hidden"> supporting documents</span></a>
+                    </dd>
+                </div>
+            </dl>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <form method="POST" novalidate="novalidate">
+                <div class="govuk-form-group">
+                    <fieldset class="govuk-fieldset">
+                        <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">Review decision</legend>
+                        <div class="govuk-radios" data-module="govuk-radios">
+                            <div class="govuk-radios__item">
+                                <input class="govuk-radios__input" id="status" name="status" type="radio"
+                                value="valid">
+                                <label class="govuk-label govuk-radios__label" for="status">Accept statement</label>
+                            </div>
+                            <div class="govuk-radios__item">
+                                <input class="govuk-radios__input" id="status-3" name="status" type="radio"
+                                value="incomplete">
+                                <label class="govuk-label govuk-radios__label" for="status-3">Statement incomplete</label>
+                            </div>
+                        </div>
+                    </fieldset>
+                </div>
+                <button type="submit" data-prevent-double-click="true" class="govuk-button"
+                data-module="govuk-button">Continue</button>
+            </form>
+        </div>
+    </div>
+</main>"
+`;
+
 exports[`lpa-statements GET / should render the review LPA statement page with the expected content if the statement is awaiting review 1`] = `
 "<main class="govuk-main-wrapper" id="main-content">
     <div class="govuk-grid-row">

--- a/appeals/web/src/server/appeals/appeal-details/representations/lpa-statement/__tests__/lpa-statement.test.js
+++ b/appeals/web/src/server/appeals/appeal-details/representations/lpa-statement/__tests__/lpa-statement.test.js
@@ -94,6 +94,34 @@ describe('lpa-statements', () => {
 			);
 		});
 
+		it('should render the review LPA statement page with no valid_requires_redaction option if no text in lpa statement', async () => {
+			nock('http://test/')
+				.get(`/appeals/${appealId}/reps?type=lpa_statement`)
+				.reply(200, {
+					...getAppealRepsResponse,
+					itemCount: 1,
+					items: [
+						{
+							...lpaStatementAwaitingReview,
+							originalRepresentation: ''
+						}
+					]
+				});
+
+			const response = await request.get(`${baseUrl}/${appealId}/lpa-statement`);
+
+			expect(response.statusCode).toBe(200);
+
+			const element = parseHtml(response.text);
+			expect(element.innerHTML).toMatchSnapshot();
+
+			const unprettifiedElement = parseHtml(response.text, { skipPrettyPrint: true });
+
+			expect(unprettifiedElement.innerHTML).not.toContain(
+				'name="status" type="radio" value="valid_requires_redaction">'
+			);
+		});
+
 		it('should render the review LPA statement page with the expected content if the statement is incomplete', async () => {
 			nock('http://test/')
 				.get(`/appeals/${appealId}/reps?type=lpa_statement`)

--- a/appeals/web/src/server/appeals/appeal-details/representations/lpa-statement/lpa-statement.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/representations/lpa-statement/lpa-statement.mapper.js
@@ -220,11 +220,12 @@ export function reviewLpaStatementPage(appealDetails, lpaStatement, session, bac
 					text: 'Accept statement',
 					checked: status === COMMENT_STATUS.VALID
 				},
-				{
-					value: COMMENT_STATUS.VALID_REQUIRES_REDACTION,
-					text: 'Redact and accept statement'
-				},
-
+				lpaStatement.originalRepresentation
+					? {
+							value: COMMENT_STATUS.VALID_REQUIRES_REDACTION,
+							text: 'Redact and accept statement'
+					  }
+					: undefined,
 				{
 					value: COMMENT_STATUS.INCOMPLETE,
 					text: 'Statement incomplete',

--- a/appeals/web/src/server/lib/mappers/utils/required-actions.js
+++ b/appeals/web/src/server/lib/mappers/utils/required-actions.js
@@ -168,7 +168,6 @@ export function getRequiredActionsForAppeal(appealDetails, view) {
 				lpaStatementRepresentationStatus === APPEAL_REPRESENTATION_STATUS.INCOMPLETE ||
 				(ipCommentsCounts?.valid && ipCommentsCounts?.valid > 0);
 
-			console.log(appealDetails);
 			if (
 				ipCommentsDueDatePassed &&
 				lpaStatementDueDatePassed &&

--- a/appeals/web/testing/app/fixtures/referencedata.js
+++ b/appeals/web/testing/app/fixtures/referencedata.js
@@ -3121,7 +3121,7 @@ export const interestedPartyCommentsAwaitingReview = {
 	items: [
 		{
 			id: 3812,
-			origin: 'citizen',
+			source: 'citizen',
 			author: 'Eva Sharma',
 			status: 'awaiting_review',
 			originalRepresentation: 'Awaiting review comment 1',
@@ -3132,7 +3132,7 @@ export const interestedPartyCommentsAwaitingReview = {
 		},
 		{
 			id: 3811,
-			origin: 'citizen',
+			source: 'citizen',
 			author: 'Roger Simmons',
 			status: 'awaiting_review',
 			originalRepresentation: 'Awaiting review comment 2',
@@ -3143,7 +3143,7 @@ export const interestedPartyCommentsAwaitingReview = {
 		},
 		{
 			id: 3810,
-			origin: 'citizen',
+			source: 'citizen',
 			author: 'Roger Simmons',
 			status: 'awaiting_review',
 			originalRepresentation: 'Awaiting review comment 3',
@@ -3163,7 +3163,7 @@ export const interestedPartyCommentsValid = {
 	items: [
 		{
 			id: 3852,
-			origin: 'citizen',
+			source: 'citizen',
 			author: 'Roger Simmons',
 			status: 'valid',
 			originalRepresentation: 'Valid comment 1',
@@ -3174,7 +3174,7 @@ export const interestedPartyCommentsValid = {
 		},
 		{
 			id: 3851,
-			origin: 'citizen',
+			source: 'citizen',
 			author: 'Roger Simmons',
 			status: 'valid',
 			originalRepresentation: 'Valid comment 2',
@@ -3185,7 +3185,7 @@ export const interestedPartyCommentsValid = {
 		},
 		{
 			id: 3850,
-			origin: 'citizen',
+			source: 'citizen',
 			author: 'Haley Eland',
 			status: 'valid',
 			originalRepresentation: 'Valid comment 3',
@@ -3205,7 +3205,7 @@ export const interestedPartyCommentsInvalid = {
 	items: [
 		{
 			id: 3872,
-			origin: 'citizen',
+			source: 'citizen',
 			author: 'Ryan Marshall',
 			status: 'invalid',
 			originalRepresentation: 'Invalid comment 1',
@@ -3216,7 +3216,7 @@ export const interestedPartyCommentsInvalid = {
 		},
 		{
 			id: 3871,
-			origin: 'citizen',
+			source: 'citizen',
 			author: 'Ryan Marshall',
 			status: 'invalid',
 			originalRepresentation: 'Invalid comment 2',
@@ -3227,7 +3227,7 @@ export const interestedPartyCommentsInvalid = {
 		},
 		{
 			id: 3870,
-			origin: 'citizen',
+			source: 'citizen',
 			author: 'Eva Sharma',
 			status: 'invalid',
 			originalRepresentation: 'Invalid comment 3',
@@ -3247,7 +3247,7 @@ export const interestedPartyCommentsForReview = {
 	items: [
 		{
 			id: 3670,
-			origin: 'citizen',
+			source: 'citizen',
 			author: 'Lee Thornton',
 			status: 'awaiting_review',
 			originalRepresentation: 'Awaiting final comment',
@@ -3278,7 +3278,7 @@ export const interestedPartyCommentsForView = {
 	items: [
 		{
 			id: 3670,
-			origin: 'citizen',
+			source: 'citizen',
 			author: 'Lee Thornton',
 			status: 'valid',
 			originalRepresentation: 'Awaiting review final comment',
@@ -3306,7 +3306,7 @@ export const interestedPartyCommentsForView = {
 
 export const interestedPartyCommentForReview = {
 	id: 3670,
-	origin: 'citizen',
+	source: 'citizen',
 	author: 'Lee Thornton',
 	status: 'awaiting_review',
 	originalRepresentation: 'Awaiting review comment 47',
@@ -3332,7 +3332,7 @@ export const interestedPartyCommentsPublished = {
 	items: [
 		{
 			id: 5001,
-			origin: 'citizen',
+			source: 'citizen',
 			author: 'Alice Wonderland',
 			status: 'published',
 			originalRepresentation: 'Comment 1',
@@ -3352,7 +3352,7 @@ export const interestedPartyCommentsPublished = {
 		},
 		{
 			id: 5002,
-			origin: 'organisation',
+			source: 'organisation',
 			author: 'Cheshire Cat Council',
 			status: 'published',
 			originalRepresentation: 'Comment 2',
@@ -3392,7 +3392,7 @@ export const finalCommentsForReview = {
 	items: [
 		{
 			id: 3670,
-			origin: 'citizen',
+			source: 'citizen',
 			author: 'Lee Thornton',
 			status: 'awaiting_review',
 			originalRepresentation: 'Awaiting final comments review',
@@ -3423,7 +3423,7 @@ export const finalCommentsForReviewWithAttachments = {
 	items: [
 		{
 			id: 3670,
-			origin: 'citizen',
+			source: 'citizen',
 			author: 'Lee Thornton',
 			status: 'awaiting_review',
 			originalRepresentation: 'Awaiting final comments review',
@@ -3477,7 +3477,6 @@ export const appellantFinalCommentsAwaitingReview = {
 	items: [
 		{
 			id: 46419,
-			origin: 'citizen',
 			author: 'Eva Sharma',
 			status: 'awaiting_review',
 			originalRepresentation:
@@ -3511,7 +3510,7 @@ export const lpaFinalCommentsAwaitingReview = {
 	items: [
 		{
 			id: 46420,
-			origin: 'lpa',
+			source: 'lpa',
 			author: 'Worthing Borough Council',
 			status: 'awaiting_review',
 			originalRepresentation:
@@ -3522,7 +3521,6 @@ export const lpaFinalCommentsAwaitingReview = {
 			attachments: [],
 			representationType: 'lpa_final_comment',
 			siteVisitRequested: false,
-			source: 'citizen',
 			rejectionReasons: []
 		}
 	],
@@ -3533,7 +3531,7 @@ export const lpaFinalCommentsAwaitingReview = {
 
 export const lpaStatementAwaitingReview = {
 	id: 66816,
-	origin: 'lpa',
+	source: 'lpa',
 	author: 'Wiltshire Council',
 	status: 'awaiting_review',
 	originalRepresentation: `Every single thing in the world has its own personality - and it is up to you to make friends with the little rascals. Steve wants reflections, so let's give him eflections It's amazing what you can do with a little love in your heart. Clouds are free they come and go as they please.\n\nThe secret to doing anything is believing that you can do it. Anything hatyou believe you can do strong enough, you can do. Anything. As long as you believe. It looks so good, I might as well not stop. This present moment is perfect simply due to the fact you're xperiencingit. Making all those little fluffies that live in the clouds.\n\nYou don't want to kill all your dark areas they are very important. I will take some magic white, and a little bit of andykebrown and a little touch of yellow. Anyone can paint. Each highlight must have it's own private shadow. Don't fiddle with it all day.`,
@@ -3543,7 +3541,6 @@ export const lpaStatementAwaitingReview = {
 	attachments: [],
 	representationType: 'lpa_statement',
 	siteVisitRequested: false,
-	source: 'lpa',
 	rejectionReasons: []
 };
 
@@ -3552,7 +3549,7 @@ export const proofOfEvidenceForReview = {
 	items: [
 		{
 			id: 3670,
-			origin: 'citizen',
+			source: 'citizen',
 			author: 'Lee Thornton',
 			status: 'awaiting_review',
 			originalRepresentation: 'Awaiting proof of evidence review',
@@ -3583,7 +3580,7 @@ export const proofOfEvidenceForReviewWithAttachments = {
 	items: [
 		{
 			id: 3670,
-			origin: 'citizen',
+			source: 'citizen',
 			author: 'Lee Thornton',
 			status: 'awaiting_review',
 			originalRepresentation: 'Awaiting proof of evidence review',
@@ -3637,7 +3634,6 @@ export const appellantProofOfEvidenceAwaitingReview = {
 	items: [
 		{
 			id: 46419,
-			origin: 'citizen',
 			author: 'Eva Sharma',
 			status: 'awaiting_review',
 			redactedRepresentation: '',
@@ -3669,7 +3665,7 @@ export const lpaProofOfEvidenceAwaitingReview = {
 	items: [
 		{
 			id: 46420,
-			origin: 'lpa',
+			source: 'lpa',
 			author: 'Worthing Borough Council',
 			status: 'awaiting_review',
 			redactedRepresentation: '',
@@ -3678,7 +3674,6 @@ export const lpaProofOfEvidenceAwaitingReview = {
 			attachments: [],
 			representationType: 'lpa_proofs_evidence',
 			siteVisitRequested: false,
-			source: 'citizen',
 			rejectionReasons: []
 		}
 	],
@@ -3697,7 +3692,7 @@ export const getAppealRepsResponse = {
 
 export const interestedPartyCommentForView = {
 	id: 3670,
-	origin: 'citizen',
+	source: 'citizen',
 	author: 'Lee Thornton',
 	status: 'valid',
 	originalRepresentation: 'Awaiting review comment 47',


### PR DESCRIPTION
## Describe your changes

### Web 
- Added logic to hide redact and accept radio option for reps (final/ip comments and lpa statement) when there's no rep text to redact (i.e only a supporting doc is added)

### Test
- Updated unit tests reference data - reps field is 'source' not origin
- Added new unit tests to ensure 'Accept and Redact' option is NOT present when no orignalRepresentation is present for each representation

<!--
    Please include a summary of the change along with any relevant context.
    List any dependencies that are required for this change.
-->

## Issue ticket number and link

[Ticket](https://pins-ds.atlassian.net.mcas.ms/browse/A2-4034)
