### PR TITLE
feat(A2-4157): displaying user name rather than email in case history

### DIFF
--- a/appeals/web/src/server/appeals/appeal-details/__tests__/__snapshots__/appeal-details.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/__tests__/__snapshots__/appeal-details.test.js.snap
@@ -60,7 +60,7 @@ exports[`appeal-details GET /:appealId Appellant costs decision should render a 
 
 exports[`appeal-details GET /:appealId Appellant costs decision should render a row in the case overview accordion, if the appeal status is "issue_determination" or after (issue_determination) 1`] = `"<div class="govuk-summary-list__row costs-appellant-decision"><dt class="govuk-summary-list__key"> Appellant costs decision</dt><dd class="govuk-summary-list__value"> Not issued</dd><dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/issue-decision/issue-appellant-costs-decision-letter-upload?backUrl=%2Fappeals-service%2Fappeal-details%2F2" data-cy="issue-appellant-costs-decision">Issue<span class="govuk-visually-hidden"> Appellant costs decision</span></a></dd></div>"`;
 
-exports[`appeal-details GET /:appealId Case notes should render the case note details 1`] = `"<details class="govuk-details"><summary class="govuk-details__summary"><span class="govuk-details__summary-text"> 2 case notes</span></summary><div class="govuk-details__text"><form method="POST" novalidate="novalidate"><div class="govuk-grid-row"><div class="govuk-grid-column-two-thirds"><div class="govuk-form-group govuk-character-count" data-module="govuk-character-count" data-maxlength="500"><textarea class="govuk-textarea govuk-js-character-count" id="comment" name="comment" rows="5" aria-describedby="comment-info"></textarea><div id="comment-info" class="govuk-hint govuk-character-count__message"> You can enter up to 500 characters</div></div></div></div><button type="submit" data-prevent-double-click="true" class="govuk-button govuk-button--secondary govuk-!-margin-bottom-1" data-module="govuk-button"> Add case note</button></form><div><hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible"><section><p class="govuk-body govuk-!-margin-bottom-1"> A case note you should see.</p><p class="govuk-hint govuk-!-margin-bottom-6"> 11:00am on Tuesday 1 October 2024 by John.Smith</p><hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible"></section><section><p class="govuk-body govuk-!-margin-bottom-1"> A case note you should see.</p><p class="govuk-hint govuk-!-margin-bottom-6"> 11:00am on Tuesday 1 October 2024 by John.Smith</p><hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible"></section></div></div></details>"`;
+exports[`appeal-details GET /:appealId Case notes should render the case note details 1`] = `"<details class="govuk-details"><summary class="govuk-details__summary"><span class="govuk-details__summary-text"> 2 case notes</span></summary><div class="govuk-details__text"><form method="POST" novalidate="novalidate"><div class="govuk-grid-row"><div class="govuk-grid-column-two-thirds"><div class="govuk-form-group govuk-character-count" data-module="govuk-character-count" data-maxlength="500"><textarea class="govuk-textarea govuk-js-character-count" id="comment" name="comment" rows="5" aria-describedby="comment-info"></textarea><div id="comment-info" class="govuk-hint govuk-character-count__message"> You can enter up to 500 characters</div></div></div></div><button type="submit" data-prevent-double-click="true" class="govuk-button govuk-button--secondary govuk-!-margin-bottom-1" data-module="govuk-button"> Add case note</button></form><div><hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible"><section><p class="govuk-body govuk-!-margin-bottom-1"> A case note you should see.</p><p class="govuk-hint govuk-!-margin-bottom-6"> 11:00am on Tuesday 1 October 2024 by Smith, John</p><hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible"></section><section><p class="govuk-body govuk-!-margin-bottom-1"> A case note you should see.</p><p class="govuk-hint govuk-!-margin-bottom-6"> 11:00am on Tuesday 1 October 2024 by Smith, John</p><hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible"></section></div></div></details>"`;
 
 exports[`appeal-details GET /:appealId Costs should render a "Appellant application" row in the costs accordion 1`] = `"<th scope="row" class="govuk-table__header appeal-costs-appellant-application-documentation">Appellant application</th>"`;
 
@@ -507,12 +507,12 @@ exports[`appeal-details GET /:appealId Linked appeals should not render a "Appea
                         <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
                         <section>
                             <p class="govuk-body govuk-!-margin-bottom-1">A case note you should see.</p>
-                            <p class="govuk-hint govuk-!-margin-bottom-6">11:00am on Tuesday 1 October 2024 by John.Smith</p>
+                            <p class="govuk-hint govuk-!-margin-bottom-6">11:00am on Tuesday 1 October 2024 by Smith, John</p>
                             <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
                         </section>
                         <section>
                             <p class="govuk-body govuk-!-margin-bottom-1">A case note you should see.</p>
-                            <p class="govuk-hint govuk-!-margin-bottom-6">11:00am on Tuesday 1 October 2024 by John.Smith</p>
+                            <p class="govuk-hint govuk-!-margin-bottom-6">11:00am on Tuesday 1 October 2024 by Smith, John</p>
                             <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
                         </section>
                     </div>
@@ -821,12 +821,12 @@ exports[`appeal-details GET /:appealId Linked appeals should not render action l
                         <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
                         <section>
                             <p class="govuk-body govuk-!-margin-bottom-1">A case note you should see.</p>
-                            <p class="govuk-hint govuk-!-margin-bottom-6">11:00am on Tuesday 1 October 2024 by John.Smith</p>
+                            <p class="govuk-hint govuk-!-margin-bottom-6">11:00am on Tuesday 1 October 2024 by Smith, John</p>
                             <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
                         </section>
                         <section>
                             <p class="govuk-body govuk-!-margin-bottom-1">A case note you should see.</p>
-                            <p class="govuk-hint govuk-!-margin-bottom-6">11:00am on Tuesday 1 October 2024 by John.Smith</p>
+                            <p class="govuk-hint govuk-!-margin-bottom-6">11:00am on Tuesday 1 October 2024 by Smith, John</p>
                             <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
                         </section>
                     </div>
@@ -1282,12 +1282,12 @@ exports[`appeal-details GET /:appealId Linked appeals should render a child tag 
                         <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
                         <section>
                             <p class="govuk-body govuk-!-margin-bottom-1">A case note you should see.</p>
-                            <p class="govuk-hint govuk-!-margin-bottom-6">11:00am on Tuesday 1 October 2024 by John.Smith</p>
+                            <p class="govuk-hint govuk-!-margin-bottom-6">11:00am on Tuesday 1 October 2024 by Smith, John</p>
                             <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
                         </section>
                         <section>
                             <p class="govuk-body govuk-!-margin-bottom-1">A case note you should see.</p>
-                            <p class="govuk-hint govuk-!-margin-bottom-6">11:00am on Tuesday 1 October 2024 by John.Smith</p>
+                            <p class="govuk-hint govuk-!-margin-bottom-6">11:00am on Tuesday 1 October 2024 by Smith, John</p>
                             <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
                         </section>
                     </div>
@@ -1596,12 +1596,12 @@ exports[`appeal-details GET /:appealId Linked appeals should render a lead tag n
                         <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
                         <section>
                             <p class="govuk-body govuk-!-margin-bottom-1">A case note you should see.</p>
-                            <p class="govuk-hint govuk-!-margin-bottom-6">11:00am on Tuesday 1 October 2024 by John.Smith</p>
+                            <p class="govuk-hint govuk-!-margin-bottom-6">11:00am on Tuesday 1 October 2024 by Smith, John</p>
                             <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
                         </section>
                         <section>
                             <p class="govuk-body govuk-!-margin-bottom-1">A case note you should see.</p>
-                            <p class="govuk-hint govuk-!-margin-bottom-6">11:00am on Tuesday 1 October 2024 by John.Smith</p>
+                            <p class="govuk-hint govuk-!-margin-bottom-6">11:00am on Tuesday 1 October 2024 by Smith, John</p>
                             <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
                         </section>
                     </div>
@@ -2054,12 +2054,12 @@ exports[`appeal-details GET /:appealId Linked appeals should render an action li
                         <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
                         <section>
                             <p class="govuk-body govuk-!-margin-bottom-1">A case note you should see.</p>
-                            <p class="govuk-hint govuk-!-margin-bottom-6">11:00am on Tuesday 1 October 2024 by John.Smith</p>
+                            <p class="govuk-hint govuk-!-margin-bottom-6">11:00am on Tuesday 1 October 2024 by Smith, John</p>
                             <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
                         </section>
                         <section>
                             <p class="govuk-body govuk-!-margin-bottom-1">A case note you should see.</p>
-                            <p class="govuk-hint govuk-!-margin-bottom-6">11:00am on Tuesday 1 October 2024 by John.Smith</p>
+                            <p class="govuk-hint govuk-!-margin-bottom-6">11:00am on Tuesday 1 October 2024 by Smith, John</p>
                             <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
                         </section>
                     </div>
@@ -2523,12 +2523,12 @@ exports[`appeal-details GET /:appealId Linked appeals should render an action li
                         <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
                         <section>
                             <p class="govuk-body govuk-!-margin-bottom-1">A case note you should see.</p>
-                            <p class="govuk-hint govuk-!-margin-bottom-6">11:00am on Tuesday 1 October 2024 by John.Smith</p>
+                            <p class="govuk-hint govuk-!-margin-bottom-6">11:00am on Tuesday 1 October 2024 by Smith, John</p>
                             <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
                         </section>
                         <section>
                             <p class="govuk-body govuk-!-margin-bottom-1">A case note you should see.</p>
-                            <p class="govuk-hint govuk-!-margin-bottom-6">11:00am on Tuesday 1 October 2024 by John.Smith</p>
+                            <p class="govuk-hint govuk-!-margin-bottom-6">11:00am on Tuesday 1 October 2024 by Smith, John</p>
                             <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
                         </section>
                     </div>
@@ -2992,12 +2992,12 @@ exports[`appeal-details GET /:appealId Linked appeals should render the case ref
                         <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
                         <section>
                             <p class="govuk-body govuk-!-margin-bottom-1">A case note you should see.</p>
-                            <p class="govuk-hint govuk-!-margin-bottom-6">11:00am on Tuesday 1 October 2024 by John.Smith</p>
+                            <p class="govuk-hint govuk-!-margin-bottom-6">11:00am on Tuesday 1 October 2024 by Smith, John</p>
                             <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
                         </section>
                         <section>
                             <p class="govuk-body govuk-!-margin-bottom-1">A case note you should see.</p>
-                            <p class="govuk-hint govuk-!-margin-bottom-6">11:00am on Tuesday 1 October 2024 by John.Smith</p>
+                            <p class="govuk-hint govuk-!-margin-bottom-6">11:00am on Tuesday 1 October 2024 by Smith, John</p>
                             <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
                         </section>
                     </div>
@@ -3452,12 +3452,12 @@ exports[`appeal-details GET /:appealId Linked appeals should render the lead or 
                         <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
                         <section>
                             <p class="govuk-body govuk-!-margin-bottom-1">A case note you should see.</p>
-                            <p class="govuk-hint govuk-!-margin-bottom-6">11:00am on Tuesday 1 October 2024 by John.Smith</p>
+                            <p class="govuk-hint govuk-!-margin-bottom-6">11:00am on Tuesday 1 October 2024 by Smith, John</p>
                             <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
                         </section>
                         <section>
                             <p class="govuk-body govuk-!-margin-bottom-1">A case note you should see.</p>
-                            <p class="govuk-hint govuk-!-margin-bottom-6">11:00am on Tuesday 1 October 2024 by John.Smith</p>
+                            <p class="govuk-hint govuk-!-margin-bottom-6">11:00am on Tuesday 1 October 2024 by Smith, John</p>
                             <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
                         </section>
                     </div>
@@ -3912,12 +3912,12 @@ exports[`appeal-details GET /:appealId Linked appeals should render the received
                         <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
                         <section>
                             <p class="govuk-body govuk-!-margin-bottom-1">A case note you should see.</p>
-                            <p class="govuk-hint govuk-!-margin-bottom-6">11:00am on Tuesday 1 October 2024 by John.Smith</p>
+                            <p class="govuk-hint govuk-!-margin-bottom-6">11:00am on Tuesday 1 October 2024 by Smith, John</p>
                             <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
                         </section>
                         <section>
                             <p class="govuk-body govuk-!-margin-bottom-1">A case note you should see.</p>
-                            <p class="govuk-hint govuk-!-margin-bottom-6">11:00am on Tuesday 1 October 2024 by John.Smith</p>
+                            <p class="govuk-hint govuk-!-margin-bottom-6">11:00am on Tuesday 1 October 2024 by Smith, John</p>
                             <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
                         </section>
                     </div>
@@ -4385,12 +4385,12 @@ exports[`appeal-details GET /:appealId Linked appeals should render the received
                         <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
                         <section>
                             <p class="govuk-body govuk-!-margin-bottom-1">A case note you should see.</p>
-                            <p class="govuk-hint govuk-!-margin-bottom-6">11:00am on Tuesday 1 October 2024 by John.Smith</p>
+                            <p class="govuk-hint govuk-!-margin-bottom-6">11:00am on Tuesday 1 October 2024 by Smith, John</p>
                             <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
                         </section>
                         <section>
                             <p class="govuk-body govuk-!-margin-bottom-1">A case note you should see.</p>
-                            <p class="govuk-hint govuk-!-margin-bottom-6">11:00am on Tuesday 1 October 2024 by John.Smith</p>
+                            <p class="govuk-hint govuk-!-margin-bottom-6">11:00am on Tuesday 1 October 2024 by Smith, John</p>
                             <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
                         </section>
                     </div>
@@ -4833,12 +4833,12 @@ exports[`appeal-details GET /:appealId Linked appeals should render the received
                         <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
                         <section>
                             <p class="govuk-body govuk-!-margin-bottom-1">A case note you should see.</p>
-                            <p class="govuk-hint govuk-!-margin-bottom-6">11:00am on Tuesday 1 October 2024 by John.Smith</p>
+                            <p class="govuk-hint govuk-!-margin-bottom-6">11:00am on Tuesday 1 October 2024 by Smith, John</p>
                             <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
                         </section>
                         <section>
                             <p class="govuk-body govuk-!-margin-bottom-1">A case note you should see.</p>
-                            <p class="govuk-hint govuk-!-margin-bottom-6">11:00am on Tuesday 1 October 2024 by John.Smith</p>
+                            <p class="govuk-hint govuk-!-margin-bottom-6">11:00am on Tuesday 1 October 2024 by Smith, John</p>
                             <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
                         </section>
                     </div>
@@ -5399,12 +5399,12 @@ exports[`appeal-details GET /:appealId Notification banners Important banners sh
                         <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
                         <section>
                             <p class="govuk-body govuk-!-margin-bottom-1">A case note you should see.</p>
-                            <p class="govuk-hint govuk-!-margin-bottom-6">11:00am on Tuesday 1 October 2024 by John.Smith</p>
+                            <p class="govuk-hint govuk-!-margin-bottom-6">11:00am on Tuesday 1 October 2024 by Smith, John</p>
                             <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
                         </section>
                         <section>
                             <p class="govuk-body govuk-!-margin-bottom-1">A case note you should see.</p>
-                            <p class="govuk-hint govuk-!-margin-bottom-6">11:00am on Tuesday 1 October 2024 by John.Smith</p>
+                            <p class="govuk-hint govuk-!-margin-bottom-6">11:00am on Tuesday 1 October 2024 by Smith, John</p>
                             <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
                         </section>
                     </div>
@@ -6415,12 +6415,12 @@ exports[`appeal-details GET /:appealId should render a Decision inset panel when
                         <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
                         <section>
                             <p class="govuk-body govuk-!-margin-bottom-1">A case note you should see.</p>
-                            <p class="govuk-hint govuk-!-margin-bottom-6">11:00am on Tuesday 1 October 2024 by John.Smith</p>
+                            <p class="govuk-hint govuk-!-margin-bottom-6">11:00am on Tuesday 1 October 2024 by Smith, John</p>
                             <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
                         </section>
                         <section>
                             <p class="govuk-body govuk-!-margin-bottom-1">A case note you should see.</p>
-                            <p class="govuk-hint govuk-!-margin-bottom-6">11:00am on Tuesday 1 October 2024 by John.Smith</p>
+                            <p class="govuk-hint govuk-!-margin-bottom-6">11:00am on Tuesday 1 October 2024 by Smith, John</p>
                             <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
                         </section>
                     </div>
@@ -6869,12 +6869,12 @@ exports[`appeal-details GET /:appealId should render a Decision inset panel when
                         <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
                         <section>
                             <p class="govuk-body govuk-!-margin-bottom-1">A case note you should see.</p>
-                            <p class="govuk-hint govuk-!-margin-bottom-6">11:00am on Tuesday 1 October 2024 by John.Smith</p>
+                            <p class="govuk-hint govuk-!-margin-bottom-6">11:00am on Tuesday 1 October 2024 by Smith, John</p>
                             <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
                         </section>
                         <section>
                             <p class="govuk-body govuk-!-margin-bottom-1">A case note you should see.</p>
-                            <p class="govuk-hint govuk-!-margin-bottom-6">11:00am on Tuesday 1 October 2024 by John.Smith</p>
+                            <p class="govuk-hint govuk-!-margin-bottom-6">11:00am on Tuesday 1 October 2024 by Smith, John</p>
                             <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
                         </section>
                     </div>
@@ -7323,12 +7323,12 @@ exports[`appeal-details GET /:appealId should render a Decision inset panel when
                         <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
                         <section>
                             <p class="govuk-body govuk-!-margin-bottom-1">A case note you should see.</p>
-                            <p class="govuk-hint govuk-!-margin-bottom-6">11:00am on Tuesday 1 October 2024 by John.Smith</p>
+                            <p class="govuk-hint govuk-!-margin-bottom-6">11:00am on Tuesday 1 October 2024 by Smith, John</p>
                             <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
                         </section>
                         <section>
                             <p class="govuk-body govuk-!-margin-bottom-1">A case note you should see.</p>
-                            <p class="govuk-hint govuk-!-margin-bottom-6">11:00am on Tuesday 1 October 2024 by John.Smith</p>
+                            <p class="govuk-hint govuk-!-margin-bottom-6">11:00am on Tuesday 1 October 2024 by Smith, John</p>
                             <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
                         </section>
                     </div>
@@ -7781,12 +7781,12 @@ exports[`appeal-details GET /:appealId should render the appellant case status a
                         <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
                         <section>
                             <p class="govuk-body govuk-!-margin-bottom-1">A case note you should see.</p>
-                            <p class="govuk-hint govuk-!-margin-bottom-6">11:00am on Tuesday 1 October 2024 by John.Smith</p>
+                            <p class="govuk-hint govuk-!-margin-bottom-6">11:00am on Tuesday 1 October 2024 by Smith, John</p>
                             <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
                         </section>
                         <section>
                             <p class="govuk-body govuk-!-margin-bottom-1">A case note you should see.</p>
-                            <p class="govuk-hint govuk-!-margin-bottom-6">11:00am on Tuesday 1 October 2024 by John.Smith</p>
+                            <p class="govuk-hint govuk-!-margin-bottom-6">11:00am on Tuesday 1 October 2024 by Smith, John</p>
                             <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
                         </section>
                     </div>
@@ -8231,12 +8231,12 @@ exports[`appeal-details GET /:appealId should render the appellant case status a
                         <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
                         <section>
                             <p class="govuk-body govuk-!-margin-bottom-1">A case note you should see.</p>
-                            <p class="govuk-hint govuk-!-margin-bottom-6">11:00am on Tuesday 1 October 2024 by John.Smith</p>
+                            <p class="govuk-hint govuk-!-margin-bottom-6">11:00am on Tuesday 1 October 2024 by Smith, John</p>
                             <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
                         </section>
                         <section>
                             <p class="govuk-body govuk-!-margin-bottom-1">A case note you should see.</p>
-                            <p class="govuk-hint govuk-!-margin-bottom-6">11:00am on Tuesday 1 October 2024 by John.Smith</p>
+                            <p class="govuk-hint govuk-!-margin-bottom-6">11:00am on Tuesday 1 October 2024 by Smith, John</p>
                             <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
                         </section>
                     </div>
@@ -8709,12 +8709,12 @@ exports[`appeal-details GET /:appealId should render the received appeal details
                         <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
                         <section>
                             <p class="govuk-body govuk-!-margin-bottom-1">A case note you should see.</p>
-                            <p class="govuk-hint govuk-!-margin-bottom-6">11:00am on Tuesday 1 October 2024 by John.Smith</p>
+                            <p class="govuk-hint govuk-!-margin-bottom-6">11:00am on Tuesday 1 October 2024 by Smith, John</p>
                             <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
                         </section>
                         <section>
                             <p class="govuk-body govuk-!-margin-bottom-1">A case note you should see.</p>
-                            <p class="govuk-hint govuk-!-margin-bottom-6">11:00am on Tuesday 1 October 2024 by John.Smith</p>
+                            <p class="govuk-hint govuk-!-margin-bottom-6">11:00am on Tuesday 1 October 2024 by Smith, John</p>
                             <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
                         </section>
                     </div>
@@ -9209,12 +9209,12 @@ exports[`appeal-details should not render a back button 1`] = `
                                     <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
                                     <section>
                                         <p class="govuk-body govuk-!-margin-bottom-1">A case note you should see.</p>
-                                        <p class="govuk-hint govuk-!-margin-bottom-6">11:00am on Tuesday 1 October 2024 by John.Smith</p>
+                                        <p class="govuk-hint govuk-!-margin-bottom-6">11:00am on Tuesday 1 October 2024 by Smith, John</p>
                                         <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
                                     </section>
                                     <section>
                                         <p class="govuk-body govuk-!-margin-bottom-1">A case note you should see.</p>
-                                        <p class="govuk-hint govuk-!-margin-bottom-6">11:00am on Tuesday 1 October 2024 by John.Smith</p>
+                                        <p class="govuk-hint govuk-!-margin-bottom-6">11:00am on Tuesday 1 October 2024 by Smith, John</p>
                                         <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
                                     </section>
                                 </div>

--- a/appeals/web/src/server/appeals/appeal-details/audit/__tests__/__snapshots__/audit.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/audit/__tests__/__snapshots__/audit.test.js.snap
@@ -39,7 +39,7 @@ exports[`audit GET /:appealId/audit should render the case history page with a r
                                 this field to test the system&#39;s ability to handle long text entries
                                 without truncation or errors. - it should show the show more compoonent</div>
                         </td>
-                        <td class="govuk-table__cell">John.Smith@planninginspectorate.gov.uk</td>
+                        <td class="govuk-table__cell">Smith, John</td>
                     </tr>
                     <tr class="govuk-table__row">
                         <td class="govuk-table__cell">27 May 2025
@@ -47,21 +47,21 @@ exports[`audit GET /:appealId/audit should render the case history page with a r
                         </td>
                         <td class="govuk-table__cell">Case progressed to <strong class="govuk-tag govuk-tag--yellow">Awaiting site visit</strong>
                         </td>
-                        <td class="govuk-table__cell">John.Smith@planninginspectorate.gov.uk</td>
+                        <td class="govuk-table__cell">Smith, John</td>
                     </tr>
                     <tr class="govuk-table__row">
                         <td class="govuk-table__cell">27 May 2025
                             <br><span>10:55</span>
                         </td>
                         <td class="govuk-table__cell">The site visit was arranged for Thursday 2 October</td>
-                        <td class="govuk-table__cell">John.Smith@planninginspectorate.gov.uk</td>
+                        <td class="govuk-table__cell">Smith, John</td>
                     </tr>
                     <tr class="govuk-table__row">
                         <td class="govuk-table__cell">27 May 2025
                             <br><span>10:55</span>
                         </td>
                         <td class="govuk-table__cell">Final comments shared</td>
-                        <td class="govuk-table__cell">John.Smith@planninginspectorate.gov.uk</td>
+                        <td class="govuk-table__cell">Smith, John</td>
                     </tr>
                     <tr class="govuk-table__row">
                         <td class="govuk-table__cell">27 May 2025
@@ -69,28 +69,28 @@ exports[`audit GET /:appealId/audit should render the case history page with a r
                         </td>
                         <td class="govuk-table__cell">Case progressed to <strong class="govuk-tag govuk-tag--green">Site visit ready to set up</strong>
                         </td>
-                        <td class="govuk-table__cell">John.Smith@planninginspectorate.gov.uk</td>
+                        <td class="govuk-table__cell">Smith, John</td>
                     </tr>
                     <tr class="govuk-table__row">
                         <td class="govuk-table__cell">27 May 2025
                             <br><span>10:55</span>
                         </td>
                         <td class="govuk-table__cell">LPA final comments accepted</td>
-                        <td class="govuk-table__cell">John.Smith@planninginspectorate.gov.uk</td>
+                        <td class="govuk-table__cell">Smith, John</td>
                     </tr>
                     <tr class="govuk-table__row">
                         <td class="govuk-table__cell">27 May 2025
                             <br><span>10:55</span>
                         </td>
                         <td class="govuk-table__cell">Appellant final comments accepted</td>
-                        <td class="govuk-table__cell">John.Smith@planninginspectorate.gov.uk</td>
+                        <td class="govuk-table__cell">Smith, John</td>
                     </tr>
                     <tr class="govuk-table__row">
                         <td class="govuk-table__cell">27 May 2025
                             <br><span>10:54</span>
                         </td>
                         <td class="govuk-table__cell">Statements and IP comments shared</td>
-                        <td class="govuk-table__cell">John.Smith@planninginspectorate.gov.uk</td>
+                        <td class="govuk-table__cell">Smith, John</td>
                     </tr>
                     <tr class="govuk-table__row">
                         <td class="govuk-table__cell">27 May 2025
@@ -98,14 +98,14 @@ exports[`audit GET /:appealId/audit should render the case history page with a r
                         </td>
                         <td class="govuk-table__cell">Case progressed to <strong class="govuk-tag govuk-tag--green">Final comments</strong>
                         </td>
-                        <td class="govuk-table__cell">John.Smith@planninginspectorate.gov.uk</td>
+                        <td class="govuk-table__cell">Smith, John</td>
                     </tr>
                     <tr class="govuk-table__row">
                         <td class="govuk-table__cell">27 May 2025
                             <br><span>10:52</span>
                         </td>
                         <td class="govuk-table__cell">LPA questionnaire updated</td>
-                        <td class="govuk-table__cell">John.Smith@planninginspectorate.gov.uk</td>
+                        <td class="govuk-table__cell">Smith, John</td>
                     </tr>
                     <tr class="govuk-table__row">
                         <td class="govuk-table__cell">27 May 2025
@@ -113,7 +113,7 @@ exports[`audit GET /:appealId/audit should render the case history page with a r
                         </td>
                         <td class="govuk-table__cell">Case progressed to <strong class="govuk-tag govuk-tag--green">Statements</strong>
                         </td>
-                        <td class="govuk-table__cell">John.Smith@planninginspectorate.gov.uk</td>
+                        <td class="govuk-table__cell">Smith, John</td>
                     </tr>
                     <tr class="govuk-table__row">
                         <td class="govuk-table__cell">27 May 2025
@@ -121,21 +121,21 @@ exports[`audit GET /:appealId/audit should render the case history page with a r
                         </td>
                         <td class="govuk-table__cell">Case progressed to <strong class="govuk-tag govuk-tag--green">LPA questionnaire</strong>
                         </td>
-                        <td class="govuk-table__cell">John.Smith@planninginspectorate.gov.uk</td>
+                        <td class="govuk-table__cell">Smith, John</td>
                     </tr>
                     <tr class="govuk-table__row">
                         <td class="govuk-table__cell">27 May 2025
                             <br><span>10:52</span>
                         </td>
                         <td class="govuk-table__cell">The case timeline was created</td>
-                        <td class="govuk-table__cell">John.Smith@planninginspectorate.gov.uk</td>
+                        <td class="govuk-table__cell">Smith, John</td>
                     </tr>
                     <tr class="govuk-table__row">
                         <td class="govuk-table__cell">27 May 2025
                             <br><span>10:52</span>
                         </td>
                         <td class="govuk-table__cell">Case updated</td>
-                        <td class="govuk-table__cell">John.Smith@planninginspectorate.gov.uk</td>
+                        <td class="govuk-table__cell">Smith, John</td>
                     </tr>
                     <tr class="govuk-table__row">
                         <td class="govuk-table__cell">27 May 2025
@@ -143,7 +143,7 @@ exports[`audit GET /:appealId/audit should render the case history page with a r
                         </td>
                         <td class="govuk-table__cell">Case progressed to <strong class="govuk-tag govuk-tag--green">Ready to start</strong>
                         </td>
-                        <td class="govuk-table__cell">John.Smith@planninginspectorate.gov.uk</td>
+                        <td class="govuk-table__cell">Smith, John</td>
                     </tr>
                     <tr class="govuk-table__row">
                         <td class="govuk-table__cell">1 October 2024
@@ -151,7 +151,7 @@ exports[`audit GET /:appealId/audit should render the case history page with a r
                         </td>
                         <td class="govuk-table__cell">Case note added:
                             <br>A case note you should see.</td>
-                        <td class="govuk-table__cell">John.Smith@planninginspectorate.gov.uk</td>
+                        <td class="govuk-table__cell">Smith, John</td>
                     </tr>
                     <tr class="govuk-table__row">
                         <td class="govuk-table__cell">1 October 2024
@@ -159,7 +159,7 @@ exports[`audit GET /:appealId/audit should render the case history page with a r
                         </td>
                         <td class="govuk-table__cell">Case note added:
                             <br>A case note you should see.</td>
-                        <td class="govuk-table__cell">John.Smith@planninginspectorate.gov.uk</td>
+                        <td class="govuk-table__cell">Smith, John</td>
                     </tr>
                 </tbody>
             </table>

--- a/appeals/web/src/server/appeals/appeal-details/audit/audit.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/audit/audit.mapper.js
@@ -56,7 +56,7 @@ export const tryMapUsers = async (log, session) => {
 
 	const user = await usersService.getUserById(uuid[2], session);
 
-	return result.replace(uuid[2], user?.email || 'User not found!');
+	return result.replace(uuid[2], user?.name || 'User not found!');
 };
 
 /**


### PR DESCRIPTION
## Describe your changes

### Web
- Simple change to display user.name rather than user.email

### Tests
- Updated snapshots and tested in browser locally
<!--
    Please include a summary of the change along with any relevant context.
    List any dependencies that are required for this change.
-->

## Issue ticket number and link

[Ticket](https://pins-ds.atlassian.net.mcas.ms/browse/A2-4157)
