### PR TITLE
[e2e-backoffice-fix-local-test-config] fixing local config for backoffice tests 

### DIFF
--- a/appeals/e2e/cypress.config.dev.env.js
+++ b/appeals/e2e/cypress.config.dev.env.js
@@ -1,6 +1,5 @@
 // @ts-nocheck
 const { defineConfig } = require('cypress');
-const { azureSignIn } = require('./cypress/support/login');
 const baseConfig = require('./cypress.config');
 
 require('dotenv').config();

--- a/appeals/e2e/cypress.config.local.env.js
+++ b/appeals/e2e/cypress.config.local.env.js
@@ -1,21 +1,21 @@
 // @ts-nocheck
 const { defineConfig } = require('cypress');
-const { azureSignIn } = require('./cypress/support/login');
 const baseConfig = require('./cypress.config');
 
 require('dotenv').config();
 
-const app = process.env.APP;
+// use backoffice defaults if not set
+if (!baseConfig.e2e.baseUrl) {
+	baseConfig.e2e.baseUrl = 'https://localhost:8080/';
+}
 
-const e2eOverride = {
-	baseUrl: 'https://localhost:8080/',
-	apiBaseUrl: 'http://localhost:3000/'
-};
+if (!baseConfig.e2e.apiBaseUrl) {
+	baseConfig.e2e.apiBaseUrl = 'http://localhost:3000/';
+}
 
 module.exports = defineConfig({
 	e2e: {
-		...baseConfig.e2e,
-		...e2eOverride
+		...baseConfig.e2e
 	},
 	env: {
 		...baseConfig.env

--- a/appeals/e2e/cypress.config.test.env.js
+++ b/appeals/e2e/cypress.config.test.env.js
@@ -1,6 +1,5 @@
 // @ts-nocheck
 const { defineConfig } = require('cypress');
-const { azureSignIn } = require('./cypress/support/login');
 const baseConfig = require('./cypress.config');
 
 require('dotenv').config();


### PR DESCRIPTION
## Describe your changes

This is a follow up fix to the change which added multi-environment config for backoffice tests 
In particular it correctly applies url/api url if set in .env file 

Also removed some unused imports! 

## Issue ticket number and link

*Follow up fix to https://github.com/Planning-Inspectorate/appeals-back-office/pull/1863*  
