### PR TITLE
fix(appeals): use lead appeal when importing representations (a2-3690)

### DIFF
--- a/appeals/api/setup-tests.js
+++ b/appeals/api/setup-tests.js
@@ -13,6 +13,7 @@ const mockRepUpdateMany = jest.fn().mockResolvedValue({});
 const mockAppealRelationshipAdd = jest.fn().mockResolvedValue({});
 const mockAppealRelationshipRemove = jest.fn().mockResolvedValue({});
 const mockAppealRelationshipFindMany = jest.fn().mockResolvedValue({});
+const mockAppealRelationshipFindFirst = jest.fn().mockResolvedValue({});
 const mockAppealRelationshipCreateMany = jest.fn().mockResolvedValue({});
 const mockAppealDecision = jest.fn().mockResolvedValue({});
 const mockAppealFindUnique = jest.fn().mockResolvedValue({});
@@ -200,6 +201,7 @@ class MockPrismaClient {
 	get appealRelationship() {
 		return {
 			findMany: mockAppealRelationshipFindMany,
+			findFirst: mockAppealRelationshipFindFirst,
 			delete: mockAppealRelationshipRemove,
 			create: mockAppealRelationshipAdd,
 			createMany: mockAppealRelationshipCreateMany

--- a/appeals/api/src/database/schema.d.ts
+++ b/appeals/api/src/database/schema.d.ts
@@ -1,6 +1,4 @@
-import { RedactionStatus } from '#repositories/document-metadata.repository';
 import * as schema from '#utils/db-client';
-import { CaseOfficer, Inspector } from '@pins/appeals';
 import { AssignedTeam } from '@pins/appeals.api';
 
 export interface Appeal extends schema.Appeal {
@@ -189,3 +187,5 @@ export interface RepresentationRejectionReasonText
 export interface AppealNotification extends schema.AppealNotification {}
 export interface HearingEstimate extends schema.HearingEstimate {}
 export interface InquiryEstimate extends schema.InquiryEstimate {}
+
+export interface AppealRelationship extends schema.AppealRelationship {}

--- a/appeals/api/src/server/endpoints/integrations/integrations.middleware.js
+++ b/appeals/api/src/server/endpoints/integrations/integrations.middleware.js
@@ -6,10 +6,13 @@ import {
 	ERROR_INVALID_APPELLANT_CASE_DATA,
 	ERROR_INVALID_LPAQ_DATA,
 	ERROR_INVALID_REP_DATA,
-	ERROR_INVALID_APPEAL_TYPE_REP
+	ERROR_INVALID_APPEAL_TYPE_REP,
+	CASE_RELATIONSHIP_LINKED
 } from '@pins/appeals/constants/support.js';
 import { getEnabledAppealTypes } from '#utils/feature-flags-appeal-types.js';
 import { APPEAL_CASE_TYPE } from '@planning-inspectorate/data-model';
+import featureFlags from '@pins/appeals.web/src/common/feature-flags.js';
+import { FEATURE_FLAG_NAMES } from '@pins/appeals/constants/common.js';
 
 /**
  * @type {import("express").RequestHandler}
@@ -122,7 +125,8 @@ export const validateRepresentation = async (req, res, next) => {
 		});
 	}
 
-	const referenceData = await loadReferenceData(body?.caseReference);
+	const useLeadAppealIfLinked = featureFlags.isFeatureActive(FEATURE_FLAG_NAMES.LINKED_APPEALS);
+	const referenceData = await loadReferenceData(body?.caseReference, useLeadAppealIfLinked);
 	if (!referenceData?.appeal) {
 		pino.error(
 			`Error associating representation to an existing appeal with reference '${body?.caseReference}'`
@@ -159,21 +163,38 @@ export const validateRepresentation = async (req, res, next) => {
 	next();
 };
 
-const loadReferenceData = async (/** @type {string|undefined} */ reference) => {
-	if (reference) {
-		const result = await databaseConnector.$transaction([
-			databaseConnector.appeal.findUnique({
-				where: { reference },
-				include: {
-					appealStatus: true,
-					appealType: true
+/**
+ * Loads reference data for an appeal
+ * @param {string|undefined} reference
+ * @param {boolean} [useLeadAppealIfLinked]
+ * @returns {Promise<*|null>}
+ */
+const loadReferenceData = async (reference, useLeadAppealIfLinked = false) => {
+	if (!reference) {
+		return null;
+	}
+	return databaseConnector.$transaction(async (tx) => {
+		if (useLeadAppealIfLinked) {
+			const linkedAppeal = await tx.appealRelationship.findFirst({
+				where: {
+					childRef: reference,
+					type: CASE_RELATIONSHIP_LINKED
 				}
-			}),
-			databaseConnector.designatedSite.findMany()
-		]);
+			});
+			if (linkedAppeal?.parentRef) {
+				reference = linkedAppeal.parentRef;
+			}
+		}
 
-		const appeal = result[0];
-		const designatedSites = result[1];
+		let appeal = await tx.appeal.findUnique({
+			where: { reference },
+			include: {
+				appealStatus: true,
+				appealType: true
+			}
+		});
+
+		const designatedSites = await tx.designatedSite.findMany();
 
 		if (appeal && designatedSites) {
 			return {
@@ -181,7 +202,5 @@ const loadReferenceData = async (/** @type {string|undefined} */ reference) => {
 				designatedSites
 			};
 		}
-	}
-
-	return null;
+	});
 };


### PR DESCRIPTION
## Describe your changes
#### Make sure imported representations use the lead appeal if they are a for a linked child appeal (a2-3690)

This is a bug fix for a previous ticket
 
### API:
- When validating and loading the appeal in the integrations middleware for representations, make sure the representations are loaded on to the lead appeal if the appeal reference supplied is for a linked child appeal.
- Remove unused imports in database schema 

### Test:
- Add extra unit tests
- Make sure tests still pass
- Tested with swagger
- Test within browser

## Issue ticket number and link
[A2-3690 - Reviewing interested party (IP) comments for linked written rep S78 planning appeals](https://pins-ds.atlassian.net/browse/A2-3690)