### PR TITLE
fix(web): infinite loop when clicking back from edit IP comment CYA page

### DIFF
--- a/appeals/web/src/server/appeals/appeal-details/representations/interested-party-comments/edit-ip-comment/__tests__/__snapshots__/edit-ip-comment.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/representations/interested-party-comments/edit-ip-comment/__tests__/__snapshots__/edit-ip-comment.test.js.snap
@@ -36,7 +36,7 @@ exports[`edit-ip-comment GET /edit/check/address should match the snapshot 1`] =
                     <span                     class="govuk-phase-banner__text">This is a new service. Help us improve it and <a href="https://forms.office.com/Pages/ResponsePage.aspx?id=mN94WIhvq0iTIpmM5VcIjYt1ax_BPvtOqhVjfvzyJN5UQzNVQjdaV0U0TDdTOE1LNktBT0w5NEQ1Vy4u"
                         class="govuk-link" target="_blank" rel="noopener noreferrer">give your feedback (opens in a new tab)</a>.</span>
                 </p>
-            </div><a href="/appeals-service/appeal-details/2/interested-party-comments/5/edit/address?editEntrypoint=/appeals-service/appeal-details/2/interested-party-comments/5/edit/address"
+            </div><a href="/appeals-service/appeal-details/2/interested-party-comments/5/edit/address"
             class="govuk-back-link">Back</a>
             <main class="govuk-main-wrapper" id="main-content">
                 <div class="govuk-grid-row">

--- a/appeals/web/src/server/appeals/appeal-details/representations/interested-party-comments/edit-ip-comment/edit-ip-comment.mappers.js
+++ b/appeals/web/src/server/appeals/appeal-details/representations/interested-party-comments/edit-ip-comment/edit-ip-comment.mappers.js
@@ -12,12 +12,12 @@ import { yesNoInput } from '#lib/mappers/components/index.js';
  * @returns {PageContent}
  * */
 export const checkAddressPage = (appealDetails, commentId, address) => {
-	const editBaseUrl = `/appeals-service/appeal-details/${appealDetails.appealId}/interested-party-comments/${commentId}/edit/address`;
-	const editPageUrl = `${editBaseUrl}?editEntrypoint=${editBaseUrl}`;
+	const backUrl = `/appeals-service/appeal-details/${appealDetails.appealId}/interested-party-comments/${commentId}/edit/address`;
+	const editPageUrl = `${backUrl}?editEntrypoint=${backUrl}`;
 
 	return {
 		title: 'Check your answers',
-		backLinkUrl: editPageUrl,
+		backLinkUrl: backUrl,
 		preHeading: `Appeal ${appealShortReference(appealDetails.appealReference)}`,
 		heading: 'Check your answers',
 		pageComponents: [


### PR DESCRIPTION
## Describe your changes

Fix infinite loop when clicking back from edit IP comment CYA page

## Issue ticket number and link

[A2-3053](https://pins-ds.atlassian.net/browse/A2-3053)


[A2-3053]: https://pins-ds.atlassian.net/browse/A2-3053?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ