### PR TITLE
fix(appeals): make sure the parent appeal test includes type of linked (a2-4282)

### DIFF
--- a/appeals/api/src/server/endpoints/linkable-appeals/linkable-appeal.controller.js
+++ b/appeals/api/src/server/endpoints/linkable-appeals/linkable-appeal.controller.js
@@ -2,6 +2,7 @@ import { canLinkAppeals } from '#endpoints/link-appeals/link-appeals.service.js'
 import { isFeatureActive } from '#utils/feature-flags.js';
 import { FEATURE_FLAG_NAMES } from '@pins/appeals/constants/common.js';
 import { getLinkableAppealSummaryByCaseReference } from './linkable-appeal.service.js';
+import { CASE_RELATIONSHIP_LINKED } from '@pins/appeals/constants/support.js';
 
 /** @typedef {import('express').Request} Request */
 /** @typedef {import('express').Response} Response */
@@ -26,7 +27,7 @@ export const getLinkableAppealById = async (req, res) => {
 
 		if (
 			isFeatureActive(FEATURE_FLAG_NAMES.LINKED_APPEALS) &&
-			linkableType === 'linked' &&
+			linkableType === CASE_RELATIONSHIP_LINKED &&
 			!canLinkAppeals(linkableAppeal, linkableType, 'lead')
 		) {
 			throw 409;

--- a/appeals/web/src/server/appeals/appeal-details/linked-appeals/__tests__/__snapshots__/linked-appeals.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/linked-appeals/__tests__/__snapshots__/linked-appeals.test.js.snap
@@ -237,7 +237,7 @@ exports[`linked-appeals GET /linked-appeals/add/check-and-confirm should render 
             class="govuk-back-link">Back</a>
             <main class="govuk-main-wrapper" id="main-content">
                 <div class="govuk-grid-row">
-                    <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Appeal 1234567</span>
+                    <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Appeal 1234765</span>
                         <h1 class="govuk-heading-l">Check details and add linked appeal</h1>
                     </div>
                 </div>
@@ -253,7 +253,7 @@ exports[`linked-appeals GET /linked-appeals/add/check-and-confirm should render 
                                 </dd>
                             </div>
                             <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Which is the lead appeal?</dt>
-                                <dd                                 class="govuk-summary-list__value"><span>1234567</span>
+                                <dd                                 class="govuk-summary-list__value"><span>1234765</span>
                                     <br><span class="govuk-hint">21 The Pavement</span>
                                     <br><span class="govuk-hint">Householder</span>
                                     </dd>
@@ -261,7 +261,7 @@ exports[`linked-appeals GET /linked-appeals/add/check-and-confirm should render 
                                     </dd>
                             </div>
                         </dl>
-                        <p class="govuk-body">1234567 will be the lead appeal of TEST-12345</p>
+                        <p class="govuk-body">1234765 will be the lead appeal of TEST-12345</p>
                         <div class="govuk-grid-row">
                             <div class="govuk-grid-column-full">
                                 <form method="post" novalidate="novalidate">

--- a/appeals/web/src/server/appeals/appeal-details/linked-appeals/add/add.controller.js
+++ b/appeals/web/src/server/appeals/appeal-details/linked-appeals/add/add.controller.js
@@ -9,6 +9,7 @@ import {
 } from './add.mapper.js';
 import { addNotificationBannerToSession } from '#lib/session-utilities.js';
 import { addBackLinkQueryToUrl, getBackLinkUrlFromQuery } from '#lib/url-utilities.js';
+import { CASE_RELATIONSHIP_LINKED } from '@pins/appeals/constants/support.js';
 
 /**
  * @param {import('@pins/express/types/express.js').Request} request
@@ -47,7 +48,7 @@ export const postAddLinkedAppeal = (request, response) => {
 		params: { appealId }
 	} = request;
 
-	if (request.body.linkConflict) {
+	if (request.body.linkConflict || request.body.linkSelf) {
 		return response.redirect(
 			`/appeals-service/appeal-details/${appealId}/linked-appeals/add/already-linked`
 		);
@@ -73,7 +74,10 @@ export const postAddLinkedAppeal = (request, response) => {
 	}
 
 	const proposedLinkableAppealIsLead = Boolean(
-		session.linkableAppeal.linkableAppealSummary?.childAppeals?.length
+		session.linkableAppeal.linkableAppealSummary?.childAppeals?.some(
+			// @ts-ignore
+			(childAppeal) => childAppeal.type === CASE_RELATIONSHIP_LINKED
+		)
 	);
 
 	if (proposedLinkableAppealIsLead && currentAppeal.isParentAppeal) {

--- a/appeals/web/src/server/appeals/appeal-details/linked-appeals/add/add.validators.js
+++ b/appeals/web/src/server/appeals/appeal-details/linked-appeals/add/add.validators.js
@@ -2,6 +2,7 @@ import logger from '#lib/logger.js';
 import { createValidator } from '@pins/express';
 import { body } from 'express-validator';
 import { getLinkableAppealByReference } from './add.service.js';
+import { appealShortReference } from '#lib/appeals-formatter.js';
 
 export const validateAddLinkedAppealReference = createValidator(
 	body('appeal-reference')
@@ -13,6 +14,11 @@ export const validateAddLinkedAppealReference = createValidator(
 		.withMessage('Appeal reference must be 7 digits')
 		.bail()
 		.custom(async (reference, { req }) => {
+			if (reference === appealShortReference(req.currentAppeal.appealReference)) {
+				req.body.linkSelf = true;
+				req.session.linkableAppeal = { linkableAppealSummary: { appealReference: reference } };
+				return Promise.resolve();
+			}
 			try {
 				const linkableAppealSummary = await getLinkableAppealByReference(
 					req.apiClient,


### PR DESCRIPTION
## Describe your changes

Fixes some bugs while attempting to link appeals found while testing a2-4214
- Prevent linking appeal to self
- Make sure the test for a parent makes sure there are only child appeals with a relationship type of linked
- Updated unit tests and snapshots

## Issue ticket number and link

[A2-4282](https://pins-ds.atlassian.net.mcas.ms/browse/A2-4282)


[A2-4282]: https://pins-ds.atlassian.net/browse/A2-4282?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ