### PR TITLE
Feat/a2 3790 update national filters list

### DIFF
--- a/appeals/api/src/database/seed/add-assigned-team-id.js
+++ b/appeals/api/src/database/seed/add-assigned-team-id.js
@@ -1,0 +1,13 @@
+/**
+ * @param {import('#db-client').PrismaClient} databaseConnector
+ */
+export const addAssignedTeamIdToAppeal = async (databaseConnector) => {
+	return databaseConnector.$executeRawUnsafe(
+		`
+		UPDATE "Appeal"
+		SET "assignedTeamId" = "LPA"."teamId"
+		FROM "LPA"
+		WHERE "Appeal"."lpaId" = "LPA"."id";
+		`
+	);
+};

--- a/appeals/api/src/database/seed/map-lpa-and-teams.js
+++ b/appeals/api/src/database/seed/map-lpa-and-teams.js
@@ -3,7 +3,7 @@
 /**
  *
  * @param {LPA[]} localPlanningDepartmentList
- * @param {Record<string, number>} lpaTeamAssignments
+ * @param {Record<string, number|null>} lpaTeamAssignments
  * @return {LPA[]}
  */
 export const mapLpasToTeams = (localPlanningDepartmentList, lpaTeamAssignments) => {

--- a/appeals/api/src/database/seed/seed-development.js
+++ b/appeals/api/src/database/seed/seed-development.js
@@ -1,5 +1,6 @@
 import { databaseConnector } from '../../server/utils/database-connector.js';
 import { lpaTeamAssignments, teamsToCreate } from '../teams/dev.js';
+import { addAssignedTeamIdToAppeal } from './add-assigned-team-id.js';
 import { seedStaticData } from './data-static.js';
 import { seedTestData } from './data-test.js';
 import { localPlanningDepartmentList } from './LPAs/dev.js';
@@ -22,6 +23,7 @@ const seedDevelopment = async () => {
 		await seedTeams(databaseConnector, teamsToCreate);
 		const mappedLPAs = mapLpasToTeams(localPlanningDepartmentList, lpaTeamAssignments);
 		await seedLPAs(databaseConnector, mappedLPAs);
+		await addAssignedTeamIdToAppeal(databaseConnector);
 	} catch (error) {
 		console.error(error);
 		throw error;

--- a/appeals/api/src/database/teams/dev.js
+++ b/appeals/api/src/database/teams/dev.js
@@ -2,16 +2,16 @@ export const teamsToCreate = [
 	{ id: 1, name: 'Ops Test', email: 'opstest@planninginspectorate.co.uk' },
 	{ id: 2, name: 'DevTeam1', email: 'devteam1@planninginspectorate.gov.uk' },
 	{ id: 3, name: 'DevTeam2', email: 'devteam2@planninginspectorate.gov.uk' },
-	{ id: 6, name: 'Major Casework Officer', email: 'majorcasework@planninginspectorate.gov.uk' },
+	{ id: 6, name: 'Major Casework Officer', email: 'ECAT@planninginspectorate.gov.uk' },
 	{
 		id: 7,
 		name: 'Enforcement Appeals Officer',
-		email: 'enforcementappeals@planninginspectorate.gov.uk'
+		email: null
 	}
 ];
 
 /**
- * @type {Record<string, number>}
+ * @type {Record<string, number|null>}
  */
 export const lpaTeamAssignments = {
 	// Ops Test
@@ -20,7 +20,7 @@ export const lpaTeamAssignments = {
 
 	// DevTeam1
 	MAID: 2,
-	BARN: 2,
+	BARN: null,
 	WORT: 2,
 	DORS: 2,
 

--- a/appeals/api/src/database/teams/prod.js
+++ b/appeals/api/src/database/teams/prod.js
@@ -1,16 +1,40 @@
 export const teamsToCreate = [
-	{ id: 1, name: 'West1', email: 'west1@planninginspectorate.gov.uk' },
-	{ id: 2, name: 'West2', email: 'west2@planninginspectorate.gov.uk' },
-	{ id: 3, name: 'West3', email: 'west3@planninginspectorate.gov.uk' },
-	{ id: 4, name: 'West4', email: 'west4@planninginspectorate.gov.uk' },
-	{ id: 5, name: 'East2', email: 'east2@planninginspectorate.gov.uk' },
-	{ id: 6, name: 'East1', email: 'east1@planninginspectorate.gov.uk' },
-	{ id: 7, name: 'East3', email: 'east3@planninginspectorate.gov.uk' },
-	{ id: 8, name: 'East4', email: 'east4@planninginspectorate.gov.uk' },
-	{ id: 9, name: 'North1', email: 'north1@planninginspectorate.gov.uk' },
-	{ id: 10, name: 'North2', email: 'north2@planninginspectorate.gov.uk' },
-	{ id: 11, name: 'North3', email: 'north3@planninginspectorate.gov.uk' },
-	{ id: 12, name: 'North4', email: 'north4@planninginspectorate.gov.uk' }
+	{ id: 1, name: 'Major Casework Officer', email: null },
+	{ id: 2, name: 'Enforcement Appeals Team', email: 'ECAT@planninginspectorate.gov.uk' },
+
+	{
+		id: 3,
+		name: 'Enforcement Appeals Team - Team 1',
+		email: 'TeamE1@planninginspectorate.gov.uk'
+	},
+	{
+		id: 4,
+		name: 'Enforcement Appeals Team - Team 2',
+		email: 'TeamE2@planninginspectorate.gov.uk'
+	},
+	{
+		id: 5,
+		name: 'Enforcement Appeals Team - Team 3',
+		email: 'TeamE3@planninginspectorate.gov.uk'
+	},
+	{
+		id: 6,
+		name: 'Enforcement Appeals Team - Team 4',
+		email: 'TeamE4@planninginspectorate.gov.uk'
+	},
+	{ id: 7, name: 'West1', email: 'west1@planninginspectorate.gov.uk' },
+	{ id: 8, name: 'West2', email: 'west2@planninginspectorate.gov.uk' },
+	{ id: 9, name: 'West3', email: 'west3@planninginspectorate.gov.uk' },
+	{ id: 10, name: 'West4', email: 'west4@planninginspectorate.gov.uk' },
+	{ id: 11, name: 'East2', email: 'east2@planninginspectorate.gov.uk' },
+	{ id: 12, name: 'East1', email: 'east1@planninginspectorate.gov.uk' },
+	{ id: 13, name: 'East3', email: 'east3@planninginspectorate.gov.uk' },
+	{ id: 14, name: 'East4', email: 'east4@planninginspectorate.gov.uk' },
+	{ id: 15, name: 'North1', email: 'north1@planninginspectorate.gov.uk' },
+	{ id: 16, name: 'North2', email: 'north2@planninginspectorate.gov.uk' },
+	{ id: 17, name: 'North3', email: 'north3@planninginspectorate.gov.uk' },
+	{ id: 18, name: 'North4', email: 'north4@planninginspectorate.gov.uk' },
+	{ id: 19, name: 'Enforcement Appeals Team', email: 'ECAT@planninginspectorate.gov.uk' }
 ];
 
 export const lpaTeamAssignments = {

--- a/appeals/api/src/server/endpoints/appeals/__tests__/appeals.test.js
+++ b/appeals/api/src/server/endpoints/appeals/__tests__/appeals.test.js
@@ -1204,6 +1204,93 @@ test('gets appeals when given a appealTypeId param', async () => {
 	});
 });
 
+test('gets appeals when given a assignedTeamId param', async () => {
+	databaseConnector.appeal.findMany
+		.mockResolvedValueOnce([householdAppeal])
+		.mockResolvedValueOnce(allAppeals);
+
+	const response = await request
+		.get('/appeals?assignedTeamId=1')
+		.set('azureAdUserId', azureAdUserId);
+
+	expect(databaseConnector.appeal.findMany).toHaveBeenCalledWith(
+		expect.objectContaining({
+			where: expect.objectContaining({
+				assignedTeamId: 1
+			})
+		})
+	);
+	expect(response.status).toEqual(200);
+	expect(response.body).toEqual({
+		itemCount: 1,
+		items: [
+			{
+				appealId: householdAppeal.id,
+				appealReference: householdAppeal.reference,
+				appealSite: {
+					addressLine1: householdAppeal.address.addressLine1,
+					addressLine2: householdAppeal.address.addressLine2,
+					town: householdAppeal.address.addressTown,
+					county: householdAppeal.address.addressCounty,
+					postCode: householdAppeal.address.postcode
+				},
+				appealStatus: householdAppeal.appealStatus[0].status,
+				appealType: householdAppeal.appealType.type,
+				awaitingLinkedAppeal: null,
+				createdAt: householdAppeal.caseCreatedDate.toISOString(),
+				localPlanningDepartment: householdAppeal.lpa.name,
+				dueDate: null,
+				documentationSummary: {
+					appellantCase: {
+						receivedAt: '2024-03-25T23:59:59.999Z',
+						status: 'received'
+					},
+					ipComments: {
+						status: 'not_received',
+						counts: {},
+						isRedacted: false
+					},
+					lpaQuestionnaire: {
+						receivedAt: '2024-06-24T00:00:00.000Z',
+						status: 'received'
+					},
+					lpaStatement: {
+						status: 'not_received',
+						representationStatus: null,
+						isRedacted: false
+					},
+					lpaFinalComments: {
+						receivedAt: null,
+						representationStatus: null,
+						status: 'not_received',
+						isRedacted: false
+					},
+					appellantFinalComments: {
+						receivedAt: null,
+						representationStatus: null,
+						status: 'not_received',
+						isRedacted: false
+					}
+				},
+				isParentAppeal: false,
+				isChildAppeal: false,
+				planningApplicationReference: householdAppeal.applicationReference,
+				procedureType: 'Written',
+				hasHearingAddress: true,
+				isHearingSetup: true,
+				numberOfResidencesNetChange: 5
+			}
+		],
+		lpas,
+		caseOfficers,
+		inspectors,
+		page: 1,
+		pageCount: 1,
+		pageSize: 30,
+		statuses: ['assign_case_officer'],
+		statusesInNationalList
+	});
+});
 describe('mapAppealToDueDate Tests', () => {
 	let mockAppeal = {
 		appealType: null,

--- a/appeals/api/src/server/endpoints/appeals/appeals.controller.js
+++ b/appeals/api/src/server/endpoints/appeals/appeals.controller.js
@@ -31,6 +31,7 @@ const getAppeals = async (req, res) => {
 	const pageSize = Number(query.pageSize) || DEFAULT_PAGE_SIZE;
 	const isGreenBelt = query.isGreenBelt === 'true';
 	const appealTypeId = Number(query.appealTypeId) || null;
+	const assignedTeamId = Number(query.assignedTeamId) || null;
 
 	const {
 		itemCount,
@@ -51,7 +52,8 @@ const getAppeals = async (req, res) => {
 		inspectorId,
 		caseOfficerId,
 		isGreenBelt,
-		appealTypeId
+		appealTypeId,
+		assignedTeamId
 	);
 
 	return res.send({

--- a/appeals/api/src/server/endpoints/appeals/appeals.service.js
+++ b/appeals/api/src/server/endpoints/appeals/appeals.service.js
@@ -131,6 +131,7 @@ const mapAppeals = (appeals) =>
  * @param {number} caseOfficerId
  * @param {boolean} isGreenBelt
  * @param {number} appealTypeId
+ * @param {number} assignedTeamId
  * @returns {Promise<{mappedStatuses: string[], statusesInNationalList: string[], mappedLPAs: any[], mappedInspectors: any[], mappedCaseOfficers: any[], mappedAppeals: any[], itemCount: number}>}
  */
 const retrieveAppealListData = async (
@@ -143,9 +144,10 @@ const retrieveAppealListData = async (
 	inspectorId,
 	caseOfficerId,
 	isGreenBelt,
-	appealTypeId
+	appealTypeId,
+	assignedTeamId
 ) => {
-	/** @type {[string, string, string, string, number, number, boolean, number]} */
+	/** @type {[string, string, string, string, number, number, boolean, number,number]} */
 	const appealFilters = [
 		searchTerm,
 		status,
@@ -154,7 +156,8 @@ const retrieveAppealListData = async (
 		inspectorId ? Number(inspectorId) : 0,
 		caseOfficerId ? Number(caseOfficerId) : 0,
 		isGreenBelt,
-		appealTypeId || 0
+		appealTypeId || 0,
+		assignedTeamId || 0
 	];
 	const appeals = await appealListRepository.getAllAppeals(...appealFilters, pageNumber, pageSize);
 	const allAppeals = await appealListRepository.getAppealsWithoutIncludes(...appealFilters);

--- a/appeals/api/src/server/repositories/appeal-lists.repository.js
+++ b/appeals/api/src/server/repositories/appeal-lists.repository.js
@@ -20,6 +20,7 @@ import { getEnabledAppealTypes } from '#utils/feature-flags-appeal-types.js';
  * @param {number} caseOfficerId
  * @param {boolean} isGreenBelt
  * @param {number} appealTypeId
+ * @param {number} assignedTeamId
  * @param {number} [pageNumber]
  * @param {number} [pageSize]
  */
@@ -32,6 +33,7 @@ const getAllAppeals = async (
 	caseOfficerId,
 	isGreenBelt,
 	appealTypeId,
+	assignedTeamId,
 	pageNumber,
 	pageSize
 ) => {
@@ -52,7 +54,8 @@ const getAllAppeals = async (
 		inspectorId,
 		caseOfficerId,
 		isGreenBelt,
-		appealTypeId
+		appealTypeId,
+		assignedTeamId
 	);
 
 	const appeals = await databaseConnector.appeal.findMany({
@@ -101,6 +104,7 @@ const getAllAppeals = async (
  * @param {number} caseOfficerId
  * @param {boolean} isGreenBelt
  * @param {number} appealTypeId
+ * @param {number} assignedTeamId
  */
 const getAllAppealsCount = async (
 	searchTerm,
@@ -110,7 +114,8 @@ const getAllAppealsCount = async (
 	inspectorId,
 	caseOfficerId,
 	isGreenBelt,
-	appealTypeId
+	appealTypeId,
+	assignedTeamId
 ) => {
 	const where = buildAllAppealsWhereClause(
 		searchTerm,
@@ -120,7 +125,8 @@ const getAllAppealsCount = async (
 		inspectorId,
 		caseOfficerId,
 		isGreenBelt,
-		appealTypeId
+		appealTypeId,
+		assignedTeamId
 	);
 
 	const count = await databaseConnector.appeal.count({ where });
@@ -137,6 +143,7 @@ const getAllAppealsCount = async (
  * @param {number} caseOfficerId
  * @param {boolean} isGreenBelt
  * @param {number} appealTypeId
+ * @param {number} assignedTeamId
  */
 const getAppealsWithoutIncludes = async (
 	searchTerm,
@@ -146,7 +153,8 @@ const getAppealsWithoutIncludes = async (
 	inspectorId,
 	caseOfficerId,
 	isGreenBelt,
-	appealTypeId
+	appealTypeId,
+	assignedTeamId
 ) => {
 	const where = buildAllAppealsWhereClause(
 		searchTerm,
@@ -156,7 +164,8 @@ const getAppealsWithoutIncludes = async (
 		inspectorId,
 		caseOfficerId,
 		isGreenBelt,
-		appealTypeId
+		appealTypeId,
+		assignedTeamId
 	);
 
 	return databaseConnector.appeal.findMany({ where });
@@ -171,6 +180,7 @@ const getAppealsWithoutIncludes = async (
  * @param {number} caseOfficerId
  * @param {boolean} isGreenBelt
  * @param {number} appealTypeId
+ * @param {number} assignedTeamId
  */
 const buildAllAppealsWhereClause = (
 	searchTerm,
@@ -180,7 +190,8 @@ const buildAllAppealsWhereClause = (
 	inspectorId,
 	caseOfficerId,
 	isGreenBelt,
-	appealTypeId
+	appealTypeId,
+	assignedTeamId
 ) => {
 	return {
 		appealStatus: {
@@ -239,6 +250,9 @@ const buildAllAppealsWhereClause = (
 		}),
 		...(!!appealTypeId && {
 			appealTypeId
+		}),
+		...(!!assignedTeamId && {
+			assignedTeamId
 		})
 	};
 };

--- a/appeals/api/src/server/tests/appeals/mocks.js
+++ b/appeals/api/src/server/tests/appeals/mocks.js
@@ -98,6 +98,7 @@ export const appealS20 = {
 export const householdAppeal = {
 	caseCreatedDate: new Date('2024-03-25T23:59:59.999Z'),
 	id: 1,
+	assignedTeamId: 1,
 	reference: '1345264',
 	procedureType: {
 		id: 1,

--- a/appeals/web/src/server/appeals/appeal-details/__tests__/__snapshots__/appeal-details.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/__tests__/__snapshots__/appeal-details.test.js.snap
@@ -6175,6 +6175,19 @@ exports[`appeal-details GET /:appealId Team section should render the case-team 
 </div>"
 `;
 
+exports[`appeal-details GET /:appealId Team section should render the case-team section for appeal with not assigned displayed when only team name exists" 1`] = `
+"<div class="govuk-summary-list__row appeal-case-team"><dt class="govuk-summary-list__key"> Case team</dt>
+    <dd class="govuk-summary-list__value">
+        <ul class="govuk-list">
+            <li>Just a name</li>
+        </ul>
+    </dd>
+    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/case-team/edit"
+        data-cy="assign-case-team">Assign<span class="govuk-visually-hidden"> Case team</span></a>
+    </dd>
+</div>"
+`;
+
 exports[`appeal-details GET /:appealId Team section should render the case-team section for appeal with team name and email displayed" 1`] = `
 "<div class="govuk-summary-list__row appeal-case-team"><dt class="govuk-summary-list__key"> Case team</dt>
     <dd class="govuk-summary-list__value">

--- a/appeals/web/src/server/appeals/appeal-details/__tests__/appeal-details.test.js
+++ b/appeals/web/src/server/appeals/appeal-details/__tests__/appeal-details.test.js
@@ -152,6 +152,25 @@ describe('appeal-details', () => {
 				expect(element.innerHTML).toMatchSnapshot();
 				expect(element.innerHTML).toContain('<li>Not assigned</li>');
 			});
+			it('should render the case-team section for appeal with not assigned displayed when only team name exists"', async () => {
+				const appealId = 2;
+				nock('http://test/')
+					.get(`/appeals/${appealId}`)
+					.reply(200, {
+						...appealData,
+						appealId,
+						appealStatus: 'ready_to_start',
+						assignedTeam: { id: 4, name: 'Just a name', email: null }
+					});
+				nock('http://test/').get(`/appeals/${appealId}/case-notes`).reply(200, caseNotes);
+				const response = await request.get(`${baseUrl}/${appealId}`);
+
+				expect(response.statusCode).toBe(200);
+				const element = parseHtml(response.text, { rootElement: '.appeal-case-team' });
+
+				expect(element.innerHTML).toMatchSnapshot();
+				expect(element.innerHTML).toContain('Just a name');
+			});
 		});
 		describe('Notification banners', () => {
 			const notificationBannerElement = '.govuk-notification-banner';

--- a/appeals/web/src/server/appeals/appeal-details/update-case-team/__tests__/__snapshots__/update-case-team.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/update-case-team/__tests__/__snapshots__/update-case-team.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`update-case-team /case-team/edit/check GET should render the check your answers page 1`] = `
+exports[`update-case-team /case-team/edit/check GET name and email available should render the check your answers page 1`] = `
 "<main class="govuk-main-wrapper" id="main-content">
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Appeal 351062</span>
@@ -13,6 +13,34 @@ exports[`update-case-team /case-team/edit/check GET should render the check your
                 <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Case team</dt>
                     <dd class="govuk-summary-list__value">temp
                         <br>temp@email.com</dd>
+                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/case-team/edit">Change<span class="govuk-visually-hidden"> Change team</span></a>
+                    </dd>
+                </div>
+            </dl>
+            <div class="govuk-grid-row">
+                <div class="govuk-grid-column-full">
+                    <form method="post" novalidate="novalidate">
+                        <button type="submit" class="govuk-button" data-module="govuk-button">Update case team</button>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </div>
+</main>"
+`;
+
+exports[`update-case-team /case-team/edit/check GET name only available should render the check your answers page 1`] = `
+"<main class="govuk-main-wrapper" id="main-content">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Appeal 351062</span>
+            <h1 class="govuk-heading-l">Check details and update case team</h1>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <dl class="govuk-summary-list">
+                <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Case team</dt>
+                    <dd class="govuk-summary-list__value">temp4</dd>
                     <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/case-team/edit">Change<span class="govuk-visually-hidden"> Change team</span></a>
                     </dd>
                 </div>
@@ -65,9 +93,14 @@ exports[`update-case-team GET /case-team/edit should render the update case team
                                     </div>
                                     <div class="govuk-radios__item">
                                         <input class="govuk-radios__input" id="case-team-4" name="case-team" type="radio"
-                                        value="0" aria-describedby="case-team-4-item-hint">
-                                        <label class="govuk-label govuk-radios__label" for="case-team-4">Unassign team</label>
-                                        <div id="case-team-4-item-hint" class="govuk-hint govuk-radios__hint">This will remove the current case team from the appeal</div>
+                                        value="4">
+                                        <label class="govuk-label govuk-radios__label" for="case-team-4">temp4</label>
+                                    </div>
+                                    <div class="govuk-radios__item">
+                                        <input class="govuk-radios__input" id="case-team-5" name="case-team" type="radio"
+                                        value="0" aria-describedby="case-team-5-item-hint">
+                                        <label class="govuk-label govuk-radios__label" for="case-team-5">Unassign team</label>
+                                        <div id="case-team-5-item-hint" class="govuk-hint govuk-radios__hint">This will remove the current case team from the appeal</div>
                                     </div>
                                 </div>
                             </fieldset>
@@ -134,9 +167,14 @@ exports[`update-case-team POST /case-team/edit should rerender the update case t
                                     </div>
                                     <div class="govuk-radios__item">
                                         <input class="govuk-radios__input" id="case-team-4" name="case-team" type="radio"
-                                        value="0" aria-describedby="case-team-4-item-hint">
-                                        <label class="govuk-label govuk-radios__label" for="case-team-4">Unassign team</label>
-                                        <div id="case-team-4-item-hint" class="govuk-hint govuk-radios__hint">This will remove the current case team from the appeal</div>
+                                        value="4">
+                                        <label class="govuk-label govuk-radios__label" for="case-team-4">temp4</label>
+                                    </div>
+                                    <div class="govuk-radios__item">
+                                        <input class="govuk-radios__input" id="case-team-5" name="case-team" type="radio"
+                                        value="0" aria-describedby="case-team-5-item-hint">
+                                        <label class="govuk-label govuk-radios__label" for="case-team-5">Unassign team</label>
+                                        <div id="case-team-5-item-hint" class="govuk-hint govuk-radios__hint">This will remove the current case team from the appeal</div>
                                     </div>
                         </div>
                         </fieldset>

--- a/appeals/web/src/server/appeals/appeal-details/update-case-team/__tests__/update-case-team.test.js
+++ b/appeals/web/src/server/appeals/appeal-details/update-case-team/__tests__/update-case-team.test.js
@@ -73,16 +73,16 @@ describe('update-case-team', () => {
 		});
 	});
 	describe('/case-team/edit/check', () => {
-		beforeEach(async () => {
-			nock('http://test/').get('/appeals/case-teams').reply(200, caseTeams);
-			nock('http://test/').get('/appeals/1/case-team').reply(200, { assignedTeamId: 1 });
-			renderSelectPage = await request.get(`${baseUrl}/1${siteVisitPath}/edit`);
-			selectTeamResponse = await request.post(`${baseUrl}/1${siteVisitPath}/edit`).send({
-				'case-team': '1'
+		describe('GET name and email available', () => {
+			beforeEach(async () => {
+				nock('http://test/').get('/appeals/case-teams').reply(200, caseTeams);
+				nock('http://test/').get('/appeals/1/case-team').reply(200, { assignedTeamId: 1 });
+				renderSelectPage = await request.get(`${baseUrl}/1${siteVisitPath}/edit`);
+				selectTeamResponse = await request.post(`${baseUrl}/1${siteVisitPath}/edit`).send({
+					'case-team': '1'
+				});
+				renderSelectPage = await request.get(`${baseUrl}/1${siteVisitPath}/edit`);
 			});
-			renderSelectPage = await request.get(`${baseUrl}/1${siteVisitPath}/edit`);
-		});
-		describe('GET', () => {
 			it('should render the check your answers page', async () => {
 				expect(renderSelectPage.statusCode).toBe(500);
 				expect(selectTeamResponse.statusCode).toBe(302);
@@ -93,6 +93,28 @@ describe('update-case-team', () => {
 				expect(element.innerHTML).toContain('Case team</dt>');
 				expect(element.innerHTML).toContain('<br>temp@email.com</dd>');
 				expect(element.innerHTML).toContain('<dd class="govuk-summary-list__value">temp');
+				expect(element.innerHTML).toContain('Change team</span>');
+				expect(element.innerHTML).toContain('Update case team');
+			});
+		});
+		describe('GET name only available', () => {
+			beforeEach(async () => {
+				nock('http://test/').get('/appeals/case-teams').reply(200, caseTeams);
+				nock('http://test/').get('/appeals/1/case-team').reply(200, { assignedTeamId: 4 });
+				renderSelectPage = await request.get(`${baseUrl}/1${siteVisitPath}/edit`);
+				selectTeamResponse = await request.post(`${baseUrl}/1${siteVisitPath}/edit`).send({
+					'case-team': '4'
+				});
+				renderSelectPage = await request.get(`${baseUrl}/1${siteVisitPath}/edit`);
+			});
+			it('should render the check your answers page', async () => {
+				expect(renderSelectPage.statusCode).toBe(500);
+				expect(selectTeamResponse.statusCode).toBe(302);
+				const response = await request.get(`${baseUrl}/1${siteVisitPath}/edit/check`);
+				const element = parseHtml(response.text);
+
+				expect(element.innerHTML).toMatchSnapshot();
+				expect(element.innerHTML).toContain('temp4</dd>');
 				expect(element.innerHTML).toContain('Change team</span>');
 				expect(element.innerHTML).toContain('Update case team');
 			});

--- a/appeals/web/src/server/appeals/appeal-details/update-case-team/update-case-team.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/update-case-team/update-case-team.mapper.js
@@ -104,9 +104,9 @@ export function checkAndConfirmPage(appealId, team, appealReference) {
 }
 
 /**
- *
  * @param {(import('@pins/appeals.api').Api.CaseTeam)} team
+ * @returns {string} The formatted team name and email.
  */
 export const mapTeamText = (team) => {
-	return `${team.name}<br>${team.email}`;
+	return team.email ? `${team.name}<br>${team.email}` : `${team.name}`;
 };

--- a/appeals/web/src/server/appeals/national-list/__tests__/__snapshots__/national-list.test.js.snap
+++ b/appeals/web/src/server/appeals/national-list/__tests__/__snapshots__/national-list.test.js.snap
@@ -92,6 +92,17 @@ exports[`national-list GET / should render national list - 10 pages - all page i
                             </select>
                         </div>
                         <div class="govuk-form-group">
+                            <label class="govuk-label govuk-!-font-weight-bold" for="case-team-filter">Case team</label>
+                            <select class="govuk-select" id="case-team-filter" name="caseTeamFilter"
+                            data-cy="filter-by-case-team">
+                                <option value="all">All</option>
+                                <option value="1">temp</option>
+                                <option value="2">temp2</option>
+                                <option value="3">temp3</option>
+                                <option value="4">temp4</option>
+                            </select>
+                        </div>
+                        <div class="govuk-form-group">
                             <label class="govuk-label govuk-!-font-weight-bold" for="inspectorFilter">Inspector</label>
                             <select class="govuk-select" id="inspectorFilter" name="inspectorFilter"
                             data-cy="filter-by-inspector">
@@ -296,6 +307,17 @@ exports[`national-list GET / should render national list - 15 pages - pagination
                             </select>
                         </div>
                         <div class="govuk-form-group">
+                            <label class="govuk-label govuk-!-font-weight-bold" for="case-team-filter">Case team</label>
+                            <select class="govuk-select" id="case-team-filter" name="caseTeamFilter"
+                            data-cy="filter-by-case-team">
+                                <option value="all">All</option>
+                                <option value="1">temp</option>
+                                <option value="2">temp2</option>
+                                <option value="3">temp3</option>
+                                <option value="4">temp4</option>
+                            </select>
+                        </div>
+                        <div class="govuk-form-group">
                             <label class="govuk-label govuk-!-font-weight-bold" for="inspectorFilter">Inspector</label>
                             <select class="govuk-select" id="inspectorFilter" name="inspectorFilter"
                             data-cy="filter-by-inspector">
@@ -477,6 +499,178 @@ exports[`national-list GET / should render national list - appeal type filter ap
                             </select>
                         </div>
                         <div class="govuk-form-group">
+                            <label class="govuk-label govuk-!-font-weight-bold" for="case-team-filter">Case team</label>
+                            <select class="govuk-select" id="case-team-filter" name="caseTeamFilter"
+                            data-cy="filter-by-case-team">
+                                <option value="all">All</option>
+                                <option value="1">temp</option>
+                                <option value="2">temp2</option>
+                                <option value="3">temp3</option>
+                                <option value="4">temp4</option>
+                            </select>
+                        </div>
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-!-font-weight-bold" for="inspectorFilter">Inspector</label>
+                            <select class="govuk-select" id="inspectorFilter" name="inspectorFilter"
+                            data-cy="filter-by-inspector">
+                                <option value="all">All</option>
+                                <option value="0">Smith, John</option>
+                                <option value="1">Doe, Jane</option>
+                                <option value="2">Bloggs, Joe</option>
+                                <option value="3">Jenkins, Leeroy</option>
+                                <option value="4">McTest, George</option>
+                            </select>
+                        </div>
+                        <div class="govuk-form-group">
+                            <div class="govuk-checkboxes govuk-checkboxes--small" data-cy="filter-by-green-belt"
+                            data-module="govuk-checkboxes">
+                                <div class="govuk-checkboxes__item">
+                                    <input class="govuk-checkboxes__input" id="greenBeltFilter" name="greenBeltFilter"
+                                    type="checkbox" value="yes">
+                                    <label class="govuk-label govuk-checkboxes__label" for="greenBeltFilter">Green belt</label>
+                                </div>
+                            </div>
+                        </div>
+                    </form>
+                </div>
+            </details>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
+            <table class="govuk-table govuk-table--small-text-until-tablet govuk-table--case-list">
+                <thead class="govuk-table__head">
+                    <tr class="govuk-table__row">
+                        <th scope="col" class="govuk-table__header">Appeal reference</th>
+                        <th scope="col" class="govuk-table__header">Planning application reference</th>
+                        <th scope="col" class="govuk-table__header">Site address</th>
+                        <th scope="col" class="govuk-table__header">Local planning authority (LPA)</th>
+                        <th scope="col" class="govuk-table__header">Appeal type</th>
+                        <th scope="col" class="govuk-table__header">Status</th>
+                    </tr>
+                </thead>
+                <tbody class="govuk-table__body">
+                    <tr class="govuk-table__row">
+                        <td class="govuk-table__cell"><a class="govuk-link" href="/appeals-service/appeal-details/1" aria-label="Appeal 9 4 3 2 4 5"
+                            data-cy="943245">943245</a>
+                        </td>
+                        <td class="govuk-table__cell"><span class="govuk-!-width-one-third"> undefined</span>
+                        </td>
+                        <td class="govuk-table__cell"><span class="govuk-!-width-one-third">Copthalls, Clevedon Road, West Hill, BS48 1PN</span>
+                        </td>
+                        <td class="govuk-table__cell"><span class="govuk-!-width-one-third">Wiltshire Council</span>
+                        </td>
+                        <td class="govuk-table__cell">Householder</td>
+                        <td class="govuk-table__cell"><strong class="govuk-tag govuk-tag--green">LPA questionnaire</strong>
+                        </td>
+                    </tr>
+                </tbody>
+            </table>
+        </div>
+    </div>
+</main>"
+`;
+
+exports[`national-list GET / should render national list - case team filter applied 1`] = `
+"<main class="govuk-main-wrapper" id="main-content">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <h1 class="govuk-heading-l">Search all cases</h1>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <form method="GET">
+                <div class="govuk-form-group">
+                    <label class="govuk-label govuk-caption-m govuk-!-margin-bottom-3 colour--secondary"
+                    for="searchTerm">Enter the appeal reference, planning application reference or postcode
+                        (including spaces)</label>
+                    <input class="govuk-input" id="searchTerm" name="searchTerm"
+                    type="text" value="" data-cy="search-term">
+                </div>
+                <div class="govuk-button-group">
+                    <button type="submit" class="govuk-button govuk-button" data-module="govuk-button"
+                    id="filters-submit">Search</button>
+                </div>
+            </form>
+            <div class="govuk-section-break--visible govuk-!-margin-top-2 govuk-!-margin-bottom-6"></div>
+        </div>
+    </div>
+    <div class="govuk-grid-row govuk-!-padding-left-3">
+        <h2 class="govuk-heading-m">1 result (filters applied)</h2>
+    </div>
+    <div class="govuk-grid-row govuk-!-padding-left-3">
+        <div class="govuk-grid-column-full">
+            <details class="govuk-details">
+                <summary class="govuk-details__summary"><span class="govuk-details__summary-text"> Filters</span>
+                </summary>
+                <div class="govuk-details__text">
+                    <form method="GET">
+                        <h2 class="govuk-heading-m">Filter</h2>
+                        <div class="govuk-button-group">
+                            <button type="submit" class="govuk-button" data-module="govuk-button"
+                            data-cy="filter-submit" id="filters-submit">Apply filters</button><a class="govuk-link" href="/appeals-service/all-cases"
+                            data-cy="filter-clear">Clear filters</a>
+                        </div>
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-!-font-weight-bold" for="appeal-type-filter">Appeal type</label>
+                            <select class="govuk-select" id="appeal-type-filter"
+                            name="appealTypeFilter" data-cy="filter-by-appeal">
+                                <option value="all">All</option>
+                                <option value="66">Householder</option>
+                                <option value="75">Planning appeal</option>
+                                <option value="77">Planning listed building and conservation area appeal</option>
+                                <option                                 value="78">CAS advert</option>
+                                    <option value="79">CAS planning</option>
+                            </select>
+                        </div>
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-!-font-weight-bold" for="appeal-status-filter">Case status</label>
+                            <select class="govuk-select" id="appeal-status-filter"
+                            name="appealStatusFilter" data-cy="filter-by-case-status">
+                                <option value="all">All</option>
+                            </select>
+                        </div>
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-!-font-weight-bold" for="inspector-status-filter">Inspector status</label>
+                            <select class="govuk-select" id="inspector-status-filter"
+                            name="inspectorStatusFilter" data-cy="filter-by-inspector-status">
+                                <option value="all">All</option>
+                                <option value="assigned">Assigned</option>
+                                <option value="unassigned">Unassigned</option>
+                            </select>
+                        </div>
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-!-font-weight-bold" for="localPlanningAuthorityFilter">Local planning authority</label>
+                            <select class="govuk-select" id="localPlanningAuthorityFilter"
+                            name="localPlanningAuthorityFilter" data-cy="filter-by-local-planning-authority">
+                                <option value="all">All</option>
+                            </select>
+                        </div>
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-!-font-weight-bold" for="caseOfficerFilter">Case officer</label>
+                            <select class="govuk-select" id="caseOfficerFilter"
+                            name="caseOfficerFilter" data-cy="filter-by-case-officer">
+                                <option value="all">All</option>
+                                <option value="0">Smith, John</option>
+                                <option value="1">Doe, Jane</option>
+                                <option value="2">Bloggs, Joe</option>
+                                <option value="3">Jenkins, Leeroy</option>
+                                <option value="4">McTest, George</option>
+                            </select>
+                        </div>
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-!-font-weight-bold" for="case-team-filter">Case team</label>
+                            <select class="govuk-select" id="case-team-filter" name="caseTeamFilter"
+                            data-cy="filter-by-case-team">
+                                <option value="all">All</option>
+                                <option value="1" selected>temp</option>
+                                <option value="2">temp2</option>
+                                <option value="3">temp3</option>
+                                <option value="4">temp4</option>
+                            </select>
+                        </div>
+                        <div class="govuk-form-group">
                             <label class="govuk-label govuk-!-font-weight-bold" for="inspectorFilter">Inspector</label>
                             <select class="govuk-select" id="inspectorFilter" name="inspectorFilter"
                             data-cy="filter-by-inspector">
@@ -627,6 +821,17 @@ exports[`national-list GET / should render national list - no pagination 1`] = `
                             name="caseOfficerFilter" data-cy="filter-by-case-officer">
                                 <option value="all">All</option>
                                 <option value="1">Doe, Jane</option>
+                            </select>
+                        </div>
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-!-font-weight-bold" for="case-team-filter">Case team</label>
+                            <select class="govuk-select" id="case-team-filter" name="caseTeamFilter"
+                            data-cy="filter-by-case-team">
+                                <option value="all">All</option>
+                                <option value="1">temp</option>
+                                <option value="2">temp2</option>
+                                <option value="3">temp3</option>
+                                <option value="4">temp4</option>
                             </select>
                         </div>
                         <div class="govuk-form-group">
@@ -799,6 +1004,17 @@ exports[`national-list GET / should render national list - no search term - filt
                             </select>
                         </div>
                         <div class="govuk-form-group">
+                            <label class="govuk-label govuk-!-font-weight-bold" for="case-team-filter">Case team</label>
+                            <select class="govuk-select" id="case-team-filter" name="caseTeamFilter"
+                            data-cy="filter-by-case-team">
+                                <option value="all">All</option>
+                                <option value="1">temp</option>
+                                <option value="2">temp2</option>
+                                <option value="3">temp3</option>
+                                <option value="4">temp4</option>
+                            </select>
+                        </div>
+                        <div class="govuk-form-group">
                             <label class="govuk-label govuk-!-font-weight-bold" for="inspectorFilter">Inspector</label>
                             <select class="govuk-select" id="inspectorFilter" name="inspectorFilter"
                             data-cy="filter-by-inspector">
@@ -960,6 +1176,17 @@ exports[`national-list GET / should render national list - search term - filter 
                             </select>
                         </div>
                         <div class="govuk-form-group">
+                            <label class="govuk-label govuk-!-font-weight-bold" for="case-team-filter">Case team</label>
+                            <select class="govuk-select" id="case-team-filter" name="caseTeamFilter"
+                            data-cy="filter-by-case-team">
+                                <option value="all">All</option>
+                                <option value="1">temp</option>
+                                <option value="2">temp2</option>
+                                <option value="3">temp3</option>
+                                <option value="4">temp4</option>
+                            </select>
+                        </div>
+                        <div class="govuk-form-group">
                             <label class="govuk-label govuk-!-font-weight-bold" for="inspectorFilter">Inspector</label>
                             <select class="govuk-select" id="inspectorFilter" name="inspectorFilter"
                             data-cy="filter-by-inspector">
@@ -1112,6 +1339,17 @@ exports[`national-list GET / should render national list - search term - no resu
                             </select>
                         </div>
                         <div class="govuk-form-group">
+                            <label class="govuk-label govuk-!-font-weight-bold" for="case-team-filter">Case team</label>
+                            <select class="govuk-select" id="case-team-filter" name="caseTeamFilter"
+                            data-cy="filter-by-case-team">
+                                <option value="all">All</option>
+                                <option value="1">temp</option>
+                                <option value="2">temp2</option>
+                                <option value="3">temp3</option>
+                                <option value="4">temp4</option>
+                            </select>
+                        </div>
+                        <div class="govuk-form-group">
                             <label class="govuk-label govuk-!-font-weight-bold" for="inspectorFilter">Inspector</label>
                             <select class="govuk-select" id="inspectorFilter" name="inspectorFilter"
                             data-cy="filter-by-inspector">
@@ -1235,6 +1473,17 @@ exports[`national-list GET / should render national list - search term 1`] = `
                             name="caseOfficerFilter" data-cy="filter-by-case-officer">
                                 <option value="all">All</option>
                                 <option value="1">Doe, Jane</option>
+                            </select>
+                        </div>
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-!-font-weight-bold" for="case-team-filter">Case team</label>
+                            <select class="govuk-select" id="case-team-filter" name="caseTeamFilter"
+                            data-cy="filter-by-case-team">
+                                <option value="all">All</option>
+                                <option value="1">temp</option>
+                                <option value="2">temp2</option>
+                                <option value="3">temp3</option>
+                                <option value="4">temp4</option>
                             </select>
                         </div>
                         <div class="govuk-form-group">
@@ -1398,6 +1647,17 @@ exports[`national-list GET / should render the header with navigation containing
                             name="caseOfficerFilter" data-cy="filter-by-case-officer">
                                 <option value="all">All</option>
                                 <option value="1">Doe, Jane</option>
+                            </select>
+                        </div>
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-!-font-weight-bold" for="case-team-filter">Case team</label>
+                            <select class="govuk-select" id="case-team-filter" name="caseTeamFilter"
+                            data-cy="filter-by-case-team">
+                                <option value="all">All</option>
+                                <option value="1">temp</option>
+                                <option value="2">temp2</option>
+                                <option value="3">temp3</option>
+                                <option value="4">temp4</option>
                             </select>
                         </div>
                         <div class="govuk-form-group">

--- a/appeals/web/src/server/appeals/national-list/__tests__/national-list.test.js
+++ b/appeals/web/src/server/appeals/national-list/__tests__/national-list.test.js
@@ -4,7 +4,8 @@ import supertest from 'supertest';
 import {
 	activeDirectoryUsersData,
 	appealsNationalList,
-	appealTypesData
+	appealTypesData,
+	caseTeams
 } from '#testing/app/fixtures/referencedata.js';
 import { createTestEnvironment } from '#testing/index.js';
 import usersService from '#appeals/appeal-users/users-service.js';
@@ -50,6 +51,7 @@ describe('national-list', () => {
 		installMockApi();
 
 		nock('http://test/').get('/appeals/appeal-types').reply(200, appealTypesData);
+		nock('http://test/').get('/appeals/case-teams').reply(200, caseTeams);
 
 		// @ts-ignore
 		usersService.getUserById = jest
@@ -99,6 +101,7 @@ describe('national-list', () => {
 			expect(unprettifiedElement.innerHTML).toContain('Site address</th>');
 			expect(unprettifiedElement.innerHTML).toContain('Local planning authority (LPA)</th>');
 			expect(unprettifiedElement.innerHTML).toContain('Appeal type</th>');
+			expect(unprettifiedElement.innerHTML).toContain('Case team');
 			expect(unprettifiedElement.innerHTML).toContain('Status</th>');
 		});
 
@@ -116,6 +119,18 @@ describe('national-list', () => {
 			);
 			expect(unprettifiedElement.innerHTML).toContain('CAS advert</option>');
 			expect(unprettifiedElement.innerHTML).toContain('CAS planning</option>');
+		});
+
+		it('should render correct case teams dropdown in filters', async () => {
+			nock('http://test/').get('/appeals?pageNumber=1&pageSize=30').reply(200, appealsNationalList);
+
+			const response = await request.get(baseUrl);
+			const unprettifiedElement = parseHtml(response.text, { skipPrettyPrint: true });
+
+			expect(unprettifiedElement.innerHTML).toContain('All</option>');
+			expect(unprettifiedElement.innerHTML).toContain('temp</option>');
+			expect(unprettifiedElement.innerHTML).toContain('temp2</option>');
+			expect(unprettifiedElement.innerHTML).toContain('temp3</option>');
 		});
 
 		it('should render national list - search term', async () => {
@@ -338,6 +353,39 @@ describe('national-list', () => {
 				'<select class="govuk-select" id="appeal-type-filter" name="appealTypeFilter"'
 			);
 			expect(unprettifiedElement.innerHTML).toContain('<option value="75" selected');
+			expect(unprettifiedElement.innerHTML).toContain('Apply filters</button>');
+			expect(unprettifiedElement.innerHTML).toContain('Clear filters</a>');
+		});
+
+		it('should render national list - case team filter applied', async () => {
+			nock('http://test/')
+				.get('/appeals?pageNumber=1&pageSize=30&assignedTeamId=1')
+				.reply(200, {
+					itemCount: 1,
+					items: [appealsNationalList.items[0]],
+					statuses,
+					lpas,
+					inspectors,
+					caseOfficers,
+					page: 1,
+					pageCount: 0,
+					pageSize: 30
+				});
+
+			const response = await request.get(`${baseUrl}?caseTeamFilter=1`);
+			const element = parseHtml(response.text);
+
+			expect(element.innerHTML).toMatchSnapshot();
+			expect(element.innerHTML).toContain('Search all cases</h1>');
+
+			const unprettifiedElement = parseHtml(response.text, { skipPrettyPrint: true });
+
+			expect(unprettifiedElement.innerHTML).toContain('1 result (filters applied)</h2>');
+			expect(unprettifiedElement.innerHTML).toContain('Case team</label>');
+			expect(unprettifiedElement.innerHTML).toContain(
+				'<select class="govuk-select" id="case-team-filter" name="caseTeamFilter" data-cy="filter-by-case-team">'
+			);
+			expect(unprettifiedElement.innerHTML).toContain('<option value="1" selected');
 			expect(unprettifiedElement.innerHTML).toContain('Apply filters</button>');
 			expect(unprettifiedElement.innerHTML).toContain('Clear filters</a>');
 		});

--- a/appeals/web/src/server/appeals/national-list/national-list.controller.js
+++ b/appeals/web/src/server/appeals/national-list/national-list.controller.js
@@ -6,6 +6,7 @@ import { getAppeals, getAppealTypes } from './national-list.service.js';
 import { getPaginationParametersFromQuery } from '#lib/pagination-utilities.js';
 import { mapPagination } from '#lib/mappers/index.js';
 import { stripQueryString } from '#lib/url-utilities.js';
+import { getTeamList } from '#appeals/appeal-details/update-case-team/update-case-team.service.js';
 
 /** @typedef {import('@pins/appeals').Pagination} Pagination */
 
@@ -39,6 +40,7 @@ export const viewNationalList = async (request, response) => {
 	const inspectorFilter = query.inspectorFilter && String(query.inspectorFilter);
 	const greenBeltFilter = query.greenBeltFilter && String(query.greenBeltFilter);
 	const appealTypeFilter = query.appealTypeFilter && String(query.appealTypeFilter);
+	const caseTeamFilter = query.caseTeamFilter && String(query.caseTeamFilter);
 	let searchTerm = query?.searchTerm ? String(query.searchTerm).trim() : '';
 	let searchTermError = '';
 
@@ -62,6 +64,7 @@ export const viewNationalList = async (request, response) => {
 		inspectorFilter,
 		greenBeltFilter,
 		appealTypeFilter,
+		caseTeamFilter,
 		paginationParameters.pageNumber,
 		paginationParameters.pageSize
 	).catch((error) => logger.error(error));
@@ -80,11 +83,12 @@ export const viewNationalList = async (request, response) => {
 			};
 		})
 	);
-
+	const caseTeams = await getTeamList(request.apiClient);
 	const mappedPageContent = nationalListPage(
 		users,
 		appeals,
 		appealTypes,
+		caseTeams,
 		urlWithoutQuery,
 		searchTerm,
 		searchTermError,
@@ -94,6 +98,7 @@ export const viewNationalList = async (request, response) => {
 		caseOfficerFilter,
 		inspectorFilter,
 		appealTypeFilter,
+		caseTeamFilter,
 		greenBeltFilter
 	);
 

--- a/appeals/web/src/server/appeals/national-list/national-list.mapper.js
+++ b/appeals/web/src/server/appeals/national-list/national-list.mapper.js
@@ -16,6 +16,7 @@ import { APPEAL_CASE_TYPE } from '@planning-inspectorate/data-model';
  * @param {{azureAdUserId: string, id: number, name: string}[]} users
  * @param {AppealList|void} appeals
  * @param {AppealType[]} appealTypes
+ * @param {import('@pins/appeals.api').Api.CaseTeams} caseTeams
  * @param {string} urlWithoutQuery
  * @param {string|undefined} searchTerm
  * @param {string|undefined} searchTermError
@@ -25,6 +26,7 @@ import { APPEAL_CASE_TYPE } from '@planning-inspectorate/data-model';
  * @param {string|undefined} caseOfficerFilter
  * @param {string|undefined} inspectorFilter
  * @param {string|undefined} appealTypeFilter
+ * @param {string|undefined} caseTeamFilter
  * @param {string|undefined} greenBeltFilter
  * @returns {PageContent}
  */
@@ -33,6 +35,7 @@ export function nationalListPage(
 	users,
 	appeals,
 	appealTypes,
+	caseTeams,
 	urlWithoutQuery,
 	searchTerm,
 	searchTermError,
@@ -42,11 +45,13 @@ export function nationalListPage(
 	caseOfficerFilter,
 	inspectorFilter,
 	appealTypeFilter,
+	caseTeamFilter,
 	greenBeltFilter
 ) {
 	const filtersApplied =
 		greenBeltFilter ||
 		appealTypeFilter ||
+		caseTeamFilter ||
 		[
 			appealStatusFilter,
 			inspectorStatusFilter,
@@ -131,6 +136,19 @@ export function nationalListPage(
 				value: id.toString(),
 				selected: appealTypeFilter === id.toString()
 			}))
+	];
+
+	const caseTeamFilterItemsArray = [
+		{
+			text: 'All',
+			value: 'all',
+			selected: caseTeamFilter === 'all'
+		},
+		...caseTeams.map(({ name, id }) => ({
+			text: name,
+			value: id,
+			selected: caseTeamFilter === id?.toString()
+		}))
 	];
 
 	let searchResultsHeader = '';
@@ -353,6 +371,20 @@ export function nationalListPage(
 							value: 'all',
 							items: caseOfficerFilterItemsArray,
 							attributes: { 'data-cy': 'filter-by-case-officer' }
+						}
+					},
+					{
+						type: 'select',
+						parameters: {
+							name: 'caseTeamFilter',
+							id: 'case-team-filter',
+							label: {
+								classes: 'govuk-!-font-weight-bold',
+								text: 'Case team'
+							},
+							value: 'all',
+							items: caseTeamFilterItemsArray,
+							attributes: { 'data-cy': 'filter-by-case-team' }
 						}
 					},
 					{

--- a/appeals/web/src/server/appeals/national-list/national-list.service.js
+++ b/appeals/web/src/server/appeals/national-list/national-list.service.js
@@ -12,6 +12,7 @@ import { paginationDefaultSettings } from '../appeal.constants.js';
  * @param {string|undefined} inspectorFilter
  * @param {string|undefined} greenBeltFilter
  * @param {string|undefined} appealTypeFilter
+ * @param {string|undefined} caseTeamFilter
  * @param {number} pageNumber
  * @param {number} pageSize
  * @returns {Promise<AppealList>}
@@ -26,6 +27,7 @@ export const getAppeals = (
 	inspectorFilter,
 	greenBeltFilter,
 	appealTypeFilter,
+	caseTeamFilter,
 	pageNumber = paginationDefaultSettings.firstPageNumber,
 	pageSize = paginationDefaultSettings.pageSize
 ) => {
@@ -65,6 +67,9 @@ export const getAppeals = (
 
 	if (appealTypeFilter && appealTypeFilter !== 'all') {
 		urlAppendix += `&appealTypeId=${appealTypeFilter}`;
+	}
+	if (caseTeamFilter && caseTeamFilter !== 'all') {
+		urlAppendix += `&assignedTeamId=${caseTeamFilter}`;
 	}
 
 	return apiClient

--- a/appeals/web/src/server/lib/mappers/data/appeal/submappers/team.mapper.js
+++ b/appeals/web/src/server/lib/mappers/data/appeal/submappers/team.mapper.js
@@ -8,11 +8,13 @@ export const mapCaseTeam = ({ appealDetails, currentRoute, userHasUpdateCasePerm
 			: true;
 	const teamRowValue = `
         <ul class="govuk-list">
-            ${
-							appealDetails.assignedTeam?.name && appealDetails.assignedTeam?.email
-								? `<li>${appealDetails.assignedTeam.name}</li><li>${appealDetails.assignedTeam.email}</li>`
-								: `<li>Not assigned</li>`
-						}
+            ${appealDetails.assignedTeam?.name ? `<li>${appealDetails.assignedTeam.name}</li>` : ``}
+			${appealDetails.assignedTeam?.email ? `<li>${appealDetails.assignedTeam.email}</li>` : ``}
+			${
+				!appealDetails.assignedTeam?.email && !appealDetails.assignedTeam?.name
+					? `<li>Not assigned</li>`
+					: ``
+			}
         </ul>
     `.trim();
 

--- a/appeals/web/testing/app/fixtures/referencedata.js
+++ b/appeals/web/testing/app/fixtures/referencedata.js
@@ -192,6 +192,12 @@ export const appealsNationalList = {
 	lpas: [{ lpaCode: '1', name: 'Test LPA' }],
 	inspectors: [{ azureAdUserId: activeDirectoryUsersData[0].id, id: 0 }],
 	caseOfficers: [{ azureAdUserId: activeDirectoryUsersData[1].id, id: 1 }],
+	assignedTeamId: 1,
+	assignedTeam: {
+		id: 1,
+		name: 'test',
+		email: 'test@email.com'
+	},
 	page: 1,
 	pageCount: 1,
 	pageSize: 30
@@ -4375,5 +4381,10 @@ export const caseTeams = [
 		id: 3,
 		email: 'temp3@email.com',
 		name: 'temp3'
+	},
+	{
+		id: 4,
+		email: null,
+		name: 'temp4'
 	}
 ];


### PR DESCRIPTION
## Describe your changes

### API
- added new seed function to assign teams to appeals according to lpa assignments - included some null mappings to have unassigned appeals when seeding
- updated production see data to match ticket 
- updated dev seed data so that different scenarios could be tested locally  
- updated appeals endpoint to filter or assignedTeamId
- updated unit tests to cover filtering  on assignedTeamId

### WEB

- added casse team filter to national list page
- added new unite tests and snapshots for national list to cover changes 
- updated submapper and CYA page to cover logic for null emails of teams
- updated unit test and snapshots  
- added new tests for filtering on assignedTeamId 
- added tests to cover scenarios for CYA and appeal details page

## Issue ticket number and link

[Ticket](https://pins-ds.atlassian.net.mcas.ms/browse/A2-3721)
