### PR TITLE
fix(appeals): prevent reviewing lpa questionnaire loop for linked appeals (a2-3630)

### DIFF
--- a/appeals/api/src/server/endpoints/appellant-cases/appellant-cases.service.js
+++ b/appeals/api/src/server/endpoints/appellant-cases/appellant-cases.service.js
@@ -30,7 +30,7 @@ import { APPEAL_TYPE } from '@pins/appeals/constants/common.js';
 import auditApplicationDecisionMapper from '#utils/audit-application-decision-mapper.js';
 import { isLinkedAppeal } from '#utils/is-linked-appeal.js';
 import { buildListOfLinkedAppeals } from '#utils/build-list-of-linked-appeals.js';
-import { allValidationOutcomesAreComplete } from '#utils/is-awaiting-linked-appeal.js';
+import { allAppellantCaseOutcomesAreValid } from '#utils/is-awaiting-linked-appeal.js';
 import { AUDIT_TRAIL_SUBMISSION_INVALID } from '@pins/appeals/constants/support.js';
 import { formatReasonsToHtmlList } from '#utils/format-reasons-to-html-list.js';
 
@@ -85,7 +85,7 @@ export const updateAppellantCaseValidationOutcome = async (
 		} else {
 			// @ts-ignore
 			const linkedAppeals = await buildListOfLinkedAppeals(appeal);
-			if (allValidationOutcomesAreComplete(linkedAppeals)) {
+			if (allAppellantCaseOutcomesAreValid(linkedAppeals, appealId, validationOutcome)) {
 				await Promise.all(
 					linkedAppeals.map((appeal) => {
 						const validationOutcome = appeal.appellantCase?.appellantCaseValidationOutcome;

--- a/appeals/api/src/server/endpoints/lpa-questionnaires/lpa-questionnaires.service.js
+++ b/appeals/api/src/server/endpoints/lpa-questionnaires/lpa-questionnaires.service.js
@@ -92,7 +92,7 @@ const updateLPAQuestionnaireValidationOutcome = async (
 			await transitionState(appealId, azureAdUserId, validationOutcome.name);
 		} else {
 			const linkedAppeals = await buildListOfLinkedAppeals(appeal);
-			if (allLpaQuestionnaireOutcomesAreComplete(linkedAppeals)) {
+			if (allLpaQuestionnaireOutcomesAreComplete(linkedAppeals, appealId, validationOutcome)) {
 				await Promise.all(
 					linkedAppeals.map((appeal) => {
 						const validationOutcome = appeal.lpaQuestionnaire?.lpaQuestionnaireValidationOutcome;

--- a/appeals/api/src/server/utils/__tests__/is-awaiting-linked-appeal.test.js
+++ b/appeals/api/src/server/utils/__tests__/is-awaiting-linked-appeal.test.js
@@ -1,5 +1,9 @@
 // @ts-nocheck
-import { isAwaitingLinkedAppeal } from '#utils/is-awaiting-linked-appeal.js';
+import {
+	allAppellantCaseOutcomesAreValid,
+	allLpaQuestionnaireOutcomesAreComplete,
+	isAwaitingLinkedAppeal
+} from '#utils/is-awaiting-linked-appeal.js';
 
 describe('isAwaitingLinkedAppeal', () => {
 	let appeal;
@@ -88,5 +92,107 @@ describe('isAwaitingLinkedAppeal', () => {
 				])
 			).toBe(false);
 		});
+	});
+});
+
+describe('allLpaQuestionnaireOutcomesAreComplete', () => {
+	test('returns true when there are no linked appeals', () => {
+		expect(allLpaQuestionnaireOutcomesAreComplete([])).toBe(true);
+	});
+
+	test('returns true when all the linked appeals are complete', () => {
+		expect(
+			allLpaQuestionnaireOutcomesAreComplete([
+				{
+					id: 1,
+					lpaQuestionnaire: { lpaQuestionnaireValidationOutcome: { name: 'complete' } }
+				},
+				{
+					id: 2,
+					lpaQuestionnaire: { lpaQuestionnaireValidationOutcome: { name: 'complete' } }
+				}
+			])
+		).toBe(true);
+	});
+
+	test('returns false when at least one of the linked appeals is not complete', () => {
+		expect(
+			allLpaQuestionnaireOutcomesAreComplete([
+				{
+					id: 1
+				},
+				{
+					id: 2,
+					lpaQuestionnaire: { lpaQuestionnaireValidationOutcome: { name: 'complete' } }
+				}
+			])
+		).toBe(false);
+	});
+
+	test('returns true when all the linked appeals are complete, making sure the current linked appeal is updated with the latest outcome', () => {
+		const linkedAppeals = [
+			{
+				id: 1
+			},
+			{
+				id: 2,
+				lpaQuestionnaire: { lpaQuestionnaireValidationOutcome: { name: 'complete' } }
+			}
+		];
+		expect(allLpaQuestionnaireOutcomesAreComplete(linkedAppeals, 1, { name: 'complete' })).toBe(
+			true
+		);
+		expect(linkedAppeals[0].lpaQuestionnaire.lpaQuestionnaireValidationOutcome.name).toBe(
+			'complete'
+		);
+	});
+});
+
+describe('allAppellantCaseOutcomesAreComplete', () => {
+	test('returns true when there are no linked appeals', () => {
+		expect(allAppellantCaseOutcomesAreValid([])).toBe(true);
+	});
+
+	test('returns true when all the linked appeals are valid', () => {
+		expect(
+			allAppellantCaseOutcomesAreValid([
+				{
+					id: 1,
+					appellantCase: { appellantCaseValidationOutcome: { name: 'valid' } }
+				},
+				{
+					id: 2,
+					appellantCase: { appellantCaseValidationOutcome: { name: 'valid' } }
+				}
+			])
+		).toBe(true);
+	});
+
+	test('returns false when at least one of the linked appeals is not valid', () => {
+		expect(
+			allAppellantCaseOutcomesAreValid([
+				{
+					id: 1
+				},
+				{
+					id: 2,
+					appellantCase: { appellantCaseValidationOutcome: { name: 'valid' } }
+				}
+			])
+		).toBe(false);
+	});
+
+	test('returns true when all the linked appeals are valid, making sure the current linked appeal is updated with the latest outcome', () => {
+		const linkedAppeals = [
+			{
+				id: 1
+			},
+			{
+				id: 2,
+				appellantCase: { appellantCaseValidationOutcome: { name: 'valid' } }
+			}
+		];
+		expect(allAppellantCaseOutcomesAreValid(linkedAppeals, 1, { name: 'valid' })).toBe(true);
+		expect(linkedAppeals[0].appellantCase.appellantCaseValidationOutcome.name).toBe('valid');
 	});
 });

--- a/appeals/api/src/server/utils/is-awaiting-linked-appeal.js
+++ b/appeals/api/src/server/utils/is-awaiting-linked-appeal.js
@@ -19,7 +19,7 @@ export const isAwaitingLinkedAppeal = (appeal, linkedAppeals) => {
 			if (validationOutcome !== 'valid') {
 				return false;
 			}
-			return !allValidationOutcomesAreComplete(linkedAppeals);
+			return !allAppellantCaseOutcomesAreValid(linkedAppeals);
 		}
 		case APPEAL_CASE_STATUS.LPA_QUESTIONNAIRE: {
 			const validationOutcome =
@@ -38,9 +38,15 @@ export const isAwaitingLinkedAppeal = (appeal, linkedAppeals) => {
 /**
  *
  * @param {*[]} linkedAppeals
+ * @param {number|undefined} [currentAppealId]
+ * @param {*} [validationOutcome]
  * @returns {*|boolean}
  */
-export const allLpaQuestionnaireOutcomesAreComplete = (linkedAppeals) => {
+export const allLpaQuestionnaireOutcomesAreComplete = (
+	linkedAppeals,
+	currentAppealId,
+	validationOutcome
+) => {
 	if (!linkedAppeals.length) {
 		return true;
 	}
@@ -48,18 +54,31 @@ export const allLpaQuestionnaireOutcomesAreComplete = (linkedAppeals) => {
 	return linkedAppeals.every((linkedAppeal) => {
 		// Make sure the linked appeal is the actual appeal and not a wrapper
 		const appeal = linkedAppeal.appeal || linkedAppeal;
-		const validationOutcome =
-			appeal.lpaQuestionnaire?.lpaQuestionnaireValidationOutcome?.name?.toLowerCase();
-		return validationOutcome === 'complete';
+		if (currentAppealId && appeal.id === currentAppealId) {
+			// Make sure the current linked appeal tests the latest validation outcome
+			if (!appeal.lpaQuestionnaire) {
+				appeal.lpaQuestionnaire = {};
+			}
+			appeal.lpaQuestionnaire.lpaQuestionnaireValidationOutcome = validationOutcome;
+		}
+		return (
+			appeal.lpaQuestionnaire?.lpaQuestionnaireValidationOutcome?.name?.toLowerCase() === 'complete'
+		);
 	});
 };
 
 /**
  *
  * @param {*[]} linkedAppeals
+ * @param {number|undefined} [currentAppealId]
+ * @param {*} [validationOutcome]
  * @returns {*|boolean}
  */
-export const allValidationOutcomesAreComplete = (linkedAppeals) => {
+export const allAppellantCaseOutcomesAreValid = (
+	linkedAppeals,
+	currentAppealId,
+	validationOutcome
+) => {
 	if (!linkedAppeals.length) {
 		return true;
 	}
@@ -67,9 +86,14 @@ export const allValidationOutcomesAreComplete = (linkedAppeals) => {
 	return linkedAppeals.every((linkedAppeal) => {
 		// Make sure the linked appeal is the actual appeal and not a wrapper
 		const appeal = linkedAppeal.appeal || linkedAppeal;
-		const validationOutcome =
-			appeal.appellantCase?.appellantCaseValidationOutcome?.name?.toLowerCase();
-		return validationOutcome === 'valid';
+		if (currentAppealId && appeal.id === currentAppealId) {
+			// Make sure the current linked appeal tests the latest validation outcome
+			if (!appeal.appellantCase) {
+				appeal.appellantCase = {};
+			}
+			appeal.appellantCase.appellantCaseValidationOutcome = validationOutcome;
+		}
+		return appeal.appellantCase?.appellantCaseValidationOutcome?.name?.toLowerCase() === 'valid';
 	});
 };
 


### PR DESCRIPTION
## Describe your changes
### Prevent reviewing LPA questionnaire and Appellant case validation loops for linked appeals (a2-3630)
#### Without these changes, sometimes the linked appeals end up in limbo without being able to progress them to the next status even though all of the LPA Questionnaires have been reviewed or all the Appellant cases have been validated.

### API:
- Make sure the review outcome current appeal LPA Questionnaire is included correctly when testing that all linked appeals have had their review completed so that the transition to the next appeal status works as it should.
- Make sure the review outcome current appeal Appellant Case is included correctly when testing that all linked appeals have had their review validated so that the transition to the next appeal status works as it should.

### Tests:
- Added detailed unit tests to test the above functionality
- Made sure all unit tests pass
- Tested within browser

## Issue ticket number and link
[A2-3630 Reviewing questionnaires for linked written rep S78 planning appeals (where the appeals have all been started together)](https://pins-ds.atlassian.net/browse/A2-3630)
