### PR TITLE
fix(appeals): viewing issue decisions for linked appeals (a2-4236)

### DIFF
--- a/appeals/web/src/server/appeals/appeal-details/issue-decision/issue-decision.utils.js
+++ b/appeals/web/src/server/appeals/appeal-details/issue-decision/issue-decision.utils.js
@@ -4,7 +4,7 @@ import {
 	DECISION_TYPE_LPA_COSTS
 } from '@pins/appeals/constants/support.js';
 import { appealShortReference } from '#lib/appeals-formatter.js';
-import isLinkedAppeal from '#lib/mappers/utils/is-linked-appeal.js';
+import isLinkedAppeal, { isChildAppeal } from '#lib/mappers/utils/is-linked-appeal.js';
 import { getSavedBackUrl } from '#lib/middleware/save-back-url.js';
 
 /**
@@ -139,6 +139,6 @@ export function issueDecisionBackUrl(currentAppeal, childAppealId, request) {
  */
 export function preHeadingText(currentAppeal, captionSuffix = '') {
 	return `Appeal ${appealShortReference(currentAppeal.appealReference)}${
-		isLinkedAppeal(currentAppeal) ? ' (lead)' : ''
+		isLinkedAppeal(currentAppeal) ? (isChildAppeal(currentAppeal) ? ' (child)' : ' (lead)') : ''
 	}${captionSuffix ? ' - ' + captionSuffix : ''}`;
 }

--- a/appeals/web/src/server/appeals/appeal-details/status-tags/status-tags.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/status-tags/status-tags.mapper.js
@@ -9,7 +9,6 @@ import config from '#environment/config.js';
 import { generateDecisionDocumentDownloadHtml } from '#lib/mappers/data/appeal/common.js';
 import { getInvalidStatusCreatedDate } from '../invalid-appeal/invalid-appeal.service.js';
 import { toSentenceCase } from '#lib/string-utilities.js';
-import { isChildAppeal } from '#lib/mappers/utils/is-linked-appeal.js';
 import { addBackLinkQueryToUrl } from '#lib/url-utilities.js';
 
 /**
@@ -112,14 +111,7 @@ export const generateStatusTags = async (mappedData, appealDetails, request) => 
 
 		if (appealDetails.decision?.outcome || hasCostsAppellantDecision || hasCostsLpaDecision) {
 			if (config.featureFlags.featureFlagIssueDecision) {
-				let appealId = appealDetails.appealId;
-				if (isChildAppeal(appealDetails)) {
-					// @ts-ignore
-					appealId = appealDetails.linkedAppeals.find(
-						(appealDetails) => appealDetails.isParentAppeal
-					)?.appealId;
-				}
-				insetTextRows.push(getViewDecisionLink(appealId, request));
+				insetTextRows.push(getViewDecisionLink(appealDetails.appealId, request));
 			} else {
 				insetTextRows.push(getViewDecisionLinkOld(appealDetails));
 			}

--- a/appeals/web/src/server/appeals/appeal-documents/appeal.documents.service.js
+++ b/appeals/web/src/server/appeals/appeal-documents/appeal.documents.service.js
@@ -40,6 +40,23 @@ export const getFolder = async (apiClient, appealId, folderId, repId) => {
 
 /**
  * @param {import('got').Got} apiClient
+ * @param {string|number} appealId
+ * @param {string} folderPath
+ * @returns {Promise<FolderInfo|undefined>}
+ * */
+export const getAttachmentsFolder = async (apiClient, appealId, folderPath) => {
+	const folders = await apiClient
+		.get(`appeals/${appealId}/document-folders?path=${folderPath}`)
+		.json();
+	if (!(folders && folders.length > 0)) {
+		throw new Error(`failed to find folder for appeal ID ${appealId}`);
+	}
+
+	return folders[0];
+};
+
+/**
+ * @param {import('got').Got} apiClient
  * @param {string} appealId
  * @param {string} fileGuid
  * @returns {Promise<DocumentInfo|undefined>}


### PR DESCRIPTION
## Describe your changes

### WEB:
- viewing issue decision for lead appeal
- viewing issue decision for child appeal

### TEST:
- added unit tests for above
- all other unit tests pass
- tested in browser

## Issue ticket number and link

[A2-4236 - BO - Issuing a decision for linked appeals (relates to all appeal types) - 'Decision' screen on lead and child appeals after decision(s) issued - Part 11](https://pins-ds.atlassian.net/browse/A2-4236)
