### PR TITLE
feat(appeals): case details page for child after issue decision (a2-4215)

### DIFF
--- a/appeals/web/src/server/lib/mappers/data/appeal/submappers/__tests__/decision-mapper.test.js
+++ b/appeals/web/src/server/lib/mappers/data/appeal/submappers/__tests__/decision-mapper.test.js
@@ -1,0 +1,113 @@
+// @ts-nocheck
+import { mapDecision } from '#lib/mappers/data/appeal/submappers/decision.mapper.js';
+
+const expectedViewDecisionRow = (params) => ({
+	id: 'decision',
+	display: {
+		summaryListItem: {
+			actions: {
+				items: [
+					{
+						attributes: {
+							'data-cy': 'view-decision'
+						},
+						href: `/appeals-service/appeal-details/1/issue-decision/view-decision?backUrl=${encodeURIComponent(
+							params.request.originalUrl
+						)}`,
+						text: 'View',
+						visuallyHiddenText: 'Decision'
+					}
+				]
+			},
+			classes: 'appeal-decision',
+			key: {
+				text: 'Decision'
+			},
+			value: {
+				text: 'Split decision'
+			}
+		}
+	}
+});
+
+const expectedIssueDecisionRow = (params) => ({
+	id: 'decision',
+	display: {
+		summaryListItem: {
+			actions: {
+				items: [
+					{
+						attributes: {
+							'data-cy': 'issue-decision'
+						},
+						href: `/appeals-service/appeal-details/1/issue-decision/decision?backUrl=${encodeURIComponent(
+							params.request.originalUrl
+						)}`,
+						text: 'Issue',
+						visuallyHiddenText: 'Decision'
+					}
+				]
+			},
+			classes: 'appeal-decision',
+			key: {
+				text: 'Decision'
+			},
+			value: {
+				text: 'Not issued'
+			}
+		}
+	}
+});
+
+const expectedEmptyDecisionRow = {
+	id: 'decision',
+	display: {}
+};
+
+const setCaseOutcome = (params) => {
+	params.appealDetails.appealStatus = 'complete';
+	params.completedStateList = ['awaiting_event', 'issue_determination'];
+	params.appealDetails.decision = { outcome: 'Split decision' };
+};
+
+describe('decision-mapper', () => {
+	let params;
+
+	beforeEach(() => {
+		params = {
+			appealDetails: {
+				appealId: 1,
+				appealStatus: 'issue_determination',
+				completedStateList: ['awaiting_event']
+			},
+			session: { permissions: { setCaseOutcome: true } },
+			request: { originalUrl: '/original-url' }
+		};
+	});
+
+	describe('for unlinked or lead linked appeal', () => {
+		it('Should display decision row with issue decision link', () => {
+			expect(mapDecision(params)).toEqual(expectedIssueDecisionRow(params));
+		});
+
+		it('Should display decision row with view decision link', () => {
+			setCaseOutcome(params);
+			expect(mapDecision(params)).toEqual(expectedViewDecisionRow(params));
+		});
+	});
+
+	describe('for child linked appeal', () => {
+		beforeEach(() => {
+			params.appealDetails.isChildAppeal = true;
+		});
+
+		it('Should not display decision row with issue decision link', () => {
+			expect(mapDecision(params)).toEqual(expectedEmptyDecisionRow);
+		});
+
+		it('Should display decision row with view decision link', () => {
+			setCaseOutcome(params);
+			expect(mapDecision(params)).toEqual(expectedViewDecisionRow(params));
+		});
+	});
+});

--- a/appeals/web/src/server/lib/mappers/data/appeal/submappers/decision.mapper.js
+++ b/appeals/web/src/server/lib/mappers/data/appeal/submappers/decision.mapper.js
@@ -17,7 +17,7 @@ export const mapDecision = ({ appealDetails, session, request }) => {
 	const { appealId, appealStatus, decision } = appealDetails;
 
 	if (
-		isChildAppeal(appealDetails) ||
+		(isChildAppeal(appealDetails) && !decision?.outcome) ||
 		!isStatePassed(appealDetails, APPEAL_CASE_STATUS.AWAITING_EVENT)
 	) {
 		return { id: 'decision', display: {} };


### PR DESCRIPTION
## Describe your changes
####  Updates to case details page for child linked appeal after issue decision (a2-4215)

### WEB:
- Allow decision row to be visible with view link when decision has been made whether the appeal is unlinked, linked lead, or linked child
- Only display row with issue link when decision has not been made and the appeal is not a linked child

### TEST:
- created missing decision row unit tests including above changes
- all other unit tests pass
- tested in browser

## Issue ticket number and link

[A2-4215- BO - Issuing a decision for linked appeals (relates to all appeal types) - Updates to 'Case details' screen on child appeal(s) after decision(s) issued - Part 10](https://pins-ds.atlassian.net/browse/A2-4215)
