### PR TITLE
fix(appeals): do not include related appeals in notifies (a2-3492)

### DIFF
--- a/appeals/api/src/server/endpoints/appeal-timetables/appeal-timetables.service.js
+++ b/appeals/api/src/server/endpoints/appeal-timetables/appeal-timetables.service.js
@@ -11,7 +11,8 @@ import {
 	AUDIT_TRAIL_CASE_TIMELINE_CREATED,
 	AUDIT_TRAIL_TIMETABLE_DUE_DATE_CHANGED,
 	AUDIT_TRAIL_SYSTEM_UUID,
-	ERROR_NOT_FOUND
+	ERROR_NOT_FOUND,
+	CASE_RELATIONSHIP_LINKED
 } from '@pins/appeals/constants/support.js';
 import transitionState from '#state/transition-state.js';
 import formatDate, { dateISOStringToDisplayDate } from '@pins/appeals/utils/date-formatter.js';
@@ -126,7 +127,10 @@ const sendStartCaseNotifies = async (
 		lpa_statement_deadline: formatDate(new Date(timetable.lpaStatementDueDate || ''), false),
 		ip_comments_deadline: formatDate(new Date(timetable.ipCommentsDueDate || ''), false),
 		final_comments_deadline: formatDate(new Date(timetable.finalCommentsDueDate || ''), false),
-		child_appeals: appeal.childAppeals?.map((appeal) => appeal.childRef) || []
+		child_appeals:
+			appeal.childAppeals
+				?.filter((appeal) => appeal.type === CASE_RELATIONSHIP_LINKED)
+				.map((appeal) => appeal.childRef) || []
 	};
 
 	if (appellantEmail) {


### PR DESCRIPTION
## Describe your changes
#### Do not include related appeals in notifies (a2-3492)

### WEB:
- Make sure only linked appeals are listed in the notify

### TEST:
- added unit tests for above
- all other unit tests pass
- tested in browser and email emulator

## Issue ticket number and link

[A2-3492- Starting linked written rep S78 planning appeals (where none have previously been started) and automated Notifies are sent - part 2](https://pins-ds.atlassian.net/browse/A2-3492?focusedCommentId=94525)
