### PR TITLE
feat(appeals): update issue decision notifies (a2-4210)

### DIFF
--- a/appeals/api/src/server/endpoints/decision/__tests__/decision.test.js
+++ b/appeals/api/src/server/endpoints/decision/__tests__/decision.test.js
@@ -22,7 +22,8 @@ import {
 	AUDIT_TRAIL_PROGRESSED_TO_STATUS,
 	DECISION_TYPE_INSPECTOR,
 	DECISION_TYPE_APPELLANT_COSTS,
-	DECISION_TYPE_LPA_COSTS
+	DECISION_TYPE_LPA_COSTS,
+	CASE_RELATIONSHIP_LINKED
 } from '@pins/appeals/constants/support.js';
 import { APPEAL_CASE_STATUS } from '@planning-inspectorate/data-model';
 import {
@@ -250,6 +251,7 @@ describe('decision routes', () => {
 				notifyClient: expect.any(Object),
 				personalisation: {
 					appeal_reference_number: appeal.reference,
+					child_appeals: [],
 					lpa_reference: appeal.applicationReference,
 					site_address: `${appeal.address.addressLine1}, ${appeal.address.addressLine2}, ${appeal.address.addressTown}, ${appeal.address.addressCounty}, ${appeal.address.postcode}, ${appeal.address.addressCountry}`,
 					decision_date: formatDate(utcDate, false),
@@ -264,6 +266,7 @@ describe('decision routes', () => {
 				notifyClient: expect.any(Object),
 				personalisation: {
 					appeal_reference_number: appeal.reference,
+					child_appeals: [],
 					lpa_reference: appeal.applicationReference,
 					site_address: `${appeal.address.addressLine1}, ${appeal.address.addressLine2}, ${appeal.address.addressTown}, ${appeal.address.addressCounty}, ${appeal.address.postcode}, ${appeal.address.addressCountry}`,
 					decision_date: formatDate(utcDate, false),
@@ -475,7 +478,12 @@ describe('decision routes', () => {
 			const withoutWeekends = await recalculateDateIfNotBusinessDay(tenDaysAgo.toISOString());
 			const utcDate = setTimeInTimeZone(withoutWeekends, 0, 0);
 			const outcome = 'allowed';
-			const linkedAppeal = { appealId: 4, inspectorDecision: outcome };
+			const childAppeal = {
+				appealId: 4,
+				childRef: 'CHILD123',
+				inspectorDecision: outcome,
+				type: CASE_RELATIONSHIP_LINKED
+			};
 			const appeal = {
 				...fullPlanningAppeal,
 				isChildAppeal: true,
@@ -485,7 +493,7 @@ describe('decision routes', () => {
 						valid: true
 					}
 				],
-				linkedAppeals: [linkedAppeal]
+				childAppeals: [childAppeal]
 			};
 
 			// @ts-ignore
@@ -506,7 +514,7 @@ describe('decision routes', () => {
 							documentGuid: documentCreated.guid
 						},
 						{
-							appealId: linkedAppeal.appealId,
+							appealId: childAppeal.appealId,
 							decisionType: DECISION_TYPE_INSPECTOR,
 							outcome,
 							documentDate: utcDate.toISOString(),
@@ -524,6 +532,7 @@ describe('decision routes', () => {
 				notifyClient: expect.any(Object),
 				personalisation: {
 					appeal_reference_number: appeal.reference,
+					child_appeals: [childAppeal.childRef],
 					lpa_reference: appeal.applicationReference,
 					site_address: `${appeal.address.addressLine1}, ${appeal.address.addressLine2}, ${appeal.address.addressTown}, ${appeal.address.addressCounty}, ${appeal.address.postcode}, ${appeal.address.addressCountry}`,
 					decision_date: formatDate(utcDate, false),
@@ -538,6 +547,7 @@ describe('decision routes', () => {
 				notifyClient: expect.any(Object),
 				personalisation: {
 					appeal_reference_number: appeal.reference,
+					child_appeals: [childAppeal.childRef],
 					lpa_reference: appeal.applicationReference,
 					site_address: `${appeal.address.addressLine1}, ${appeal.address.addressLine2}, ${appeal.address.addressTown}, ${appeal.address.addressCounty}, ${appeal.address.postcode}, ${appeal.address.addressCountry}`,
 					decision_date: formatDate(utcDate, false),
@@ -551,7 +561,7 @@ describe('decision routes', () => {
 
 			expect(databaseConnector.auditTrail.create).toHaveBeenNthCalledWith(1, {
 				data: {
-					appealId: linkedAppeal.appealId,
+					appealId: childAppeal.appealId,
 					details: stringTokenReplacement(AUDIT_TRAIL_DECISION_ISSUED, [
 						outcome[0].toUpperCase() + outcome.slice(1)
 					]),
@@ -562,7 +572,7 @@ describe('decision routes', () => {
 
 			expect(databaseConnector.auditTrail.create).toHaveBeenNthCalledWith(2, {
 				data: {
-					appealId: linkedAppeal.appealId,
+					appealId: childAppeal.appealId,
 					details: stringTokenReplacement(AUDIT_TRAIL_PROGRESSED_TO_STATUS, ['complete']),
 					loggedAt: expect.any(Date),
 					userId: appeal.caseOfficer.id

--- a/appeals/api/src/server/endpoints/decision/decision.service.js
+++ b/appeals/api/src/server/endpoints/decision/decision.service.js
@@ -14,7 +14,8 @@ import {
 	AUDIT_TRAIL_APPELLANT_COSTS_DECISION_ISSUED,
 	AUDIT_TRAIL_LPA_COSTS_DECISION_ISSUED,
 	DECISION_TYPE_APPELLANT_COSTS,
-	DECISION_TYPE_LPA_COSTS
+	DECISION_TYPE_LPA_COSTS,
+	CASE_RELATIONSHIP_LINKED
 } from '@pins/appeals/constants/support.js';
 import stringTokenReplacement from '#utils/string-token-replacement.js';
 import { AUDIT_TRAIL_CORRECTION_NOTICE_ADDED } from '@pins/appeals/constants/support.js';
@@ -60,7 +61,11 @@ export const publishDecision = async (
 			lpa_reference: appeal.applicationReference || '',
 			site_address: siteAddress,
 			front_office_url: environment.FRONT_OFFICE_URL || '',
-			decision_date: formatDate(new Date(documentDate || ''), false)
+			decision_date: formatDate(new Date(documentDate || ''), false),
+			child_appeals:
+				appeal.childAppeals
+					?.filter((childAppeal) => childAppeal.type === CASE_RELATIONSHIP_LINKED)
+					.map((childAppeal) => childAppeal.childRef) || []
 		};
 		const recipientEmail = appeal.agent?.email || appeal.appellant?.email;
 		const lpaEmail = appeal.lpa?.email || '';

--- a/appeals/api/src/server/notify/templates/__tests__/notify-decision-is-allowed-split-dismissed-appellant.test.js
+++ b/appeals/api/src/server/notify/templates/__tests__/notify-decision-is-allowed-split-dismissed-appellant.test.js
@@ -1,51 +1,89 @@
+// @ts-nocheck
 import { notifySend } from '#notify/notify-send.js';
 import { jest } from '@jest/globals';
 import { householdAppeal } from '#tests/appeals/mocks.js';
+import { cloneDeep } from 'lodash-es';
+
+const genericNotifySendData = {
+	doNotMockNotifySend: true,
+	templateName: 'decision-is-allowed-split-dismissed-appellant',
+	notifyClient: {
+		sendEmail: jest.fn()
+	},
+	recipientEmail: householdAppeal.appellant.email,
+	personalisation: {
+		appeal_reference_number: 'ABC45678',
+		site_address: '10, Test Street',
+		lpa_reference: '12345XYZ',
+		decision_date: '01 January 2021',
+		front_office_url: '/mock-front-office-url'
+	}
+};
+
+const expectedContentRows = (replacementRows) => [
+	'# Appeal details',
+	'',
+	'^Appeal reference number: ABC45678',
+	'Address: 10, Test Street',
+	'Planning application reference: 12345XYZ',
+	'',
+	'# Appeal decision',
+	'',
+	...replacementRows,
+	'',
+	'[Sign in to our service](/mock-front-office-url/appeals/ABC45678) to view the decision letter dated 01 January 2021.',
+	'',
+	'We have also informed the local planning authority of the decision.',
+	'',
+	'# The Planning Inspectorate’s role',
+	'',
+	'The Planning Inspectorate cannot change or revoke the decision. You can [challenge the decision in the High Court](https://www.gov.uk/appeal-planning-decision/if-you-think-the-appeal-decision-is-legally-incorrect) if you think the Planning Inspectorate made a legal mistake.',
+	'',
+	'# Feedback',
+	'',
+	'We welcome your feedback on our appeals service. Tell us on this short [feedback form](https://forms.office.com/pages/responsepage.aspx?id=mN94WIhvq0iTIpmM5VcIjfMZj__F6D9LmMUUyoUrZDZUOERYMEFBN0NCOFdNU1BGWEhHUFQxWVhUUy4u).',
+	'',
+	'The Planning Inspectorate',
+	'[Get help with your appeal decision](https://contact-us.planninginspectorate.gov.uk/hc/en-gb/requests/new)'
+];
 
 describe('decision-is-allowed-split-dismissed-appellant.md', () => {
-	test('should call notify sendEmail with the correct data', async () => {
-		const notifySendData = {
-			doNotMockNotifySend: true,
-			templateName: 'decision-is-allowed-split-dismissed-appellant',
-			notifyClient: {
-				sendEmail: jest.fn()
-			},
-			recipientEmail: householdAppeal.appellant.email,
-			personalisation: {
-				appeal_reference_number: 'ABC45678',
-				site_address: '10, Test Street',
-				lpa_reference: '12345XYZ',
-				decision_date: '01 January 2021',
-				front_office_url: '/mock-front-office-url'
-			}
-		};
+	beforeEach(() => {
+		jest.clearAllMocks();
+	});
 
-		const expectedContent = [
-			'# Appeal details',
-			'',
-			'^Appeal reference number: ABC45678',
-			'Address: 10, Test Street',
-			'Planning application reference: 12345XYZ',
-			'',
-			'# Appeal decision',
-			'',
-			'We have made a decision on your appeal.',
-			'',
-			'[Sign in to our service](/mock-front-office-url/appeals/ABC45678) to view the decision letter dated 01 January 2021.',
-			'',
-			'We have also informed the local planning authority of the decision.',
-			'',
-			'# The Planning Inspectorate’s role',
-			'',
-			'The Planning Inspectorate cannot change or revoke the decision. You can [challenge the decision in the High Court](https://www.gov.uk/appeal-planning-decision/if-you-think-the-appeal-decision-is-legally-incorrect) if you think the Planning Inspectorate made a legal mistake.',
-			'',
-			'# Feedback',
-			'',
-			'We welcome your feedback on our appeals service. Tell us on this short [feedback form](https://forms.office.com/pages/responsepage.aspx?id=mN94WIhvq0iTIpmM5VcIjfMZj__F6D9LmMUUyoUrZDZUOERYMEFBN0NCOFdNU1BGWEhHUFQxWVhUUy4u).',
-			'',
-			'The Planning Inspectorate',
-			'[Get help with your appeal decision](https://contact-us.planninginspectorate.gov.uk/hc/en-gb/requests/new)'
-		].join('\n');
+	test('should call notify sendEmail with the correct data', async () => {
+		const notifySendData = cloneDeep(genericNotifySendData);
+
+		const expectedContent = expectedContentRows(['We have made a decision on your appeal.']).join(
+			'\n'
+		);
+
+		await notifySend(notifySendData);
+
+		expect(notifySendData.notifyClient.sendEmail).toHaveBeenCalledWith(
+			{
+				id: 'mock-appeal-generic-id'
+			},
+			householdAppeal.appellant.email,
+			{
+				content: expectedContent,
+				subject: 'Appeal decision: ABC45678'
+			}
+		);
+	});
+
+	test('should call notify sendEmail with the correct data when a linked appeal', async () => {
+		const notifySendData = cloneDeep(genericNotifySendData);
+		notifySendData.personalisation.child_appeals = ['CHILD123', 'CHILD456', 'CHILD789'];
+
+		const expectedContent = expectedContentRows([
+			'We have made a decision on the following appeals:',
+			'- ABC45678',
+			'- CHILD123',
+			'- CHILD456',
+			'- CHILD789'
+		]).join('\n');
 
 		await notifySend(notifySendData);
 

--- a/appeals/api/src/server/notify/templates/__tests__/notify-decision-is-allowed-split-dismissed-lpa.test.js
+++ b/appeals/api/src/server/notify/templates/__tests__/notify-decision-is-allowed-split-dismissed-lpa.test.js
@@ -1,51 +1,89 @@
+// @ts-nocheck
 import { notifySend } from '#notify/notify-send.js';
 import { jest } from '@jest/globals';
 import { householdAppeal } from '#tests/appeals/mocks.js';
+import { cloneDeep } from 'lodash-es';
+
+const genericNotifySendData = {
+	doNotMockNotifySend: true,
+	templateName: 'decision-is-allowed-split-dismissed-lpa',
+	notifyClient: {
+		sendEmail: jest.fn()
+	},
+	recipientEmail: householdAppeal.lpa.email,
+	personalisation: {
+		appeal_reference_number: 'ABC45678',
+		site_address: '10, Test Street',
+		lpa_reference: '12345XYZ',
+		decision_date: '01 January 2021',
+		front_office_url: '/mock-front-office-url'
+	}
+};
+
+const expectedContentRows = (replacementRows) => [
+	'# Appeal details',
+	'',
+	'^Appeal reference number: ABC45678',
+	'Address: 10, Test Street',
+	'Planning application reference: 12345XYZ',
+	'',
+	'# Appeal decision',
+	'',
+	...replacementRows,
+	'',
+	'[Sign in to our service](/mock-front-office-url/manage-appeals/ABC45678) to view the decision letter dated 01 January 2021.',
+	'',
+	'We have also informed the appellant of the decision.',
+	'',
+	'# The Planning Inspectorate’s role',
+	'',
+	'The Planning Inspectorate cannot change or revoke the decision. You can [challenge the decision in the High Court](https://www.gov.uk/appeal-planning-decision/if-you-think-the-appeal-decision-is-legally-incorrect) if you think the Planning Inspectorate made a legal mistake.',
+	'',
+	'# Feedback',
+	'',
+	'We welcome your feedback on our appeals service. Tell us on this short [feedback form](https://forms.office.com/pages/responsepage.aspx?id=mN94WIhvq0iTIpmM5VcIjfMZj__F6D9LmMUUyoUrZDZUOERYMEFBN0NCOFdNU1BGWEhHUFQxWVhUUy4u).',
+	'',
+	'The Planning Inspectorate',
+	'enquiries@planninginspectorate.gov.uk'
+];
 
 describe('decision-is-allowed-split-dismissed-lpa.md', () => {
-	test('should call notify sendEmail with the correct data', async () => {
-		const notifySendData = {
-			doNotMockNotifySend: true,
-			templateName: 'decision-is-allowed-split-dismissed-lpa',
-			notifyClient: {
-				sendEmail: jest.fn()
-			},
-			recipientEmail: householdAppeal.lpa.email,
-			personalisation: {
-				appeal_reference_number: 'ABC45678',
-				site_address: '10, Test Street',
-				lpa_reference: '12345XYZ',
-				decision_date: '01 January 2021',
-				front_office_url: '/mock-front-office-url'
-			}
-		};
+	beforeEach(() => {
+		jest.clearAllMocks();
+	});
 
-		const expectedContent = [
-			'# Appeal details',
-			'',
-			'^Appeal reference number: ABC45678',
-			'Address: 10, Test Street',
-			'Planning application reference: 12345XYZ',
-			'',
-			'# Appeal decision',
-			'',
-			'We have made a decision on this appeal.',
-			'',
-			'[Sign in to our service](/mock-front-office-url/manage-appeals/ABC45678) to view the decision letter dated 01 January 2021.',
-			'',
-			'We have also informed the appellant of the decision.',
-			'',
-			'# The Planning Inspectorate’s role',
-			'',
-			'The Planning Inspectorate cannot change or revoke the decision. You can [challenge the decision in the High Court](https://www.gov.uk/appeal-planning-decision/if-you-think-the-appeal-decision-is-legally-incorrect) if you think the Planning Inspectorate made a legal mistake.',
-			'',
-			'# Feedback',
-			'',
-			'We welcome your feedback on our appeals service. Tell us on this short [feedback form](https://forms.office.com/pages/responsepage.aspx?id=mN94WIhvq0iTIpmM5VcIjfMZj__F6D9LmMUUyoUrZDZUOERYMEFBN0NCOFdNU1BGWEhHUFQxWVhUUy4u).',
-			'',
-			'The Planning Inspectorate',
-			'enquiries@planninginspectorate.gov.uk'
-		].join('\n');
+	test('should call notify sendEmail with the correct data', async () => {
+		const notifySendData = cloneDeep(genericNotifySendData);
+
+		const expectedContent = expectedContentRows(['We have made a decision on this appeal.']).join(
+			'\n'
+		);
+
+		await notifySend(notifySendData);
+
+		expect(notifySendData.notifyClient.sendEmail).toHaveBeenCalledWith(
+			{
+				id: 'mock-appeal-generic-id'
+			},
+			householdAppeal.lpa.email,
+			{
+				content: expectedContent,
+				subject: 'Appeal decision: ABC45678'
+			}
+		);
+	});
+
+	test('should call notify sendEmail with the correct data when a linked appeal', async () => {
+		const notifySendData = cloneDeep(genericNotifySendData);
+		notifySendData.personalisation.child_appeals = ['CHILD123', 'CHILD456', 'CHILD789'];
+
+		const expectedContent = expectedContentRows([
+			'We have made a decision on the following appeals:',
+			'- ABC45678',
+			'- CHILD123',
+			'- CHILD456',
+			'- CHILD789'
+		]).join('\n');
 
 		await notifySend(notifySendData);
 

--- a/appeals/api/src/server/notify/templates/decision-is-allowed-split-dismissed-appellant.content.md
+++ b/appeals/api/src/server/notify/templates/decision-is-allowed-split-dismissed-appellant.content.md
@@ -2,7 +2,17 @@
 
 # Appeal decision
 
+{%- if child_appeals.length > 1 %}
+
+We have made a decision on the following appeals:
+- {{ appeal_reference_number }}
+  {%- for child_appeal in child_appeals %}
+- {{ child_appeal }}
+  {%- endfor %}
+  {%- else %}
+
 We have made a decision on your appeal.
+{%- endif %}
 
 [Sign in to our service]({{front_office_url}}/appeals/{{appeal_reference_number}}) to view the decision letter dated {{decision_date}}.
 

--- a/appeals/api/src/server/notify/templates/decision-is-allowed-split-dismissed-lpa.content.md
+++ b/appeals/api/src/server/notify/templates/decision-is-allowed-split-dismissed-lpa.content.md
@@ -2,7 +2,17 @@
 
 # Appeal decision
 
+{%- if child_appeals.length > 1 %}
+
+We have made a decision on the following appeals:
+- {{ appeal_reference_number }}
+{%- for child_appeal in child_appeals %}
+- {{ child_appeal }}
+{%- endfor %}
+{%- else %}
+
 We have made a decision on this appeal.
+{%- endif %}
 
 [Sign in to our service]({{front_office_url}}/manage-appeals/{{appeal_reference_number}}) to view the decision letter dated {{decision_date}}.
 


### PR DESCRIPTION
## Describe your changes
### Update issue decision notifies for linked appeals (a2-4210)

### API:
- Updated notify templates
- Added child appeals to personalisation where these notifies are used

### Tests:
- Updated and added unit tests to test the above functionality
- Made sure all unit tests pass
- Tested within browser and email emulator

## Issue ticket number and link
[A2-4210 BO - Issuing a decision for linked appeals (relates to all appeal types) - Notifies - Part 8](https://pins-ds.atlassian.net/browse/A2-4210)
