### PR TITLE
feat(web): display Not assigned on CYA update team page (A2-4123)

### DIFF
--- a/appeals/web/src/server/appeals/appeal-details/update-case-team/__tests__/__snapshots__/update-case-team.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/update-case-team/__tests__/__snapshots__/update-case-team.test.js.snap
@@ -1,5 +1,33 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`update-case-team /case-team/edit/check GET Unassig team should display not assigned when unassign team is selected 1`] = `
+"<main class="govuk-main-wrapper" id="main-content">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Appeal 351062</span>
+            <h1 class="govuk-heading-l">Check details and update case team</h1>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <dl class="govuk-summary-list">
+                <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Case team</dt>
+                    <dd class="govuk-summary-list__value">Not assigned</dd>
+                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/case-team/edit">Change<span class="govuk-visually-hidden"> Change team</span></a>
+                    </dd>
+                </div>
+            </dl>
+            <div class="govuk-grid-row">
+                <div class="govuk-grid-column-full">
+                    <form method="post" novalidate="novalidate">
+                        <button type="submit" class="govuk-button" data-module="govuk-button">Update case team</button>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </div>
+</main>"
+`;
+
 exports[`update-case-team /case-team/edit/check GET name and email available should render the check your answers page 1`] = `
 "<main class="govuk-main-wrapper" id="main-content">
     <div class="govuk-grid-row">

--- a/appeals/web/src/server/appeals/appeal-details/update-case-team/__tests__/update-case-team.test.js
+++ b/appeals/web/src/server/appeals/appeal-details/update-case-team/__tests__/update-case-team.test.js
@@ -114,6 +114,28 @@ describe('update-case-team', () => {
 				expect(element.innerHTML).toContain('Update case team');
 			});
 		});
+
+		describe('GET Unassig team', () => {
+			beforeEach(async () => {
+				nock('http://test/').get('/appeals/1/case-team').reply(200, { assignedTeamId: 4 });
+				renderSelectPage = await request.get(`${baseUrl}/1${caseTeamPath}/edit`);
+				selectTeamResponse = await request.post(`${baseUrl}/1${caseTeamPath}/edit`).send({
+					'case-team': '0'
+				});
+				renderSelectPage = await request.get(`${baseUrl}/1${caseTeamPath}/edit`);
+			});
+			it('should display not assigned when unassign team is selected', async () => {
+				expect(renderSelectPage.statusCode).toBe(500);
+				expect(selectTeamResponse.statusCode).toBe(302);
+				const response = await request.get(`${baseUrl}/1${caseTeamPath}/edit/check`);
+				const element = parseHtml(response.text);
+
+				expect(element.innerHTML).toMatchSnapshot();
+				expect(element.innerHTML).toContain('Not assigned</dd>');
+				expect(element.innerHTML).toContain('Change team</span>');
+				expect(element.innerHTML).toContain('Update case team');
+			});
+		});
 		describe('POST', () => {
 			it('should redirect to the appeal detail page', async () => {
 				nock('http://test/').patch('/appeals/1/case-team').reply(200, { assignedTeamId: 1 });

--- a/appeals/web/src/server/appeals/appeal-details/update-case-team/update-case-team.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/update-case-team/update-case-team.mapper.js
@@ -110,5 +110,7 @@ export function checkAndConfirmPage(appealId, team, appealReference) {
  * @returns {string} The formatted team name and email.
  */
 export const mapTeamText = (team) => {
-	return team.email ? `${team.name}<br>${team.email}` : `${team.name}`;
+	const renderedText =
+		team.id === 0 ? `Not assigned` : team.email ? `${team.name}<br>${team.email}` : `${team.name}`;
+	return renderedText;
 };


### PR DESCRIPTION
## Describe your changes

### WEB

- Updated update case team to display NOt assigned on check your answers page when unassign team is selected
- added unit test and snapshot to cover this scenario

## Issue ticket number and link

[Ticket](https://pins-ds.atlassian.net.mcas.ms/browse/A2-4123)
