### PR TITLE
Fix(A2-4034): removing original comments row when final comment is suppor…

### DIFF
--- a/appeals/web/src/server/appeals/appeal-details/representations/final-comments/accept/__tests__/__snapshots__/accept-final-comments.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/representations/final-comments/accept/__tests__/__snapshots__/accept-final-comments.test.js.snap
@@ -52,6 +52,51 @@ exports[`final-comments GET / should render the accept appellant final comments 
 </main>"
 `;
 
+exports[`final-comments GET / should render the accept appellant final comments page with the expected content when no comment 1`] = `
+"<main class="govuk-main-wrapper" id="main-content">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Appeal 351062</span>
+            <h1 class="govuk-heading-l">Check details and accept appellant final comments</h1>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
+            <dl class="govuk-summary-list">
+                <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Supporting documents</dt>
+                    <dd class="govuk-summary-list__value">
+                        <ol class="govuk-list govuk-!-margin-top-0 govuk-!-padding-left-0">
+                            <li><a class="govuk-link" href="/documents/4881/download/ed52cdc1-3cc2-462a-8623-c1ae256969d6/blank copy 5.pdf"
+                                target="_blank">blank copy 5.pdf</a>
+                            </li>
+                        </ol>
+                    </dd>
+                    <dd class="govuk-summary-list__actions">
+                        <ul class="govuk-summary-list__actions-list">
+                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/2/final-comments/appellant/manage-documents/135568/?backUrl=/final-comments/appellant/accept">Manage<span class="govuk-visually-hidden"> supporting documents</span></a>
+                            </li>
+                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/2/final-comments/appellant/add-document/?backUrl=/final-comments/appellant/accept">Add<span class="govuk-visually-hidden"> supporting documents</span></a>
+                            </li>
+                        </ul>
+                    </dd>
+                </div>
+                <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Review decisions</dt>
+                    <dd class="govuk-summary-list__value">Accept final comments</dd>
+                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/final-comments/appellant?backUrl=/appeals-service/appeal-details/2/final-comments/appellant/accept">Change</a>
+                    </dd>
+                </div>
+            </dl>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
+            <form action="" method="POST" novalidate>
+                <button type="submit" class="govuk-button" data-module="govuk-button">Accept appellant final comments</button>
+            </form>
+        </div>
+    </div>
+</main>"
+`;
+
 exports[`final-comments GET / should render the accept lpa final comments page with the expected content 1`] = `
 "<main class="govuk-main-wrapper" id="main-content">
     <div class="govuk-grid-row">
@@ -69,6 +114,51 @@ exports[`final-comments GET / should render the accept lpa final comments page w
                     <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/final-comments/lpa/redact?backUrl=/final-comments/lpa/accept">Redact<span class="govuk-visually-hidden"> Redact statement</span></a>
                     </dd>
                 </div>
+                <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Supporting documents</dt>
+                    <dd class="govuk-summary-list__value">
+                        <ol class="govuk-list govuk-!-margin-top-0 govuk-!-padding-left-0">
+                            <li><a class="govuk-link" href="/documents/4881/download/ed52cdc1-3cc2-462a-8623-c1ae256969d6/blank copy 5.pdf"
+                                target="_blank">blank copy 5.pdf</a>
+                            </li>
+                        </ol>
+                    </dd>
+                    <dd class="govuk-summary-list__actions">
+                        <ul class="govuk-summary-list__actions-list">
+                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/2/final-comments/lpa/manage-documents/135568/?backUrl=/final-comments/lpa/accept">Manage<span class="govuk-visually-hidden"> supporting documents</span></a>
+                            </li>
+                            <li class="govuk-summary-list__actions-list-item"><a class="govuk-link" href="/appeals-service/appeal-details/2/final-comments/lpa/add-document/?backUrl=/final-comments/lpa/accept">Add<span class="govuk-visually-hidden"> supporting documents</span></a>
+                            </li>
+                        </ul>
+                    </dd>
+                </div>
+                <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Review decisions</dt>
+                    <dd class="govuk-summary-list__value">Accept final comments</dd>
+                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/final-comments/lpa?backUrl=/appeals-service/appeal-details/2/final-comments/lpa/accept">Change</a>
+                    </dd>
+                </div>
+            </dl>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
+            <form action="" method="POST" novalidate>
+                <button type="submit" class="govuk-button" data-module="govuk-button">Accept LPA final comments</button>
+            </form>
+        </div>
+    </div>
+</main>"
+`;
+
+exports[`final-comments GET / should render the accept lpa final comments page with the expected content when no comment 1`] = `
+"<main class="govuk-main-wrapper" id="main-content">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Appeal 351062</span>
+            <h1 class="govuk-heading-l">Check details and accept LPA final comments</h1>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
+            <dl class="govuk-summary-list">
                 <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Supporting documents</dt>
                     <dd class="govuk-summary-list__value">
                         <ol class="govuk-list govuk-!-margin-top-0 govuk-!-padding-left-0">

--- a/appeals/web/src/server/appeals/appeal-details/representations/final-comments/accept/components/summary-list.js
+++ b/appeals/web/src/server/appeals/appeal-details/representations/final-comments/accept/components/summary-list.js
@@ -8,72 +8,81 @@
  * @param {string|null} attachmentsList
  * @returns {PageComponent}
  */
-export const summaryList = (appealDetails, comment, finalCommentsType, attachmentsList) => ({
-	type: 'summary-list',
-	wrapperHtml: {
-		opening: '<div class="govuk-grid-row"><div class="govuk-grid-column-full">',
-		closing: '</div></div>'
-	},
-	parameters: {
-		rows: [
-			{
-				key: { text: 'Original final comments' },
-				value: {
-					html: '',
-					pageComponents: [
-						{
-							type: 'show-more',
-							parameters: {
-								text: comment.originalRepresentation,
-								labelText: 'Read more'
-							}
+export const summaryList = (appealDetails, comment, finalCommentsType, attachmentsList) => {
+	const rows = [];
+
+	if (comment.originalRepresentation) {
+		rows.push({
+			key: { text: 'Original final comments' },
+			value: {
+				html: '',
+				pageComponents: [
+					{
+						type: 'show-more',
+						parameters: {
+							text: comment.originalRepresentation,
+							labelText: 'Read more'
 						}
-					]
-				},
-				actions: {
-					items: [
-						{
-							href: `/appeals-service/appeal-details/${appealDetails.appealId}/final-comments/${finalCommentsType}/redact?backUrl=/final-comments/${finalCommentsType}/accept`,
-							text: 'Redact',
-							visuallyHiddenText: 'Redact statement'
-						}
-					]
-				}
+					}
+				]
 			},
-			{
-				key: { text: 'Supporting documents' },
-				value: attachmentsList ? { html: attachmentsList } : { text: 'No documents' },
-				actions: {
-					items: [
-						...(comment.attachments?.length > 0
-							? [
-									{
-										text: 'Manage',
-										href: `/appeals-service/appeal-details/${appealDetails.appealId}/final-comments/${finalCommentsType}/manage-documents/${comment.attachments?.[0]?.documentVersion?.document?.folderId}/?backUrl=/final-comments/${finalCommentsType}/accept`,
-										visuallyHiddenText: 'supporting documents'
-									}
-							  ]
-							: []),
-						{
-							text: 'Add',
-							href: `/appeals-service/appeal-details/${appealDetails.appealId}/final-comments/${finalCommentsType}/add-document/?backUrl=/final-comments/${finalCommentsType}/accept`,
-							visuallyHiddenText: 'supporting documents'
-						}
-					]
-				}
-			},
-			{
-				key: { text: 'Review decisions' },
-				value: { text: 'Accept final comments' },
-				actions: {
-					items: [
-						{
-							text: 'Change',
-							href: `/appeals-service/appeal-details/${appealDetails.appealId}/final-comments/${finalCommentsType}?backUrl=/appeals-service/appeal-details/${appealDetails.appealId}/final-comments/${finalCommentsType}/accept`
-						}
-					]
-				}
+			actions: {
+				items: [
+					{
+						href: `/appeals-service/appeal-details/${appealDetails.appealId}/final-comments/${finalCommentsType}/redact?backUrl=/final-comments/${finalCommentsType}/accept`,
+						text: 'Redact',
+						visuallyHiddenText: 'Redact statement'
+					}
+				]
 			}
-		]
+		});
 	}
-});
+
+	rows.push(
+		{
+			key: { text: 'Supporting documents' },
+			value: attachmentsList ? { html: attachmentsList } : { text: 'No documents' },
+			actions: {
+				items: [
+					...(comment.attachments?.length > 0
+						? [
+								{
+									text: 'Manage',
+									href: `/appeals-service/appeal-details/${appealDetails.appealId}/final-comments/${finalCommentsType}/manage-documents/${comment.attachments?.[0]?.documentVersion?.document?.folderId}/?backUrl=/final-comments/${finalCommentsType}/accept`,
+									visuallyHiddenText: 'supporting documents'
+								}
+						  ]
+						: []),
+					{
+						text: 'Add',
+						href: `/appeals-service/appeal-details/${appealDetails.appealId}/final-comments/${finalCommentsType}/add-document/?backUrl=/final-comments/${finalCommentsType}/accept`,
+						visuallyHiddenText: 'supporting documents'
+					}
+				]
+			}
+		},
+		{
+			key: { text: 'Review decisions' },
+			value: { text: 'Accept final comments' },
+			actions: {
+				items: [
+					{
+						text: 'Change',
+						href: `/appeals-service/appeal-details/${appealDetails.appealId}/final-comments/${finalCommentsType}?backUrl=/appeals-service/appeal-details/${appealDetails.appealId}/final-comments/${finalCommentsType}/accept`
+					}
+				]
+			}
+		}
+	);
+
+	return {
+		type: 'summary-list',
+		wrapperHtml: {
+			opening: '<div class="govuk-grid-row"><div class="govuk-grid-column-full">',
+			closing: '</div></div>'
+		},
+		parameters: {
+			rows
+		}
+	};
+};


### PR DESCRIPTION

## Describe your changes
- Removing original final comments row when the final comment is the supporting doc.
<!--
    Please include a summary of the change along with any relevant context.
    List any dependencies that are required for this change.
-->

## Issue ticket number and link

[Ticket](https://pins-ds.atlassian.net.mcas.ms/browse/A2-4034)
