### PR TITLE
fix(appeals): prevent undefined decision result (a2-3175)

### DIFF
--- a/appeals/api/src/server/endpoints/decision/decision.controller.js
+++ b/appeals/api/src/server/endpoints/decision/decision.controller.js
@@ -90,7 +90,7 @@ export const postInspectorDecision = async (req, res) => {
 		)
 	);
 
-	const decision = results.find((result) => result !== null) ?? null;
+	const decision = results.find((result) => !!result?.documentType) ?? null;
 
 	return res.status(201).send(decision);
 };


### PR DESCRIPTION
## Describe your changes
#### Prevent undefined decision result (a2-3175)

##### This is a fix for ticket a2-3175 implemented previously

### API:
- Make sure if all decisions are undefined, a null is returned as expected 

### Test:
- Made sure unit tests pass,
- Made sure affected e2e tests pass
- Tested manually in browser

[a2-3175](https://pins-ds.atlassian.net/browse/A2-3175)
