### PR TITLE
[test/e2e] - fix hearing tests 

### DIFF
--- a/appeals/e2e/cypress/e2e/back-office-appeals/hearing.spec.js
+++ b/appeals/e2e/cypress/e2e/back-office-appeals/hearing.spec.js
@@ -543,7 +543,7 @@ describe('Setup hearing and add hearing estimates', () => {
 		happyPathHelper.reviewLPaStatement(caseRef);
 
 		// Verify Hearing ready to set up tag - all cases page
-		cy.visit(urlPaths.allCases);
+		cy.visit(urlPaths.appealsList);
 		hearingSectionPage.verifyTagOnAllCasesPage(caseRef, 'Hearing ready to set up');
 
 		// Verify Hearing ready to set up tag - personal list page
@@ -573,7 +573,7 @@ describe('Setup hearing and add hearing estimates', () => {
 			caseDetailsPage.validateBannerMessage('Important', 'Add hearing address');
 
 			// Verify Hearing ready to set up tag - all cases page
-			cy.visit(urlPaths.allCases);
+			cy.visit(urlPaths.appealsList);
 			hearingSectionPage.verifyTagOnAllCasesPage(caseRef, 'Hearing ready to set up');
 
 			// Verify Hearing ready to set up tag - personal list page
@@ -590,7 +590,7 @@ describe('Setup hearing and add hearing estimates', () => {
 			caseDetailsPage.validateBannerMessage('Success', 'Hearing updated');
 
 			// Verify Awaiting hearing tag - all cases page
-			cy.visit(urlPaths.allCases);
+			cy.visit(urlPaths.appealsList);
 			hearingSectionPage.verifyTagOnAllCasesPage(caseRef, 'Awaiting hearing');
 
 			// Verify Awaiting hearing tag - personal list page
@@ -684,7 +684,7 @@ describe('Setup hearing and add hearing estimates', () => {
 			happyPathHelper.reviewLPaStatement(caseRef);
 
 			// Verify Hearing ready to set up tag - all cases page
-			cy.visit(urlPaths.allCases);
+			cy.visit(urlPaths.appealsList);
 			hearingSectionPage.verifyTagOnAllCasesPage(caseRef, 'Hearing ready to set up');
 
 			// Verify Hearing ready to set up tag - personal list page
@@ -714,7 +714,7 @@ describe('Setup hearing and add hearing estimates', () => {
 				caseDetailsPage.validateBannerMessage('Success', 'Hearing set up');
 
 				// Verify Awaiting hearing tag - all cases page
-				cy.visit(urlPaths.allCases);
+				cy.visit(urlPaths.appealsList);
 				hearingSectionPage.verifyTagOnAllCasesPage(caseRef, 'Awaiting hearing');
 
 				// Verify Awaiting hearing tag - personal list page
@@ -733,7 +733,7 @@ describe('Setup hearing and add hearing estimates', () => {
 				caseDetailsPage.validateBannerMessage('Important', 'Add hearing address');
 
 				// Verify Awaiting hearing tag - all cases page
-				cy.visit(urlPaths.allCases);
+				cy.visit(urlPaths.appealsList);
 				hearingSectionPage.verifyTagOnAllCasesPage(caseRef, 'Hearing ready to set up');
 
 				// Verify Awaiting hearing tag - personal list page


### PR DESCRIPTION
## Describe your changes

Looking into test failures for `hearing.spec` in last nightly run (https://dev.azure.com/planninginspectorate/appeals-back-office/_build/results?buildId=130903&view=artifacts&pathAsName=false&type=publishedArtifacts) 
 
It looks like the url https://back-office-appeals-dev.planninginspectorate.gov.uk/appeals-service/all-cases?pageSize=1000&pageNumber=1 is not working - yet the equivalent in test env seems to works ok? 

For now have updated the 'all cases' url to be consistent with other tests - as `hearing.spec` seems to be only one using this version?  

## Issue ticket number and link

*{Fix - no ticket}*   
