### PR TITLE
fix(appeals): only display cost decision rows when appropriate (a2-4217)

### DIFF
--- a/appeals/web/src/server/lib/mappers/data/appeal/submappers/__tests__/costs-appellant-decision.mapper.test.js
+++ b/appeals/web/src/server/lib/mappers/data/appeal/submappers/__tests__/costs-appellant-decision.mapper.test.js
@@ -1,0 +1,104 @@
+// @ts-nocheck
+import { mapCostsAppellantDecision } from '#lib/mappers/data/appeal/submappers/costs-appellant-decision.mapper.js';
+
+describe('costs-appellant-decision.mapper', () => {
+	let data;
+
+	beforeEach(() => {
+		data = {
+			appealDetails: {
+				appealId: 1,
+				appealType: 'Planning appeal',
+				appealReference: '12345678',
+				costs: {
+					appellantApplicationFolder: { documents: [{ id: 1 }] },
+					appellantWithdrawalFolder: { documents: [] },
+					appellantDecisionFolder: { documents: [] }
+				},
+				completedStateList: ['ready_to_start', 'lpa_questionnaire', 'awaiting_event']
+			},
+			currentRoute: '/test',
+			session: { permissions: { setCaseOutcome: true } },
+			request: { originalUrl: '/original-url' }
+		};
+	});
+
+	describe('should display a correctly populated display object', () => {
+		it('when the decision has not been issued', () => {
+			const result = mapCostsAppellantDecision(data);
+			expect(result).toEqual({
+				id: 'appellant-costs-decision',
+				display: {
+					summaryListItem: {
+						actions: {
+							items: [
+								{
+									attributes: { 'data-cy': 'issue-appellant-costs-decision' },
+									href: '/test/issue-decision/issue-appellant-costs-decision-letter-upload?backUrl=%2Foriginal-url',
+									text: 'Issue',
+									visuallyHiddenText: 'Appellant costs decision'
+								}
+							]
+						},
+						classes: 'costs-appellant-decision',
+						key: {
+							text: 'Appellant costs decision'
+						},
+						value: {
+							text: 'Not issued'
+						}
+					}
+				}
+			});
+		});
+
+		it('when the decision has been issued', () => {
+			data.appealDetails.costs.appellantDecisionFolder.documents = [{ id: 3 }];
+			const result = mapCostsAppellantDecision(data);
+			expect(result).toEqual({
+				id: 'appellant-costs-decision',
+				display: {
+					summaryListItem: {
+						actions: {
+							items: [
+								{
+									attributes: { 'data-cy': 'view-appellant-costs-decision' },
+									href: '/appeals-service/appeal-details/1/issue-decision/view-decision?backUrl=%2Foriginal-url',
+									text: 'View',
+									visuallyHiddenText: 'Appellant costs decision'
+								}
+							]
+						},
+						classes: 'costs-appellant-decision',
+						key: {
+							text: 'Appellant costs decision'
+						},
+						value: {
+							text: 'Issued'
+						}
+					}
+				}
+			});
+		});
+	});
+
+	describe('should return an empty display object', () => {
+		it('when the appeal is a child linked appeal', () => {
+			data.appealDetails.isChildAppeal = true;
+			const result = mapCostsAppellantDecision(data);
+			expect(result).toEqual({ id: 'appellant-costs-decision', display: {} });
+		});
+
+		it('when the appeal has not yet moved to the issue decision stage', () => {
+			data.appealDetails.completedStateList = ['ready_to_start', 'lpa_questionnaire'];
+			const result = mapCostsAppellantDecision(data);
+			expect(result).toEqual({ id: 'appellant-costs-decision', display: {} });
+		});
+
+		it('when the appeal has less cost application documents than cost withdrawal documents', () => {
+			data.appealDetails.costs.appellantWithdrawalFolder.documents = [{ id: 2 }];
+			const result = mapCostsAppellantDecision(data);
+			expect(result).toEqual({ id: 'appellant-costs-decision', display: {} });
+		});
+	});
+});

--- a/appeals/web/src/server/lib/mappers/data/appeal/submappers/__tests__/costs-lpa-decision.mapper.test.js
+++ b/appeals/web/src/server/lib/mappers/data/appeal/submappers/__tests__/costs-lpa-decision.mapper.test.js
@@ -1,0 +1,104 @@
+// @ts-nocheck
+import { mapCostsLpaDecision } from '#lib/mappers/data/appeal/submappers/costs-lpa-decision.mapper.js';
+
+describe('costs-lpa-decision.mapper', () => {
+	let data;
+
+	beforeEach(() => {
+		data = {
+			appealDetails: {
+				appealId: 1,
+				appealType: 'Planning appeal',
+				appealReference: '12345678',
+				costs: {
+					lpaApplicationFolder: { documents: [{ id: 1 }] },
+					lpaWithdrawalFolder: { documents: [] },
+					lpaDecisionFolder: { documents: [] }
+				},
+				completedStateList: ['ready_to_start', 'lpa_questionnaire', 'awaiting_event']
+			},
+			currentRoute: '/test',
+			session: { permissions: { setCaseOutcome: true } },
+			request: { originalUrl: '/original-url' }
+		};
+	});
+
+	describe('should display a correctly populated display object', () => {
+		it('when the decision has not been issued', () => {
+			const result = mapCostsLpaDecision(data);
+			expect(result).toEqual({
+				id: 'lpa-costs-decision',
+				display: {
+					summaryListItem: {
+						actions: {
+							items: [
+								{
+									attributes: { 'data-cy': 'issue-lpa-costs-decision' },
+									href: '/test/issue-decision/issue-lpa-costs-decision-letter-upload?backUrl=%2Foriginal-url',
+									text: 'Issue',
+									visuallyHiddenText: 'LPA costs decision'
+								}
+							]
+						},
+						classes: 'costs-lpa-decision',
+						key: {
+							text: 'LPA costs decision'
+						},
+						value: {
+							text: 'Not issued'
+						}
+					}
+				}
+			});
+		});
+
+		it('when the decision has been issued', () => {
+			data.appealDetails.costs.lpaDecisionFolder.documents = [{ id: 3 }];
+			const result = mapCostsLpaDecision(data);
+			expect(result).toEqual({
+				id: 'lpa-costs-decision',
+				display: {
+					summaryListItem: {
+						actions: {
+							items: [
+								{
+									attributes: { 'data-cy': 'view-lpa-costs-decision' },
+									href: '/appeals-service/appeal-details/1/issue-decision/view-decision?backUrl=%2Foriginal-url',
+									text: 'View',
+									visuallyHiddenText: 'LPA costs decision'
+								}
+							]
+						},
+						classes: 'costs-lpa-decision',
+						key: {
+							text: 'LPA costs decision'
+						},
+						value: {
+							text: 'Issued'
+						}
+					}
+				}
+			});
+		});
+	});
+
+	describe('should return an empty display object', () => {
+		it('when the appeal is a child linked appeal', () => {
+			data.appealDetails.isChildAppeal = true;
+			const result = mapCostsLpaDecision(data);
+			expect(result).toEqual({ id: 'lpa-costs-decision', display: {} });
+		});
+
+		it('when the appeal has not yet moved to the issue decision stage', () => {
+			data.appealDetails.completedStateList = ['ready_to_start', 'lpa_questionnaire'];
+			const result = mapCostsLpaDecision(data);
+			expect(result).toEqual({ id: 'lpa-costs-decision', display: {} });
+		});
+
+		it('when the appeal has less cost application documents than cost withdrawal documents', () => {
+			data.appealDetails.costs.lpaWithdrawalFolder.documents = [{ id: 2 }];
+			const result = mapCostsLpaDecision(data);
+			expect(result).toEqual({ id: 'lpa-costs-decision', display: {} });
+		});
+	});
+});

--- a/appeals/web/src/server/lib/mappers/data/appeal/submappers/costs-appellant-decision.mapper.js
+++ b/appeals/web/src/server/lib/mappers/data/appeal/submappers/costs-appellant-decision.mapper.js
@@ -11,11 +11,13 @@ export const mapCostsAppellantDecision = ({ appealDetails, currentRoute, session
 	const { appellantApplicationFolder, appellantWithdrawalFolder, appellantDecisionFolder } =
 		appealDetails.costs ?? {};
 
+	const appellantApplicationCount = appellantApplicationFolder?.documents?.length || 0;
+	const appellantWithdrawalCount = appellantWithdrawalFolder?.documents?.length || 0;
+
 	if (
 		isChildAppeal(appealDetails) ||
 		!isStatePassed(appealDetails, APPEAL_CASE_STATUS.AWAITING_EVENT) ||
-		!appellantApplicationFolder?.documents?.length ||
-		appellantWithdrawalFolder?.documents?.length
+		appellantApplicationCount <= appellantWithdrawalCount
 	) {
 		return { id: 'appellant-costs-decision', display: {} };
 	}

--- a/appeals/web/src/server/lib/mappers/data/appeal/submappers/costs-lpa-decision.mapper.js
+++ b/appeals/web/src/server/lib/mappers/data/appeal/submappers/costs-lpa-decision.mapper.js
@@ -11,11 +11,13 @@ export const mapCostsLpaDecision = ({ appealDetails, currentRoute, session, requ
 	const { lpaApplicationFolder, lpaWithdrawalFolder, lpaDecisionFolder } =
 		appealDetails.costs ?? {};
 
+	const lpaApplicationCount = lpaApplicationFolder?.documents?.length || 0;
+	const lpaWithdrawalCount = lpaWithdrawalFolder?.documents?.length || 0;
+
 	if (
 		isChildAppeal(appealDetails) ||
 		!isStatePassed(appealDetails, APPEAL_CASE_STATUS.AWAITING_EVENT) ||
-		!lpaApplicationFolder?.documents?.length ||
-		lpaWithdrawalFolder?.documents?.length
+		lpaApplicationCount <= lpaWithdrawalCount
 	) {
 		return { id: 'lpa-costs-decision', display: {} };
 	}

--- a/appeals/web/src/server/lib/string-utilities.js
+++ b/appeals/web/src/server/lib/string-utilities.js
@@ -32,7 +32,7 @@ export const uncapitalizeFirstLetter = (str) => {
  * Pad a number with leading zeros
  *
  * @param {number | string} num
- * @params {number} [length]
+ * @param {number} [length]
  * @returns {string}
  */
 export const padNumberWithZero = (num, length = 2) => num.toString().padStart(length, '0');
@@ -75,5 +75,9 @@ export const toCamelCase = (str) => {
  * @param {string} str - The string to convert.
  * @returns {string} - The sentence case formatted string.
  */
-export const toSentenceCase = (str) =>
-	capitalizeFirstLetter(camelCaseToWords(toCamelCase(str)).toLowerCase());
+export const toSentenceCase = (str) => {
+	if (!str) {
+		return '';
+	}
+	return capitalizeFirstLetter(camelCaseToWords(toCamelCase(str)).toLowerCase());
+};


### PR DESCRIPTION
## Describe your changes
####  Updates to case details page for child linked appeal after issue decision (a2-4217)

### WEB:
- Make sure appellant and LPA cost rows are shown only when appropriate as described in the ticket
- Allow toSentenceCase utility function to be more forgiving (fixes an earlier PR)

### TEST:
- Added new unit tests to extensively test this functionality
- Make sure all other unit tests pass
- Tested in browser

## Issue ticket number and link

[A2-4217- BO - Linked appeals - Appeals are at 'Issue decision' stage - Appellant and LPA cost decision rows](https://pins-ds.atlassian.net/browse/A2-4217)
