### PR TITLE
fix(appeals): add error message when linking appeal to itself or an horizon appeal (a2-4367)

### DIFF
--- a/appeals/web/src/server/appeals/appeal-details/linked-appeals/__tests__/__snapshots__/linked-appeals.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/linked-appeals/__tests__/__snapshots__/linked-appeals.test.js.snap
@@ -546,6 +546,138 @@ exports[`linked-appeals POST /linked-appeals/add should re-render the add linked
 </main>"
 `;
 
+exports[`linked-appeals POST /linked-appeals/add should re-render the add linked appeal reference page with the expected error message if the provided appeal reference is a horizon appeal (starting with 2) 1`] = `
+"<main class="govuk-main-wrapper" id="main-content">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <div class="govuk-error-summary" data-module="govuk-error-summary">
+                <div role="alert">
+                    <h2 class="govuk-error-summary__title"> There is a problem</h2>
+                    <div class="govuk-error-summary__body">
+                        <ul class="govuk-list govuk-error-summary__list">
+                            <li><a href="#appeal-reference">Enter a valid appeal reference</a>
+                            </li>
+                        </ul>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Appeal 351062 - add linked appeal</span>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <div class="govuk-grid-row">
+                <div class="govuk-grid-column-full">
+                    <form method="POST" novalidate="novalidate">
+                        <div class="govuk-form-group govuk-form-group--error">
+                            <h1 class="govuk-label-wrapper"><label class="govuk-label govuk-label--l" for="appeal-reference"> Appeal reference</label></h1>
+                            <p id="appeal-reference-error" class="govuk-error-message"><span class="govuk-visually-hidden">Error:</span> Enter a valid appeal
+                                reference</p>
+                            <input class="govuk-input govuk-input govuk-input--width-10 govuk-input--error"
+                            id="appeal-reference" name="appeal-reference" type="text" value="2345678"
+                            aria-describedby="appeal-reference-error">
+                        </div>
+                        <button type="submit" data-prevent-double-click="true" class="govuk-button"
+                        data-module="govuk-button">Continue</button>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </div>
+</main>"
+`;
+
+exports[`linked-appeals POST /linked-appeals/add should re-render the add linked appeal reference page with the expected error message if the provided appeal reference is a horizon appeal (starting with 3) 1`] = `
+"<main class="govuk-main-wrapper" id="main-content">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <div class="govuk-error-summary" data-module="govuk-error-summary">
+                <div role="alert">
+                    <h2 class="govuk-error-summary__title"> There is a problem</h2>
+                    <div class="govuk-error-summary__body">
+                        <ul class="govuk-list govuk-error-summary__list">
+                            <li><a href="#appeal-reference">Enter a valid appeal reference</a>
+                            </li>
+                        </ul>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Appeal 351062 - add linked appeal</span>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <div class="govuk-grid-row">
+                <div class="govuk-grid-column-full">
+                    <form method="POST" novalidate="novalidate">
+                        <div class="govuk-form-group govuk-form-group--error">
+                            <h1 class="govuk-label-wrapper"><label class="govuk-label govuk-label--l" for="appeal-reference"> Appeal reference</label></h1>
+                            <p id="appeal-reference-error" class="govuk-error-message"><span class="govuk-visually-hidden">Error:</span> Enter a valid appeal
+                                reference</p>
+                            <input class="govuk-input govuk-input govuk-input--width-10 govuk-input--error"
+                            id="appeal-reference" name="appeal-reference" type="text" value="3456789"
+                            aria-describedby="appeal-reference-error">
+                        </div>
+                        <button type="submit" data-prevent-double-click="true" class="govuk-button"
+                        data-module="govuk-button">Continue</button>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </div>
+</main>"
+`;
+
+exports[`linked-appeals POST /linked-appeals/add should re-render the add linked appeal reference page with the expected error message if the provided appeal reference is a horizon appeal (starting with 4) 1`] = `
+"<main class="govuk-main-wrapper" id="main-content">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <div class="govuk-error-summary" data-module="govuk-error-summary">
+                <div role="alert">
+                    <h2 class="govuk-error-summary__title"> There is a problem</h2>
+                    <div class="govuk-error-summary__body">
+                        <ul class="govuk-list govuk-error-summary__list">
+                            <li><a href="#appeal-reference">Enter a valid appeal reference</a>
+                            </li>
+                        </ul>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Appeal 351062 - add linked appeal</span>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <div class="govuk-grid-row">
+                <div class="govuk-grid-column-full">
+                    <form method="POST" novalidate="novalidate">
+                        <div class="govuk-form-group govuk-form-group--error">
+                            <h1 class="govuk-label-wrapper"><label class="govuk-label govuk-label--l" for="appeal-reference"> Appeal reference</label></h1>
+                            <p id="appeal-reference-error" class="govuk-error-message"><span class="govuk-visually-hidden">Error:</span> Enter a valid appeal
+                                reference</p>
+                            <input class="govuk-input govuk-input govuk-input--width-10 govuk-input--error"
+                            id="appeal-reference" name="appeal-reference" type="text" value="4567890"
+                            aria-describedby="appeal-reference-error">
+                        </div>
+                        <button type="submit" data-prevent-double-click="true" class="govuk-button"
+                        data-module="govuk-button">Continue</button>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </div>
+</main>"
+`;
+
 exports[`linked-appeals POST /linked-appeals/add should re-render the add linked appeal reference page with the expected error message if the provided appeal reference is greater than 7 digits 1`] = `
 "<main class="govuk-main-wrapper" id="main-content">
     <div class="govuk-grid-row">
@@ -577,7 +709,8 @@ exports[`linked-appeals POST /linked-appeals/add should re-render the add linked
                             <p id="appeal-reference-error" class="govuk-error-message"><span class="govuk-visually-hidden">Error:</span> Appeal reference must
                                 be 7 digits</p>
                             <input class="govuk-input govuk-input govuk-input--width-10 govuk-input--error"
-                            id="appeal-reference" name="appeal-reference" type="text" aria-describedby="appeal-reference-error">
+                            id="appeal-reference" name="appeal-reference" type="text" value="12345678"
+                            aria-describedby="appeal-reference-error">
                         </div>
                         <button type="submit" data-prevent-double-click="true" class="govuk-button"
                         data-module="govuk-button">Continue</button>
@@ -620,7 +753,52 @@ exports[`linked-appeals POST /linked-appeals/add should re-render the add linked
                             <p id="appeal-reference-error" class="govuk-error-message"><span class="govuk-visually-hidden">Error:</span> Appeal reference must
                                 be 7 digits</p>
                             <input class="govuk-input govuk-input govuk-input--width-10 govuk-input--error"
-                            id="appeal-reference" name="appeal-reference" type="text" aria-describedby="appeal-reference-error">
+                            id="appeal-reference" name="appeal-reference" type="text" value="123456"
+                            aria-describedby="appeal-reference-error">
+                        </div>
+                        <button type="submit" data-prevent-double-click="true" class="govuk-button"
+                        data-module="govuk-button">Continue</button>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </div>
+</main>"
+`;
+
+exports[`linked-appeals POST /linked-appeals/add should re-render the add linked appeal reference page with the expected error message if the reference is the same as appeal being linked to 1`] = `
+"<main class="govuk-main-wrapper" id="main-content">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <div class="govuk-error-summary" data-module="govuk-error-summary">
+                <div role="alert">
+                    <h2 class="govuk-error-summary__title"> There is a problem</h2>
+                    <div class="govuk-error-summary__body">
+                        <ul class="govuk-list govuk-error-summary__list">
+                            <li><a href="#appeal-reference">Enter a valid appeal reference</a>
+                            </li>
+                        </ul>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Appeal 6000123 - add linked appeal</span>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <div class="govuk-grid-row">
+                <div class="govuk-grid-column-full">
+                    <form method="POST" novalidate="novalidate">
+                        <div class="govuk-form-group govuk-form-group--error">
+                            <h1 class="govuk-label-wrapper"><label class="govuk-label govuk-label--l" for="appeal-reference"> Appeal reference</label></h1>
+                            <p id="appeal-reference-error" class="govuk-error-message"><span class="govuk-visually-hidden">Error:</span> Enter a valid appeal
+                                reference</p>
+                            <input class="govuk-input govuk-input govuk-input--width-10 govuk-input--error"
+                            id="appeal-reference" name="appeal-reference" type="text" value="6000123"
+                            aria-describedby="appeal-reference-error">
                         </div>
                         <button type="submit" data-prevent-double-click="true" class="govuk-button"
                         data-module="govuk-button">Continue</button>
@@ -663,7 +841,8 @@ exports[`linked-appeals POST /linked-appeals/add should re-render the add linked
                             <p id="appeal-reference-error" class="govuk-error-message"><span class="govuk-visually-hidden">Error:</span> Enter a valid appeal
                                 reference</p>
                             <input class="govuk-input govuk-input govuk-input--width-10 govuk-input--error"
-                            id="appeal-reference" name="appeal-reference" type="text" aria-describedby="appeal-reference-error">
+                            id="appeal-reference" name="appeal-reference" type="text" value="7654321"
+                            aria-describedby="appeal-reference-error">
                         </div>
                         <button type="submit" data-prevent-double-click="true" class="govuk-button"
                         data-module="govuk-button">Continue</button>

--- a/appeals/web/src/server/appeals/appeal-details/linked-appeals/__tests__/linked-appeals.test.js
+++ b/appeals/web/src/server/appeals/appeal-details/linked-appeals/__tests__/linked-appeals.test.js
@@ -1,3 +1,4 @@
+import { appealShortReference } from '#lib/appeals-formatter.js';
 import {
 	appealData,
 	documentFileInfo,
@@ -206,6 +207,65 @@ describe('linked-appeals', () => {
 			expect(errorSummaryHtml).toContain('Enter a valid appeal reference</a>');
 		});
 
+		it('should re-render the add linked appeal reference page with the expected error message if the reference is the same as appeal being linked to', async () => {
+			const appealReference = '6000123';
+			nock.cleanAll();
+			nock('http://test/')
+				.get('/appeals/1')
+				.reply(200, { ...appealData, appealReference });
+			nock('http://test/')
+				.get(`/appeals/linkable-appeal/${testInvalidLinkableAppealReference}/linked`)
+				.reply(404);
+
+			const response = await request.post(linkedAppealsAddUrl).send({
+				'appeal-reference': appealShortReference(appealReference)
+			});
+			const element = parseHtml(response.text);
+
+			expect(element.innerHTML).toMatchSnapshot();
+
+			expect(element.innerHTML).toContain('Appeal reference</label></h1>');
+
+			const errorSummaryHtml = parseHtml(response.text, {
+				rootElement: '.govuk-error-summary',
+				skipPrettyPrint: true
+			}).innerHTML;
+
+			expect(errorSummaryHtml).toContain('There is a problem</h2>');
+			expect(errorSummaryHtml).toContain('Enter a valid appeal reference</a>');
+		});
+
+		it.each([
+			['2', '2345678'],
+			['3', '3456789'],
+			['4', '4567890']
+		])(
+			'should re-render the add linked appeal reference page with the expected error message if the provided appeal reference is a horizon appeal (starting with %s)',
+			async (_, appealReference) => {
+				nock.cleanAll();
+				nock('http://test/').get('/appeals/1').reply(200, appealData);
+				nock('http://test/')
+					.get(`/appeals/linkable-appeal/${testValidLinkableAppealReference}/linked`)
+					.reply(200, linkableAppealSummaryBackOffice);
+
+				const response = await request.post(linkedAppealsAddUrl).send({
+					'appeal-reference': appealReference
+				});
+				const element = parseHtml(response.text);
+
+				expect(element.innerHTML).toMatchSnapshot();
+				expect(element.innerHTML).toContain('Appeal reference</label></h1>');
+
+				const errorSummaryHtml = parseHtml(response.text, {
+					rootElement: '.govuk-error-summary',
+					skipPrettyPrint: true
+				}).innerHTML;
+
+				expect(errorSummaryHtml).toContain('There is a problem</h2>');
+				expect(errorSummaryHtml).toContain('Enter a valid appeal reference</a>');
+			}
+		);
+
 		it('should redirect to the check and confirm page if the reference was provided, a matching appeal was found, is unlinked, and the current appeal is already a lead', async () => {
 			nock.cleanAll();
 			nock('http://test/')
@@ -277,26 +337,6 @@ describe('linked-appeals', () => {
 
 			expect(response.statusCode).toBe(302);
 			expect(response.text).toEqual(`Found. Redirecting to ${linkedAppealsAddUrl}/already-linked`);
-		});
-
-		it('should redirect to a drop out page if attempting to link to itself', async () => {
-			nock.cleanAll();
-			nock('http://test/')
-				.get('/appeals/1')
-				.reply(200, { ...appealData, appealReference: testValidLinkableAppealReference })
-				.persist();
-			nock('http://test/')
-				.get(`/appeals/linkable-appeal/${testValidLinkableAppealReference}/linked`)
-				.reply(200, linkableAppealSummaryBackOffice);
-
-			const addLinkedAppealReferenceResponse = await request.post(linkedAppealsAddUrl).send({
-				'appeal-reference': testValidLinkableAppealReference
-			});
-
-			expect(addLinkedAppealReferenceResponse.statusCode).toBe(302);
-			expect(addLinkedAppealReferenceResponse.text).toEqual(
-				`Found. Redirecting to ${linkedAppealsAddUrl}/already-linked`
-			);
 		});
 
 		it('should redirect to a drop out page if both appeals are already linked as lead appeals', async () => {

--- a/appeals/web/src/server/appeals/appeal-details/linked-appeals/add/add.controller.js
+++ b/appeals/web/src/server/appeals/appeal-details/linked-appeals/add/add.controller.js
@@ -16,7 +16,7 @@ import { linkAppealToBackOfficeAppeal, linkAppealToLegacyAppeal } from './add.se
  * @param {import('@pins/express/types/express.js').RenderedResponse<any, any, Number>} response
  */
 export const renderAddLinkedAppealReference = (request, response) => {
-	const { errors, session } = request;
+	const { errors, session, body } = request;
 
 	const appealDetails = request.currentAppeal;
 
@@ -24,7 +24,8 @@ export const renderAddLinkedAppealReference = (request, response) => {
 		appealDetails,
 		session.linkableAppeal?.linkableAppealSummary,
 		getBackLinkUrlFromQuery(request),
-		errors?.['appeal-reference'].msg
+		errors?.['appeal-reference'].msg,
+		body?.['appeal-reference'] || null
 	);
 
 	return response.status(200).render('patterns/change-page.pattern.njk', {
@@ -48,7 +49,7 @@ export const postAddLinkedAppeal = (request, response) => {
 		params: { appealId }
 	} = request;
 
-	if (request.body.linkConflict || request.body.linkSelf) {
+	if (request.body.linkConflict) {
 		return response.redirect(
 			`/appeals-service/appeal-details/${appealId}/linked-appeals/add/already-linked`
 		);

--- a/appeals/web/src/server/appeals/appeal-details/linked-appeals/add/add.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/linked-appeals/add/add.mapper.js
@@ -11,9 +11,16 @@ import { APPEAL_CASE_STATUS } from '@planning-inspectorate/data-model';
  * @param {{ appealReference: string }} [sessionData]
  * @param {string} [backLinkUrl]
  * @param {string} [errorMsg]
+ * @param {string} [enteredAppealReference]
  * @returns {PageContent}
  */
-export function addLinkedAppealPage(appealData, sessionData, backLinkUrl, errorMsg) {
+export function addLinkedAppealPage(
+	appealData,
+	sessionData,
+	backLinkUrl,
+	errorMsg,
+	enteredAppealReference
+) {
 	const shortAppealReference = appealShortReference(appealData.appealReference);
 
 	/** @type {PageContent} */
@@ -28,7 +35,7 @@ export function addLinkedAppealPage(appealData, sessionData, backLinkUrl, errorM
 					id: 'appeal-reference',
 					name: 'appeal-reference',
 					type: 'text',
-					value: sessionData?.appealReference,
+					value: errorMsg ? enteredAppealReference : sessionData?.appealReference,
 					errorMessage: errorMsg
 						? {
 								text: errorMsg

--- a/appeals/web/src/server/appeals/appeal-details/linked-appeals/add/add.validators.js
+++ b/appeals/web/src/server/appeals/appeal-details/linked-appeals/add/add.validators.js
@@ -15,9 +15,14 @@ export const validateAddLinkedAppealReference = createValidator(
 		.bail()
 		.custom(async (reference, { req }) => {
 			if (reference === appealShortReference(req.currentAppeal.appealReference)) {
-				req.body.linkSelf = true;
+				// Appeal cannot link to itself
 				req.session.linkableAppeal = { linkableAppealSummary: { appealReference: reference } };
-				return Promise.resolve();
+				return Promise.reject();
+			}
+			if (['2', '3', '4'].includes(reference[0])) {
+				// Horizon appeals are not linkable
+				req.session.linkableAppeal = { linkableAppealSummary: { appealReference: reference } };
+				return Promise.reject();
 			}
 			try {
 				const linkableAppealSummary = await getLinkableAppealByReference(


### PR DESCRIPTION
## Describe your changes
####  Add error message when linking appeal to itself or an horizon appeal (a2-4367)

### WEB:
- Add error message when user tries to link an appeal to itself
- Add error message when user tries to link an appeal to an horizon appeal
- Make sure the entered appeal reference is displayed when there is a error message

### TEST:
- Added new unit tests to test this functionality
- Fixed snapshots
- Make sure all other unit tests pass
- Tested in browser

## Issue ticket number and link

[A2-4367- BO linked appeals - Add error message when user tries to link an appeal to itself or link an Horizon appeal to a CBOS appeal (applies to all appeal types)](https://pins-ds.atlassian.net/browse/A2-4367)
