### PR TITLE
fix(appeals): add update questionnaire action links to personal list (a2-4368)

### DIFF
--- a/appeals/web/src/server/appeals/personal-list/__tests__/__snapshots__/personal-list.test.js.snap
+++ b/appeals/web/src/server/appeals/personal-list/__tests__/__snapshots__/personal-list.test.js.snap
@@ -622,7 +622,8 @@ exports[`personal-list GET / should render the second page of the personal list 
                         <td class="govuk-table__cell"><strong><a class="govuk-link" href="/appeals-service/appeal-details/28525" aria-label="Appeal 6 0 2 8 5 2 5">6028525</a></strong>
                         </td>
                         <td class="govuk-table__cell"></td>
-                        <td class="govuk-table__cell action-required">Awaiting LPA update</td>
+                        <td class="govuk-table__cell action-required"><a class="govuk-link" href="/appeals-service/appeal-details/28525/lpa-questionnaire/25064?backUrl=%2Fappeals-service%2Fpersonal-list%3FpageNumber%3D2%26pageSize%3D1%26appealStatusFilter%3Dlpa_questionnaire">Update questionnaire<span class="govuk-visually-hidden"> for appeal 28525</span></a>
+                        </td>
                         <td class="govuk-table__cell">10 April 2025</td>
                         <td class="govuk-table__cell"><strong class="govuk-tag govuk-tag--green">LPA questionnaire</strong>
                         </td>
@@ -747,7 +748,8 @@ exports[`personal-list GET / should render the second page of the personal list 
                         <td class="govuk-table__cell"><strong><a class="govuk-link" href="/appeals-service/appeal-details/28525" aria-label="Appeal 6 0 2 8 5 2 5">6028525</a></strong>
                         </td>
                         <td class="govuk-table__cell"></td>
-                        <td class="govuk-table__cell action-required">Awaiting LPA update</td>
+                        <td class="govuk-table__cell action-required"><a class="govuk-link" href="/appeals-service/appeal-details/28525/lpa-questionnaire/25064?backUrl=%2Fappeals-service%2Fpersonal-list%3FpageNumber%3D2%26pageSize%3D5">Update questionnaire<span class="govuk-visually-hidden"> for appeal 28525</span></a>
+                        </td>
                         <td class="govuk-table__cell">10 April 2025</td>
                         <td class="govuk-table__cell"><strong class="govuk-tag govuk-tag--green">LPA questionnaire</strong>
                         </td>

--- a/appeals/web/src/server/appeals/personal-list/__tests__/personal-list.test.js
+++ b/appeals/web/src/server/appeals/personal-list/__tests__/personal-list.test.js
@@ -285,10 +285,11 @@ describe('personal-list', () => {
 				}
 			},
 			{
-				name: 'Awaiting LPA update',
+				name: 'Update questionnaire',
 				requiredAction: 'awaitingLpaUpdate',
 				expectedHtml: {
-					caseOfficer: 'Awaiting LPA update'
+					caseOfficer: `<a class="govuk-link" href="/appeals-service/appeal-details/${appealId}/lpa-questionnaire/${lpaQuestionnaireId}?backUrl=%2Fappeals-service%2Fpersonal-list">Update questionnaire<span class="govuk-visually-hidden"> for appeal ${appealId}</span></a>`,
+					nonCaseOfficer: 'Update questionnaire'
 				}
 			},
 			{

--- a/appeals/web/src/server/appeals/personal-list/personal-list.mapper.js
+++ b/appeals/web/src/server/appeals/personal-list/personal-list.mapper.js
@@ -318,7 +318,15 @@ function mapRequiredActionToPersonalListActionHtml(
 			return `<span>Awaiting LPA statement<span class="govuk-visually-hidden"> for appeal ${appealId}</span></span>`;
 		}
 		case 'awaitingLpaUpdate': {
-			return 'Awaiting LPA update';
+			if (!lpaQuestionnaireId) {
+				return '';
+			}
+			return isCaseOfficer
+				? `<a class="govuk-link" href="${addBackLinkQueryToUrl(
+						request,
+						`/appeals-service/appeal-details/${appealId}/lpa-questionnaire/${lpaQuestionnaireId}`
+				  )}">Update questionnaire<span class="govuk-visually-hidden"> for appeal ${appealId}</span></a>`
+				: 'Update questionnaire';
 		}
 		case 'issueDecision': {
 			return `<a class="govuk-link" href="${addBackLinkQueryToUrl(


### PR DESCRIPTION
## Describe your changes
### Add update questionnaire action links to personal list (a2-4368)

### WEB:
- Replace the text "Awaiting LPA update" with an action link "Update questionnaire" in the personal list for LPA questionnaires marked as invalid

### Tests:
- Updated snapshots
- Updated unit tests 
- Made sure all unit tests pass
- Tested within browser

## Issue ticket number and link
[A2-4368 Reviewing questionnaires for linked written rep S78 planning appeals (where the appeals have all been started together)](https://pins-ds.atlassian.net/browse/A2-4368)
