### PR TITLE
fix(web): synchronise session dates after date validation updates

### DIFF
--- a/appeals/web/src/server/appeals/appeal-details/timetable/__tests__/__snapshots__/timetable.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/timetable/__tests__/__snapshots__/timetable.test.js.snap
@@ -1914,7 +1914,67 @@ exports[`Timetable GET /edit/check S78 and S20 should render correct "Timetable 
 </main>"
 `;
 
-exports[`Timetable GET /edit/check should render "Timetable CYA" page for householder appeal type 1`] = `
+exports[`Timetable GET /edit/check should render "Timetable CYA" page for householder appeal type: Month as a number 1`] = `
+"<main class="govuk-main-wrapper" id="main-content">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Appeal APP/Q9999/D/21/351062</span>
+            <h1 class="govuk-heading-l">Check details and update timetable due dates</h1>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <dl class="govuk-summary-list">
+                <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> LPA questionnaire due</dt>
+                    <dd class="govuk-summary-list__value">13 October 2030</dd>
+                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/timetable/edit">Change <span class="govuk-visually-hidden">LPA questionnaire due date</span></a>
+                    </dd>
+                </div>
+            </dl>
+            <p class="govuk-body">We’ll send an email to the appellant and LPA to tell them about the new
+                timetable</p>
+            <div class="govuk-grid-row">
+                <div class="govuk-grid-column-full">
+                    <form method="post" novalidate="novalidate">
+                        <button type="submit" class="govuk-button" data-module="govuk-button">Update timetable due dates</button>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </div>
+</main>"
+`;
+
+exports[`Timetable GET /edit/check should render "Timetable CYA" page for householder appeal type: Month as full uppercase text 1`] = `
+"<main class="govuk-main-wrapper" id="main-content">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Appeal APP/Q9999/D/21/351062</span>
+            <h1 class="govuk-heading-l">Check details and update timetable due dates</h1>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <dl class="govuk-summary-list">
+                <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> LPA questionnaire due</dt>
+                    <dd class="govuk-summary-list__value">13 October 2030</dd>
+                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/timetable/edit">Change <span class="govuk-visually-hidden">LPA questionnaire due date</span></a>
+                    </dd>
+                </div>
+            </dl>
+            <p class="govuk-body">We’ll send an email to the appellant and LPA to tell them about the new
+                timetable</p>
+            <div class="govuk-grid-row">
+                <div class="govuk-grid-column-full">
+                    <form method="post" novalidate="novalidate">
+                        <button type="submit" class="govuk-button" data-module="govuk-button">Update timetable due dates</button>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </div>
+</main>"
+`;
+
+exports[`Timetable GET /edit/check should render "Timetable CYA" page for householder appeal type: Month as short text 1`] = `
 "<main class="govuk-main-wrapper" id="main-content">
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Appeal APP/Q9999/D/21/351062</span>

--- a/appeals/web/src/server/appeals/appeal-details/timetable/__tests__/timetable.test.js
+++ b/appeals/web/src/server/appeals/appeal-details/timetable/__tests__/timetable.test.js
@@ -934,25 +934,42 @@ describe('Timetable', () => {
 		});
 
 		it('should render "Timetable CYA" page for householder appeal type', async () => {
-			await request.post(`${baseUrl}/edit`).send({
-				'lpa-questionnaire-due-date-day': '13',
-				'lpa-questionnaire-due-date-month': '10',
-				'lpa-questionnaire-due-date-year': '2030'
-			});
+			const monthVariants = [
+				{
+					month: '10',
+					description: 'Month as a number'
+				},
+				{
+					month: 'Oct',
+					description: 'Month as short text'
+				},
+				{
+					month: 'OCTOBER',
+					description: 'Month as full uppercase text'
+				}
+			];
 
-			const response = await request.get(`${baseUrl}/edit/check`);
-			const element = parseHtml(response.text);
+			for (const variant of monthVariants) {
+				await request.post(`${baseUrl}/edit`).send({
+					'lpa-questionnaire-due-date-day': '13',
+					'lpa-questionnaire-due-date-month': variant.month,
+					'lpa-questionnaire-due-date-year': '2030'
+				});
 
-			expect(element.innerHTML).toMatchSnapshot();
-			expect(element.innerHTML).toContain('LPA questionnaire due</dt>');
-			expect(element.innerHTML).toContain('13 October 2030</dd>');
-			expect(element.innerHTML).toContain(
-				'<a class="govuk-link" href="/appeals-service/appeal-details/1/timetable/edit">Change '
-			);
-			expect(element.innerHTML).toContain(
-				'We’ll send an email to the appellant and LPA to tell them about the new'
-			);
-			expect(element.innerHTML).toContain('Update timetable due dates</button>');
+				const response = await request.get(`${baseUrl}/edit/check`);
+				const element = parseHtml(response.text);
+
+				expect(element.innerHTML).toMatchSnapshot(variant.description);
+				expect(element.innerHTML).toContain('LPA questionnaire due</dt>');
+				expect(element.innerHTML).toContain('13 October 2030</dd>');
+				expect(element.innerHTML).toContain(
+					'<a class="govuk-link" href="/appeals-service/appeal-details/1/timetable/edit">Change '
+				);
+				expect(element.innerHTML).toContain(
+					'We’ll send an email to the appellant and LPA to tell them about the new'
+				);
+				expect(element.innerHTML).toContain('Update timetable due dates</button>');
+			}
 		});
 
 		describe.each([APPEAL_TYPE.S78, APPEAL_TYPE.PLANNED_LISTED_BUILDING])(

--- a/appeals/web/src/server/appeals/appeal-details/timetable/timetable.controller.js
+++ b/appeals/web/src/server/appeals/appeal-details/timetable/timetable.controller.js
@@ -1,3 +1,4 @@
+import { buildSessionDate } from '#appeals/appeal-details/timetable/timetable.validators.js';
 import { dateISOStringToDisplayDate } from '#lib/dates.js';
 import logger from '#lib/logger.js';
 import { renderCheckYourAnswersComponent } from '#lib/mappers/components/page-components/check-your-answers.js';
@@ -9,6 +10,7 @@ import { DEFAULT_TIMEZONE } from '@pins/appeals/constants/dates.js';
 import { zonedTimeToUtc } from 'date-fns-tz';
 import {
 	getAppealTimetableTypes,
+	getIdText,
 	getTimetableTypeText,
 	mapEditTimetablePage
 } from './timetable.mapper.js';
@@ -26,10 +28,17 @@ export const getEditTimetable = async (request, response) => {
  */
 export const postEditTimetable = async (request, response) => {
 	const { appealId } = request.params;
-	const { errors } = request;
+	const { appellantCase } = request.locals;
+	const { errors, session, currentAppeal } = request;
 	if (errors) {
 		return renderEditTimetable(request, response);
 	}
+	let timetableTypes = getAppealTimetableTypes(currentAppeal, appellantCase);
+	session.appealTimetable = session.appealTimetable || {};
+	timetableTypes.forEach((timetableType) => {
+		const idText = getIdText(timetableType);
+		session.appealTimetable[timetableType] = buildSessionDate(request, idText);
+	});
 
 	return response.redirect(`/appeals-service/appeal-details/${appealId}/timetable/edit/check`);
 };

--- a/appeals/web/src/server/appeals/appeal-details/timetable/timetable.validators.js
+++ b/appeals/web/src/server/appeals/appeal-details/timetable/timetable.validators.js
@@ -103,7 +103,7 @@ const validatorsMap = {
  * @param {string} idText
  * @returns {string}
  */
-const buildSessionDate = (req, idText) => {
+export const buildSessionDate = (req, idText) => {
 	const updatedDueDateDay = parseInt(req.body[`${idText}-due-date-day`], 10);
 	const updatedDueDateMonth = parseInt(req.body[`${idText}-due-date-month`], 10);
 	const updatedDueDateYear = parseInt(req.body[`${idText}-due-date-year`], 10);


### PR DESCRIPTION
## Describe your changes

<!--
    Please include a summary of the change along with any relevant context.
    List any dependencies that are required for this change.
-->
This PR addresses a bug in the timetable section of the case details view, where an error was triggered when updating any date field using a month name (e.g., "March") instead of a numeric value.
- updates the session value after validation checks and formatting for date fields in timetable section
- add test cases for different month formats  and update test snapshots

## Issue ticket number and link

[A2-4035](https://pins-ds.atlassian.net/browse/A2-4035)


[A2-4035]: https://pins-ds.atlassian.net/browse/A2-4035?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ