### PR TITLE
feat(web): a2-3847 change the description of the advertisement

### DIFF
--- a/appeals/web/src/server/appeals/appeal-details/appellant-case/__tests__/__snapshots__/appellant-case.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/appellant-case/__tests__/__snapshots__/appellant-case.test.js.snap
@@ -1741,6 +1741,12 @@ exports[`appellant-case GET /appellant-case should render the appellant case pag
                                     data-cy="change-application-date">Change<span class="govuk-visually-hidden"> What date did you submit your application? (3. Application details)</span></a>
                                 </dd>
                         </div>
+                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Agreement to change the description of the advertisement</dt>
+                            <dd                             class="govuk-summary-list__value">No documents</dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/add-documents/70459"
+                                    data-cy="add-agreement-to-change-description-evidence">Add<span class="govuk-visually-hidden"> Agreement to change the description of the advertisement (3. Application details)</span></a>
+                                </dd>
+                        </div>
                         <div class="govuk-summary-list__row appeal-related-appeals"><dt class="govuk-summary-list__key"> Are there other appeals linked to your development?</dt>
                             <dd                             class="govuk-summary-list__value"><span>No</span>
                                 </dd>

--- a/appeals/web/src/server/appeals/appeal-details/appellant-case/__tests__/appellant-case.test.js
+++ b/appeals/web/src/server/appeals/appeal-details/appellant-case/__tests__/appellant-case.test.js
@@ -349,6 +349,9 @@ describe('appellant-case', () => {
 			expect(unprettifiedElement.innerHTML).toContain('What is the application reference number?');
 			expect(unprettifiedElement.innerHTML).toContain('What date did you submit your application?');
 			expect(unprettifiedElement.innerHTML).toContain(
+				'Agreement to change the description of the advertisement'
+			);
+			expect(unprettifiedElement.innerHTML).toContain(
 				'Are there other appeals linked to your development?'
 			);
 			expect(unprettifiedElement.innerHTML).toContain('Was your application granted or refused?');

--- a/appeals/web/src/server/appeals/appeal-details/appellant-case/page-components/cas-advert.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/appellant-case/page-components/cas-advert.mapper.js
@@ -85,6 +85,7 @@ export function generateCASAdvertComponents(appealDetails, mappedAppellantCaseDa
 				mappedAppellantCaseData.localPlanningAuthority.display.summaryListItem,
 				mappedAppellantCaseData.applicationReference.display.summaryListItem,
 				mappedAppellantCaseData.applicationDate.display.summaryListItem,
+				mappedAppellantCaseData.changedAdvertisementDescriptionDocument.display.summaryListItem,
 				mappedAppellantCaseData.relatedAppeals.display.summaryListItem,
 				mappedAppellantCaseData.applicationDecision.display.summaryListItem,
 				mappedAppellantCaseData.applicationDecisionDate.display.summaryListItem,

--- a/appeals/web/src/server/lib/mappers/data/appellant-case/cas-advert.js
+++ b/appeals/web/src/server/lib/mappers/data/appellant-case/cas-advert.js
@@ -1,9 +1,11 @@
 import { submaps as hasSubmaps } from './has.js';
+import { mapChangedAdvertisementDescriptionDocument } from './submappers/changed-advertisement-description-document.js';
 import { mapDesignAccessStatement } from './submappers/design-access-statement.js';
 import { mapSupportingDocuments } from './submappers/supporting-documents.js';
 
 export const submaps = {
 	...hasSubmaps,
 	supportingDocuments: mapSupportingDocuments,
-	designAndAccessStatement: mapDesignAccessStatement
+	designAndAccessStatement: mapDesignAccessStatement,
+	changedAdvertisementDescriptionDocument: mapChangedAdvertisementDescriptionDocument
 };

--- a/appeals/web/src/server/lib/mappers/data/appellant-case/submappers/changed-advertisement-description-document.js
+++ b/appeals/web/src/server/lib/mappers/data/appellant-case/submappers/changed-advertisement-description-document.js
@@ -1,0 +1,22 @@
+import { documentSummaryListItem } from '#lib/mappers/components/index.js';
+import { documentUploadUrlTemplate, mapDocumentManageUrl } from '../common.js';
+
+//TODO: update with new document type
+/** @type {import('../mapper.js').SubMapper} */
+export const mapChangedAdvertisementDescriptionDocument = ({
+	appellantCaseData,
+	userHasUpdateCase
+}) =>
+	documentSummaryListItem({
+		manageUrl: mapDocumentManageUrl(
+			appellantCaseData.appealId,
+			appellantCaseData.documents.changedDescription?.folderId
+		),
+		appealId: appellantCaseData.appealId,
+		editable: userHasUpdateCase,
+		uploadUrlTemplate: documentUploadUrlTemplate,
+		id: 'changed-advertisement-description.document',
+		text: 'Agreement to change the description of the advertisement',
+		folderInfo: appellantCaseData.documents.changedDescription,
+		cypressDataName: 'agreement-to-change-description-evidence'
+	});


### PR DESCRIPTION
## Describe your changes

###  Web
Adds the change description of advertisement document row using the changed description of development document type
As it uses an existing document type no api changes are required

### Tests

- Snapshots updated
- Row added to cas advert appellent case controller test
- Change and add document behaviour tested manually in browser 

## Issue ticket number and link

[Ticket](https://pins-ds.atlassian.net/browse/A2-3847)
