### PR TITLE
feat(appeals): sync team and hide on child appeal (a2-4374)

### DIFF
--- a/appeals/api/src/server/endpoints/appeal-details/__tests__/appeals-details.test.js
+++ b/appeals/api/src/server/endpoints/appeal-details/__tests__/appeals-details.test.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import { request } from '#tests/../app-test.js';
 import { mocks } from '#tests/appeals/index.js';
 import { savedFolder } from '#tests/documents/mocks.js';
@@ -7,6 +8,8 @@ import { jest } from '@jest/globals';
 import {
 	AUDIT_TRAIL_ASSIGNED_CASE_OFFICER,
 	AUDIT_TRAIL_ASSIGNED_INSPECTOR,
+	CASE_RELATIONSHIP_LINKED,
+	CASE_RELATIONSHIP_RELATED,
 	ERROR_CANNOT_BE_EMPTY_STRING,
 	ERROR_FAILED_TO_SAVE_DATA,
 	ERROR_MUST_BE_CORRECT_UTC_DATE_FORMAT,
@@ -17,6 +20,7 @@ import {
 	ERROR_NOT_FOUND
 } from '@pins/appeals/constants/support.js';
 import { APPEAL_CASE_STAGE, APPEAL_DOCUMENT_TYPE } from '@planning-inspectorate/data-model';
+import { cloneDeep } from 'lodash-es';
 
 const { databaseConnector } = await import('#utils/database-connector.js');
 const householdAppeal = mocks.householdAppeal;
@@ -270,6 +274,12 @@ const folders = [
 ];
 
 describe('Appeal detail routes', () => {
+	beforeAll(() => {
+		jest.clearAllMocks();
+	});
+	afterEach(() => {
+		jest.clearAllMocks();
+	});
 	describe('/appeals/:appealId', () => {
 		describe('GET', () => {
 			test('gets a single household appeal', async () => {
@@ -482,6 +492,8 @@ describe('Appeal detail routes', () => {
 					})
 					.set('azureAdUserId', azureAdUserId);
 
+				expect(databaseConnector.appeal.update).toHaveBeenCalledTimes(1);
+
 				expect(databaseConnector.appeal.update).toHaveBeenCalledWith({
 					data: {
 						caseOfficerUserId: householdAppeal.caseOfficer.id,
@@ -528,6 +540,8 @@ describe('Appeal detail routes', () => {
 					})
 					.set('azureAdUserId', azureAdUserId);
 
+				expect(databaseConnector.appeal.update).toHaveBeenCalledTimes(1);
+
 				expect(databaseConnector.appeal.update).toHaveBeenCalledWith({
 					data: {
 						caseOfficerUserId: householdAppeal.caseOfficer.id,
@@ -559,7 +573,6 @@ describe('Appeal detail routes', () => {
 			});
 
 			test('assigns an inspector to an appeal', async () => {
-				jest.clearAllMocks();
 				const inspector = '37b537ee-8a4e-42c3-8b97-089ddb8949e7';
 				// @ts-ignore
 				databaseConnector.appeal.findUnique.mockResolvedValue(householdAppeal);
@@ -572,6 +585,8 @@ describe('Appeal detail routes', () => {
 						inspector
 					})
 					.set('azureAdUserId', azureAdUserId);
+
+				expect(databaseConnector.appeal.update).toHaveBeenCalledTimes(1);
 
 				expect(databaseConnector.appeal.update).toHaveBeenCalledWith({
 					data: {
@@ -596,6 +611,302 @@ describe('Appeal detail routes', () => {
 						userId: 10
 					}
 				});
+				expect(response.status).toEqual(200);
+				expect(response.body).toEqual({
+					inspector
+				});
+			});
+
+			test('assigns a case officer to linked appeals', async () => {
+				const leadAppeal = cloneDeep(householdAppeal);
+				leadAppeal.childAppeals = [
+					{ child: { id: 10 }, childId: 10, type: CASE_RELATIONSHIP_LINKED },
+					{ child: { id: 20 }, childId: 20, type: CASE_RELATIONSHIP_RELATED },
+					{ child: { id: 30 }, childId: 30, type: CASE_RELATIONSHIP_LINKED }
+				];
+				// @ts-ignore
+				databaseConnector.appeal.findUnique.mockResolvedValue({
+					...leadAppeal,
+					caseOfficerId: null,
+					caseOfficer: undefined
+				});
+				// @ts-ignore
+				databaseConnector.user.upsert.mockResolvedValue(leadAppeal.caseOfficer);
+
+				const response = await request
+					.patch(`/appeals/${leadAppeal.id}`)
+					.send({
+						caseOfficer: leadAppeal.caseOfficer.azureAdUserId
+					})
+					.set('azureAdUserId', azureAdUserId);
+
+				expect(databaseConnector.appeal.update).toHaveBeenCalledTimes(3);
+				expect(databaseConnector.appeal.update).toHaveBeenNthCalledWith(1, {
+					data: {
+						caseOfficerUserId: leadAppeal.caseOfficer.id,
+						caseUpdatedDate: expect.any(Date)
+					},
+					include: {
+						appealStatus: true,
+						appealType: true
+					},
+					where: {
+						id: leadAppeal.id
+					}
+				});
+				expect(databaseConnector.appeal.update).toHaveBeenNthCalledWith(2, {
+					data: {
+						caseOfficerUserId: leadAppeal.caseOfficer.id,
+						caseUpdatedDate: expect.any(Date)
+					},
+					include: {
+						appealStatus: true,
+						appealType: true
+					},
+					where: {
+						id: leadAppeal.childAppeals[0].childId
+					}
+				});
+				expect(databaseConnector.appeal.update).toHaveBeenNthCalledWith(3, {
+					data: {
+						caseOfficerUserId: leadAppeal.caseOfficer.id,
+						caseUpdatedDate: expect.any(Date)
+					},
+					include: {
+						appealStatus: true,
+						appealType: true
+					},
+					where: {
+						id: leadAppeal.childAppeals[2].childId
+					}
+				});
+
+				expect(databaseConnector.appealStatus.create).not.toHaveBeenCalled();
+
+				expect(databaseConnector.auditTrail.create).toHaveBeenCalledTimes(3);
+				expect(databaseConnector.auditTrail.create).toHaveBeenNthCalledWith(1, {
+					data: {
+						appealId: leadAppeal.id,
+						details: stringTokenReplacement(AUDIT_TRAIL_ASSIGNED_CASE_OFFICER, [
+							leadAppeal.caseOfficer.azureAdUserId
+						]),
+						loggedAt: expect.any(Date),
+						userId: leadAppeal.caseOfficer.id
+					}
+				});
+				expect(databaseConnector.auditTrail.create).toHaveBeenNthCalledWith(2, {
+					data: {
+						appealId: leadAppeal.childAppeals[0].childId,
+						details: stringTokenReplacement(AUDIT_TRAIL_ASSIGNED_CASE_OFFICER, [
+							leadAppeal.caseOfficer.azureAdUserId
+						]),
+						loggedAt: expect.any(Date),
+						userId: leadAppeal.caseOfficer.id
+					}
+				});
+				expect(databaseConnector.auditTrail.create).toHaveBeenNthCalledWith(3, {
+					data: {
+						appealId: leadAppeal.childAppeals[2].childId,
+						details: stringTokenReplacement(AUDIT_TRAIL_ASSIGNED_CASE_OFFICER, [
+							leadAppeal.caseOfficer.azureAdUserId
+						]),
+						loggedAt: expect.any(Date),
+						userId: leadAppeal.caseOfficer.id
+					}
+				});
+
+				expect(response.status).toEqual(200);
+				expect(response.body).toEqual({
+					caseOfficer: leadAppeal.caseOfficer.azureAdUserId
+				});
+			});
+
+			test('replace a case officer to linked appeals', async () => {
+				const leadAppeal = cloneDeep(householdAppeal);
+				leadAppeal.childAppeals = [
+					{ child: { id: 10 }, childId: 10, type: CASE_RELATIONSHIP_LINKED },
+					{ child: { id: 20 }, childId: 20, type: CASE_RELATIONSHIP_RELATED },
+					{ child: { id: 30 }, childId: 30, type: CASE_RELATIONSHIP_LINKED }
+				];
+				// @ts-ignore
+				databaseConnector.appeal.findUnique.mockResolvedValue(leadAppeal);
+				// @ts-ignore
+				databaseConnector.user.upsert.mockResolvedValue(leadAppeal.caseOfficer);
+
+				const response = await request
+					.patch(`/appeals/${leadAppeal.id}`)
+					.send({
+						caseOfficer: leadAppeal.caseOfficer.azureAdUserId
+					})
+					.set('azureAdUserId', azureAdUserId);
+
+				expect(databaseConnector.appeal.update).toHaveBeenCalledTimes(3);
+				expect(databaseConnector.appeal.update).toHaveBeenNthCalledWith(1, {
+					data: {
+						caseOfficerUserId: 1,
+						caseUpdatedDate: expect.any(Date)
+					},
+					where: {
+						id: leadAppeal.id
+					},
+					include: {
+						appealStatus: true,
+						appealType: true
+					}
+				});
+				expect(databaseConnector.appeal.update).toHaveBeenNthCalledWith(2, {
+					data: {
+						caseOfficerUserId: 1,
+						caseUpdatedDate: expect.any(Date)
+					},
+					where: {
+						id: leadAppeal.childAppeals[0].childId
+					},
+					include: {
+						appealStatus: true,
+						appealType: true
+					}
+				});
+				expect(databaseConnector.appeal.update).toHaveBeenNthCalledWith(3, {
+					data: {
+						caseOfficerUserId: 1,
+						caseUpdatedDate: expect.any(Date)
+					},
+					where: {
+						id: leadAppeal.childAppeals[2].childId
+					},
+					include: {
+						appealStatus: true,
+						appealType: true
+					}
+				});
+
+				expect(databaseConnector.appealStatus.create).not.toHaveBeenCalled();
+
+				expect(databaseConnector.auditTrail.create).toHaveBeenCalledTimes(3);
+				expect(databaseConnector.auditTrail.create).toHaveBeenNthCalledWith(1, {
+					data: {
+						appealId: leadAppeal.id,
+						details: stringTokenReplacement(AUDIT_TRAIL_ASSIGNED_CASE_OFFICER, [
+							leadAppeal.caseOfficer.azureAdUserId
+						]),
+						loggedAt: expect.any(Date),
+						userId: leadAppeal.caseOfficer.id
+					}
+				});
+				expect(databaseConnector.auditTrail.create).toHaveBeenNthCalledWith(2, {
+					data: {
+						appealId: leadAppeal.childAppeals[0].childId,
+						details: stringTokenReplacement(AUDIT_TRAIL_ASSIGNED_CASE_OFFICER, [
+							leadAppeal.caseOfficer.azureAdUserId
+						]),
+						loggedAt: expect.any(Date),
+						userId: leadAppeal.caseOfficer.id
+					}
+				});
+				expect(databaseConnector.auditTrail.create).toHaveBeenNthCalledWith(3, {
+					data: {
+						appealId: leadAppeal.childAppeals[2].childId,
+						details: stringTokenReplacement(AUDIT_TRAIL_ASSIGNED_CASE_OFFICER, [
+							leadAppeal.caseOfficer.azureAdUserId
+						]),
+						loggedAt: expect.any(Date),
+						userId: leadAppeal.caseOfficer.id
+					}
+				});
+				expect(response.status).toEqual(200);
+				expect(response.body).toEqual({
+					caseOfficer: leadAppeal.caseOfficer.azureAdUserId
+				});
+			});
+
+			test('assigns an inspector to linked appeals', async () => {
+				const leadAppeal = cloneDeep(householdAppeal);
+				leadAppeal.childAppeals = [
+					{ child: { id: 10 }, childId: 10, type: CASE_RELATIONSHIP_LINKED },
+					{ child: { id: 20 }, childId: 20, type: CASE_RELATIONSHIP_RELATED },
+					{ child: { id: 30 }, childId: 30, type: CASE_RELATIONSHIP_LINKED }
+				];
+				const inspector = '37b537ee-8a4e-42c3-8b97-089ddb8949e7';
+				// @ts-ignore
+				databaseConnector.appeal.findUnique.mockResolvedValue(leadAppeal);
+				// @ts-ignore
+				databaseConnector.user.upsert.mockResolvedValue({ id: 10, azureAdUserId: inspector });
+
+				const response = await request
+					.patch(`/appeals/${leadAppeal.id}`)
+					.send({
+						inspector
+					})
+					.set('azureAdUserId', azureAdUserId);
+
+				expect(databaseConnector.appeal.update).toHaveBeenCalledTimes(3);
+				expect(databaseConnector.appeal.update).toHaveBeenNthCalledWith(1, {
+					data: {
+						inspectorUserId: 10,
+						caseUpdatedDate: expect.any(Date)
+					},
+					where: {
+						id: leadAppeal.id
+					},
+					include: {
+						appealStatus: true,
+						appealType: true
+					}
+				});
+				expect(databaseConnector.appeal.update).toHaveBeenNthCalledWith(2, {
+					data: {
+						inspectorUserId: 10,
+						caseUpdatedDate: expect.any(Date)
+					},
+					where: {
+						id: leadAppeal.childAppeals[0].childId
+					},
+					include: {
+						appealStatus: true,
+						appealType: true
+					}
+				});
+				expect(databaseConnector.appeal.update).toHaveBeenNthCalledWith(3, {
+					data: {
+						inspectorUserId: 10,
+						caseUpdatedDate: expect.any(Date)
+					},
+					where: {
+						id: leadAppeal.childAppeals[2].childId
+					},
+					include: {
+						appealStatus: true,
+						appealType: true
+					}
+				});
+
+				expect(databaseConnector.auditTrail.create).toHaveBeenCalledTimes(3);
+				expect(databaseConnector.auditTrail.create).toHaveBeenNthCalledWith(1, {
+					data: {
+						appealId: leadAppeal.id,
+						details: stringTokenReplacement(AUDIT_TRAIL_ASSIGNED_INSPECTOR, [inspector]),
+						loggedAt: expect.any(Date),
+						userId: 10
+					}
+				});
+				expect(databaseConnector.auditTrail.create).toHaveBeenNthCalledWith(2, {
+					data: {
+						appealId: leadAppeal.childAppeals[0].childId,
+						details: stringTokenReplacement(AUDIT_TRAIL_ASSIGNED_INSPECTOR, [inspector]),
+						loggedAt: expect.any(Date),
+						userId: 10
+					}
+				});
+				expect(databaseConnector.auditTrail.create).toHaveBeenNthCalledWith(3, {
+					data: {
+						appealId: leadAppeal.childAppeals[2].childId,
+						details: stringTokenReplacement(AUDIT_TRAIL_ASSIGNED_INSPECTOR, [inspector]),
+						loggedAt: expect.any(Date),
+						userId: 10
+					}
+				});
+
 				expect(response.status).toEqual(200);
 				expect(response.body).toEqual({
 					inspector
@@ -835,6 +1146,12 @@ describe('Appeal detail routes', () => {
 });
 
 describe('appeals/case-reference/:caseReference', () => {
+	beforeAll(() => {
+		jest.clearAllMocks();
+	});
+	afterEach(() => {
+		jest.clearAllMocks();
+	});
 	describe('GET', () => {
 		test('gets a single household appeal', async () => {
 			// @ts-ignore

--- a/appeals/api/src/server/endpoints/appeal-details/appeal-details.controller.js
+++ b/appeals/api/src/server/endpoints/appeal-details/appeal-details.controller.js
@@ -1,6 +1,8 @@
 import { broadcasters } from '#endpoints/integrations/integrations.broadcasters.js';
 import { contextEnum } from '#mappers/context-enum.js';
+import { isFeatureActive } from '#utils/feature-flags.js';
 import logger from '#utils/logger.js';
+import { FEATURE_FLAG_NAMES } from '@pins/appeals/constants/common.js';
 import { ERROR_FAILED_TO_SAVE_DATA } from '@pins/appeals/constants/support.js';
 import { appealDetailService } from './appeal-details.service.js';
 
@@ -44,6 +46,13 @@ const updateAppealById = async (req, res) => {
 	try {
 		if (appealDetailService.assignedUserType({ caseOfficer, inspector })) {
 			await appealDetailService.assignUser(appeal, { caseOfficer, inspector }, azureAdUserId);
+			if (isFeatureActive(FEATURE_FLAG_NAMES.LINKED_APPEALS) && appeal.childAppeals?.length) {
+				await appealDetailService.assignUserForLinkedAppeals(
+					appeal,
+					{ caseOfficer, inspector },
+					azureAdUserId
+				);
+			}
 		} else {
 			await appealDetailService.updateAppealDetails(
 				{

--- a/appeals/api/src/server/endpoints/case-team/case-team.controller.js
+++ b/appeals/api/src/server/endpoints/case-team/case-team.controller.js
@@ -1,5 +1,7 @@
 import * as caseTeamRepository from '#repositories/team.repository.js';
-import { setAssignedTeamId } from './case-team.service.js';
+import { isFeatureActive } from '#utils/feature-flags.js';
+import { FEATURE_FLAG_NAMES } from '@pins/appeals/constants/common.js';
+import { setAssignedTeamId, setAssignedTeamIdForLinkedAppeals } from './case-team.service.js';
 
 /** @typedef {import('express').Request} Request */
 /** @typedef {import('express').Response} Response */
@@ -32,6 +34,12 @@ export const updateAssignedTeamId = async (req, res) => {
 	}
 
 	const result = await setAssignedTeamId(appealId, teamId, azureAdUserId);
+	if (
+		Object.hasOwn(result, 'assignedTeamId') &&
+		isFeatureActive(FEATURE_FLAG_NAMES.LINKED_APPEALS)
+	) {
+		await setAssignedTeamIdForLinkedAppeals(appealId, teamId, azureAdUserId);
+	}
 
 	return res.send(result);
 };

--- a/appeals/api/src/server/endpoints/case-team/case-team.service.js
+++ b/appeals/api/src/server/endpoints/case-team/case-team.service.js
@@ -1,7 +1,10 @@
 import { createAuditTrail } from '#endpoints/audit-trails/audit-trails.service.js';
 import { broadcasters } from '#endpoints/integrations/integrations.broadcasters.js';
 import appealRepository from '#repositories/appeal.repository.js';
-import { AUDIT_TRAIL_ASSIGNED_TEAM_UPDATED } from '@pins/appeals/constants/support.js';
+import {
+	AUDIT_TRAIL_ASSIGNED_TEAM_UPDATED,
+	CASE_RELATIONSHIP_LINKED
+} from '@pins/appeals/constants/support.js';
 
 /**
  *
@@ -21,5 +24,32 @@ export const setAssignedTeamId = async (appealId, assignedTeamId, azureAdUserId)
 		details: AUDIT_TRAIL_ASSIGNED_TEAM_UPDATED
 	});
 	await broadcasters.broadcastAppeal(appealId);
+
 	return result;
+};
+
+/**
+ *
+ * @param {number} appealId
+ * @param {number|null} assignedTeamId
+ * @param {string|undefined} azureAdUserId
+ * @returns
+ */
+export const setAssignedTeamIdForLinkedAppeals = async (
+	appealId,
+	assignedTeamId,
+	azureAdUserId
+) => {
+	const linkedAppeals = await appealRepository.getLinkedAppealsById(
+		appealId,
+		CASE_RELATIONSHIP_LINKED
+	);
+	if (linkedAppeals?.length) {
+		await Promise.all(
+			linkedAppeals.map((linkedAppeal) =>
+				// @ts-ignore
+				setAssignedTeamId(linkedAppeal.childId, assignedTeamId, azureAdUserId)
+			)
+		);
+	}
 };

--- a/appeals/api/src/server/endpoints/decision/__tests__/decision.test.js
+++ b/appeals/api/src/server/endpoints/decision/__tests__/decision.test.js
@@ -36,6 +36,9 @@ import { request } from '../../../app-test.js';
 import { sendNewDecisionLetter } from '../decision.service';
 const { databaseConnector } = await import('#utils/database-connector.js');
 describe('decision routes', () => {
+	beforeAll(() => {
+		jest.clearAllMocks();
+	});
 	beforeEach(() => {
 		// @ts-ignore
 		databaseConnector.appealRelationship.findMany.mockResolvedValue([]);

--- a/appeals/api/src/server/endpoints/link-appeals/link-appeals.controller.js
+++ b/appeals/api/src/server/endpoints/link-appeals/link-appeals.controller.js
@@ -1,5 +1,7 @@
 import { formatAddressSingleLine } from '#endpoints/addresses/addresses.formatter.js';
+import { appealDetailService } from '#endpoints/appeal-details/appeal-details.service.js';
 import { createAuditTrail } from '#endpoints/audit-trails/audit-trails.service.js';
+import { setAssignedTeamId } from '#endpoints/case-team/case-team.service.js';
 import { broadcasters } from '#endpoints/integrations/integrations.broadcasters.js';
 import { notifySend } from '#notify/notify-send.js';
 import appealRepository from '#repositories/appeal.repository.js';
@@ -74,6 +76,12 @@ export const linkAppeal = async (req, res) => {
 
 	if (result) {
 		await duplicateFiles(childAppeal, parentAppeal, APPEAL_CASE_STAGE.COSTS);
+		const azureAdUserId = req.get('azureAdUserId') || '';
+		await setAssignedTeamId(childAppeal.id, parentAppeal.assignedTeamId || null, azureAdUserId);
+		const caseOfficer = parentAppeal.caseOfficer?.azureAdUserId || null;
+		const inspector = parentAppeal.inspector?.azureAdUserId || null;
+		await appealDetailService.assignUser(childAppeal, { caseOfficer }, azureAdUserId);
+		await appealDetailService.assignUser(childAppeal, { inspector }, azureAdUserId);
 	}
 
 	const siteAddress = currentAppeal.address

--- a/appeals/api/src/server/endpoints/representations/__tests__/representations.test.js
+++ b/appeals/api/src/server/endpoints/representations/__tests__/representations.test.js
@@ -20,7 +20,9 @@ import { cloneDeep } from 'lodash-es';
 const { databaseConnector } = await import('#utils/database-connector.js');
 
 describe('/appeals/:id/reps', () => {
-	beforeEach(() => {});
+	beforeAll(() => {
+		jest.clearAllMocks();
+	});
 	afterEach(() => {
 		jest.clearAllMocks();
 	});

--- a/appeals/api/src/server/repositories/appeal.repository.js
+++ b/appeals/api/src/server/repositories/appeal.repository.js
@@ -147,6 +147,7 @@ const appealDetailsInclude = {
 
 /**
  * @param {number} id
+ * @param {boolean} [includeDetails]
  * @returns {Promise<Appeal|undefined>}
  */
 const getAppealById = async (id, includeDetails = true) => {
@@ -358,6 +359,38 @@ const getLinkedAppeals = async (appealReference, relationshipType) => {
 
 /**
  *
+ * @param {number} appealId
+ * @param {string} relationshipType
+ * @returns {Promise<AppealRelationship[]>}
+ */
+const getLinkedAppealsById = async (appealId, relationshipType) => {
+	// ToDo Fix this typescript type
+	// @ts-ignore
+	return await databaseConnector.appealRelationship.findMany({
+		where: {
+			AND: [
+				{ type: relationshipType },
+				{
+					OR: [
+						{
+							parentId: {
+								equals: appealId
+							}
+						},
+						{
+							childId: {
+								equals: appealId
+							}
+						}
+					]
+				}
+			]
+		}
+	});
+};
+
+/**
+ *
  * @param {AppealRelationshipRequest} relation
  * @returns {Promise<AppealRelationship>}
  */
@@ -494,6 +527,7 @@ const setAssignedTeamId = (id, assignedTeamId) => {
 
 export default {
 	getLinkedAppeals,
+	getLinkedAppealsById,
 	getAppealById,
 	getAppealByAppealReference,
 	updateAppealById,

--- a/appeals/web/src/server/appeals/appeal-details/__tests__/__snapshots__/appeal-details.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/__tests__/__snapshots__/appeal-details.test.js.snap
@@ -670,45 +670,9 @@ exports[`appeal-details GET /:appealId Linked appeals should not render a "Appea
                 </div>
                 <div class="govuk-accordion__section">
                     <div class="govuk-accordion__section-header">
-                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default2-heading-5"> Team</span></h2>
+                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default2-heading-5"> Case management</span></h2>
                     </div>
                     <div id="accordion-default2-content-5" class="govuk-accordion__section-content">
-                        <dl class="govuk-summary-list">
-                            <div class="govuk-summary-list__row appeal-case-team"><dt class="govuk-summary-list__key"> Case team</dt>
-                                <dd class="govuk-summary-list__value">
-                                    <ul class="govuk-list">
-                                        <li>Test Team</li>
-                                        <li>test@emai.com</li>
-                                    </ul>
-                                </dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/case-team/edit"
-                                    data-cy="change-case-team">Change<span class="govuk-visually-hidden"> Case team</span></a>
-                                </dd>
-                            </div>
-                            <div class="govuk-summary-list__row appeal-case-officer"><dt class="govuk-summary-list__key"> Case officer</dt>
-                                <dd class="govuk-summary-list__value">
-                                    <p class="govuk-body">Not assigned</p>
-                                </dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/assign-case-officer/search-case-officer"
-                                    data-cy="assign-case-officer">Assign<span class="govuk-visually-hidden"> Case officer</span></a>
-                                </dd>
-                            </div>
-                            <div class="govuk-summary-list__row appeal-inspector"><dt class="govuk-summary-list__key"> Inspector</dt>
-                                <dd class="govuk-summary-list__value">
-                                    <p class="govuk-body">Not assigned</p>
-                                </dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/assign-inspector/search-inspector"
-                                    data-cy="assign-inspector">Assign<span class="govuk-visually-hidden"> Inspector</span></a>
-                                </dd>
-                            </div>
-                        </dl>
-                    </div>
-                </div>
-                <div class="govuk-accordion__section">
-                    <div class="govuk-accordion__section-header">
-                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default2-heading-6"> Case management</span></h2>
-                    </div>
-                    <div id="accordion-default2-content-6" class="govuk-accordion__section-content">
                         <dl class="govuk-summary-list">
                             <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Cross-team correspondence</dt>
                                 <dd                                 class="govuk-summary-list__value">No documents</dd>
@@ -1442,45 +1406,9 @@ exports[`appeal-details GET /:appealId Linked appeals should render a child tag 
                 </div>
                 <div class="govuk-accordion__section">
                     <div class="govuk-accordion__section-header">
-                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-5"> Team</span></h2>
+                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-5"> Case management</span></h2>
                     </div>
                     <div id="accordion-default1-content-5" class="govuk-accordion__section-content">
-                        <dl class="govuk-summary-list">
-                            <div class="govuk-summary-list__row appeal-case-team"><dt class="govuk-summary-list__key"> Case team</dt>
-                                <dd class="govuk-summary-list__value">
-                                    <ul class="govuk-list">
-                                        <li>Test Team</li>
-                                        <li>test@emai.com</li>
-                                    </ul>
-                                </dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/case-team/edit"
-                                    data-cy="change-case-team">Change<span class="govuk-visually-hidden"> Case team</span></a>
-                                </dd>
-                            </div>
-                            <div class="govuk-summary-list__row appeal-case-officer"><dt class="govuk-summary-list__key"> Case officer</dt>
-                                <dd class="govuk-summary-list__value">
-                                    <p class="govuk-body">Not assigned</p>
-                                </dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/assign-case-officer/search-case-officer"
-                                    data-cy="assign-case-officer">Assign<span class="govuk-visually-hidden"> Case officer</span></a>
-                                </dd>
-                            </div>
-                            <div class="govuk-summary-list__row appeal-inspector"><dt class="govuk-summary-list__key"> Inspector</dt>
-                                <dd class="govuk-summary-list__value">
-                                    <p class="govuk-body">Not assigned</p>
-                                </dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/assign-inspector/search-inspector"
-                                    data-cy="assign-inspector">Assign<span class="govuk-visually-hidden"> Inspector</span></a>
-                                </dd>
-                            </div>
-                        </dl>
-                    </div>
-                </div>
-                <div class="govuk-accordion__section">
-                    <div class="govuk-accordion__section-header">
-                        <h2 class="govuk-accordion__section-heading"><span class="govuk-accordion__section-button" id="accordion-default1-heading-6"> Case management</span></h2>
-                    </div>
-                    <div id="accordion-default1-content-6" class="govuk-accordion__section-content">
                         <dl class="govuk-summary-list">
                             <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Cross-team correspondence</dt>
                                 <dd                                 class="govuk-summary-list__value">No documents</dd>

--- a/appeals/web/src/server/appeals/appeal-details/accordions/has.js
+++ b/appeals/web/src/server/appeals/appeal-details/accordions/has.js
@@ -74,7 +74,7 @@ export function generateAccordion(appealDetails, mappedData, session) {
 
 	const caseContacts = getCaseContacts(mappedData);
 
-	const caseTeam = getCaseTeam(mappedData);
+	const caseTeam = !isChildAppeal(appealDetails) && getCaseTeam(mappedData);
 
 	const caseManagement = getCaseManagement(mappedData);
 
@@ -92,6 +92,7 @@ export function generateAccordion(appealDetails, mappedData, session) {
 		!userHasPermission(permissionNames.viewCaseDetails, session) ||
 		appealDetails.appealStatus === APPEAL_CASE_STATUS.AWAITING_TRANSFER
 	) {
+		// @ts-ignore
 		removeAccordionComponentsActions(accordionComponents);
 	}
 
@@ -137,10 +138,14 @@ export function generateAccordion(appealDetails, mappedData, session) {
 					heading: { text: 'Contacts' },
 					content: { html: '', pageComponents: [caseContacts] }
 				},
-				{
-					heading: { text: 'Team' },
-					content: { html: '', pageComponents: [caseTeam] }
-				},
+				...(caseTeam
+					? [
+							{
+								heading: { text: 'Team' },
+								content: { html: '', pageComponents: [caseTeam] }
+							}
+					  ]
+					: []),
 				{
 					heading: { text: 'Case management' },
 					content: { html: '', pageComponents: [caseManagement] }

--- a/appeals/web/src/server/appeals/appeal-details/accordions/s78.js
+++ b/appeals/web/src/server/appeals/appeal-details/accordions/s78.js
@@ -59,7 +59,7 @@ export function generateAccordion(appealDetails, mappedData, session) {
 
 	const caseContacts = getCaseContacts(mappedData);
 
-	const caseTeam = getCaseTeam(mappedData);
+	const caseTeam = !isChildAppeal(appealDetails) && getCaseTeam(mappedData);
 
 	const caseManagement = getCaseManagement(mappedData);
 
@@ -83,6 +83,7 @@ export function generateAccordion(appealDetails, mappedData, session) {
 		!userHasPermission(permissionNames.viewCaseDetails, session) ||
 		appealDetails.appealStatus === APPEAL_CASE_STATUS.AWAITING_TRANSFER
 	) {
+		// @ts-ignore
 		removeAccordionComponentsActions(accordionComponents);
 	}
 
@@ -144,10 +145,14 @@ export function generateAccordion(appealDetails, mappedData, session) {
 					heading: { text: 'Contacts' },
 					content: { html: '', pageComponents: [caseContacts] }
 				},
-				{
-					heading: { text: 'Team' },
-					content: { html: '', pageComponents: [caseTeam] }
-				},
+				...(caseTeam
+					? [
+							{
+								heading: { text: 'Team' },
+								content: { html: '', pageComponents: [caseTeam] }
+							}
+					  ]
+					: []),
 				{
 					heading: { text: 'Case management' },
 					content: { html: '', pageComponents: [caseManagement] }


### PR DESCRIPTION
## Describe your changes
####  Update and hide 'Team' section on child appeal(s) upon linking (relates to all appeal types) (a2-4374)
##### Please note this also synchronises the team details of the lead appeal with the child appeals upon linking

### WEB:
- Hide "Team" section in case details page for child appeals

### API:
- Make sure child appeals inherit lead appeal team, inspector, and case officer upon linking
- Make sure all child appeals synchronise their case team with the lead appeal when the lead appeal's case team is updated
- Make sure all child appeals synchronise their inspector with the lead appeal when the lead appeal's inspector is updated
- Make sure all child appeals synchronise their case officer with the lead appeal when the lead appeal's case officer is updated

### TEST:
- Make sure tests are stable by clearing all mocks before all tests within affected test files (spotted intermittent failures locally)
- Added new unit tests to extensively test the above functionality
- Updated snap shots where required
- Make sure all other unit tests pass
- Tested within the browser

## Issue ticket number and link

[A2-4374- BO - linked appeals - Update and hide 'Team' section on child appeal(s) upon linking (relates to all appeal types)](https://pins-ds.atlassian.net/browse/A2-4374)
