### PR TITLE
feat(appeals): hide appeal type change link for linked appeals (a2-4386)

### DIFF
--- a/appeals/web/src/server/appeals/appeal-details/__tests__/__snapshots__/appeal-details.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/__tests__/__snapshots__/appeal-details.test.js.snap
@@ -534,9 +534,6 @@ exports[`appeal-details GET /:appealId Linked appeals should not render a "Appea
                             </div>
                             <div class="govuk-summary-list__row appeal-appeal-type"><dt class="govuk-summary-list__key"> Appeal type</dt>
                                 <dd class="govuk-summary-list__value">Householder</dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/change-appeal-type/appeal-type"
-                                    data-cy="change-appeal-type">Change<span class="govuk-visually-hidden"> Appeal type</span></a>
-                                </dd>
                             </div>
                             <div class="govuk-summary-list__row govuk-summary-list__row--no-actions appeal-case-procedure"><dt class="govuk-summary-list__key"> Appeal procedure</dt>
                                 <dd class="govuk-summary-list__value">Written</dd>
@@ -1309,9 +1306,6 @@ exports[`appeal-details GET /:appealId Linked appeals should render a child tag 
                             </div>
                             <div class="govuk-summary-list__row appeal-appeal-type"><dt class="govuk-summary-list__key"> Appeal type</dt>
                                 <dd class="govuk-summary-list__value">Householder</dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/change-appeal-type/appeal-type"
-                                    data-cy="change-appeal-type">Change<span class="govuk-visually-hidden"> Appeal type</span></a>
-                                </dd>
                             </div>
                             <div class="govuk-summary-list__row govuk-summary-list__row--no-actions appeal-case-procedure"><dt class="govuk-summary-list__key"> Appeal procedure</dt>
                                 <dd class="govuk-summary-list__value">Written</dd>
@@ -1623,9 +1617,6 @@ exports[`appeal-details GET /:appealId Linked appeals should render a lead tag n
                             </div>
                             <div class="govuk-summary-list__row appeal-appeal-type"><dt class="govuk-summary-list__key"> Appeal type</dt>
                                 <dd class="govuk-summary-list__value">Householder</dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/change-appeal-type/appeal-type"
-                                    data-cy="change-appeal-type">Change<span class="govuk-visually-hidden"> Appeal type</span></a>
-                                </dd>
                             </div>
                             <div class="govuk-summary-list__row govuk-summary-list__row--no-actions appeal-case-procedure"><dt class="govuk-summary-list__key"> Appeal procedure</dt>
                                 <dd class="govuk-summary-list__value">Written</dd>
@@ -2081,9 +2072,6 @@ exports[`appeal-details GET /:appealId Linked appeals should render an action li
                             </div>
                             <div class="govuk-summary-list__row appeal-appeal-type"><dt class="govuk-summary-list__key"> Appeal type</dt>
                                 <dd class="govuk-summary-list__value">Householder</dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/change-appeal-type/appeal-type"
-                                    data-cy="change-appeal-type">Change<span class="govuk-visually-hidden"> Appeal type</span></a>
-                                </dd>
                             </div>
                             <div class="govuk-summary-list__row govuk-summary-list__row--no-actions appeal-case-procedure"><dt class="govuk-summary-list__key"> Appeal procedure</dt>
                                 <dd class="govuk-summary-list__value">Written</dd>

--- a/appeals/web/src/server/lib/mappers/data/appeal/submappers/__tests__/appeal-type.mapper.test.js
+++ b/appeals/web/src/server/lib/mappers/data/appeal/submappers/__tests__/appeal-type.mapper.test.js
@@ -1,0 +1,84 @@
+// @ts-nocheck
+import { mapAppealType } from '#lib/mappers/data/appeal/submappers/appeal-type.mapper.js';
+import { jest } from '@jest/globals';
+import { APPEAL_TYPE } from '@pins/appeals/constants/common.js';
+import { DOCUMENT_STATUS_RECEIVED } from '@pins/appeals/constants/support.js';
+import { APPEAL_CASE_PROCEDURE } from '@planning-inspectorate/data-model';
+
+describe('appeal-type.mapper', () => {
+	let params;
+
+	beforeEach(() => {
+		params = {
+			appealDetails: {
+				startedAt: new Date('2025-01-01'),
+				procedureType: APPEAL_CASE_PROCEDURE.HEARING,
+				appealTimetable: {},
+				appealType: APPEAL_TYPE.S78,
+				documentationSummary: {
+					lpaStatement: {
+						status: DOCUMENT_STATUS_RECEIVED
+					}
+				}
+			},
+			userHasUpdateCasePermission: true,
+			currentRoute: '/appeal-questionnaire',
+			request: { originalUrl: '/original-url' }
+		};
+	});
+	afterEach(() => {
+		jest.clearAllMocks();
+	});
+
+	it('Should display appeal type when not a linked appeal', () => {
+		const result = mapAppealType(params);
+		expect(result).toEqual({
+			display: {
+				summaryListItem: {
+					actions: {
+						items: [
+							{
+								attributes: {
+									'data-cy': 'change-appeal-type'
+								},
+								href: '/appeal-questionnaire/change-appeal-type/appeal-type',
+								text: 'Change',
+								visuallyHiddenText: 'Appeal type'
+							}
+						]
+					},
+					classes: 'appeal-appeal-type',
+					key: {
+						text: 'Appeal type'
+					},
+					value: {
+						text: 'Planning appeal'
+					}
+				}
+			},
+			id: 'appeal-type'
+		});
+	});
+
+	it('Should not display appeal type when a linked appeal', () => {
+		params.appealDetails.isParentAppeal = true;
+		const result = mapAppealType(params);
+		expect(result).toEqual({
+			display: {
+				summaryListItem: {
+					actions: {
+						items: []
+					},
+					classes: 'appeal-appeal-type',
+					key: {
+						text: 'Appeal type'
+					},
+					value: {
+						text: 'Planning appeal'
+					}
+				}
+			},
+			id: 'appeal-type'
+		});
+	});
+});

--- a/appeals/web/src/server/lib/mappers/data/appeal/submappers/appeal-type.mapper.js
+++ b/appeals/web/src/server/lib/mappers/data/appeal/submappers/appeal-type.mapper.js
@@ -1,4 +1,5 @@
 import { textSummaryListItem } from '#lib/mappers/index.js';
+import isLinkedAppeal from '#lib/mappers/utils/is-linked-appeal.js';
 
 /** @type {import('../mapper.js').SubMapper} */
 export const mapAppealType = ({ appealDetails, currentRoute, userHasUpdateCasePermission }) =>
@@ -7,6 +8,6 @@ export const mapAppealType = ({ appealDetails, currentRoute, userHasUpdateCasePe
 		text: 'Appeal type',
 		value: appealDetails.appealType || 'No appeal type',
 		link: `${currentRoute}/change-appeal-type/appeal-type`,
-		editable: userHasUpdateCasePermission,
+		editable: userHasUpdateCasePermission && !isLinkedAppeal(appealDetails),
 		classes: 'appeal-appeal-type'
 	});


### PR DESCRIPTION
## Describe your changes
####  Hide appeal type change link for linked appeals (a2-4386)

### WEB:
- Hide appeal type change link within overview section in case details page when the appeal has been linked

### TEST:
- Added unit test for above
- Updated snap shots where required
- Make sure all other unit tests pass
- Tested within the browser

## Issue ticket number and link

[A2-4386- BO linked appeals - Hide 'Change' link on 'Appeal type' row on lead and child appeal(s) upon linking (relates to all appeal types)](https://pins-ds.atlassian.net/browse/A2-4386)
