### PR TITLE
feat(appeals): include published ip comments (a2-4121)

### DIFF
--- a/appeals/pdf-service-api/src/mappers/ip-comments/__tests__/__snapshots__/ip-comments.mapper.test.js.snap
+++ b/appeals/pdf-service-api/src/mappers/ip-comments/__tests__/__snapshots__/ip-comments.mapper.test.js.snap
@@ -417,6 +417,83 @@ exports[`mapIpCommentsData should map interested party comments data correctly 1
     "otherAppeals": [],
     "planningApplicationReference": "44377/APP/3/218453",
     "procedureType": "Written",
+    "publishedComments": [
+      {
+        "attachments": [
+          {
+            "documentGuid": "58565a17-f943-4548-9588-596205ad7ac1",
+            "documentVersion": {
+              "blobStoragePath": "appeal/6000072/58565a17-f943-4548-9588-596205ad7ac1/v1/file_example_XLSX_5000.xlsx",
+              "document": {
+                "caseId": 72,
+                "createdAt": "2025-07-09T00:00:00.000Z",
+                "folderId": 3600,
+                "guid": "58565a17-f943-4548-9588-596205ad7ac1",
+                "isDeleted": false,
+                "latestVersionId": 1,
+                "name": "file_example_XLSX_5000.xlsx",
+              },
+              "documentGuid": "58565a17-f943-4548-9588-596205ad7ac1",
+              "documentType": "representationAttachments",
+              "documentURI": "https://127.0.0.1:10000/devstoreaccount1/document-service-uploads/document-service-uploads/appeal/6000072/58565a17-f943-4548-9588-596205ad7ac1/v1/file_example_XLSX_5000.xlsx",
+              "fileName": "file_example_XLSX_5000.xlsx",
+              "mime": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+              "originalFilename": "file_example_XLSX_5000.xlsx",
+              "size": 188887,
+              "version": 1,
+            },
+            "representationId": 236,
+            "version": 1,
+          },
+          {
+            "documentGuid": "7416a70a-321b-45f5-a045-e426e46e9a7f",
+            "documentVersion": {
+              "blobStoragePath": "appeal/6000072/7416a70a-321b-45f5-a045-e426e46e9a7f/v1/file_example_PNG_2100kB.png",
+              "document": {
+                "caseId": 72,
+                "createdAt": "2025-07-09T11:27:45.191Z",
+                "folderId": 3600,
+                "guid": "7416a70a-321b-45f5-a045-e426e46e9a7f",
+                "isDeleted": false,
+                "latestVersionId": 1,
+                "name": "file_example_PNG_2100kB.png",
+              },
+              "documentGuid": "7416a70a-321b-45f5-a045-e426e46e9a7f",
+              "documentType": "representationAttachments",
+              "documentURI": "https://127.0.0.1:10000/devstoreaccount1/document-service-uploads/document-service-uploads/appeal/6000072/7416a70a-321b-45f5-a045-e426e46e9a7f/v1/file_example_PNG_2100kB.png",
+              "fileName": "file_example_PNG_2100kB.png",
+              "mime": "image/png",
+              "originalFilename": "file_example_PNG_2100kB.png",
+              "size": 2060826,
+              "version": 1,
+            },
+            "representationId": 236,
+            "version": 1,
+          },
+        ],
+        "author": "Eva Sharma - Source: Back Office - Has email: true",
+        "created": "2025-07-03T15:13:59.982Z",
+        "id": 240,
+        "notes": "",
+        "origin": "citizen",
+        "originalRepresentation": "I love cheese, especially cottage cheese queso. Ricotta monterey jack emmental cheese and biscuits jarlsberg manchego roquefort babybel. Chalk and cheese cut the cheese cream cheese croque monsieur cheese strings blue castello halloumi say cheese.",
+        "redactedRepresentation": "",
+        "rejectionReasons": [],
+        "representationType": "comment",
+        "represented": {
+          "address": {
+            "addressLine1": "",
+            "postCode": "",
+          },
+          "email": "test9@example.com",
+          "id": 317,
+          "name": "Eva Sharma - Source: Back Office - Has email: true",
+        },
+        "siteVisitRequested": false,
+        "source": "back-office-appeals",
+        "status": "valid",
+      },
+    ],
     "rejectedComments": [
       {
         "attachments": [],
@@ -625,126 +702,6 @@ exports[`mapIpCommentsData should map interested party comments data correctly 1
           "items": [
             {
               "key": "Interested party",
-              "text": "Fiona Burgess - Source: Front Office - Has email: true",
-            },
-            {
-              "key": "Date received",
-              "text": "3 July 2025, 16:13",
-            },
-            {
-              "key": "Comment",
-              "text": String {
-                "length": 247,
-                "val": "I love cheese, especially cottage cheese queso. Ricotta monterey jack emmental cheese and biscuits jarlsberg manchego roquefort babybel. Chalk and cheese cut the cheese cream cheese croque monsieur cheese strings blue castello halloumi say cheese.",
-              },
-            },
-            {
-              "html": "file-sample_100kB.docx",
-              "key": "Supporting documents",
-            },
-          ],
-        },
-        {
-          "items": [
-            {
-              "key": "Interested party",
-              "text": "Ryan Marshall - Source: Back Office - Has email: true",
-            },
-            {
-              "key": "Date received",
-              "text": "3 July 2025, 16:13",
-            },
-            {
-              "key": "Comment",
-              "text": String {
-                "length": 247,
-                "val": "I love cheese, especially cottage cheese queso. Ricotta monterey jack emmental cheese and biscuits jarlsberg manchego roquefort babybel. Chalk and cheese cut the cheese cream cheese croque monsieur cheese strings blue castello halloumi say cheese.",
-              },
-            },
-            {
-              "html": "No documents",
-              "key": "Supporting documents",
-            },
-          ],
-        },
-        {
-          "items": [
-            {
-              "key": "Interested party",
-              "text": "Sophie Skinner - Source: Front Office - Has email: false",
-            },
-            {
-              "key": "Date received",
-              "text": "3 July 2025, 16:13",
-            },
-            {
-              "key": "Comment",
-              "text": String {
-                "length": 247,
-                "val": "I love cheese, especially cottage cheese queso. Ricotta monterey jack emmental cheese and biscuits jarlsberg manchego roquefort babybel. Chalk and cheese cut the cheese cream cheese croque monsieur cheese strings blue castello halloumi say cheese.",
-              },
-            },
-            {
-              "html": "No documents",
-              "key": "Supporting documents",
-            },
-          ],
-        },
-        {
-          "items": [
-            {
-              "key": "Interested party",
-              "text": "Haley Eland - Source: Front Office - Has email: true",
-            },
-            {
-              "key": "Date received",
-              "text": "3 July 2025, 16:13",
-            },
-            {
-              "key": "Comment",
-              "text": String {
-                "length": 247,
-                "val": "I love cheese, especially cottage cheese queso. Ricotta monterey jack emmental cheese and biscuits jarlsberg manchego roquefort babybel. Chalk and cheese cut the cheese cream cheese croque monsieur cheese strings blue castello halloumi say cheese.",
-              },
-            },
-            {
-              "html": "No documents",
-              "key": "Supporting documents",
-            },
-          ],
-        },
-        {
-          "items": [
-            {
-              "key": "Interested party",
-              "text": "Lee Thornton - Source: Back Office - Has email: false",
-            },
-            {
-              "key": "Date received",
-              "text": "3 July 2025, 16:13",
-            },
-            {
-              "key": "Comment",
-              "text": String {
-                "length": 247,
-                "val": "I love cheese, especially cottage cheese queso. Ricotta monterey jack emmental cheese and biscuits jarlsberg manchego roquefort babybel. Chalk and cheese cut the cheese cream cheese croque monsieur cheese strings blue castello halloumi say cheese.",
-              },
-            },
-            {
-              "html": "No documents",
-              "key": "Supporting documents",
-            },
-          ],
-        },
-      ],
-      "heading": "Awaiting review",
-    },
-    {
-      "comments": [
-        {
-          "items": [
-            {
-              "key": "Interested party",
               "text": "Eva Sharma - Source: Back Office - Has email: true",
             },
             {
@@ -765,7 +722,7 @@ exports[`mapIpCommentsData should map interested party comments data correctly 1
           ],
         },
       ],
-      "heading": "Accepted",
+      "heading": "Published",
     },
   ],
 }

--- a/appeals/pdf-service-api/src/mappers/ip-comments/ip-comments.mapper.js
+++ b/appeals/pdf-service-api/src/mappers/ip-comments/ip-comments.mapper.js
@@ -1,13 +1,22 @@
 import { commentsSection } from './sections/comments.section.js';
 
 export default function mapIpCommentsData(templateData) {
-	const { awaitingReviewComments, acceptedComments /*rejectedComments*/ } = templateData;
-	return {
-		details: templateData,
-		sections: [
-			commentsSection(awaitingReviewComments, 'Awaiting review'),
-			commentsSection(acceptedComments, 'Accepted')
-			// commentsSection(rejectedComments, 'Rejected')
-		]
-	};
+	const {
+		awaitingReviewComments = [],
+		acceptedComments = [],
+		publishedComments = [] /*rejectedComments*/
+	} = templateData || {};
+	const sections = [];
+	if (publishedComments.length) {
+		sections.push(commentsSection(publishedComments, 'Published'));
+	} else {
+		sections.push(commentsSection(awaitingReviewComments, 'Awaiting review'));
+		sections.push(commentsSection(acceptedComments, 'Accepted'));
+		// sections.push(commentsSection(rejectedComments, 'Rejected'));
+	}
+	if (publishedComments)
+		return {
+			details: templateData,
+			sections
+		};
 }

--- a/appeals/pdf-service-api/src/mappers/ip-comments/sections/comments.section.js
+++ b/appeals/pdf-service-api/src/mappers/ip-comments/sections/comments.section.js
@@ -14,6 +14,12 @@ function mapComment(ipComment) {
 		name: attachment.documentVersion.fileName
 	}));
 
+	let dateFormat = 'd MMMM yyyy, HH:mm';
+	// Only display the time if it's not midnight
+	if (new Date(created).getTime().toString().endsWith('00000')) {
+		dateFormat = 'd MMMM yyyy';
+	}
+
 	return {
 		items: [
 			{
@@ -22,7 +28,7 @@ function mapComment(ipComment) {
 			},
 			{
 				key: 'Date received',
-				text: formatDate(created, 'd MMMM yyyy, HH:mm')
+				text: formatDate(created, dateFormat)
 			},
 			{
 				key: 'Comment',

--- a/appeals/pdf-service-api/src/mocks/mock-ip-comments-data.json
+++ b/appeals/pdf-service-api/src/mocks/mock-ip-comments-data.json
@@ -613,6 +613,83 @@
 					}
 				]
 			}
+		],
+		"publishedComments": [
+			{
+				"id": 240,
+				"origin": "citizen",
+				"author": "Eva Sharma - Source: Back Office - Has email: true",
+				"status": "valid",
+				"originalRepresentation": "I love cheese, especially cottage cheese queso. Ricotta monterey jack emmental cheese and biscuits jarlsberg manchego roquefort babybel. Chalk and cheese cut the cheese cream cheese croque monsieur cheese strings blue castello halloumi say cheese.",
+				"redactedRepresentation": "",
+				"created": "2025-07-03T15:13:59.982Z",
+				"notes": "",
+				"attachments": [
+					{
+						"documentGuid": "58565a17-f943-4548-9588-596205ad7ac1",
+						"version": 1,
+						"representationId": 236,
+						"documentVersion": {
+							"documentGuid": "58565a17-f943-4548-9588-596205ad7ac1",
+							"version": 1,
+							"documentType": "representationAttachments",
+							"originalFilename": "file_example_XLSX_5000.xlsx",
+							"fileName": "file_example_XLSX_5000.xlsx",
+							"mime": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+							"size": 188887,
+							"blobStoragePath": "appeal/6000072/58565a17-f943-4548-9588-596205ad7ac1/v1/file_example_XLSX_5000.xlsx",
+							"documentURI": "https://127.0.0.1:10000/devstoreaccount1/document-service-uploads/document-service-uploads/appeal/6000072/58565a17-f943-4548-9588-596205ad7ac1/v1/file_example_XLSX_5000.xlsx",
+							"document": {
+								"guid": "58565a17-f943-4548-9588-596205ad7ac1",
+								"name": "file_example_XLSX_5000.xlsx",
+								"caseId": 72,
+								"folderId": 3600,
+								"createdAt": "2025-07-09T00:00:00.000Z",
+								"isDeleted": false,
+								"latestVersionId": 1
+							}
+						}
+					},
+					{
+						"documentGuid": "7416a70a-321b-45f5-a045-e426e46e9a7f",
+						"version": 1,
+						"representationId": 236,
+						"documentVersion": {
+							"documentGuid": "7416a70a-321b-45f5-a045-e426e46e9a7f",
+							"version": 1,
+							"documentType": "representationAttachments",
+							"originalFilename": "file_example_PNG_2100kB.png",
+							"fileName": "file_example_PNG_2100kB.png",
+							"mime": "image/png",
+							"size": 2060826,
+							"blobStoragePath": "appeal/6000072/7416a70a-321b-45f5-a045-e426e46e9a7f/v1/file_example_PNG_2100kB.png",
+							"documentURI": "https://127.0.0.1:10000/devstoreaccount1/document-service-uploads/document-service-uploads/appeal/6000072/7416a70a-321b-45f5-a045-e426e46e9a7f/v1/file_example_PNG_2100kB.png",
+							"document": {
+								"guid": "7416a70a-321b-45f5-a045-e426e46e9a7f",
+								"name": "file_example_PNG_2100kB.png",
+								"caseId": 72,
+								"folderId": 3600,
+								"createdAt": "2025-07-09T11:27:45.191Z",
+								"isDeleted": false,
+								"latestVersionId": 1
+							}
+						}
+					}
+				],
+				"representationType": "comment",
+				"siteVisitRequested": false,
+				"source": "back-office-appeals",
+				"represented": {
+					"id": 317,
+					"name": "Eva Sharma - Source: Back Office - Has email: true",
+					"email": "test9@example.com",
+					"address": {
+						"addressLine1": "",
+						"postCode": ""
+					}
+				},
+				"rejectionReasons": []
+			}
 		]
 	}
 }


### PR DESCRIPTION
## Describe your changes
### PDF generator - Add published IP comments and correct date for those uploaded from BO (a2-4121)

### WEB:
- Add published IP comments to the information requested when building data for the PDF
- Replaced some console.log statements with logger.debug and logger.info

### PDF:
- Add new Published section for IP comments.  This will replace the other IP comment sections if the data exists
- Do not show time (as it is not entered) when showing the date received for an IP comment entered from back office

### Tests:
- Updated snapshots
- Updated unit tests 
- Made sure all unit tests pass
- Tested within browser
- Checked generated pdf

## Issue ticket number and link
[A2-4121 - BO: PDF generator - IP comments have no info after they have been shared and incorrect time for upload from BO](https://pins-ds.atlassian.net/browse/A2-4121)
