### PR TITLE
fix(web): changing event status tags to pull from a general appeal ty…

### DIFF
--- a/appeals/web/src/common/__tests__/feature-flags-appeal-types.test.js
+++ b/appeals/web/src/common/__tests__/feature-flags-appeal-types.test.js
@@ -1,0 +1,66 @@
+import { APPEAL_TYPE } from '@pins/appeals/constants/common.js';
+import { APPEAL_CASE_TYPE } from '@planning-inspectorate/data-model';
+import {
+	appealCaseTypeToAppealTypeMapper,
+	appealTypeToAppealCaseTypeMapper,
+	getEnabledAppealCaseTypes,
+	getEnabledAppealTypes,
+	isAppealTypeEnabled
+} from '../feature-flags-appeal-types.js';
+
+describe('isAppealTypeEnabled', () => {
+	it('Returns flag as a boolean', () => {
+		const feature = isAppealTypeEnabled(APPEAL_CASE_TYPE.D);
+
+		expect(typeof feature).toBe('boolean');
+	});
+
+	it('Returns false when no flag set in the .env file or in the config', () => {
+		const feature = isAppealTypeEnabled('featureFlagBOAS2SomeFeatrue');
+		expect(feature).toBe(false);
+	});
+});
+
+describe('getEnabledAppealCaseTypes', () => {
+	it('should return an object', () => {
+		const enabledAppealTypes = getEnabledAppealCaseTypes();
+		expect(typeof enabledAppealTypes).toBe('object');
+	});
+
+	it('should have at least length one', () => {
+		const enabledAppealTypes = getEnabledAppealCaseTypes();
+		expect(enabledAppealTypes.length).toBeGreaterThan(1);
+	});
+});
+
+describe('getEnabledAppealTypes', () => {
+	it('should return an object', () => {
+		const enabledAppealTypes = getEnabledAppealTypes();
+		expect(typeof enabledAppealTypes).toBe('object');
+	});
+
+	it('should have at least length one', () => {
+		const enabledAppealTypes = getEnabledAppealTypes();
+		expect(enabledAppealTypes.length).toBeGreaterThanOrEqual(1);
+	});
+});
+
+describe('mappers', () => {
+	test('appealTypeToAppealCaseTypeMapper should return an empty string for an invalid appeal type', () => {
+		const testMap = appealTypeToAppealCaseTypeMapper('Not a valid appeal type');
+		expect(testMap).toBe('');
+	});
+
+	test('appealCaseTypeToAppealTypeMapper should return an empty string for an invalid appeal type', () => {
+		const testMap = appealCaseTypeToAppealTypeMapper('Not a valid case appeal type');
+		expect(testMap).toBe('');
+	});
+
+	test('combining both mappers for a valid appeal type returns the same appeal type', () => {
+		const appealType = APPEAL_TYPE.HOUSEHOLDER;
+		const returnedAppealType = appealCaseTypeToAppealTypeMapper(
+			appealTypeToAppealCaseTypeMapper(appealType)
+		);
+		expect(returnedAppealType).toBe(appealType);
+	});
+});

--- a/appeals/web/src/common/feature-flags-appeal-types.js
+++ b/appeals/web/src/common/feature-flags-appeal-types.js
@@ -1,0 +1,149 @@
+import { APPEAL_TYPE, FEATURE_FLAG_NAMES } from '@pins/appeals/constants/common.js';
+import { APPEAL_CASE_TYPE } from '@planning-inspectorate/data-model';
+import { isFeatureActive } from './feature-flags.js';
+
+/**
+ *
+ * @param {string} appealCaseType
+ * @returns boolean
+ */
+export const isAppealCaseTypeEnabled = (appealCaseType) => {
+	switch (appealCaseType) {
+		case APPEAL_CASE_TYPE.D: {
+			return true;
+		}
+		case APPEAL_CASE_TYPE.W: {
+			return isFeatureActive(FEATURE_FLAG_NAMES.SECTION_78);
+		}
+		case APPEAL_CASE_TYPE.Y: {
+			return isFeatureActive(FEATURE_FLAG_NAMES.SECTION_20);
+		}
+		case APPEAL_CASE_TYPE.ZP: {
+			return isFeatureActive(FEATURE_FLAG_NAMES.CAS);
+		}
+		case APPEAL_CASE_TYPE.ZA: {
+			return isFeatureActive(FEATURE_FLAG_NAMES.CAS_ADVERT);
+		}
+		case APPEAL_CASE_TYPE.H: {
+			return isFeatureActive(FEATURE_FLAG_NAMES.ADVERTISEMENT);
+		}
+	}
+
+	return false;
+};
+
+/**
+ *
+ * @param {string} appealType
+ * @returns boolean
+ */
+export const isAppealTypeEnabled = (appealType) => {
+	return isAppealCaseTypeEnabled(appealTypeToAppealCaseTypeMapper(appealType));
+};
+
+export const getEnabledAppealTypes = () => {
+	const enabledAppealCaseTypes = getEnabledAppealCaseTypes();
+	return enabledAppealCaseTypes.map(appealCaseTypeToAppealTypeMapper);
+};
+
+export const getEnabledAppealCaseTypes = () => {
+	const enabledAppeals = [APPEAL_CASE_TYPE.D];
+
+	if (isAppealCaseTypeEnabled(APPEAL_CASE_TYPE.W)) {
+		enabledAppeals.push(APPEAL_CASE_TYPE.W);
+	}
+	if (isAppealCaseTypeEnabled(APPEAL_CASE_TYPE.Y)) {
+		enabledAppeals.push(APPEAL_CASE_TYPE.Y);
+	}
+	if (isAppealCaseTypeEnabled(APPEAL_CASE_TYPE.ZP)) {
+		enabledAppeals.push(APPEAL_CASE_TYPE.ZP);
+	}
+	if (isAppealCaseTypeEnabled(APPEAL_CASE_TYPE.ZA)) {
+		enabledAppeals.push(APPEAL_CASE_TYPE.ZA);
+	}
+	if (isAppealCaseTypeEnabled(APPEAL_CASE_TYPE.H)) {
+		enabledAppeals.push(APPEAL_CASE_TYPE.H);
+	}
+
+	return enabledAppeals;
+};
+
+/**
+ *
+ * @param {string} appealType
+ * @returns string
+ */
+export const appealTypeToAppealCaseTypeMapper = (appealType) => {
+	switch (appealType) {
+		case APPEAL_TYPE.HOUSEHOLDER:
+			return APPEAL_CASE_TYPE.D;
+		case APPEAL_TYPE.ENFORCEMENT_NOTICE:
+			return APPEAL_CASE_TYPE.C;
+		case APPEAL_TYPE.ENFORCEMENT_LISTED_BUILDING:
+			return APPEAL_CASE_TYPE.F;
+		case APPEAL_TYPE.DISCONTINUANCE_NOTICE:
+			return APPEAL_CASE_TYPE.G;
+		case APPEAL_TYPE.ADVERTISEMENT:
+			return APPEAL_CASE_TYPE.H;
+		case APPEAL_TYPE.COMMUNITY_INFRASTRUCTURE_LEVY:
+			return APPEAL_CASE_TYPE.L;
+		case APPEAL_TYPE.PLANNING_OBLIGATION:
+			return APPEAL_CASE_TYPE.Q;
+		case APPEAL_TYPE.AFFORDABLE_HOUSING_OBLIGATION:
+			return APPEAL_CASE_TYPE.S;
+		case APPEAL_TYPE.CALL_IN_APPLICATION:
+			return APPEAL_CASE_TYPE.V;
+		case APPEAL_TYPE.S78:
+			return APPEAL_CASE_TYPE.W;
+		case APPEAL_TYPE.LAWFUL_DEVELOPMENT_CERTIFICATE:
+			return APPEAL_CASE_TYPE.X;
+		case APPEAL_TYPE.PLANNED_LISTED_BUILDING:
+			return APPEAL_CASE_TYPE.Y;
+		case APPEAL_TYPE.CAS_ADVERTISEMENT:
+			return APPEAL_CASE_TYPE.ZA;
+		case APPEAL_TYPE.CAS_PLANNING:
+			return APPEAL_CASE_TYPE.ZP;
+		default:
+			return '';
+	}
+};
+
+/**
+ *
+ * @param {string} appealCaseType
+ * @returns string
+ */
+export const appealCaseTypeToAppealTypeMapper = (appealCaseType) => {
+	switch (appealCaseType) {
+		case APPEAL_CASE_TYPE.D:
+			return APPEAL_TYPE.HOUSEHOLDER;
+		case APPEAL_CASE_TYPE.C:
+			return APPEAL_TYPE.ENFORCEMENT_NOTICE;
+		case APPEAL_CASE_TYPE.F:
+			return APPEAL_TYPE.ENFORCEMENT_LISTED_BUILDING;
+		case APPEAL_CASE_TYPE.G:
+			return APPEAL_TYPE.DISCONTINUANCE_NOTICE;
+		case APPEAL_CASE_TYPE.H:
+			return APPEAL_TYPE.ADVERTISEMENT;
+		case APPEAL_CASE_TYPE.L:
+			return APPEAL_TYPE.COMMUNITY_INFRASTRUCTURE_LEVY;
+		case APPEAL_CASE_TYPE.Q:
+			return APPEAL_TYPE.PLANNING_OBLIGATION;
+		case APPEAL_CASE_TYPE.S:
+			return APPEAL_TYPE.AFFORDABLE_HOUSING_OBLIGATION;
+		case APPEAL_CASE_TYPE.V:
+			return APPEAL_TYPE.CALL_IN_APPLICATION;
+		case APPEAL_CASE_TYPE.W:
+			return APPEAL_TYPE.S78;
+		case APPEAL_CASE_TYPE.X:
+			return APPEAL_TYPE.LAWFUL_DEVELOPMENT_CERTIFICATE;
+		case APPEAL_CASE_TYPE.Y:
+			return APPEAL_TYPE.PLANNED_LISTED_BUILDING;
+		case APPEAL_CASE_TYPE.ZA:
+			return APPEAL_TYPE.CAS_ADVERTISEMENT;
+		case APPEAL_CASE_TYPE.ZP:
+			return APPEAL_TYPE.CAS_PLANNING;
+		default:
+			return '';
+	}
+};

--- a/appeals/web/src/server/appeals/national-list/national-list.mapper.js
+++ b/appeals/web/src/server/appeals/national-list/national-list.mapper.js
@@ -1,3 +1,4 @@
+import { getEnabledAppealCaseTypes } from '#common/feature-flags-appeal-types.js';
 import { isFeatureActive } from '#common/feature-flags.js';
 import { numberToAccessibleDigitLabel } from '#lib/accessibility.js';
 import { addressToString } from '#lib/address-formatter.js';
@@ -6,7 +7,7 @@ import { appealShortReference } from '#lib/appeals-formatter.js';
 import { preRenderPageComponents } from '#lib/nunjucks-template-builders/page-component-rendering.js';
 import { capitalizeFirstLetter } from '#lib/string-utilities.js';
 import { FEATURE_FLAG_NAMES } from '@pins/appeals/constants/common.js';
-import { APPEAL_CASE_PROCEDURE, APPEAL_CASE_TYPE } from '@planning-inspectorate/data-model';
+import { APPEAL_CASE_PROCEDURE } from '@planning-inspectorate/data-model';
 
 /** @typedef {import('@pins/appeals').AppealList} AppealList */
 /** @typedef {import('@pins/appeals').Pagination} Pagination */
@@ -113,21 +114,7 @@ export function nationalListPage(
 		selected: inspectorFilter === String(inspector?.id)
 	}));
 
-	//TODO: maybe make this a shared function across web
-	const enabledAppealTypes = [APPEAL_CASE_TYPE.D];
-
-	if (isFeatureActive(FEATURE_FLAG_NAMES.SECTION_78)) {
-		enabledAppealTypes.push(APPEAL_CASE_TYPE.W);
-	}
-	if (isFeatureActive(FEATURE_FLAG_NAMES.SECTION_20)) {
-		enabledAppealTypes.push(APPEAL_CASE_TYPE.Y);
-	}
-	if (isFeatureActive(FEATURE_FLAG_NAMES.CAS_ADVERT)) {
-		enabledAppealTypes.push(APPEAL_CASE_TYPE.ZA);
-	}
-	if (isFeatureActive(FEATURE_FLAG_NAMES.CAS)) {
-		enabledAppealTypes.push(APPEAL_CASE_TYPE.ZP);
-	}
+	const enabledAppealTypes = getEnabledAppealCaseTypes();
 
 	let enabledAppealProcedures = [];
 

--- a/appeals/web/src/server/lib/__tests__/libraries.test.js
+++ b/appeals/web/src/server/lib/__tests__/libraries.test.js
@@ -1792,32 +1792,21 @@ describe('appeal-status', () => {
 			});
 		}
 
-		it(`should return 'site_visit_ready_to_set_up' if appealStatus is 'event' and appealProcedureType is undefined`, () => {
-			expect(mapStatusText(APPEAL_CASE_STATUS.EVENT, APPEAL_TYPE.S78, undefined)).toBe(
-				'site_visit_ready_to_set_up'
-			);
-		});
-
-		it(`should return 'site_visit_ready_to_set_up' if appealStatus is 'event' appeal type is S20 and appealProcedureType is undefined`, () => {
-			expect(
-				mapStatusText(APPEAL_CASE_STATUS.EVENT, APPEAL_TYPE.PLANNED_LISTED_BUILDING, undefined)
-			).toBe('site_visit_ready_to_set_up');
-		});
-
-		it(`should return 'site_visit_ready_to_set_up' if appealStatus is 'event' and appealProcedureType is 'written'`, () => {
-			expect(
-				mapStatusText(APPEAL_CASE_STATUS.EVENT, APPEAL_TYPE.S78, APPEAL_CASE_PROCEDURE.WRITTEN)
-			).toBe('site_visit_ready_to_set_up');
-		});
-		it(`should return 'site_visit_ready_to_set_up' if appealStatus is 'event', appeal type is S20 and appealProcedureType is 'written'`, () => {
-			expect(
-				mapStatusText(
-					APPEAL_CASE_STATUS.EVENT,
-					APPEAL_TYPE.PLANNED_LISTED_BUILDING,
-					APPEAL_CASE_PROCEDURE.WRITTEN
-				)
-			).toBe('site_visit_ready_to_set_up');
-		});
+		it.each([
+			[APPEAL_TYPE.S78, undefined],
+			[APPEAL_TYPE.S78, APPEAL_CASE_PROCEDURE.WRITTEN],
+			[APPEAL_TYPE.PLANNED_LISTED_BUILDING, undefined],
+			[APPEAL_TYPE.PLANNED_LISTED_BUILDING, APPEAL_CASE_PROCEDURE.WRITTEN],
+			[APPEAL_TYPE.CAS_PLANNING, undefined],
+			[APPEAL_TYPE.CAS_PLANNING, APPEAL_CASE_PROCEDURE.WRITTEN]
+		])(
+			"should return 'site_visit_ready_to_set_up' if appealStatus is 'event', appeal type is %s and appealProcedureType is '%s'",
+			(appealType, procedureType) => {
+				expect(mapStatusText(APPEAL_CASE_STATUS.EVENT, appealType, procedureType)).toBe(
+					'site_visit_ready_to_set_up'
+				);
+			}
+		);
 
 		it(`should return 'hearing_ready_to_set_up' if appealStatus is 'event' and appealProcedureType is 'hearing'`, () => {
 			expect(
@@ -1831,40 +1820,21 @@ describe('appeal-status', () => {
 			).toBe('inquiry_ready_to_set_up');
 		});
 
-		it(`should return 'awaiting_site_visit' if appealStatus is 'awaiting_event' and appealProcedureType is undefined`, () => {
-			expect(mapStatusText(APPEAL_CASE_STATUS.AWAITING_EVENT, APPEAL_TYPE.S78, undefined)).toBe(
-				'awaiting_site_visit'
-			);
-		});
-
-		it(`should return 'awaiting_site_visit' if appealStatus is 'awaiting_event, event type is S20and appealProcedureType is undefined`, () => {
-			expect(
-				mapStatusText(
-					APPEAL_CASE_STATUS.AWAITING_EVENT,
-					APPEAL_TYPE.PLANNED_LISTED_BUILDING,
-					undefined
-				)
-			).toBe('awaiting_site_visit');
-		});
-
-		it(`should return 'awaiting_site_visit' if appealStatus is 'awaiting_event' and appealProcedureType is 'written'`, () => {
-			expect(
-				mapStatusText(
-					APPEAL_CASE_STATUS.AWAITING_EVENT,
-					APPEAL_TYPE.S78,
-					APPEAL_CASE_PROCEDURE.WRITTEN
-				)
-			).toBe('awaiting_site_visit');
-		});
-		it(`should return 'awaiting_site_visit' if appealStatus is 'awaiting_event', appeal type is S20 and appealProcedureType is 'written'`, () => {
-			expect(
-				mapStatusText(
-					APPEAL_CASE_STATUS.AWAITING_EVENT,
-					APPEAL_TYPE.PLANNED_LISTED_BUILDING,
-					APPEAL_CASE_PROCEDURE.WRITTEN
-				)
-			).toBe('awaiting_site_visit');
-		});
+		it.each([
+			[APPEAL_TYPE.S78, undefined],
+			[APPEAL_TYPE.S78, APPEAL_CASE_PROCEDURE.WRITTEN],
+			[APPEAL_TYPE.PLANNED_LISTED_BUILDING, undefined],
+			[APPEAL_TYPE.PLANNED_LISTED_BUILDING, APPEAL_CASE_PROCEDURE.WRITTEN],
+			[APPEAL_TYPE.CAS_PLANNING, undefined],
+			[APPEAL_TYPE.CAS_PLANNING, APPEAL_CASE_PROCEDURE.WRITTEN]
+		])(
+			"should return 'awaiting_site_visit' if appealStatus is 'awaiting_event', appeal type is %s and appealProcedureType is '%s'",
+			(appealType, procedureType) => {
+				expect(mapStatusText(APPEAL_CASE_STATUS.AWAITING_EVENT, appealType, procedureType)).toBe(
+					'awaiting_site_visit'
+				);
+			}
+		);
 
 		it(`should return 'awaiting_hearing' if appealStatus is 'awaiting_event' and appealProcedureType is 'hearing'`, () => {
 			expect(

--- a/appeals/web/src/server/lib/appeal-status.js
+++ b/appeals/web/src/server/lib/appeal-status.js
@@ -1,5 +1,5 @@
+import { isAppealTypeEnabled } from '#common/feature-flags-appeal-types.js';
 import { capitalizeFirstLetter } from '#lib/string-utilities.js';
-import { APPEAL_TYPE } from '@pins/appeals/constants/common.js';
 
 /** @typedef {import('#appeals/appeal-details/appeal-details.types.js').WebAppeal} WebAppeal */
 
@@ -10,11 +10,7 @@ import { APPEAL_TYPE } from '@pins/appeals/constants/common.js';
  * @returns {string}
  * */
 export function mapStatusText(appealStatus, appealType, appealProcedureType) {
-	if (
-		![APPEAL_TYPE.HOUSEHOLDER, APPEAL_TYPE.S78, APPEAL_TYPE.PLANNED_LISTED_BUILDING].includes(
-			appealType
-		)
-	) {
+	if (!isAppealTypeEnabled(appealType)) {
 		return appealStatus;
 	}
 


### PR DESCRIPTION
…pes enabled list (A2-4276)

## Describe your changes

- Created generic functions for getting enabled appeal types on the web side
- Replaced a couple of instances of the logic with those functions

### Testing

- Added some tests for the generic functions
- Added tests for CAS planning having the correct event status tags

Manually checked that the CAS planning tags show up correctly (screenshots taken from a locally running version):
<img width="1367" height="1052" alt="image" src="https://github.com/user-attachments/assets/4ebed721-6fd4-476b-a498-53411adcf61b" />
<img width="1323" height="860" alt="image" src="https://github.com/user-attachments/assets/3ecd9659-967b-4453-b339-4330bcbc8ac5" />


## Issue ticket number and link

[Ticket](https://pins-ds.atlassian.net/browse/A2-4276)
