### PR TITLE
fix(api): rep rejected reason mapping

### DIFF
--- a/appeals/api/src/server/endpoints/integrations/__tests__/representation-mapping.test.js
+++ b/appeals/api/src/server/endpoints/integrations/__tests__/representation-mapping.test.js
@@ -54,6 +54,11 @@ const reasons = [
 		id: 6,
 		name: 'Received after deadline',
 		hasText: false
+	},
+	{
+		id: 7,
+		name: 'other_reason',
+		hasText: true
 	}
 ];
 
@@ -149,6 +154,44 @@ describe('representation mapper', () => {
 				expect(validationResult).toBe(true);
 			});
 		}
+
+		test('Mapping rejection reasons', async () => {
+			const mapped = mapRepresentationEntity({
+				...mockRepresentation,
+				representationRejectionReasonsSelected: [
+					{
+						// @ts-ignore
+						representationRejectionReason: {
+							name: 'Contains links to web pages',
+							hasText: false
+						}
+					},
+					{
+						// @ts-ignore
+						representationRejectionReason: {
+							name: 'other_reason',
+							hasText: true
+						},
+						representationRejectionReasonText: [
+							// @ts-ignore
+							{ text: 'Custom rejection reason text' }
+						]
+					}
+				]
+			});
+
+			expect(mapped?.invalidOrIncompleteDetails).toEqual(['Contains links to web pages']);
+			expect(mapped?.otherInvalidOrIncompleteDetails).toEqual([
+				'other_reason: Custom rejection reason text'
+			]);
+
+			const validationResult = await validateFromSchema(
+				schemas.events.appealRepresentation,
+				// @ts-ignore
+				mapped
+			);
+			expect(validationResult).toBe(true);
+		});
 	});
 
 	describe('unsuccessfull representation mapping', () => {

--- a/appeals/api/src/server/mappers/integration/map-representation-entity.js
+++ b/appeals/api/src/server/mappers/integration/map-representation-entity.js
@@ -120,9 +120,9 @@ const mapReasons = (data) => {
 	data.representationRejectionReasonsSelected
 		?.filter((reason) => reason.representationRejectionReason?.hasText === true)
 		.forEach((reason) => {
-			reason.representationRejectionReasonText.map((txt) =>
-				customReasons.push(`${reason.representationRejectionReason.name}: ${txt}`)
-			);
+			reason.representationRejectionReasonText.forEach((txt) => {
+				customReasons.push(`${reason.representationRejectionReason.name}: ${txt.text}`);
+			});
 		});
 
 	return {


### PR DESCRIPTION
## Describe your changes

Rejection reason is coming through in service bus as: ["Other reason: [object Object]"]

This PR gets the text property from the representationRejectionReasonText object so the mapping is handled correctly