### PR TITLE
feat(appeals): update linked appeals e2e tests (a2-4374)

### DIFF
--- a/appeals/e2e/cypress/e2e/back-office-appeals/linkAppeals.spec.js
+++ b/appeals/e2e/cypress/e2e/back-office-appeals/linkAppeals.spec.js
@@ -186,7 +186,7 @@ describe('link appeals', () => {
 						caseDetailsPage.checkStatusOfCase('Lead', 1);
 
 						//attempt to add a child appeal from a child appeal
-						happyPathHelper.assignCaseOfficer(childCase1);
+						happyPathHelper.viewCaseDetails(childCase1);
 						caseDetailsPage.clickAccordionByButton('Overview');
 						caseDetailsPage.checkAddLinkedAppealDoesNotExist();
 					});

--- a/appeals/e2e/cypress/support/happyPathHelper.js
+++ b/appeals/e2e/cypress/support/happyPathHelper.js
@@ -15,9 +15,13 @@ const fileUploader = new FileUploader();
 let sampleFiles = fileUploader.sampleFiles;
 
 export const happyPathHelper = {
-	assignCaseOfficer(caseRef) {
+	viewCaseDetails(caseRef) {
 		cy.visit(urlPaths.appealsList);
 		listCasesPage.clickAppealByRef(caseRef);
+	},
+
+	assignCaseOfficer(caseRef) {
+		happyPathHelper.viewCaseDetails(caseRef);
 		caseDetailsPage.clickAssignCaseOfficer();
 		caseDetailsPage.searchForCaseOfficer('case');
 		caseDetailsPage.chooseSummaryListValue(users.appeals.caseAdmin.email);
@@ -26,8 +30,7 @@ export const happyPathHelper = {
 		caseDetailsPage.verifyAnswerSummaryValue(users.appeals.caseAdmin.email);
 	},
 	reviewAppellantCase(caseRef) {
-		cy.visit(urlPaths.appealsList);
-		listCasesPage.clickAppealByRef(caseRef);
+		happyPathHelper.viewCaseDetails(caseRef);
 		caseDetailsPage.clickReviewAppellantCase();
 		caseDetailsPage.selectRadioButtonByValue('Valid');
 		caseDetailsPage.clickButtonByText('Continue');
@@ -36,8 +39,7 @@ export const happyPathHelper = {
 	reviewLpaq(caseRef) {
 		let dueDate = new Date();
 
-		cy.visit(urlPaths.appealsList);
-		listCasesPage.clickAppealByRef(caseRef);
+		happyPathHelper.viewCaseDetails(caseRef);
 		caseDetailsPage.clickReviewLpaq();
 		caseDetailsPage.selectRadioButtonByValue('Complete');
 		caseDetailsPage.clickButtonByText('Confirm');
@@ -45,8 +47,7 @@ export const happyPathHelper = {
 	reviewS78Lpaq(caseRef) {
 		let dueDate = new Date();
 
-		cy.visit(urlPaths.appealsList);
-		listCasesPage.clickAppealByRef(caseRef);
+		happyPathHelper.viewCaseDetails(caseRef);
 		caseDetailsPage.clickReviewLpaq();
 		caseDetailsPage.selectRadioButtonByValue('Complete');
 		caseDetailsPage.clickButtonByText('Confirm');
@@ -55,15 +56,13 @@ export const happyPathHelper = {
 	},
 
 	startCase(caseRef) {
-		cy.visit(urlPaths.appealsList);
-		listCasesPage.clickAppealByRef(caseRef);
+		happyPathHelper.viewCaseDetails(caseRef);
 		caseDetailsPage.clickReadyToStartCase();
 		caseDetailsPage.clickButtonByText('Confirm');
 	},
 
 	startS78Case(caseRef, procedureType) {
-		cy.visit(urlPaths.appealsList);
-		listCasesPage.clickAppealByRef(caseRef);
+		happyPathHelper.viewCaseDetails(caseRef);
 		caseDetailsPage.clickReadyToStartCase();
 		caseDetailsPage.selectRadioButtonByValue(procedureType);
 		caseDetailsPage.clickButtonByText('Continue');
@@ -71,8 +70,7 @@ export const happyPathHelper = {
 	},
 
 	startS78InquiryCase(caseRef, procedureType) {
-		cy.visit(urlPaths.appealsList);
-		listCasesPage.clickAppealByRef(caseRef);
+		happyPathHelper.viewCaseDetails(caseRef);
 		caseDetailsPage.clickReadyToStartCase();
 		caseDetailsPage.selectRadioButtonByValue(procedureType);
 		caseDetailsPage.clickButtonByText('Continue');
@@ -114,8 +112,6 @@ export const happyPathHelper = {
 	},
 
 	uploadDocAppellantCase(caseRef) {
-		cy.visit(urlPaths.appealsList);
-		listCasesPage.clickAppealByRef(caseRef);
 		happyPathHelper.assignCaseOfficer(caseRef);
 		caseDetailsPage.clickReviewAppellantCase();
 		caseDetailsPage.clickAddAgreementToChangeDescriptionEvidence();
@@ -130,8 +126,6 @@ export const happyPathHelper = {
 	},
 
 	manageDocsAppellantCase(caseRef) {
-		cy.visit(urlPaths.appealsList);
-		listCasesPage.clickAppealByRef(caseRef);
 		happyPathHelper.uploadDocAppellantCase(caseRef);
 		cy.reloadUntilVirusCheckComplete();
 		caseDetailsPage.clickManageAgreementToChangeDescriptionEvidence();


### PR DESCRIPTION
## Describe your changes
#### Update linked appeals e2e tests (a2-4374)
##### Recent changes in ticket a2-4374 automatically assign the case officer, so this can no longer be done manually against a child appeal.

E2E: 
- Create new happyPathHelper.viewCaseDetails function for use in linkAppeals.spec test "As a child appeal, I am unable to link to another child appeal"
- Reuse viewCaseDetails function in other happy path helpers to reduce repetition.

## Issue ticket number and link

[a2-4374 - BO: linked appeals - Update and hide 'Team' section on child appeal(s) upon linking (relates to all appeal types)](https://pins-ds.atlassian.net/browse/A2-4374)
