### PR TITLE
feat(appeals): setting to ensure prisma updated in sync

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,11 @@ updates:
     directory: '/' # Location of package manifests
     schedule:
       interval: 'weekly'
+    groups:
+      prisma: # group prisma library and client updates together
+        patterns:
+          - 'prisma'
+          - '@prisma/*'
     rebase-strategy: 'disabled'
   - package-ecosystem: 'terraform'
     directory: '/infrastructure' # Location of package manifests


### PR DESCRIPTION
## Describe your changes

Libraries like prisma and @prisma/client should be kept in sync. This release configures dependabot to update them together.
