### PR TITLE
fix(api): handle broadcast of document type correctly for reps

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -19,7 +19,8 @@ module.exports = {
 				jest: true
 			},
 			globals: {
-				mockNotifySend: true
+				mockNotifySend: true,
+				mockBroadcasters: true
 			}
 		},
 		{

--- a/appeals/api/setup-tests.js
+++ b/appeals/api/setup-tests.js
@@ -640,3 +640,16 @@ jest.unstable_mockModule('./src/server/config/config.js', () => ({
 		}
 	}
 }));
+
+const broadcastersMock = {
+	broadcastServiceUser: jest.fn(),
+	broadcastDocument: jest.fn(),
+	broadcastAppeal: jest.fn(),
+	broadcastEvent: jest.fn(),
+	broadcastEventEstimates: jest.fn(),
+	broadcastRepresentation: jest.fn()
+};
+global.mockBroadcasters = broadcastersMock;
+jest.unstable_mockModule('#endpoints/integrations/integrations.broadcasters.js', () => ({
+	broadcasters: broadcastersMock
+}));

--- a/appeals/api/src/server/endpoints/representations/__tests__/representations.test.js
+++ b/appeals/api/src/server/endpoints/representations/__tests__/representations.test.js
@@ -760,6 +760,12 @@ describe('/appeals/:id/reps', () => {
 
 		test('200 when representation with address and attachment is successfully created', async () => {
 			databaseConnector.appeal.findUnique.mockResolvedValue(householdAppeal);
+			const mockDocument = {
+				guid: '39ad6cd8-60ab-43f0-a995-4854db8f12c6',
+				name: 'test.pdf'
+			};
+
+			databaseConnector.document.findUnique.mockResolvedValue(mockDocument);
 
 			const response = await request
 				.post('/appeals/1/reps/comments')
@@ -772,6 +778,11 @@ describe('/appeals/:id/reps', () => {
 				.set('azureAdUserId', '732652365');
 
 			expect(response.status).toEqual(201);
+			expect(mockBroadcasters.broadcastDocument).toHaveBeenCalledWith(
+				'39ad6cd8-60ab-43f0-a995-4854db8f12c6',
+				1,
+				'Create'
+			);
 		});
 	});
 
@@ -901,7 +912,18 @@ describe('/appeals/:id/reps', () => {
 			};
 			const mockDocument = {
 				guid: '39ad6cd8-60ab-43f0-a995-4854db8f12c6',
-				latestDocumentVersion: { version: 1 }
+				name: 'test.pdf',
+				caseId: 1,
+				latestDocumentVersion: { version: 1 },
+				versions: [
+					{
+						version: 1,
+						documentURI: 'http://example.com/test.pdf',
+						fileMD5: 'abc123',
+						dateCreated: new Date(),
+						dateReceived: new Date()
+					}
+				]
 			};
 
 			databaseConnector.document.findUnique.mockResolvedValue(mockDocument);
@@ -931,6 +953,74 @@ describe('/appeals/:id/reps', () => {
 					}
 				}
 			});
+
+			expect(mockBroadcasters.broadcastDocument).toHaveBeenCalledWith(
+				'39ad6cd8-60ab-43f0-a995-4854db8f12c6',
+				1,
+				'Create'
+			);
+		});
+
+		test('200 with new version updated', async () => {
+			const mockRepresentation = {
+				id: 1,
+				appealId: 1,
+				attachments: [{ documentGuid: 'b6f15730-2d7f-4fa0-8752-2d26a62474de', version: 2 }]
+			};
+			const mockUpdatedRepresentation = {
+				id: 1,
+				appealId: 1,
+				attachments: [{ documentGuid: '39ad6cd8-60ab-43f0-a995-4854db8f12c6', version: 2 }]
+			};
+			const mockDocument = {
+				guid: '39ad6cd8-60ab-43f0-a995-4854db8f12c6',
+				name: 'test.pdf',
+				caseId: 1,
+				latestDocumentVersion: { version: 2 },
+				versions: [
+					{
+						version: 2,
+						documentURI: 'http://example.com/test.pdf',
+						fileMD5: 'abc123',
+						dateCreated: new Date(),
+						dateReceived: new Date()
+					}
+				]
+			};
+
+			databaseConnector.document.findUnique.mockResolvedValue(mockDocument);
+			databaseConnector.representation.findUnique.mockResolvedValue(mockRepresentation);
+			databaseConnector.representation.update.mockResolvedValue(mockUpdatedRepresentation);
+
+			const response = await request
+				.patch('/appeals/1/reps/1/attachments')
+				.send({ attachments: ['39ad6cd8-60ab-43f0-a995-4854db8f12c6'] })
+				.set('azureAdUserId', '732652365');
+
+			expect(response.status).toEqual(200);
+			expect(response.body).toEqual(mockUpdatedRepresentation);
+
+			expect(databaseConnector.representation.update).toHaveBeenCalledWith({
+				where: { id: 1 },
+				data: {
+					attachments: {
+						connect: [
+							{
+								documentGuid_version: {
+									documentGuid: '39ad6cd8-60ab-43f0-a995-4854db8f12c6',
+									version: 2
+								}
+							}
+						]
+					}
+				}
+			});
+
+			expect(mockBroadcasters.broadcastDocument).toHaveBeenCalledWith(
+				'39ad6cd8-60ab-43f0-a995-4854db8f12c6',
+				2,
+				'Update'
+			);
 		});
 
 		test('500 when database operation fails', async () => {

--- a/appeals/api/src/server/endpoints/representations/representations.service.js
+++ b/appeals/api/src/server/endpoints/representations/representations.service.js
@@ -152,6 +152,16 @@ export const createRepresentation = async (appealId, input) => {
 		}));
 
 		await representationRepository.addAttachments(representation.id, mappedDocuments);
+
+		for (const document of mappedDocuments) {
+			if (document?.documentGuid) {
+				await broadcasters.broadcastDocument(
+					document.documentGuid,
+					document.version,
+					document.version > 1 ? EventType.Update : EventType.Create
+				);
+			}
+		}
 	}
 
 	return representation;
@@ -183,6 +193,17 @@ export const updateAttachments = async (repId, attachments) => {
 		repId,
 		mappedDocuments
 	);
+
+	for (const document of mappedDocuments) {
+		if (document?.documentGuid) {
+			await broadcasters.broadcastDocument(
+				document.documentGuid,
+				document.version,
+				document.version > 1 ? EventType.Update : EventType.Create
+			);
+		}
+	}
+
 	return updatedRepresentation;
 };
 

--- a/appeals/api/src/server/mappers/integration/commands/document.mapper.js
+++ b/appeals/api/src/server/mappers/integration/commands/document.mapper.js
@@ -1,4 +1,5 @@
 import config from '#config/config.js';
+import { REP_ATTACHMENT_DOCTYPE } from '@pins/appeals/constants/documents.js';
 import { APPEAL_CASE_STAGE } from '@planning-inspectorate/data-model';
 import { randomUUID } from 'node:crypto';
 
@@ -22,7 +23,7 @@ export const mapDocumentIn = (doc, stage = null) => {
 	if (stage === 'representation') {
 		metadata.fileName = `${randomUUID()}_${metadata.originalFilename}`;
 		// @ts-ignore
-		metadata.documentType = 'representationAttachments';
+		metadata.documentType = REP_ATTACHMENT_DOCTYPE;
 	}
 
 	metadata.blobStorageContainer = config.BO_BLOB_CONTAINER;

--- a/appeals/api/src/server/mappers/integration/map-document-entity.js
+++ b/appeals/api/src/server/mappers/integration/map-document-entity.js
@@ -6,6 +6,7 @@ import {
 	APPEAL_REPRESENTATION_TYPE as INTERNAL_REPRESENTATION_TYPE,
 	ODW_SYSTEM_ID
 } from '@pins/appeals/constants/common.js';
+import { REP_ATTACHMENT_DOCTYPE } from '@pins/appeals/constants/documents.js';
 import {
 	APPEAL_CASE_STAGE,
 	APPEAL_DOCUMENT_TYPE,
@@ -148,7 +149,7 @@ const mapOrigin = (stage) => {
  * @returns {string}
  */
 const mapDocumentType = (doc) => {
-	if (doc.documentType === 'representationAttachments') {
+	if (doc.documentType === REP_ATTACHMENT_DOCTYPE) {
 		const rep = doc.representation?.representation;
 		switch (rep?.representationType) {
 			case INTERNAL_REPRESENTATION_TYPE.APPELLANT_FINAL_COMMENT:
@@ -159,8 +160,10 @@ const mapDocumentType = (doc) => {
 				return APPEAL_DOCUMENT_TYPE.APPELLANT_STATEMENT;
 			case INTERNAL_REPRESENTATION_TYPE.LPA_STATEMENT:
 				return APPEAL_DOCUMENT_TYPE.LPA_STATEMENT;
-			default:
+			case INTERNAL_REPRESENTATION_TYPE.COMMENT:
 				return APPEAL_DOCUMENT_TYPE.INTERESTED_PARTY_COMMENT;
+			default:
+				return APPEAL_DOCUMENT_TYPE.UNCATEGORISED;
 		}
 	}
 
@@ -173,7 +176,7 @@ const mapDocumentType = (doc) => {
  * @returns {string}
  */
 const mapStage = (doc) => {
-	if (doc.documentType === 'representationAttachments') {
+	if (doc.documentType === REP_ATTACHMENT_DOCTYPE) {
 		const rep = doc.representation?.representation;
 		switch (rep?.representationType) {
 			case INTERNAL_REPRESENTATION_TYPE.APPELLANT_FINAL_COMMENT:

--- a/packages/appeals/constants/documents.js
+++ b/packages/appeals/constants/documents.js
@@ -1,5 +1,7 @@
 import { APPEAL_CASE_STAGE, APPEAL_DOCUMENT_TYPE } from '@planning-inspectorate/data-model';
 
+export const REP_ATTACHMENT_DOCTYPE = 'representationAttachments';
+
 /** @type {string[]} */
 export const FOLDERS = [
 	`${APPEAL_CASE_STAGE.APPELLANT_CASE}/${APPEAL_DOCUMENT_TYPE.APPELLANT_STATEMENT}`,
@@ -52,7 +54,7 @@ export const FOLDERS = [
 	`${APPEAL_CASE_STAGE.INTERNAL}/${APPEAL_DOCUMENT_TYPE.MAIN_PARTY_CORRESPONDENCE}`,
 	`${APPEAL_CASE_STAGE.INTERNAL}/${APPEAL_DOCUMENT_TYPE.UNCATEGORISED}`,
 	`${APPEAL_CASE_STAGE.APPEAL_DECISION}/${APPEAL_DOCUMENT_TYPE.CASE_DECISION_LETTER}`,
-	'representation/representationAttachments'
+	`representation/${REP_ATTACHMENT_DOCTYPE}`
 ];
 
 export const VALID_MIME_TYPES = Object.freeze({


### PR DESCRIPTION
## Describe your changes

Was broadcasting rep docs with a default doc type of IP comment, as the attachment used for deciding the doctype was set after the initial broadcast

- adds a check to not broadcast in this scenario
- defaults doc type to UNCATEGORISED rather than IP Comment
- calls broadcastDocument after attachment is made
- create and use doc type const

had to mock integrations.broadcasters globally - was unable to get it to work with mocking at a higher level without impacting other tests

## Issue ticket number and link

[Ticket](https://pins-ds.atlassian.net/browse/A2-4406)
