### PR TITLE
feat(api): calculate timetable endpoint

### DIFF
--- a/appeals/api/src/server/endpoints/appeal-timetables/__tests__/appeal-timetables.test.js
+++ b/appeals/api/src/server/endpoints/appeal-timetables/__tests__/appeal-timetables.test.js
@@ -1394,4 +1394,71 @@ describe('appeal timetables routes', () => {
 			});
 		});
 	});
+
+	describe('GET /appeals/:appealId/appeal-timetables/calculate', () => {
+		beforeEach(() => {
+			databaseConnector.appeal.findUnique.mockResolvedValue(fullPlanningAppealWithTimetable);
+		});
+
+		test('returns the calculated appeal timetable', async () => {
+			const { id } = fullPlanningAppeal;
+			const response = await request
+				.get(
+					`/appeals/${id}/appeal-timetables/calculate?startDate=2024-06-12T22:59:00.000Z&procedureType=hearing`
+				)
+				.set('azureAdUserId', azureAdUserId);
+
+			expect(response.status).toEqual(200);
+			expect(response.body).toEqual({
+				appellantStatementDueDate: '2024-07-17T22:59:00.000Z',
+				finalCommentsDueDate: '2024-07-31T22:59:00.000Z',
+				ipCommentsDueDate: '2024-07-17T22:59:00.000Z',
+				lpaQuestionnaireDueDate: '2024-06-19T22:59:00.000Z',
+				lpaStatementDueDate: '2024-07-17T22:59:00.000Z',
+				s106ObligationDueDate: '2024-07-31T22:59:00.000Z',
+				statementOfCommonGroundDueDate: '2024-07-17T22:59:00.000Z',
+				startDate: '2024-06-11T23:00:00.000Z'
+			});
+		});
+
+		test('returns the calculated appeal timetable for a weekend start date', async () => {
+			const { id } = fullPlanningAppeal;
+			const response = await request
+				.get(
+					`/appeals/${id}/appeal-timetables/calculate?startDate=2024-06-15T22:59:00.000Z&procedureType=hearing`
+				)
+				.set('azureAdUserId', azureAdUserId);
+
+			expect(response.status).toEqual(200);
+			expect(response.body).toEqual({
+				appellantStatementDueDate: '2024-07-22T22:59:00.000Z',
+				finalCommentsDueDate: '2024-08-05T22:59:00.000Z',
+				ipCommentsDueDate: '2024-07-22T22:59:00.000Z',
+				lpaQuestionnaireDueDate: '2024-06-24T22:59:00.000Z',
+				lpaStatementDueDate: '2024-07-22T22:59:00.000Z',
+				s106ObligationDueDate: '2024-08-05T22:59:00.000Z',
+				statementOfCommonGroundDueDate: '2024-07-22T22:59:00.000Z',
+				startDate: '2024-06-16T23:00:00.000Z'
+			});
+		});
+
+		test('returns the calculated appeal timetable with no start date', async () => {
+			const { id } = fullPlanningAppeal;
+			const response = await request
+				.get(`/appeals/${id}/appeal-timetables/calculate?procedureType=hearing`)
+				.set('azureAdUserId', azureAdUserId);
+
+			expect(response.status).toEqual(200);
+			expect(response.body).toEqual({
+				appellantStatementDueDate: '2024-07-10T22:59:00.000Z',
+				finalCommentsDueDate: '2024-07-24T22:59:00.000Z',
+				ipCommentsDueDate: '2024-07-10T22:59:00.000Z',
+				lpaQuestionnaireDueDate: '2024-06-12T22:59:00.000Z',
+				lpaStatementDueDate: '2024-07-10T22:59:00.000Z',
+				s106ObligationDueDate: '2024-07-24T22:59:00.000Z',
+				startDate: '2024-06-04T23:00:00.000Z',
+				statementOfCommonGroundDueDate: '2024-07-10T22:59:00.000Z'
+			});
+		});
+	});
 });

--- a/appeals/api/src/server/endpoints/appeal-timetables/appeal-timetables.controller.js
+++ b/appeals/api/src/server/endpoints/appeal-timetables/appeal-timetables.controller.js
@@ -4,7 +4,11 @@ import { isLinkedAppeal } from '#utils/is-linked-appeal.js';
 import logger from '#utils/logger.js';
 import { FEATURE_FLAG_NAMES } from '@pins/appeals/constants/common.js';
 import { ERROR_FAILED_TO_SAVE_DATA } from '@pins/appeals/constants/support.js';
-import { startCase, updateAppealTimetable } from './appeal-timetables.service.js';
+import {
+	calculateAppealTimetable,
+	startCase,
+	updateAppealTimetable
+} from './appeal-timetables.service.js';
 
 /** @typedef {import('express').Request} Request */
 /** @typedef {import('express').Response} Response */
@@ -109,4 +113,18 @@ const updateAppealTimetableById = async (req, res) => {
 	}
 };
 
-export { startAppeal, updateAppealTimetableById };
+/**
+ * @param {Request} req
+ * @param {Response} res
+ * @returns {Promise<Response>}
+ */
+const getCalculatedAppealTimetable = async (req, res) => {
+	const { appeal, query } = req;
+	let startDate = query.startDate ? String(query.startDate) : new Date().toISOString();
+	const procedureType = String(query.procedureType) || 'written';
+
+	const timetable = await calculateAppealTimetable(appeal, startDate, procedureType);
+	return res.send(timetable);
+};
+
+export { getCalculatedAppealTimetable, startAppeal, updateAppealTimetableById };

--- a/appeals/api/src/server/endpoints/appeal-timetables/appeal-timetables.routes.js
+++ b/appeals/api/src/server/endpoints/appeal-timetables/appeal-timetables.routes.js
@@ -1,7 +1,11 @@
 import { checkAppealExistsByIdAndAddToRequest } from '#middleware/check-appeal-exists-and-add-to-request.js';
 import { asyncHandler } from '@pins/express';
 import { Router as createRouter } from 'express';
-import { startAppeal, updateAppealTimetableById } from './appeal-timetables.controller.js';
+import {
+	getCalculatedAppealTimetable,
+	startAppeal,
+	updateAppealTimetableById
+} from './appeal-timetables.controller.js';
 import { checkAppealTimetableExists } from './appeal-timetables.service.js';
 import {
 	createAppealTimetableValidator,
@@ -67,6 +71,39 @@ router.patch(
 	checkAppealTimetableExists,
 	patchAppealTimetableValidator,
 	asyncHandler(updateAppealTimetableById)
+);
+
+router.get(
+	'/:appealId/appeal-timetables/calculate',
+	/*
+		#swagger.tags = ['Appeal Timetables']
+		#swagger.path = '/appeals/{appealId}/appeal-timetables/calculate'
+		#swagger.description = 'Calculates the timetable that would result from starting this appeal'
+		#swagger.parameters['azureAdUserId'] = {
+			in: 'header',
+			required: true,
+			example: '434bff4e-8191-4ce0-9a0a-91e5d6cdd882'
+		}
+		#swagger.parameters['startDate'] = {
+			in: 'query',
+			required: false,
+			example: '2025-01-01'
+		}
+		#swagger.parameters['procedureType'] = {
+			in: 'query',
+			required: false,
+			example: 'written'
+		}
+		#swagger.responses[200] = {
+			description: 'The timetable that would result from starting this appeal',
+			schema: { $ref: '#/components/schemas/CalculateAppealTimetableResponse' }
+		}
+		#swagger.responses[400] = {}
+		#swagger.responses[404] = {}
+		#swagger.responses[500] = {}
+	 */
+	checkAppealExistsByIdAndAddToRequest,
+	asyncHandler(getCalculatedAppealTimetable)
 );
 
 export { router as appealTimetablesRoutes };

--- a/appeals/api/src/server/openapi-types.ts
+++ b/appeals/api/src/server/openapi-types.ts
@@ -243,28 +243,14 @@ export interface QuestionnaireData {
 	casedata?: {
 		/** @example "6000000" */
 		caseReference?: string;
-		/** @example "D" */
-		caseType?: string;
+		/** @example ["1000000"] */
+		nearbyCaseReferences?: string[];
 		/** @example "2024-05-31T23:00:00.000Z" */
 		lpaQuestionnaireSubmittedDate?: string;
-		/** @example "cupidatat ipsum eu culpa" */
-		lpaStatement?: string;
 		/** @example ["Here it is"] */
 		siteAccessDetails?: string[];
 		/** @example ["Fine"] */
 		siteSafetyDetails?: string[];
-		/** @example true */
-		isCorrectAppealType?: boolean;
-		/** @example false */
-		isGreenBelt?: boolean;
-		/** @example true */
-		inConservationArea?: boolean;
-		/** @example "cupidatat" */
-		newConditionDetails?: string;
-		/** @example ["notice","letter"] */
-		notificationMethod?: string[];
-		/** @example ["1000000"] */
-		nearbyCaseReferences?: string[];
 		neighbouringSiteAddresses?: {
 			/** @example "deserunt in irure do" */
 			neighbouringSiteAddressLine1?: string;
@@ -279,6 +265,21 @@ export interface QuestionnaireData {
 			/** @example "magna proident incididunt in non" */
 			neighbouringSiteSafetyDetails?: string;
 		}[];
+		reasonForNeighbourVisits?: undefined;
+		/** @example "D" */
+		caseType?: string;
+		/** @example "cupidatat ipsum eu culpa" */
+		lpaStatement?: string;
+		/** @example true */
+		isCorrectAppealType?: boolean;
+		/** @example false */
+		isGreenBelt?: boolean;
+		/** @example true */
+		inConservationArea?: boolean;
+		/** @example "cupidatat" */
+		newConditionDetails?: string;
+		/** @example ["notice","letter"] */
+		notificationMethod?: string[];
 		/** @example ["10001","10002"] */
 		affectedListedBuildingNumbers?: string[];
 		/** @example false */
@@ -2272,6 +2273,25 @@ export interface UpdateAppealTimetableResponse {
 	planningObligationDueDate?: string;
 	/** @example "2024-08-14T01:00:00.000Z" */
 	proofOfEvidenceAndWitnessesDueDate?: string;
+}
+
+export interface CalculateAppealTimetableResponse {
+	/** @example "2024-08-09T01:00:00.000Z" */
+	finalCommentReviewDate?: string;
+	/** @example "2024-08-10T01:00:00.000Z" */
+	issueDeterminationDate?: string;
+	/** @example "2024-08-11T01:00:00.000Z" */
+	lpaQuestionnaireDueDate?: string;
+	/** @example "2024-08-12T01:00:00.000Z" */
+	statementReviewDate?: string;
+	/** @example "2024-08-12T01:00:00.000Z" */
+	statementOfCommonGroundDueDate?: string;
+	/** @example "2024-08-13T01:00:00.000Z" */
+	planningObligationDueDate?: string;
+	/** @example "2024-08-14T01:00:00.000Z" */
+	proofOfEvidenceAndWitnessesDueDate?: string;
+	/** @example "2024-08-09T01:00:00.000Z" */
+	startDate?: string;
 }
 
 export interface AllDocumentRedactionStatusesResponse {

--- a/appeals/api/src/server/openapi.json
+++ b/appeals/api/src/server/openapi.json
@@ -618,6 +618,75 @@
 				}
 			}
 		},
+		"/appeals/{appealId}/appeal-timetables/calculate": {
+			"get": {
+				"tags": ["Appeal Timetables"],
+				"description": "Calculates the timetable that would result from starting this appeal",
+				"parameters": [
+					{
+						"name": "appealId",
+						"in": "path",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"name": "azureAdUserId",
+						"in": "header",
+						"required": true,
+						"example": "434bff4e-8191-4ce0-9a0a-91e5d6cdd882",
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"name": "startDate",
+						"in": "query",
+						"required": false,
+						"example": "2025-01-01",
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"name": "procedureType",
+						"in": "query",
+						"required": false,
+						"example": "written",
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "The timetable that would result from starting this appeal",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/CalculateAppealTimetableResponse"
+								}
+							},
+							"application/xml": {
+								"schema": {
+									"$ref": "#/components/schemas/CalculateAppealTimetableResponse"
+								}
+							}
+						}
+					},
+					"400": {
+						"description": "Bad Request"
+					},
+					"404": {
+						"description": "Not Found"
+					},
+					"500": {
+						"description": "Internal Server Error"
+					}
+				}
+			}
+		},
 		"/appeals/appeal-types": {
 			"get": {
 				"tags": ["Appeal Types"],
@@ -6754,17 +6823,16 @@
 								"type": "string",
 								"example": "6000000"
 							},
-							"caseType": {
-								"type": "string",
-								"example": "D"
+							"nearbyCaseReferences": {
+								"type": "array",
+								"example": ["1000000"],
+								"items": {
+									"type": "string"
+								}
 							},
 							"lpaQuestionnaireSubmittedDate": {
 								"type": "string",
 								"example": "2024-05-31T23:00:00.000Z"
-							},
-							"lpaStatement": {
-								"type": "string",
-								"example": "cupidatat ipsum eu culpa"
 							},
 							"siteAccessDetails": {
 								"type": "array",
@@ -6776,36 +6844,6 @@
 							"siteSafetyDetails": {
 								"type": "array",
 								"example": ["Fine"],
-								"items": {
-									"type": "string"
-								}
-							},
-							"isCorrectAppealType": {
-								"type": "boolean",
-								"example": true
-							},
-							"isGreenBelt": {
-								"type": "boolean",
-								"example": false
-							},
-							"inConservationArea": {
-								"type": "boolean",
-								"example": true
-							},
-							"newConditionDetails": {
-								"type": "string",
-								"example": "cupidatat"
-							},
-							"notificationMethod": {
-								"type": "array",
-								"example": ["notice", "letter"],
-								"items": {
-									"type": "string"
-								}
-							},
-							"nearbyCaseReferences": {
-								"type": "array",
-								"example": ["1000000"],
 								"items": {
 									"type": "string"
 								}
@@ -6838,6 +6876,40 @@
 											"example": "magna proident incididunt in non"
 										}
 									}
+								}
+							},
+							"reasonForNeighbourVisits": {
+								"type": "undefined"
+							},
+							"caseType": {
+								"type": "string",
+								"example": "D"
+							},
+							"lpaStatement": {
+								"type": "string",
+								"example": "cupidatat ipsum eu culpa"
+							},
+							"isCorrectAppealType": {
+								"type": "boolean",
+								"example": true
+							},
+							"isGreenBelt": {
+								"type": "boolean",
+								"example": false
+							},
+							"inConservationArea": {
+								"type": "boolean",
+								"example": true
+							},
+							"newConditionDetails": {
+								"type": "string",
+								"example": "cupidatat"
+							},
+							"notificationMethod": {
+								"type": "array",
+								"example": ["notice", "letter"],
+								"items": {
+									"type": "string"
 								}
 							},
 							"affectedListedBuildingNumbers": {
@@ -11215,6 +11287,46 @@
 				},
 				"xml": {
 					"name": "UpdateAppealTimetableResponse"
+				}
+			},
+			"CalculateAppealTimetableResponse": {
+				"type": "object",
+				"properties": {
+					"finalCommentReviewDate": {
+						"type": "string",
+						"example": "2024-08-09T01:00:00.000Z"
+					},
+					"issueDeterminationDate": {
+						"type": "string",
+						"example": "2024-08-10T01:00:00.000Z"
+					},
+					"lpaQuestionnaireDueDate": {
+						"type": "string",
+						"example": "2024-08-11T01:00:00.000Z"
+					},
+					"statementReviewDate": {
+						"type": "string",
+						"example": "2024-08-12T01:00:00.000Z"
+					},
+					"statementOfCommonGroundDueDate": {
+						"type": "string",
+						"example": "2024-08-12T01:00:00.000Z"
+					},
+					"planningObligationDueDate": {
+						"type": "string",
+						"example": "2024-08-13T01:00:00.000Z"
+					},
+					"proofOfEvidenceAndWitnessesDueDate": {
+						"type": "string",
+						"example": "2024-08-14T01:00:00.000Z"
+					},
+					"startDate": {
+						"type": "string",
+						"example": "2024-08-09T01:00:00.000Z"
+					}
+				},
+				"xml": {
+					"name": "CalculateAppealTimetableResponse"
 				}
 			},
 			"AllDocumentRedactionStatusesResponse": {

--- a/appeals/api/src/server/swagger.js
+++ b/appeals/api/src/server/swagger.js
@@ -902,6 +902,16 @@ export const spec = {
 			planningObligationDueDate: '2024-08-13T01:00:00.000Z',
 			proofOfEvidenceAndWitnessesDueDate: '2024-08-14T01:00:00.000Z'
 		},
+		CalculateAppealTimetableResponse: {
+			finalCommentReviewDate: '2024-08-09T01:00:00.000Z',
+			issueDeterminationDate: '2024-08-10T01:00:00.000Z',
+			lpaQuestionnaireDueDate: '2024-08-11T01:00:00.000Z',
+			statementReviewDate: '2024-08-12T01:00:00.000Z',
+			statementOfCommonGroundDueDate: '2024-08-12T01:00:00.000Z',
+			planningObligationDueDate: '2024-08-13T01:00:00.000Z',
+			proofOfEvidenceAndWitnessesDueDate: '2024-08-14T01:00:00.000Z',
+			startDate: '2024-08-09T01:00:00.000Z'
+		},
 		AllDocumentRedactionStatusesResponse: {
 			id: 1,
 			name: 'Document redaction status'


### PR DESCRIPTION
## Describe your changes

Add an endpoint for calculating the start date and timetable of a case without actually starting it yet. This is useful if we are generating a preview of the comms that will be sent out for example.

## Issue ticket number and link

[A2-4273](https://pins-ds.atlassian.net/browse/A2-4273)


[A2-4273]: https://pins-ds.atlassian.net/browse/A2-4273?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ