### PR TITLE
fix(api): handle broadcast of document type correctly for reps

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -19,7 +19,8 @@ module.exports = {
 				jest: true
 			},
 			globals: {
-				mockNotifySend: true
+				mockNotifySend: true,
+				mockBroadcasters: true
 			}
 		},
 		{

--- a/appeals/api/setup-tests.js
+++ b/appeals/api/setup-tests.js
@@ -640,3 +640,16 @@ jest.unstable_mockModule('./src/server/config/config.js', () => ({
 		}
 	}
 }));
+
+const broadcastersMock = {
+	broadcastServiceUser: jest.fn(),
+	broadcastDocument: jest.fn(),
+	broadcastAppeal: jest.fn(),
+	broadcastEvent: jest.fn(),
+	broadcastEventEstimates: jest.fn(),
+	broadcastRepresentation: jest.fn()
+};
+global.mockBroadcasters = broadcastersMock;
+jest.unstable_mockModule('#endpoints/integrations/integrations.broadcasters.js', () => ({
+	broadcasters: broadcastersMock
+}));

--- a/appeals/api/src/server/endpoints/representations/representations.service.js
+++ b/appeals/api/src/server/endpoints/representations/representations.service.js
@@ -152,6 +152,16 @@ export const createRepresentation = async (appealId, input) => {
 		}));
 
 		await representationRepository.addAttachments(representation.id, mappedDocuments);
+
+		for (const document of mappedDocuments) {
+			if (document?.documentGuid) {
+				await broadcasters.broadcastDocument(
+					document.documentGuid,
+					document.version,
+					document.version > 1 ? EventType.Update : EventType.Create
+				);
+			}
+		}
 	}
 
 	return representation;
@@ -183,6 +193,17 @@ export const updateAttachments = async (repId, attachments) => {
 		repId,
 		mappedDocuments
 	);
+
+	for (const document of mappedDocuments) {
+		if (document?.documentGuid) {
+			await broadcasters.broadcastDocument(
+				document.documentGuid,
+				document.version,
+				document.version > 1 ? EventType.Update : EventType.Create
+			);
+		}
+	}
+
 	return updatedRepresentation;
 };
 

--- a/appeals/api/src/server/mappers/integration/__tests__/mappers.test.js
+++ b/appeals/api/src/server/mappers/integration/__tests__/mappers.test.js
@@ -4,8 +4,14 @@ import { fullPlanningAppeal } from '#tests/appeals/mocks.js';
 import { isCaseInvalid } from '#utils/case-invalid.js';
 import { findStatusDate } from '#utils/mapping/map-dates.js';
 import { APPEAL_REPRESENTATION_TYPE } from '@pins/appeals/constants/common.js';
-import { APPEAL_CASE_STATUS } from '@planning-inspectorate/data-model';
+import { REP_ATTACHMENT_DOCTYPE } from '@pins/appeals/constants/documents.js';
+import {
+	APPEAL_CASE_STAGE,
+	APPEAL_CASE_STATUS,
+	APPEAL_DOCUMENT_TYPE
+} from '@planning-inspectorate/data-model';
 import { mapDesignatedSiteNames } from '../commands/questionnaire.mapper.js';
+import { mapDocumentEntity } from '../map-document-entity.js';
 import { mapCaseDates } from '../shared/s20s78/map-case-dates.js';
 
 describe('appeals generic mappers', () => {
@@ -232,5 +238,87 @@ describe('mapCaseDates', () => {
 			siteNoticesSentDate: null,
 			lpaProofsSubmittedDate: null
 		});
+	});
+});
+
+describe('map-document-entity', () => {
+	const internalRepDocType = REP_ATTACHMENT_DOCTYPE;
+	test.each([
+		{
+			desc: 'representationAttachments - APPELLANT_FINAL_COMMENT',
+			documentType: internalRepDocType,
+			representationType: APPEAL_REPRESENTATION_TYPE.APPELLANT_FINAL_COMMENT,
+			expected: APPEAL_DOCUMENT_TYPE.APPELLANT_FINAL_COMMENT
+		},
+		{
+			desc: 'representationAttachments - LPA_FINAL_COMMENT',
+			documentType: internalRepDocType,
+			representationType: APPEAL_REPRESENTATION_TYPE.LPA_FINAL_COMMENT,
+			expected: APPEAL_DOCUMENT_TYPE.LPA_FINAL_COMMENT
+		},
+		{
+			desc: 'representationAttachments - APPELLANT_STATEMENT',
+			documentType: internalRepDocType,
+			representationType: APPEAL_REPRESENTATION_TYPE.APPELLANT_STATEMENT,
+			expected: APPEAL_DOCUMENT_TYPE.APPELLANT_STATEMENT
+		},
+		{
+			desc: 'representationAttachments - LPA_STATEMENT',
+			documentType: internalRepDocType,
+			representationType: APPEAL_REPRESENTATION_TYPE.LPA_STATEMENT,
+			expected: APPEAL_DOCUMENT_TYPE.LPA_STATEMENT
+		},
+		{
+			desc: 'representationAttachments - COMMENT',
+			documentType: internalRepDocType,
+			representationType: APPEAL_REPRESENTATION_TYPE.COMMENT,
+			expected: APPEAL_DOCUMENT_TYPE.INTERESTED_PARTY_COMMENT
+		},
+		{
+			desc: 'representationAttachments - unknown type',
+			documentType: internalRepDocType,
+			representationType: 'SOMETHING_UNKNOWN',
+			expected: APPEAL_DOCUMENT_TYPE.UNCATEGORISED
+		},
+		{
+			desc: 'other documentType',
+			documentType: 'someOtherType',
+			representationType: null,
+			expected: 'someOtherType'
+		},
+		{
+			desc: 'documentType undefined',
+			documentType: undefined,
+			representationType: null,
+			expected: APPEAL_DOCUMENT_TYPE.UNCATEGORISED
+		}
+	])('handles document type: $desc', ({ documentType, representationType, expected }) => {
+		const doc = {
+			guid: 'doc-123',
+			caseId: 'case-456',
+			name: '123e4567-e89b-12d3-a456-426614174000_test.pdf',
+			case: { reference: 'REF-1', appealType: { key: 'D' } },
+			versions: [
+				{
+					version: 1,
+					originalFilename: 'test.pdf',
+					size: 1000,
+					mime: 'application/pdf',
+					documentURI: 'http://doc.uri',
+					fileMD5: 'md5hash',
+					dateCreated: new Date('2025-01-01T10:00:00.000Z'),
+					dateReceived: new Date('2025-01-01T11:00:00.000Z'),
+					lastModified: new Date('2025-01-01T12:00:00.000Z'),
+					documentType,
+					stage: APPEAL_CASE_STAGE.APPEAL_DECISION,
+					redactionStatus: { key: 'NOT_REDACTED' },
+					representation: representationType
+						? { representation: { representationType } }
+						: undefined
+				}
+			]
+		};
+		const result = mapDocumentEntity(doc);
+		expect(result.documentType).toBe(expected);
 	});
 });

--- a/appeals/api/src/server/mappers/integration/commands/document.mapper.js
+++ b/appeals/api/src/server/mappers/integration/commands/document.mapper.js
@@ -1,4 +1,5 @@
 import config from '#config/config.js';
+import { REP_ATTACHMENT_DOCTYPE } from '@pins/appeals/constants/documents.js';
 import { APPEAL_CASE_STAGE } from '@planning-inspectorate/data-model';
 import { randomUUID } from 'node:crypto';
 
@@ -22,7 +23,7 @@ export const mapDocumentIn = (doc, stage = null) => {
 	if (stage === 'representation') {
 		metadata.fileName = `${randomUUID()}_${metadata.originalFilename}`;
 		// @ts-ignore
-		metadata.documentType = 'representationAttachments';
+		metadata.documentType = REP_ATTACHMENT_DOCTYPE;
 	}
 
 	metadata.blobStorageContainer = config.BO_BLOB_CONTAINER;

--- a/appeals/api/src/server/mappers/integration/map-document-entity.js
+++ b/appeals/api/src/server/mappers/integration/map-document-entity.js
@@ -6,6 +6,7 @@ import {
 	APPEAL_REPRESENTATION_TYPE as INTERNAL_REPRESENTATION_TYPE,
 	ODW_SYSTEM_ID
 } from '@pins/appeals/constants/common.js';
+import { REP_ATTACHMENT_DOCTYPE } from '@pins/appeals/constants/documents.js';
 import {
 	APPEAL_CASE_STAGE,
 	APPEAL_DOCUMENT_TYPE,
@@ -148,7 +149,7 @@ const mapOrigin = (stage) => {
  * @returns {string}
  */
 const mapDocumentType = (doc) => {
-	if (doc.documentType === 'representationAttachments') {
+	if (doc.documentType === REP_ATTACHMENT_DOCTYPE) {
 		const rep = doc.representation?.representation;
 		switch (rep?.representationType) {
 			case INTERNAL_REPRESENTATION_TYPE.APPELLANT_FINAL_COMMENT:
@@ -159,8 +160,10 @@ const mapDocumentType = (doc) => {
 				return APPEAL_DOCUMENT_TYPE.APPELLANT_STATEMENT;
 			case INTERNAL_REPRESENTATION_TYPE.LPA_STATEMENT:
 				return APPEAL_DOCUMENT_TYPE.LPA_STATEMENT;
-			default:
+			case INTERNAL_REPRESENTATION_TYPE.COMMENT:
 				return APPEAL_DOCUMENT_TYPE.INTERESTED_PARTY_COMMENT;
+			default:
+				return APPEAL_DOCUMENT_TYPE.UNCATEGORISED;
 		}
 	}
 
@@ -173,7 +176,7 @@ const mapDocumentType = (doc) => {
  * @returns {string}
  */
 const mapStage = (doc) => {
-	if (doc.documentType === 'representationAttachments') {
+	if (doc.documentType === REP_ATTACHMENT_DOCTYPE) {
 		const rep = doc.representation?.representation;
 		switch (rep?.representationType) {
 			case INTERNAL_REPRESENTATION_TYPE.APPELLANT_FINAL_COMMENT:

--- a/packages/appeals/constants/documents.js
+++ b/packages/appeals/constants/documents.js
@@ -1,5 +1,7 @@
 import { APPEAL_CASE_STAGE, APPEAL_DOCUMENT_TYPE } from '@planning-inspectorate/data-model';
 
+export const REP_ATTACHMENT_DOCTYPE = 'representationAttachments';
+
 /** @type {string[]} */
 export const FOLDERS = [
 	`${APPEAL_CASE_STAGE.APPELLANT_CASE}/${APPEAL_DOCUMENT_TYPE.APPELLANT_STATEMENT}`,
@@ -52,7 +54,7 @@ export const FOLDERS = [
 	`${APPEAL_CASE_STAGE.INTERNAL}/${APPEAL_DOCUMENT_TYPE.MAIN_PARTY_CORRESPONDENCE}`,
 	`${APPEAL_CASE_STAGE.INTERNAL}/${APPEAL_DOCUMENT_TYPE.UNCATEGORISED}`,
 	`${APPEAL_CASE_STAGE.APPEAL_DECISION}/${APPEAL_DOCUMENT_TYPE.CASE_DECISION_LETTER}`,
-	'representation/representationAttachments'
+	`representation/${REP_ATTACHMENT_DOCTYPE}`
 ];
 
 export const VALID_MIME_TYPES = Object.freeze({


### PR DESCRIPTION
## Describe your changes

Was broadcasting rep docs with a default doc type of IP comment, as the attachment used for deciding the doctype was set after the initial broadcast

- adds a check to not broadcast in this scenario
- defaults doc type to UNCATEGORISED rather than IP Comment
- calls broadcastDocument after attachment is made
- create and use doc type const

had to mock integrations.broadcasters globally - was unable to get it to work with mocking at a higher level without impacting other tests

## Issue ticket number and link

[Ticket](https://pins-ds.atlassian.net/browse/A2-4406)
