### PR TITLE
test(appeals): change to written procedure type

### DIFF
--- a/appeals/e2e/cypress/e2e/back-office-appeals/changeAppealProcedureType.spec.js
+++ b/appeals/e2e/cypress/e2e/back-office-appeals/changeAppealProcedureType.spec.js
@@ -1,0 +1,109 @@
+// @ts-nocheck
+/// <reference types="cypress"/>
+
+import { users } from '../../fixtures/users';
+import { OverviewSectionPage } from '../../page_objects/caseDetails/overviewSectionPage';
+import { CaseDetailsPage } from '../../page_objects/caseDetailsPage.js';
+import { CYASection } from '../../page_objects/cyaSection.js';
+import { DateTimeSection } from '../../page_objects/dateTimeSection';
+import { ProcedureTypePage } from '../../page_objects/procedureTypePage';
+import { happyPathHelper } from '../../support/happyPathHelper.js';
+import { formatDateAndTime, getDateAndTimeValues } from '../../support/utils/format';
+
+const overviewSectionPage = new OverviewSectionPage();
+const caseDetailsPage = new CaseDetailsPage();
+const procedureTypePage = new ProcedureTypePage();
+const dateTimeSection = new DateTimeSection();
+const cyaSection = new CYASection();
+
+describe('change appeal procedure types', () => {
+	let caseRef;
+
+	const overviewDetails = {
+		written: {
+			appealType: 'Planning appeal',
+			applicationReference: '123',
+			appealProcedure: 'Written',
+			allocationLevel: 'No allocation level for this appeal',
+			linkedAppeals: 'No linked appeals',
+			relatedAppeals: '1000000',
+			netGainResidential: 'Not provided'
+		}
+	};
+
+	const timetableItems = [
+		{
+			row: 'final-comments-due-date',
+			editable: true
+		}
+	];
+
+	const procedureTypeCaption = () => `Appeal ${caseRef} - update appeal procedure`;
+
+	it('should change appeal procedure type - written in LPAQ state', () => {
+		cy.login(users.appeals.caseAdmin);
+		cy.createCase({ caseType: 'W' }).then((ref) => {
+			caseRef = ref;
+			cy.addLpaqSubmissionToCase(caseRef);
+			happyPathHelper.assignCaseOfficer(caseRef);
+			caseDetailsPage.checkStatusOfCase('Validation', 0);
+			happyPathHelper.reviewAppellantCase(caseRef);
+			caseDetailsPage.checkStatusOfCase('Ready to start', 0);
+
+			happyPathHelper.startS78Case(caseRef, 'written');
+			caseDetailsPage.checkStatusOfCase('LPA questionnaire', 0);
+			caseDetailsPage.clickAccordionByButton('Overview');
+			overviewSectionPage.verifyCaseOverviewDetails(overviewDetails.written);
+
+			overviewSectionPage.clickRowChangeLink('case-procedure');
+
+			procedureTypePage.verifyHeader(procedureTypeCaption());
+			procedureTypePage.selectProcedureType('written');
+
+			// verify previous values are prepopulated
+			cy.loadAppealDetails(caseRef).then((appealDetails) => {
+				procedureTypePage.verifyHeader(procedureTypeCaption());
+				const appealTimetable = appealDetails?.appealTimetable;
+				const lpaQuestionnaireDueDate = new Date(appealTimetable.lpaQuestionnaireDueDate);
+				const lpaStatementDueDate = new Date(appealTimetable.lpaStatementDueDate);
+				const ipCommentsDueDate = new Date(appealTimetable.ipCommentsDueDate);
+
+				dateTimeSection.verifyPrepopulatedTimeTableDueDates(
+					'lpaQuestionnaireDueDate',
+					getDateAndTimeValues(lpaQuestionnaireDueDate)
+				);
+				dateTimeSection.verifyPrepopulatedTimeTableDueDates(
+					'lpaStatementDueDate',
+					getDateAndTimeValues(lpaStatementDueDate)
+				);
+				dateTimeSection.verifyPrepopulatedTimeTableDueDates(
+					'ipCommentsDueDate',
+					getDateAndTimeValues(ipCommentsDueDate)
+				);
+
+				// update final comments due date and check CYA page
+				cy.getBusinessActualDate(new Date(), 60).then((dueDate) => {
+					caseDetailsPage.changeTimetableDates(timetableItems, dueDate, 0); //update and continue
+					const updateFinalCommentsDueDate = new Date(dueDate);
+
+					cyaSection.verifyCheckYourAnswers(
+						'LPA questionnaire due',
+						formatDateAndTime(lpaQuestionnaireDueDate).date
+					);
+					cyaSection.verifyCheckYourAnswers(
+						'Statements due',
+						formatDateAndTime(lpaStatementDueDate).date
+					);
+					cyaSection.verifyCheckYourAnswers(
+						'Interested party comments due',
+						formatDateAndTime(ipCommentsDueDate).date
+					);
+					cyaSection.verifyCheckYourAnswers(
+						'Final comments due',
+						formatDateAndTime(updateFinalCommentsDueDate).date
+					);
+				});
+			});
+		});
+	});
+});

--- a/appeals/e2e/cypress/page_objects/dateTimeSection.js
+++ b/appeals/e2e/cypress/page_objects/dateTimeSection.js
@@ -28,12 +28,12 @@ export class DateTimeSection extends Page {
 		withdrawalRequestDate: '#withdrawal-request-date-',
 		hearingDate: '#hearing-date-',
 		inquiryEstimationDays: '#inquiry-estimation-days',
-		lpaQuestionnaireDueDate: '#lpa-questionnaire-due-date-',
-		lpaStatementDueDate: '#statement-due-date-',
-		ipCommentsDueDate: '#ip-comments-due-date-',
-		finalCommentsDueDate: '#final-comments-due-date-',
-		statementOfCommonGroundDueDate: '#statement-of-common-ground-due-date-',
-		proofOfEvidenceAndWitnessesDueDate: '#proof-of-evidence-and-witnesses-due-date-',
+		lpaQuestionnaireDueDate: '#lpa-questionnaire-due',
+		lpaStatementDueDate: '#lpa-statement-due',
+		ipCommentsDueDate: '#ip-comments-due',
+		finalCommentsDueDate: '#final-comments-due',
+		statementOfCommonGroundDueDate: '#statement-of-common-ground-due',
+		proofOfEvidenceAndWitnessesDueDate: '#proof-of-evidence-and-witnesses-due',
 		inquiryDate: '#inquiry-date-',
 		inquiry: '#inquiry',
 		hearing: '#hearing'
@@ -143,7 +143,7 @@ export class DateTimeSection extends Page {
 		this.#verifyPrepopulatedValues(this.selectorPrefix.inquiry, expectedValues);
 	}
 
-	#verifyPrepopulatedValues(dateSelector, expectedValues) {
+	#verifyPrepopulatedValues(dateSelector, expectedValues, includeTime = true) {
 		// verify date
 		cy.get(dateSelector + '-date-day')
 			.invoke('prop', 'value')
@@ -162,16 +162,22 @@ export class DateTimeSection extends Page {
 			});
 
 		// verify time
-		cy.get(dateSelector + '-time-hour')
-			.invoke('prop', 'value')
-			.then((text) => {
-				expect(formatAsWholeNumber(text)).to.equal(expectedValues.hours);
-			});
-		cy.get(dateSelector + '-time-minute')
-			.invoke('prop', 'value')
-			.then((text) => {
-				expect(formatAsWholeNumber(text)).to.equal(expectedValues.minutes);
-			});
+		if (includeTime) {
+			cy.get(dateSelector + '-time-hour')
+				.invoke('prop', 'value')
+				.then((text) => {
+					expect(formatAsWholeNumber(text)).to.equal(expectedValues.hours);
+				});
+			cy.get(dateSelector + '-time-minute')
+				.invoke('prop', 'value')
+				.then((text) => {
+					expect(formatAsWholeNumber(text)).to.equal(expectedValues.minutes);
+				});
+		}
+	}
+
+	verifyPrepopulatedTimeTableDueDates(field, expectedValues) {
+		this.#verifyPrepopulatedValues(this.selectorPrefix[field], expectedValues, false);
 	}
 
 	// Private helper methods

--- a/appeals/e2e/cypress/page_objects/procedureTypePage.js
+++ b/appeals/e2e/cypress/page_objects/procedureTypePage.js
@@ -1,0 +1,49 @@
+// @ts-nocheck
+import { CaseDetailsPage } from './caseDetailsPage.js';
+
+export class ProcedureTypePage extends CaseDetailsPage {
+	procedureTypeElements = {
+		...this.elements, // Inherit parent elements
+		written: () => cy.get('#appeal-procedure'),
+		hearing: () => cy.get('#appeal-procedure-1'),
+		inquiry: () => cy.get('#appeal-procedure-2')
+	};
+
+	selectProcedureType(label) {
+		const procedureTypeLabelMappings = {
+			written: {
+				element: this.procedureTypeElements.written,
+				displayName: 'Written representations'
+			},
+			hearing: {
+				element: this.procedureTypeElements.hearing,
+				displayName: 'Hearing'
+			},
+			inquiry: {
+				element: this.procedureTypeElements.inquiry,
+				displayName: 'Inquiry'
+			}
+		};
+
+		const normalizedLabel = label.toLowerCase().trim();
+
+		if (procedureTypeLabelMappings.hasOwnProperty(normalizedLabel)) {
+			const mapping = procedureTypeLabelMappings[normalizedLabel];
+			// Click and verify it's checked
+			mapping.element().click().should('be.checked');
+			this.clickButtonByText('Continue');
+			cy.log(`Selected procedure type: ${mapping.displayName}`);
+		} else {
+			const availableOptions = Object.values(procedureTypeLabelMappings)
+				.map((m) => m.displayName)
+				.join(', ');
+			throw new Error(
+				`Procedure type "${label}" not found. Available options: ${availableOptions}`
+			);
+		}
+	}
+
+	verifyHeader(sectionHeader) {
+		this.elements.getAppealRefCaseDetails().should('contain.text', sectionHeader);
+	}
+}


### PR DESCRIPTION
## Describe your changes

**What's Added:** 

- New Cypress test for changing appeal procedure types in LPAQ state 
- Tests the complete flow from case creation to procedure type update
- Includes date validation and CYA page verification 

**Test Coverage:** 

- Creates planning appeal case and sets to LPA questionnaire state 
- Changes appeal procedure type to "written" 
- Verifies prepopulated timetable dates are correct
- Updates final comments due date 
- Validates all dates on Check Your Answers page 

**No breaking changes - adds new test functionality only.**

## Issue ticket number and link

[Ticket](https://pins-ds.atlassian.net/browse/A2-3926)
