### PR TITLE
feat(appeals): add unassigned filter option (A2-3790)

### DIFF
--- a/appeals/api/src/server/endpoints/appeals/__tests__/appeals.test.js
+++ b/appeals/api/src/server/endpoints/appeals/__tests__/appeals.test.js
@@ -1402,6 +1402,24 @@ test('gets appeals when given a assignedTeamId param', async () => {
 		statusesInNationalList
 	});
 });
+test('gets unassigned teams when assignedTeamId param is -1', async () => {
+	databaseConnector.appeal.findMany
+		.mockResolvedValueOnce([householdAppeal])
+		.mockResolvedValueOnce(allAppeals);
+
+	const response = await request
+		.get('/appeals?assignedTeamId=-1')
+		.set('azureAdUserId', azureAdUserId);
+
+	expect(databaseConnector.appeal.findMany).toHaveBeenCalledWith(
+		expect.objectContaining({
+			where: expect.objectContaining({
+				assignedTeamId: null
+			})
+		})
+	);
+	expect(response.status).toEqual(200);
+});
 describe('mapAppealToDueDate Tests', () => {
 	let mockAppeal = {
 		appealType: null,

--- a/appeals/api/src/server/repositories/appeal-lists.repository.js
+++ b/appeals/api/src/server/repositories/appeal-lists.repository.js
@@ -262,9 +262,15 @@ const buildAllAppealsWhereClause = (
 		...(!!appealTypeId && {
 			appealTypeId
 		}),
-		...(!!assignedTeamId && {
-			assignedTeamId
+		// Search for records where assignedTeamId is null
+		...(assignedTeamId === -1 && {
+			assignedTeamId: null
 		}),
+		// Otherwise, filter by assignedTeamId if provided and not zero
+		...(!!assignedTeamId &&
+			assignedTeamId !== -1 && {
+				assignedTeamId
+			}),
 		...(!!procedureTypeId && {
 			procedureTypeId
 		})

--- a/appeals/web/src/server/appeals/national-list/__tests__/__snapshots__/national-list.test.js.snap
+++ b/appeals/web/src/server/appeals/national-list/__tests__/__snapshots__/national-list.test.js.snap
@@ -106,6 +106,7 @@ exports[`national-list GET / should render national list - 10 pages - all page i
                             <select class="govuk-select" id="case-team-filter" name="caseTeamFilter"
                             data-cy="filter-by-case-team">
                                 <option value="all">All</option>
+                                <option value="-1">Unassigned</option>
                                 <option value="1">temp</option>
                                 <option value="2">temp2</option>
                                 <option value="3">temp3</option>
@@ -331,6 +332,7 @@ exports[`national-list GET / should render national list - 15 pages - pagination
                             <select class="govuk-select" id="case-team-filter" name="caseTeamFilter"
                             data-cy="filter-by-case-team">
                                 <option value="all">All</option>
+                                <option value="-1">Unassigned</option>
                                 <option value="1">temp</option>
                                 <option value="2">temp2</option>
                                 <option value="3">temp3</option>
@@ -533,6 +535,7 @@ exports[`national-list GET / should render national list - appeal procedure type
                             <select class="govuk-select" id="case-team-filter" name="caseTeamFilter"
                             data-cy="filter-by-case-team">
                                 <option value="all">All</option>
+                                <option value="-1">Unassigned</option>
                                 <option value="1">temp</option>
                                 <option value="2">temp2</option>
                                 <option value="3">temp3</option>
@@ -704,6 +707,7 @@ exports[`national-list GET / should render national list - appeal type filter ap
                             <select class="govuk-select" id="case-team-filter" name="caseTeamFilter"
                             data-cy="filter-by-case-team">
                                 <option value="all">All</option>
+                                <option value="-1">Unassigned</option>
                                 <option value="1">temp</option>
                                 <option value="2">temp2</option>
                                 <option value="3">temp3</option>
@@ -875,6 +879,7 @@ exports[`national-list GET / should render national list - case team filter appl
                             <select class="govuk-select" id="case-team-filter" name="caseTeamFilter"
                             data-cy="filter-by-case-team">
                                 <option value="all">All</option>
+                                <option value="-1">Unassigned</option>
                                 <option value="1" selected>temp</option>
                                 <option value="2">temp2</option>
                                 <option value="3">temp3</option>
@@ -1049,6 +1054,7 @@ exports[`national-list GET / should render national list - no pagination 1`] = `
                             <select class="govuk-select" id="case-team-filter" name="caseTeamFilter"
                             data-cy="filter-by-case-team">
                                 <option value="all">All</option>
+                                <option value="-1">Unassigned</option>
                                 <option value="1">temp</option>
                                 <option value="2">temp2</option>
                                 <option value="3">temp3</option>
@@ -1239,6 +1245,7 @@ exports[`national-list GET / should render national list - no search term - filt
                             <select class="govuk-select" id="case-team-filter" name="caseTeamFilter"
                             data-cy="filter-by-case-team">
                                 <option value="all">All</option>
+                                <option value="-1">Unassigned</option>
                                 <option value="1">temp</option>
                                 <option value="2">temp2</option>
                                 <option value="3">temp3</option>
@@ -1421,6 +1428,7 @@ exports[`national-list GET / should render national list - search term - filter 
                             <select class="govuk-select" id="case-team-filter" name="caseTeamFilter"
                             data-cy="filter-by-case-team">
                                 <option value="all">All</option>
+                                <option value="-1">Unassigned</option>
                                 <option value="1">temp</option>
                                 <option value="2">temp2</option>
                                 <option value="3">temp3</option>
@@ -1594,6 +1602,7 @@ exports[`national-list GET / should render national list - search term - no resu
                             <select class="govuk-select" id="case-team-filter" name="caseTeamFilter"
                             data-cy="filter-by-case-team">
                                 <option value="all">All</option>
+                                <option value="-1">Unassigned</option>
                                 <option value="1">temp</option>
                                 <option value="2">temp2</option>
                                 <option value="3">temp3</option>
@@ -1741,6 +1750,7 @@ exports[`national-list GET / should render national list - search term 1`] = `
                             <select class="govuk-select" id="case-team-filter" name="caseTeamFilter"
                             data-cy="filter-by-case-team">
                                 <option value="all">All</option>
+                                <option value="-1">Unassigned</option>
                                 <option value="1">temp</option>
                                 <option value="2">temp2</option>
                                 <option value="3">temp3</option>
@@ -1925,6 +1935,7 @@ exports[`national-list GET / should render the header with navigation containing
                             <select class="govuk-select" id="case-team-filter" name="caseTeamFilter"
                             data-cy="filter-by-case-team">
                                 <option value="all">All</option>
+                                <option value="-1">Unassigned</option>
                                 <option value="1">temp</option>
                                 <option value="2">temp2</option>
                                 <option value="3">temp3</option>

--- a/appeals/web/src/server/appeals/national-list/national-list.mapper.js
+++ b/appeals/web/src/server/appeals/national-list/national-list.mapper.js
@@ -149,6 +149,11 @@ export function nationalListPage(
 			value: 'all',
 			selected: caseTeamFilter === 'all'
 		},
+		{
+			text: 'Not assigned',
+			value: -1,
+			selected: caseTeamFilter === '-1'
+		},
 		...caseTeams.map(({ name, id }) => ({
 			text: name,
 			value: id,


### PR DESCRIPTION
## Describe your changes

### WEB/API

- Add option to filter for appeals that are unassigned

### TESTING

- added new unit test to covert scenario
- updated existing unit tests and checked that they were correct
- Manually tested within browser

## Issue ticket number and link

[Ticket](https://pins-ds.atlassian.net/browse/A2-3790)
