### PR TITLE
fix(web): Validating IP params before calling api

### DIFF
--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/changed-listed-buildings/changed-listed-buildings.controller.js
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/changed-listed-buildings/changed-listed-buildings.controller.js
@@ -1,4 +1,5 @@
 import { addNotificationBannerToSession } from '#lib/session-utilities.js';
+import { areIdParamsValid } from '#lib/validators/id-param.validator.js';
 import { getLpaQuestionnaireFromId } from '../lpa-questionnaire.service.js';
 import {
 	addChangedListedBuildingCheckAndConfirmPage,
@@ -184,6 +185,10 @@ export const postRemoveChangedListedBuilding = async (request, response) => {
 
 	if (errors) {
 		return renderRemoveChangedListedBuilding(request, response);
+	}
+
+	if (!areIdParamsValid(appealId, listedBuildingId, lpaQuestionnaireId)) {
+		return response.status(400).render('app/400.njk');
 	}
 
 	if (!appealId || !listedBuildingId || !lpaQuestionnaireId) {

--- a/appeals/web/src/server/appeals/appeal-details/representations/interested-party-comments/interested-party-comments.middleware.js
+++ b/appeals/web/src/server/appeals/appeal-details/representations/interested-party-comments/interested-party-comments.middleware.js
@@ -1,3 +1,4 @@
+import { areIdParamsValid } from '#lib/validators/id-param.validator.js';
 import { getInterestedPartyComment } from './interested-party-comments.service.js';
 
 /**
@@ -6,6 +7,10 @@ import { getInterestedPartyComment } from './interested-party-comments.service.j
  * */
 export const validateComment = async (req, res, next) => {
 	const { appealId, commentId } = req.params;
+
+	if (!areIdParamsValid(appealId, commentId)) {
+		return res.status(400).render('app/400.njk');
+	}
 
 	try {
 		const representation = await getInterestedPartyComment(req.apiClient, appealId, commentId);

--- a/appeals/web/src/server/lib/validators/id-param.validator.js
+++ b/appeals/web/src/server/lib/validators/id-param.validator.js
@@ -1,0 +1,9 @@
+/**
+ * @param {...(string)} ids
+ * @returns {boolean}
+ */
+export const areIdParamsValid = (...ids) => {
+	const ID_PATTERN = /^[0-9]+$/;
+
+	return ids.every((id) => ID_PATTERN.test(id));
+};

--- a/appeals/web/src/server/views/app/400.njk
+++ b/appeals/web/src/server/views/app/400.njk
@@ -1,0 +1,11 @@
+{% extends "app/layouts/app-two-column.layout.njk" %}
+
+{% set pageTitle = 'Bad request' %}
+{% set heading = 'Sorry, there is a problem with your request' %}
+
+{% block pageContent %}
+    <p class="govuk-body">The page you are looking for cannot be displayed because of a problem with the web address.</p>
+    <p class="govuk-body">
+        <a href="https://has-appeal.herokuapp.com/help/contact" class="govuk-link">Contact the Planning Inspectorate Customer Support</a> if the problem persists.
+    </p>
+{% endblock %}


### PR DESCRIPTION
## Describe your changes
- This is an attempt to fix consistent Server-side request forgery issues flagged by Github code scans. 
- The idea is that ID parameters used in API calls will be validated just before making the API call. Especially in cases where these IP params are taken from the query parameters. 

Hopefully this will resolve the top 2 scan issues: 
1. appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/changed-listed-buildings/changed-listed-buildings.controller.js
2. appeals/web/src/server/appeals/appeal-details/representations/interested-party-comments/interested-party-comments.middleware.js
<img width="747" height="246" alt="Screenshot 2025-09-17 at 14 41 05" src="https://github.com/user-attachments/assets/edae2628-2c4c-4ada-af67-b107413813ba" />

<!--
    Please include a summary of the change along with any relevant context.
    List any dependencies that are required for this change.
-->

