### PR TITLE
fix/a2 4433 use standard apostrophe in emails for release (a2-4433)

### DIFF
--- a/appeals/api/src/server/endpoints/notify-preview/__tests__/__snapshots__/notify-preview.test.js.snap
+++ b/appeals/api/src/server/endpoints/notify-preview/__tests__/__snapshots__/notify-preview.test.js.snap
@@ -17,7 +17,7 @@ Planning application reference: planningApplicationReference<br>
 
 <p><a href="/manage-appeals/12345" class="govuk-link">Sign in to our service</a> to view the decision letter dated dateISOStringToDisplayDate(file.receivedDate).</p>
 
-<h3> The Planning Inspectorate’s role</h3>
+<h3> The Planning Inspectorate's role</h3>
 
 <p>The Planning Inspectorate cannot change or revoke the decision. Only the High Court can change this decision.</p>
 

--- a/appeals/api/src/server/notify/templates/__tests__/appeal-valid-start-case-appellant.test.js
+++ b/appeals/api/src/server/notify/templates/__tests__/appeal-valid-start-case-appellant.test.js
@@ -37,7 +37,7 @@ describe('appeal-valid-start-case-appellant.md', () => {
 			'',
 			'# Next steps',
 			'',
-			'We’ve asked Bristol City Council to complete a questionnaire about your appeal. They will send you a copy of their completed questionnaire.',
+			"We've asked Bristol City Council to complete a questionnaire about your appeal. They will send you a copy of their completed questionnaire.",
 			'',
 			'We will arrange for an inspector to visit the address. You may need to attend the visit.',
 			'',

--- a/appeals/api/src/server/notify/templates/__tests__/correction-notice-decision.test.js
+++ b/appeals/api/src/server/notify/templates/__tests__/correction-notice-decision.test.js
@@ -41,7 +41,7 @@ describe('correction-notice-decision.md', () => {
 			'',
 			'[Sign in to our service](/mock-front-office-url/manage-appeals/134526) to view the decision letter dated 01 January 2025.',
 			'',
-			'# The Planning Inspectorate’s role',
+			"# The Planning Inspectorate's role",
 			'',
 			'The Planning Inspectorate cannot change or revoke the decision. Only the High Court can change this decision.',
 			'',

--- a/appeals/api/src/server/notify/templates/__tests__/notify-decision-is-allowed-split-dismissed-appellant.test.js
+++ b/appeals/api/src/server/notify/templates/__tests__/notify-decision-is-allowed-split-dismissed-appellant.test.js
@@ -35,7 +35,7 @@ const expectedContentRows = (replacementRows) => [
 	'',
 	'We have also informed the local planning authority of the decision.',
 	'',
-	'# The Planning Inspectorate’s role',
+	"# The Planning Inspectorate's role",
 	'',
 	'The Planning Inspectorate cannot change or revoke the decision. You can [challenge the decision in the High Court](https://www.gov.uk/appeal-planning-decision/if-you-think-the-appeal-decision-is-legally-incorrect) if you think the Planning Inspectorate made a legal mistake.',
 	'',

--- a/appeals/api/src/server/notify/templates/__tests__/notify-decision-is-allowed-split-dismissed-lpa.test.js
+++ b/appeals/api/src/server/notify/templates/__tests__/notify-decision-is-allowed-split-dismissed-lpa.test.js
@@ -35,7 +35,7 @@ const expectedContentRows = (replacementRows) => [
 	'',
 	'We have also informed the appellant of the decision.',
 	'',
-	'# The Planning Inspectorate’s role',
+	"# The Planning Inspectorate's role",
 	'',
 	'The Planning Inspectorate cannot change or revoke the decision. You can [challenge the decision in the High Court](https://www.gov.uk/appeal-planning-decision/if-you-think-the-appeal-decision-is-legally-incorrect) if you think the Planning Inspectorate made a legal mistake.',
 	'',

--- a/appeals/api/src/server/notify/templates/__tests__/notify-final-comments-done-appellant.test.js
+++ b/appeals/api/src/server/notify/templates/__tests__/notify-final-comments-done-appellant.test.js
@@ -18,7 +18,7 @@ describe('final-comments-done-appellant.md', () => {
 		};
 
 		const expectedContent = [
-			'We have received the local planning authority’s final comments.',
+			"We have received the local planning authority's final comments.",
 			'',
 			'# Appeal details',
 			'',
@@ -28,7 +28,7 @@ describe('final-comments-done-appellant.md', () => {
 			'',
 			'# What happens next',
 			'',
-			'You can [view the local planning authority’s final comments](/mock-front-office-url/appeals/ABC45678).',
+			"You can [view the local planning authority's final comments](/mock-front-office-url/appeals/ABC45678).",
 			'',
 			'The inspector will visit the site and we will contact you when we have made the decision.',
 			'',
@@ -45,7 +45,7 @@ describe('final-comments-done-appellant.md', () => {
 			'test@136s7.com',
 			{
 				content: expectedContent,
-				subject: 'We have received the local planning authority’s final comments: ABC45678'
+				subject: "We have received the local planning authority's final comments: ABC45678"
 			}
 		);
 	});

--- a/appeals/api/src/server/notify/templates/__tests__/notify-final-comments-done-lpa.test.js
+++ b/appeals/api/src/server/notify/templates/__tests__/notify-final-comments-done-lpa.test.js
@@ -18,7 +18,7 @@ describe('final-comments-done-lpa.md', () => {
 		};
 
 		const expectedContent = [
-			'We have received the appellant’s final comments.',
+			"We have received the appellant's final comments.",
 			'',
 			'# Appeal details',
 			'',
@@ -28,7 +28,7 @@ describe('final-comments-done-lpa.md', () => {
 			'',
 			'# What happens next',
 			'',
-			'You can [view the appellant’s final comments](/mock-front-office-url/manage-appeals/ABC45678).',
+			"You can [view the appellant's final comments](/mock-front-office-url/manage-appeals/ABC45678).",
 			'',
 			'The inspector will visit the site and we will contact you when we have made the decision.',
 			'',
@@ -45,7 +45,7 @@ describe('final-comments-done-lpa.md', () => {
 			'test@136s7.com',
 			{
 				content: expectedContent,
-				subject: 'We have received the appellant’s final comments: ABC45678'
+				subject: "We have received the appellant's final comments: ABC45678"
 			}
 		);
 	});

--- a/appeals/api/src/server/notify/templates/__tests__/notify-final-comments-none.test.js
+++ b/appeals/api/src/server/notify/templates/__tests__/notify-final-comments-none.test.js
@@ -18,7 +18,7 @@ describe('final-comments-done-lpa.md', () => {
 		};
 
 		const expectedContent = [
-			'We have received the appellant’s final comments.',
+			"We have received the appellant's final comments.",
 			'',
 			'# Appeal details',
 			'',
@@ -28,7 +28,7 @@ describe('final-comments-done-lpa.md', () => {
 			'',
 			'# What happens next',
 			'',
-			'You can [view the appellant’s final comments](/mock-front-office-url/manage-appeals/ABC45678).',
+			"You can [view the appellant's final comments](/mock-front-office-url/manage-appeals/ABC45678).",
 			'',
 			'The inspector will visit the site and we will contact you when we have made the decision.',
 			'',
@@ -45,7 +45,7 @@ describe('final-comments-done-lpa.md', () => {
 			'test@136s7.com',
 			{
 				content: expectedContent,
-				subject: 'We have received the appellant’s final comments: ABC45678'
+				subject: "We have received the appellant's final comments: ABC45678"
 			}
 		);
 	});

--- a/appeals/api/src/server/notify/templates/__tests__/notify-lpaq-complete-appellant.test.js
+++ b/appeals/api/src/server/notify/templates/__tests__/notify-lpaq-complete-appellant.test.js
@@ -18,7 +18,7 @@ describe('lpaq-complete-appellant.md', () => {
 		};
 
 		const expectedContent = [
-			'We have received the local planning authority’s questionnaire.',
+			"We have received the local planning authority's questionnaire.",
 			'',
 			'You can [view this information in the appeals service](/mock-front-office-url/appeals/ABC45678).',
 			'',

--- a/appeals/api/src/server/notify/templates/__tests__/notify-lpaq-complete-has-appellant.test.js
+++ b/appeals/api/src/server/notify/templates/__tests__/notify-lpaq-complete-has-appellant.test.js
@@ -18,7 +18,7 @@ describe('lpaq-complete-has-appellant.md', () => {
 		};
 
 		const expectedContent = [
-			'We have received the local planning authority’s questionnaire.',
+			"We have received the local planning authority's questionnaire.",
 			'',
 			'You can [view this information in the appeals service](/mock-front-office-url/appeals/ABC45678).',
 			'',

--- a/appeals/api/src/server/notify/templates/__tests__/notify-received-statement-and-ip-comments-appellant.test.js
+++ b/appeals/api/src/server/notify/templates/__tests__/notify-received-statement-and-ip-comments-appellant.test.js
@@ -41,7 +41,7 @@ describe('received-statement-and-ip-comments-appellant.md', () => {
 	});
 	test('should call notify sendEmail with the correct data when there is both a statement and ip comments', async () => {
 		const expectedContent = [
-			'We have received the local planning authority’s questionnaire, all statements and comments from interested parties.',
+			"We have received the local planning authority's questionnaire, all statements and comments from interested parties.",
 			'You can [view this information in the appeals service](/mock-front-office-url/appeals/ABC45678).',
 			...expectedTailContent
 		].join('\n');
@@ -111,7 +111,7 @@ describe('received-statement-and-ip-comments-appellant.md', () => {
 		];
 
 		const expectedContent = [
-			'We have received the local planning authority’s questionnaire, all statements and comments from interested parties.',
+			"We have received the local planning authority's questionnaire, all statements and comments from interested parties.",
 			'You can [view this information in the appeals service](/mock-front-office-url/appeals/ABC45678).',
 			...expectedTailContentWithoutWhatHappensNext
 		].join('\n');

--- a/appeals/api/src/server/notify/templates/__tests__/notify-received-statement-and-ip-comments-lpa.test.js
+++ b/appeals/api/src/server/notify/templates/__tests__/notify-received-statement-and-ip-comments-lpa.test.js
@@ -30,7 +30,7 @@ describe('received-statement-and-ip-comments-lpa.md', () => {
 		};
 
 		const expectedContent = [
-			'We’ve received comments from interested parties.',
+			"We've received comments from interested parties.",
 			'You can [view this information in the appeals service](/mock-front-office-url/manage-appeals/ABC45678).',
 			'# Appeal details',
 			'',
@@ -105,7 +105,7 @@ describe('received-statement-and-ip-comments-lpa.md', () => {
 		};
 
 		const expectedContent = [
-			'We’ve received comments from interested parties.',
+			"We've received comments from interested parties.",
 			'You can [view this information in the appeals service](/mock-front-office-url/manage-appeals/ABC45678).',
 			'# Appeal details',
 			'',

--- a/appeals/api/src/server/notify/templates/appeal-valid-start-case-appellant.content.md
+++ b/appeals/api/src/server/notify/templates/appeal-valid-start-case-appellant.content.md
@@ -6,7 +6,7 @@ We started your appeal on {{start_date}}.
 
 # Next steps
 
-We’ve asked {{local_planning_authority}} to complete a questionnaire about your appeal. They will send you a copy of their completed questionnaire.
+We've asked {{local_planning_authority}} to complete a questionnaire about your appeal. They will send you a copy of their completed questionnaire.
 
 We will arrange for an inspector to visit the address. You may need to attend the visit.
 

--- a/appeals/api/src/server/notify/templates/correction-notice-decision.content.md
+++ b/appeals/api/src/server/notify/templates/correction-notice-decision.content.md
@@ -12,7 +12,7 @@ Planning application reference: {{lpa_reference}}
 
 [Sign in to our service]({{front_office_url}}/manage-appeals/{{appeal_reference_number}}) to view the decision letter dated {{decision_date}}.
 
-# The Planning Inspectorate’s role
+# The Planning Inspectorate's role
 
 The Planning Inspectorate cannot change or revoke the decision. Only the High Court can change this decision.
 

--- a/appeals/api/src/server/notify/templates/decision-is-allowed-split-dismissed-appellant.content.md
+++ b/appeals/api/src/server/notify/templates/decision-is-allowed-split-dismissed-appellant.content.md
@@ -18,7 +18,7 @@ We have made a decision on your appeal.
 
 We have also informed the local planning authority of the decision.
 
-# The Planning Inspectorate’s role
+# The Planning Inspectorate's role
 
 The Planning Inspectorate cannot change or revoke the decision. You can [challenge the decision in the High Court](https://www.gov.uk/appeal-planning-decision/if-you-think-the-appeal-decision-is-legally-incorrect) if you think the Planning Inspectorate made a legal mistake.
 

--- a/appeals/api/src/server/notify/templates/decision-is-allowed-split-dismissed-lpa.content.md
+++ b/appeals/api/src/server/notify/templates/decision-is-allowed-split-dismissed-lpa.content.md
@@ -18,7 +18,7 @@ We have made a decision on this appeal.
 
 We have also informed the appellant of the decision.
 
-# The Planning Inspectorate’s role
+# The Planning Inspectorate's role
 
 The Planning Inspectorate cannot change or revoke the decision. You can [challenge the decision in the High Court](https://www.gov.uk/appeal-planning-decision/if-you-think-the-appeal-decision-is-legally-incorrect) if you think the Planning Inspectorate made a legal mistake.
 

--- a/appeals/api/src/server/notify/templates/final-comments-done-appellant.content.md
+++ b/appeals/api/src/server/notify/templates/final-comments-done-appellant.content.md
@@ -1,10 +1,10 @@
-We have received the local planning authority’s final comments.
+We have received the local planning authority's final comments.
 
 {% include 'parts/appeal-details.md' %}
 
 # What happens next
 
-You can [view the local planning authority’s final comments]({{front_office_url}}/appeals/{{appeal_reference_number}}).
+You can [view the local planning authority's final comments]({{front_office_url}}/appeals/{{appeal_reference_number}}).
 
 The inspector will visit the site and we will contact you when we have made the decision.
 

--- a/appeals/api/src/server/notify/templates/final-comments-done-appellant.subject.md
+++ b/appeals/api/src/server/notify/templates/final-comments-done-appellant.subject.md
@@ -1,1 +1,1 @@
-We have received the local planning authority’s final comments: {{appeal_reference_number}}
+We have received the local planning authority's final comments: {{appeal_reference_number}}

--- a/appeals/api/src/server/notify/templates/final-comments-done-lpa.content.md
+++ b/appeals/api/src/server/notify/templates/final-comments-done-lpa.content.md
@@ -1,10 +1,10 @@
-We have received the appellant’s final comments.
+We have received the appellant's final comments.
 
 {% include 'parts/appeal-details.md' %}
 
 # What happens next
 
-You can [view the appellant’s final comments]({{front_office_url}}/manage-appeals/{{appeal_reference_number}}).
+You can [view the appellant's final comments]({{front_office_url}}/manage-appeals/{{appeal_reference_number}}).
 
 The inspector will visit the site and we will contact you when we have made the decision.
 

--- a/appeals/api/src/server/notify/templates/final-comments-done-lpa.subject.md
+++ b/appeals/api/src/server/notify/templates/final-comments-done-lpa.subject.md
@@ -1,1 +1,1 @@
-We have received the appellant’s final comments: {{appeal_reference_number}}
+We have received the appellant's final comments: {{appeal_reference_number}}

--- a/appeals/api/src/server/notify/templates/lpaq-complete-appellant.content.md
+++ b/appeals/api/src/server/notify/templates/lpaq-complete-appellant.content.md
@@ -1,4 +1,4 @@
-We have received the local planning authority’s questionnaire.
+We have received the local planning authority's questionnaire.
 
 You can [view this information in the appeals service]({{front_office_url}}/appeals/{{appeal_reference_number}}).
 

--- a/appeals/api/src/server/notify/templates/lpaq-complete-has-appellant.content.md
+++ b/appeals/api/src/server/notify/templates/lpaq-complete-has-appellant.content.md
@@ -1,4 +1,4 @@
-We have received the local planning authority’s questionnaire.
+We have received the local planning authority's questionnaire.
 
 You can [view this information in the appeals service]({{front_office_url}}/appeals/{{appeal_reference_number}}).
 

--- a/appeals/api/src/server/notify/templates/received-statement-and-ip-comments-appellant.content.md
+++ b/appeals/api/src/server/notify/templates/received-statement-and-ip-comments-appellant.content.md
@@ -1,7 +1,7 @@
 
 
 {% if has_statement and has_ip_comments -%}
-   We have received the local planning authority’s questionnaire, all statements and comments from interested parties.
+   We have received the local planning authority's questionnaire, all statements and comments from interested parties.
 {% elif has_statement -%}
    We have received a statement from the local planning authority.
 {% elif has_ip_comments -%}

--- a/appeals/api/src/server/notify/templates/received-statement-and-ip-comments-lpa.content.md
+++ b/appeals/api/src/server/notify/templates/received-statement-and-ip-comments-lpa.content.md
@@ -1,5 +1,5 @@
 {% if has_ip_comments -%}
-   We’ve received comments from interested parties.
+   We've received comments from interested parties.
 {% else -%}
    We did not receive any comments from interested parties.
 {% endif -%}


### PR DESCRIPTION
## Describe your changes
#### Use standard apostrophe in emails to prevent invalid characters (a2-4433) - patch for release
##### **** PLEASE NOTE THIS IS THE PATCH VERSION OF THIS FIX FOR THE RELEASE ****
See the original PR against main for reference here: [fix(appeals): use standard apostrophe in emails to prevent invalid characters (a2-4433)](https://github.com/Planning-Inspectorate/appeals-back-office/pull/2049)

### API:
- Replace the invalid apostrophe with the standard apostrophe within all email templates so they will display correctly without invalid characters

### TEST:
- Updated tests for notify changes above
- Make sure unit tests pass

## Issue ticket number and link

[A2-4433- Invalid subject Displaying for S78 -Hearing notify email upon sharing IP comments and Statements for both LPA and Appellant. "&#39;s" padding to the Subject.](https://pins-ds.atlassian.net/browse/A2-4433)
