### PR TITLE
fix(appeals): amend badly formed blob storage container (a2-4173)

### DIFF
--- a/appeals/api/src/server/endpoints/link-appeals/__tests__/link-appeal.test.js
+++ b/appeals/api/src/server/endpoints/link-appeals/__tests__/link-appeal.test.js
@@ -1,4 +1,5 @@
 // @ts-nocheck
+import { eventClient } from '#infrastructure/event-client.js';
 import { request } from '#tests/../app-test.js';
 import { householdAppeal, linkedAppeals } from '#tests/appeals/mocks.js';
 import { documentCreated, documentVersionCreated, savedFolder } from '#tests/documents/mocks.js';
@@ -11,6 +12,7 @@ import {
 	CASE_RELATIONSHIP_LINKED,
 	CASE_RELATIONSHIP_RELATED
 } from '@pins/appeals/constants/support.js';
+import { EventType } from '@pins/event-client';
 
 const { databaseConnector } = await import('#utils/database-connector.js');
 const { default: got } = await import('got');
@@ -167,6 +169,17 @@ describe('appeal linked appeals routes', () => {
 						externalSource: false
 					}
 				});
+
+				expect(eventClient.sendEvents).toHaveBeenCalledWith(
+					'appeal-document-to-move',
+					[
+						{
+							importedURI: `https://127.0.0.1:10000/document-service-uploads/appeal/1345264/mock-uuid/v1/mydoc-4567654.pdf`,
+							originalURI: `https://127.0.0.1:10000/document-service-uploads/appeal/6000001/27d0fda4-8a9a-4f5a-a158-68eaea676158/v1/mydoc.pdf`
+						}
+					],
+					EventType.Create
+				);
 
 				expect(databaseConnector.document.create).toHaveBeenCalledWith({
 					data: {

--- a/appeals/api/src/server/utils/blob-copy.js
+++ b/appeals/api/src/server/utils/blob-copy.js
@@ -13,17 +13,25 @@ import { EventType } from '@pins/event-client';
  */
 export const copyBlobs = async (copyList) => {
 	if (config.useBlobEmulator) {
-		return copyBlobsUsingEmulator(copyList);
+		await copyBlobsUsingEmulator(copyList);
 	}
 
-	// Copy blobs using the event client
+	return copyBlobsUsingAzure(copyList);
+};
+
+/**
+ * Copies blobs from one location to another using Azure event client
+ * @param {{sourceBlobName:  string | null | undefined, destinationBlobName: string}[]} copyList
+ * @returns {Promise<Promise<Awaited<unknown>[]> | Promise<{[p: string]: Awaited<*>, [p: number]: Awaited<*>, [p: symbol]: Awaited<*>}>>}
+ */
+const copyBlobsUsingAzure = async (copyList) => {
 	const messages = copyList
 		.map((copyDetails) => {
 			const { sourceBlobName, destinationBlobName } = copyDetails;
 			if (!sourceBlobName || !destinationBlobName) {
 				return null;
 			}
-			const container = `${config.BO_BLOB_STORAGE_ACCOUNT}/${config.BO_BLOB_CONTAINER}`;
+			const container = `${config.BO_BLOB_STORAGE_ACCOUNT}${config.BO_BLOB_CONTAINER}`;
 			return {
 				originalURI: `${container}/${sourceBlobName}`,
 				importedURI: `${container}/${destinationBlobName}`
@@ -41,7 +49,7 @@ export const copyBlobs = async (copyList) => {
 };
 
 /**
- *
+ * Copies blobs from one location to another within the blob emulator
  * @param {{sourceBlobName:  string | null | undefined, destinationBlobName: string}[]} copyList
  * @returns {Promise<Promise<Awaited<unknown>[]> | Promise<{[p: string]: Awaited<*>, [p: number]: Awaited<*>, [p: symbol]: Awaited<*>}>>}
  */


### PR DESCRIPTION
## Describe your changes
#### Make sure the blob storage container is correctly formatted (a2-4173)
##### This allows the same process used for moving blobs while importing them within integration, to be used for moving them between appeals with the correct blob container

### API:
- When not emulating blob storage, use the topic "appeal-document-to-move" to send an event to move the blobs between appeals with the correctly formatted blob container
- Always use above even if using the blob emulator locally as the event itself will be mocked and displayed within the local api log for debugging purposes.

### TEST:
- Add unit tests to make sure event message is formatted correctly
- Make sure unit tests pass

## Issue ticket number and link
- [A2-4173 - BO - What happens to cost files/'Costs' accordion on child appeals when linking (relates to all appeal types)](https://pins-ds.atlassian.net/browse/A2-4173)
- [A2-4408 - BO - Linked Appeal: Child Appeal cost documents duplicated in Lead Appeal is not viewable, ends up in error page)](https://pins-ds.atlassian.net/browse/A2-4408)
