### PR TITLE
fix(appeals): some front office links in emails are broken (a2-4447) - patch for release

### DIFF
--- a/appeals/api/src/server/notify/templates/__tests__/appeal-start-date-change-lpa.test.js
+++ b/appeals/api/src/server/notify/templates/__tests__/appeal-start-date-change-lpa.test.js
@@ -17,8 +17,7 @@ describe('appeal-start-date-change-appellant.md', () => {
 				site_address: '96 The Avenue, Leftfield, Maidstone, Kent, MD21 5XY, United Kingdom',
 				start_date: '01 January 2025',
 				procedure_type: 'a hearing',
-				questionnaire_due_date: '01 January 2025',
-				front_office_url: 'https://front-office-url.com'
+				questionnaire_due_date: '01 January 2025'
 			},
 			appeal: {
 				id: 'mock-appeal-generic-id',

--- a/appeals/api/src/server/notify/templates/__tests__/notify-appellant-costs-decision-appellant.test.js
+++ b/appeals/api/src/server/notify/templates/__tests__/notify-appellant-costs-decision-appellant.test.js
@@ -14,7 +14,7 @@ describe('appellant-costs-decision-appellant.md', () => {
 				lpa_reference: '48269/APP/2021/1482',
 				appeal_reference_number: '134526',
 				site_address: '96 The Avenue, Leftfield, Maidstone, Kent, MD21 5XY, United Kingdom',
-				front_office_url: 'mock-front-office-url'
+				front_office_url: '/mock-front-office-url'
 			}
 		};
 
@@ -29,7 +29,7 @@ describe('appellant-costs-decision-appellant.md', () => {
 			'',
 			'# Appeal costs decision',
 			'',
-			'[Sign in to our service](https://mock-front-office-url/appeals/134526/appeal-details) to view the decision.',
+			'[Sign in to our service](/mock-front-office-url/appeals/134526/appeal-details) to view the decision.',
 			'',
 			'We have also informed the local planning authority of the decision.',
 			'',

--- a/appeals/api/src/server/notify/templates/__tests__/notify-appellant-costs-decision-lpa.test.js
+++ b/appeals/api/src/server/notify/templates/__tests__/notify-appellant-costs-decision-lpa.test.js
@@ -14,7 +14,7 @@ describe('appellant-costs-decision-lpa.md', () => {
 				lpa_reference: '48269/APP/2021/1482',
 				appeal_reference_number: '134526',
 				site_address: '96 The Avenue, Leftfield, Maidstone, Kent, MD21 5XY, United Kingdom',
-				front_office_url: 'mock-front-office-url'
+				front_office_url: '/mock-front-office-url'
 			}
 		};
 
@@ -29,7 +29,7 @@ describe('appellant-costs-decision-lpa.md', () => {
 			'',
 			'# Appeal costs decision',
 			'',
-			'[Sign in to our service](https://mock-front-office-url/manage-appeals/134526/appeal-details) to view the decision.',
+			'[Sign in to our service](/mock-front-office-url/manage-appeals/134526/appeal-details) to view the decision.',
 			'',
 			'We have also informed the appellant of the decision.',
 			'',

--- a/appeals/api/src/server/notify/templates/__tests__/notify-lpa-costs-decision-appellant.test.js
+++ b/appeals/api/src/server/notify/templates/__tests__/notify-lpa-costs-decision-appellant.test.js
@@ -14,7 +14,7 @@ describe('lpa-costs-decision-lpa.md', () => {
 				lpa_reference: '48269/APP/2021/1482',
 				appeal_reference_number: '134526',
 				site_address: '96 The Avenue, Leftfield, Maidstone, Kent, MD21 5XY, United Kingdom',
-				front_office_url: 'mock-front-office-url'
+				front_office_url: '/mock-front-office-url'
 			}
 		};
 
@@ -29,7 +29,7 @@ describe('lpa-costs-decision-lpa.md', () => {
 			'',
 			'# Appeal costs decision',
 			'',
-			'[Sign in to our service](https://mock-front-office-url/manage-appeals/134526/appeal-details) to view the decision.',
+			'[Sign in to our service](/mock-front-office-url/manage-appeals/134526/appeal-details) to view the decision.',
 			'',
 			'We have also informed the appellant of the decision.',
 			'',

--- a/appeals/api/src/server/notify/templates/__tests__/notify-lpa-costs-decision-lpa.test.js
+++ b/appeals/api/src/server/notify/templates/__tests__/notify-lpa-costs-decision-lpa.test.js
@@ -14,7 +14,7 @@ describe('lpa-costs-decision-appellant.md', () => {
 				lpa_reference: '48269/APP/2021/1482',
 				appeal_reference_number: '134526',
 				site_address: '96 The Avenue, Leftfield, Maidstone, Kent, MD21 5XY, United Kingdom',
-				front_office_url: 'mock-front-office-url'
+				front_office_url: '/mock-front-office-url'
 			}
 		};
 
@@ -29,7 +29,7 @@ describe('lpa-costs-decision-appellant.md', () => {
 			'',
 			'# Appeal costs decision',
 			'',
-			'[Sign in to our service](https://mock-front-office-url/appeals/134526/appeal-details) to view the decision.',
+			'[Sign in to our service](/mock-front-office-url/appeals/134526/appeal-details) to view the decision.',
 			'',
 			'We have also informed the local planning authority of the decision.',
 			'',

--- a/appeals/api/src/server/notify/templates/appellant-costs-decision-appellant.content.md
+++ b/appeals/api/src/server/notify/templates/appellant-costs-decision-appellant.content.md
@@ -4,7 +4,7 @@ We have made a decision on your application for an award of appeal costs.
 
 # Appeal costs decision
 
-[Sign in to our service](https://{{front_office_url}}/appeals/{{appeal_reference_number}}/appeal-details) to view the decision.
+[Sign in to our service]({{front_office_url}}/appeals/{{appeal_reference_number}}/appeal-details) to view the decision.
 
 We have also informed the local planning authority of the decision.
 

--- a/appeals/api/src/server/notify/templates/appellant-costs-decision-lpa.content.md
+++ b/appeals/api/src/server/notify/templates/appellant-costs-decision-lpa.content.md
@@ -4,7 +4,7 @@ We have made a decision on the appellant's application for an award of appeal co
 
 # Appeal costs decision
 
-[Sign in to our service](https://{{front_office_url}}/manage-appeals/{{appeal_reference_number}}/appeal-details) to view the decision.
+[Sign in to our service]({{front_office_url}}/manage-appeals/{{appeal_reference_number}}/appeal-details) to view the decision.
 
 We have also informed the appellant of the decision.
 

--- a/appeals/api/src/server/notify/templates/lpa-costs-decision-appellant.content.md
+++ b/appeals/api/src/server/notify/templates/lpa-costs-decision-appellant.content.md
@@ -4,7 +4,7 @@ We have made a decision on the local planning authority's application for an awa
 
 # Appeal costs decision
 
-[Sign in to our service](https://{{front_office_url}}/appeals/{{appeal_reference_number}}/appeal-details) to view the decision.
+[Sign in to our service]({{front_office_url}}/appeals/{{appeal_reference_number}}/appeal-details) to view the decision.
 
 We have also informed the local planning authority of the decision.
 

--- a/appeals/api/src/server/notify/templates/lpa-costs-decision-lpa.content.md
+++ b/appeals/api/src/server/notify/templates/lpa-costs-decision-lpa.content.md
@@ -4,7 +4,7 @@ We have made a decision on your application for an award of appeal costs.
 
 # Appeal costs decision
 
-[Sign in to our service](https://{{front_office_url}}/manage-appeals/{{appeal_reference_number}}/appeal-details) to view the decision.
+[Sign in to our service]({{front_office_url}}/manage-appeals/{{appeal_reference_number}}/appeal-details) to view the decision.
 
 We have also informed the appellant of the decision.
 


### PR DESCRIPTION
## Describe your changes
#### Some front office links in emails are broken (a2-4447) - patch for release
##### **** PLEASE NOTE THIS IS THE PATCH VERSION OF THIS FIX FOR THE RELEASE ****
See the original PR against main for reference here: [fix(appeals): links in some emails are broken (a2-4447)](https://github.com/Planning-Inspectorate/appeals-back-office/pull/2056)

### API:
- Fix templates to make sure they are not prefixing the front office links with additional "https://"

### TEST:
- Updated tests for notify changes above
- Make sure unit tests pass

## Issue ticket number and link

[A2-4447- BO: "Sign in to our service" link in costs decision notify email returns the "can't reach this page" error](https://pins-ds.atlassian.net/browse/A2-4447)
