### PR TITLE
fix(appeals): use an event to move blobs between appeals (a2-4408) - patch for release

### DIFF
--- a/appeals/api/src/server/endpoints/link-appeals/__tests__/link-appeal.test.js
+++ b/appeals/api/src/server/endpoints/link-appeals/__tests__/link-appeal.test.js
@@ -1,4 +1,5 @@
 // @ts-nocheck
+import { eventClient } from '#infrastructure/event-client.js';
 import { request } from '#tests/../app-test.js';
 import { householdAppeal, linkedAppeals } from '#tests/appeals/mocks.js';
 import { documentCreated, documentVersionCreated, savedFolder } from '#tests/documents/mocks.js';
@@ -11,6 +12,7 @@ import {
 	CASE_RELATIONSHIP_LINKED,
 	CASE_RELATIONSHIP_RELATED
 } from '@pins/appeals/constants/support.js';
+import { EventType } from '@pins/event-client';
 import { cloneDeep } from 'lodash-es';
 
 const { databaseConnector } = await import('#utils/database-connector.js');
@@ -168,6 +170,17 @@ describe('appeal linked appeals routes', () => {
 						externalSource: false
 					}
 				});
+
+				expect(eventClient.sendEvents).toHaveBeenCalledWith(
+					'appeal-document-to-move',
+					[
+						{
+							importedURI: `https://127.0.0.1:10000/document-service-uploads/appeal/1345264/mock-uuid/v1/mydoc-4567654.pdf`,
+							originalURI: `https://127.0.0.1:10000/document-service-uploads/appeal/6000001/27d0fda4-8a9a-4f5a-a158-68eaea676158/v1/mydoc.pdf`
+						}
+					],
+					EventType.Create
+				);
 
 				expect(databaseConnector.document.create).toHaveBeenCalledWith({
 					data: {

--- a/appeals/api/src/server/utils/blob-copy.js
+++ b/appeals/api/src/server/utils/blob-copy.js
@@ -1,7 +1,10 @@
 import config from '#config/config.js';
+import { eventClient } from '#infrastructure/event-client.js';
+import { producers } from '#infrastructure/topics.js';
 import logger from '#utils/logger.js';
 import { BlobServiceClient } from '@azure/storage-blob';
 import { BlobStorageClient } from '@pins/blob-storage-client';
+import { EventType } from '@pins/event-client';
 
 /**
  * Copies blobs from one location to another
@@ -9,11 +12,50 @@ import { BlobStorageClient } from '@pins/blob-storage-client';
  * @returns {Promise<Promise<Awaited<unknown>[]> | Promise<{[p: string]: Awaited<*>, [p: number]: Awaited<*>, [p: symbol]: Awaited<*>}>>}
  */
 export const copyBlobs = async (copyList) => {
-	const storageContainer = config.BO_BLOB_CONTAINER;
-	const storageClient = config.useBlobEmulator
-		? new BlobStorageClient(new BlobServiceClient(config.blobEmulatorSasUrl))
-		: BlobStorageClient.fromUrl(config.BO_BLOB_STORAGE_ACCOUNT);
+	if (config.useBlobEmulator) {
+		await copyBlobsUsingEmulator(copyList);
+	}
 
+	return copyBlobsUsingAzure(copyList);
+};
+
+/**
+ * Copies blobs from one location to another using Azure event client
+ * @param {{sourceBlobName:  string | null | undefined, destinationBlobName: string}[]} copyList
+ * @returns {Promise<Promise<Awaited<unknown>[]> | Promise<{[p: string]: Awaited<*>, [p: number]: Awaited<*>, [p: symbol]: Awaited<*>}>>}
+ */
+const copyBlobsUsingAzure = async (copyList) => {
+	const messages = copyList
+		.map((copyDetails) => {
+			const { sourceBlobName, destinationBlobName } = copyDetails;
+			if (!sourceBlobName || !destinationBlobName) {
+				return null;
+			}
+			const container = `${config.BO_BLOB_STORAGE_ACCOUNT}${config.BO_BLOB_CONTAINER}`;
+			return {
+				originalURI: `${container}/${sourceBlobName}`,
+				importedURI: `${container}/${destinationBlobName}`
+			};
+		})
+		.filter((message) => message !== null);
+	if (messages.length > 0) {
+		const topic = producers.boBlobMove;
+		const res = await eventClient.sendEvents(topic, messages, EventType.Create);
+		if (res) {
+			return Promise.resolve(res);
+		}
+	}
+	return Promise.resolve([]);
+};
+
+/**
+ * Copies blobs from one location to another within the blob emulator
+ * @param {{sourceBlobName:  string | null | undefined, destinationBlobName: string}[]} copyList
+ * @returns {Promise<Promise<Awaited<unknown>[]> | Promise<{[p: string]: Awaited<*>, [p: number]: Awaited<*>, [p: symbol]: Awaited<*>}>>}
+ */
+const copyBlobsUsingEmulator = async (copyList) => {
+	const storageContainer = config.BO_BLOB_CONTAINER;
+	const storageClient = new BlobStorageClient(new BlobServiceClient(config.blobEmulatorSasUrl));
 	return Promise.all(
 		// @ts-ignore
 		copyList.map(async (copyDetails) => {


### PR DESCRIPTION
## Describe your changes
#### Use an event to move blobs between appeals (a2-4408) - patch for release
##### **** PLEASE NOTE THIS IS THE PATCH VERSION OF THIS FIX FOR THE RELEASE ****
##### This allows the same process used for moving blobs while importing them within integration, to be used for moving them between appeals

### API:
- When not emulating blob storage, use the topic "appeal-document-to-move" to send an event to move the blobs between appeals
- Always use above even if using the blob emulator locally as the event itself will be mocked and displayed within the local api log for debugging purposes.

### TEST:
- Add unit tests to make sure event message is formatted correctly
- Make sure unit tests pass

## Issue ticket number and link
- [A2-4408 - BO - Linked Appeal: Child Appeal cost documents duplicated in Lead Appeal is not viewable, ends up in error page)](https://pins-ds.atlassian.net/browse/A2-4408)
