### PR TITLE
fix(appeals): issue with email subject line (a2-4433)

### DIFF
--- a/appeals/api/src/server/endpoints/representations/__tests__/representations.test.js
+++ b/appeals/api/src/server/endpoints/representations/__tests__/representations.test.js
@@ -1252,9 +1252,9 @@ describe('/appeals/:id/reps', () => {
 						...expectedEmailPayload,
 						has_ip_comments: true,
 						has_statement: true,
+						is_hearing_procedure: false,
 						what_happens_next:
-							'You need to [submit your final comments](/mock-front-office-url/manage-appeals/6000002) by 4 December 2024.',
-						subject: 'Submit your final comments'
+							'You need to [submit your final comments](/mock-front-office-url/manage-appeals/6000002) by 4 December 2024.'
 					},
 					recipientEmail: appealS78.lpa.email,
 					templateName: 'received-statement-and-ip-comments-lpa'
@@ -1267,9 +1267,9 @@ describe('/appeals/:id/reps', () => {
 						...expectedEmailPayload,
 						has_ip_comments: true,
 						has_statement: true,
+						is_hearing_procedure: false,
 						what_happens_next:
-							'You need to [submit your final comments](/mock-front-office-url/appeals/6000002) by 4 December 2024.',
-						subject: 'Submit your final comments'
+							'You need to [submit your final comments](/mock-front-office-url/appeals/6000002) by 4 December 2024.'
 					},
 					recipientEmail: appealS78.appellant.email,
 					templateName: 'received-statement-and-ip-comments-appellant'
@@ -1338,9 +1338,9 @@ describe('/appeals/:id/reps', () => {
 						...expectedEmailPayload,
 						has_ip_comments: true,
 						has_statement: true,
+						is_hearing_procedure: false,
 						what_happens_next:
-							'You need to [submit your final comments](/mock-front-office-url/manage-appeals/6000002) by 4 December 2024.',
-						subject: 'Submit your final comments'
+							'You need to [submit your final comments](/mock-front-office-url/manage-appeals/6000002) by 4 December 2024.'
 					},
 					recipientEmail: appealS78.lpa.email,
 					templateName: 'received-statement-and-ip-comments-lpa'
@@ -1353,9 +1353,9 @@ describe('/appeals/:id/reps', () => {
 						...expectedEmailPayload,
 						has_ip_comments: true,
 						has_statement: true,
+						is_hearing_procedure: false,
 						what_happens_next:
-							'You need to [submit your final comments](/mock-front-office-url/appeals/6000002) by 4 December 2024.',
-						subject: 'Submit your final comments'
+							'You need to [submit your final comments](/mock-front-office-url/appeals/6000002) by 4 December 2024.'
 					},
 					recipientEmail: appealS78.appellant.email,
 					templateName: 'received-statement-and-ip-comments-appellant'
@@ -1451,9 +1451,9 @@ describe('/appeals/:id/reps', () => {
 						...expectedEmailPayload,
 						has_ip_comments: true,
 						has_statement: false,
+						is_hearing_procedure: false,
 						what_happens_next:
-							'You need to [submit your final comments](/mock-front-office-url/manage-appeals/6000002) by 4 December 2024.',
-						subject: 'Submit your final comments'
+							'You need to [submit your final comments](/mock-front-office-url/manage-appeals/6000002) by 4 December 2024.'
 					},
 					recipientEmail: appealS78.lpa.email,
 					templateName: 'received-statement-and-ip-comments-lpa'
@@ -1466,9 +1466,9 @@ describe('/appeals/:id/reps', () => {
 						...expectedEmailPayload,
 						has_ip_comments: true,
 						has_statement: false,
+						is_hearing_procedure: false,
 						what_happens_next:
-							'You need to [submit your final comments](/mock-front-office-url/appeals/6000002) by 4 December 2024.',
-						subject: 'Submit your final comments'
+							'You need to [submit your final comments](/mock-front-office-url/appeals/6000002) by 4 December 2024.'
 					},
 					recipientEmail: appealS78.appellant.email,
 					templateName: 'received-statement-and-ip-comments-appellant'
@@ -1526,9 +1526,9 @@ describe('/appeals/:id/reps', () => {
 						...expectedEmailPayload,
 						has_ip_comments: false,
 						has_statement: true,
+						is_hearing_procedure: false,
 						what_happens_next:
-							'You need to [submit your final comments](/mock-front-office-url/manage-appeals/6000002) by 4 December 2024.',
-						subject: 'Submit your final comments'
+							'You need to [submit your final comments](/mock-front-office-url/manage-appeals/6000002) by 4 December 2024.'
 					},
 					recipientEmail: appealS78.lpa.email,
 					templateName: 'received-statement-and-ip-comments-lpa'
@@ -1541,9 +1541,9 @@ describe('/appeals/:id/reps', () => {
 						...expectedEmailPayload,
 						has_ip_comments: false,
 						has_statement: true,
+						is_hearing_procedure: false,
 						what_happens_next:
-							'You need to [submit your final comments](/mock-front-office-url/appeals/6000002) by 4 December 2024.',
-						subject: 'Submit your final comments'
+							'You need to [submit your final comments](/mock-front-office-url/appeals/6000002) by 4 December 2024.'
 					},
 					recipientEmail: appealS78.appellant.email,
 					templateName: 'received-statement-and-ip-comments-appellant'
@@ -1599,9 +1599,9 @@ describe('/appeals/:id/reps', () => {
 						...expectedEmailPayload,
 						has_ip_comments: false,
 						has_statement: false,
+						is_hearing_procedure: false,
 						what_happens_next:
-							'You need to [submit your final comments](/mock-front-office-url/manage-appeals/6000002) by 4 December 2024.',
-						subject: 'Submit your final comments'
+							'You need to [submit your final comments](/mock-front-office-url/manage-appeals/6000002) by 4 December 2024.'
 					},
 					recipientEmail: appealS78.lpa.email,
 					templateName: 'received-statement-and-ip-comments-lpa'
@@ -1614,9 +1614,9 @@ describe('/appeals/:id/reps', () => {
 						...expectedEmailPayload,
 						has_ip_comments: false,
 						has_statement: false,
+						is_hearing_procedure: false,
 						what_happens_next:
-							'You need to [submit your final comments](/mock-front-office-url/appeals/6000002) by 4 December 2024.',
-						subject: 'Submit your final comments'
+							'You need to [submit your final comments](/mock-front-office-url/appeals/6000002) by 4 December 2024.'
 					},
 					recipientEmail: appealS78.appellant.email,
 					templateName: 'received-statement-and-ip-comments-appellant'
@@ -1676,9 +1676,9 @@ describe('/appeals/:id/reps', () => {
 						...expectedEmailPayload,
 						has_ip_comments: true,
 						has_statement: true,
+						is_hearing_procedure: false,
 						what_happens_next:
-							'You need to [submit your final comments](/mock-front-office-url/manage-appeals/6000002) by 4 December 2024.',
-						subject: 'Submit your final comments'
+							'You need to [submit your final comments](/mock-front-office-url/manage-appeals/6000002) by 4 December 2024.'
 					},
 					recipientEmail: mockS20Appeal.lpa.email,
 					templateName: 'received-statement-and-ip-comments-lpa'
@@ -1691,9 +1691,9 @@ describe('/appeals/:id/reps', () => {
 						...expectedEmailPayload,
 						has_ip_comments: true,
 						has_statement: true,
+						is_hearing_procedure: false,
 						what_happens_next:
-							'You need to [submit your final comments](/mock-front-office-url/appeals/6000002) by 4 December 2024.',
-						subject: 'Submit your final comments'
+							'You need to [submit your final comments](/mock-front-office-url/appeals/6000002) by 4 December 2024.'
 					},
 					recipientEmail: mockS20Appeal.appellant.email,
 					templateName: 'received-statement-and-ip-comments-appellant'
@@ -1761,8 +1761,8 @@ describe('/appeals/:id/reps', () => {
 						...expectedEmailPayload,
 						has_ip_comments: true,
 						has_statement: true,
-						what_happens_next: 'We will contact you when the hearing has been set up.',
-						subject: `We've received all statements and comments`
+						is_hearing_procedure: true,
+						what_happens_next: 'We will contact you when the hearing has been set up.'
 					},
 					recipientEmail: appealS78.lpa.email,
 					templateName: 'received-statement-and-ip-comments-lpa'
@@ -1775,8 +1775,8 @@ describe('/appeals/:id/reps', () => {
 						...expectedEmailPayload,
 						has_ip_comments: true,
 						has_statement: true,
-						what_happens_next: 'We will contact you if we need any more information.',
-						subject: `We have received the local planning authority's questionnaire, all statements and comments from interested parties`
+						is_hearing_procedure: true,
+						what_happens_next: 'We will contact you if we need any more information.'
 					},
 					recipientEmail: appealS78.appellant.email,
 					templateName: 'received-statement-and-ip-comments-appellant'
@@ -1843,8 +1843,8 @@ describe('/appeals/:id/reps', () => {
 						...expectedEmailPayload,
 						has_ip_comments: true,
 						has_statement: true,
-						what_happens_next: 'We will contact you when the hearing has been set up.',
-						subject: `We've received all statements and comments`
+						is_hearing_procedure: true,
+						what_happens_next: 'We will contact you when the hearing has been set up.'
 					},
 					recipientEmail: appealS78.lpa.email,
 					templateName: 'received-statement-and-ip-comments-lpa'
@@ -1857,8 +1857,8 @@ describe('/appeals/:id/reps', () => {
 						...expectedEmailPayload,
 						has_ip_comments: true,
 						has_statement: true,
-						what_happens_next: 'We will contact you if we need any more information.',
-						subject: `We have received the local planning authority's questionnaire, all statements and comments from interested parties`
+						is_hearing_procedure: true,
+						what_happens_next: 'We will contact you if we need any more information.'
 					},
 					recipientEmail: appealS78.appellant.email,
 					templateName: 'received-statement-and-ip-comments-appellant'
@@ -1930,8 +1930,8 @@ describe('/appeals/:id/reps', () => {
 						...expectedEmailPayload,
 						has_ip_comments: true,
 						has_statement: true,
-						what_happens_next: 'The hearing is on 31 January 2025.',
-						subject: `We've received all statements and comments`
+						is_hearing_procedure: true,
+						what_happens_next: 'The hearing is on 31 January 2025.'
 					},
 					recipientEmail: appealS78.lpa.email,
 					templateName: 'received-statement-and-ip-comments-lpa'
@@ -1944,9 +1944,9 @@ describe('/appeals/:id/reps', () => {
 						...expectedEmailPayload,
 						has_ip_comments: true,
 						has_statement: true,
+						is_hearing_procedure: true,
 						what_happens_next:
-							'Your hearing is on 31 January 2025.\n\nWe will contact you if we need any more information.',
-						subject: `We have received the local planning authority's questionnaire, all statements and comments from interested parties`
+							'Your hearing is on 31 January 2025.\n\nWe will contact you if we need any more information.'
 					},
 					recipientEmail: appealS78.appellant.email,
 					templateName: 'received-statement-and-ip-comments-appellant'
@@ -2016,8 +2016,8 @@ describe('/appeals/:id/reps', () => {
 						...expectedEmailPayload,
 						has_ip_comments: true,
 						has_statement: true,
-						what_happens_next: 'The hearing is on 31 January 2025.',
-						subject: `We've received all statements and comments`
+						is_hearing_procedure: true,
+						what_happens_next: 'The hearing is on 31 January 2025.'
 					},
 					recipientEmail: appealS78.lpa.email,
 					templateName: 'received-statement-and-ip-comments-lpa'
@@ -2030,9 +2030,9 @@ describe('/appeals/:id/reps', () => {
 						...expectedEmailPayload,
 						has_ip_comments: true,
 						has_statement: true,
+						is_hearing_procedure: true,
 						what_happens_next:
-							'Your hearing is on 31 January 2025.\n\nWe will contact you if we need any more information.',
-						subject: `We have received the local planning authority's questionnaire, all statements and comments from interested parties`
+							'Your hearing is on 31 January 2025.\n\nWe will contact you if we need any more information.'
 					},
 					recipientEmail: appealS78.appellant.email,
 					templateName: 'received-statement-and-ip-comments-appellant'
@@ -2105,6 +2105,7 @@ describe('/appeals/:id/reps', () => {
 					lpa_reference: mockS78Appeal.applicationReference,
 					has_ip_comments: false,
 					has_statement: false,
+					is_hearing_procedure: false,
 					appeal_reference_number: mockS78Appeal.reference,
 					final_comments_deadline: '',
 					site_address: expectedSiteAddress,
@@ -2173,6 +2174,7 @@ describe('/appeals/:id/reps', () => {
 					lpa_reference: mockS78Appeal.applicationReference,
 					has_ip_comments: false,
 					has_statement: false,
+					is_hearing_procedure: false,
 					appeal_reference_number: mockS78Appeal.reference,
 					final_comments_deadline: '',
 					site_address: expectedSiteAddress,
@@ -2290,6 +2292,7 @@ describe('/appeals/:id/reps', () => {
 					lpa_reference: mockS20Appeal.applicationReference,
 					has_ip_comments: false,
 					has_statement: false,
+					is_hearing_procedure: false,
 					appeal_reference_number: mockS20Appeal.reference,
 					final_comments_deadline: '',
 					site_address: expectedSiteAddress,
@@ -2361,6 +2364,7 @@ describe('/appeals/:id/reps', () => {
 					lpa_reference: mockS20Appeal.applicationReference,
 					has_ip_comments: false,
 					has_statement: false,
+					is_hearing_procedure: false,
 					appeal_reference_number: mockS20Appeal.reference,
 					final_comments_deadline: '',
 					site_address: expectedSiteAddress,
@@ -2419,6 +2423,7 @@ describe('/appeals/:id/reps', () => {
 					lpa_reference: mockS78Appeal.applicationReference,
 					has_ip_comments: false,
 					has_statement: false,
+					is_hearing_procedure: false,
 					appeal_reference_number: mockS78Appeal.reference,
 					final_comments_deadline: '',
 					site_address: expectedSiteAddress,
@@ -2485,6 +2490,7 @@ describe('/appeals/:id/reps', () => {
 					lpa_reference: mockS20Appeal.applicationReference,
 					has_ip_comments: false,
 					has_statement: false,
+					is_hearing_procedure: false,
 					appeal_reference_number: mockS20Appeal.reference,
 					final_comments_deadline: '',
 					site_address: expectedSiteAddress,
@@ -2553,6 +2559,7 @@ describe('/appeals/:id/reps', () => {
 					lpa_reference: mockS20Appeal.applicationReference,
 					has_ip_comments: false,
 					has_statement: false,
+					is_hearing_procedure: false,
 					appeal_reference_number: mockS20Appeal.reference,
 					final_comments_deadline: '',
 					site_address: expectedSiteAddress,

--- a/appeals/api/src/server/endpoints/representations/representations.service.js
+++ b/appeals/api/src/server/endpoints/representations/representations.service.js
@@ -337,15 +337,12 @@ export async function publishLpaStatements(appeal, azureAdUserId, notifyClient) 
 	const hasIpComments = result.some(
 		(rep) => rep.representationType === APPEAL_REPRESENTATION_TYPE.COMMENT
 	);
+	const isHearingProcedure = String(appeal.procedureType?.key) === APPEAL_CASE_PROCEDURE.HEARING;
 
 	try {
 		let whatHappensNextAppellant;
 		let whatHappensNextLpa;
-		let lpaSubject;
-		let appellantSubject;
-		if (String(appeal.procedureType?.key) === APPEAL_CASE_PROCEDURE.HEARING) {
-			lpaSubject = `We've received all statements and comments`;
-			appellantSubject = `We have received the local planning authority's questionnaire, all statements and comments from interested parties`;
+		if (isHearingProcedure) {
 			if (appeal.hearing?.hearingStartTime) {
 				whatHappensNextAppellant = `Your hearing is on ${formatDate(
 					appeal.hearing?.hearingStartTime,
@@ -360,8 +357,6 @@ export async function publishLpaStatements(appeal, azureAdUserId, notifyClient) 
 				whatHappensNextLpa = `We will contact you when the hearing has been set up.`;
 			}
 		} else {
-			lpaSubject = 'Submit your final comments';
-			appellantSubject = 'Submit your final comments';
 			whatHappensNextAppellant = `You need to [submit your final comments](${config.frontOffice.url}/appeals/${appeal.reference}) by ${finalCommentsDueDate}.`;
 			whatHappensNextLpa = `You need to [submit your final comments](${config.frontOffice.url}/manage-appeals/${appeal.reference}) by ${finalCommentsDueDate}.`;
 		}
@@ -371,11 +366,11 @@ export async function publishLpaStatements(appeal, azureAdUserId, notifyClient) 
 			notifyClient,
 			hasLpaStatement,
 			hasIpComments,
+			isHearingProcedure,
 			templateName: 'received-statement-and-ip-comments-lpa',
 			recipientEmail: appeal.lpa?.email,
 			finalCommentsDueDate,
 			whatHappensNext: whatHappensNextLpa,
-			subject: lpaSubject,
 			azureAdUserId
 		});
 
@@ -384,11 +379,11 @@ export async function publishLpaStatements(appeal, azureAdUserId, notifyClient) 
 			notifyClient,
 			hasLpaStatement,
 			hasIpComments,
+			isHearingProcedure,
 			templateName: 'received-statement-and-ip-comments-appellant',
 			recipientEmail: appeal.agent?.email || appeal.appellant?.email,
 			finalCommentsDueDate,
 			whatHappensNext: whatHappensNextAppellant,
-			subject: appellantSubject,
 			azureAdUserId
 		});
 	} catch (error) {
@@ -466,7 +461,7 @@ export async function publishFinalComments(appeal, azureAdUserId, notifyClient) 
  * @property {string} [whatHappensNext]
  * @property {boolean} [hasLpaStatement]
  * @property {boolean} [hasIpComments]
- * @property {string} [subject]
+ * @property {boolean} [isHearingProcedure]
  * @property {string} [userTypeNoCommentSubmitted]
  * @property {string} azureAdUserId
  */
@@ -484,7 +479,7 @@ async function notifyPublished({
 	whatHappensNext = '',
 	hasLpaStatement = false,
 	hasIpComments = false,
-	subject = '',
+	isHearingProcedure = false,
 	userTypeNoCommentSubmitted = '',
 	azureAdUserId
 }) {
@@ -517,7 +512,7 @@ async function notifyPublished({
 			what_happens_next: whatHappensNext,
 			has_ip_comments: hasIpComments,
 			has_statement: hasLpaStatement,
-			...(subject ? { subject } : {}),
+			is_hearing_procedure: isHearingProcedure,
 			user_type: userTypeNoCommentSubmitted
 		}
 	});

--- a/appeals/api/src/server/notify/templates/__tests__/notify-received-statement-and-ip-comments-appellant.test.js
+++ b/appeals/api/src/server/notify/templates/__tests__/notify-received-statement-and-ip-comments-appellant.test.js
@@ -130,4 +130,26 @@ describe('received-statement-and-ip-comments-appellant.md', () => {
 			}
 		);
 	});
+	test('should call notify sendEmail with the correct data when a hearing procedure', async () => {
+		const expectedContent = [
+			"We have received the local planning authority's questionnaire, all statements and comments from interested parties.",
+			'You can [view this information in the appeals service](/mock-front-office-url/appeals/ABC45678).',
+			...expectedTailContent
+		].join('\n');
+
+		notifySendData.personalisation.is_hearing_procedure = true;
+
+		await notifySend(notifySendData);
+		expect(notifySendData.notifyClient.sendEmail).toHaveBeenCalledWith(
+			{
+				id: 'mock-appeal-generic-id'
+			},
+			'test@136s7.com',
+			{
+				content: expectedContent,
+				subject:
+					"We have received the local planning authority's questionnaire, all statements and comments from interested parties: ABC45678"
+			}
+		);
+	});
 });

--- a/appeals/api/src/server/notify/templates/__tests__/notify-received-statement-and-ip-comments-lpa.test.js
+++ b/appeals/api/src/server/notify/templates/__tests__/notify-received-statement-and-ip-comments-lpa.test.js
@@ -174,4 +174,40 @@ describe('received-statement-and-ip-comments-lpa.md', () => {
 			}
 		);
 	});
+
+	test('should call notify sendEmail with the correct data when a hearing procedure', async () => {
+		const notifySendData = {
+			doNotMockNotifySend: true,
+			templateName: 'received-statement-and-ip-comments-lpa',
+			notifyClient,
+			recipientEmail,
+			personalisation: {
+				...basePersonalisation,
+				is_hearing_procedure: true
+			}
+		};
+
+		const expectedContent = [
+			'We did not receive any comments from interested parties.',
+			'# Appeal details',
+			'',
+			'^Appeal reference number: ABC45678',
+			'Address: 10, Test Street',
+			'Planning application reference: 12345XYZ',
+			'',
+			'The Planning Inspectorate',
+			'caseofficers@planninginspectorate.gov.uk'
+		].join('\n');
+
+		await notifySend(notifySendData);
+
+		expect(notifyClient.sendEmail).toHaveBeenCalledWith(
+			{ id: 'mock-appeal-generic-id' },
+			recipientEmail,
+			{
+				content: expectedContent,
+				subject: "We've received all statements and comments: ABC45678"
+			}
+		);
+	});
 });

--- a/appeals/api/src/server/notify/templates/received-statement-and-ip-comments-appellant.subject.md
+++ b/appeals/api/src/server/notify/templates/received-statement-and-ip-comments-appellant.subject.md
@@ -1,1 +1,5 @@
-{{subject}}: {{appeal_reference_number}}
+{%- if is_hearing_procedure -%}
+	We have received the local planning authority's questionnaire, all statements and comments from interested parties: {{appeal_reference_number}}
+{%- else -%}
+	Submit your final comments: {{appeal_reference_number}}
+{%- endif -%}

--- a/appeals/api/src/server/notify/templates/received-statement-and-ip-comments-lpa.subject.md
+++ b/appeals/api/src/server/notify/templates/received-statement-and-ip-comments-lpa.subject.md
@@ -1,1 +1,5 @@
-{{subject}}: {{appeal_reference_number}}
+{%- if is_hearing_procedure -%}
+	We've received all statements and comments: {{appeal_reference_number}}
+{%- else -%}
+	Submit your final comments: {{appeal_reference_number}}
+{%- endif -%}


### PR DESCRIPTION
## Describe your changes
#### Issue with email subject line (a2-4433)

### API:
- Move conditional and text for subject line into the template itself in an attempt to prevent the invalid characters replacing the apostrophe. 

### TEST:
- Updated tests for notify changes above
- Make sure unit tests pass

## Issue ticket number and link

[A2-4433- Invalid subject Displaying for S78 -Hearing notify email upon sharing IP comments and Statements for both LPA and Appellant. "&#39;s" padding to the Subject.](https://pins-ds.atlassian.net/browse/A2-4433)
