### PR TITLE
fix(appeals): issue with email subject line (a2-4433) - patch for release

### DIFF
--- a/appeals/api/src/server/endpoints/representations/__tests__/representations.test.js
+++ b/appeals/api/src/server/endpoints/representations/__tests__/representations.test.js
@@ -1177,9 +1177,9 @@ describe('/appeals/:id/reps', () => {
 						...expectedEmailPayload,
 						has_ip_comments: true,
 						has_statement: true,
+						is_hearing_procedure: false,
 						what_happens_next:
-							'You need to [submit your final comments](/mock-front-office-url/manage-appeals/6000002) by 4 December 2024.',
-						subject: 'Submit your final comments'
+							'You need to [submit your final comments](/mock-front-office-url/manage-appeals/6000002) by 4 December 2024.'
 					},
 					recipientEmail: appealS78.lpa.email,
 					templateName: 'received-statement-and-ip-comments-lpa'
@@ -1192,9 +1192,9 @@ describe('/appeals/:id/reps', () => {
 						...expectedEmailPayload,
 						has_ip_comments: true,
 						has_statement: true,
+						is_hearing_procedure: false,
 						what_happens_next:
-							'You need to [submit your final comments](/mock-front-office-url/appeals/6000002) by 4 December 2024.',
-						subject: 'Submit your final comments'
+							'You need to [submit your final comments](/mock-front-office-url/appeals/6000002) by 4 December 2024.'
 					},
 					recipientEmail: appealS78.appellant.email,
 					templateName: 'received-statement-and-ip-comments-appellant'
@@ -1263,9 +1263,9 @@ describe('/appeals/:id/reps', () => {
 						...expectedEmailPayload,
 						has_ip_comments: true,
 						has_statement: true,
+						is_hearing_procedure: false,
 						what_happens_next:
-							'You need to [submit your final comments](/mock-front-office-url/manage-appeals/6000002) by 4 December 2024.',
-						subject: 'Submit your final comments'
+							'You need to [submit your final comments](/mock-front-office-url/manage-appeals/6000002) by 4 December 2024.'
 					},
 					recipientEmail: appealS78.lpa.email,
 					templateName: 'received-statement-and-ip-comments-lpa'
@@ -1278,9 +1278,9 @@ describe('/appeals/:id/reps', () => {
 						...expectedEmailPayload,
 						has_ip_comments: true,
 						has_statement: true,
+						is_hearing_procedure: false,
 						what_happens_next:
-							'You need to [submit your final comments](/mock-front-office-url/appeals/6000002) by 4 December 2024.',
-						subject: 'Submit your final comments'
+							'You need to [submit your final comments](/mock-front-office-url/appeals/6000002) by 4 December 2024.'
 					},
 					recipientEmail: appealS78.appellant.email,
 					templateName: 'received-statement-and-ip-comments-appellant'
@@ -1376,9 +1376,9 @@ describe('/appeals/:id/reps', () => {
 						...expectedEmailPayload,
 						has_ip_comments: true,
 						has_statement: false,
+						is_hearing_procedure: false,
 						what_happens_next:
-							'You need to [submit your final comments](/mock-front-office-url/manage-appeals/6000002) by 4 December 2024.',
-						subject: 'Submit your final comments'
+							'You need to [submit your final comments](/mock-front-office-url/manage-appeals/6000002) by 4 December 2024.'
 					},
 					recipientEmail: appealS78.lpa.email,
 					templateName: 'received-statement-and-ip-comments-lpa'
@@ -1391,9 +1391,9 @@ describe('/appeals/:id/reps', () => {
 						...expectedEmailPayload,
 						has_ip_comments: true,
 						has_statement: false,
+						is_hearing_procedure: false,
 						what_happens_next:
-							'You need to [submit your final comments](/mock-front-office-url/appeals/6000002) by 4 December 2024.',
-						subject: 'Submit your final comments'
+							'You need to [submit your final comments](/mock-front-office-url/appeals/6000002) by 4 December 2024.'
 					},
 					recipientEmail: appealS78.appellant.email,
 					templateName: 'received-statement-and-ip-comments-appellant'
@@ -1451,9 +1451,9 @@ describe('/appeals/:id/reps', () => {
 						...expectedEmailPayload,
 						has_ip_comments: false,
 						has_statement: true,
+						is_hearing_procedure: false,
 						what_happens_next:
-							'You need to [submit your final comments](/mock-front-office-url/manage-appeals/6000002) by 4 December 2024.',
-						subject: 'Submit your final comments'
+							'You need to [submit your final comments](/mock-front-office-url/manage-appeals/6000002) by 4 December 2024.'
 					},
 					recipientEmail: appealS78.lpa.email,
 					templateName: 'received-statement-and-ip-comments-lpa'
@@ -1466,9 +1466,9 @@ describe('/appeals/:id/reps', () => {
 						...expectedEmailPayload,
 						has_ip_comments: false,
 						has_statement: true,
+						is_hearing_procedure: false,
 						what_happens_next:
-							'You need to [submit your final comments](/mock-front-office-url/appeals/6000002) by 4 December 2024.',
-						subject: 'Submit your final comments'
+							'You need to [submit your final comments](/mock-front-office-url/appeals/6000002) by 4 December 2024.'
 					},
 					recipientEmail: appealS78.appellant.email,
 					templateName: 'received-statement-and-ip-comments-appellant'
@@ -1524,9 +1524,9 @@ describe('/appeals/:id/reps', () => {
 						...expectedEmailPayload,
 						has_ip_comments: false,
 						has_statement: false,
+						is_hearing_procedure: false,
 						what_happens_next:
-							'You need to [submit your final comments](/mock-front-office-url/manage-appeals/6000002) by 4 December 2024.',
-						subject: 'Submit your final comments'
+							'You need to [submit your final comments](/mock-front-office-url/manage-appeals/6000002) by 4 December 2024.'
 					},
 					recipientEmail: appealS78.lpa.email,
 					templateName: 'received-statement-and-ip-comments-lpa'
@@ -1539,9 +1539,9 @@ describe('/appeals/:id/reps', () => {
 						...expectedEmailPayload,
 						has_ip_comments: false,
 						has_statement: false,
+						is_hearing_procedure: false,
 						what_happens_next:
-							'You need to [submit your final comments](/mock-front-office-url/appeals/6000002) by 4 December 2024.',
-						subject: 'Submit your final comments'
+							'You need to [submit your final comments](/mock-front-office-url/appeals/6000002) by 4 December 2024.'
 					},
 					recipientEmail: appealS78.appellant.email,
 					templateName: 'received-statement-and-ip-comments-appellant'
@@ -1601,9 +1601,9 @@ describe('/appeals/:id/reps', () => {
 						...expectedEmailPayload,
 						has_ip_comments: true,
 						has_statement: true,
+						is_hearing_procedure: false,
 						what_happens_next:
-							'You need to [submit your final comments](/mock-front-office-url/manage-appeals/6000002) by 4 December 2024.',
-						subject: 'Submit your final comments'
+							'You need to [submit your final comments](/mock-front-office-url/manage-appeals/6000002) by 4 December 2024.'
 					},
 					recipientEmail: mockS20Appeal.lpa.email,
 					templateName: 'received-statement-and-ip-comments-lpa'
@@ -1616,9 +1616,9 @@ describe('/appeals/:id/reps', () => {
 						...expectedEmailPayload,
 						has_ip_comments: true,
 						has_statement: true,
+						is_hearing_procedure: false,
 						what_happens_next:
-							'You need to [submit your final comments](/mock-front-office-url/appeals/6000002) by 4 December 2024.',
-						subject: 'Submit your final comments'
+							'You need to [submit your final comments](/mock-front-office-url/appeals/6000002) by 4 December 2024.'
 					},
 					recipientEmail: mockS20Appeal.appellant.email,
 					templateName: 'received-statement-and-ip-comments-appellant'
@@ -1686,8 +1686,8 @@ describe('/appeals/:id/reps', () => {
 						...expectedEmailPayload,
 						has_ip_comments: true,
 						has_statement: true,
-						what_happens_next: 'We will contact you when the hearing has been set up.',
-						subject: `We've received all statements and comments`
+						is_hearing_procedure: true,
+						what_happens_next: 'We will contact you when the hearing has been set up.'
 					},
 					recipientEmail: appealS78.lpa.email,
 					templateName: 'received-statement-and-ip-comments-lpa'
@@ -1700,8 +1700,8 @@ describe('/appeals/:id/reps', () => {
 						...expectedEmailPayload,
 						has_ip_comments: true,
 						has_statement: true,
-						what_happens_next: 'We will contact you if we need any more information.',
-						subject: `We have received the local planning authority's questionnaire, all statements and comments from interested parties`
+						is_hearing_procedure: true,
+						what_happens_next: 'We will contact you if we need any more information.'
 					},
 					recipientEmail: appealS78.appellant.email,
 					templateName: 'received-statement-and-ip-comments-appellant'
@@ -1768,8 +1768,8 @@ describe('/appeals/:id/reps', () => {
 						...expectedEmailPayload,
 						has_ip_comments: true,
 						has_statement: true,
-						what_happens_next: 'We will contact you when the hearing has been set up.',
-						subject: `We've received all statements and comments`
+						is_hearing_procedure: true,
+						what_happens_next: 'We will contact you when the hearing has been set up.'
 					},
 					recipientEmail: appealS78.lpa.email,
 					templateName: 'received-statement-and-ip-comments-lpa'
@@ -1782,8 +1782,8 @@ describe('/appeals/:id/reps', () => {
 						...expectedEmailPayload,
 						has_ip_comments: true,
 						has_statement: true,
-						what_happens_next: 'We will contact you if we need any more information.',
-						subject: `We have received the local planning authority's questionnaire, all statements and comments from interested parties`
+						is_hearing_procedure: true,
+						what_happens_next: 'We will contact you if we need any more information.'
 					},
 					recipientEmail: appealS78.appellant.email,
 					templateName: 'received-statement-and-ip-comments-appellant'
@@ -1855,8 +1855,8 @@ describe('/appeals/:id/reps', () => {
 						...expectedEmailPayload,
 						has_ip_comments: true,
 						has_statement: true,
-						what_happens_next: 'The hearing is on 31 January 2025.',
-						subject: `We've received all statements and comments`
+						is_hearing_procedure: true,
+						what_happens_next: 'The hearing is on 31 January 2025.'
 					},
 					recipientEmail: appealS78.lpa.email,
 					templateName: 'received-statement-and-ip-comments-lpa'
@@ -1869,9 +1869,9 @@ describe('/appeals/:id/reps', () => {
 						...expectedEmailPayload,
 						has_ip_comments: true,
 						has_statement: true,
+						is_hearing_procedure: true,
 						what_happens_next:
-							'Your hearing is on 31 January 2025.\n\nWe will contact you if we need any more information.',
-						subject: `We have received the local planning authority's questionnaire, all statements and comments from interested parties`
+							'Your hearing is on 31 January 2025.\n\nWe will contact you if we need any more information.'
 					},
 					recipientEmail: appealS78.appellant.email,
 					templateName: 'received-statement-and-ip-comments-appellant'
@@ -1941,8 +1941,8 @@ describe('/appeals/:id/reps', () => {
 						...expectedEmailPayload,
 						has_ip_comments: true,
 						has_statement: true,
-						what_happens_next: 'The hearing is on 31 January 2025.',
-						subject: `We've received all statements and comments`
+						is_hearing_procedure: true,
+						what_happens_next: 'The hearing is on 31 January 2025.'
 					},
 					recipientEmail: appealS78.lpa.email,
 					templateName: 'received-statement-and-ip-comments-lpa'
@@ -1955,9 +1955,9 @@ describe('/appeals/:id/reps', () => {
 						...expectedEmailPayload,
 						has_ip_comments: true,
 						has_statement: true,
+						is_hearing_procedure: true,
 						what_happens_next:
-							'Your hearing is on 31 January 2025.\n\nWe will contact you if we need any more information.',
-						subject: `We have received the local planning authority's questionnaire, all statements and comments from interested parties`
+							'Your hearing is on 31 January 2025.\n\nWe will contact you if we need any more information.'
 					},
 					recipientEmail: appealS78.appellant.email,
 					templateName: 'received-statement-and-ip-comments-appellant'
@@ -2030,6 +2030,7 @@ describe('/appeals/:id/reps', () => {
 					lpa_reference: mockS78Appeal.applicationReference,
 					has_ip_comments: false,
 					has_statement: false,
+					is_hearing_procedure: false,
 					appeal_reference_number: mockS78Appeal.reference,
 					final_comments_deadline: '',
 					site_address: expectedSiteAddress,
@@ -2098,6 +2099,7 @@ describe('/appeals/:id/reps', () => {
 					lpa_reference: mockS78Appeal.applicationReference,
 					has_ip_comments: false,
 					has_statement: false,
+					is_hearing_procedure: false,
 					appeal_reference_number: mockS78Appeal.reference,
 					final_comments_deadline: '',
 					site_address: expectedSiteAddress,
@@ -2215,6 +2217,7 @@ describe('/appeals/:id/reps', () => {
 					lpa_reference: mockS20Appeal.applicationReference,
 					has_ip_comments: false,
 					has_statement: false,
+					is_hearing_procedure: false,
 					appeal_reference_number: mockS20Appeal.reference,
 					final_comments_deadline: '',
 					site_address: expectedSiteAddress,
@@ -2286,6 +2289,7 @@ describe('/appeals/:id/reps', () => {
 					lpa_reference: mockS20Appeal.applicationReference,
 					has_ip_comments: false,
 					has_statement: false,
+					is_hearing_procedure: false,
 					appeal_reference_number: mockS20Appeal.reference,
 					final_comments_deadline: '',
 					site_address: expectedSiteAddress,
@@ -2344,6 +2348,7 @@ describe('/appeals/:id/reps', () => {
 					lpa_reference: mockS78Appeal.applicationReference,
 					has_ip_comments: false,
 					has_statement: false,
+					is_hearing_procedure: false,
 					appeal_reference_number: mockS78Appeal.reference,
 					final_comments_deadline: '',
 					site_address: expectedSiteAddress,
@@ -2410,6 +2415,7 @@ describe('/appeals/:id/reps', () => {
 					lpa_reference: mockS20Appeal.applicationReference,
 					has_ip_comments: false,
 					has_statement: false,
+					is_hearing_procedure: false,
 					appeal_reference_number: mockS20Appeal.reference,
 					final_comments_deadline: '',
 					site_address: expectedSiteAddress,
@@ -2478,6 +2484,7 @@ describe('/appeals/:id/reps', () => {
 					lpa_reference: mockS20Appeal.applicationReference,
 					has_ip_comments: false,
 					has_statement: false,
+					is_hearing_procedure: false,
 					appeal_reference_number: mockS20Appeal.reference,
 					final_comments_deadline: '',
 					site_address: expectedSiteAddress,

--- a/appeals/api/src/server/endpoints/representations/representations.service.js
+++ b/appeals/api/src/server/endpoints/representations/representations.service.js
@@ -301,15 +301,12 @@ export async function publishLpaStatements(appeal, azureAdUserId, notifyClient) 
 	const hasIpComments = result.some(
 		(rep) => rep.representationType === APPEAL_REPRESENTATION_TYPE.COMMENT
 	);
+	const isHearingProcedure = String(appeal.procedureType?.key) === APPEAL_CASE_PROCEDURE.HEARING;
 
 	try {
 		let whatHappensNextAppellant;
 		let whatHappensNextLpa;
-		let lpaSubject;
-		let appellantSubject;
-		if (String(appeal.procedureType?.key) === APPEAL_CASE_PROCEDURE.HEARING) {
-			lpaSubject = `We've received all statements and comments`;
-			appellantSubject = `We have received the local planning authority's questionnaire, all statements and comments from interested parties`;
+		if (isHearingProcedure) {
 			if (appeal.hearing?.hearingStartTime) {
 				whatHappensNextAppellant = `Your hearing is on ${formatDate(
 					appeal.hearing?.hearingStartTime,
@@ -324,8 +321,6 @@ export async function publishLpaStatements(appeal, azureAdUserId, notifyClient) 
 				whatHappensNextLpa = `We will contact you when the hearing has been set up.`;
 			}
 		} else {
-			lpaSubject = 'Submit your final comments';
-			appellantSubject = 'Submit your final comments';
 			whatHappensNextAppellant = `You need to [submit your final comments](${config.frontOffice.url}/appeals/${appeal.reference}) by ${finalCommentsDueDate}.`;
 			whatHappensNextLpa = `You need to [submit your final comments](${config.frontOffice.url}/manage-appeals/${appeal.reference}) by ${finalCommentsDueDate}.`;
 		}
@@ -335,11 +330,11 @@ export async function publishLpaStatements(appeal, azureAdUserId, notifyClient) 
 			notifyClient,
 			hasLpaStatement,
 			hasIpComments,
+			isHearingProcedure,
 			templateName: 'received-statement-and-ip-comments-lpa',
 			recipientEmail: appeal.lpa?.email,
 			finalCommentsDueDate,
 			whatHappensNext: whatHappensNextLpa,
-			subject: lpaSubject,
 			azureAdUserId
 		});
 
@@ -348,11 +343,11 @@ export async function publishLpaStatements(appeal, azureAdUserId, notifyClient) 
 			notifyClient,
 			hasLpaStatement,
 			hasIpComments,
+			isHearingProcedure,
 			templateName: 'received-statement-and-ip-comments-appellant',
 			recipientEmail: appeal.agent?.email || appeal.appellant?.email,
 			finalCommentsDueDate,
 			whatHappensNext: whatHappensNextAppellant,
-			subject: appellantSubject,
 			azureAdUserId
 		});
 	} catch (error) {
@@ -430,7 +425,7 @@ export async function publishFinalComments(appeal, azureAdUserId, notifyClient) 
  * @property {string} [whatHappensNext]
  * @property {boolean} [hasLpaStatement]
  * @property {boolean} [hasIpComments]
- * @property {string} [subject]
+ * @property {boolean} [isHearingProcedure]
  * @property {string} [userTypeNoCommentSubmitted]
  * @property {string} azureAdUserId
  */
@@ -448,7 +443,7 @@ async function notifyPublished({
 	whatHappensNext = '',
 	hasLpaStatement = false,
 	hasIpComments = false,
-	subject = '',
+	isHearingProcedure = false,
 	userTypeNoCommentSubmitted = '',
 	azureAdUserId
 }) {
@@ -481,7 +476,7 @@ async function notifyPublished({
 			what_happens_next: whatHappensNext,
 			has_ip_comments: hasIpComments,
 			has_statement: hasLpaStatement,
-			...(subject ? { subject } : {}),
+			is_hearing_procedure: isHearingProcedure,
 			user_type: userTypeNoCommentSubmitted
 		}
 	});

--- a/appeals/api/src/server/notify/templates/__tests__/notify-received-statement-and-ip-comments-appellant.test.js
+++ b/appeals/api/src/server/notify/templates/__tests__/notify-received-statement-and-ip-comments-appellant.test.js
@@ -130,4 +130,26 @@ describe('received-statement-and-ip-comments-appellant.md', () => {
 			}
 		);
 	});
+	test('should call notify sendEmail with the correct data when a hearing procedure', async () => {
+		const expectedContent = [
+			"We have received the local planning authority's questionnaire, all statements and comments from interested parties.",
+			'You can [view this information in the appeals service](/mock-front-office-url/appeals/ABC45678).',
+			...expectedTailContent
+		].join('\n');
+
+		notifySendData.personalisation.is_hearing_procedure = true;
+
+		await notifySend(notifySendData);
+		expect(notifySendData.notifyClient.sendEmail).toHaveBeenCalledWith(
+			{
+				id: 'mock-appeal-generic-id'
+			},
+			'test@136s7.com',
+			{
+				content: expectedContent,
+				subject:
+					"We have received the local planning authority's questionnaire, all statements and comments from interested parties: ABC45678"
+			}
+		);
+	});
 });

--- a/appeals/api/src/server/notify/templates/__tests__/notify-received-statement-and-ip-comments-lpa.test.js
+++ b/appeals/api/src/server/notify/templates/__tests__/notify-received-statement-and-ip-comments-lpa.test.js
@@ -174,4 +174,40 @@ describe('received-statement-and-ip-comments-lpa.md', () => {
 			}
 		);
 	});
+
+	test('should call notify sendEmail with the correct data when a hearing procedure', async () => {
+		const notifySendData = {
+			doNotMockNotifySend: true,
+			templateName: 'received-statement-and-ip-comments-lpa',
+			notifyClient,
+			recipientEmail,
+			personalisation: {
+				...basePersonalisation,
+				is_hearing_procedure: true
+			}
+		};
+
+		const expectedContent = [
+			'We did not receive any comments from interested parties.',
+			'# Appeal details',
+			'',
+			'^Appeal reference number: ABC45678',
+			'Address: 10, Test Street',
+			'Planning application reference: 12345XYZ',
+			'',
+			'The Planning Inspectorate',
+			'caseofficers@planninginspectorate.gov.uk'
+		].join('\n');
+
+		await notifySend(notifySendData);
+
+		expect(notifyClient.sendEmail).toHaveBeenCalledWith(
+			{ id: 'mock-appeal-generic-id' },
+			recipientEmail,
+			{
+				content: expectedContent,
+				subject: "We've received all statements and comments: ABC45678"
+			}
+		);
+	});
 });

--- a/appeals/api/src/server/notify/templates/received-statement-and-ip-comments-appellant.subject.md
+++ b/appeals/api/src/server/notify/templates/received-statement-and-ip-comments-appellant.subject.md
@@ -1,1 +1,5 @@
-{{subject}}: {{appeal_reference_number}}
+{%- if is_hearing_procedure -%}
+	We have received the local planning authority's questionnaire, all statements and comments from interested parties: {{appeal_reference_number}}
+{%- else -%}
+	Submit your final comments: {{appeal_reference_number}}
+{%- endif -%}

--- a/appeals/api/src/server/notify/templates/received-statement-and-ip-comments-lpa.subject.md
+++ b/appeals/api/src/server/notify/templates/received-statement-and-ip-comments-lpa.subject.md
@@ -1,1 +1,5 @@
-{{subject}}: {{appeal_reference_number}}
+{%- if is_hearing_procedure -%}
+	We've received all statements and comments: {{appeal_reference_number}}
+{%- else -%}
+	Submit your final comments: {{appeal_reference_number}}
+{%- endif -%}


### PR DESCRIPTION
## Describe your changes
#### Issue with email subject line (a2-4433) - patch for release
##### **** PLEASE NOTE THIS IS THE PATCH VERSION OF THIS FIX FOR THE RELEASE ****
See the original PR against main for reference here: [fix(appeals): issue with email subject line (a2-4433)](https://github.com/Planning-Inspectorate/appeals-back-office/pull/2059)

### API:
- Move conditional and text for subject line into the template itself in an attempt to prevent the invalid characters replacing the apostrophe. 

### TEST:
- Updated tests for notify changes above
- Make sure unit tests pass

## Issue ticket number and link

[A2-4433- Invalid subject Displaying for S78 -Hearing notify email upon sharing IP comments and Statements for both LPA and Appellant. "&#39;s" padding to the Subject.](https://pins-ds.atlassian.net/browse/A2-4433)
