### PR TITLE
test(appeals): change to hearing procedure type

### DIFF
--- a/appeals/e2e/cypress/e2e/back-office-appeals/changeAppealProcedureType.spec.js
+++ b/appeals/e2e/cypress/e2e/back-office-appeals/changeAppealProcedureType.spec.js
@@ -46,121 +46,118 @@ describe('change appeal procedure types', () => {
 	});
 
 	it('should change appeal procedure type - written in LPAQ state', () => {
-			happyPathHelper.startS78Case(caseRef, 'written');
-			caseDetailsPage.checkStatusOfCase('LPA questionnaire', 0);
+		happyPathHelper.startS78Case(caseRef, 'written');
+		caseDetailsPage.checkStatusOfCase('LPA questionnaire', 0);
 
-			// For written procedure:
-			const writtenDetails = { ...overviewDetails, appealProcedure: 'Written' };
-			overviewSectionPage.verifyCaseOverviewDetails(writtenDetails);
+		const writtenDetails = { ...overviewDetails, appealProcedure: 'Written' };
+		overviewSectionPage.verifyCaseOverviewDetails(writtenDetails);
 
-			overviewSectionPage.clickRowChangeLink('case-procedure');
+		overviewSectionPage.clickRowChangeLink('case-procedure');
 
+		procedureTypePage.verifyHeader(procedureTypeCaption());
+		procedureTypePage.selectProcedureType('written');
+
+		// verify previous values are prepopulated
+		cy.loadAppealDetails(caseRef).then((appealDetails) => {
 			procedureTypePage.verifyHeader(procedureTypeCaption());
-			procedureTypePage.selectProcedureType('written');
+			const appealTimetable = appealDetails?.appealTimetable;
+			const lpaQuestionnaireDueDate = new Date(appealTimetable.lpaQuestionnaireDueDate);
+			const lpaStatementDueDate = new Date(appealTimetable.lpaStatementDueDate);
+			const ipCommentsDueDate = new Date(appealTimetable.ipCommentsDueDate);
 
-			// verify previous values are prepopulated
-			cy.loadAppealDetails(caseRef).then((appealDetails) => {
-				procedureTypePage.verifyHeader(procedureTypeCaption());
-				const appealTimetable = appealDetails?.appealTimetable;
-				const lpaQuestionnaireDueDate = new Date(appealTimetable.lpaQuestionnaireDueDate);
-				const lpaStatementDueDate = new Date(appealTimetable.lpaStatementDueDate);
-				const ipCommentsDueDate = new Date(appealTimetable.ipCommentsDueDate);
+			dateTimeSection.verifyPrepopulatedTimeTableDueDates(
+				'lpaQuestionnaireDueDate',
+				getDateAndTimeValues(lpaQuestionnaireDueDate)
+			);
+			dateTimeSection.verifyPrepopulatedTimeTableDueDates(
+				'lpaStatementDueDate',
+				getDateAndTimeValues(lpaStatementDueDate)
+			);
+			dateTimeSection.verifyPrepopulatedTimeTableDueDates(
+				'ipCommentsDueDate',
+				getDateAndTimeValues(ipCommentsDueDate)
+			);
 
-				dateTimeSection.verifyPrepopulatedTimeTableDueDates(
-					'lpaQuestionnaireDueDate',
-					getDateAndTimeValues(lpaQuestionnaireDueDate)
+			// update final comments due date and check CYA page
+			cy.getBusinessActualDate(new Date(), 60).then((dueDate) => {
+				caseDetailsPage.changeTimetableDates(timetableItems.slice(0, 1), dueDate, 0); //update and continue
+				const updateFinalCommentsDueDate = new Date(dueDate);
+
+				cyaSection.verifyCheckYourAnswers(
+					'LPA questionnaire due',
+					formatDateAndTime(lpaQuestionnaireDueDate).date
 				);
-				dateTimeSection.verifyPrepopulatedTimeTableDueDates(
-					'lpaStatementDueDate',
-					getDateAndTimeValues(lpaStatementDueDate)
+				cyaSection.verifyCheckYourAnswers(
+					'Statements due',
+					formatDateAndTime(lpaStatementDueDate).date
 				);
-				dateTimeSection.verifyPrepopulatedTimeTableDueDates(
-					'ipCommentsDueDate',
-					getDateAndTimeValues(ipCommentsDueDate)
+				cyaSection.verifyCheckYourAnswers(
+					'Interested party comments due',
+					formatDateAndTime(ipCommentsDueDate).date
 				);
-
-				// update final comments due date and check CYA page
-				cy.getBusinessActualDate(new Date(), 60).then((dueDate) => {
-					caseDetailsPage.changeTimetableDates(timetableItems.slice(0,1), dueDate, 0); //update and continue
-					const updateFinalCommentsDueDate = new Date(dueDate);
-
-					cyaSection.verifyCheckYourAnswers(
-						'LPA questionnaire due',
-						formatDateAndTime(lpaQuestionnaireDueDate).date
-					);
-					cyaSection.verifyCheckYourAnswers(
-						'Statements due',
-						formatDateAndTime(lpaStatementDueDate).date
-					);
-					cyaSection.verifyCheckYourAnswers(
-						'Interested party comments due',
-						formatDateAndTime(ipCommentsDueDate).date
-					);
-					cyaSection.verifyCheckYourAnswers(
-						'Final comments due',
-						formatDateAndTime(updateFinalCommentsDueDate).date
-					);
-				});
+				cyaSection.verifyCheckYourAnswers(
+					'Final comments due',
+					formatDateAndTime(updateFinalCommentsDueDate).date
+				);
 			});
-
+		});
 	});
 
 	it('should change appeal procedure type - hearing in LPAQ state', () => {
-			happyPathHelper.startS78Case(caseRef, 'hearing');
-			caseDetailsPage.checkStatusOfCase('LPA questionnaire', 0);
+		happyPathHelper.startS78Case(caseRef, 'hearing');
+		caseDetailsPage.checkStatusOfCase('LPA questionnaire', 0);
 
-			// For hearing procedure:
-			const hearingDetails = { ...overviewDetails, appealProcedure: 'Hearing' };
-			overviewSectionPage.verifyCaseOverviewDetails(hearingDetails);
+		const hearingDetails = { ...overviewDetails, appealProcedure: 'Hearing' };
+		overviewSectionPage.verifyCaseOverviewDetails(hearingDetails);
 
-			overviewSectionPage.clickRowChangeLink('case-procedure');
+		overviewSectionPage.clickRowChangeLink('case-procedure');
 
+		procedureTypePage.verifyHeader(procedureTypeCaption());
+		procedureTypePage.selectProcedureType('hearing');
+
+		// verify previous values are prepopulated
+		cy.loadAppealDetails(caseRef).then((appealDetails) => {
 			procedureTypePage.verifyHeader(procedureTypeCaption());
-			procedureTypePage.selectProcedureType('hearing');
+			const appealTimetable = appealDetails?.appealTimetable;
+			const lpaQuestionnaireDueDate = new Date(appealTimetable.lpaQuestionnaireDueDate);
+			const lpaStatementDueDate = new Date(appealTimetable.lpaStatementDueDate);
+			const ipCommentsDueDate = new Date(appealTimetable.ipCommentsDueDate);
 
-			// verify previous values are prepopulated
-			cy.loadAppealDetails(caseRef).then((appealDetails) => {
-				procedureTypePage.verifyHeader(procedureTypeCaption());
-				const appealTimetable = appealDetails?.appealTimetable;
-				const lpaQuestionnaireDueDate = new Date(appealTimetable.lpaQuestionnaireDueDate);
-				const lpaStatementDueDate = new Date(appealTimetable.lpaStatementDueDate);
-				const ipCommentsDueDate = new Date(appealTimetable.ipCommentsDueDate);
+			dateTimeSection.verifyPrepopulatedTimeTableDueDates(
+				'lpaQuestionnaireDueDate',
+				getDateAndTimeValues(lpaQuestionnaireDueDate)
+			);
+			dateTimeSection.verifyPrepopulatedTimeTableDueDates(
+				'lpaStatementDueDate',
+				getDateAndTimeValues(lpaStatementDueDate)
+			);
+			dateTimeSection.verifyPrepopulatedTimeTableDueDates(
+				'ipCommentsDueDate',
+				getDateAndTimeValues(ipCommentsDueDate)
+			);
 
-				dateTimeSection.verifyPrepopulatedTimeTableDueDates(
-					'lpaQuestionnaireDueDate',
-					getDateAndTimeValues(lpaQuestionnaireDueDate)
+			// update statement of common ground due date and check CYA page
+			cy.getBusinessActualDate(new Date(), 60).then((dueDate) => {
+				caseDetailsPage.changeTimetableDates(timetableItems.slice(1, 2), dueDate, 0); //update and continue
+				const updateStatementOfCommonGroundDueDate = new Date(dueDate);
+
+				cyaSection.verifyCheckYourAnswers(
+					'LPA questionnaire due',
+					formatDateAndTime(lpaQuestionnaireDueDate).date
 				);
-				dateTimeSection.verifyPrepopulatedTimeTableDueDates(
-					'lpaStatementDueDate',
-					getDateAndTimeValues(lpaStatementDueDate)
+				cyaSection.verifyCheckYourAnswers(
+					'Statements due',
+					formatDateAndTime(lpaStatementDueDate).date
 				);
-				dateTimeSection.verifyPrepopulatedTimeTableDueDates(
-					'ipCommentsDueDate',
-					getDateAndTimeValues(ipCommentsDueDate)
+				cyaSection.verifyCheckYourAnswers(
+					'Interested party comments due',
+					formatDateAndTime(ipCommentsDueDate).date
 				);
-
-				// update statement of common ground due date and check CYA page
-				cy.getBusinessActualDate(new Date(), 60).then((dueDate) => {
-					caseDetailsPage.changeTimetableDates(timetableItems.slice(1, 2), dueDate, 0); //update and continue
-					const updateStatementOfCommonGroundDueDate = new Date(dueDate);
-
-					cyaSection.verifyCheckYourAnswers(
-						'LPA questionnaire due',
-						formatDateAndTime(lpaQuestionnaireDueDate).date
-					);
-					cyaSection.verifyCheckYourAnswers(
-						'Statements due',
-						formatDateAndTime(lpaStatementDueDate).date
-					);
-					cyaSection.verifyCheckYourAnswers(
-						'Interested party comments due',
-						formatDateAndTime(ipCommentsDueDate).date
-					);
-					cyaSection.verifyCheckYourAnswers(
-						'Statement of common ground due',
-						formatDateAndTime(updateStatementOfCommonGroundDueDate).date
-					);
-				});
+				cyaSection.verifyCheckYourAnswers(
+					'Statement of common ground due',
+					formatDateAndTime(updateStatementOfCommonGroundDueDate).date
+				);
+			});
 		});
 	});
 

--- a/appeals/e2e/cypress/e2e/back-office-appeals/changeAppealProcedureType.spec.js
+++ b/appeals/e2e/cypress/e2e/back-office-appeals/changeAppealProcedureType.spec.js
@@ -20,39 +20,38 @@ describe('change appeal procedure types', () => {
 	let caseRef;
 
 	const overviewDetails = {
-		written: {
-			appealType: 'Planning appeal',
-			applicationReference: '123',
-			appealProcedure: 'Written',
-			allocationLevel: 'No allocation level for this appeal',
-			linkedAppeals: 'No linked appeals',
-			relatedAppeals: '1000000',
-			netGainResidential: 'Not provided'
-		}
+		appealType: 'Planning appeal',
+		applicationReference: '123',
+		allocationLevel: 'No allocation level for this appeal',
+		linkedAppeals: 'No linked appeals',
+		relatedAppeals: '1000000',
+		netGainResidential: 'Not provided'
 	};
 
 	const timetableItems = [
 		{
 			row: 'final-comments-due-date',
 			editable: true
+		},
+		{
+			row: 'statement-of-common-ground-due-date',
+			editable: true
 		}
 	];
 
 	const procedureTypeCaption = () => `Appeal ${caseRef} - update appeal procedure`;
 
-	it('should change appeal procedure type - written in LPAQ state', () => {
-		cy.login(users.appeals.caseAdmin);
-		cy.createCase({ caseType: 'W' }).then((ref) => {
-			caseRef = ref;
-			cy.addLpaqSubmissionToCase(caseRef);
-			happyPathHelper.assignCaseOfficer(caseRef);
-			caseDetailsPage.checkStatusOfCase('Validation', 0);
-			happyPathHelper.reviewAppellantCase(caseRef);
-			caseDetailsPage.checkStatusOfCase('Ready to start', 0);
+	beforeEach(() => {
+		setupTestCase();
+	});
 
+	it('should change appeal procedure type - written in LPAQ state', () => {
 			happyPathHelper.startS78Case(caseRef, 'written');
 			caseDetailsPage.checkStatusOfCase('LPA questionnaire', 0);
-			overviewSectionPage.verifyCaseOverviewDetails(overviewDetails.written);
+
+			// For written procedure:
+			const writtenDetails = { ...overviewDetails, appealProcedure: 'Written' };
+			overviewSectionPage.verifyCaseOverviewDetails(writtenDetails);
 
 			overviewSectionPage.clickRowChangeLink('case-procedure');
 
@@ -82,7 +81,7 @@ describe('change appeal procedure types', () => {
 
 				// update final comments due date and check CYA page
 				cy.getBusinessActualDate(new Date(), 60).then((dueDate) => {
-					caseDetailsPage.changeTimetableDates(timetableItems, dueDate, 0); //update and continue
+					caseDetailsPage.changeTimetableDates(timetableItems.slice(0,1), dueDate, 0); //update and continue
 					const updateFinalCommentsDueDate = new Date(dueDate);
 
 					cyaSection.verifyCheckYourAnswers(
@@ -103,6 +102,77 @@ describe('change appeal procedure types', () => {
 					);
 				});
 			});
+
+	});
+
+	it('should change appeal procedure type - hearing in LPAQ state', () => {
+			happyPathHelper.startS78Case(caseRef, 'hearing');
+			caseDetailsPage.checkStatusOfCase('LPA questionnaire', 0);
+
+			// For hearing procedure:
+			const hearingDetails = { ...overviewDetails, appealProcedure: 'Hearing' };
+			overviewSectionPage.verifyCaseOverviewDetails(hearingDetails);
+
+			overviewSectionPage.clickRowChangeLink('case-procedure');
+
+			procedureTypePage.verifyHeader(procedureTypeCaption());
+			procedureTypePage.selectProcedureType('hearing');
+
+			// verify previous values are prepopulated
+			cy.loadAppealDetails(caseRef).then((appealDetails) => {
+				procedureTypePage.verifyHeader(procedureTypeCaption());
+				const appealTimetable = appealDetails?.appealTimetable;
+				const lpaQuestionnaireDueDate = new Date(appealTimetable.lpaQuestionnaireDueDate);
+				const lpaStatementDueDate = new Date(appealTimetable.lpaStatementDueDate);
+				const ipCommentsDueDate = new Date(appealTimetable.ipCommentsDueDate);
+
+				dateTimeSection.verifyPrepopulatedTimeTableDueDates(
+					'lpaQuestionnaireDueDate',
+					getDateAndTimeValues(lpaQuestionnaireDueDate)
+				);
+				dateTimeSection.verifyPrepopulatedTimeTableDueDates(
+					'lpaStatementDueDate',
+					getDateAndTimeValues(lpaStatementDueDate)
+				);
+				dateTimeSection.verifyPrepopulatedTimeTableDueDates(
+					'ipCommentsDueDate',
+					getDateAndTimeValues(ipCommentsDueDate)
+				);
+
+				// update statement of common ground due date and check CYA page
+				cy.getBusinessActualDate(new Date(), 60).then((dueDate) => {
+					caseDetailsPage.changeTimetableDates(timetableItems.slice(1, 2), dueDate, 0); //update and continue
+					const updateStatementOfCommonGroundDueDate = new Date(dueDate);
+
+					cyaSection.verifyCheckYourAnswers(
+						'LPA questionnaire due',
+						formatDateAndTime(lpaQuestionnaireDueDate).date
+					);
+					cyaSection.verifyCheckYourAnswers(
+						'Statements due',
+						formatDateAndTime(lpaStatementDueDate).date
+					);
+					cyaSection.verifyCheckYourAnswers(
+						'Interested party comments due',
+						formatDateAndTime(ipCommentsDueDate).date
+					);
+					cyaSection.verifyCheckYourAnswers(
+						'Statement of common ground due',
+						formatDateAndTime(updateStatementOfCommonGroundDueDate).date
+					);
+				});
 		});
 	});
+
+	const setupTestCase = () => {
+		cy.login(users.appeals.caseAdmin);
+		cy.createCase({ caseType: 'W' }).then((ref) => {
+			caseRef = ref;
+			cy.addLpaqSubmissionToCase(caseRef);
+			happyPathHelper.assignCaseOfficer(caseRef);
+			caseDetailsPage.checkStatusOfCase('Validation', 0);
+			happyPathHelper.reviewAppellantCase(caseRef);
+			caseDetailsPage.checkStatusOfCase('Ready to start', 0);
+		});
+	};
 });

--- a/appeals/e2e/cypress/page_objects/procedureTypePage.js
+++ b/appeals/e2e/cypress/page_objects/procedureTypePage.js
@@ -1,46 +1,62 @@
-// @ts-nocheck
 import { CaseDetailsPage } from './caseDetailsPage.js';
 
 export class ProcedureTypePage extends CaseDetailsPage {
 	procedureTypeElements = {
 		...this.elements, // Inherit parent elements
 		written: () => cy.get('#appeal-procedure'),
-		hearing: () => cy.get('#appeal-procedure-1'),
-		inquiry: () => cy.get('#appeal-procedure-2')
+		hearing: () => cy.get('#appeal-procedure-2'),
+		inquiry: () => cy.get('#appeal-procedure-3')
 	};
 
-	selectProcedureType(label) {
-		const procedureTypeLabelMappings = {
-			written: {
-				element: this.procedureTypeElements.written,
-				displayName: 'Written representations'
-			},
-			hearing: {
-				element: this.procedureTypeElements.hearing,
-				displayName: 'Hearing'
-			},
-			inquiry: {
-				element: this.procedureTypeElements.inquiry,
-				displayName: 'Inquiry'
-			}
-		};
+	procedureTypeMappings = {
+		written: {
+			element: this.procedureTypeElements.written,
+			displayName: 'Written representations',
+			value: 'written'
+		},
+		hearing: {
+			element: this.procedureTypeElements.hearing,
+			displayName: 'Hearing',
+			value: 'hearing'
+		},
+		inquiry: {
+			element: this.procedureTypeElements.inquiry,
+			displayName: 'Inquiry',
+			value: 'inquiry'
+		}
+	};
 
+	procedureTypeExists(label) {
+		const normalizedLabel = label.toLowerCase().trim();
+		return Object.prototype.hasOwnProperty.call(this.procedureTypeMappings, normalizedLabel);
+	}
+
+	/**
+	 * Selects a procedure type and continues
+	 * @param {string} label - The procedure type to select (case-insensitive)
+	 * @throws {Error} If the procedure type is not found
+	 */
+	selectProcedureType(label) {
 		const normalizedLabel = label.toLowerCase().trim();
 
-		if (procedureTypeLabelMappings.hasOwnProperty(normalizedLabel)) {
-			const mapping = procedureTypeLabelMappings[normalizedLabel];
-			// Click and verify it's checked
-			mapping.element().click().should('be.checked');
-			this.clickButtonByText('Continue');
-			cy.log(`Selected procedure type: ${mapping.displayName}`);
-		} else {
-			const availableOptions = Object.values(procedureTypeLabelMappings)
-				.map((m) => m.displayName)
-				.join(', ');
+		if (!this.procedureTypeExists(normalizedLabel)) {
+			const availableOptions = this.getAvailableProcedureTypes().join(', ');
 			throw new Error(
 				`Procedure type "${label}" not found. Available options: ${availableOptions}`
 			);
 		}
+
+		const mapping = this.procedureTypeMappings[normalizedLabel];
+
+		// Click and verify it's checked with value validation
+		mapping.element().click().should('be.checked').and('have.value', mapping.value);
+
+		this.clickButtonByText('Continue');
+		cy.log(`Selected procedure type: ${mapping.displayName}`);
+	}
+
+	getAvailableProcedureTypes() {
+		return Object.values(this.procedureTypeMappings).map((mapping) => mapping.displayName);
 	}
 
 	verifyHeader(sectionHeader) {


### PR DESCRIPTION
## Describe your changes

**What's Added:**
- New Cypress test for reselecting appeal procedure type hearing in LPAQ state
- Tests the complete flow from case creation to procedure type update
- Includes date validation and CYA page verification

**Test Coverage:**
- Creates planning appeal case and sets to LPA questionnaire state
- Changes appeal procedure type to "hearing"
- Verifies prepopulated timetable dates are correct
- Updates statement of common ground due date
- Validates all dates on Check Your Answers page
- No breaking changes - adds new test functionality only.

## Issue ticket number and link

[Ticket](https://pins-ds.atlassian.net/browse/A2-3934)
