### PR TITLE
fix(infrastructure): stop commit validation on merge queues

### DIFF
--- a/infrastructure/pipelines/terraform-ci-commit.yaml
+++ b/infrastructure/pipelines/terraform-ci-commit.yaml
@@ -1,10 +1,3 @@
-trigger:
-  branches:
-    include:
-      # trigger for merge queue branches
-      - gh-readonly-queue/*
-
-
 pr:
   branches:
     include:


### PR DESCRIPTION
## Describe your changes

Don't run commit lint on merge queue