### PR TITLE
fix(appeals): hide change link for case officer when child appeal (a2-4462)

### DIFF
--- a/appeals/web/src/server/appeals/appeal-details/__tests__/__snapshots__/appeal-details.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/__tests__/__snapshots__/appeal-details.test.js.snap
@@ -457,9 +457,6 @@ exports[`appeal-details GET /:appealId Linked appeals should not render a "Appea
                     <dd class="govuk-summary-list__value">
                         <p class="govuk-body">Not assigned</p>
                     </dd>
-                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/assign-case-officer/search-case-officer"
-                        data-cy="assign-case-officer-name">Assign<span class="govuk-visually-hidden"> Case officer</span></a>
-                    </dd>
                 </div>
                 <div class="govuk-summary-list__row appeal-site-address"><dt class="govuk-summary-list__key"> Site address</dt>
                     <dd class="govuk-summary-list__value">21 The Pavement, Wandsworth, SW4 0HY</dd>
@@ -1102,9 +1099,6 @@ exports[`appeal-details GET /:appealId Linked appeals should render a child tag 
                 <div class="govuk-summary-list__row appeal-case-officer"><dt class="govuk-summary-list__key"> Case officer</dt>
                     <dd class="govuk-summary-list__value">
                         <p class="govuk-body">Not assigned</p>
-                    </dd>
-                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/assign-case-officer/search-case-officer"
-                        data-cy="assign-case-officer-name">Assign<span class="govuk-visually-hidden"> Case officer</span></a>
                     </dd>
                 </div>
                 <div class="govuk-summary-list__row appeal-site-address"><dt class="govuk-summary-list__key"> Site address</dt>

--- a/appeals/web/src/server/lib/mappers/data/appeal/submappers/__tests__/case-officer.mapper.test.js
+++ b/appeals/web/src/server/lib/mappers/data/appeal/submappers/__tests__/case-officer.mapper.test.js
@@ -1,0 +1,75 @@
+// @ts-nocheck
+import { mapCaseOfficer } from '#lib/mappers/data/appeal/submappers/case-officer.mapper.js';
+
+describe('case-officer.mapper', () => {
+	let data;
+	let expectedSummaryListItem;
+
+	beforeEach(() => {
+		data = {
+			appealDetails: {},
+			currentRoute: '/test',
+			skipAssignedUsersData: false,
+			caseOfficerUser: { name: 'Bloggs, Fred', email: 'fred.bloggs@test.com' },
+			userHasUpdateCasePermission: true
+		};
+
+		expectedSummaryListItem = {
+			classes: 'appeal-case-officer',
+			key: {
+				text: 'Case officer'
+			},
+			value: {
+				html: '<ul class="govuk-list"><li> Fred Bloggs</li><li>fred.bloggs@test.com</li></ul>'
+			},
+			actions: {
+				items: [
+					{
+						attributes: {
+							'data-cy': 'change-case-officer'
+						},
+						href: '/test/assign-case-officer/search-case-officer',
+						text: 'Change',
+						visuallyHiddenText: 'Case officer'
+					}
+				]
+			}
+		};
+	});
+
+	describe('should display case officer row', () => {
+		it('with a change link', () => {
+			const mappedData = mapCaseOfficer(data);
+			expect(mappedData).toEqual({
+				display: {
+					summaryListItem: expectedSummaryListItem
+				},
+				id: 'case-officer'
+			});
+		});
+
+		describe('without a change link', () => {
+			let expectedMappedData;
+
+			beforeEach(() => {
+				const { classes, key, value } = expectedSummaryListItem;
+				expectedMappedData = {
+					display: {
+						summaryListItem: { key, value, classes, actions: { items: [] } }
+					},
+					id: 'case-officer'
+				};
+			});
+
+			it('when the user does not have update case permission', () => {
+				const mappedData = mapCaseOfficer({ ...data, userHasUpdateCasePermission: false });
+				expect(mappedData).toEqual(expectedMappedData);
+			});
+
+			it('when the appeal is a linked child appeal', () => {
+				const mappedData = mapCaseOfficer({ ...data, appealDetails: { isChildAppeal: true } });
+				expect(mappedData).toEqual(expectedMappedData);
+			});
+		});
+	});
+});

--- a/appeals/web/src/server/lib/mappers/data/appeal/submappers/case-officer.mapper.js
+++ b/appeals/web/src/server/lib/mappers/data/appeal/submappers/case-officer.mapper.js
@@ -1,9 +1,11 @@
 import config from '#environment/config.js';
 import { textSummaryListItem } from '#lib/mappers/index.js';
+import { isChildAppeal } from '#lib/mappers/utils/is-linked-appeal.js';
 import { surnameFirstToFullName } from '#lib/person-name-formatter.js';
 
 /** @type {import('../mapper.js').SubMapper} */
 export const mapCaseOfficer = ({
+	appealDetails,
 	currentRoute,
 	skipAssignedUsersData,
 	caseOfficerUser,
@@ -34,7 +36,7 @@ export const mapCaseOfficer = ({
 			html: caseOfficerRowValue
 		},
 		link: `${currentRoute}/${caseOfficerRoute}`,
-		editable: userHasUpdateCasePermission,
+		editable: !isChildAppeal(appealDetails) && Boolean(userHasUpdateCasePermission),
 		classes: 'appeal-case-officer',
 		actionText: caseOfficerUser ? 'Change' : 'Assign'
 	});


### PR DESCRIPTION
## Describe your changes
####  Hide case officer change link for linked child appeals (a2-4462)

### WEB:
- Hide case officer change link in case details page when the appeal is a linked
 child appeal
 
### TEST:
- Added unit test for above
- Make sure all other unit tests pass
- Tested within the browser

## Issue ticket number and link

[A2-4462- BO linked appeals - Hide 'Change' CTA on 'Case officer' row which appears at top of 'Case details' on child appeal(s) (applies to all appeal types)](https://pins-ds.atlassian.net/browse/A2-4462)
