### PR TITLE
feat(appeals): update timetable on child appeals (a2-4425)

### DIFF
--- a/appeals/api/src/server/endpoints/appeal-timetables/appeal-timetables.service.js
+++ b/appeals/api/src/server/endpoints/appeal-timetables/appeal-timetables.service.js
@@ -267,9 +267,9 @@ const updateAppealTimetable = async (appeal, body, notifyClient, azureAdUserId) 
 	);
 
 	// @ts-ignore
-	const result = await appealTimetableRepository.updateAppealTimetableById(
+	const result = await appealTimetableRepository.updateAppealTimetableByAppealId(
 		// @ts-ignore
-		appeal.appealTimetable.id,
+		appeal.id,
 		// @ts-ignore
 		processedBody
 	);

--- a/appeals/api/src/server/repositories/appeal-timetable.repository.js
+++ b/appeals/api/src/server/repositories/appeal-timetable.repository.js
@@ -37,4 +37,19 @@ const updateAppealTimetableById = (id, data) =>
 		data
 	});
 
-export default { updateAppealTimetableById, upsertAppealTimetableById };
+/**
+ * @param {number} appealId
+ * @param {Timetable} data
+ * @returns {PrismaPromise<AppealTimetable>}
+ */
+const updateAppealTimetableByAppealId = (appealId, data) =>
+	databaseConnector.appealTimetable.update({
+		where: { appealId },
+		data
+	});
+
+export default {
+	updateAppealTimetableById,
+	upsertAppealTimetableById,
+	updateAppealTimetableByAppealId
+};


### PR DESCRIPTION
## Describe your changes
#### Update timetable on child appeals (a2-4425)

### API:
- Update the timetable on child appeals when updating the timetable of a lead appeal

### TEST:
- Added unit test for above
- Make sure unit tests pass

## Issue ticket number and link

[A2-4425- BO linked appeals - Changing due dates on the timetable on the lead appeal and it updates on the child appeal(s) (applies to all appeal types)](https://pins-ds.atlassian.net/browse/A2-4425)
