### PR TITLE
fix(web): removing locally stored erroring text (A2-4453)

### DIFF
--- a/appeals/web/src/server/appeals/appeal-details/appellant-case/advertisement-description/advertisement-description.controller.js
+++ b/appeals/web/src/server/appeals/appeal-details/appellant-case/advertisement-description/advertisement-description.controller.js
@@ -31,6 +31,9 @@ const renderChangeAdvertisementDescription = async (request, response) => {
 		appellantCaseData,
 		request.session.advertisementDescription
 	);
+
+	delete request.session.advertisementDescription;
+
 	return response.status(200).render('patterns/change-page.pattern.njk', {
 		pageContent: mappedPageContents,
 		errors

--- a/appeals/web/src/server/appeals/appeal-details/appellant-case/development-description/development-description.controller.js
+++ b/appeals/web/src/server/appeals/appeal-details/appellant-case/development-description/development-description.controller.js
@@ -31,6 +31,9 @@ const renderChangeDevelopmentDescription = async (request, response) => {
 		appellantCaseData,
 		request.session.developmentDescription
 	);
+
+	delete request.session.developmentDescription;
+
 	return response.status(200).render('patterns/change-page.pattern.njk', {
 		pageContent: mappedPageContents,
 		errors


### PR DESCRIPTION
## Describe your changes

- Removing the session information once the variable to be rendered has been assigned

## Testing

- Manually tested for the enter description of development and description of advertisement fields
- Manually tested to check that this was not observed in other text fields (probably not exhaustively)

## Issue ticket number and link

[Ticket](https://pins-ds.atlassian.net/browse/A2-4453)
