### PR TITLE
fix(appeals): fixed the expected number of days prepopulate bug

### DIFF
--- a/appeals/web/src/server/appeals/appeal-details/inquiry/setup/__tests__/__snapshots__/set-up-inquiry.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/inquiry/setup/__tests__/__snapshots__/set-up-inquiry.test.js.snap
@@ -288,56 +288,7 @@ exports[`set up inquiry GET /inquiry/setup/date should match the snapshot 1`] = 
 </main>"
 `;
 
-exports[`set up inquiry GET /inquiry/setup/estimation should match the snapshot 1`] = `
-"<main class="govuk-main-wrapper" id="main-content">
-    <div class="govuk-grid-row">
-        <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Appeal 351062 - set up inquiry</span>
-        </div>
-    </div>
-    <div class="govuk-grid-row">
-        <div class="govuk-grid-column-two-thirds">
-            <div class="govuk-grid-row">
-                <div class="govuk-grid-column-full">
-                    <form method="POST" novalidate="novalidate">
-                        <div class="govuk-form-group">
-                            <fieldset class="govuk-fieldset">
-                                <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
-                                    <h1 class="govuk-fieldset__heading"> Do you know the expected number of days to carry out the inquiry?</h1>
-                                </legend>
-                                <div class="govuk-radios" data-module="govuk-radios">
-                                    <div class="govuk-radios__item">
-                                        <input class="govuk-radios__input" id="inquiry-estimation-yes-no" name="inquiryEstimationYesNo"
-                                        type="radio" value="yes" data-aria-controls="conditional-inquiry-estimation-yes-no">
-                                        <label class="govuk-label govuk-radios__label" for="inquiry-estimation-yes-no">Yes</label>
-                                    </div>
-                                    <div class="govuk-radios__conditional govuk-radios__conditional--hidden"
-                                    id="conditional-inquiry-estimation-yes-no">
-                                        <div class="govuk-form-group">
-                                            <label class="govuk-label govuk-label--s" for="inquiry-estimation-days">Expected number of days to carry out the inquiry</label>
-                                            <div class="govuk-input__wrapper">
-                                                <input class="govuk-input govuk-input--width-3" id="inquiry-estimation-days"
-                                                name="inquiryEstimationDays" type="text">
-                                                <div class="govuk-input__suffix" aria-hidden="true">Days</div>
-                                            </div>
-                                        </div>
-                                    </div>
-                                    <div class="govuk-radios__item">
-                                        <input class="govuk-radios__input" id="inquiry-estimation-yes-no-2" name="inquiryEstimationYesNo"
-                                        type="radio" value="no">
-                                        <label class="govuk-label govuk-radios__label" for="inquiry-estimation-yes-no-2">No</label>
-                                    </div>
-                                </div>
-                            </fieldset>
-                        </div>
-                        <button type="submit" data-prevent-double-click="true" class="govuk-button"
-                        data-module="govuk-button">Continue</button>
-                    </form>
-                </div>
-            </div>
-        </div>
-    </div>
-</main>"
-`;
+exports[`set up inquiry GET /inquiry/setup/estimation should match the snapshot 1`] = `"<main class="govuk-main-wrapper" id="main-content"><div class="govuk-grid-row"><div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Appeal 351062 - set up inquiry</span></div></div><div class="govuk-grid-row"><div class="govuk-grid-column-two-thirds"><div class="govuk-grid-row"><div class="govuk-grid-column-full"><form method="POST" novalidate="novalidate"><div class="govuk-form-group"><fieldset class="govuk-fieldset"><legend class="govuk-fieldset__legend govuk-fieldset__legend--l"><h1 class="govuk-fieldset__heading"> Do you know the expected number of days to carry out the inquiry?</h1></legend><div class="govuk-radios" data-module="govuk-radios"><div class="govuk-radios__item"><input class="govuk-radios__input" id="inquiry-estimation-yes-no" name="inquiryEstimationYesNo" type="radio" value="yes" checked data-aria-controls="conditional-inquiry-estimation-yes-no"><label class="govuk-label govuk-radios__label" for="inquiry-estimation-yes-no"> Yes</label></div><div class="govuk-radios__conditional" id="conditional-inquiry-estimation-yes-no"><div class="govuk-form-group"><label class="govuk-label govuk-label--s" for="inquiry-estimation-days"> Expected number of days to carry out the inquiry</label><div class="govuk-input__wrapper"><input class="govuk-input govuk-input--width-3" id="inquiry-estimation-days" name="inquiryEstimationDays" type="text" value="8"><div class="govuk-input__suffix" aria-hidden="true">Days</div></div></div></div><div class="govuk-radios__item"><input class="govuk-radios__input" id="inquiry-estimation-yes-no-2" name="inquiryEstimationYesNo" type="radio" value="no"><label class="govuk-label govuk-radios__label" for="inquiry-estimation-yes-no-2"> No</label></div></div></fieldset></div><button type="submit" data-prevent-double-click="true" class="govuk-button" data-module="govuk-button"> Continue</button></form></div></div></div></div></main>"`;
 
 exports[`set up inquiry GET /inquiry/setup/timetable-due-dates should match the snapshot 1`] = `
 "<main class="govuk-main-wrapper" id="main-content">

--- a/appeals/web/src/server/appeals/appeal-details/inquiry/setup/__tests__/set-up-inquiry.test.js
+++ b/appeals/web/src/server/appeals/appeal-details/inquiry/setup/__tests__/set-up-inquiry.test.js
@@ -236,11 +236,12 @@ describe('set up inquiry', () => {
 
 			// set session data with post request
 			await request.post(`${baseUrl}/${appealId}/Inquiry/setup/estimation`).send({
-				inquiryEstimationYesNo: 'yes'
+				inquiryEstimationYesNo: 'yes',
+				inquiryEstimationDays: 8
 			});
 
 			const response = await request.get(`${baseUrl}/${appealId}/Inquiry/setup/estimation`);
-			pageHtml = parseHtml(response.text);
+			pageHtml = parseHtml(response.text, { skipPrettyPrint: true });
 		});
 
 		it('should match the snapshot', () => {
@@ -259,6 +260,15 @@ describe('set up inquiry', () => {
 
 		it('should render an input for inquiry estimation days', () => {
 			expect(pageHtml.querySelector('input[name="inquiryEstimationDays"]')).not.toBeNull();
+		});
+
+		it('should render correct values when session is set', () => {
+			expect(pageHtml.innerHTML).toContain(
+				`name="inquiryEstimationYesNo" type="radio" value="yes" checked`
+			);
+			expect(pageHtml.innerHTML).toContain(
+				`id="inquiry-estimation-days" name="inquiryEstimationDays" type="text" value="8"`
+			);
 		});
 	});
 

--- a/appeals/web/src/server/appeals/appeal-details/inquiry/setup/set-up-inquiry.controller.js
+++ b/appeals/web/src/server/appeals/appeal-details/inquiry/setup/set-up-inquiry.controller.js
@@ -188,7 +188,7 @@ export const postChangeInquiryDate = async (request, response) => {
  * @param {import('@pins/express/types/express.js').RenderedResponse<any, any, Number>} response
  */
 export const getInquiryEstimation = async (request, response) => {
-	return renderInquiryEstimation(request, response, 'setup');
+	return renderInquiryEstimation(request, response, 'setup', request.session.setUpInquiry || {});
 };
 
 /**


### PR DESCRIPTION
## Describe your changes


  When starting the case as inquiry user has to answer Yes or No to "do you know the estimated number of days" - when clicking back through the flow or clicking change on check your answers this value is not pre-populate.
  I have fixed the bug . when a user click back through the flow, the data is now prepopulated.


## Issue ticket number and link

https://pins-ds.atlassian.net/browse/A2-4146
