### PR TITLE
fix(api): fix appeal status rollback bug

### DIFF
--- a/appeals/api/src/server/endpoints/hearings/__tests__/hearing.test.js
+++ b/appeals/api/src/server/endpoints/hearings/__tests__/hearing.test.js
@@ -423,6 +423,7 @@ describe('hearing routes', () => {
 
 				expect(databaseConnector.appealStatus.deleteMany).toHaveBeenCalledWith({
 					where: {
+						appealId: fullPlanningAppeal.id,
 						createdAt: {
 							gt: new Date('2999-01-01T12:00:00.000Z')
 						}

--- a/appeals/api/src/server/repositories/appeal-status.repository.js
+++ b/appeals/api/src/server/repositories/appeal-status.repository.js
@@ -38,6 +38,7 @@ const rollBackAppealStatusTo = (appealId, status) =>
 
 		await tx.appealStatus.deleteMany({
 			where: {
+				appealId: prevStatus.appealId,
 				createdAt: {
 					gt: prevStatus.createdAt
 				}


### PR DESCRIPTION
## Describe your changes

When status needs to roll back to a previous value (as it does when a hearing address is removed for example) it was deleting statuses for all appeals instead of just the specific appeal. This was causing some appeals to have no status in production!

## Issue ticket number and link

[A2-4499](https://pins-ds.atlassian.net/browse/A2-4499)


[A2-4499]: https://pins-ds.atlassian.net/browse/A2-4499?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ