### PR TITLE
feat(web): adding who missed site visit page

### DIFF
--- a/appeals/web/src/server/appeals/appeal-details/__tests__/__snapshots__/appeal-details.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/__tests__/__snapshots__/appeal-details.test.js.snap
@@ -809,7 +809,7 @@ exports[`appeal-details GET /:appealId Linked appeals should not render action l
     </dl>
     <div id="site-visit-section">
         <h1 class="govuk-heading-l">Site</h1>
-        <p class="govuk-body"><a class="govuk-link" href="/appeals-service/1/site-visit/missed/index">Record missed site visit</a>
+        <p class="govuk-body"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/missed">Record missed site visit</a>
         </p>
         <dl class="govuk-summary-list">
             <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Date</dt>
@@ -1447,7 +1447,7 @@ exports[`appeal-details GET /:appealId Linked appeals should render a lead tag n
     </dl>
     <div id="site-visit-section">
         <h1 class="govuk-heading-l">Site</h1>
-        <p class="govuk-body"><a class="govuk-link" href="/appeals-service/1/site-visit/missed/index">Record missed site visit</a>
+        <p class="govuk-body"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/missed">Record missed site visit</a>
         </p>
         <dl class="govuk-summary-list">
             <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Date</dt>
@@ -1857,7 +1857,7 @@ exports[`appeal-details GET /:appealId Linked appeals should render an action li
     </dl>
     <div id="site-visit-section">
         <h1 class="govuk-heading-l">Site</h1>
-        <p class="govuk-body"><a class="govuk-link" href="/appeals-service/1/site-visit/missed/index">Record missed site visit</a>
+        <p class="govuk-body"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/missed">Record missed site visit</a>
         </p>
         <dl class="govuk-summary-list">
             <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Date</dt>
@@ -2273,7 +2273,7 @@ exports[`appeal-details GET /:appealId Linked appeals should render an action li
     </dl>
     <div id="site-visit-section">
         <h1 class="govuk-heading-l">Site</h1>
-        <p class="govuk-body"><a class="govuk-link" href="/appeals-service/1/site-visit/missed/index">Record missed site visit</a>
+        <p class="govuk-body"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/missed">Record missed site visit</a>
         </p>
         <dl class="govuk-summary-list">
             <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Date</dt>
@@ -2683,7 +2683,7 @@ exports[`appeal-details GET /:appealId Linked appeals should render the case ref
     </dl>
     <div id="site-visit-section">
         <h1 class="govuk-heading-l">Site</h1>
-        <p class="govuk-body"><a class="govuk-link" href="/appeals-service/1/site-visit/missed/index">Record missed site visit</a>
+        <p class="govuk-body"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/missed">Record missed site visit</a>
         </p>
         <dl class="govuk-summary-list">
             <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Date</dt>
@@ -3090,7 +3090,7 @@ exports[`appeal-details GET /:appealId Linked appeals should render the lead or 
     </dl>
     <div id="site-visit-section">
         <h1 class="govuk-heading-l">Site</h1>
-        <p class="govuk-body"><a class="govuk-link" href="/appeals-service/1/site-visit/missed/index">Record missed site visit</a>
+        <p class="govuk-body"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/missed">Record missed site visit</a>
         </p>
         <dl class="govuk-summary-list">
             <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Date</dt>
@@ -3511,7 +3511,7 @@ exports[`appeal-details GET /:appealId Linked appeals should render the received
     </dl>
     <div id="site-visit-section">
         <h1 class="govuk-heading-l">Site</h1>
-        <p class="govuk-body"><a class="govuk-link" href="/appeals-service/3/site-visit/missed/index">Record missed site visit</a>
+        <p class="govuk-body"><a class="govuk-link" href="/appeals-service/appeal-details/3/site-visit/missed">Record missed site visit</a>
         </p>
         <dl class="govuk-summary-list">
             <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Date</dt>
@@ -3905,7 +3905,7 @@ exports[`appeal-details GET /:appealId Linked appeals should render the received
     </dl>
     <div id="site-visit-section">
         <h1 class="govuk-heading-l">Site</h1>
-        <p class="govuk-body"><a class="govuk-link" href="/appeals-service/1/site-visit/missed/index">Record missed site visit</a>
+        <p class="govuk-body"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/missed">Record missed site visit</a>
         </p>
         <dl class="govuk-summary-list">
             <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Date</dt>
@@ -4316,7 +4316,7 @@ exports[`appeal-details GET /:appealId Linked appeals should render the received
     </dl>
     <div id="site-visit-section">
         <h1 class="govuk-heading-l">Site</h1>
-        <p class="govuk-body"><a class="govuk-link" href="/appeals-service/2/site-visit/missed/index">Record missed site visit</a>
+        <p class="govuk-body"><a class="govuk-link" href="/appeals-service/appeal-details/2/site-visit/missed">Record missed site visit</a>
         </p>
         <dl class="govuk-summary-list">
             <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Date</dt>
@@ -4836,7 +4836,7 @@ exports[`appeal-details GET /:appealId Notification banners Important banners sh
     </dl>
     <div id="site-visit-section">
         <h1 class="govuk-heading-l">Site</h1>
-        <p class="govuk-body"><a class="govuk-link" href="/appeals-service/1/site-visit/missed/index">Record missed site visit</a>
+        <p class="govuk-body"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/missed">Record missed site visit</a>
         </p>
         <dl class="govuk-summary-list">
             <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Date</dt>
@@ -5832,7 +5832,7 @@ exports[`appeal-details GET /:appealId should render a Decision inset panel when
     </dl>
     <div id="site-visit-section">
         <h1 class="govuk-heading-l">Site</h1>
-        <p class="govuk-body"><a class="govuk-link" href="/appeals-service/1/site-visit/missed/index">Record missed site visit</a>
+        <p class="govuk-body"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/missed">Record missed site visit</a>
         </p>
         <dl class="govuk-summary-list">
             <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Date</dt>
@@ -6233,7 +6233,7 @@ exports[`appeal-details GET /:appealId should render a Decision inset panel when
     </dl>
     <div id="site-visit-section">
         <h1 class="govuk-heading-l">Site</h1>
-        <p class="govuk-body"><a class="govuk-link" href="/appeals-service/1/site-visit/missed/index">Record missed site visit</a>
+        <p class="govuk-body"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/missed">Record missed site visit</a>
         </p>
         <dl class="govuk-summary-list">
             <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Date</dt>
@@ -6628,7 +6628,7 @@ exports[`appeal-details GET /:appealId should render a Decision inset panel when
     </dl>
     <div id="site-visit-section">
         <h1 class="govuk-heading-l">Site</h1>
-        <p class="govuk-body"><a class="govuk-link" href="/appeals-service/1/site-visit/missed/index">Record missed site visit</a>
+        <p class="govuk-body"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/missed">Record missed site visit</a>
         </p>
         <dl class="govuk-summary-list">
             <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Date</dt>
@@ -7036,7 +7036,7 @@ exports[`appeal-details GET /:appealId should render the appellant case status a
     </dl>
     <div id="site-visit-section">
         <h1 class="govuk-heading-l">Site</h1>
-        <p class="govuk-body"><a class="govuk-link" href="/appeals-service/1/site-visit/missed/index">Record missed site visit</a>
+        <p class="govuk-body"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/missed">Record missed site visit</a>
         </p>
         <dl class="govuk-summary-list">
             <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Date</dt>
@@ -7433,7 +7433,7 @@ exports[`appeal-details GET /:appealId should render the appellant case status a
     </dl>
     <div id="site-visit-section">
         <h1 class="govuk-heading-l">Site</h1>
-        <p class="govuk-body"><a class="govuk-link" href="/appeals-service/1/site-visit/missed/index">Record missed site visit</a>
+        <p class="govuk-body"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/missed">Record missed site visit</a>
         </p>
         <dl class="govuk-summary-list">
             <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Date</dt>
@@ -7855,7 +7855,7 @@ exports[`appeal-details GET /:appealId should render the received appeal details
     </dl>
     <div id="site-visit-section">
         <h1 class="govuk-heading-l">Site</h1>
-        <p class="govuk-body"><a class="govuk-link" href="/appeals-service/1/site-visit/missed/index">Record missed site visit</a>
+        <p class="govuk-body"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/missed">Record missed site visit</a>
         </p>
         <dl class="govuk-summary-list">
             <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Date</dt>
@@ -8302,7 +8302,7 @@ exports[`appeal-details should not render a back button 1`] = `
                 </dl>
                 <div id="site-visit-section">
                     <h1 class="govuk-heading-l">Site</h1>
-                    <p class="govuk-body"><a class="govuk-link" href="/appeals-service/2/site-visit/missed/index">Record missed site visit</a>
+                    <p class="govuk-body"><a class="govuk-link" href="/appeals-service/appeal-details/2/site-visit/missed">Record missed site visit</a>
                     </p>
                     <dl class="govuk-summary-list">
                         <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Date</dt>

--- a/appeals/web/src/server/appeals/appeal-details/appeal-details-page-sections/common/site-details.js
+++ b/appeals/web/src/server/appeals/appeal-details/appeal-details-page-sections/common/site-details.js
@@ -21,14 +21,14 @@ export const getSiteDetails = (mappedData, appealDetails) => {
 	const cancelSiteVisitLink = {
 		type: 'html',
 		parameters: {
-			html: `<p class="govuk-body"><a class="govuk-link" href="/appeals-service/${appealDetails.appealId}/site-visit/delete">Cancel site visit</a></p>`
+			html: `<p class="govuk-body"><a class="govuk-link" href="/appeals-service/appeal-details/${appealDetails.appealId}/site-visit/delete">Cancel site visit</a></p>`
 		}
 	};
 	/** @type {PageComponent} */
 	const recordMissedSiteVisitLink = {
 		type: 'html',
 		parameters: {
-			html: `<p class="govuk-body"><a class="govuk-link" href="/appeals-service/${appealDetails.appealId}/site-visit/missed/index" >Record missed site visit</a></p>`
+			html: `<p class="govuk-body"><a class="govuk-link" href="/appeals-service/appeal-details/${appealDetails.appealId}/site-visit/missed" >Record missed site visit</a></p>`
 		}
 	};
 

--- a/appeals/web/src/server/appeals/appeal-details/site-visit/__tests__/__snapshots__/site-visit.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/site-visit/__tests__/__snapshots__/site-visit.test.js.snap
@@ -132,6 +132,46 @@ exports[`site-visit GET /site-visit/manage-visit should render the manage visit 
 </main>"
 `;
 
+exports[`site-visit GET /site-visit/missed should render the who missed the site visit page 1`] = `
+"<main class="govuk-main-wrapper" id="main-content">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Appeal 351062 - record missed site visit</span>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
+            <form action="" method="POST" novalidate>
+                <div class="govuk-form-group">
+                    <fieldset class="govuk-fieldset">
+                        <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+                            <h1 class="govuk-fieldset__heading"> Who missed the site visit?</h1>
+                        </legend>
+                        <div class="govuk-radios" data-module="govuk-radios">
+                            <div class="govuk-radios__item">
+                                <input class="govuk-radios__input" id="who-missed-site-visit-radio" name="whoMissedSiteVisitRadio"
+                                type="radio" value="appellant">
+                                <label class="govuk-label govuk-radios__label" for="who-missed-site-visit-radio">Appellant</label>
+                            </div>
+                            <div class="govuk-radios__item">
+                                <input class="govuk-radios__input" id="who-missed-site-visit-radio-2"
+                                name="whoMissedSiteVisitRadio" type="radio" value="lpa">
+                                <label class="govuk-label govuk-radios__label" for="who-missed-site-visit-radio-2">LPA</label>
+                            </div>
+                            <div class="govuk-radios__item">
+                                <input class="govuk-radios__input" id="who-missed-site-visit-radio-3"
+                                name="whoMissedSiteVisitRadio" type="radio" value="inspector">
+                                <label class="govuk-label govuk-radios__label" for="who-missed-site-visit-radio-3">Inspector</label>
+                            </div>
+                        </div>
+                    </fieldset>
+                </div>
+                <button type="submit" class="govuk-button" data-module="govuk-button">Continue</button>
+            </form>
+        </div>
+    </div>
+</main>"
+`;
+
 exports[`site-visit GET /site-visit/schedule-visit should render the schedule visit page 1`] = `
 "<main class="govuk-main-wrapper" id="main-content">
     <div class="govuk-grid-row">
@@ -2296,6 +2336,63 @@ exports[`site-visit POST /site-visit/manage-visit should re-render the manage vi
             </div>
         </div>
     </div>
+    </div>
+</main>"
+`;
+
+exports[`site-visit POST /site-visit/missed should re-render the who missed the site visit page with the expected error messages if required field is not populated 1`] = `
+"<main class="govuk-main-wrapper" id="main-content">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <div class="govuk-error-summary" data-module="govuk-error-summary">
+                <div role="alert">
+                    <h2 class="govuk-error-summary__title"> There is a problem</h2>
+                    <div class="govuk-error-summary__body">
+                        <ul class="govuk-list govuk-error-summary__list">
+                            <li><a href="#who-missed-site-visit-radio">Select who missed the site visit</a>
+                            </li>
+                        </ul>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Appeal 351062 - record missed site visit</span>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
+            <form action="" method="POST" novalidate>
+                <div class="govuk-form-group govuk-form-group--error">
+                    <fieldset class="govuk-fieldset" aria-describedby="who-missed-site-visit-radio-error">
+                        <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+                            <h1 class="govuk-fieldset__heading"> Who missed the site visit?</h1>
+                        </legend>
+                        <p id="who-missed-site-visit-radio-error" class="govuk-error-message"><span class="govuk-visually-hidden">Error:</span> Select who missed the
+                            site visit</p>
+                        <div class="govuk-radios" data-module="govuk-radios">
+                            <div class="govuk-radios__item">
+                                <input class="govuk-radios__input" id="who-missed-site-visit-radio" name="whoMissedSiteVisitRadio"
+                                type="radio" value="appellant">
+                                <label class="govuk-label govuk-radios__label" for="who-missed-site-visit-radio">Appellant</label>
+                            </div>
+                            <div class="govuk-radios__item">
+                                <input class="govuk-radios__input" id="who-missed-site-visit-radio-2"
+                                name="whoMissedSiteVisitRadio" type="radio" value="lpa">
+                                <label class="govuk-label govuk-radios__label" for="who-missed-site-visit-radio-2">LPA</label>
+                            </div>
+                            <div class="govuk-radios__item">
+                                <input class="govuk-radios__input" id="who-missed-site-visit-radio-3"
+                                name="whoMissedSiteVisitRadio" type="radio" value="inspector">
+                                <label class="govuk-label govuk-radios__label" for="who-missed-site-visit-radio-3">Inspector</label>
+                            </div>
+                        </div>
+                    </fieldset>
+                </div>
+                <button type="submit" class="govuk-button" data-module="govuk-button">Continue</button>
+            </form>
+        </div>
     </div>
 </main>"
 `;

--- a/appeals/web/src/server/appeals/appeal-details/site-visit/site-visit.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/site-visit/site-visit.mapper.js
@@ -559,3 +559,51 @@ export function setPreviousVisitTypeIfChanged(updateOrCreateSiteVisitParameters,
 		updateOrCreateSiteVisitParameters.previousVisitType = oldApiVisitType;
 	}
 }
+
+/**
+ * @param {string} appealId
+ * @param {string} appealReference
+ * @param {string|undefined} errorMessage
+ * @returns {PageContent}
+ */
+export function siteVisitMissedPage(appealId, appealReference, errorMessage) {
+	return {
+		title: 'Who missed the site visit?',
+		backLinkUrl: `/appeals-service/appeal-details/${appealId}`,
+		preHeading: `Appeal ${appealShortReference(appealReference)} - record missed site visit`,
+		pageComponents: [
+			{
+				type: 'radios',
+				parameters: {
+					name: 'whoMissedSiteVisitRadio',
+					idPrefix: 'who-missed-site-visit-radio',
+					fieldset: {
+						legend: {
+							text: 'Who missed the site visit?',
+							isPageHeading: true,
+							classes: 'govuk-fieldset__legend--l'
+						}
+					},
+					items: [
+						{
+							value: 'appellant',
+							text: 'Appellant'
+							// checked: planningObligationStatus === 'appellant'
+						},
+						{
+							value: 'lpa',
+							text: 'LPA'
+							// checked: planningObligationStatus === 'lpa'
+						},
+						{
+							value: 'inspector',
+							text: 'Inspector'
+							// checked: planningObligationStatus === 'inspector'
+						}
+					],
+					errorMessage: errorMessage && { text: errorMessage }
+				}
+			}
+		]
+	};
+}

--- a/appeals/web/src/server/appeals/appeal-details/site-visit/site-visit.router.js
+++ b/appeals/web/src/server/appeals/appeal-details/site-visit/site-visit.router.js
@@ -58,4 +58,16 @@ router
 
 router.route('/visit-booked').get(asyncHandler(controller.getSiteVisitBooked));
 
+router
+	.route('/missed')
+	.get(
+		assertUserHasPermission(permissionNames.setEvents),
+		asyncHandler(controller.getSiteVisitMissed)
+	)
+	.post(
+		assertUserHasPermission(permissionNames.setEvents),
+		validators.validateWhoMissedSiteVisit,
+		asyncHandler(controller.postSiteVisitMissed)
+	);
+
 export default router;

--- a/appeals/web/src/server/appeals/appeal-details/site-visit/site-visit.validators.js
+++ b/appeals/web/src/server/appeals/appeal-details/site-visit/site-visit.validators.js
@@ -54,3 +54,12 @@ export const validateVisitStartTimeBeforeEndTime = createStartTimeBeforeEndTimeV
 		);
 	}
 );
+
+export const validateWhoMissedSiteVisit = createValidator(
+	body('whoMissedSiteVisitRadio')
+		.exists()
+		.withMessage('Select who missed the site visit')
+		.bail()
+		.notEmpty()
+		.withMessage('Select who missed the site visit')
+);

--- a/appeals/web/src/server/appeals/appeal-details/start-case/hearing/__tests__/__snapshots__/start-case-hearing.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/start-case/hearing/__tests__/__snapshots__/start-case-hearing.test.js.snap
@@ -406,7 +406,7 @@ exports[`start case hearing flow POST /start-case/hearing/confirm should redirec
     </dl>
     <div id="site-visit-section">
         <h1 class="govuk-heading-l">Site</h1>
-        <p class="govuk-body"><a class="govuk-link" href="/appeals-service/1/site-visit/missed/index">Record missed site visit</a>
+        <p class="govuk-body"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/missed">Record missed site visit</a>
         </p>
         <dl class="govuk-summary-list">
             <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Date</dt>


### PR DESCRIPTION
## Describe your changes

### WEB
- Adding the who missed site visit page with radio button options
- Ensured error message displays on post
- Successful post redirects to CYA page and saves answer to session

### TEST
- Added unit tests for every possible answer for POST
- Unit test to check content 
- Added validator to check POST input - empty and existence

<!--
    Please include a summary of the change along with any relevant context.
    List any dependencies that are required for this change.
-->

## Issue ticket number and link

[Ticket](https://pins-ds.atlassian.net.mcas.ms/browse/A2-4231)
