### PR TITLE
fix(appeals): remove key from appeal status in child appeal (a2-4492)

### DIFF
--- a/appeals/api/src/server/endpoints/appeals/__tests__/appeals.test.js
+++ b/appeals/api/src/server/endpoints/appeals/__tests__/appeals.test.js
@@ -1824,7 +1824,13 @@ describe('updateCompletedEvents', () => {
 	test('updates completed events', async () => {
 		const siteVisit = structuredClone({ ...householdAppeal.siteVisit, appealId: appealS78.id });
 		const appealStatus = [{ status: 'awaiting_event', valid: true }];
-		const childAppeals = [{ childId: 100, type: CASE_RELATIONSHIP_LINKED }];
+		const childAppeals = [
+			{
+				childId: 100,
+				type: CASE_RELATIONSHIP_LINKED,
+				child: { appealStatus }
+			}
+		];
 		const linkedLeadAppeal = structuredClone({
 			...appealS78,
 			siteVisit,
@@ -1850,7 +1856,7 @@ describe('updateCompletedEvents', () => {
 
 		expect(databaseConnector.auditTrail.create).toHaveBeenNthCalledWith(1, {
 			data: {
-				appealId: linkedLeadAppeal.id,
+				appealId: childAppeals[0].childId,
 				details: stringTokenReplacement(AUDIT_TRAIL_PROGRESSED_TO_STATUS, ['issue_determination']),
 				loggedAt: expect.any(Date),
 				userId: linkedLeadAppeal.caseOfficer.id
@@ -1859,7 +1865,7 @@ describe('updateCompletedEvents', () => {
 
 		expect(databaseConnector.auditTrail.create).toHaveBeenNthCalledWith(2, {
 			data: {
-				appealId: childAppeals[0].childId,
+				appealId: linkedLeadAppeal.id,
 				details: stringTokenReplacement(AUDIT_TRAIL_PROGRESSED_TO_STATUS, ['issue_determination']),
 				loggedAt: expect.any(Date),
 				userId: linkedLeadAppeal.caseOfficer.id

--- a/appeals/api/src/server/endpoints/appeals/appeals.service.js
+++ b/appeals/api/src/server/endpoints/appeals/appeals.service.js
@@ -190,12 +190,11 @@ async function updateCompletedEvents(azureAdUserId) {
 
 	await Promise.all(
 		appealsToUpdate.map(async (appeal) => {
-			await transitionState(appeal.id, azureAdUserId, VALIDATION_OUTCOME_COMPLETE);
-
 			if (isFeatureActive(FEATURE_FLAG_NAMES.LINKED_APPEALS)) {
 				// @ts-ignore
 				await transitionLinkedChildAppealsState(appeal, azureAdUserId, VALIDATION_OUTCOME_COMPLETE);
 			}
+			await transitionState(appeal.id, azureAdUserId, VALIDATION_OUTCOME_COMPLETE);
 		})
 	);
 

--- a/appeals/api/src/server/endpoints/representations/__tests__/representations.test.js
+++ b/appeals/api/src/server/endpoints/representations/__tests__/representations.test.js
@@ -1300,9 +1300,21 @@ describe('/appeals/:id/reps', () => {
 				};
 
 				const childAppeals = [
-					{ type: CASE_RELATIONSHIP_LINKED, childId: 100 },
-					{ type: CASE_RELATIONSHIP_RELATED, childId: 200 },
-					{ type: CASE_RELATIONSHIP_LINKED, childId: 300 }
+					{
+						type: CASE_RELATIONSHIP_LINKED,
+						childId: 100,
+						child: { appealStatus: mockS78Appeal.appealStatus }
+					},
+					{
+						type: CASE_RELATIONSHIP_RELATED,
+						childId: 200,
+						child: { appealStatus: mockS78Appeal.appealStatus }
+					},
+					{
+						type: CASE_RELATIONSHIP_LINKED,
+						childId: 300,
+						child: { appealStatus: mockS78Appeal.appealStatus }
+					}
 				];
 
 				databaseConnector.appeal.findUnique.mockResolvedValue({
@@ -1365,7 +1377,7 @@ describe('/appeals/:id/reps', () => {
 
 				expect(databaseConnector.auditTrail.create).toHaveBeenNthCalledWith(1, {
 					data: {
-						appealId: mockS78Appeal.id,
+						appealId: childAppeals[0].childId,
 						details: 'Case progressed to final_comments',
 						loggedAt: expect.any(Date),
 						userId: 1
@@ -1374,7 +1386,7 @@ describe('/appeals/:id/reps', () => {
 
 				expect(databaseConnector.auditTrail.create).toHaveBeenNthCalledWith(2, {
 					data: {
-						appealId: childAppeals[0].childId,
+						appealId: childAppeals[2].childId,
 						details: 'Case progressed to final_comments',
 						loggedAt: expect.any(Date),
 						userId: 1
@@ -1383,7 +1395,7 @@ describe('/appeals/:id/reps', () => {
 
 				expect(databaseConnector.auditTrail.create).toHaveBeenNthCalledWith(3, {
 					data: {
-						appealId: childAppeals[2].childId,
+						appealId: mockS78Appeal.id,
 						details: 'Case progressed to final_comments',
 						loggedAt: expect.any(Date),
 						userId: 1
@@ -2182,9 +2194,21 @@ describe('/appeals/:id/reps', () => {
 				};
 
 				const childAppeals = [
-					{ type: CASE_RELATIONSHIP_LINKED, childId: 100 },
-					{ type: CASE_RELATIONSHIP_RELATED, childId: 200 },
-					{ type: CASE_RELATIONSHIP_LINKED, childId: 300 }
+					{
+						type: CASE_RELATIONSHIP_LINKED,
+						childId: 100,
+						child: { appealStatus: mockS78Appeal.appealStatus }
+					},
+					{
+						type: CASE_RELATIONSHIP_RELATED,
+						childId: 200,
+						child: { appealStatus: mockS78Appeal.appealStatus }
+					},
+					{
+						type: CASE_RELATIONSHIP_LINKED,
+						childId: 300,
+						child: { appealStatus: mockS78Appeal.appealStatus }
+					}
 				];
 
 				databaseConnector.appeal.findUnique.mockResolvedValue({
@@ -2240,7 +2264,7 @@ describe('/appeals/:id/reps', () => {
 
 				expect(databaseConnector.auditTrail.create).toHaveBeenNthCalledWith(1, {
 					data: {
-						appealId: mockS78Appeal.id,
+						appealId: childAppeals[0].childId,
 						details: 'Case progressed to event',
 						loggedAt: expect.any(Date),
 						userId: 1
@@ -2249,7 +2273,7 @@ describe('/appeals/:id/reps', () => {
 
 				expect(databaseConnector.auditTrail.create).toHaveBeenNthCalledWith(2, {
 					data: {
-						appealId: childAppeals[0].childId,
+						appealId: childAppeals[2].childId,
 						details: 'Case progressed to event',
 						loggedAt: expect.any(Date),
 						userId: 1
@@ -2258,7 +2282,7 @@ describe('/appeals/:id/reps', () => {
 
 				expect(databaseConnector.auditTrail.create).toHaveBeenNthCalledWith(3, {
 					data: {
-						appealId: childAppeals[2].childId,
+						appealId: mockS78Appeal.id,
 						details: 'Case progressed to event',
 						loggedAt: expect.any(Date),
 						userId: 1

--- a/appeals/api/src/server/endpoints/representations/representations.service.js
+++ b/appeals/api/src/server/endpoints/representations/representations.service.js
@@ -320,11 +320,10 @@ export async function publishLpaStatements(appeal, azureAdUserId, notifyClient) 
 		}
 	);
 
-	await transitionState(appeal.id, azureAdUserId, VALIDATION_OUTCOME_COMPLETE);
-
 	if (isFeatureActive(FEATURE_FLAG_NAMES.LINKED_APPEALS)) {
 		await transitionLinkedChildAppealsState(appeal, azureAdUserId, VALIDATION_OUTCOME_COMPLETE);
 	}
+	await transitionState(appeal.id, azureAdUserId, VALIDATION_OUTCOME_COMPLETE);
 
 	const finalCommentsDueDate = formatDate(
 		new Date(appeal.appealTimetable?.finalCommentsDueDate || ''),
@@ -419,11 +418,10 @@ export async function publishFinalComments(appeal, azureAdUserId, notifyClient) 
 		}
 	);
 
-	await transitionState(appeal.id, azureAdUserId, VALIDATION_OUTCOME_COMPLETE);
-
 	if (isFeatureActive(FEATURE_FLAG_NAMES.LINKED_APPEALS)) {
 		await transitionLinkedChildAppealsState(appeal, azureAdUserId, VALIDATION_OUTCOME_COMPLETE);
 	}
+	await transitionState(appeal.id, azureAdUserId, VALIDATION_OUTCOME_COMPLETE);
 
 	try {
 		const hasLpaFinalComment = result.some(

--- a/appeals/api/src/server/endpoints/site-visits/__tests__/site-visits.test.js
+++ b/appeals/api/src/server/endpoints/site-visits/__tests__/site-visits.test.js
@@ -256,7 +256,13 @@ describe('site visit routes', () => {
 			test('creates a site visit for linked appeals', async () => {
 				const siteVisit = structuredClone({ ...householdAppeal.siteVisit, appealId: appealS78.id });
 				const appealStatus = [{ status: 'event', valid: true }];
-				const childAppeals = [{ childId: 100, type: CASE_RELATIONSHIP_LINKED }];
+				const childAppeals = [
+					{
+						childId: 100,
+						type: CASE_RELATIONSHIP_LINKED,
+						child: { appealStatus }
+					}
+				];
 				const linkedLeadAppeal = structuredClone({
 					...appealS78,
 					siteVisit,
@@ -306,7 +312,7 @@ describe('site visit routes', () => {
 				});
 				expect(databaseConnector.auditTrail.create).toHaveBeenNthCalledWith(2, {
 					data: {
-						appealId: linkedLeadAppeal.id,
+						appealId: childAppeals[0].childId,
 						details: stringTokenReplacement(AUDIT_TRAIL_PROGRESSED_TO_STATUS, ['awaiting_event']),
 						loggedAt: expect.any(Date),
 						userId: linkedLeadAppeal.caseOfficer.id
@@ -314,7 +320,7 @@ describe('site visit routes', () => {
 				});
 				expect(databaseConnector.auditTrail.create).toHaveBeenNthCalledWith(3, {
 					data: {
-						appealId: childAppeals[0].childId,
+						appealId: linkedLeadAppeal.id,
 						details: stringTokenReplacement(AUDIT_TRAIL_PROGRESSED_TO_STATUS, ['awaiting_event']),
 						loggedAt: expect.any(Date),
 						userId: linkedLeadAppeal.caseOfficer.id

--- a/appeals/api/src/server/endpoints/site-visits/site-visits.controller.js
+++ b/appeals/api/src/server/endpoints/site-visits/site-visits.controller.js
@@ -79,11 +79,10 @@ const postSiteVisit = async (req, res) => {
 	}
 
 	if (arrayOfStatusesContainsString(appeal.appealStatus, APPEAL_CASE_STATUS.EVENT)) {
-		await transitionState(appealId, azureAdUserId, VALIDATION_OUTCOME_COMPLETE);
-
 		if (isFeatureActive(FEATURE_FLAG_NAMES.LINKED_APPEALS)) {
 			await transitionLinkedChildAppealsState(appeal, azureAdUserId, VALIDATION_OUTCOME_COMPLETE);
 		}
+		await transitionState(appeal.id, azureAdUserId, VALIDATION_OUTCOME_COMPLETE);
 	}
 
 	return res.status(201).send({

--- a/appeals/api/src/server/mappers/api/shared/map-appeal-relationships.js
+++ b/appeals/api/src/server/mappers/api/shared/map-appeal-relationships.js
@@ -110,7 +110,7 @@ const mapLinkedAppeal = (relationship, isParentAppeal) => {
 		appealReference,
 		externalSource: externalSource === true,
 		linkingDate: linkingDate.toISOString(),
-		appealType: `${appealType?.type} (${appealType?.key})`,
+		appealType: appealType?.type,
 		externalAppealType,
 		externalId,
 		isParentAppeal,

--- a/appeals/api/src/server/state/transition-state.js
+++ b/appeals/api/src/server/state/transition-state.js
@@ -105,7 +105,12 @@ async function transitionLinkedChildAppealsState(appeal, azureAdUserId, trigger)
 	if (appeal.childAppeals?.length) {
 		await Promise.all(
 			appeal.childAppeals
-				.filter((childAppeal) => childAppeal.type === CASE_RELATIONSHIP_LINKED)
+				.filter(
+					(childAppeal) =>
+						childAppeal.type === CASE_RELATIONSHIP_LINKED &&
+						childAppeal.child &&
+						currentStatus(childAppeal.child) === currentStatus(appeal)
+				)
 				.map((childAppeal) =>
 					// @ts-ignore
 					transitionState(childAppeal.childId, azureAdUserId, trigger)


### PR DESCRIPTION
## Describe your changes
#### Remove key from appeal status in child appeal (a2-4492)
##### Also fixed an issue where differing appeal types have transitions with different statuses

### API:
- Remove the key from the child appeal status when mapping appeal relationships
- Make sure child appeals only transition when they have the same appeal status as the lead
- Transition children first so above check can be done

### TEST:
- Fixed unit tests for above
- Make sure all unit tests pass

## Issue ticket number and link

[A2-4492- Child appeal type showing incorrectly on issuing decision](https://pins-ds.atlassian.net/browse/A2-4492)
