### PR TITLE
feat(web): using team emails for notify (A2-4396)

### DIFF
--- a/appeals/api/src/server/endpoints/Inquiry/__tests__/inquiry.test.js
+++ b/appeals/api/src/server/endpoints/Inquiry/__tests__/inquiry.test.js
@@ -112,7 +112,8 @@ describe('inquiry routes', () => {
 					inquiry_date: '1 January 2999',
 					inquiry_time: '1:00pm',
 					inquiry_address:
-						'Court 2, 24 Court Street, Test Town, Test County, AB12 3CD, United Kingdom'
+						'Court 2, 24 Court Street, Test Town, Test County, AB12 3CD, United Kingdom',
+					team_email_address: 'caseofficers@planninginspectorate.gov.uk'
 				};
 
 				expect(mockNotifySend).toHaveBeenCalledTimes(2);

--- a/appeals/api/src/server/endpoints/Inquiry/inquiry.service.js
+++ b/appeals/api/src/server/endpoints/Inquiry/inquiry.service.js
@@ -1,4 +1,5 @@
 import { formatAddressSingleLine } from '#endpoints/addresses/addresses.formatter.js';
+import { getTeamEmailFromAppealId } from '#endpoints/case-team/case-team.service.js';
 import { broadcasters } from '#endpoints/integrations/integrations.broadcasters.js';
 import { notifySend } from '#notify/notify-send.js';
 import inquiryRepository from '#repositories/inquiry.repository.js';
@@ -49,7 +50,8 @@ const sendInquiryDetailsNotifications = async (
 		inquiry_time: formatTime12h(
 			typeof inquiryStartTime === 'string' ? new Date(inquiryStartTime) : inquiryStartTime
 		),
-		inquiry_address: formatAddressSingleLine({ ...address, id: 0 })
+		inquiry_address: formatAddressSingleLine({ ...address, id: 0 }),
+		team_email_address: await getTeamEmailFromAppealId(appeal.id)
 	};
 	await sendInquiryNotifications(notifyClient, templateName, appeal, personalisation);
 };

--- a/appeals/api/src/server/endpoints/appeal-timetables/__tests__/appeal-timetables.test.js
+++ b/appeals/api/src/server/endpoints/appeal-timetables/__tests__/appeal-timetables.test.js
@@ -176,7 +176,8 @@ describe('appeal timetables routes', () => {
 							),
 							lpa_reference: appealWithTimetable.applicationReference,
 							lpa_statement_due_date: dateISOStringToDisplayDate(responseBody?.lpaStatementDueDate),
-							site_address: `${appealWithTimetable.address.addressLine1}, ${appealWithTimetable.address.addressLine2}, ${appealWithTimetable.address.addressTown}, ${appealWithTimetable.address.addressCounty}, ${appealWithTimetable.address.postcode}, ${appealWithTimetable.address.addressCountry}`
+							site_address: `${appealWithTimetable.address.addressLine1}, ${appealWithTimetable.address.addressLine2}, ${appealWithTimetable.address.addressTown}, ${appealWithTimetable.address.addressCounty}, ${appealWithTimetable.address.postcode}, ${appealWithTimetable.address.addressCountry}`,
+							team_email_address: 'caseofficers@planninginspectorate.gov.uk'
 						},
 						recipientEmail: appealWithTimetable.agent.email,
 						templateName: 'has-appeal-timetable-updated'
@@ -196,7 +197,8 @@ describe('appeal timetables routes', () => {
 							),
 							lpa_reference: appealWithTimetable.applicationReference,
 							lpa_statement_due_date: dateISOStringToDisplayDate(responseBody?.lpaStatementDueDate),
-							site_address: `${appealWithTimetable.address.addressLine1}, ${appealWithTimetable.address.addressLine2}, ${appealWithTimetable.address.addressTown}, ${appealWithTimetable.address.addressCounty}, ${appealWithTimetable.address.postcode}, ${appealWithTimetable.address.addressCountry}`
+							site_address: `${appealWithTimetable.address.addressLine1}, ${appealWithTimetable.address.addressLine2}, ${appealWithTimetable.address.addressTown}, ${appealWithTimetable.address.addressCounty}, ${appealWithTimetable.address.postcode}, ${appealWithTimetable.address.addressCountry}`,
+							team_email_address: 'caseofficers@planninginspectorate.gov.uk'
 						},
 						recipientEmail: appealWithTimetable.lpa.email,
 						templateName: 'has-appeal-timetable-updated'
@@ -258,7 +260,8 @@ describe('appeal timetables routes', () => {
 							),
 							lpa_reference: appealWithTimetable.applicationReference,
 							lpa_statement_due_date: dateISOStringToDisplayDate(responseBody?.lpaStatementDueDate),
-							site_address: `${appealWithTimetable.address.addressLine1}, ${appealWithTimetable.address.addressLine2}, ${appealWithTimetable.address.addressTown}, ${appealWithTimetable.address.addressCounty}, ${appealWithTimetable.address.postcode}, ${appealWithTimetable.address.addressCountry}`
+							site_address: `${appealWithTimetable.address.addressLine1}, ${appealWithTimetable.address.addressLine2}, ${appealWithTimetable.address.addressTown}, ${appealWithTimetable.address.addressCounty}, ${appealWithTimetable.address.postcode}, ${appealWithTimetable.address.addressCountry}`,
+							team_email_address: 'caseofficers@planninginspectorate.gov.uk'
 						},
 						recipientEmail: appealWithTimetable.agent.email,
 						templateName: 'appeal-timetable-updated'
@@ -278,7 +281,8 @@ describe('appeal timetables routes', () => {
 							),
 							lpa_reference: appealWithTimetable.applicationReference,
 							lpa_statement_due_date: dateISOStringToDisplayDate(responseBody?.lpaStatementDueDate),
-							site_address: `${appealWithTimetable.address.addressLine1}, ${appealWithTimetable.address.addressLine2}, ${appealWithTimetable.address.addressTown}, ${appealWithTimetable.address.addressCounty}, ${appealWithTimetable.address.postcode}, ${appealWithTimetable.address.addressCountry}`
+							site_address: `${appealWithTimetable.address.addressLine1}, ${appealWithTimetable.address.addressLine2}, ${appealWithTimetable.address.addressTown}, ${appealWithTimetable.address.addressCounty}, ${appealWithTimetable.address.postcode}, ${appealWithTimetable.address.addressCountry}`,
+							team_email_address: 'caseofficers@planninginspectorate.gov.uk'
 						},
 						recipientEmail: appealWithTimetable.lpa.email,
 						templateName: 'appeal-timetable-updated'
@@ -691,7 +695,8 @@ describe('appeal timetables routes', () => {
 									'when you can view information from other parties in the appeals service.',
 								site_visit: true,
 								costs_info: true,
-								statement_of_common_ground_due_date: ''
+								statement_of_common_ground_due_date: '',
+								team_email_address: 'caseofficers@planninginspectorate.gov.uk'
 							},
 							recipientEmail: appeal.appellant.email,
 							templateName: 'appeal-start-date-change-appellant'
@@ -723,7 +728,8 @@ describe('appeal timetables routes', () => {
 								site_address: `${appeal.address.addressLine1}, ${appeal.address.addressLine2}, ${appeal.address.addressTown}, ${appeal.address.addressCounty}, ${appeal.address.postcode}, ${appeal.address.addressCountry}`,
 								start_date: '5 June 2024',
 								statement_of_common_ground_due_date: '',
-								...additionalPersonalisation
+								...additionalPersonalisation,
+								team_email_address: 'caseofficers@planninginspectorate.gov.uk'
 							},
 							recipientEmail: appeal.lpa.email,
 							templateName: 'appeal-start-date-change-lpa'
@@ -780,7 +786,8 @@ describe('appeal timetables routes', () => {
 									'when you can view information from other parties in the appeals service.',
 								site_visit: true,
 								costs_info: true,
-								statement_of_common_ground_due_date: ''
+								statement_of_common_ground_due_date: '',
+								team_email_address: 'caseofficers@planninginspectorate.gov.uk'
 							},
 							recipientEmail: appeal.appellant.email,
 							templateName: 'appeal-start-date-change-appellant'
@@ -812,7 +819,8 @@ describe('appeal timetables routes', () => {
 								site_address: `${appeal.address.addressLine1}, ${appeal.address.addressLine2}, ${appeal.address.addressTown}, ${appeal.address.addressCounty}, ${appeal.address.postcode}, ${appeal.address.addressCountry}`,
 								start_date: '5 June 2024',
 								statement_of_common_ground_due_date: '',
-								...additionalPersonalisation
+								...additionalPersonalisation,
+								team_email_address: 'caseofficers@planninginspectorate.gov.uk'
 							},
 							recipientEmail: appeal.lpa.email,
 							templateName: 'appeal-start-date-change-lpa'
@@ -914,7 +922,8 @@ describe('appeal timetables routes', () => {
 								'when you can view information from other parties in the appeals service.',
 							site_visit: true,
 							costs_info: true,
-							statement_of_common_ground_due_date: ''
+							statement_of_common_ground_due_date: '',
+							team_email_address: 'caseofficers@planninginspectorate.gov.uk'
 						},
 						recipientEmail: appeal.appellant.email,
 						templateName: 'appeal-start-date-change-appellant'
@@ -946,7 +955,8 @@ describe('appeal timetables routes', () => {
 							site_address: `${appeal.address.addressLine1}, ${appeal.address.addressLine2}, ${appeal.address.addressTown}, ${appeal.address.addressCounty}, ${appeal.address.postcode}, ${appeal.address.addressCountry}`,
 							start_date: '3 June 2024', // the following working day
 							statement_of_common_ground_due_date: '',
-							...additionalPersonalisation
+							...additionalPersonalisation,
+							team_email_address: 'caseofficers@planninginspectorate.gov.uk'
 						},
 						recipientEmail: appeal.lpa.email,
 						templateName: 'appeal-start-date-change-lpa'
@@ -1000,7 +1010,8 @@ describe('appeal timetables routes', () => {
 							'when you can view information from other parties in the appeals service.',
 						site_visit: true,
 						costs_info: true,
-						statement_of_common_ground_due_date: ''
+						statement_of_common_ground_due_date: '',
+						team_email_address: 'caseofficers@planninginspectorate.gov.uk'
 					},
 					recipientEmail: appeal.appellant.email,
 					templateName: 'appeal-valid-start-case-appellant'
@@ -1025,7 +1036,8 @@ describe('appeal timetables routes', () => {
 						questionnaire_due_date: '12 June 2024',
 						site_address: `${appeal.address.addressLine1}, ${appeal.address.addressLine2}, ${appeal.address.addressTown}, ${appeal.address.addressCounty}, ${appeal.address.postcode}, ${appeal.address.addressCountry}`,
 						start_date: '5 June 2024',
-						statement_of_common_ground_due_date: ''
+						statement_of_common_ground_due_date: '',
+						team_email_address: 'caseofficers@planninginspectorate.gov.uk'
 					},
 					recipientEmail: appeal.lpa.email,
 					templateName: 'appeal-valid-start-case-lpa'
@@ -1120,7 +1132,8 @@ describe('appeal timetables routes', () => {
 							],
 							site_visit: false,
 							costs_info: false,
-							statement_of_common_ground_due_date: '10 July 2024'
+							statement_of_common_ground_due_date: '10 July 2024',
+							team_email_address: 'caseofficers@planninginspectorate.gov.uk'
 						},
 						recipientEmail: appeal.appellant.email,
 						templateName: 'appeal-valid-start-case-s78-appellant'
@@ -1146,7 +1159,8 @@ describe('appeal timetables routes', () => {
 							site_address: `${appeal.address.addressLine1}, ${appeal.address.addressLine2}, ${appeal.address.addressTown}, ${appeal.address.addressCounty}, ${appeal.address.postcode}, ${appeal.address.addressCountry}`,
 							start_date: '5 June 2024',
 							...personalisation,
-							statement_of_common_ground_due_date: '10 July 2024'
+							statement_of_common_ground_due_date: '10 July 2024',
+							team_email_address: 'caseofficers@planninginspectorate.gov.uk'
 						},
 						recipientEmail: appeal.lpa.email,
 						templateName: 'appeal-valid-start-case-s78-lpa'
@@ -1260,7 +1274,8 @@ describe('appeal timetables routes', () => {
 							costs_info: false,
 							statement_of_common_ground_due_date: '10 July 2024',
 							hearing_date: '10 Jul 2024',
-							hearing_time: '14:45'
+							hearing_time: '14:45',
+							team_email_address: 'caseofficers@planninginspectorate.gov.uk'
 						},
 						recipientEmail: appeal.appellant.email,
 						templateName: 'appeal-valid-start-case-s78-appellant-hearing'
@@ -1288,7 +1303,8 @@ describe('appeal timetables routes', () => {
 							statement_of_common_ground_due_date: '10 July 2024',
 							hearing_date: '10 Jul 2024',
 							hearing_time: '14:45',
-							...personalisation
+							...personalisation,
+							team_email_address: 'caseofficers@planninginspectorate.gov.uk'
 						},
 						recipientEmail: appeal.lpa.email,
 						templateName: 'appeal-valid-start-case-s78-lpa-hearing'
@@ -1376,7 +1392,8 @@ describe('appeal timetables routes', () => {
 							],
 							site_visit: false,
 							costs_info: false,
-							statement_of_common_ground_due_date: '10 July 2024'
+							statement_of_common_ground_due_date: '10 July 2024',
+							team_email_address: 'caseofficers@planninginspectorate.gov.uk'
 						},
 						recipientEmail: appeal.appellant.email,
 						templateName: 'appeal-start-date-change-appellant'
@@ -1402,7 +1419,8 @@ describe('appeal timetables routes', () => {
 							site_address: `${appeal.address.addressLine1}, ${appeal.address.addressLine2}, ${appeal.address.addressTown}, ${appeal.address.addressCounty}, ${appeal.address.postcode}, ${appeal.address.addressCountry}`,
 							start_date: '5 June 2024',
 							statement_of_common_ground_due_date: '10 July 2024',
-							...personalisation
+							...personalisation,
+							team_email_address: 'caseofficers@planninginspectorate.gov.uk'
 						},
 						recipientEmail: appeal.lpa.email,
 						templateName: 'appeal-start-date-change-lpa'
@@ -1494,7 +1512,8 @@ describe('appeal timetables routes', () => {
 							],
 							site_visit: false,
 							costs_info: false,
-							statement_of_common_ground_due_date: '10 July 2024'
+							statement_of_common_ground_due_date: '10 July 2024',
+							team_email_address: 'caseofficers@planninginspectorate.gov.uk'
 						},
 						recipientEmail: appeal.appellant.email,
 						templateName: 'appeal-valid-start-case-s78-appellant'
@@ -1520,7 +1539,8 @@ describe('appeal timetables routes', () => {
 							site_address: `${appeal.address.addressLine1}, ${appeal.address.addressLine2}, ${appeal.address.addressTown}, ${appeal.address.addressCounty}, ${appeal.address.postcode}, ${appeal.address.addressCountry}`,
 							start_date: '5 June 2024',
 							statement_of_common_ground_due_date: '10 July 2024',
-							...personalisation
+							...personalisation,
+							team_email_address: 'caseofficers@planninginspectorate.gov.uk'
 						},
 						recipientEmail: appeal.lpa.email,
 						templateName: 'appeal-valid-start-case-s78-lpa'

--- a/appeals/api/src/server/endpoints/appeal-timetables/appeal-timetables.service.js
+++ b/appeals/api/src/server/endpoints/appeal-timetables/appeal-timetables.service.js
@@ -1,5 +1,6 @@
 import { formatAddressSingleLine } from '#endpoints/addresses/addresses.formatter.js';
 import { createAuditTrail } from '#endpoints/audit-trails/audit-trails.service.js';
+import { getTeamEmailFromAppealId } from '#endpoints/case-team/case-team.service.js';
 import { broadcasters } from '#endpoints/integrations/integrations.broadcasters.js';
 import { notifySend } from '#notify/notify-send.js';
 import appealTimetableRepository from '#repositories/appeal-timetable.repository.js';
@@ -119,6 +120,8 @@ const sendStartCaseNotifies = async (
 			  ]
 			: 'when you can view information from other parties in the appeals service.';
 
+	const teamEmail = await getTeamEmailFromAppealId(appeal.id);
+
 	// Note that those properties not used within the specified template will be ignored
 	const commonEmailVariables = {
 		appeal_reference_number: appeal.reference,
@@ -142,7 +145,8 @@ const sendStartCaseNotifies = async (
 		child_appeals:
 			appeal.childAppeals
 				?.filter((appeal) => appeal.type === CASE_RELATIONSHIP_LINKED)
-				.map((appeal) => appeal.childRef) || []
+				.map((appeal) => appeal.childRef) || [],
+		team_email_address: teamEmail
 	};
 
 	if (appellantEmail) {
@@ -412,7 +416,8 @@ const sendTimetableUpdateNotify = async (appeal, processedBody, notifyClient, az
 					appeal.appealTimetable?.finalCommentsDueDate
 			),
 			false
-		)
+		),
+		team_email_address: await getTeamEmailFromAppealId(appeal.id)
 	};
 
 	const recipientEmail = appeal.agent?.email || appeal.appellant?.email;

--- a/appeals/api/src/server/endpoints/appellant-cases/__tests__/appellant-cases.test.js
+++ b/appeals/api/src/server/endpoints/appellant-cases/__tests__/appellant-cases.test.js
@@ -43,6 +43,11 @@ describe('appellant cases routes', () => {
 	beforeEach(() => {
 		// @ts-ignore
 		databaseConnector.appealRelationship.findMany.mockResolvedValue([]);
+		databaseConnector.team.findUnique.mockResolvedValue({
+			id: 1,
+			name: 'Case Team',
+			email: 'caseofficers@planninginspectorate.gov.uk'
+		});
 	});
 	afterEach(() => {
 		jest.resetAllMocks();
@@ -626,7 +631,8 @@ describe('appellant cases routes', () => {
 							reasons: [
 								'The original application form is incomplete',
 								'Other: Appellant contact information is incorrect or missing'
-							]
+							],
+							team_email_address: 'caseofficers@planninginspectorate.gov.uk'
 						},
 						recipientEmail: appeal.agent.email,
 						templateName: 'appeal-incomplete'
@@ -898,7 +904,8 @@ describe('appellant cases routes', () => {
 							reasons: [
 								'Appeal has not been submitted on time',
 								'Other: The appeal site address does not match'
-							]
+							],
+							team_email_address: 'caseofficers@planninginspectorate.gov.uk'
 						},
 						recipientEmail: appeal.agent.email,
 						templateName: 'appeal-invalid'
@@ -914,7 +921,8 @@ describe('appellant cases routes', () => {
 							reasons: [
 								'Appeal has not been submitted on time',
 								'Other: The appeal site address does not match'
-							]
+							],
+							team_email_address: 'caseofficers@planninginspectorate.gov.uk'
 						},
 						recipientEmail: appeal.lpa.email,
 						templateName: 'appeal-invalid-lpa'
@@ -998,7 +1006,8 @@ describe('appellant cases routes', () => {
 							lpa_reference: appeal.applicationReference,
 							site_address: `${appeal.address.addressLine1}, ${appeal.address.addressLine2}, ${appeal.address.addressTown}, ${appeal.address.addressCounty}, ${appeal.address.postcode}, ${appeal.address.addressCountry}`,
 
-							feedback_link: 'https://forms.office.com/r/9U4Sq9rEff'
+							feedback_link: 'https://forms.office.com/r/9U4Sq9rEff',
+							team_email_address: 'caseofficers@planninginspectorate.gov.uk'
 						},
 						recipientEmail: appeal.agent.email,
 						templateName: 'appeal-confirmed'

--- a/appeals/api/src/server/endpoints/appellant-cases/appellant-cases.service.js
+++ b/appeals/api/src/server/endpoints/appellant-cases/appellant-cases.service.js
@@ -11,6 +11,7 @@ import {
 } from '@pins/appeals/constants/support.js';
 
 import { createAuditTrail } from '#endpoints/audit-trails/audit-trails.service.js';
+import { getTeamEmailFromAppealId } from '#endpoints/case-team/case-team.service.js';
 import { broadcasters } from '#endpoints/integrations/integrations.broadcasters.js';
 import { notifySend } from '#notify/notify-send.js';
 import appealRepository from '#repositories/appeal.repository.js';
@@ -69,6 +70,7 @@ export const updateAppellantCaseValidationOutcome = async (
 ) => {
 	const { id: appealId } = appeal;
 	const { appealDueDate, incompleteReasons, invalidReasons } = data;
+	const teamEmail = await getTeamEmailFromAppealId(appealId);
 
 	await appellantCaseRepository.updateAppellantCaseValidationOutcome({
 		appealId,
@@ -119,7 +121,8 @@ export const updateAppellantCaseValidationOutcome = async (
 			feedback_link:
 				appeal.appealType.type === APPEAL_TYPE.S78
 					? 'https://forms.cloud.microsoft/Pages/ResponsePage.aspx?id=mN94WIhvq0iTIpmM5VcIjYt1ax_BPvtOqhVjfvzyJN5UQzg1SlNPQjA3V0FDNUFJTldHMlEzMDdMRS4u'
-					: 'https://forms.office.com/r/9U4Sq9rEff'
+					: 'https://forms.office.com/r/9U4Sq9rEff',
+			team_email_address: teamEmail
 		};
 		await notifySend({
 			azureAdUserId,
@@ -161,7 +164,8 @@ export const updateAppellantCaseValidationOutcome = async (
 					lpa_reference: appeal.applicationReference,
 					site_address: siteAddress,
 					due_date: formatDate(new Date(updatedDueDate), false),
-					reasons: incompleteReasonsList
+					reasons: incompleteReasonsList,
+					team_email_address: teamEmail
 				};
 
 				await notifySend({
@@ -187,7 +191,8 @@ export const updateAppellantCaseValidationOutcome = async (
 				appeal_reference_number: appeal.reference,
 				lpa_reference: appeal.applicationReference,
 				site_address: siteAddress,
-				reasons: invalidReasonsList
+				reasons: invalidReasonsList,
+				team_email_address: teamEmail
 			};
 			await notifySend({
 				azureAdUserId,

--- a/appeals/api/src/server/endpoints/case-team/case-team.controller.js
+++ b/appeals/api/src/server/endpoints/case-team/case-team.controller.js
@@ -1,7 +1,11 @@
 import * as caseTeamRepository from '#repositories/team.repository.js';
 import { isFeatureActive } from '#utils/feature-flags.js';
 import { FEATURE_FLAG_NAMES } from '@pins/appeals/constants/common.js';
-import { setAssignedTeamId, setAssignedTeamIdForLinkedAppeals } from './case-team.service.js';
+import {
+	getTeamEmailFromAppealId,
+	setAssignedTeamId,
+	setAssignedTeamIdForLinkedAppeals
+} from './case-team.service.js';
 
 /** @typedef {import('express').Request} Request */
 /** @typedef {import('express').Response} Response */
@@ -15,6 +19,15 @@ export const getAllCaseTeams = async (request, response) => {
 	return response.send(await caseTeamRepository.getCaseTeams());
 };
 
+/**
+ * @param {Request} request
+ * @param {Response} response
+ * @returns {Promise<Response>}
+ */
+export const getCaseTeamEmailFromAppealId = async (request, response) => {
+	const { appealId } = request.params;
+	return response.send({ email: await getTeamEmailFromAppealId(Number(appealId)) });
+};
 /**
  * @param {Request} req
  * @param {Response} res

--- a/appeals/api/src/server/endpoints/case-team/case-team.routes.js
+++ b/appeals/api/src/server/endpoints/case-team/case-team.routes.js
@@ -25,6 +25,25 @@ router.get(
 	 */
 	asyncHandler(controller.getAllCaseTeams)
 );
+router.get(
+	'/:appealId/case-team-email',
+	/*
+		#swagger.tags = ['Case Team']
+		#swagger.path = '/appeals/{appealId}/case-team-email'
+		#swagger.description = 'Gets the case team from an appeal id'
+		#swagger.parameters['azureAdUserId'] = {
+			in: 'header',
+			required: true,
+			example: '434bff4e-8191-4ce0-9a0a-91e5d6cdd882'
+		}
+		#swagger.responses[200] = {
+			description: 'Assigned case team for the appeal',
+			schema: { $ref: '#/components/schemas/TeamEmailResponse' },
+		}
+		#swagger.responses[400] = {}
+	 */
+	asyncHandler(controller.getCaseTeamEmailFromAppealId)
+);
 
 router.patch(
 	'/:appealId/case-team',

--- a/appeals/api/src/server/endpoints/case-team/case-team.service.js
+++ b/appeals/api/src/server/endpoints/case-team/case-team.service.js
@@ -35,6 +35,22 @@ export const setAssignedTeamId = async (appealId, assignedTeamId, azureAdUserId)
 /**
  *
  * @param {number} appealId
+ * @returns {Promise<string>}
+ */
+export const getTeamEmailFromAppealId = async (appealId) => {
+	const DEFAULT_EMAIL = 'caseofficers@planninginspectorate.gov.uk';
+
+	const appeal = await appealRepository.getAppealById(appealId);
+	const teamId = appeal?.assignedTeamId;
+	if (!teamId) return DEFAULT_EMAIL;
+
+	const team = await getAssignedTeam(teamId);
+	return team?.email || DEFAULT_EMAIL;
+};
+
+/**
+ *
+ * @param {number} appealId
  * @param {number|null} assignedTeamId
  * @param {string|undefined} azureAdUserId
  * @returns

--- a/appeals/api/src/server/endpoints/change-appeal-type/__tests__/change-appeal-type.test.js
+++ b/appeals/api/src/server/endpoints/change-appeal-type/__tests__/change-appeal-type.test.js
@@ -266,7 +266,8 @@ describe('appeal change type resubmit routes', () => {
 					lpa_reference: appeal.applicationReference,
 					appeal_type: appealTypes[newType - 1].type.toLowerCase(),
 					site_address: `${appeal.address.addressLine1}, ${appeal.address.addressLine2}, ${appeal.address.addressTown}, ${appeal.address.addressCounty}, ${appeal.address.postcode}, ${appeal.address.addressCountry}`,
-					due_date: formatDate(new Date('3000-02-05'), false)
+					due_date: formatDate(new Date('3000-02-05'), false),
+					team_email_address: 'caseofficers@planninginspectorate.gov.uk'
 				},
 				recipientEmail: 'test@136s7.com',
 				templateName: 'appeal-type-change-non-has'

--- a/appeals/api/src/server/endpoints/change-appeal-type/change-appeal-type.service.js
+++ b/appeals/api/src/server/endpoints/change-appeal-type/change-appeal-type.service.js
@@ -1,3 +1,4 @@
+import { getTeamEmailFromAppealId } from '#endpoints/case-team/case-team.service.js';
 import { broadcasters } from '#endpoints/integrations/integrations.broadcasters.js';
 import { notifySend } from '#notify/notify-send.js';
 import timetableRepository from '#repositories/appeal-timetable.repository.js';
@@ -54,7 +55,8 @@ const changeAppealType = async (
 		lpa_reference: appeal.applicationReference || '',
 		site_address: siteAddress,
 		due_date: formatDate(new Date(dueDate || ''), false),
-		appeal_type: newAppealType || ''
+		appeal_type: newAppealType || '',
+		team_email_address: await getTeamEmailFromAppealId(appeal.id)
 	};
 
 	if (recipientEmail) {

--- a/appeals/api/src/server/endpoints/decision/__tests__/decision.test.js
+++ b/appeals/api/src/server/endpoints/decision/__tests__/decision.test.js
@@ -679,7 +679,8 @@ describe('decision routes', () => {
 						site_address: '96 The Avenue, Leftfield, Maidstone, Kent, MD21 5XY, United Kingdom',
 						front_office_url: 'https://appeal-planning-decision.service.gov.uk/appeals/1345264',
 						correction_notice_reason: correctionNotice,
-						decision_date: formatDate(decisionDate, false)
+						decision_date: formatDate(decisionDate, false),
+						team_email_address: 'caseofficers@planninginspectorate.gov.uk'
 					}
 				});
 			});
@@ -735,7 +736,8 @@ describe('decision routes', () => {
 					site_address: '96 The Avenue, Leftfield, Maidstone, Kent, MD21 5XY, United Kingdom',
 					front_office_url: 'https://appeal-planning-decision.service.gov.uk/appeals/1345264',
 					correction_notice_reason: correctionNotice,
-					decision_date: formatDate(decisionDate, false)
+					decision_date: formatDate(decisionDate, false),
+					team_email_address: 'caseofficers@planninginspectorate.gov.uk'
 				}
 			});
 		});

--- a/appeals/api/src/server/endpoints/decision/decision.service.js
+++ b/appeals/api/src/server/endpoints/decision/decision.service.js
@@ -1,5 +1,6 @@
 import { formatAddressSingleLine } from '#endpoints/addresses/addresses.formatter.js';
 import { createAuditTrail } from '#endpoints/audit-trails/audit-trails.service.js';
+import { getTeamEmailFromAppealId } from '#endpoints/case-team/case-team.service.js';
 import { broadcasters } from '#endpoints/integrations/integrations.broadcasters.js';
 import { getRepresentations } from '#endpoints/representations/representations.service.js';
 import { notifySend } from '#notify/notify-send.js';
@@ -262,7 +263,8 @@ export const sendNewDecisionLetter = async (
 			: 'Address not available',
 		correction_notice_reason: correctionNotice,
 		decision_date: formatDate(decisionDate, false),
-		front_office_url: environment.FRONT_OFFICE_URL || ''
+		front_office_url: environment.FRONT_OFFICE_URL || '',
+		team_email_address: await getTeamEmailFromAppealId(appeal.id)
 	};
 
 	await Promise.all(

--- a/appeals/api/src/server/endpoints/hearings/__tests__/hearing.test.js
+++ b/appeals/api/src/server/endpoints/hearings/__tests__/hearing.test.js
@@ -226,7 +226,8 @@ describe('hearing routes', () => {
 					hearing_date: '1 January 2999',
 					hearing_time: '12:00pm',
 					hearing_address:
-						'Court 2, 24 Court Street, Test Town, Test County, AB12 3CD, United Kingdom'
+						'Court 2, 24 Court Street, Test Town, Test County, AB12 3CD, United Kingdom',
+					team_email_address: 'caseofficers@planninginspectorate.gov.uk'
 				};
 
 				expect(mockNotifySend).toHaveBeenCalledTimes(2);
@@ -345,7 +346,8 @@ describe('hearing routes', () => {
 					hearing_date: '2 January 2999',
 					hearing_time: '12:00pm',
 					hearing_address:
-						'Court 2, 24 Court Street, Test Town, Test County, AB12 3CD, United Kingdom'
+						'Court 2, 24 Court Street, Test Town, Test County, AB12 3CD, United Kingdom',
+					team_email_address: 'caseofficers@planninginspectorate.gov.uk'
 				};
 
 				expect(mockNotifySend).toHaveBeenCalledTimes(2);
@@ -1135,7 +1137,8 @@ describe('hearing routes', () => {
 					hearing_date: '1 January 2999',
 					hearing_time: '1:00pm',
 					hearing_address:
-						'Court 2, 24 Court Street, Test Town, Test County, AB12 3CD, United Kingdom'
+						'Court 2, 24 Court Street, Test Town, Test County, AB12 3CD, United Kingdom',
+					team_email_address: 'caseofficers@planninginspectorate.gov.uk'
 				};
 
 				expect(mockNotifySend).toHaveBeenCalledTimes(2);
@@ -1806,7 +1809,8 @@ describe('hearing routes', () => {
 				const personalisation = {
 					appeal_reference_number: '1345264',
 					site_address: '96 The Avenue, Leftfield, Maidstone, Kent, MD21 5XY, United Kingdom',
-					lpa_reference: '48269/APP/2021/1482'
+					lpa_reference: '48269/APP/2021/1482',
+					team_email_address: 'caseofficers@planninginspectorate.gov.uk'
 				};
 
 				expect(mockNotifySend).toHaveBeenCalledTimes(2);

--- a/appeals/api/src/server/endpoints/hearings/hearing.service.js
+++ b/appeals/api/src/server/endpoints/hearings/hearing.service.js
@@ -1,4 +1,5 @@
 import { formatAddressSingleLine } from '#endpoints/addresses/addresses.formatter.js';
+import { getTeamEmailFromAppealId } from '#endpoints/case-team/case-team.service.js';
 import { broadcasters } from '#endpoints/integrations/integrations.broadcasters.js';
 import { notifySend } from '#notify/notify-send.js';
 import hearingRepository from '#repositories/hearing.repository.js';
@@ -65,7 +66,8 @@ const sendHearingDetailsNotifications = async (
 		hearing_time: formatTime12h(
 			typeof hearingStartTime === 'string' ? new Date(hearingStartTime) : hearingStartTime
 		),
-		hearing_address: address ? formatAddressSingleLine({ ...address, id: 0 }) : ''
+		hearing_address: address ? formatAddressSingleLine({ ...address, id: 0 }) : '',
+		team_email_address: await getTeamEmailFromAppealId(appeal.id)
 	};
 	await sendHearingNotifications(
 		notifyClient,
@@ -106,7 +108,8 @@ const sendHearingNotifications = async (
 				appeal_reference_number: appeal.reference,
 				site_address: appeal.address ? formatAddressSingleLine(appeal.address) : '',
 				lpa_reference: appeal.applicationReference ?? '',
-				...personalisation
+				...personalisation,
+				team_email_address: await getTeamEmailFromAppealId(appeal.id)
 			},
 			recipientEmail: email
 		});

--- a/appeals/api/src/server/endpoints/link-appeals/__tests__/link-appeal.test.js
+++ b/appeals/api/src/server/endpoints/link-appeals/__tests__/link-appeal.test.js
@@ -225,7 +225,8 @@ describe('appeal linked appeals routes', () => {
 						event_type: 'site visit',
 						lpa_reference: householdAppeal.applicationReference,
 						site_address: '96 The Avenue, Leftfield, Maidstone, Kent, MD21 5XY, United Kingdom',
-						linked_before_lpa_questionnaire: true
+						linked_before_lpa_questionnaire: true,
+						team_email_address: 'caseofficers@planninginspectorate.gov.uk'
 					},
 					recipientEmail: householdAppeal.agent.email,
 					templateName: 'link-appeal'
@@ -240,7 +241,8 @@ describe('appeal linked appeals routes', () => {
 						event_type: 'site visit',
 						lpa_reference: householdAppeal.applicationReference,
 						site_address: '96 The Avenue, Leftfield, Maidstone, Kent, MD21 5XY, United Kingdom',
-						linked_before_lpa_questionnaire: true
+						linked_before_lpa_questionnaire: true,
+						team_email_address: 'caseofficers@planninginspectorate.gov.uk'
 					},
 					recipientEmail: householdAppeal.agent.email,
 					templateName: 'link-appeal'

--- a/appeals/api/src/server/endpoints/link-appeals/link-appeals.controller.js
+++ b/appeals/api/src/server/endpoints/link-appeals/link-appeals.controller.js
@@ -1,7 +1,10 @@
 import { formatAddressSingleLine } from '#endpoints/addresses/addresses.formatter.js';
 import { appealDetailService } from '#endpoints/appeal-details/appeal-details.service.js';
 import { createAuditTrail } from '#endpoints/audit-trails/audit-trails.service.js';
-import { setAssignedTeamId } from '#endpoints/case-team/case-team.service.js';
+import {
+	getTeamEmailFromAppealId,
+	setAssignedTeamId
+} from '#endpoints/case-team/case-team.service.js';
 import { broadcasters } from '#endpoints/integrations/integrations.broadcasters.js';
 import { notifySend } from '#notify/notify-send.js';
 import appealRepository from '#repositories/appeal.repository.js';
@@ -101,7 +104,8 @@ export const linkAppeal = async (req, res) => {
 		lpa_reference: currentAppeal.applicationReference || '',
 		site_address: siteAddress,
 		event_type: 'site visit',
-		linked_before_lpa_questionnaire: linkedBeforeLPAQ
+		linked_before_lpa_questionnaire: linkedBeforeLPAQ,
+		team_email_address: await getTeamEmailFromAppealId(currentAppeal.id)
 	};
 
 	const appellantEmail = currentAppeal.agent?.email || currentAppeal.appellant?.email;

--- a/appeals/api/src/server/endpoints/lpa-questionnaires/__tests__/lpa-questionnaires.test.js
+++ b/appeals/api/src/server/endpoints/lpa-questionnaires/__tests__/lpa-questionnaires.test.js
@@ -254,7 +254,8 @@ describe('lpa questionnaires routes', () => {
 						personalisation: {
 							lpa_reference: householdAppeal.applicationReference,
 							appeal_reference_number: householdAppeal.reference,
-							site_address: `${householdAppeal.address.addressLine1}, ${householdAppeal.address.addressLine2}, ${householdAppeal.address.addressTown}, ${householdAppeal.address.addressCounty}, ${householdAppeal.address.postcode}, ${householdAppeal.address.addressCountry}`
+							site_address: `${householdAppeal.address.addressLine1}, ${householdAppeal.address.addressLine2}, ${householdAppeal.address.addressTown}, ${householdAppeal.address.addressCounty}, ${householdAppeal.address.postcode}, ${householdAppeal.address.addressCountry}`,
+							team_email_address: 'caseofficers@planninginspectorate.gov.uk'
 						}
 					}
 				],
@@ -266,7 +267,8 @@ describe('lpa questionnaires routes', () => {
 						personalisation: {
 							lpa_reference: casPlanningAppeal.applicationReference,
 							appeal_reference_number: casPlanningAppeal.reference,
-							site_address: `${casPlanningAppeal.address.addressLine1}, ${casPlanningAppeal.address.addressLine2}, ${casPlanningAppeal.address.addressTown}, ${casPlanningAppeal.address.addressCounty}, ${casPlanningAppeal.address.postcode}, ${casPlanningAppeal.address.addressCountry}`
+							site_address: `${casPlanningAppeal.address.addressLine1}, ${casPlanningAppeal.address.addressLine2}, ${casPlanningAppeal.address.addressTown}, ${casPlanningAppeal.address.addressCounty}, ${casPlanningAppeal.address.postcode}, ${casPlanningAppeal.address.addressCountry}`,
+							team_email_address: 'caseofficers@planninginspectorate.gov.uk'
 						}
 					}
 				],
@@ -280,7 +282,8 @@ describe('lpa questionnaires routes', () => {
 							appeal_reference_number: fullPlanningAppeal.reference,
 							site_address: `${fullPlanningAppeal.address.addressLine1}, ${fullPlanningAppeal.address.addressLine2}, ${fullPlanningAppeal.address.addressTown}, ${fullPlanningAppeal.address.addressCounty}, ${fullPlanningAppeal.address.postcode}, ${fullPlanningAppeal.address.addressCountry}`,
 							what_happens_next:
-								'We will send you another email when the local planning authority submits their statement and we receive any comments from interested parties.'
+								'We will send you another email when the local planning authority submits their statement and we receive any comments from interested parties.',
+							team_email_address: 'caseofficers@planninginspectorate.gov.uk'
 						}
 					}
 				],
@@ -294,7 +297,8 @@ describe('lpa questionnaires routes', () => {
 							appeal_reference_number: listedBuildingAppeal.reference,
 							site_address: `${listedBuildingAppeal.address.addressLine1}, ${listedBuildingAppeal.address.addressLine2}, ${listedBuildingAppeal.address.addressTown}, ${listedBuildingAppeal.address.addressCounty}, ${listedBuildingAppeal.address.postcode}, ${listedBuildingAppeal.address.addressCountry}`,
 							what_happens_next:
-								'We will send you another email when the local planning authority submits their statement and we receive any comments from interested parties.'
+								'We will send you another email when the local planning authority submits their statement and we receive any comments from interested parties.',
+							team_email_address: 'caseofficers@planninginspectorate.gov.uk'
 						}
 					}
 				]
@@ -353,7 +357,8 @@ describe('lpa questionnaires routes', () => {
 						personalisation: {
 							lpa_reference: test.appeal.applicationReference,
 							appeal_reference_number: test.appeal.reference,
-							site_address: `${test.appeal.address.addressLine1}, ${test.appeal.address.addressLine2}, ${test.appeal.address.addressTown}, ${test.appeal.address.addressCounty}, ${test.appeal.address.postcode}, ${test.appeal.address.addressCountry}`
+							site_address: `${test.appeal.address.addressLine1}, ${test.appeal.address.addressLine2}, ${test.appeal.address.addressTown}, ${test.appeal.address.addressCounty}, ${test.appeal.address.postcode}, ${test.appeal.address.addressCountry}`,
+							team_email_address: 'caseofficers@planninginspectorate.gov.uk'
 						},
 						recipientEmail: test.appeal.lpa.email,
 						templateName: 'lpaq-complete-lpa'
@@ -1010,7 +1015,8 @@ describe('lpa questionnaires routes', () => {
 							reasons: [
 								'Documents or information are missing: Policy is missing',
 								'Other: Addresses are incorrect or missing'
-							]
+							],
+							team_email_address: 'caseofficers@planninginspectorate.gov.uk'
 						},
 						recipientEmail: appeal.lpa.email,
 						templateName: 'lpaq-incomplete'

--- a/appeals/api/src/server/endpoints/lpa-questionnaires/lpa-questionnaires.service.js
+++ b/appeals/api/src/server/endpoints/lpa-questionnaires/lpa-questionnaires.service.js
@@ -1,4 +1,5 @@
 import { createAuditTrail } from '#endpoints/audit-trails/audit-trails.service.js';
+import { getTeamEmailFromAppealId } from '#endpoints/case-team/case-team.service.js';
 import { broadcasters } from '#endpoints/integrations/integrations.broadcasters.js';
 import { notifySend } from '#notify/notify-send.js';
 import appealRepository from '#repositories/appeal.repository.js';
@@ -144,7 +145,8 @@ const updateLPAQuestionnaireValidationOutcome = async (
 				lpa_reference: lpaReference || '',
 				site_address: siteAddress,
 				due_date: formatDate(new Date(lpaQuestionnaireDueDate), false),
-				reasons: incompleteReasonsList
+				reasons: incompleteReasonsList,
+				team_email_address: await getTeamEmailFromAppealId(appeal.id)
 			};
 
 			await notifySend({
@@ -261,7 +263,8 @@ async function sendLpaqCompleteEmail(
 	const personalisation = {
 		...fields,
 		appeal_reference_number: appeal.reference,
-		lpa_reference: appeal.applicationReference || ''
+		lpa_reference: appeal.applicationReference || '',
+		team_email_address: await getTeamEmailFromAppealId(appeal.id)
 	};
 
 	await notifySend({

--- a/appeals/api/src/server/endpoints/notify-preview/__tests__/notify-preview.test.js
+++ b/appeals/api/src/server/endpoints/notify-preview/__tests__/notify-preview.test.js
@@ -15,7 +15,8 @@ describe('notify preview tests', () => {
 					site_address: `2222`,
 					lpa_reference: `planningApplicationReference`,
 					correction_notice_reason: `correctionNotice`,
-					decision_date: `dateISOStringToDisplayDate(file.receivedDate)`
+					decision_date: `dateISOStringToDisplayDate(file.receivedDate)`,
+					team_email_address: 'caseofficers@planninginspectorate.gov.uk'
 				};
 				const response = await request
 					.post(`/appeals/notify-preview/correction-notice-decision.content.md`)

--- a/appeals/api/src/server/endpoints/notify-preview/notify-preview.controller.js
+++ b/appeals/api/src/server/endpoints/notify-preview/notify-preview.controller.js
@@ -11,7 +11,10 @@ const environment = loadEnvironment(process.env.NODE_ENV);
  * @returns {Promise<Response>}
  */
 const generateNotifyTemplate = async (req, res) => {
-	const personalisation = { ...req.body, front_office_url: environment.FRONT_OFFICE_URL || '' };
+	const personalisation = {
+		...req.body,
+		front_office_url: environment.FRONT_OFFICE_URL || ''
+	};
 	const template = renderTemplate(req.params.templateName, personalisation);
 	const renderedHtml = generateNotifyPreview(template);
 	const reply = { renderedHtml: renderedHtml };

--- a/appeals/api/src/server/endpoints/representations/__tests__/representations.test.js
+++ b/appeals/api/src/server/endpoints/representations/__tests__/representations.test.js
@@ -234,7 +234,8 @@ describe('/appeals/:id/reps', () => {
 					lpa_reference: appeal.applicationReference,
 					appeal_reference_number: appeal.reference,
 					reasons: ['Invalid submission', 'Other: Provided documents were incomplete'],
-					site_address: expectedSiteAddress
+					site_address: expectedSiteAddress,
+					team_email_address: 'caseofficers@planninginspectorate.gov.uk'
 				};
 
 				databaseConnector.appeal.findUnique.mockResolvedValue(appeal);
@@ -324,7 +325,8 @@ describe('/appeals/:id/reps', () => {
 					lpa_reference: appeal.applicationReference,
 					appeal_reference_number: appeal.reference,
 					reasons: ['Invalid submission', 'Other: Provided documents were incomplete'],
-					site_address: expectedSiteAddress
+					site_address: expectedSiteAddress,
+					team_email_address: 'caseofficers@planninginspectorate.gov.uk'
 				};
 
 				databaseConnector.appeal.findUnique.mockResolvedValue(appeal);
@@ -423,7 +425,8 @@ describe('/appeals/:id/reps', () => {
 					resubmit_comment_to_fo: true,
 					appeal_reference_number: mockAppeal.reference,
 					reasons: ['Invalid submission', 'Other: Provided documents were incomplete'],
-					site_address: expectedSiteAddress
+					site_address: expectedSiteAddress,
+					team_email_address: 'caseofficers@planninginspectorate.gov.uk'
 				};
 
 				databaseConnector.appeal.findUnique.mockResolvedValue(appeal);
@@ -522,7 +525,8 @@ describe('/appeals/:id/reps', () => {
 					resubmit_comment_to_fo: false,
 					appeal_reference_number: mockAppeal.reference,
 					reasons: ['Invalid submission', 'Other: Provided documents were incomplete'],
-					site_address: expectedSiteAddress
+					site_address: expectedSiteAddress,
+					team_email_address: 'caseofficers@planninginspectorate.gov.uk'
 				};
 
 				databaseConnector.appeal.findUnique.mockResolvedValue(appeal);
@@ -613,7 +617,8 @@ describe('/appeals/:id/reps', () => {
 					deadline_date: '',
 					appeal_reference_number: appeal.reference,
 					reasons: ['Supporting documents missing', 'Other: Provided documents were incomplete'],
-					site_address: expectedSiteAddress
+					site_address: expectedSiteAddress,
+					team_email_address: 'caseofficers@planninginspectorate.gov.uk'
 				};
 
 				databaseConnector.appeal.findUnique.mockResolvedValue(appeal);
@@ -1254,7 +1259,8 @@ describe('/appeals/:id/reps', () => {
 						has_statement: true,
 						is_hearing_procedure: false,
 						what_happens_next:
-							'You need to [submit your final comments](/mock-front-office-url/manage-appeals/6000002) by 4 December 2024.'
+							'You need to [submit your final comments](/mock-front-office-url/manage-appeals/6000002) by 4 December 2024.',
+						team_email_address: 'caseofficers@planninginspectorate.gov.uk'
 					},
 					recipientEmail: appealS78.lpa.email,
 					templateName: 'received-statement-and-ip-comments-lpa'
@@ -1269,7 +1275,8 @@ describe('/appeals/:id/reps', () => {
 						has_statement: true,
 						is_hearing_procedure: false,
 						what_happens_next:
-							'You need to [submit your final comments](/mock-front-office-url/appeals/6000002) by 4 December 2024.'
+							'You need to [submit your final comments](/mock-front-office-url/appeals/6000002) by 4 December 2024.',
+						team_email_address: 'caseofficers@planninginspectorate.gov.uk'
 					},
 					recipientEmail: appealS78.appellant.email,
 					templateName: 'received-statement-and-ip-comments-appellant'
@@ -1340,7 +1347,8 @@ describe('/appeals/:id/reps', () => {
 						has_statement: true,
 						is_hearing_procedure: false,
 						what_happens_next:
-							'You need to [submit your final comments](/mock-front-office-url/manage-appeals/6000002) by 4 December 2024.'
+							'You need to [submit your final comments](/mock-front-office-url/manage-appeals/6000002) by 4 December 2024.',
+						team_email_address: 'caseofficers@planninginspectorate.gov.uk'
 					},
 					recipientEmail: appealS78.lpa.email,
 					templateName: 'received-statement-and-ip-comments-lpa'
@@ -1355,7 +1363,8 @@ describe('/appeals/:id/reps', () => {
 						has_statement: true,
 						is_hearing_procedure: false,
 						what_happens_next:
-							'You need to [submit your final comments](/mock-front-office-url/appeals/6000002) by 4 December 2024.'
+							'You need to [submit your final comments](/mock-front-office-url/appeals/6000002) by 4 December 2024.',
+						team_email_address: 'caseofficers@planninginspectorate.gov.uk'
 					},
 					recipientEmail: appealS78.appellant.email,
 					templateName: 'received-statement-and-ip-comments-appellant'
@@ -1453,7 +1462,8 @@ describe('/appeals/:id/reps', () => {
 						has_statement: false,
 						is_hearing_procedure: false,
 						what_happens_next:
-							'You need to [submit your final comments](/mock-front-office-url/manage-appeals/6000002) by 4 December 2024.'
+							'You need to [submit your final comments](/mock-front-office-url/manage-appeals/6000002) by 4 December 2024.',
+						team_email_address: 'caseofficers@planninginspectorate.gov.uk'
 					},
 					recipientEmail: appealS78.lpa.email,
 					templateName: 'received-statement-and-ip-comments-lpa'
@@ -1468,7 +1478,8 @@ describe('/appeals/:id/reps', () => {
 						has_statement: false,
 						is_hearing_procedure: false,
 						what_happens_next:
-							'You need to [submit your final comments](/mock-front-office-url/appeals/6000002) by 4 December 2024.'
+							'You need to [submit your final comments](/mock-front-office-url/appeals/6000002) by 4 December 2024.',
+						team_email_address: 'caseofficers@planninginspectorate.gov.uk'
 					},
 					recipientEmail: appealS78.appellant.email,
 					templateName: 'received-statement-and-ip-comments-appellant'
@@ -1528,7 +1539,8 @@ describe('/appeals/:id/reps', () => {
 						has_statement: true,
 						is_hearing_procedure: false,
 						what_happens_next:
-							'You need to [submit your final comments](/mock-front-office-url/manage-appeals/6000002) by 4 December 2024.'
+							'You need to [submit your final comments](/mock-front-office-url/manage-appeals/6000002) by 4 December 2024.',
+						team_email_address: 'caseofficers@planninginspectorate.gov.uk'
 					},
 					recipientEmail: appealS78.lpa.email,
 					templateName: 'received-statement-and-ip-comments-lpa'
@@ -1543,7 +1555,8 @@ describe('/appeals/:id/reps', () => {
 						has_statement: true,
 						is_hearing_procedure: false,
 						what_happens_next:
-							'You need to [submit your final comments](/mock-front-office-url/appeals/6000002) by 4 December 2024.'
+							'You need to [submit your final comments](/mock-front-office-url/appeals/6000002) by 4 December 2024.',
+						team_email_address: 'caseofficers@planninginspectorate.gov.uk'
 					},
 					recipientEmail: appealS78.appellant.email,
 					templateName: 'received-statement-and-ip-comments-appellant'
@@ -1601,7 +1614,8 @@ describe('/appeals/:id/reps', () => {
 						has_statement: false,
 						is_hearing_procedure: false,
 						what_happens_next:
-							'You need to [submit your final comments](/mock-front-office-url/manage-appeals/6000002) by 4 December 2024.'
+							'You need to [submit your final comments](/mock-front-office-url/manage-appeals/6000002) by 4 December 2024.',
+						team_email_address: 'caseofficers@planninginspectorate.gov.uk'
 					},
 					recipientEmail: appealS78.lpa.email,
 					templateName: 'received-statement-and-ip-comments-lpa'
@@ -1616,7 +1630,8 @@ describe('/appeals/:id/reps', () => {
 						has_statement: false,
 						is_hearing_procedure: false,
 						what_happens_next:
-							'You need to [submit your final comments](/mock-front-office-url/appeals/6000002) by 4 December 2024.'
+							'You need to [submit your final comments](/mock-front-office-url/appeals/6000002) by 4 December 2024.',
+						team_email_address: 'caseofficers@planninginspectorate.gov.uk'
 					},
 					recipientEmail: appealS78.appellant.email,
 					templateName: 'received-statement-and-ip-comments-appellant'
@@ -1678,7 +1693,8 @@ describe('/appeals/:id/reps', () => {
 						has_statement: true,
 						is_hearing_procedure: false,
 						what_happens_next:
-							'You need to [submit your final comments](/mock-front-office-url/manage-appeals/6000002) by 4 December 2024.'
+							'You need to [submit your final comments](/mock-front-office-url/manage-appeals/6000002) by 4 December 2024.',
+						team_email_address: 'caseofficers@planninginspectorate.gov.uk'
 					},
 					recipientEmail: mockS20Appeal.lpa.email,
 					templateName: 'received-statement-and-ip-comments-lpa'
@@ -1693,7 +1709,8 @@ describe('/appeals/:id/reps', () => {
 						has_statement: true,
 						is_hearing_procedure: false,
 						what_happens_next:
-							'You need to [submit your final comments](/mock-front-office-url/appeals/6000002) by 4 December 2024.'
+							'You need to [submit your final comments](/mock-front-office-url/appeals/6000002) by 4 December 2024.',
+						team_email_address: 'caseofficers@planninginspectorate.gov.uk'
 					},
 					recipientEmail: mockS20Appeal.appellant.email,
 					templateName: 'received-statement-and-ip-comments-appellant'
@@ -1762,7 +1779,8 @@ describe('/appeals/:id/reps', () => {
 						has_ip_comments: true,
 						has_statement: true,
 						is_hearing_procedure: true,
-						what_happens_next: 'We will contact you when the hearing has been set up.'
+						what_happens_next: 'We will contact you when the hearing has been set up.',
+						team_email_address: 'caseofficers@planninginspectorate.gov.uk'
 					},
 					recipientEmail: appealS78.lpa.email,
 					templateName: 'received-statement-and-ip-comments-lpa'
@@ -1776,7 +1794,8 @@ describe('/appeals/:id/reps', () => {
 						has_ip_comments: true,
 						has_statement: true,
 						is_hearing_procedure: true,
-						what_happens_next: 'We will contact you if we need any more information.'
+						what_happens_next: 'We will contact you if we need any more information.',
+						team_email_address: 'caseofficers@planninginspectorate.gov.uk'
 					},
 					recipientEmail: appealS78.appellant.email,
 					templateName: 'received-statement-and-ip-comments-appellant'
@@ -1844,7 +1863,8 @@ describe('/appeals/:id/reps', () => {
 						has_ip_comments: true,
 						has_statement: true,
 						is_hearing_procedure: true,
-						what_happens_next: 'We will contact you when the hearing has been set up.'
+						what_happens_next: 'We will contact you when the hearing has been set up.',
+						team_email_address: 'caseofficers@planninginspectorate.gov.uk'
 					},
 					recipientEmail: appealS78.lpa.email,
 					templateName: 'received-statement-and-ip-comments-lpa'
@@ -1858,7 +1878,8 @@ describe('/appeals/:id/reps', () => {
 						has_ip_comments: true,
 						has_statement: true,
 						is_hearing_procedure: true,
-						what_happens_next: 'We will contact you if we need any more information.'
+						what_happens_next: 'We will contact you if we need any more information.',
+						team_email_address: 'caseofficers@planninginspectorate.gov.uk'
 					},
 					recipientEmail: appealS78.appellant.email,
 					templateName: 'received-statement-and-ip-comments-appellant'
@@ -1931,7 +1952,8 @@ describe('/appeals/:id/reps', () => {
 						has_ip_comments: true,
 						has_statement: true,
 						is_hearing_procedure: true,
-						what_happens_next: 'The hearing is on 31 January 2025.'
+						what_happens_next: 'The hearing is on 31 January 2025.',
+						team_email_address: 'caseofficers@planninginspectorate.gov.uk'
 					},
 					recipientEmail: appealS78.lpa.email,
 					templateName: 'received-statement-and-ip-comments-lpa'
@@ -1946,7 +1968,8 @@ describe('/appeals/:id/reps', () => {
 						has_statement: true,
 						is_hearing_procedure: true,
 						what_happens_next:
-							'Your hearing is on 31 January 2025.\n\nWe will contact you if we need any more information.'
+							'Your hearing is on 31 January 2025.\n\nWe will contact you if we need any more information.',
+						team_email_address: 'caseofficers@planninginspectorate.gov.uk'
 					},
 					recipientEmail: appealS78.appellant.email,
 					templateName: 'received-statement-and-ip-comments-appellant'
@@ -2017,7 +2040,8 @@ describe('/appeals/:id/reps', () => {
 						has_ip_comments: true,
 						has_statement: true,
 						is_hearing_procedure: true,
-						what_happens_next: 'The hearing is on 31 January 2025.'
+						what_happens_next: 'The hearing is on 31 January 2025.',
+						team_email_address: 'caseofficers@planninginspectorate.gov.uk'
 					},
 					recipientEmail: appealS78.lpa.email,
 					templateName: 'received-statement-and-ip-comments-lpa'
@@ -2032,7 +2056,8 @@ describe('/appeals/:id/reps', () => {
 						has_statement: true,
 						is_hearing_procedure: true,
 						what_happens_next:
-							'Your hearing is on 31 January 2025.\n\nWe will contact you if we need any more information.'
+							'Your hearing is on 31 January 2025.\n\nWe will contact you if we need any more information.',
+						team_email_address: 'caseofficers@planninginspectorate.gov.uk'
 					},
 					recipientEmail: appealS78.appellant.email,
 					templateName: 'received-statement-and-ip-comments-appellant'
@@ -2139,7 +2164,8 @@ describe('/appeals/:id/reps', () => {
 					notifyClient: expect.anything(),
 					personalisation: {
 						...expectedEmailPayload,
-						what_happens_next: ''
+						what_happens_next: '',
+						team_email_address: 'caseofficers@planninginspectorate.gov.uk'
 					},
 					recipientEmail: appealS78.appellant.email,
 					templateName: 'final-comments-done-appellant'
@@ -2150,7 +2176,8 @@ describe('/appeals/:id/reps', () => {
 					notifyClient: expect.anything(),
 					personalisation: {
 						...expectedEmailPayload,
-						what_happens_next: ''
+						what_happens_next: '',
+						team_email_address: 'caseofficers@planninginspectorate.gov.uk'
 					},
 					recipientEmail: appealS78.lpa.email,
 					templateName: 'final-comments-done-lpa'
@@ -2219,7 +2246,8 @@ describe('/appeals/:id/reps', () => {
 					notifyClient: expect.anything(),
 					personalisation: {
 						...expectedEmailPayload,
-						what_happens_next: ''
+						what_happens_next: '',
+						team_email_address: 'caseofficers@planninginspectorate.gov.uk'
 					},
 					recipientEmail: appealS78.appellant.email,
 					templateName: 'final-comments-done-appellant'
@@ -2230,7 +2258,8 @@ describe('/appeals/:id/reps', () => {
 					notifyClient: expect.anything(),
 					personalisation: {
 						...expectedEmailPayload,
-						what_happens_next: ''
+						what_happens_next: '',
+						team_email_address: 'caseofficers@planninginspectorate.gov.uk'
 					},
 					recipientEmail: appealS78.lpa.email,
 					templateName: 'final-comments-done-lpa'
@@ -2326,7 +2355,8 @@ describe('/appeals/:id/reps', () => {
 					notifyClient: expect.anything(),
 					personalisation: {
 						...expectedEmailPayload,
-						what_happens_next: ''
+						what_happens_next: '',
+						team_email_address: 'caseofficers@planninginspectorate.gov.uk'
 					},
 					recipientEmail: appealS20.appellant.email,
 					templateName: 'final-comments-done-appellant'
@@ -2337,7 +2367,8 @@ describe('/appeals/:id/reps', () => {
 					notifyClient: expect.anything(),
 					personalisation: {
 						...expectedEmailPayload,
-						what_happens_next: ''
+						what_happens_next: '',
+						team_email_address: 'caseofficers@planninginspectorate.gov.uk'
 					},
 					recipientEmail: appealS20.lpa.email,
 					templateName: 'final-comments-done-lpa'
@@ -2389,7 +2420,8 @@ describe('/appeals/:id/reps', () => {
 					notifyClient: expect.anything(),
 					personalisation: {
 						...expectedEmailPayload,
-						what_happens_next: ''
+						what_happens_next: '',
+						team_email_address: 'caseofficers@planninginspectorate.gov.uk'
 					},
 					recipientEmail: mockS20Appeal.agent.email,
 					templateName: 'final-comments-done-appellant'
@@ -2399,7 +2431,8 @@ describe('/appeals/:id/reps', () => {
 					notifyClient: expect.anything(),
 					personalisation: {
 						...expectedEmailPayload,
-						what_happens_next: ''
+						what_happens_next: '',
+						team_email_address: 'caseofficers@planninginspectorate.gov.uk'
 					},
 					recipientEmail: mockS20Appeal.lpa.email,
 					templateName: 'final-comments-done-lpa'
@@ -2455,7 +2488,8 @@ describe('/appeals/:id/reps', () => {
 					notifyClient: expect.anything(),
 					personalisation: {
 						...expectedEmailPayload,
-						user_type: 'local planning authority'
+						user_type: 'local planning authority',
+						team_email_address: 'caseofficers@planninginspectorate.gov.uk'
 					},
 					recipientEmail: mockS78Appeal.appellant.email,
 					templateName: 'final-comments-none'
@@ -2466,7 +2500,8 @@ describe('/appeals/:id/reps', () => {
 					notifyClient: expect.anything(),
 					personalisation: {
 						...expectedEmailPayload,
-						user_type: 'appellant'
+						user_type: 'appellant',
+						team_email_address: 'caseofficers@planninginspectorate.gov.uk'
 					},
 					recipientEmail: mockS78Appeal.lpa.email,
 					templateName: 'final-comments-none'
@@ -2523,7 +2558,8 @@ describe('/appeals/:id/reps', () => {
 					notifyClient: expect.anything(),
 					personalisation: {
 						...expectedEmailPayload,
-						what_happens_next: ''
+						what_happens_next: '',
+						team_email_address: 'caseofficers@planninginspectorate.gov.uk'
 					},
 					recipientEmail: appealS20.appellant.email,
 					templateName: 'final-comments-done-appellant'
@@ -2535,7 +2571,8 @@ describe('/appeals/:id/reps', () => {
 					personalisation: {
 						...expectedEmailPayload,
 						user_type: 'appellant',
-						what_happens_next: ''
+						what_happens_next: '',
+						team_email_address: 'caseofficers@planninginspectorate.gov.uk'
 					},
 					recipientEmail: mockS78Appeal.lpa.email,
 					templateName: 'final-comments-none'
@@ -2563,7 +2600,8 @@ describe('/appeals/:id/reps', () => {
 					appeal_reference_number: mockS20Appeal.reference,
 					final_comments_deadline: '',
 					site_address: expectedSiteAddress,
-					user_type: ''
+					user_type: '',
+					team_email_address: 'caseofficers@planninginspectorate.gov.uk'
 				};
 
 				databaseConnector.appeal.findUnique.mockResolvedValue(mockS20Appeal);
@@ -2593,7 +2631,8 @@ describe('/appeals/:id/reps', () => {
 					personalisation: {
 						...expectedEmailPayload,
 						what_happens_next: '',
-						user_type: 'local planning authority'
+						user_type: 'local planning authority',
+						team_email_address: 'caseofficers@planninginspectorate.gov.uk'
 					},
 					recipientEmail: mockS78Appeal.appellant.email,
 					templateName: 'final-comments-none'
@@ -2604,7 +2643,8 @@ describe('/appeals/:id/reps', () => {
 					notifyClient: expect.anything(),
 					personalisation: {
 						...expectedEmailPayload,
-						what_happens_next: ''
+						what_happens_next: '',
+						team_email_address: 'caseofficers@planninginspectorate.gov.uk'
 					},
 					recipientEmail: appealS20.lpa.email,
 					templateName: 'final-comments-done-lpa'

--- a/appeals/api/src/server/endpoints/representations/notify/services/index.js
+++ b/appeals/api/src/server/endpoints/representations/notify/services/index.js
@@ -6,6 +6,7 @@
  * code will the switching logic for you.
  */
 
+import { getTeamEmailFromAppealId } from '#endpoints/case-team/case-team.service.js';
 import { notifySend } from '#notify/notify-send.js';
 import { getDetailsForCommentResubmission } from '@pins/appeals/utils/notify.js';
 import { formatExtendedDeadline, formatReasons, formatSiteAddress } from './utils.js';
@@ -51,7 +52,8 @@ export const ipCommentRejection = async ({
 			site_address: siteAddress,
 			reasons,
 			deadline_date: resubmissionDueDate,
-			resubmit_comment_to_fo: resubmitToFO
+			resubmit_comment_to_fo: resubmitToFO,
+			team_email_address: await getTeamEmailFromAppealId(appeal.id)
 		};
 
 		await notifySend({
@@ -88,7 +90,8 @@ export const appellantFinalCommentRejection = async ({
 			appeal_reference_number: appeal.reference,
 			lpa_reference: appeal.applicationReference || '',
 			site_address: siteAddress,
-			reasons
+			reasons,
+			team_email_address: await getTeamEmailFromAppealId(appeal.id)
 		}
 	});
 };
@@ -117,7 +120,8 @@ export const lpaFinalCommentRejection = async ({
 			appeal_reference_number: appeal.reference,
 			lpa_reference: appeal.applicationReference || '',
 			site_address: siteAddress,
-			reasons
+			reasons,
+			team_email_address: await getTeamEmailFromAppealId(appeal.id)
 		}
 	});
 };
@@ -150,7 +154,8 @@ export const lpaStatementIncomplete = async ({
 			lpa_reference: appeal.applicationReference || '',
 			site_address: siteAddress,
 			deadline_date: extendedDeadline,
-			reasons
+			reasons,
+			team_email_address: await getTeamEmailFromAppealId(appeal.id)
 		}
 	});
 };

--- a/appeals/api/src/server/endpoints/representations/representations.service.js
+++ b/appeals/api/src/server/endpoints/representations/representations.service.js
@@ -1,5 +1,6 @@
 import config from '#config/config.js';
 import { formatAddressSingleLine } from '#endpoints/addresses/addresses.formatter.js';
+import { getTeamEmailFromAppealId } from '#endpoints/case-team/case-team.service.js';
 import { broadcasters } from '#endpoints/integrations/integrations.broadcasters.js';
 import { notifySend } from '#notify/notify-send.js';
 import addressRepository from '#repositories/address.repository.js';
@@ -513,7 +514,8 @@ async function notifyPublished({
 			has_ip_comments: hasIpComments,
 			has_statement: hasLpaStatement,
 			is_hearing_procedure: isHearingProcedure,
-			user_type: userTypeNoCommentSubmitted
+			user_type: userTypeNoCommentSubmitted,
+			team_email_address: await getTeamEmailFromAppealId(appeal.id)
 		}
 	});
 }

--- a/appeals/api/src/server/endpoints/site-visits/__tests__/site-visits.test.js
+++ b/appeals/api/src/server/endpoints/site-visits/__tests__/site-visits.test.js
@@ -424,7 +424,8 @@ describe('site visit routes', () => {
 							site_address: `${appeal.address.addressLine1}, ${appeal.address.addressLine2}, ${appeal.address.addressTown}, ${appeal.address.addressCounty}, ${appeal.address.postcode}, ${appeal.address.addressCountry}`,
 							start_time: formatTime(siteVisit.visitStartTime),
 							end_time: formatTime(siteVisit.visitEndTime),
-							visit_date: dateISOStringToDisplayDate(siteVisit.visitDate)
+							visit_date: dateISOStringToDisplayDate(siteVisit.visitDate),
+							team_email_address: 'caseofficers@planninginspectorate.gov.uk'
 						},
 						recipientEmail: appeal.agent.email
 					});
@@ -472,7 +473,8 @@ describe('site visit routes', () => {
 							inspector_name: '',
 							site_address: `${appeal.address.addressLine1}, ${appeal.address.addressLine2}, ${appeal.address.addressTown}, ${appeal.address.addressCounty}, ${appeal.address.postcode}, ${appeal.address.addressCountry}`,
 							start_time: '11:00',
-							visit_date: '1 March 2022'
+							visit_date: '1 March 2022',
+							team_email_address: 'caseofficers@planninginspectorate.gov.uk'
 						},
 						recipientEmail: appeal.agent.email
 					});
@@ -488,7 +490,8 @@ describe('site visit routes', () => {
 							inspector_name: '',
 							site_address: `${appeal.address.addressLine1}, ${appeal.address.addressLine2}, ${appeal.address.addressTown}, ${appeal.address.addressCounty}, ${appeal.address.postcode}, ${appeal.address.addressCountry}`,
 							start_time: '11:00',
-							visit_date: '1 March 2022'
+							visit_date: '1 March 2022',
+							team_email_address: 'caseofficers@planninginspectorate.gov.uk'
 						},
 						recipientEmail: appeal.lpa.email
 					});
@@ -539,7 +542,8 @@ describe('site visit routes', () => {
 							inspector_name: inspectorName,
 							site_address: `${appeal.address.addressLine1}, ${appeal.address.addressLine2}, ${appeal.address.addressTown}, ${appeal.address.addressCounty}, ${appeal.address.postcode}, ${appeal.address.addressCountry}`,
 							start_time: '12:00',
-							visit_date: dateISOStringToDisplayDate(siteVisit.visitDate)
+							visit_date: dateISOStringToDisplayDate(siteVisit.visitDate),
+							team_email_address: 'caseofficers@planninginspectorate.gov.uk'
 						},
 						recipientEmail: appeal.agent.email
 					});
@@ -1350,7 +1354,8 @@ describe('site visit routes', () => {
 							end_time: formatTime(siteVisit.visitEndTime),
 							inspector_name: '',
 							lpa_reference: appeal.applicationReference,
-							visit_date: dateISOStringToDisplayDate(siteVisit.visitDate)
+							visit_date: dateISOStringToDisplayDate(siteVisit.visitDate),
+							team_email_address: 'caseofficers@planninginspectorate.gov.uk'
 						},
 						recipientEmail: appeal.agent.email
 					});
@@ -1422,7 +1427,8 @@ describe('site visit routes', () => {
 							end_time: formatTime(siteVisit.visitEndTime),
 							inspector_name: '',
 							lpa_reference: appeal.applicationReference,
-							visit_date: dateISOStringToDisplayDate(siteVisit.visitDate)
+							visit_date: dateISOStringToDisplayDate(siteVisit.visitDate),
+							team_email_address: 'caseofficers@planninginspectorate.gov.uk'
 						},
 						recipientEmail: appeal.agent.email
 					});
@@ -1438,7 +1444,8 @@ describe('site visit routes', () => {
 							end_time: formatTime(siteVisit.visitEndTime),
 							inspector_name: '',
 							lpa_reference: appeal.applicationReference,
-							visit_date: dateISOStringToDisplayDate(siteVisit.visitDate)
+							visit_date: dateISOStringToDisplayDate(siteVisit.visitDate),
+							team_email_address: 'caseofficers@planninginspectorate.gov.uk'
 						},
 						recipientEmail: appeal.lpa.email
 					});
@@ -1511,7 +1518,8 @@ describe('site visit routes', () => {
 							end_time: formatTime(siteVisit.visitEndTime),
 							inspector_name: inspectorName,
 							lpa_reference: appeal.applicationReference,
-							visit_date: dateISOStringToDisplayDate(siteVisit.visitDate)
+							visit_date: dateISOStringToDisplayDate(siteVisit.visitDate),
+							team_email_address: 'caseofficers@planninginspectorate.gov.uk'
 						},
 						recipientEmail: appeal.agent.email
 					});
@@ -1583,7 +1591,8 @@ describe('site visit routes', () => {
 							end_time: formatTime(siteVisit.visitEndTime),
 							inspector_name: '',
 							lpa_reference: appeal.applicationReference,
-							visit_date: dateISOStringToDisplayDate(siteVisit.visitDate)
+							visit_date: dateISOStringToDisplayDate(siteVisit.visitDate),
+							team_email_address: 'caseofficers@planninginspectorate.gov.uk'
 						},
 						recipientEmail: appeal.agent.email
 					});
@@ -1599,7 +1608,8 @@ describe('site visit routes', () => {
 							end_time: formatTime(siteVisit.visitEndTime),
 							inspector_name: '',
 							lpa_reference: appeal.applicationReference,
-							visit_date: dateISOStringToDisplayDate(siteVisit.visitDate)
+							visit_date: dateISOStringToDisplayDate(siteVisit.visitDate),
+							team_email_address: 'caseofficers@planninginspectorate.gov.uk'
 						},
 						recipientEmail: appeal.lpa.email
 					});
@@ -1671,7 +1681,8 @@ describe('site visit routes', () => {
 							end_time: formatTime(siteVisit.visitEndTime),
 							inspector_name: '',
 							lpa_reference: appeal.applicationReference,
-							visit_date: dateISOStringToDisplayDate(siteVisit.visitDate)
+							visit_date: dateISOStringToDisplayDate(siteVisit.visitDate),
+							team_email_address: 'caseofficers@planninginspectorate.gov.uk'
 						},
 						recipientEmail: appeal.agent.email
 					});
@@ -1687,7 +1698,8 @@ describe('site visit routes', () => {
 							end_time: formatTime(siteVisit.visitEndTime),
 							inspector_name: '',
 							lpa_reference: appeal.applicationReference,
-							visit_date: dateISOStringToDisplayDate(siteVisit.visitDate)
+							visit_date: dateISOStringToDisplayDate(siteVisit.visitDate),
+							team_email_address: 'caseofficers@planninginspectorate.gov.uk'
 						},
 						recipientEmail: appeal.lpa.email
 					});
@@ -1759,7 +1771,8 @@ describe('site visit routes', () => {
 							end_time: formatTime(siteVisit.visitEndTime),
 							inspector_name: '',
 							lpa_reference: appeal.applicationReference,
-							visit_date: dateISOStringToDisplayDate(siteVisit.visitDate)
+							visit_date: dateISOStringToDisplayDate(siteVisit.visitDate),
+							team_email_address: 'caseofficers@planninginspectorate.gov.uk'
 						},
 						recipientEmail: appeal.agent.email
 					});
@@ -1775,7 +1788,8 @@ describe('site visit routes', () => {
 							end_time: formatTime(siteVisit.visitEndTime),
 							inspector_name: '',
 							lpa_reference: appeal.applicationReference,
-							visit_date: dateISOStringToDisplayDate(siteVisit.visitDate)
+							visit_date: dateISOStringToDisplayDate(siteVisit.visitDate),
+							team_email_address: 'caseofficers@planninginspectorate.gov.uk'
 						},
 						recipientEmail: appeal.lpa.email
 					});
@@ -1848,7 +1862,8 @@ describe('site visit routes', () => {
 							end_time: formatTime(siteVisit.visitEndTime),
 							inspector_name: inspectorName,
 							lpa_reference: appeal.applicationReference,
-							visit_date: dateISOStringToDisplayDate(siteVisit.visitDate)
+							visit_date: dateISOStringToDisplayDate(siteVisit.visitDate),
+							team_email_address: 'caseofficers@planninginspectorate.gov.uk'
 						},
 						recipientEmail: appeal.agent.email
 					});
@@ -1864,7 +1879,8 @@ describe('site visit routes', () => {
 							end_time: formatTime(siteVisit.visitEndTime),
 							inspector_name: inspectorName,
 							lpa_reference: appeal.applicationReference,
-							visit_date: dateISOStringToDisplayDate(siteVisit.visitDate)
+							visit_date: dateISOStringToDisplayDate(siteVisit.visitDate),
+							team_email_address: 'caseofficers@planninginspectorate.gov.uk'
 						},
 						recipientEmail: appeal.lpa.email
 					});
@@ -1936,7 +1952,8 @@ describe('site visit routes', () => {
 							end_time: formatTime(siteVisit.visitEndTime),
 							inspector_name: '',
 							lpa_reference: appeal.applicationReference,
-							visit_date: dateISOStringToDisplayDate(siteVisit.visitDate)
+							visit_date: dateISOStringToDisplayDate(siteVisit.visitDate),
+							team_email_address: 'caseofficers@planninginspectorate.gov.uk'
 						},
 						recipientEmail: appeal.agent.email
 					});
@@ -1952,7 +1969,8 @@ describe('site visit routes', () => {
 							end_time: formatTime(siteVisit.visitEndTime),
 							inspector_name: '',
 							lpa_reference: appeal.applicationReference,
-							visit_date: dateISOStringToDisplayDate(siteVisit.visitDate)
+							visit_date: dateISOStringToDisplayDate(siteVisit.visitDate),
+							team_email_address: 'caseofficers@planninginspectorate.gov.uk'
 						},
 						recipientEmail: appeal.lpa.email
 					});
@@ -2024,7 +2042,8 @@ describe('site visit routes', () => {
 							end_time: formatTime(siteVisit.visitEndTime),
 							inspector_name: '',
 							lpa_reference: appeal.applicationReference,
-							visit_date: dateISOStringToDisplayDate(siteVisit.visitDate)
+							visit_date: dateISOStringToDisplayDate(siteVisit.visitDate),
+							team_email_address: 'caseofficers@planninginspectorate.gov.uk'
 						},
 						recipientEmail: appeal.agent.email
 					});
@@ -2097,7 +2116,8 @@ describe('site visit routes', () => {
 							end_time: formatTime(siteVisit.visitEndTime),
 							inspector_name: '',
 							lpa_reference: appeal.applicationReference,
-							visit_date: dateISOStringToDisplayDate(siteVisit.visitDate)
+							visit_date: dateISOStringToDisplayDate(siteVisit.visitDate),
+							team_email_address: 'caseofficers@planninginspectorate.gov.uk'
 						},
 						recipientEmail: appeal.agent.email
 					});

--- a/appeals/api/src/server/endpoints/site-visits/site-visits.service.js
+++ b/appeals/api/src/server/endpoints/site-visits/site-visits.service.js
@@ -12,6 +12,7 @@ import {
 } from '@pins/appeals/constants/support.js';
 import formatDate, { formatTime } from '@pins/appeals/utils/date-formatter.js';
 // eslint-disable-next-line no-unused-vars
+import { getTeamEmailFromAppealId } from '#endpoints/case-team/case-team.service.js';
 import { broadcasters } from '#endpoints/integrations/integrations.broadcasters.js';
 import { notifySend } from '#notify/notify-send.js';
 import { DEFAULT_TIMEZONE } from '@pins/appeals/constants/dates.js';
@@ -69,7 +70,8 @@ export const createSiteVisit = async (azureAdUserId, siteVisitData, notifyClient
 			start_time: formatTime(siteVisitData.visitStartTime),
 			end_time: formatTime(siteVisitData.visitEndTime),
 			visit_date: formatDate(new Date(siteVisitData.visitDate || ''), false),
-			inspector_name: siteVisitData.inspectorName || ''
+			inspector_name: siteVisitData.inspectorName || '',
+			team_email_address: await getTeamEmailFromAppealId(appealId)
 		};
 
 		if (notifyTemplateIds.appellant && siteVisitData.appellantEmail) {
@@ -179,7 +181,8 @@ const updateSiteVisit = async (azureAdUserId, updateSiteVisitData, notifyClient)
 			start_time: formatTime(updateSiteVisitData.visitStartTime),
 			end_time: formatTime(updateSiteVisitData.visitEndTime),
 			visit_date: formatDate(new Date(updateSiteVisitData.visitDate || ''), false),
-			inspector_name: updateSiteVisitData.inspectorName || ''
+			inspector_name: updateSiteVisitData.inspectorName || '',
+			team_email_address: await getTeamEmailFromAppealId(appealId)
 		};
 
 		if (notifyTemplateIds.appellant && updateSiteVisitData.appellantEmail) {

--- a/appeals/api/src/server/endpoints/withdrawal/__tests__/withdrawal.test.js
+++ b/appeals/api/src/server/endpoints/withdrawal/__tests__/withdrawal.test.js
@@ -107,7 +107,8 @@ describe('appeal withdrawal routes', () => {
 					site_address: `${appeal.address.addressLine1}, ${appeal.address.addressLine2}, ${appeal.address.addressTown}, ${appeal.address.addressCounty}, ${appeal.address.postcode}, ${appeal.address.addressCountry}`,
 					withdrawal_date: formatDate(utcDate, false),
 					event_set: true,
-					event_type: 'site visit'
+					event_type: 'site visit',
+					team_email_address: 'caseofficers@planninginspectorate.gov.uk'
 				},
 				recipientEmail: 'test@136s7.com',
 				templateName: 'appeal-withdrawn-appellant'
@@ -122,7 +123,8 @@ describe('appeal withdrawal routes', () => {
 					site_address: `${appeal.address.addressLine1}, ${appeal.address.addressLine2}, ${appeal.address.addressTown}, ${appeal.address.addressCounty}, ${appeal.address.postcode}, ${appeal.address.addressCountry}`,
 					withdrawal_date: formatDate(utcDate, false),
 					event_set: true,
-					event_type: 'site visit'
+					event_type: 'site visit',
+					team_email_address: 'caseofficers@planninginspectorate.gov.uk'
 				},
 				recipientEmail: 'maid@lpa-email.gov.uk',
 				templateName: 'appeal-withdrawn-lpa'

--- a/appeals/api/src/server/endpoints/withdrawal/withdrawal.service.js
+++ b/appeals/api/src/server/endpoints/withdrawal/withdrawal.service.js
@@ -1,3 +1,4 @@
+import { getTeamEmailFromAppealId } from '#endpoints/case-team/case-team.service.js';
 import { broadcasters } from '#endpoints/integrations/integrations.broadcasters.js';
 import { notifySend } from '#notify/notify-send.js';
 import appealRepository from '#repositories/appeal.repository.js';
@@ -39,7 +40,8 @@ export const publishWithdrawal = async (
 		site_address: siteAddress,
 		withdrawal_date: formatDate(new Date(withdrawalRequestDate || ''), false),
 		event_type: eventType,
-		event_set: !!eventType
+		event_set: !!eventType,
+		team_email_address: await getTeamEmailFromAppealId(appeal.id)
 	};
 
 	if (recipientEmail) {

--- a/appeals/api/src/server/notify/templates/__tests__/appeal-start-date-change-appellant.test.js
+++ b/appeals/api/src/server/notify/templates/__tests__/appeal-start-date-change-appellant.test.js
@@ -17,7 +17,8 @@ describe('appeal-start-date-change-appellant.md', () => {
 				start_date: '01 January 2025',
 				local_planning_authority: 'Bristol City Council',
 				site_visit: true,
-				costs_info: true
+				costs_info: true,
+				team_email_address: 'caseofficers@planninginspectorate.gov.uk'
 			},
 			appeal: {
 				id: 'mock-appeal-generic-id',
@@ -70,7 +71,8 @@ describe('appeal-start-date-change-appellant.md', () => {
 				start_date: '01 January 2025',
 				local_planning_authority: 'Bristol City Council',
 				site_visit: false,
-				costs_info: false
+				costs_info: false,
+				team_email_address: 'caseofficers@planninginspectorate.gov.uk'
 			},
 			appeal: {
 				id: 'mock-appeal-generic-id',

--- a/appeals/api/src/server/notify/templates/__tests__/appeal-start-date-change-lpa.test.js
+++ b/appeals/api/src/server/notify/templates/__tests__/appeal-start-date-change-lpa.test.js
@@ -17,7 +17,8 @@ describe('appeal-start-date-change-appellant.md', () => {
 				site_address: '96 The Avenue, Leftfield, Maidstone, Kent, MD21 5XY, United Kingdom',
 				start_date: '01 January 2025',
 				procedure_type: 'a hearing',
-				questionnaire_due_date: '01 January 2025'
+				questionnaire_due_date: '01 January 2025',
+				team_email_address: 'caseofficers@planninginspectorate.gov.uk'
 			},
 			appeal: {
 				id: 'mock-appeal-generic-id',

--- a/appeals/api/src/server/notify/templates/__tests__/appeal-type-change-non-has.test.js
+++ b/appeals/api/src/server/notify/templates/__tests__/appeal-type-change-non-has.test.js
@@ -18,7 +18,8 @@ describe('appeal-type-change-non-has.md', () => {
 				local_planning_authority: 'Bristol City Council',
 				existing_appeal_type: 'Householder',
 				appeal_type: 'D',
-				due_date: '01 January 2025'
+				due_date: '01 January 2025',
+				team_email_address: 'caseofficers@planninginspectorate.gov.uk'
 			},
 			appeal: {
 				id: 'mock-appeal-generic-id',

--- a/appeals/api/src/server/notify/templates/__tests__/appeal-valid-start-case-appellant.test.js
+++ b/appeals/api/src/server/notify/templates/__tests__/appeal-valid-start-case-appellant.test.js
@@ -15,7 +15,8 @@ describe('appeal-valid-start-case-appellant.md', () => {
 				appeal_reference_number: '134526',
 				site_address: '96 The Avenue, Leftfield, Maidstone, Kent, MD21 5XY, United Kingdom',
 				start_date: '01 January 2025',
-				local_planning_authority: 'Bristol City Council'
+				local_planning_authority: 'Bristol City Council',
+				team_email_address: 'caseofficers@planninginspectorate.gov.uk'
 			},
 			appeal: {
 				id: 'mock-appeal-generic-id',

--- a/appeals/api/src/server/notify/templates/__tests__/appeal-valid-start-case-lpa.test.js
+++ b/appeals/api/src/server/notify/templates/__tests__/appeal-valid-start-case-lpa.test.js
@@ -18,13 +18,15 @@ describe('appeal-valid-start-case-lpa.md', () => {
 				local_planning_authority: 'Bristol City Council',
 				appeal_type: 'Householder',
 				procedure_type: 'a written procedure',
-				questionnaire_due_date: '01 January 2025'
+				questionnaire_due_date: '01 January 2025',
+				team_email_address: 'caseofficers@planninginspectorate.gov.uk'
 			},
 			appeal: {
 				id: 'mock-appeal-generic-id',
 				reference: '134526'
 			},
-			startDate: new Date('2025-01-01')
+			startDate: new Date('2025-01-01'),
+			team_email_address: 'caseofficers@planninginspectorate.gov.uk'
 		};
 
 		const expectedContent = [

--- a/appeals/api/src/server/notify/templates/__tests__/appeal-valid-start-case-s78-appellant-hearing.test.js
+++ b/appeals/api/src/server/notify/templates/__tests__/appeal-valid-start-case-s78-appellant-hearing.test.js
@@ -20,7 +20,8 @@ describe('appeal-valid-start-case-appellant-hearing.md', () => {
 				lpa_statement_deadline: '01 March 2025',
 				ip_comments_deadline: '01 April 2025',
 				hearing_date: '01 May 2025',
-				hearing_time: '1pm'
+				hearing_time: '1pm',
+				team_email_address: 'caseofficers@planninginspectorate.gov.uk'
 			},
 			appeal: {
 				id: 'mock-appeal-generic-id',

--- a/appeals/api/src/server/notify/templates/__tests__/appeal-valid-start-case-s78-appellant.test.js
+++ b/appeals/api/src/server/notify/templates/__tests__/appeal-valid-start-case-s78-appellant.test.js
@@ -23,7 +23,8 @@ describe('appeal-valid-start-case-s78-appellant.md', () => {
 				ip_comments_deadline: '20 January 2025',
 				final_comments_deadline: '30 January 2025',
 				we_will_email_when:
-					'when you can view information from other parties in the appeals service.'
+					'when you can view information from other parties in the appeals service.',
+				team_email_address: 'caseofficers@planninginspectorate.gov.uk'
 			},
 			appeal: {
 				id: 'mock-appeal-generic-id',
@@ -115,7 +116,8 @@ describe('appeal-valid-start-case-s78-appellant.md', () => {
 				ip_comments_deadline: '20 January 2025',
 				final_comments_deadline: '30 January 2025',
 				child_appeals: ['656565'],
-				we_will_email_when: 'as this is a test'
+				we_will_email_when: 'as this is a test',
+				team_email_address: 'caseofficers@planninginspectorate.gov.uk'
 			},
 			appeal: {
 				id: 'mock-appeal-generic-id',
@@ -209,7 +211,8 @@ describe('appeal-valid-start-case-s78-appellant.md', () => {
 				ip_comments_deadline: '20 January 2025',
 				final_comments_deadline: '30 January 2025',
 				child_appeals: ['111111', '222222', '333333', '444444', '555555'],
-				we_will_email_when: 'as this is a test'
+				we_will_email_when: 'as this is a test',
+				team_email_address: 'caseofficers@planninginspectorate.gov.uk'
 			},
 			appeal: {
 				id: 'mock-appeal-generic-id',
@@ -310,7 +313,8 @@ describe('appeal-valid-start-case-s78-appellant.md', () => {
 				we_will_email_when: [
 					'to let you know when you can view information from other parties in the appeals service',
 					'when we set up your hearing'
-				]
+				],
+				team_email_address: 'caseofficers@planninginspectorate.gov.uk'
 			},
 			appeal: {
 				id: 'mock-appeal-generic-id',

--- a/appeals/api/src/server/notify/templates/__tests__/appeal-valid-start-case-s78-lpa-hearing.test.js
+++ b/appeals/api/src/server/notify/templates/__tests__/appeal-valid-start-case-s78-lpa-hearing.test.js
@@ -23,7 +23,8 @@ describe('appeal-valid-start-case-lpa-hearing.md', () => {
 				statement_of_common_ground_due_date: '01 April 2025',
 				planning_obligation_due_date: '01 May 2025',
 				hearing_date: '01 April 2025',
-				hearing_time: '1pm'
+				hearing_time: '1pm',
+				team_email_address: 'caseofficers@planninginspectorate.gov.uk'
 			},
 			appeal: {
 				id: 'mock-appeal-generic-id',

--- a/appeals/api/src/server/notify/templates/__tests__/appeal-valid-start-case-s78-lpa.test.js
+++ b/appeals/api/src/server/notify/templates/__tests__/appeal-valid-start-case-s78-lpa.test.js
@@ -21,7 +21,8 @@ describe('appeal-valid-start-case-s78-lpa.md', () => {
 				questionnaire_due_date: '01 January 2025',
 				lpa_statement_deadline: '10 January 2025',
 				ip_comments_deadline: '20 January 2025',
-				final_comments_deadline: '30 January 2025'
+				final_comments_deadline: '30 January 2025',
+				team_email_address: 'caseofficers@planninginspectorate.gov.uk'
 			},
 			appeal: {
 				id: 'mock-appeal-generic-id',
@@ -104,7 +105,8 @@ describe('appeal-valid-start-case-s78-lpa.md', () => {
 				lpa_statement_deadline: '10 January 2025',
 				ip_comments_deadline: '20 January 2025',
 				final_comments_deadline: '30 January 2025',
-				child_appeals: ['656565']
+				child_appeals: ['656565'],
+				team_email_address: 'caseofficers@planninginspectorate.gov.uk'
 			},
 			appeal: {
 				id: 'mock-appeal-generic-id',
@@ -189,7 +191,8 @@ describe('appeal-valid-start-case-s78-lpa.md', () => {
 				lpa_statement_deadline: '10 January 2025',
 				ip_comments_deadline: '20 January 2025',
 				final_comments_deadline: '30 January 2025',
-				child_appeals: ['111111', '222222', '333333', '444444', '555555']
+				child_appeals: ['111111', '222222', '333333', '444444', '555555'],
+				team_email_address: 'caseofficers@planninginspectorate.gov.uk'
 			},
 			appeal: {
 				id: 'mock-appeal-generic-id',
@@ -280,7 +283,8 @@ describe('appeal-valid-start-case-s78-lpa.md', () => {
 				ip_comments_deadline: '20 January 2025',
 				final_comments_deadline: '30 January 2025',
 				statement_of_common_ground_deadline: '25 January 2025',
-				planning_obligation_deadline: '30 January 2025'
+				planning_obligation_deadline: '30 January 2025',
+				team_email_address: 'caseofficers@planninginspectorate.gov.uk'
 			},
 			appeal: {
 				id: 'mock-appeal-generic-id',
@@ -369,7 +373,8 @@ describe('appeal-valid-start-case-s78-lpa.md', () => {
 				lpa_statement_deadline: '10 January 2025',
 				ip_comments_deadline: '20 January 2025',
 				statement_of_common_ground_deadline: '25 January 2025',
-				planning_obligation_deadline: ''
+				planning_obligation_deadline: '',
+				team_email_address: 'caseofficers@planninginspectorate.gov.uk'
 			},
 			appeal: {
 				id: 'mock-appeal-generic-id',

--- a/appeals/api/src/server/notify/templates/__tests__/correction-notice-decision.test.js
+++ b/appeals/api/src/server/notify/templates/__tests__/correction-notice-decision.test.js
@@ -17,7 +17,8 @@ describe('correction-notice-decision.md', () => {
 				start_date: '01 January 2025',
 				existing_appeal_type: 'Householder',
 				correction_notice_reason: 'There has been a mistake - but we fixed it thanks',
-				decision_date: '01 January 2025'
+				decision_date: '01 January 2025',
+				team_email_address: 'caseofficers@planninginspectorate.gov.uk'
 			},
 			appeal: {
 				id: 'mock-appeal-generic-id',

--- a/appeals/api/src/server/notify/templates/__tests__/notify-appeal-confirmed.test.js
+++ b/appeals/api/src/server/notify/templates/__tests__/notify-appeal-confirmed.test.js
@@ -14,7 +14,8 @@ describe('appeal-confirmed.md', () => {
 				lpa_reference: '48269/APP/2021/1482',
 				appeal_reference_number: '134526',
 				site_address: '96 The Avenue, Leftfield, Maidstone, Kent, MD21 5XY, United Kingdom',
-				feedback_link: 'https://forms.office.com/r/9U4Sq9rEff'
+				feedback_link: 'https://forms.office.com/r/9U4Sq9rEff',
+				team_email_address: 'caseofficers@planninginspectorate.gov.uk'
 			}
 		};
 

--- a/appeals/api/src/server/notify/templates/__tests__/notify-appeal-incomplete.test.js
+++ b/appeals/api/src/server/notify/templates/__tests__/notify-appeal-incomplete.test.js
@@ -18,7 +18,8 @@ describe('appeal-incomplete.md', () => {
 				reasons: [
 					'The original application form is incomplete',
 					'Other: Appellant contact information is incorrect or missing'
-				]
+				],
+				team_email_address: 'caseofficers@planninginspectorate.gov.uk'
 			}
 		};
 

--- a/appeals/api/src/server/notify/templates/__tests__/notify-appeal-invalid-lpa.test.js
+++ b/appeals/api/src/server/notify/templates/__tests__/notify-appeal-invalid-lpa.test.js
@@ -17,7 +17,8 @@ describe('appeal-invalid-lpa.md', () => {
 				reasons: [
 					'Appeal has not been submitted on time',
 					'Other: The appeal site address does not match'
-				]
+				],
+				team_email_address: 'caseofficers@planninginspectorate.gov.uk'
 			}
 		};
 

--- a/appeals/api/src/server/notify/templates/__tests__/notify-appeal-invalid.test.js
+++ b/appeals/api/src/server/notify/templates/__tests__/notify-appeal-invalid.test.js
@@ -17,7 +17,8 @@ describe('appeal-invalid.md', () => {
 				reasons: [
 					'Appeal has not been submitted on time',
 					'Other: The appeal site address does not match'
-				]
+				],
+				team_email_address: 'caseofficers@planninginspectorate.gov.uk'
 			}
 		};
 

--- a/appeals/api/src/server/notify/templates/__tests__/notify-appeal-withdrawn-appellant.test.js
+++ b/appeals/api/src/server/notify/templates/__tests__/notify-appeal-withdrawn-appellant.test.js
@@ -15,7 +15,8 @@ test('should call notify sendEmail for appeal-withdrawn-appellant with the corre
 			site_address: '96 The Avenue, Leftfield, Maidstone, Kent, MD21 5XY, United Kingdom',
 			withdrawal_date: '01 January 2025',
 			event_set: true,
-			event_type: 'site visit'
+			event_type: 'site visit',
+			team_email_address: 'caseofficers@planninginspectorate.gov.uk'
 		},
 		appeal: {
 			id: 'mock-appeal-generic-id',
@@ -74,7 +75,8 @@ test('should call notify sendEmail for appeal-withdrawn-appellant without event_
 			lpa_reference: '48269/APP/2021/1482',
 			site_address: '96 The Avenue, Leftfield, Maidstone, Kent, MD21 5XY, United Kingdom',
 			withdrawal_date: '01 January 2025',
-			event_set: false
+			event_set: false,
+			team_email_address: 'caseofficers@planninginspectorate.gov.uk'
 		},
 		appeal: {
 			id: 'mock-appeal-generic-id',

--- a/appeals/api/src/server/notify/templates/__tests__/notify-appeal-withdrawn-lpa.test.js
+++ b/appeals/api/src/server/notify/templates/__tests__/notify-appeal-withdrawn-lpa.test.js
@@ -15,7 +15,8 @@ test('should call notify sendEmail for appeal-withdrawn-lpa with the correct dat
 			site_address: '98 The Avenue, Leftfield, Maidstone, Kent, MD21 5YY, United Kingdom',
 			withdrawal_date: '03 January 2025',
 			event_set: true,
-			event_type: 'site visit'
+			event_type: 'site visit',
+			team_email_address: 'caseofficers@planninginspectorate.gov.uk'
 		},
 		appeal: {
 			id: 'mock-appeal-generic-id',
@@ -73,7 +74,8 @@ test('should call notify sendEmail for appeal-withdrawn-lpa without site visit c
 			site_address: '98 The Avenue, Leftfield, Maidstone, Kent, MD21 5YY, United Kingdom',
 			withdrawal_date: '03 January 2025',
 			event_set: false,
-			event_type: ''
+			event_type: '',
+			team_email_address: 'caseofficers@planninginspectorate.gov.uk'
 		},
 		appeal: {
 			id: 'mock-appeal-generic-id',
@@ -131,7 +133,8 @@ test('should call notify sendEmail for appeal-withdrawn-lpa with the correct dat
 			site_address: '98 The Avenue, Leftfield, Maidstone, Kent, MD21 5YY, United Kingdom',
 			withdrawal_date: '03 January 2025',
 			event_set: true,
-			event_type: 'hearing'
+			event_type: 'hearing',
+			team_email_address: 'caseofficers@planninginspectorate.gov.uk'
 		},
 		appeal: {
 			id: 'mock-appeal-generic-id',

--- a/appeals/api/src/server/notify/templates/__tests__/notify-final-comment-rejected-appellant.test.js
+++ b/appeals/api/src/server/notify/templates/__tests__/notify-final-comment-rejected-appellant.test.js
@@ -15,7 +15,8 @@ describe('final-comment-rejected-appellant.md', () => {
 				site_address: '10, Test Street',
 				lpa_reference: '12345XYZ',
 				deadline_date: '01 January 2021',
-				reasons: ['Reason one', 'Reason two', 'Reason three']
+				reasons: ['Reason one', 'Reason two', 'Reason three'],
+				team_email_address: 'caseofficers@planninginspectorate.gov.uk'
 			}
 		};
 

--- a/appeals/api/src/server/notify/templates/__tests__/notify-final-comment-rejected-lpa.test.js
+++ b/appeals/api/src/server/notify/templates/__tests__/notify-final-comment-rejected-lpa.test.js
@@ -15,7 +15,8 @@ describe('final-comment-rejected-lpa.md', () => {
 				site_address: '10, Test Street',
 				lpa_reference: '12345XYZ',
 				deadline_date: '01 January 2021',
-				reasons: ['Reason one', 'Reason two', 'Reason three']
+				reasons: ['Reason one', 'Reason two', 'Reason three'],
+				team_email_address: 'caseofficers@planninginspectorate.gov.uk'
 			}
 		};
 

--- a/appeals/api/src/server/notify/templates/__tests__/notify-final-comments-done-appellant.test.js
+++ b/appeals/api/src/server/notify/templates/__tests__/notify-final-comments-done-appellant.test.js
@@ -13,7 +13,8 @@ describe('final-comments-done-appellant.md', () => {
 			personalisation: {
 				appeal_reference_number: 'ABC45678',
 				site_address: '10, Test Street',
-				lpa_reference: '12345XYZ'
+				lpa_reference: '12345XYZ',
+				team_email_address: 'caseofficers@planninginspectorate.gov.uk'
 			}
 		};
 

--- a/appeals/api/src/server/notify/templates/__tests__/notify-final-comments-done-lpa.test.js
+++ b/appeals/api/src/server/notify/templates/__tests__/notify-final-comments-done-lpa.test.js
@@ -13,7 +13,8 @@ describe('final-comments-done-lpa.md', () => {
 			personalisation: {
 				appeal_reference_number: 'ABC45678',
 				site_address: '10, Test Street',
-				lpa_reference: '12345XYZ'
+				lpa_reference: '12345XYZ',
+				team_email_address: 'caseofficers@planninginspectorate.gov.uk'
 			}
 		};
 

--- a/appeals/api/src/server/notify/templates/__tests__/notify-final-comments-none.test.js
+++ b/appeals/api/src/server/notify/templates/__tests__/notify-final-comments-none.test.js
@@ -13,7 +13,8 @@ describe('final-comments-done-lpa.md', () => {
 			personalisation: {
 				appeal_reference_number: 'ABC45678',
 				site_address: '10, Test Street',
-				lpa_reference: '12345XYZ'
+				lpa_reference: '12345XYZ',
+				team_email_address: 'caseofficers@planninginspectorate.gov.uk'
 			}
 		};
 

--- a/appeals/api/src/server/notify/templates/__tests__/notify-hearing-cancelled.test.js
+++ b/appeals/api/src/server/notify/templates/__tests__/notify-hearing-cancelled.test.js
@@ -13,7 +13,8 @@ describe('hearing-cancelled.md', () => {
 			personalisation: {
 				appeal_reference_number: 'ABC45678',
 				site_address: '10, Test Street',
-				lpa_reference: '12345XYZ'
+				lpa_reference: '12345XYZ',
+				team_email_address: 'caseofficers@planninginspectorate.gov.uk'
 			}
 		};
 

--- a/appeals/api/src/server/notify/templates/__tests__/notify-hearing-set-up.test.js
+++ b/appeals/api/src/server/notify/templates/__tests__/notify-hearing-set-up.test.js
@@ -16,7 +16,8 @@ describe('hearing-set-up.md', () => {
 				lpa_reference: '12345XYZ',
 				hearing_date: '31 January 2025',
 				hearing_time: '1:30pm',
-				hearing_address: '24, Court Street'
+				hearing_address: '24, Court Street',
+				team_email_address: 'caseofficers@planninginspectorate.gov.uk'
 			}
 		};
 

--- a/appeals/api/src/server/notify/templates/__tests__/notify-hearing-updated.test.js
+++ b/appeals/api/src/server/notify/templates/__tests__/notify-hearing-updated.test.js
@@ -16,7 +16,8 @@ describe('hearing-updated.md', () => {
 				lpa_reference: '12345XYZ',
 				hearing_date: '31 January 2025',
 				hearing_time: '1:30pm',
-				hearing_address: '24, Court Street'
+				hearing_address: '24, Court Street',
+				team_email_address: 'caseofficers@planninginspectorate.gov.uk'
 			}
 		};
 

--- a/appeals/api/src/server/notify/templates/__tests__/notify-ip-comment-rejected-deadline-extended.test.js
+++ b/appeals/api/src/server/notify/templates/__tests__/notify-ip-comment-rejected-deadline-extended.test.js
@@ -19,7 +19,8 @@ describe('ip-comment-rejected-deadline-extended.md', () => {
 				lpa_reference: '12345XYZ',
 				deadline_date: '01 January 2021',
 				reasons: ['Reason one', 'Reason two', 'Reason three'],
-				resubmit_comment_to_fo: true
+				resubmit_comment_to_fo: true,
+				team_email_address: 'caseofficers@planninginspectorate.gov.uk'
 			}
 		};
 	});
@@ -69,7 +70,8 @@ describe('ip-comment-rejected-deadline-extended.md', () => {
 			...notifySendData,
 			personalisation: {
 				...notifySendData.personalisation,
-				resubmit_comment_to_fo: false
+				resubmit_comment_to_fo: false,
+				team_email_address: 'caseofficers@planninginspectorate.gov.uk'
 			}
 		};
 

--- a/appeals/api/src/server/notify/templates/__tests__/notify-ip-comment-rejected.test.js
+++ b/appeals/api/src/server/notify/templates/__tests__/notify-ip-comment-rejected.test.js
@@ -15,7 +15,8 @@ describe('ip-comment-rejected.md', () => {
 				site_address: '10, Test Street',
 				lpa_reference: '12345XYZ',
 				deadline_date: '01 January 2021',
-				reasons: ['Reason one', 'Reason two', 'Reason three']
+				reasons: ['Reason one', 'Reason two', 'Reason three'],
+				team_email_address: 'caseofficers@planninginspectorate.gov.uk'
 			}
 		};
 

--- a/appeals/api/src/server/notify/templates/__tests__/notify-link-appeal.test.js
+++ b/appeals/api/src/server/notify/templates/__tests__/notify-link-appeal.test.js
@@ -17,7 +17,8 @@ describe('link-appeal.md', () => {
 				site_address: '10, Test Street',
 				lpa_reference: '12345XYZ',
 				event_type: 'site visit',
-				linked_before_lpa_questionnaire: true
+				linked_before_lpa_questionnaire: true,
+				team_email_address: 'caseofficers@planninginspectorate.gov.uk'
 			}
 		};
 
@@ -69,7 +70,8 @@ describe('link-appeal.md', () => {
 				site_address: '10, Test Street',
 				lpa_reference: '12345XYZ',
 				event_type: 'site visit',
-				linked_before_lpa_questionnaire: false
+				linked_before_lpa_questionnaire: false,
+				team_email_address: 'caseofficers@planninginspectorate.gov.uk'
 			}
 		};
 

--- a/appeals/api/src/server/notify/templates/__tests__/notify-lpa-statement-incomplete.test.js
+++ b/appeals/api/src/server/notify/templates/__tests__/notify-lpa-statement-incomplete.test.js
@@ -15,7 +15,8 @@ describe('lpa-statement-incomplete.md', () => {
 				site_address: '10, Test Street',
 				lpa_reference: '12345XYZ',
 				deadline_date: '01 January 2021',
-				reasons: ['Reason one', 'Reason two', 'Reason three']
+				reasons: ['Reason one', 'Reason two', 'Reason three'],
+				team_email_address: 'caseofficers@planninginspectorate.gov.uk'
 			}
 		};
 

--- a/appeals/api/src/server/notify/templates/__tests__/notify-lpaq-complete-appellant.test.js
+++ b/appeals/api/src/server/notify/templates/__tests__/notify-lpaq-complete-appellant.test.js
@@ -13,7 +13,8 @@ describe('lpaq-complete-appellant.md', () => {
 			personalisation: {
 				appeal_reference_number: 'ABC45678',
 				site_address: '10, Test Street',
-				lpa_reference: '12345XYZ'
+				lpa_reference: '12345XYZ',
+				team_email_address: 'caseofficers@planninginspectorate.gov.uk'
 			}
 		};
 

--- a/appeals/api/src/server/notify/templates/__tests__/notify-lpaq-complete-has-appellant.test.js
+++ b/appeals/api/src/server/notify/templates/__tests__/notify-lpaq-complete-has-appellant.test.js
@@ -13,7 +13,8 @@ describe('lpaq-complete-has-appellant.md', () => {
 			personalisation: {
 				appeal_reference_number: 'ABC45678',
 				site_address: '10, Test Street',
-				lpa_reference: '12345XYZ'
+				lpa_reference: '12345XYZ',
+				team_email_address: 'caseofficers@planninginspectorate.gov.uk'
 			}
 		};
 

--- a/appeals/api/src/server/notify/templates/__tests__/notify-lpaq-complete-lpa.test.js
+++ b/appeals/api/src/server/notify/templates/__tests__/notify-lpaq-complete-lpa.test.js
@@ -13,7 +13,8 @@ describe('lpaq-complete-lpa.md', () => {
 			personalisation: {
 				appeal_reference_number: 'ABC45678',
 				site_address: '10, Test Street',
-				lpa_reference: '12345XYZ'
+				lpa_reference: '12345XYZ',
+				team_email_address: 'caseofficers@planninginspectorate.gov.uk'
 			}
 		};
 

--- a/appeals/api/src/server/notify/templates/__tests__/notify-lpaq-incomplete.test.js
+++ b/appeals/api/src/server/notify/templates/__tests__/notify-lpaq-incomplete.test.js
@@ -18,7 +18,8 @@ describe('lpaq-incomplete.md', () => {
 				reasons: [
 					'Documents or information are missing: Policy is missing',
 					'Other: Addresses are incorrect or missing'
-				]
+				],
+				team_email_address: 'caseofficers@planninginspectorate.gov.uk'
 			}
 		};
 

--- a/appeals/api/src/server/notify/templates/__tests__/notify-received-statement-and-ip-comments-appellant.test.js
+++ b/appeals/api/src/server/notify/templates/__tests__/notify-received-statement-and-ip-comments-appellant.test.js
@@ -21,7 +21,8 @@ describe('received-statement-and-ip-comments-appellant.md', () => {
 				has_ip_comments: true,
 				what_happens_next:
 					'You need to [submit your final comments](/mock-front-office-url/appeals/ABC45678) by 01 January 2021.',
-				subject: 'Submit your final comments'
+				subject: 'Submit your final comments',
+				team_email_address: 'caseofficers@planninginspectorate.gov.uk'
 			}
 		};
 		expectedTailContent = [

--- a/appeals/api/src/server/notify/templates/__tests__/notify-received-statement-and-ip-comments-lpa.test.js
+++ b/appeals/api/src/server/notify/templates/__tests__/notify-received-statement-and-ip-comments-lpa.test.js
@@ -25,7 +25,8 @@ describe('received-statement-and-ip-comments-lpa.md', () => {
 			recipientEmail,
 			personalisation: {
 				...basePersonalisation,
-				has_ip_comments: true
+				has_ip_comments: true,
+				team_email_address: 'caseofficers@planninginspectorate.gov.uk'
 			}
 		};
 
@@ -62,7 +63,8 @@ describe('received-statement-and-ip-comments-lpa.md', () => {
 			recipientEmail,
 			personalisation: {
 				...basePersonalisation,
-				has_ip_comments: false
+				has_ip_comments: false,
+				team_email_address: 'caseofficers@planninginspectorate.gov.uk'
 			}
 		};
 
@@ -100,7 +102,8 @@ describe('received-statement-and-ip-comments-lpa.md', () => {
 				...basePersonalisation,
 				has_ip_comments: true,
 				what_happens_next:
-					'You need to [submit your final comments](/mock-front-office-url/manage-appeals/ABC45678) by 01 January 2021.'
+					'You need to [submit your final comments](/mock-front-office-url/manage-appeals/ABC45678) by 01 January 2021.',
+				team_email_address: 'caseofficers@planninginspectorate.gov.uk'
 			}
 		};
 
@@ -143,7 +146,8 @@ describe('received-statement-and-ip-comments-lpa.md', () => {
 				...basePersonalisation,
 				has_ip_comments: false,
 				what_happens_next:
-					'You need to [submit your final comments](/mock-front-office-url/manage-appeals/ABC45678) by 01 January 2021.'
+					'You need to [submit your final comments](/mock-front-office-url/manage-appeals/ABC45678) by 01 January 2021.',
+				team_email_address: 'caseofficers@planninginspectorate.gov.uk'
 			}
 		};
 
@@ -183,7 +187,8 @@ describe('received-statement-and-ip-comments-lpa.md', () => {
 			recipientEmail,
 			personalisation: {
 				...basePersonalisation,
-				is_hearing_procedure: true
+				is_hearing_procedure: true,
+				team_email_address: 'caseofficers@planninginspectorate.gov.uk'
 			}
 		};
 

--- a/appeals/api/src/server/notify/templates/__tests__/notify-site-visit-change-access-required-date-change-appellant.test.js
+++ b/appeals/api/src/server/notify/templates/__tests__/notify-site-visit-change-access-required-date-change-appellant.test.js
@@ -15,7 +15,8 @@ describe('site-visit-change-access-required-date-change-appellant.md', () => {
 				site_address: '22, Example Lane',
 				lpa_reference: 'REF-67890',
 				visit_date: '12 June 2025',
-				start_time: '10:30am'
+				start_time: '10:30am',
+				team_email_address: 'caseofficers@planninginspectorate.gov.uk'
 			}
 		};
 

--- a/appeals/api/src/server/notify/templates/__tests__/notify-site-visit-change-access-required-to-accompanied-appellant.test.js
+++ b/appeals/api/src/server/notify/templates/__tests__/notify-site-visit-change-access-required-to-accompanied-appellant.test.js
@@ -15,7 +15,8 @@ describe('site-visit-change-access-required-to-accompanied-appellant.md', () => 
 				site_address: '55, Sample Road',
 				lpa_reference: 'APP-45678',
 				visit_date: '19 June 2025',
-				start_time: '2:00pm'
+				start_time: '2:00pm',
+				team_email_address: 'caseofficers@planninginspectorate.gov.uk'
 			}
 		};
 

--- a/appeals/api/src/server/notify/templates/__tests__/notify-site-visit-change-access-required-to-accompanied-lpa.test.js
+++ b/appeals/api/src/server/notify/templates/__tests__/notify-site-visit-change-access-required-to-accompanied-lpa.test.js
@@ -15,7 +15,8 @@ describe('site-visit-change-access-required-to-accompanied-lpa.md', () => {
 				site_address: '77, Decision Way',
 				lpa_reference: 'PLA-98765',
 				visit_date: '25 July 2025',
-				start_time: '11:15am'
+				start_time: '11:15am',
+				team_email_address: 'caseofficers@planninginspectorate.gov.uk'
 			}
 		};
 

--- a/appeals/api/src/server/notify/templates/__tests__/notify-site-visit-change-access-required-to-unaccompanied-appellant.test.js
+++ b/appeals/api/src/server/notify/templates/__tests__/notify-site-visit-change-access-required-to-unaccompanied-appellant.test.js
@@ -14,7 +14,8 @@ describe('site-visit-change-access-required-to-unaccompanied-appellant.md', () =
 				appeal_reference_number: 'UVW98765',
 				site_address: '9, Quiet Close',
 				lpa_reference: 'PLN-11223',
-				visit_date: '2 August 2025'
+				visit_date: '2 August 2025',
+				team_email_address: 'caseofficers@planninginspectorate.gov.uk'
 			}
 		};
 

--- a/appeals/api/src/server/notify/templates/__tests__/notify-site-visit-change-accompanied-date-change-appellant.test.js
+++ b/appeals/api/src/server/notify/templates/__tests__/notify-site-visit-change-accompanied-date-change-appellant.test.js
@@ -15,7 +15,8 @@ describe('site-visit-change-accompanied-date-change-appellant.md', () => {
 				site_address: '12, New Site Lane',
 				lpa_reference: 'REF-32100',
 				visit_date: '30 August 2025',
-				start_time: '9:00am'
+				start_time: '9:00am',
+				team_email_address: 'caseofficers@planninginspectorate.gov.uk'
 			}
 		};
 

--- a/appeals/api/src/server/notify/templates/__tests__/notify-site-visit-change-accompanied-date-change-lpa.test.js
+++ b/appeals/api/src/server/notify/templates/__tests__/notify-site-visit-change-accompanied-date-change-lpa.test.js
@@ -15,7 +15,8 @@ describe('site-visit-change-accompanied-date-change-lpa.md', () => {
 				site_address: '44, Reschedule Road',
 				lpa_reference: 'LPA-00987',
 				visit_date: '5 September 2025',
-				start_time: '3:15pm'
+				start_time: '3:15pm',
+				team_email_address: 'caseofficers@planninginspectorate.gov.uk'
 			}
 		};
 

--- a/appeals/api/src/server/notify/templates/__tests__/notify-site-visit-change-accompanied-to-access-required-appellant.test.js
+++ b/appeals/api/src/server/notify/templates/__tests__/notify-site-visit-change-accompanied-to-access-required-appellant.test.js
@@ -16,7 +16,8 @@ describe('site-visit-change-accompanied-to-access-required-appellant.md', () => 
 				lpa_reference: 'APP-20256',
 				visit_date: '10 September 2025',
 				start_time: '8:00am',
-				end_time: '12:00pm'
+				end_time: '12:00pm',
+				team_email_address: 'caseofficers@planninginspectorate.gov.uk'
 			}
 		};
 

--- a/appeals/api/src/server/notify/templates/__tests__/notify-site-visit-change-accompanied-to-access-required-lpa.test.js
+++ b/appeals/api/src/server/notify/templates/__tests__/notify-site-visit-change-accompanied-to-access-required-lpa.test.js
@@ -15,7 +15,8 @@ describe('site-visit-change-accompanied-to-access-required-lpa.md', () => {
 				site_address: '23, Transition Street',
 				lpa_reference: 'CASE-45632',
 				visit_date: '14 September 2025',
-				start_time: '10:00am'
+				start_time: '10:00am',
+				team_email_address: 'caseofficers@planninginspectorate.gov.uk'
 			}
 		};
 

--- a/appeals/api/src/server/notify/templates/__tests__/notify-site-visit-change-accompanied-to-unaccompanied-appellant.test.js
+++ b/appeals/api/src/server/notify/templates/__tests__/notify-site-visit-change-accompanied-to-unaccompanied-appellant.test.js
@@ -14,7 +14,8 @@ describe('site-visit-change-accompanied-to-unaccompanied-appellant.md', () => {
 				appeal_reference_number: 'MNO11223',
 				site_address: '66, Solitude Way',
 				lpa_reference: 'PLN-34567',
-				visit_date: '18 September 2025'
+				visit_date: '18 September 2025',
+				team_email_address: 'caseofficers@planninginspectorate.gov.uk'
 			}
 		};
 

--- a/appeals/api/src/server/notify/templates/__tests__/notify-site-visit-change-accompanied-to-unaccompanied-lpa.test.js
+++ b/appeals/api/src/server/notify/templates/__tests__/notify-site-visit-change-accompanied-to-unaccompanied-lpa.test.js
@@ -15,7 +15,8 @@ describe('site-visit-change-accompanied-to-unaccompanied-lpa.md', () => {
 				site_address: '99, Final Close',
 				lpa_reference: 'CASE-89012',
 				visit_date: '22 September 2025',
-				start_time: '1:45pm'
+				start_time: '1:45pm',
+				team_email_address: 'caseofficers@planninginspectorate.gov.uk'
 			}
 		};
 

--- a/appeals/api/src/server/notify/templates/__tests__/notify-site-visit-change-unaccompanied-to-access-required-appellant.test.js
+++ b/appeals/api/src/server/notify/templates/__tests__/notify-site-visit-change-unaccompanied-to-access-required-appellant.test.js
@@ -16,7 +16,8 @@ describe('site-visit-change-unaccompanied-to-access-required-appellant.md', () =
 				lpa_reference: 'REF-20201',
 				visit_date: '27 September 2025',
 				start_time: '9:00am',
-				end_time: '11:00am'
+				end_time: '11:00am',
+				team_email_address: 'caseofficers@planninginspectorate.gov.uk'
 			}
 		};
 

--- a/appeals/api/src/server/notify/templates/__tests__/notify-site-visit-change-unaccompanied-to-accompanied-appellant.test.js
+++ b/appeals/api/src/server/notify/templates/__tests__/notify-site-visit-change-unaccompanied-to-accompanied-appellant.test.js
@@ -15,7 +15,8 @@ describe('site-visit-change-unaccompanied-to-accompanied-appellant.md', () => {
 				site_address: '88, Inspector Rise',
 				lpa_reference: 'LPA-30303',
 				visit_date: '3 October 2025',
-				start_time: '10:45am'
+				start_time: '10:45am',
+				team_email_address: 'caseofficers@planninginspectorate.gov.uk'
 			}
 		};
 

--- a/appeals/api/src/server/notify/templates/__tests__/notify-site-visit-change-unaccompanied-to-accompanied-lpa.test.js
+++ b/appeals/api/src/server/notify/templates/__tests__/notify-site-visit-change-unaccompanied-to-accompanied-lpa.test.js
@@ -15,7 +15,8 @@ describe('site-visit-change-unaccompanied-to-accompanied-lpa.md', () => {
 				site_address: '21, Appeal Avenue',
 				lpa_reference: 'LPA-40404',
 				visit_date: '6 October 2025',
-				start_time: '2:30pm'
+				start_time: '2:30pm',
+				team_email_address: 'caseofficers@planninginspectorate.gov.uk'
 			}
 		};
 

--- a/appeals/api/src/server/notify/templates/__tests__/notify-site-visit-schedule-access-required-appellant.test.js
+++ b/appeals/api/src/server/notify/templates/__tests__/notify-site-visit-schedule-access-required-appellant.test.js
@@ -16,7 +16,8 @@ describe('site-visit-schedule-access-required-appellant.md', () => {
 				lpa_reference: 'LPA-77889',
 				visit_date: '9 October 2025',
 				start_time: '8:30am',
-				end_time: '12:30pm'
+				end_time: '12:30pm',
+				team_email_address: 'caseofficers@planninginspectorate.gov.uk'
 			}
 		};
 

--- a/appeals/api/src/server/notify/templates/__tests__/notify-site-visit-schedule-accompanied-appellant.test.js
+++ b/appeals/api/src/server/notify/templates/__tests__/notify-site-visit-schedule-accompanied-appellant.test.js
@@ -15,7 +15,8 @@ describe('site-visit-schedule-accompanied-appellant.md', () => {
 				site_address: '45, Hearing Road',
 				lpa_reference: 'PLAN-12345',
 				visit_date: '15 October 2025',
-				start_time: '11:00am'
+				start_time: '11:00am',
+				team_email_address: 'caseofficers@planninginspectorate.gov.uk'
 			}
 		};
 

--- a/appeals/api/src/server/notify/templates/__tests__/notify-site-visit-schedule-accompanied-lpa.test.js
+++ b/appeals/api/src/server/notify/templates/__tests__/notify-site-visit-schedule-accompanied-lpa.test.js
@@ -15,7 +15,8 @@ describe('site-visit-schedule-accompanied-lpa.md', () => {
 				site_address: '72, Planning Crescent',
 				lpa_reference: 'REF-56789',
 				visit_date: '20 October 2025',
-				start_time: '2:00pm'
+				start_time: '2:00pm',
+				team_email_address: 'caseofficers@planninginspectorate.gov.uk'
 			}
 		};
 

--- a/appeals/api/src/server/notify/templates/__tests__/notify-site-visit-schedule-unaccompanied-appellant.test.js
+++ b/appeals/api/src/server/notify/templates/__tests__/notify-site-visit-schedule-unaccompanied-appellant.test.js
@@ -13,7 +13,8 @@ describe('site-visit-schedule-unaccompanied-appellant.md', () => {
 			personalisation: {
 				appeal_reference_number: 'CCC33445',
 				site_address: '61, Viewpoint Hill',
-				lpa_reference: 'PLAN-98765'
+				lpa_reference: 'PLAN-98765',
+				team_email_address: 'caseofficers@planninginspectorate.gov.uk'
 			}
 		};
 

--- a/appeals/api/src/server/notify/templates/appeal-confirmed.content.md
+++ b/appeals/api/src/server/notify/templates/appeal-confirmed.content.md
@@ -7,4 +7,4 @@ We have reviewed your appeal and you have submitted all of the information we ne
 [Give feedback on the appeals service]({{feedback_link}}) (takes 2 minutes)
 
 The Planning Inspectorate
-caseofficers@planninginspectorate.gov.uk
+{{team_email_address}}

--- a/appeals/api/src/server/notify/templates/appeal-incomplete.content.md
+++ b/appeals/api/src/server/notify/templates/appeal-incomplete.content.md
@@ -4,11 +4,11 @@ We have received your appeal and we need more information.
 
 # Next steps
 
-You need to submit the following by {{due_date}} to caseofficers@planninginspectorate.gov.uk
+You need to submit the following by {{due_date}} to {{team_email_address}}
 {% for reason in reasons %}
 - {{reason}}
 {%- endfor %}
 
 The Planning Inspectorate
-caseofficers@planninginspectorate.gov.uk
+{{team_email_address}}
 

--- a/appeals/api/src/server/notify/templates/appeal-invalid-lpa.content.md
+++ b/appeals/api/src/server/notify/templates/appeal-invalid-lpa.content.md
@@ -17,4 +17,4 @@ This is a new service. Help us improve it and [give your feedback](https://forms
 
 The Planning Inspectorate
 
-caseofficers@planninginspectorate.gov.uk
+{{team_email_address}}

--- a/appeals/api/src/server/notify/templates/appeal-invalid.content.md
+++ b/appeals/api/src/server/notify/templates/appeal-invalid.content.md
@@ -18,4 +18,4 @@ Your appeal is now closed. We have told the local planning authority.
 This is a new service. Help us improve it and [give your feedback (opens in new tab)](https://forms.office.com/pages/responsepage.aspx?id=mN94WIhvq0iTIpmM5VcIjfMZj__F6D9LmMUUyoUrZDZUOERYMEFBN0NCOFdNU1BGWEhHUFQxWVhUUy4u).
 
 The Planning Inspectorate
-caseofficers@planninginspectorate.gov.uk
+{{team_email_address}}

--- a/appeals/api/src/server/notify/templates/appeal-start-date-change-appellant.content.md
+++ b/appeals/api/src/server/notify/templates/appeal-start-date-change-appellant.content.md
@@ -5,4 +5,4 @@
 We have changed the start date of your appeal to {{start_date}}.
 
 The Planning Inspectorate
-caseofficers@planninginspectorate.gov.uk
+{{team_email_address}}

--- a/appeals/api/src/server/notify/templates/appeal-start-date-change-lpa.content.md
+++ b/appeals/api/src/server/notify/templates/appeal-start-date-change-lpa.content.md
@@ -9,4 +9,4 @@ The new start date is {{start_date}}.
 We will decide the appeal by {{procedure_type}}. You can tell us if you think a different procedure is more appropriate in the questionnaire.
 
 The Planning Inspectorate
-caseofficers@planninginspectorate.gov.uk
+{{team_email_address}}

--- a/appeals/api/src/server/notify/templates/appeal-timetable-updated.content.md
+++ b/appeals/api/src/server/notify/templates/appeal-timetable-updated.content.md
@@ -17,4 +17,4 @@ Due by {{ip_comments_due_date}}.
 Due by {{final_comments_due_date}}.
 
 The Planning Inspectorate
-caseofficers@planninginspectorate.gov.uk
+{{team_email_address}}

--- a/appeals/api/src/server/notify/templates/appeal-type-change-non-has.content.md
+++ b/appeals/api/src/server/notify/templates/appeal-type-change-non-has.content.md
@@ -11,4 +11,4 @@ You need to submit a new {{appeal_type}} by {{due_date}} at {{front_office_url}}
 We have closed your {{existing_appeal_type}}.
 
 The Planning Inspectorate
-caseofficers@planninginspectorate.gov.uk
+{{team_email_address}}

--- a/appeals/api/src/server/notify/templates/appeal-valid-start-case-appellant.content.md
+++ b/appeals/api/src/server/notify/templates/appeal-valid-start-case-appellant.content.md
@@ -21,4 +21,4 @@ You may have to pay costs if you:
 [Find out more about appeal costs](https://www.gov.uk/claim-planning-appeal-costs).
 
 The Planning Inspectorate
-caseofficers@planninginspectorate.gov.uk
+{{team_email_address}}

--- a/appeals/api/src/server/notify/templates/appeal-valid-start-case-lpa.content.md
+++ b/appeals/api/src/server/notify/templates/appeal-valid-start-case-lpa.content.md
@@ -10,4 +10,4 @@ Start date: {{start_date}}
 [Find out your responsibilities in the appeal process](http://www.gov.uk/government/publications/planning-appeals-procedural-guide/procedural-guide-planning-appeals-england).
 
 The Planning Inspectorate
-caseofficers@planninginspectorate.gov.uk
+{{team_email_address}}

--- a/appeals/api/src/server/notify/templates/appeal-valid-start-case-s78-appellant-hearing.content.md
+++ b/appeals/api/src/server/notify/templates/appeal-valid-start-case-s78-appellant-hearing.content.md
@@ -39,4 +39,4 @@ You may have to pay costs if you:
 [Find out more about appeal costs](https://www.gov.uk/claim-planning-appeal-costs).
 
 The Planning Inspectorate
-caseofficers@planninginspectorate.gov.uk
+{{team_email_address}}

--- a/appeals/api/src/server/notify/templates/appeal-valid-start-case-s78-appellant.content.md
+++ b/appeals/api/src/server/notify/templates/appeal-valid-start-case-s78-appellant.content.md
@@ -60,4 +60,4 @@ You may have to pay costs if you:
 [Find out more about appeal costs](https://www.gov.uk/claim-planning-appeal-costs).
 
 The Planning Inspectorate
-caseofficers@planninginspectorate.gov.uk
+{{team_email_address}}

--- a/appeals/api/src/server/notify/templates/appeal-valid-start-case-s78-lpa-hearing.content.md
+++ b/appeals/api/src/server/notify/templates/appeal-valid-start-case-s78-lpa-hearing.content.md
@@ -29,6 +29,6 @@ We will contact you if we make any changes to the hearing.
 # What happens next
 
 1. [Submit your questionnaire and other documents]({{front_office_url}}/manage-appeals/{{appeal_reference_number}}), including your appeal notification letter and a list of those notified by {{questionnaire_due_date}}.
-2. Email caseofficers@planninginspectorate.gov.uk to confirm the venue address for the hearing.
+2. Email {{team_email_address}} to confirm the venue address for the hearing.
 
 The Planning Inspectorate

--- a/appeals/api/src/server/notify/templates/appeal-valid-start-case-s78-lpa.content.md
+++ b/appeals/api/src/server/notify/templates/appeal-valid-start-case-s78-lpa.content.md
@@ -60,4 +60,4 @@ We will send you another email when we set up the hearing.
 
 {% endif -%}
 The Planning Inspectorate
-caseofficers@planninginspectorate.gov.uk
+{{team_email_address}}

--- a/appeals/api/src/server/notify/templates/appeal-withdrawn-appellant.content.md
+++ b/appeals/api/src/server/notify/templates/appeal-withdrawn-appellant.content.md
@@ -13,4 +13,4 @@ We have closed the appeal{% if event_set %} and cancelled the {{event_type}}{% e
 We welcome your feedback on our appeals process. Tell us on this short [feedback form](https://forms.office.com/pages/responsepage.aspx?id=mN94WIhvq0iTIpmM5VcIjfMZj__F6D9LmMUUyoUrZDZUOERYMEFBN0NCOFdNU1BGWEhHUFQxWVhUUy4u).
 
 The Planning Inspectorate
-caseofficers@planninginspectorate.gov.uk
+{{team_email_address}}

--- a/appeals/api/src/server/notify/templates/appeal-withdrawn-lpa.content.md
+++ b/appeals/api/src/server/notify/templates/appeal-withdrawn-lpa.content.md
@@ -11,4 +11,4 @@ We have closed the appeal{% if event_set %} and cancelled the {{event_type}}{% e
 We welcome your feedback on our appeals process. Tell us on this short [feedback form](https://forms.office.com/pages/responsepage.aspx?id=mN94WIhvq0iTIpmM5VcIjfMZj__F6D9LmMUUyoUrZDZUOERYMEFBN0NCOFdNU1BGWEhHUFQxWVhUUy4u).
 
 The Planning Inspectorate
-caseofficers@planninginspectorate.gov.uk
+{{team_email_address}}

--- a/appeals/api/src/server/notify/templates/correction-notice-decision.content.md
+++ b/appeals/api/src/server/notify/templates/correction-notice-decision.content.md
@@ -21,4 +21,4 @@ The Planning Inspectorate cannot change or revoke the decision. Only the High Co
 We welcome your feedback on our appeals service. Tell us on this short [feedback form](https://forms.office.com/pages/responsepage.aspx?id=mN94WIhvq0iTIpmM5VcIjfMZj__F6D9LmMUUyoUrZDZUOERYMEFBN0NCOFdNU1BGWEhHUFQxWVhUUy4u).
 
 The Planning Inspectorate
-caseofficers@planninginspectorate.gov.uk
+{{team_email_address}}

--- a/appeals/api/src/server/notify/templates/final-comment-rejected-appellant.content.md
+++ b/appeals/api/src/server/notify/templates/final-comment-rejected-appellant.content.md
@@ -11,8 +11,8 @@ We rejected your final comments because:
 
 # What happens next
 
-You can send different final comments to caseofficers@planninginspectorate.gov.uk. The case officer will decide whether to accept any new final comments.
+You can send different final comments to {{team_email_address}}. The case officer will decide whether to accept any new final comments.
 
 The Planning Inspectorate
-caseofficers@planninginspectorate.gov.uk
+{{team_email_address}}
 

--- a/appeals/api/src/server/notify/templates/final-comment-rejected-lpa.content.md
+++ b/appeals/api/src/server/notify/templates/final-comment-rejected-lpa.content.md
@@ -11,8 +11,8 @@ We rejected your final comments because:
 
 # What happens next
 
-You can send different final comments to caseofficers@planninginspectorate.gov.uk. The case officer will decide whether to accept any new final comments.
+You can send different final comments to {{team_email_address}}. The case officer will decide whether to accept any new final comments.
 
 The Planning Inspectorate
-caseofficers@planninginspectorate.gov.uk
+{{team_email_address}}
 

--- a/appeals/api/src/server/notify/templates/final-comments-done-appellant.content.md
+++ b/appeals/api/src/server/notify/templates/final-comments-done-appellant.content.md
@@ -9,4 +9,4 @@ You can [view the local planning authority's final comments]({{front_office_url}
 The inspector will visit the site and we will contact you when we have made the decision.
 
 The Planning Inspectorate
-caseofficers@planninginspectorate.gov.uk
+{{team_email_address}}

--- a/appeals/api/src/server/notify/templates/final-comments-done-lpa.content.md
+++ b/appeals/api/src/server/notify/templates/final-comments-done-lpa.content.md
@@ -9,4 +9,4 @@ You can [view the appellant's final comments]({{front_office_url}}/manage-appeal
 The inspector will visit the site and we will contact you when we have made the decision.
 
 The Planning Inspectorate
-caseofficers@planninginspectorate.gov.uk
+{{team_email_address}}

--- a/appeals/api/src/server/notify/templates/final-comments-none.content.md
+++ b/appeals/api/src/server/notify/templates/final-comments-none.content.md
@@ -7,4 +7,4 @@ The {{user_type}} did not submit any final comments.
 The inspector will visit the site and we will contact you when we have made the decision.
 
 The Planning Inspectorate
-caseofficers@planninginspectorate.gov.uk
+{{team_email_address}}

--- a/appeals/api/src/server/notify/templates/has-appeal-timetable-updated.content.md
+++ b/appeals/api/src/server/notify/templates/has-appeal-timetable-updated.content.md
@@ -8,4 +8,4 @@ We have updated your timetable.
 Due by {{lpa_questionnaire_due_date}}.
 
 The Planning Inspectorate
-caseofficers@planninginspectorate.gov.uk
+{{team_email_address}}

--- a/appeals/api/src/server/notify/templates/hearing-cancelled.content.md
+++ b/appeals/api/src/server/notify/templates/hearing-cancelled.content.md
@@ -7,4 +7,4 @@ We have cancelled your hearing.
 We will contact you by email when we rearrange your hearing.
 
 The Planning Inspectorate
-caseofficers@planninginspectorate.gov.uk
+{{team_email_address}}

--- a/appeals/api/src/server/notify/templates/hearing-set-up.content.md
+++ b/appeals/api/src/server/notify/templates/hearing-set-up.content.md
@@ -16,4 +16,4 @@ The details of the hearing are subject to change. We will contact you by email i
 We expect the hearing to finish on the same day. If the hearing needs more time, you will arrange the next steps on the day.
 
 The Planning Inspectorate
-caseofficers@planninginspectorate.gov.uk
+{{team_email_address}}

--- a/appeals/api/src/server/notify/templates/hearing-updated.content.md
+++ b/appeals/api/src/server/notify/templates/hearing-updated.content.md
@@ -16,4 +16,4 @@ The details of the hearing are subject to change. We will contact you by email i
 We expect the hearing to finish on the same day. If the hearing needs more time, you will arrange the next steps on the day.
 
 The Planning Inspectorate
-caseofficers@planninginspectorate.gov.uk
+{{team_email_address}}

--- a/appeals/api/src/server/notify/templates/inquiry-cancelled.content.md
+++ b/appeals/api/src/server/notify/templates/inquiry-cancelled.content.md
@@ -7,4 +7,4 @@ We have cancelled your inquiry.
 We will contact you by email when we rearrange your inquiry.
 
 The Planning Inspectorate
-caseofficers@planninginspectorate.gov.uk
+{{team_email_address}}

--- a/appeals/api/src/server/notify/templates/inquiry-set-up.content.md
+++ b/appeals/api/src/server/notify/templates/inquiry-set-up.content.md
@@ -18,4 +18,4 @@ We expect the inquiry to finish on the same day. If the inquiry needs
 more time, you will arrange the next steps on the day.
 
 The Planning Inspectorate
-caseofficers@planninginspectorate.gov.uk
+{{team_email_address}}

--- a/appeals/api/src/server/notify/templates/inquiry-updated.content.md
+++ b/appeals/api/src/server/notify/templates/inquiry-updated.content.md
@@ -18,4 +18,4 @@ We expect the inquiry to finish on the same day. If the inquiry needs
 more time, you will arrange the next steps on the day.
 
 The Planning Inspectorate
-caseofficers@planninginspectorate.gov.uk
+{{team_email_address}}

--- a/appeals/api/src/server/notify/templates/ip-comment-rejected-deadline-extended.content.md
+++ b/appeals/api/src/server/notify/templates/ip-comment-rejected-deadline-extended.content.md
@@ -15,9 +15,9 @@ We rejected your comment because:
     You can [submit a different comment]({{front_office_url}}/comment-planning-appeal/enter-appeal-reference) by {{deadline_date}}.
 
 {% else -%}
-    You can send a different comment to caseofficers@planninginspectorate.gov.uk by {{deadline_date}}.
+    You can send a different comment to {{team_email_address}} by {{deadline_date}}.
 
 {% endif -%}
 
 The Planning Inspectorate
-caseofficers@planninginspectorate.gov.uk
+{{team_email_address}}

--- a/appeals/api/src/server/notify/templates/ip-comment-rejected.content.md
+++ b/appeals/api/src/server/notify/templates/ip-comment-rejected.content.md
@@ -10,5 +10,5 @@ We rejected your comment because:
 {%- endfor %}
 
 The Planning Inspectorate
-caseofficers@planninginspectorate.gov.uk
+{{team_email_address}}
 

--- a/appeals/api/src/server/notify/templates/link-appeal.content.md
+++ b/appeals/api/src/server/notify/templates/link-appeal.content.md
@@ -15,4 +15,4 @@ There will be one {{event_type}} for all of the linked appeals.
 {% endif -%}
 
 The Planning Inspectorate
-caseofficers@planninginspectorate.gov.uk
+{{team_email_address}}

--- a/appeals/api/src/server/notify/templates/lpa-statement-incomplete.content.md
+++ b/appeals/api/src/server/notify/templates/lpa-statement-incomplete.content.md
@@ -8,8 +8,8 @@ We need more information before we can review your statement.
 
 # What happens next
 
-You need to send the information to caseofficers@planninginspectorate.gov.uk by {{deadline_date}}.
+You need to send the information to {{team_email_address}} by {{deadline_date}}.
 
 The Planning Inspectorate
-caseofficers@planninginspectorate.gov.uk
+{{team_email_address}}
 

--- a/appeals/api/src/server/notify/templates/lpaq-complete-appellant.content.md
+++ b/appeals/api/src/server/notify/templates/lpaq-complete-appellant.content.md
@@ -9,4 +9,4 @@ You can [view this information in the appeals service]({{front_office_url}}/appe
 We will send you another email when the local planning authority submits their statement and we receive any comments from interested parties.
 
 The Planning Inspectorate
-caseofficers@planninginspectorate.gov.uk
+{{team_email_address}}

--- a/appeals/api/src/server/notify/templates/lpaq-complete-has-appellant.content.md
+++ b/appeals/api/src/server/notify/templates/lpaq-complete-has-appellant.content.md
@@ -9,4 +9,4 @@ You can [view this information in the appeals service]({{front_office_url}}/appe
 We will send you another email when we set up your site visit.
 
 The Planning Inspectorate
-caseofficers@planninginspectorate.gov.uk
+{{team_email_address}}

--- a/appeals/api/src/server/notify/templates/lpaq-complete-lpa.content.md
+++ b/appeals/api/src/server/notify/templates/lpaq-complete-lpa.content.md
@@ -5,4 +5,4 @@ We have reviewed your questionnaire.
 You have submitted all the information we need.
 
 The Planning Inspectorate
-caseofficers@planninginspectorate.gov.uk
+{{team_email_address}}

--- a/appeals/api/src/server/notify/templates/lpaq-incomplete.content.md
+++ b/appeals/api/src/server/notify/templates/lpaq-incomplete.content.md
@@ -6,11 +6,11 @@ We need more information before we can review your questionnaire about this appe
 
 # What we need
 
-Send the following to caseofficers@planninginspectorate.gov.uk by {{due_date}}:
+Send the following to {{team_email_address}} by {{due_date}}:
 {% for reason in reasons %}
 - {{reason}}
 {%- endfor %}
 
 The Planning Inspectorate
-caseofficers@planninginspectorate.gov.uk
+{{team_email_address}}
 

--- a/appeals/api/src/server/notify/templates/received-statement-and-ip-comments-appellant.content.md
+++ b/appeals/api/src/server/notify/templates/received-statement-and-ip-comments-appellant.content.md
@@ -29,4 +29,4 @@ You can [view this information in the appeals service]({{front_office_url}}/appe
 {% endif -%}
 
 The Planning Inspectorate
-caseofficers@planninginspectorate.gov.uk
+{{team_email_address}}

--- a/appeals/api/src/server/notify/templates/received-statement-and-ip-comments-lpa.content.md
+++ b/appeals/api/src/server/notify/templates/received-statement-and-ip-comments-lpa.content.md
@@ -18,4 +18,4 @@ You can [view this information in the appeals service]({{front_office_url}}/mana
 {% endif -%}
 
 The Planning Inspectorate
-caseofficers@planninginspectorate.gov.uk
+{{team_email_address}}

--- a/appeals/api/src/server/notify/templates/site-visit-change-access-required-date-change-appellant.content.md
+++ b/appeals/api/src/server/notify/templates/site-visit-change-access-required-date-change-appellant.content.md
@@ -8,7 +8,7 @@ Our inspector (or their representative) will now visit {{site_address}} at {{sta
 
 You, or someone else, must be at the site at the scheduled time to provide access for our inspector.
 
-Alternatively, and only if it is possible at the site, you can provide written consent for access for our inspector at caseofficers@planninginspectorate.gov.uk.
+Alternatively, and only if it is possible at the site, you can provide written consent for access for our inspector at {{team_email_address}}.
 
 Include our appeal reference number in any communication.
 
@@ -19,4 +19,4 @@ You cannot give the inspector any documents or discuss the appeal with them.
 The inspector will carry out the inspection on their own.
 
 The Planning Inspectorate
-caseofficers@planninginspectorate.gov.uk
+{{team_email_address}}

--- a/appeals/api/src/server/notify/templates/site-visit-change-access-required-to-accompanied-appellant.content.md
+++ b/appeals/api/src/server/notify/templates/site-visit-change-access-required-to-accompanied-appellant.content.md
@@ -13,4 +13,4 @@ You will accompany the inspector throughout the visit.
 If you need to contact us, include our appeal reference number in any communication.
 
 The Planning Inspectorate
-caseofficers@planninginspectorate.gov.uk
+{{team_email_address}}

--- a/appeals/api/src/server/notify/templates/site-visit-change-access-required-to-accompanied-lpa.content.md
+++ b/appeals/api/src/server/notify/templates/site-visit-change-access-required-to-accompanied-lpa.content.md
@@ -9,4 +9,4 @@ Our inspector (or their representative) will visit {{site_address}} at {{start_t
 You must be at the site at the scheduled time to accompany our inspector and the appellant .
 
 The Planning Inspectorate
-caseofficers@planninginspectorate.gov.uk
+{{team_email_address}}

--- a/appeals/api/src/server/notify/templates/site-visit-change-access-required-to-unaccompanied-appellant.content.md
+++ b/appeals/api/src/server/notify/templates/site-visit-change-access-required-to-unaccompanied-appellant.content.md
@@ -13,4 +13,4 @@ If you see the inspector, you cannot give them any documents or discuss the appe
 If you need to contact us, include our appeal reference number in any communication.
 
 The Planning Inspectorate
-caseofficers@planninginspectorate.gov.uk
+{{team_email_address}}

--- a/appeals/api/src/server/notify/templates/site-visit-change-accompanied-date-change-appellant.content.md
+++ b/appeals/api/src/server/notify/templates/site-visit-change-accompanied-date-change-appellant.content.md
@@ -17,4 +17,4 @@ You will accompany the inspector throughout the visit.
 If you need to contact us, include our appeal reference number in any communication.
 
 The Planning Inspectorate
-caseofficers@planninginspectorate.gov.uk
+{{team_email_address}}

--- a/appeals/api/src/server/notify/templates/site-visit-change-accompanied-date-change-lpa.content.md
+++ b/appeals/api/src/server/notify/templates/site-visit-change-accompanied-date-change-lpa.content.md
@@ -9,4 +9,4 @@ Our inspector (or their representative) will now visit {{site_address}} at {{sta
 You must be at the site at the scheduled time to accompany our inspector and the appellant.
 
 The Planning Inspectorate
-caseofficers@planninginspectorate.gov.uk
+{{team_email_address}}

--- a/appeals/api/src/server/notify/templates/site-visit-change-accompanied-to-access-required-appellant.content.md
+++ b/appeals/api/src/server/notify/templates/site-visit-change-accompanied-to-access-required-appellant.content.md
@@ -8,7 +8,7 @@ We now require you (or someone else) to attend the site visit to provide access 
 
 Our inspector (or their representative) will visit {{site_address}} between {{start_time}} and {{end_time}} on {{visit_date}}.
 
-Alternatively, and only if it is possible at the site, you can provide written consent for access for our inspector at caseofficers@planninginspectorate.gov.uk. Include our appeal reference number in any communication.
+Alternatively, and only if it is possible at the site, you can provide written consent for access for our inspector at {{team_email_address}}. Include our appeal reference number in any communication.
 
 # About the visit
 

--- a/appeals/api/src/server/notify/templates/site-visit-change-accompanied-to-access-required-lpa.content.md
+++ b/appeals/api/src/server/notify/templates/site-visit-change-accompanied-to-access-required-lpa.content.md
@@ -7,4 +7,4 @@ You are no longer required to accompany our inspector on the site visit to {{sit
 Our inspector (or their representative) will now carry out the inspection on their own.
 
 The Planning Inspectorate
-caseofficers@planninginspectorate.gov.uk
+{{team_email_address}}

--- a/appeals/api/src/server/notify/templates/site-visit-change-accompanied-to-unaccompanied-appellant.content.md
+++ b/appeals/api/src/server/notify/templates/site-visit-change-accompanied-to-unaccompanied-appellant.content.md
@@ -13,4 +13,4 @@ If you see the inspector, you cannot give them any documents or discuss the appe
 If you need to contact us, include our reference number in any communication.
 
 The Planning Inspectorate
-caseofficers@planninginspectorate.gov.uk
+{{team_email_address}}

--- a/appeals/api/src/server/notify/templates/site-visit-change-accompanied-to-unaccompanied-lpa.content.md
+++ b/appeals/api/src/server/notify/templates/site-visit-change-accompanied-to-unaccompanied-lpa.content.md
@@ -7,4 +7,4 @@ You are no longer required to accompany our inspector on the site visit to {{sit
 Our inspector (or their representative) will now carry out the inspection on their own.
 
 The Planning Inspectorate
-caseofficers@planninginspectorate.gov.uk
+{{team_email_address}}

--- a/appeals/api/src/server/notify/templates/site-visit-change-unaccompanied-to-access-required-appellant.content.md
+++ b/appeals/api/src/server/notify/templates/site-visit-change-unaccompanied-to-access-required-appellant.content.md
@@ -8,7 +8,7 @@ We now require you, or someone else, to attend the site visit to provide access 
 
 Our inspector (or their representative) will visit {{site_address}} between {{start_time}} and {{end_time}} on {{visit_date}}.
 
-You can provide written consent for access for our inspector at caseofficers@planninginspectorate.gov.uk (only if it is possible at the site). Include our appeal reference number in any communication.
+You can provide written consent for access for our inspector at {{team_email_address}} (only if it is possible at the site). Include our appeal reference number in any communication.
 
 # About the visit
 
@@ -17,4 +17,4 @@ You cannot give the inspector any documents or discuss the appeal with them.
 The inspector will carry out the inspection on their own.
 
 The Planning Inspectorate
-caseofficers@planninginspectorate.gov.uk
+{{team_email_address}}

--- a/appeals/api/src/server/notify/templates/site-visit-change-unaccompanied-to-accompanied-appellant.content.md
+++ b/appeals/api/src/server/notify/templates/site-visit-change-unaccompanied-to-accompanied-appellant.content.md
@@ -13,4 +13,4 @@ Our inspector will visit {{site_address}} at {{start_time}} on {{visit_date}}.
 If you need to contact us, include our appeal reference number in any communication.
 
 The Planning Inspectorate
-caseofficers@planninginspectorate.gov.uk
+{{team_email_address}}

--- a/appeals/api/src/server/notify/templates/site-visit-change-unaccompanied-to-accompanied-lpa.content.md
+++ b/appeals/api/src/server/notify/templates/site-visit-change-unaccompanied-to-accompanied-lpa.content.md
@@ -9,4 +9,4 @@ Our inspector (or their representative) will visit {{site_address}} at {{start_t
 You must be at the site at the scheduled time to accompany our inspector and the appellant .
 
 The Planning Inspectorate
-caseofficers@planninginspectorate.gov.uk
+{{team_email_address}}

--- a/appeals/api/src/server/notify/templates/site-visit-schedule-access-required-appellant.content.md
+++ b/appeals/api/src/server/notify/templates/site-visit-schedule-access-required-appellant.content.md
@@ -10,7 +10,7 @@ Someone must be at the site at the scheduled time to give the inspector access t
 
 If nobody is available, you can give written consent for the inspector to access the site by themselves. Explain how the inspector can safely access the site with your consent.
 
-In all cases, email caseofficers@planninginspectorate.gov.uk to either give:
+In all cases, email {{team_email_address}} to either give:
 
 - the details of who will be at the site to give the inspector access
 - your consent for the inspector to access the site by themselves
@@ -26,4 +26,4 @@ You cannot give the inspector any documents or discuss the appeal with them.
 The inspector will carry out the inspection on their own.
 
 The Planning Inspectorate
-caseofficers@planninginspectorate.gov.uk
+{{team_email_address}}

--- a/appeals/api/src/server/notify/templates/site-visit-schedule-accompanied-appellant.content.md
+++ b/appeals/api/src/server/notify/templates/site-visit-schedule-accompanied-appellant.content.md
@@ -15,4 +15,4 @@ You will accompany the inspector throughout the visit.
 If you need to contact us, include our appeal reference number in any communication.
 
 The Planning Inspectorate
-caseofficers@planninginspectorate.gov.uk
+{{team_email_address}}

--- a/appeals/api/src/server/notify/templates/site-visit-schedule-accompanied-lpa.content.md
+++ b/appeals/api/src/server/notify/templates/site-visit-schedule-accompanied-lpa.content.md
@@ -9,4 +9,4 @@ Our inspector (or their representative) will visit {{site_address}} at {{start_t
 You must be at the site at the scheduled time to accompany our inspector and the appellant .
 
 The Planning Inspectorate
-caseofficers@planninginspectorate.gov.uk
+{{team_email_address}}

--- a/appeals/api/src/server/notify/templates/site-visit-schedule-unaccompanied-appellant.content.md
+++ b/appeals/api/src/server/notify/templates/site-visit-schedule-unaccompanied-appellant.content.md
@@ -19,4 +19,4 @@ The inspector will carry out the inspection on their own.
 We will contact you when the inspector makes a decision.
 
 The Planning Inspectorate
-caseofficers@planninginspectorate.gov.uk
+{{team_email_address}}

--- a/appeals/api/src/server/openapi-types.ts
+++ b/appeals/api/src/server/openapi-types.ts
@@ -2402,6 +2402,11 @@ export interface UpdateAsssignedTeamResponse {
 	teamId?: number;
 }
 
+export interface TeamEmailResponse {
+	/** @example "email@email.com" */
+	teamEmail?: string;
+}
+
 export interface SingleLinkableAppealSummaryResponse {
 	/**
 	 * ID in back-office or horizon

--- a/appeals/api/src/server/openapi.json
+++ b/appeals/api/src/server/openapi.json
@@ -770,6 +770,51 @@
 				}
 			}
 		},
+		"/appeals/{appealId}/case-team-email": {
+			"get": {
+				"tags": ["Case Team"],
+				"description": "Gets the case team from an appeal id",
+				"parameters": [
+					{
+						"name": "appealId",
+						"in": "path",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"name": "azureAdUserId",
+						"in": "header",
+						"required": true,
+						"example": "434bff4e-8191-4ce0-9a0a-91e5d6cdd882",
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "Assigned case team for the appeal",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/TeamEmailResponse"
+								}
+							},
+							"application/xml": {
+								"schema": {
+									"$ref": "#/components/schemas/TeamEmailResponse"
+								}
+							}
+						}
+					},
+					"400": {
+						"description": "Bad Request"
+					}
+				}
+			}
+		},
 		"/appeals/{appealId}/case-team": {
 			"patch": {
 				"tags": ["Case Team"],
@@ -11668,6 +11713,18 @@
 				},
 				"xml": {
 					"name": "UpdateAsssignedTeamResponse"
+				}
+			},
+			"TeamEmailResponse": {
+				"type": "object",
+				"properties": {
+					"teamEmail": {
+						"type": "string",
+						"example": "email@email.com"
+					}
+				},
+				"xml": {
+					"name": "TeamEmailResponse"
 				}
 			},
 			"SingleLinkableAppealSummaryResponse": {

--- a/appeals/api/src/server/repositories/team.repository.js
+++ b/appeals/api/src/server/repositories/team.repository.js
@@ -65,3 +65,20 @@ export const getCaseTeams = () => {
 		}
 	});
 };
+
+/**
+ *
+ * @param {number} appealId
+ * @returns
+ */
+export const getTeamFromAppeal = async (appealId) => {
+	const appeal = await databaseConnector.appeal.findUnique({
+		where: { id: appealId },
+		select: { assignedTeamId: true }
+	});
+
+	if (!appeal || !appeal.assignedTeamId) {
+		return null;
+	}
+	return getAssignedTeam(appeal.assignedTeamId);
+};

--- a/appeals/api/src/server/swagger.js
+++ b/appeals/api/src/server/swagger.js
@@ -995,6 +995,9 @@ export const spec = {
 
 		UpdateAsssignedTeamResponse: {
 			teamId: 1
+		},
+		TeamEmailResponse: {
+			teamEmail: 'email@email.com'
 		}
 	},
 	'@definitions': {

--- a/appeals/web/src/server/appeals/appeal-details/update-case-team/update-case-team.service.js
+++ b/appeals/web/src/server/appeals/appeal-details/update-case-team/update-case-team.service.js
@@ -19,3 +19,12 @@ export async function postUpdateTeam(apiClient, appealId, teamId) {
 		}
 	});
 }
+
+/**
+ * @param {import('got').Got} apiClient
+ * @param {string} appealId
+ * @returns {Promise<{email:string}>}
+ */
+export async function getTeamFromAppealId(apiClient, appealId) {
+	return apiClient.get(`appeals/${appealId}/case-team-email`).json();
+}

--- a/appeals/web/src/server/appeals/appeal-details/update-decision-letter/__tests__/update-decision-letter.test.js
+++ b/appeals/web/src/server/appeals/appeal-details/update-decision-letter/__tests__/update-decision-letter.test.js
@@ -229,6 +229,14 @@ describe('update-decision-letter', () => {
 		afterEach(teardown);
 
 		it('should render the check your decision page', async () => {
+			nock('http://test/')
+				.get('/appeals/1/case-team-email')
+				.reply(200, {
+					id: 1,
+					email: 'caseofficers@planninginspectorate.gov.uk',
+					name: 'standard email'
+				})
+				.persist();
 			expect(uploadDecisionLetterResponse.statusCode).toBe(302);
 			expect(correctionNoticeResponse.statusCode).toBe(302);
 

--- a/appeals/web/src/server/appeals/appeal-details/update-decision-letter/update-decision-letter.controller.js
+++ b/appeals/web/src/server/appeals/appeal-details/update-decision-letter/update-decision-letter.controller.js
@@ -11,6 +11,7 @@ import { simpleHtmlComponent } from '#lib/mappers/index.js';
 import { addNotificationBannerToSession } from '#lib/session-utilities.js';
 import { addBackLinkQueryToUrl } from '#lib/url-utilities.js';
 import config from '@pins/appeals.web/environment/config.js';
+import { getTeamFromAppealId } from '../update-case-team/update-case-team.service.js';
 import { correctionNoticePage } from './update-decision-letter.mapper.js';
 
 /** @type {import('@pins/express').RequestHandler<Response>}  */
@@ -75,13 +76,14 @@ export const renderUpdateDocumentCheckDetails = async (request, response) => {
 
 	const documentVersion = fileInfo.latestDocumentVersion.version + 1;
 	const documentName = fileInfo.name;
-
+	const { email: assignedTeamEmail } = await getTeamFromAppealId(request.apiClient, appealId);
 	const personalisation = {
 		appeal_reference_number: appealReference,
 		site_address: appealSiteToAddressString(appealSite),
 		lpa_reference: planningApplicationReference,
 		correction_notice_reason: correctionNotice,
-		decision_date: dateISOStringToDisplayDate(file.receivedDate)
+		decision_date: dateISOStringToDisplayDate(file.receivedDate),
+		team_email_address: assignedTeamEmail
 	};
 	const templateName = 'correction-notice-decision.content.md';
 	const template = await generateNotifyPreview(request.apiClient, templateName, personalisation);

--- a/appeals/web/src/server/appeals/appeal-details/withdrawal/__tests__/withdrawal.test.js
+++ b/appeals/web/src/server/appeals/appeal-details/withdrawal/__tests__/withdrawal.test.js
@@ -86,6 +86,11 @@ describe('withdrawal', () => {
 		beforeEach(async () => {
 			nock.cleanAll();
 			nock('http://test/').get('/appeals/1').reply(200, appealData).persist();
+			nock('http://test/').get('/appeals/1/case-team-email').reply(200, {
+				id: 1,
+				email: 'caseofficers@planninginspectorate.gov.uk',
+				name: 'standard email'
+			});
 			nock('http://test/')
 				.get('/appeals/document-redaction-statuses')
 				.reply(200, documentRedactionStatuses)

--- a/appeals/web/src/server/appeals/appeal-details/withdrawal/withdrawal.controller.js
+++ b/appeals/web/src/server/appeals/appeal-details/withdrawal/withdrawal.controller.js
@@ -17,6 +17,7 @@ import {
 } from '../../appeal-documents/appeal-documents.controller.js';
 import { addDocumentDetailsFormDataToFileUploadInfo } from '../../appeal-documents/appeal-documents.mapper.js';
 import { getDocumentRedactionStatuses } from '../../appeal-documents/appeal.documents.service.js';
+import { getTeamFromAppealId } from '../update-case-team/update-case-team.service.js';
 import { checkAndConfirmPage, manageWithdrawalRequestFolderPage } from './withdrawal.mapper.js';
 import { postWithdrawalRequest } from './withdrawal.service.js';
 
@@ -195,13 +196,18 @@ export const renderCheckYourAnswers = async (request, response) => {
 	if (!objectContainsAllKeys(session, ['fileUploadInfo'])) {
 		return response.status(500).render('app/500.njk');
 	}
+	const { email: assignedTeamEmail } = await getTeamFromAppealId(
+		request.apiClient,
+		currentAppeal.appealId
+	);
 	const personalisation = {
 		appeal_reference_number: currentAppeal.appealReference,
 		lpa_reference: currentAppeal.planningApplicationReference,
 		site_address: addressToString(currentAppeal.appealSite),
 		withdrawal_date: formatDate(new Date(), false),
 		event_set: !!getEventType(currentAppeal),
-		event_type: getEventType(currentAppeal)
+		event_type: getEventType(currentAppeal),
+		team_email_address: assignedTeamEmail
 	};
 	const appealWithdrawnAppellantTemplateName = 'appeal-withdrawn-appellant.content.md';
 	const appealWithdrawnAppellantTemplate = await generateNotifyPreview(


### PR DESCRIPTION
## Describe your changes

### UPDATES

- Replaced the standard case officer email for notifies with a variable to use the team email
- create new endpoint to get the team email for displaying email previews in web
- updated the calls to the template to include the team email
- updated calls to generate the notify previews with the team email
- updated api documentation

### TEST

- updated unit tests for notify templates
- updated unit tests for calls to generate notfies
- created new unit test for function to get the team email

## Issue ticket number and link

[Ticket](https://pins-ds.atlassian.net.mcas.ms/browse/A2-4396)
