### PR TITLE
fix(api): Paginating appeals AFTER sorting them by due date

### DIFF
--- a/appeals/api/src/server/endpoints/appeals/appeals.controller.js
+++ b/appeals/api/src/server/endpoints/appeals/appeals.controller.js
@@ -90,8 +90,6 @@ const getMyAppeals = async (req, res) => {
 
 	const [itemCount, appeals = [], statuses] = await appealListRepository.getUserAppeals(
 		azureUserId,
-		pageNumber,
-		pageSize,
 		status
 	);
 
@@ -136,6 +134,12 @@ const getMyAppeals = async (req, res) => {
 
 	const sortedAppeals = sortAppeals(filteredAppeals);
 
+	//TODO: find solution for only fetching appropriately paginated appeals directly from DB instead
+	const paginatedAppeals = sortedAppeals.slice(
+		(pageNumber - 1) * pageSize,
+		(pageNumber - 1) * pageSize + pageSize
+	);
+
 	// Flatten to a unique array of strings
 	// @ts-ignore
 	const formattedStatuses = statuses
@@ -146,7 +150,7 @@ const getMyAppeals = async (req, res) => {
 
 	return res.send({
 		itemCount,
-		items: sortedAppeals,
+		items: paginatedAppeals,
 		statuses: formattedStatuses,
 		page: pageNumber,
 		pageCount: getPageCount(itemCount, pageSize),

--- a/appeals/api/src/server/repositories/appeal-lists.repository.js
+++ b/appeals/api/src/server/repositories/appeal-lists.repository.js
@@ -279,11 +279,9 @@ const buildAllAppealsWhereClause = (
 
 /**
  * @param {string} userId
- * @param {number} pageNumber
- * @param {number} pageSize
  * @param {string} [status]
  */
-const getUserAppeals = (userId, pageNumber, pageSize, status) => {
+const getUserAppeals = (userId, status) => {
 	const where = {
 		appealType: { key: { in: getEnabledAppealTypes() } },
 		AND: [
@@ -372,9 +370,10 @@ const getUserAppeals = (userId, pageNumber, pageSize, status) => {
 				},
 				hearing: true,
 				inquiry: true
-			},
-			skip: getSkipValue(pageNumber, pageSize),
-			take: pageSize
+			}
+			// temporary measure to get all the appeals for a user and paginate them AFTER sorting instead
+			// skip: getSkipValue(pageNumber, pageSize),
+			// take: pageSize
 		}),
 		getAppealsStatusesInPersonalList(userId)
 	]);


### PR DESCRIPTION
## Describe your changes
On the personal list page, we are currently paginating within the database query to fetch appeals. However this doesn't work because we don't store the 'due date' inside the DB which is what the sorting and pagination should be based on. 
- This change removes the database pagination and instead paginates the appeals AFTER they have been sorted by due date 
   - This is not an ideal solution since it'll have a performance impact as we are getting ALL the appeals assigned to the user EVERY time and on every page - this is a temporary fix.

<!--
    Please include a summary of the change along with any relevant context.
    List any dependencies that are required for this change.
-->

## Issue ticket number and link

[Ticket](<!--Paste your ticket link here-->)
