### PR TITLE
fix(web): adding numeric input validation

### DIFF
--- a/appeals/web/src/server/appeals/appeal-details/net-residence/__tests__/__snapshots__/net-residence.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/net-residence/__tests__/__snapshots__/net-residence.test.js.snap
@@ -57,7 +57,7 @@ exports[`net-residence GET /residential-units/new should render net gain or loss
 </main>"
 `;
 
-exports[`net-residence POST /residential-units/new should return error when net gain radio button selected and decimal entered 1`] = `
+exports[`net-residence POST /residential-units/new should return error when net gain radio button selected and 0 entered 1`] = `
 "<main class="govuk-main-wrapper" id="main-content">
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">
@@ -66,7 +66,7 @@ exports[`net-residence POST /residential-units/new should return error when net 
                     <h2 class="govuk-error-summary__title"> There is a problem</h2>
                     <div class="govuk-error-summary__body">
                         <ul class="govuk-list govuk-error-summary__list">
-                            <li><a href="#net-gain">Net gain must be a whole number, like 5</a>
+                            <li><a href="#net-gain">Net gain must be a number, like 5</a>
                             </li>
                         </ul>
                     </div>
@@ -94,8 +94,81 @@ exports[`net-residence POST /residential-units/new should return error when net 
                                 <div class="govuk-radios__conditional" id="conditional-net-residence">
                                     <div class="govuk-form-group govuk-form-group--error">
                                         <label class="govuk-label" for="net-gain">Net gain</label>
-                                        <p id="net-gain-error" class="govuk-error-message"><span class="govuk-visually-hidden">Error:</span> Net gain must be a whole
-                                            number, like 5</p>
+                                        <p id="net-gain-error" class="govuk-error-message"><span class="govuk-visually-hidden">Error:</span> Net gain must be a number,
+                                            like 5</p>
+                                        <input class="govuk-input govuk-input--width-3 govuk-input--error"
+                                        id="net-gain" name="net-gain" type="text" value="1.0" aria-describedby="net-gain-error">
+                                    </div>
+                                </div>
+                                <div class="govuk-radios__item">
+                                    <input class="govuk-radios__input" id="net-residence-2" name="net-residence"
+                                    type="radio" value="loss" data-aria-controls="conditional-net-residence-2">
+                                    <label class="govuk-label govuk-radios__label" for="net-residence-2">Net loss</label>
+                                </div>
+                                <div class="govuk-radios__conditional govuk-radios__conditional--hidden"
+                                id="conditional-net-residence-2">
+                                    <div class="govuk-form-group">
+                                        <label class="govuk-label" for="net-loss">Net loss</label>
+                                        <input class="govuk-input govuk-input--width-3" id="net-loss"
+                                        name="net-loss" type="text" value="">
+                                    </div>
+                                </div>
+                                <div class="govuk-radios__item">
+                                    <input class="govuk-radios__input" id="net-residence-3" name="net-residence"
+                                    type="radio" value="noChange">
+                                    <label class="govuk-label govuk-radios__label" for="net-residence-3">No change in number of residential units</label>
+                                </div>
+                            </div>
+                        </div>
+                        <button type="submit" data-prevent-double-click="true" class="govuk-button"
+                        data-module="govuk-button">Save and return</button>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </div>
+</main>"
+`;
+
+exports[`net-residence POST /residential-units/new should return error when net gain radio button selected and decimal entered 1`] = `
+"<main class="govuk-main-wrapper" id="main-content">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <div class="govuk-error-summary" data-module="govuk-error-summary">
+                <div role="alert">
+                    <h2 class="govuk-error-summary__title"> There is a problem</h2>
+                    <div class="govuk-error-summary__body">
+                        <ul class="govuk-list govuk-error-summary__list">
+                            <li><a href="#net-gain">Net gain must be a number, like 5</a>
+                            </li>
+                        </ul>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Appeal 351062</span>
+            <h1 class="govuk-heading-l">Is there a net gain or loss of residential units?</h1>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <div class="govuk-grid-row">
+                <div class="govuk-grid-column-full">
+                    <form method="POST" novalidate="novalidate">
+                        <div class="govuk-form-group">
+                            <div class="govuk-radios" data-module="govuk-radios">
+                                <div class="govuk-radios__item">
+                                    <input class="govuk-radios__input" id="net-residence" name="net-residence"
+                                    type="radio" value="gain" checked data-aria-controls="conditional-net-residence">
+                                    <label class="govuk-label govuk-radios__label" for="net-residence">Net gain</label>
+                                </div>
+                                <div class="govuk-radios__conditional" id="conditional-net-residence">
+                                    <div class="govuk-form-group govuk-form-group--error">
+                                        <label class="govuk-label" for="net-gain">Net gain</label>
+                                        <p id="net-gain-error" class="govuk-error-message"><span class="govuk-visually-hidden">Error:</span> Net gain must be a number,
+                                            like 5</p>
                                         <input class="govuk-input govuk-input--width-3 govuk-input--error"
                                         id="net-gain" name="net-gain" type="text" value="1.43" aria-describedby="net-gain-error">
                                     </div>
@@ -275,7 +348,7 @@ exports[`net-residence POST /residential-units/new should return error when net 
 </main>"
 `;
 
-exports[`net-residence POST /residential-units/new should return error when net loss radio button selected and decimal entered 1`] = `
+exports[`net-residence POST /residential-units/new should return error when net loss radio button selected and 0 entered 1`] = `
 "<main class="govuk-main-wrapper" id="main-content">
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">
@@ -327,6 +400,79 @@ exports[`net-residence POST /residential-units/new should return error when net 
                                         <label class="govuk-label" for="net-loss">Net loss</label>
                                         <p id="net-loss-error" class="govuk-error-message"><span class="govuk-visually-hidden">Error:</span> Net loss must be a whole
                                             number, like 5</p>
+                                        <input class="govuk-input govuk-input--width-3 govuk-input--error"
+                                        id="net-loss" name="net-loss" type="text" value="0" aria-describedby="net-loss-error">
+                                    </div>
+                                </div>
+                                <div class="govuk-radios__item">
+                                    <input class="govuk-radios__input" id="net-residence-3" name="net-residence"
+                                    type="radio" value="noChange">
+                                    <label class="govuk-label govuk-radios__label" for="net-residence-3">No change in number of residential units</label>
+                                </div>
+                            </div>
+                        </div>
+                        <button type="submit" data-prevent-double-click="true" class="govuk-button"
+                        data-module="govuk-button">Save and return</button>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </div>
+</main>"
+`;
+
+exports[`net-residence POST /residential-units/new should return error when net loss radio button selected and decimal entered 1`] = `
+"<main class="govuk-main-wrapper" id="main-content">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <div class="govuk-error-summary" data-module="govuk-error-summary">
+                <div role="alert">
+                    <h2 class="govuk-error-summary__title"> There is a problem</h2>
+                    <div class="govuk-error-summary__body">
+                        <ul class="govuk-list govuk-error-summary__list">
+                            <li><a href="#net-loss">Net loss must be a number, like 5</a>
+                            </li>
+                        </ul>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Appeal 351062</span>
+            <h1 class="govuk-heading-l">Is there a net gain or loss of residential units?</h1>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <div class="govuk-grid-row">
+                <div class="govuk-grid-column-full">
+                    <form method="POST" novalidate="novalidate">
+                        <div class="govuk-form-group">
+                            <div class="govuk-radios" data-module="govuk-radios">
+                                <div class="govuk-radios__item">
+                                    <input class="govuk-radios__input" id="net-residence" name="net-residence"
+                                    type="radio" value="gain" data-aria-controls="conditional-net-residence">
+                                    <label class="govuk-label govuk-radios__label" for="net-residence">Net gain</label>
+                                </div>
+                                <div class="govuk-radios__conditional govuk-radios__conditional--hidden"
+                                id="conditional-net-residence">
+                                    <div class="govuk-form-group">
+                                        <label class="govuk-label" for="net-gain">Net gain</label>
+                                        <input class="govuk-input govuk-input--width-3" id="net-gain"
+                                        name="net-gain" type="text" value="">
+                                    </div>
+                                </div>
+                                <div class="govuk-radios__item">
+                                    <input class="govuk-radios__input" id="net-residence-2" name="net-residence"
+                                    type="radio" value="loss" checked data-aria-controls="conditional-net-residence-2">
+                                    <label class="govuk-label govuk-radios__label" for="net-residence-2">Net loss</label>
+                                </div>
+                                <div class="govuk-radios__conditional" id="conditional-net-residence-2">
+                                    <div class="govuk-form-group govuk-form-group--error">
+                                        <label class="govuk-label" for="net-loss">Net loss</label>
+                                        <p id="net-loss-error" class="govuk-error-message"><span class="govuk-visually-hidden">Error:</span> Net loss must be a number,
+                                            like 5</p>
                                         <input class="govuk-input govuk-input--width-3 govuk-input--error"
                                         id="net-loss" name="net-loss" type="text" value="1.43" aria-describedby="net-loss-error">
                                     </div>

--- a/appeals/web/src/server/appeals/appeal-details/net-residence/__tests__/net-residence.test.js
+++ b/appeals/web/src/server/appeals/appeal-details/net-residence/__tests__/net-residence.test.js
@@ -189,7 +189,28 @@ describe('net-residence', () => {
 
 			expect(element.innerHTML).toMatchSnapshot();
 			expect(element.innerHTML).toContain(
-				`<a href="#net-gain">Net gain must be a whole number, like 5</a>`
+				`<a href="#net-gain">Net gain must be a number, like 5</a>`
+			);
+		});
+
+		it('should return error when net gain radio button selected and 0 entered', async () => {
+			const appealId = appealData.appealId.toString();
+
+			nock('http://test/').patch(`/appeals/1/appellant-cases/0`).reply(200, {});
+
+			const invalidData = {
+				'net-residence': 'gain',
+				'net-gain': '1.0'
+			};
+			const response = await request
+				.post(`${baseUrl}/${appealId}/residential-units/new`)
+				.send(invalidData);
+
+			const element = parseHtml(response.text);
+
+			expect(element.innerHTML).toMatchSnapshot();
+			expect(element.innerHTML).toContain(
+				`<a href="#net-gain">Net gain must be a number, like 5</a>`
 			);
 		});
 
@@ -241,6 +262,27 @@ describe('net-residence', () => {
 			const invalidData = {
 				'net-residence': 'loss',
 				'net-loss': '1.43'
+			};
+			const response = await request
+				.post(`${baseUrl}/${appealId}/residential-units/new`)
+				.send(invalidData);
+
+			const element = parseHtml(response.text);
+
+			expect(element.innerHTML).toMatchSnapshot();
+			expect(element.innerHTML).toContain(
+				`<a href="#net-loss">Net loss must be a number, like 5</a>`
+			);
+		});
+
+		it('should return error when net loss radio button selected and 0 entered', async () => {
+			const appealId = appealData.appealId.toString();
+
+			nock('http://test/').patch(`/appeals/1/appellant-cases/0`).reply(200, {});
+
+			const invalidData = {
+				'net-residence': 'loss',
+				'net-loss': '0'
 			};
 			const response = await request
 				.post(`${baseUrl}/${appealId}/residential-units/new`)

--- a/appeals/web/src/server/appeals/appeal-details/net-residence/net-residence.controller.js
+++ b/appeals/web/src/server/appeals/appeal-details/net-residence/net-residence.controller.js
@@ -1,4 +1,5 @@
 import logger from '#lib/logger.js';
+import { removeCommasFromNumericInput } from '#lib/sanitizers/numeric-input-sanitizer.js';
 import { addNotificationBannerToSession } from '#lib/session-utilities.js';
 import { getBackLinkUrlFromQuery } from '#lib/url-utilities.js';
 import { HTTPError } from 'got';
@@ -58,10 +59,13 @@ export const postNetResidence = async (request, response) => {
 
 	switch (numberOfResidencesNetChange) {
 		case 'gain':
-			request.currentAppeal.numberOfResidencesNetChange = parseInt(request.body['net-gain']);
+			request.currentAppeal.numberOfResidencesNetChange = removeCommasFromNumericInput(
+				request.body['net-gain']
+			);
 			break;
 		case 'loss':
-			request.currentAppeal.numberOfResidencesNetChange = parseInt(request.body['net-loss']) * -1;
+			request.currentAppeal.numberOfResidencesNetChange =
+				removeCommasFromNumericInput(request.body['net-loss']) * -1;
 			break;
 		case 'noChange':
 			request.currentAppeal.numberOfResidencesNetChange = 0;

--- a/appeals/web/src/server/appeals/appeal-details/net-residence/net-residence.validators.js
+++ b/appeals/web/src/server/appeals/appeal-details/net-residence/net-residence.validators.js
@@ -1,3 +1,5 @@
+import { removeCommasFromNumericInput } from '#lib/sanitizers/numeric-input-sanitizer.js';
+import { NUMERIC_INPUT_REGEX } from '@pins/appeals/constants/support.js';
 import { createValidator } from '@pins/express';
 import { body } from 'express-validator';
 import { capitalize } from 'lodash-es';
@@ -6,6 +8,9 @@ import { capitalize } from 'lodash-es';
  * @typedef {import('express-validator').ValidationChain} ValidationChain
  * @typedef {import('express-validator').CustomValidator} CustomValidator
  */
+
+const MIN_NET_RESIDENCE_GAIN_OR_LOSS = 1;
+const MAX_NET_RESIDENCE_GAIN_OR_LOSS = 999999;
 
 export const validateNetResidenceSelected = createValidator(
 	body('net-residence')
@@ -34,9 +39,21 @@ export const validateNetGainOrLoss = (
 			.trim()
 			.notEmpty()
 			.withMessage(`Enter the ${fieldName}`)
-			.isNumeric()
+			.matches(NUMERIC_INPUT_REGEX)
 			.withMessage(`${capitalize(fieldName)} must be a number, like 5`)
-			.isInt({ min: 1 })
-			.withMessage(`${capitalize(fieldName)} must be a whole number, like 5`)
+			.custom((value) => {
+				// Remove commas
+				const sanitizedValue = removeCommasFromNumericInput(value);
+
+				if (sanitizedValue < MIN_NET_RESIDENCE_GAIN_OR_LOSS) {
+					throw new Error(`${capitalize(fieldName)} must be a whole number, like 5`);
+				}
+
+				if (sanitizedValue > MAX_NET_RESIDENCE_GAIN_OR_LOSS) {
+					throw new Error(`${capitalize(fieldName)} must be 6 digits or less`);
+				}
+
+				return true;
+			})
 	);
 };

--- a/appeals/web/src/server/lib/sanitizers/numeric-input-sanitizer.js
+++ b/appeals/web/src/server/lib/sanitizers/numeric-input-sanitizer.js
@@ -1,0 +1,2 @@
+export const removeCommasFromNumericInput = (/** @type {string} */ value) =>
+	Number(value.replace(/[,]/g, ''));

--- a/packages/appeals/constants/support.js
+++ b/packages/appeals/constants/support.js
@@ -357,7 +357,7 @@ export const UK_POSTCODE_REGEX = /^([A-Za-z]{1,2}\d[A-Za-z\d]? ?\d[A-Za-z]{2}|GI
 
 export const UUID_REGEX =
 	/^[0-9a-f]{8}-[0-9a-f]{4}-[0-5][0-9a-f]{3}-[089ab][0-9a-f]{3}-[0-9a-f]{12}$/;
-
+export const NUMERIC_INPUT_REGEX = /^[,0-9 ]+$/;
 export const LENGTH_1 = 1;
 export const LENGTH_8 = 8;
 export const LENGTH_10 = 10;


### PR DESCRIPTION
## Describe your changes
- Numeric inputs should accept digits and commas - new regex for this added
- The numeric input has to be santized (stripped of commas) before being passed on in request
- Added length validation for number of residences

### Test 
- Amending the unit test to reflect change in validation logic
- Added new unit test to test net residence error message when 0 entered 
<!--
    Please include a summary of the change along with any relevant context.
    List any dependencies that are required for this change.
-->

## Issue ticket number and link

[Ticket](https://pins-ds.atlassian.net.mcas.ms/browse/A2-4470)
