### PR TITLE
feat(web): get team emails previews that were missed  (A2-4234)

### DIFF
--- a/appeals/web/src/server/appeals/appeal-details/invalid-appeal/__tests__/invalid-appeal.test.js
+++ b/appeals/web/src/server/appeals/appeal-details/invalid-appeal/__tests__/invalid-appeal.test.js
@@ -285,6 +285,11 @@ describe('invalid-appeal', () => {
 			await request.post(`${baseUrl}/invalid/new`).send({
 				invalidReason: invalidReasonsWithoutTextIds[0]
 			});
+			nock('http://test/').get('/appeals/1/case-team-email').reply(200, {
+				id: 1,
+				email: 'caseofficers@planninginspectorate.gov.uk',
+				name: 'standard email'
+			});
 			const response = await request.get(`${baseUrl}/invalid/check`);
 			const element = parseHtml(response.text);
 

--- a/appeals/web/src/server/appeals/appeal-details/invalid-appeal/invalid-appeal.controller.js
+++ b/appeals/web/src/server/appeals/appeal-details/invalid-appeal/invalid-appeal.controller.js
@@ -12,6 +12,7 @@ import {
 	buildRejectionReasons,
 	rejectionReasonHtml
 } from '../representations/common/components/reject-reasons.js';
+import { getTeamFromAppealId } from '../update-case-team/update-case-team.service.js';
 import {
 	decisionInvalidConfirmationPage,
 	mapInvalidReasonPage,
@@ -185,11 +186,17 @@ export const getCheckPage = async (request, response) => {
 			webAppellantCaseReviewOutcome.reasonsText
 		);
 
+		const { email: assignedTeamEmail } = await getTeamFromAppealId(
+			request.apiClient,
+			currentAppeal.appealId
+		);
+
 		const personalisation = {
 			appeal_reference_number: currentAppeal.appealReference,
 			lpa_reference: currentAppeal.planningApplicationReference || '',
 			site_address: appealSiteToAddressString(currentAppeal.appealSite),
-			reasons: invalidReasons
+			reasons: invalidReasons,
+			team_email_address: assignedTeamEmail
 		};
 
 		const { appellantTemplate, lpaTemplate } = await generateInvalidAppealNotifyPreviews(

--- a/appeals/web/src/server/appeals/appeal-details/start-case/hearing/__tests__/start-case-hearing.test.js
+++ b/appeals/web/src/server/appeals/appeal-details/start-case/hearing/__tests__/start-case-hearing.test.js
@@ -430,8 +430,14 @@ describe('start case hearing flow', () => {
 				hearing_date: '1 February 3025',
 				hearing_time: '12:00pm',
 				procedure_type: 'a hearing',
-				child_appeals: []
+				child_appeals: [],
+				team_email_address: 'caseofficers@planninginspectorate.gov.uk'
 			};
+			nock('http://test/').get('/appeals/1/case-team-email').reply(200, {
+				id: 1,
+				email: 'caseofficers@planninginspectorate.gov.uk',
+				name: 'standard email'
+			});
 			nock('http://test/')
 				.get('/appeals/1')
 				.times(3)
@@ -530,8 +536,14 @@ describe('start case hearing flow', () => {
 				hearing_date: '',
 				hearing_time: '',
 				procedure_type: 'a hearing',
-				child_appeals: []
+				child_appeals: [],
+				team_email_address: 'caseofficers@planninginspectorate.gov.uk'
 			};
+			nock('http://test/').get('/appeals/1/case-team-email').reply(200, {
+				id: 1,
+				email: 'caseofficers@planninginspectorate.gov.uk',
+				name: 'standard email'
+			});
 			nock('http://test/')
 				.get('/appeals/1')
 				.twice()

--- a/appeals/web/src/server/appeals/appeal-details/start-case/hearing/hearing.controller.js
+++ b/appeals/web/src/server/appeals/appeal-details/start-case/hearing/hearing.controller.js
@@ -1,6 +1,7 @@
 import { appealProcedureToLabelText } from '#appeals/appeal-details/change-appeal-procedure-type/check-and-confirm/check-and-confirm.mapper.js';
 import { sessionValuesToDateTime } from '#appeals/appeal-details/hearing/setup/set-up-hearing.controller.js';
 import { hearingDatePage } from '#appeals/appeal-details/hearing/setup/set-up-hearing.mapper.js';
+import { getTeamFromAppealId } from '#appeals/appeal-details/update-case-team/update-case-team.service.js';
 import { appealSiteToAddressString } from '#lib/address-formatter.js';
 import { generateNotifyPreview } from '#lib/api/notify-preview.api.js';
 import { appealShortReference } from '#lib/appeals-formatter.js';
@@ -199,6 +200,10 @@ export const getHearingConfirm = async (request, response) => {
 		currentAppeal.appealId,
 		sessionValues.appealProcedure
 	);
+	const { email: assignedTeamEmail } = await getTeamFromAppealId(
+		request.apiClient,
+		currentAppeal.appealId
+	);
 
 	const personalisation = {
 		appeal_reference_number: currentAppeal.appealReference,
@@ -217,7 +222,8 @@ export const getHearingConfirm = async (request, response) => {
 		hearing_date: dateISOStringToDisplayDate(hearingStartTime),
 		hearing_time: dateISOStringToDisplayTime12hr(hearingStartTime),
 		procedure_type: 'a hearing',
-		child_appeals: []
+		child_appeals: [],
+		team_email_address: assignedTeamEmail
 	};
 
 	/** @type {string} */

--- a/appeals/web/src/server/appeals/appeal-details/withdrawal/__tests__/withdrawal.test.js
+++ b/appeals/web/src/server/appeals/appeal-details/withdrawal/__tests__/withdrawal.test.js
@@ -113,6 +113,11 @@ describe('withdrawal', () => {
 			const response = await request.get(
 				`${baseUrl}/${mockAppealId}${withdrawalPath}${checkYourAnswersPath}`
 			);
+			nock('http://test/').get('/appeals/1/case-team-email').reply(200, {
+				id: 1,
+				email: 'caseofficers@planninginspectorate.gov.uk',
+				name: 'standard email'
+			});
 			const element = parseHtml(response.text);
 
 			expect(element.innerHTML).toMatchSnapshot();


### PR DESCRIPTION
## Describe your changes

### WEB

- fixed issue where team email wasn't populated when generating notify previews on the front end


### TEST

- manual testing within browser
- updated unit tests and snapshots

## Issue ticket number and link

[Ticket](https://pins-ds.atlassian.net/browse/A2-4396)
