### PR TITLE
Feature/a2 4047 pdf generator for household appeal

### DIFF
--- a/appeals/web/src/server/app/components/file-downloader.component.js
+++ b/appeals/web/src/server/app/components/file-downloader.component.js
@@ -2,8 +2,10 @@ import { generateAllPdfs } from '#app/components/download-all-generated-pdfs.com
 import {
 	getAllCaseFolders,
 	getFileInfo,
-	getFileVersionsInfo
+	getFileVersionsInfo,
+	getRepresentationAttachments
 } from '#appeals/appeal-documents/appeal.documents.service.js';
+import { camelCaseToWords, toSentenceCase } from '#lib/string-utilities.js';
 import { BlobServiceClient } from '@azure/storage-blob';
 import config from '@pins/appeals.web/environment/config.js';
 import { BlobStorageClient } from '@pins/blob-storage-client';
@@ -243,29 +245,9 @@ export const getBulkDocumentDownload = async (
 	{ apiClient, params, session, currentAppeal },
 	response
 ) => {
-	const { filename: requestedFilename, caseId } = params;
-
-	const folders = await getAllCaseFolders(apiClient, caseId);
-	const bulkFileInfo = folders
-		?.filter((folder) => folder.documents.length)
-		.filter((folder) => !folder.path.startsWith(APPEAL_CASE_STAGE.INTERNAL))
-		.flatMap((folder) => {
-			return folder.documents.map((document) => {
-				const { blobStorageContainer, blobStoragePath, documentURI } =
-					document.latestDocumentVersion;
-				return {
-					fullName: `${folder.path}/${document.name}`,
-					blobStorageContainer,
-					blobStoragePath,
-					documentURI
-				};
-			});
-		});
-
-	const timestampTokens = new Date().toISOString().split('T');
-	const dateString = timestampTokens[0].replaceAll('-', '');
-	const timeString = timestampTokens[1].split('.')[0].replaceAll(':', '');
-	const zipFileName = requestedFilename?.replace('.zip', `_${dateString}${timeString}.zip`);
+	const { filename = '', caseId } = params;
+	const bulkFileInfo = await getBulkFileInfo(apiClient, caseId);
+	const zipFileName = buildZipFileName(caseId, filename);
 
 	response.setHeader('content-type', 'application/zip');
 	response.setHeader('content-disposition', `attachment; filename=${zipFileName}`);
@@ -283,6 +265,7 @@ export const getBulkDocumentDownload = async (
 	} else {
 		const blobStorageClient = await createBlobStorageClient(session);
 		const blobStreams = await Promise.all(
+			// @ts-ignore
 			bulkFileInfo.map((fileInfo) =>
 				createBlobDownloadStream(
 					blobStorageClient,
@@ -314,4 +297,82 @@ export const getBulkDocumentDownload = async (
 
 	await archive.finalize();
 	return response.status(200);
+};
+
+/**
+ * Build a zipped file name
+ *
+ * @param {string} caseId
+ * @param {string} filename
+ * @returns {*}
+ */
+const buildZipFileName = (caseId, filename) => {
+	const timestampTokens = new Date().toISOString().split('T');
+	const dateString = timestampTokens[0].replaceAll('-', '');
+	const timeString = timestampTokens[1].split('.')[0].replaceAll(':', '');
+
+	return filename?.replace('.zip', `_${dateString}${timeString}.zip`);
+};
+
+/**
+ * Get all representation's documents
+ *
+ * @param {import('got').Got} apiClient
+ * @param {string} caseId
+ * @returns {Promise<*>}
+ */
+const getRepresentationAttachmentFullNames = async (apiClient, caseId) => {
+	const representations = await getRepresentationAttachments(apiClient, caseId);
+	const fullAttachmentNames = {};
+	// @ts-ignore
+	representations?.items?.forEach((representation, index) =>
+		// @ts-ignore
+		representation.attachments.forEach((attachment) => {
+			const { document } = attachment.documentVersion || {};
+			const representationType =
+				representation.representationType === 'comment'
+					? `Interested party comments/Comment ${index + 1}`
+					: toSentenceCase(representation.representationType).replace('Lpa', 'LPA');
+			// @ts-ignore
+			fullAttachmentNames[document.guid] = `Representations/${representationType}/${document.name}`;
+		})
+	);
+	return fullAttachmentNames;
+};
+
+/**
+ * Get bulk file info
+ *
+ * @param {import('got').Got} apiClient
+ * @param {string} caseId
+ * @returns {Promise<*>}
+ */
+export const getBulkFileInfo = async (apiClient, caseId) => {
+	const representationAttachmentFullNames = await getRepresentationAttachmentFullNames(
+		apiClient,
+		caseId
+	);
+	const folders = await getAllCaseFolders(apiClient, caseId);
+	return folders
+		?.filter(
+			(folder) => folder.documents?.length && !folder.path.startsWith(APPEAL_CASE_STAGE.INTERNAL)
+		)
+		.flatMap((folder) => {
+			const folderPath = folder.path
+				.split('/')
+				.map((folderName) => camelCaseToWords(folderName.trim()).replace('Lpa', 'LPA'))
+				.join('/');
+			return folder.documents.map((document) => {
+				const { blobStorageContainer, blobStoragePath, documentURI } =
+					document.latestDocumentVersion;
+				return {
+					fullName:
+						// @ts-ignore
+						representationAttachmentFullNames[document.guid] || `${folderPath}/${document.name}`,
+					blobStorageContainer,
+					blobStoragePath,
+					documentURI
+				};
+			});
+		});
 };

--- a/appeals/web/src/server/appeals/appeal-documents/appeal.documents.service.js
+++ b/appeals/web/src/server/appeals/appeal-documents/appeal.documents.service.js
@@ -222,3 +222,21 @@ export const deleteDocument = async (apiClient, appealId, documentId, versionId)
 		);
 	}
 };
+
+/**
+ * @param {import('got').Got} apiClient
+ * @param {string} appealId
+ * @returns {Promise<*>}
+ */
+export const getRepresentationAttachments = async (apiClient, appealId) => {
+	try {
+		return await apiClient.get(`appeals/${appealId}/reps`).json();
+	} catch (error) {
+		logger.error(
+			error,
+			error instanceof Error
+				? error.message
+				: `An error occurred while attempting to retrieve the representation attachments for appeal ID ${appealId}`
+		);
+	}
+};


### PR DESCRIPTION
## Describe your changes
#### Put files within more suitable folders within the downloaded zip file (a2-4047)
##### Please note I have left out unit tests after struggling for the best part of a day due to trouble mocking the BlobStorageClient.

### WEB:
- Make folder names sentence case
- For representations, create additional folder structure for each representation
- IP Comment attachments required even more additional folder structure for statuses published, awaiting review, and accepted, as well as multiple comments within each status. 

### TEST:
- Make sure all unit tests pass

## Issue ticket number and link

[A2-4047- BO Zipped Folder (PDF Generator) - Householder appeal (HAS)](https://pins-ds.atlassian.net/browse/A2-4492)
