### PR TITLE
fix(api): amend broadcasting of appeal following transfer

### DIFF
--- a/appeals/api/src/server/endpoints/change-appeal-type/change-appeal-type.controller.js
+++ b/appeals/api/src/server/endpoints/change-appeal-type/change-appeal-type.controller.js
@@ -119,9 +119,10 @@ export const requestTransferOfAppeal = async (req, res) => {
 			where: { id: appeal.id },
 			data
 		}),
-		await transitionState(appeal.id, azureAdUserId, APPEAL_CASE_STATUS.AWAITING_TRANSFER),
-		await broadcasters.broadcastAppeal(appeal.id)
+		await transitionState(appeal.id, azureAdUserId, APPEAL_CASE_STATUS.AWAITING_TRANSFER)
 	]);
+
+	await broadcasters.broadcastAppeal(appeal.id);
 
 	return res.send(true);
 };
@@ -144,9 +145,10 @@ export const requestConfirmationTransferOfAppeal = async (req, res) => {
 				caseUpdatedDate: new Date()
 			}
 		}),
-		await transitionState(appeal.id, azureAdUserId, APPEAL_CASE_STATUS.TRANSFERRED),
-		await broadcasters.broadcastAppeal(appeal.id)
+		await transitionState(appeal.id, azureAdUserId, APPEAL_CASE_STATUS.TRANSFERRED)
 	]);
+
+	await broadcasters.broadcastAppeal(appeal.id);
 
 	return res.send(true);
 };


### PR DESCRIPTION
## Describe your changes

Moving broadcast of appeal out of Promise.all block to ensure broadcast occurs after state transitions

## Issue ticket number and link

[Ticket](https://pins-ds.atlassian.net/browse/A2-3882)
