### PR TITLE
[test/A2-4152-v2] - adding scenarios for estimated days validation 

### DIFF
--- a/appeals/e2e/cypress/e2e/back-office-appeals/inquiry.spec.js
+++ b/appeals/e2e/cypress/e2e/back-office-appeals/inquiry.spec.js
@@ -164,7 +164,6 @@ it('Can start case as inquiry with address and estimated days', () => {
 });
 
 it('Can start case as inquiry without address or estimated days', () => {
-	cy.wait(1000);
 	cy.getBusinessActualDate(new Date(), 28).then((inquiryDate) => {
 		dateTimeSection.enterInquiryDate(inquiryDate);
 		dateTimeSection.enterInquiryTime('12', '00');
@@ -184,6 +183,40 @@ it('Can start case as inquiry without address or estimated days', () => {
 	caseDetailsPage.clickButtonByText('Start case');
 	caseDetailsPage.validateBannerMessage('Success', 'Appeal started');
 	caseDetailsPage.validateBannerMessage('Success', 'Timetable started');
+});
+
+it('Displays error if inquiry estimated days not entered', () => {
+	cy.getBusinessActualDate(new Date(), 28).then((inquiryDate) => {
+		dateTimeSection.enterInquiryDate(inquiryDate);
+		dateTimeSection.enterInquiryTime('12', '00');
+	});
+	caseDetailsPage.clickButtonByText('Continue');
+	inquirySectionPage.selectEstimatedDaysOption('Yes');
+	inquirySectionPage.clearEstimatedDays();
+	caseDetailsPage.clickButtonByText('Continue');
+
+	// verify error message
+	inquirySectionPage.verifyErrorMessages({
+		messages: ['Enter the expected number of days to carry out the inquiry'],
+		fields: ['inquiry-estimation-days']
+	});
+});
+
+it('Displays error if invalid input entered for inquiry estimated days', () => {
+	cy.getBusinessActualDate(new Date(), 28).then((inquiryDate) => {
+		dateTimeSection.enterInquiryDate(inquiryDate);
+		dateTimeSection.enterInquiryTime('12', '00');
+	});
+	caseDetailsPage.clickButtonByText('Continue');
+	inquirySectionPage.selectEstimatedDaysOption('Yes');
+	inquirySectionPage.enterEstimatedDays('abc');
+	caseDetailsPage.clickButtonByText('Continue');
+
+	// verify error message
+	inquirySectionPage.verifyErrorMessages({
+		messages: ['Enter the number of days using numbers 0 to 99'],
+		fields: ['inquiry-estimation-days']
+	});
 });
 
 it('Can update inquiry date', () => {

--- a/appeals/e2e/cypress/page_objects/caseDetails/inquirySectionPage.js
+++ b/appeals/e2e/cypress/page_objects/caseDetails/inquirySectionPage.js
@@ -65,6 +65,18 @@ export class InquirySectionPage extends CaseDetailsPage {
 		dateTimeSection.clearInquiryDateAndTime();
 	}
 
+	clearEstimatedDays() {
+		estimatedDaysSection.clearEstimatedDays();
+	}
+
+	enterEstimatedDays(estimatedDays) {
+		estimatedDaysSection.enterEstimatedInquiryDays(estimatedDays);
+	}
+
+	selectEstimatedDaysOption(option) {
+		estimatedDaysSection.selectEstimatedDaysOption(option);
+	}
+
 	setUpInquiry(day, month, year, hour, minute) {
 		dateTimeSection.setInquiryDate(day, month, year);
 		dateTimeSection.enterInquiryTime(hour, minute);

--- a/appeals/e2e/cypress/page_objects/estimatedDaysSection.js
+++ b/appeals/e2e/cypress/page_objects/estimatedDaysSection.js
@@ -19,6 +19,11 @@ export class EstimatedDaysSection extends CaseDetailsPage {
 
 	// A C T I O N S
 
+	clearEstimatedDays() {
+		// clear estimated day
+		this.elements.inquiryEstimatedDaysInput().clear();
+	}
+
 	enterEstimatedInquiryDays(estimatedInquiryDays) {
 		this.elements.inquiryEstimatedDaysInput().clear().type(estimatedInquiryDays.toString());
 	}


### PR DESCRIPTION
## Describe your changes

While testing inquiry flow noticed that the validation for inquiry estimated days field was broken - 
- field was not visible in event of error 
- field was not selected by clicking on error link 

These issues have been confirmed as working, and have added scenarios for this to cover both empty and invalid input 

## Issue ticket number and link 

https://pins-ds.atlassian.net/browse/A2-4152 