### PR TITLE
feat(appeals): add record missed site visit CYA page (A2-4232)

### DIFF
--- a/appeals/api/src/server/notify/templates/__tests__/record-missed-site-visit-appellant.test.js
+++ b/appeals/api/src/server/notify/templates/__tests__/record-missed-site-visit-appellant.test.js
@@ -1,0 +1,55 @@
+import { notifySend } from '#notify/notify-send.js';
+import { jest } from '@jest/globals';
+
+describe('site-visit-change-access-required-date-change-appellant.md', () => {
+	test('should call notify sendEmail with the correct data', async () => {
+		const notifySendData = {
+			doNotMockNotifySend: true,
+			templateName: 'record-missed-site-visit-appellant',
+			notifyClient: {
+				sendEmail: jest.fn()
+			},
+			recipientEmail: 'test@example.com',
+			personalisation: {
+				appeal_reference_number: 'XYZ12345',
+				site_address: '22, Example Lane',
+				lpa_reference: 'REF-67890',
+				visit_date: '12 June 2025',
+				'5_day_deadline': '17 June 2025',
+				start_time: '10:30am',
+				team_email_address: 'caseofficers@planninginspectorate.gov.uk'
+			}
+		};
+
+		const expectedContent = [
+			'Our inspector visited the site at 10:30am on 12 June 2025. Nobody was at the site to give the inspector access.',
+			'',
+			'# Appeal details',
+			'',
+			'^Appeal reference number: XYZ12345',
+			'Address: 22, Example Lane',
+			'Planning application reference: REF-67890',
+			'',
+			'# What happens next',
+			'',
+			'Send an email to explain why you could not attend to caseofficers@planninginspectorate.gov.uk by 17 June 2025.',
+			'',
+			'If you missed your site visit without a good reason, we may dismiss your appeal.',
+			'',
+			'The Planning Inspectorate'
+		].join('\n');
+
+		await notifySend(notifySendData);
+
+		expect(notifySendData.notifyClient.sendEmail).toHaveBeenCalledWith(
+			{
+				id: 'mock-appeal-generic-id'
+			},
+			'test@example.com',
+			{
+				content: expectedContent,
+				subject: 'Missed site visit: XYZ12345'
+			}
+		);
+	});
+});

--- a/appeals/api/src/server/notify/templates/__tests__/record-missed-site-visit-lpa.test.js
+++ b/appeals/api/src/server/notify/templates/__tests__/record-missed-site-visit-lpa.test.js
@@ -1,0 +1,55 @@
+import { notifySend } from '#notify/notify-send.js';
+import { jest } from '@jest/globals';
+
+describe('record-missed-site-visit-lpa.md', () => {
+	test('should call notify sendEmail with the correct data', async () => {
+		const notifySendData = {
+			doNotMockNotifySend: true,
+			templateName: 'record-missed-site-visit-lpa',
+			notifyClient: {
+				sendEmail: jest.fn()
+			},
+			recipientEmail: 'test@example.com',
+			personalisation: {
+				appeal_reference_number: 'XYZ12345',
+				site_address: '22, Example Lane',
+				lpa_reference: 'REF-67890',
+				visit_date: '12 June 2025',
+				'5_day_deadline': '17 June 2025',
+				start_time: '10:30am',
+				team_email_address: 'caseofficers@planninginspectorate.gov.uk'
+			}
+		};
+
+		const expectedContent = [
+			'Our inspector visited the site at 10:30am on 12 June 2025. You did not attend the site visit.',
+			'',
+			'# Appeal details',
+			'',
+			'^Appeal reference number: XYZ12345',
+			'Address: 22, Example Lane',
+			'Planning application reference: REF-67890',
+			'',
+			'# What happens next',
+			'',
+			'Send an email to explain why you could not attend to caseofficers@planninginspectorate.gov.uk by 17 June 2025.',
+			'',
+			'If you missed your site visit without a good reason, you may need to pay appeal costs.',
+			'',
+			'The Planning Inspectorate'
+		].join('\n');
+
+		await notifySend(notifySendData);
+
+		expect(notifySendData.notifyClient.sendEmail).toHaveBeenCalledWith(
+			{
+				id: 'mock-appeal-generic-id'
+			},
+			'test@example.com',
+			{
+				content: expectedContent,
+				subject: 'Missed site visit: XYZ12345'
+			}
+		);
+	});
+});

--- a/appeals/api/src/server/notify/templates/record-missed-site-visit-appellant.content.md
+++ b/appeals/api/src/server/notify/templates/record-missed-site-visit-appellant.content.md
@@ -1,0 +1,12 @@
+Our inspector visited the site at {{start_time}} on {{visit_date}}. Nobody was at the site to give the inspector access.
+
+{% include 'parts/appeal-details.md' %}
+
+# What happens next
+
+Send an email to explain why you could not attend to {{team_email_address}} by {{5_day_deadline}}.
+
+If you missed your site visit without a good reason, we may dismiss your appeal.
+
+The Planning Inspectorate
+

--- a/appeals/api/src/server/notify/templates/record-missed-site-visit-appellant.subject.md
+++ b/appeals/api/src/server/notify/templates/record-missed-site-visit-appellant.subject.md
@@ -1,0 +1,1 @@
+Missed site visit: {{appeal_reference_number}}

--- a/appeals/api/src/server/notify/templates/record-missed-site-visit-lpa.content.md
+++ b/appeals/api/src/server/notify/templates/record-missed-site-visit-lpa.content.md
@@ -1,0 +1,11 @@
+Our inspector visited the site at {{start_time}} on {{visit_date}}. You did not attend the site visit.
+
+{% include 'parts/appeal-details.md' %}
+
+# What happens next
+
+Send an email to explain why you could not attend to {{team_email_address}} by {{5_day_deadline}}.
+
+If you missed your site visit without a good reason, you may need to pay appeal costs.
+
+The Planning Inspectorate

--- a/appeals/api/src/server/notify/templates/record-missed-site-visit-lpa.subject.md
+++ b/appeals/api/src/server/notify/templates/record-missed-site-visit-lpa.subject.md
@@ -1,0 +1,1 @@
+Missed site visit: {{appeal_reference_number}}

--- a/appeals/web/src/server/appeals/appeal-details/site-visit/__tests__/__snapshots__/site-visit.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/site-visit/__tests__/__snapshots__/site-visit.test.js.snap
@@ -224,6 +224,158 @@ exports[`site-visit GET /site-visit/missed should render the who missed the site
 </main>"
 `;
 
+exports[`site-visit GET /site-visit/missed/check should render the who missed the site visit page for appellant 1`] = `
+"<main class="govuk-main-wrapper" id="main-content">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Appeal 351062</span>
+            <h1 class="govuk-heading-l">Check details and record missed site visit</h1>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <div class="govuk-grid-row">
+                <div class="govuk-grid-column-full">
+                    <form method="POST" novalidate="novalidate">
+                        <dl class="govuk-summary-list">
+                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Who missed the site visit?</dt>
+                                <dd                                 class="govuk-summary-list__value">Appellant</dd>
+                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/missed">Change<span class="govuk-visually-hidden"> Change who missed site visit</span></a>
+                                    </dd>
+                            </div>
+                        </dl>
+                        <div class="govuk-grid-row">
+                            <div class="govuk-grid-column-full">
+                                <details class="govuk-details">
+                                    <summary class="govuk-details__summary"><span class="govuk-details__summary-text"> Preview email to appellant</span>
+                                    </summary>
+                                    <div class="govuk-details__text">
+                                        <div class="pins-notify-preview-border">
+                                            <h2>Appeal details</h2>
+                                            <div class="govuk-inset-text">Appeal reference number: 134526
+                                                <br>Address: 96 The Avenue, Leftfield, Maidstone, Kent, MD21 5XY, United Kingdom
+                                                <br>Planning application reference: 48269/APP/2021/1482
+                                                <br>
+                                            </div>
+                                            <h2>Appeal withdrawn</h2>We have withdrawn the appeal following your request on 01 January 2025.
+                                            <br>
+                                            <br>
+                                            <h2>What happens next</h2>We have closed the appeal and cancelled the site visit.
+                                            <br>
+                                            <br>
+                                            <h2>Feedback</h2>We welcome your feedback on our appeals process. Tell us on this short
+                                            <a                                             href="https://forms.office.com/pages/responsepage.aspx?id=mN94WIhvq0iTIpmM5VcIjfMZj__F6D9LmMUUyoUrZDZUOERYMEFBN0NCOFdNU1BGWEhHUFQxWVhUUy4u"
+                                            class="govuk-link">feedback form</a>.
+                                                <br>
+                                                <br>The Planning Inspectorate
+                                                <br>
+                                                <br>caseofficers@planninginspectorate.gov.uk
+                                                <br>
+                                                <br>
+                                        </div>
+                                    </div>
+                                </details>
+                            </div>
+                        </div>
+                        <button type="submit" data-prevent-double-click="true" class="govuk-button"
+                        data-module="govuk-button">Record missed site visit</button>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </div>
+</main>"
+`;
+
+exports[`site-visit GET /site-visit/missed/check should render the who missed the site visit page for inspector 1`] = `
+"<main class="govuk-main-wrapper" id="main-content">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Appeal 351062</span>
+            <h1 class="govuk-heading-l">Check details and record missed site visit</h1>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <div class="govuk-grid-row">
+                <div class="govuk-grid-column-full">
+                    <form method="POST" novalidate="novalidate">
+                        <dl class="govuk-summary-list">
+                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Who missed the site visit?</dt>
+                                <dd                                 class="govuk-summary-list__value">Inspector</dd>
+                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/missed">Change<span class="govuk-visually-hidden"> Change who missed site visit</span></a>
+                                    </dd>
+                            </div>
+                        </dl>
+                        <button type="submit" data-prevent-double-click="true" class="govuk-button"
+                        data-module="govuk-button">Record missed site visit</button>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </div>
+</main>"
+`;
+
+exports[`site-visit GET /site-visit/missed/check should render the who missed the site visit page for lpa 1`] = `
+"<main class="govuk-main-wrapper" id="main-content">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Appeal 351062</span>
+            <h1 class="govuk-heading-l">Check details and record missed site visit</h1>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <div class="govuk-grid-row">
+                <div class="govuk-grid-column-full">
+                    <form method="POST" novalidate="novalidate">
+                        <dl class="govuk-summary-list">
+                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Who missed the site visit?</dt>
+                                <dd                                 class="govuk-summary-list__value">LPA</dd>
+                                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/missed">Change<span class="govuk-visually-hidden"> Change who missed site visit</span></a>
+                                    </dd>
+                            </div>
+                        </dl>
+                        <div class="govuk-grid-row">
+                            <div class="govuk-grid-column-full">
+                                <details class="govuk-details">
+                                    <summary class="govuk-details__summary"><span class="govuk-details__summary-text"> Preview email to LPA</span>
+                                    </summary>
+                                    <div class="govuk-details__text">
+                                        <div class="pins-notify-preview-border">We have withdrawn the appeal after the appellant's request.
+                                            <br>
+                                            <br>
+                                            <h2>Appeal details</h2>
+                                            <div class="govuk-inset-text">Appeal reference number: 234567
+                                                <br>Address: 98 The Avenue, Leftfield, Maidstone, Kent, MD21 5YY, United Kingdom
+                                                <br>Planning application reference: 48269/APP/2021/1483
+                                                <br>
+                                            </div>
+                                            <h2>What happens next</h2>We have closed the appeal and cancelled the site visit.
+                                            <br>
+                                            <br>
+                                            <h2>Feedback</h2>We welcome your feedback on our appeals process. Tell us on this short
+                                            <a                                             href="https://forms.office.com/pages/responsepage.aspx?id=mN94WIhvq0iTIpmM5VcIjfMZj__F6D9LmMUUyoUrZDZUOERYMEFBN0NCOFdNU1BGWEhHUFQxWVhUUy4u"
+                                            class="govuk-link">feedback form</a>.
+                                                <br>
+                                                <br>The Planning Inspectorate
+                                                <br>
+                                                <br>caseofficers@planninginspectorate.gov.uk
+                                                <br>
+                                                <br>
+                                        </div>
+                                    </div>
+                                </details>
+                            </div>
+                        </div>
+                        <button type="submit" data-prevent-double-click="true" class="govuk-button"
+                        data-module="govuk-button">Record missed site visit</button>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </div>
+</main>"
+`;
+
 exports[`site-visit GET /site-visit/schedule-visit should render the schedule visit page 1`] = `
 "<main class="govuk-main-wrapper" id="main-content">
     <div class="govuk-grid-row">

--- a/appeals/web/src/server/appeals/appeal-details/site-visit/site-visit.router.js
+++ b/appeals/web/src/server/appeals/appeal-details/site-visit/site-visit.router.js
@@ -81,4 +81,11 @@ router
 		asyncHandler(controller.postSiteVisitMissed)
 	);
 
+router
+	.route('/missed/check')
+	.get(
+		assertUserHasPermission(permissionNames.setEvents),
+		asyncHandler(controller.getSiteVisitMissedCya)
+	);
+
 export default router;

--- a/docs/notifications-and-triggers.md
+++ b/docs/notifications-and-triggers.md
@@ -284,3 +284,17 @@ The following notifications are sent from the back-office using these [Notify Te
 - **Appeal type:** all
 - **Notify Template:** [decision-is-invalid-lpa](../appeals/api/src/server/notify/templates/decision-is-invalid-lpa.content.md)
 - **Trigger:** Issue decision and select invalid and continue
+
+## Missed site visit
+
+### Record missed site visit appellant
+
+- **Appeal type:** all
+- **Notify Template:** [record-missed-site-visit-appellant](../appeals/api/src/server/notify/templates/decision-is-allowed-split-dismissed-appellant.content.md)
+- **Trigger:** Record missed site visit for appellant
+
+### Record missed site visit lpa
+
+- **Appeal type:** all
+- **Notify Template:** [record-missed-site-visit-lpa](../appeals/api/src/server/notify/templates/decision-is-allowed-split-dismissed-lpa.content.md)
+- **Trigger:** Record missed site visit for lpa

--- a/package-lock.json
+++ b/package-lock.json
@@ -721,7 +721,7 @@
 				"nodemon": "3.0.3"
 			},
 			"devDependencies": {
-				"@badeball/cypress-cucumber-preprocessor": "23.2.0",
+				"@badeball/cypress-cucumber-preprocessor": "^23.2.0",
 				"@bahmutov/cypress-esbuild-preprocessor": "^2.1.5",
 				"@cypress/grep": "^4.1.0",
 				"@cypress/webpack-preprocessor": "^5.16.1",
@@ -34285,7 +34285,7 @@
 		"@pins/e2e": {
 			"version": "file:appeals/e2e",
 			"requires": {
-				"@badeball/cypress-cucumber-preprocessor": "23.2.0",
+				"@badeball/cypress-cucumber-preprocessor": "^23.2.0",
 				"@bahmutov/cypress-esbuild-preprocessor": "^2.1.5",
 				"@cypress/grep": "^4.1.0",
 				"@cypress/webpack-preprocessor": "^5.16.1",


### PR DESCRIPTION
## Describe your changes

### API

- Added notify templates for record missed site visit for lpa and appellant
- added new unit test for these emails 
- updated documentation

### WEB

- Added new record missed site visit CYA page
- added new unit tests and snapshots

## Issue ticket number and link

[Ticket](https://pins-ds.atlassian.net.mcas.ms/browse/A2-4232)
