### PR TITLE
feat(appeals): pdf add before you start section (a2-4540)

### DIFF
--- a/appeals/pdf-service-api/src/mappers/appellant-case/appellant-case.mapper.js
+++ b/appeals/pdf-service-api/src/mappers/appellant-case/appellant-case.mapper.js
@@ -2,6 +2,7 @@ import { additionalDocumentsSection } from './sections/additional-documents.sect
 import { appealDetailsSection } from './sections/appeal-details.section.js';
 import { appellantDetailsSection } from './sections/appellant-details.section.js';
 import { applicationDetailsSection } from './sections/application-details.section.js';
+import { beforeYouStartSection } from './sections/before-you-start.section.js';
 import { siteDetailsSection } from './sections/site-details.section.js';
 import { uploadDocumentsSection } from './sections/upload-documents.section.js';
 
@@ -10,6 +11,7 @@ export default function mapAppellantCaseData(templateData) {
 	return {
 		details: { appealSite, appealReference, localPlanningDepartment },
 		sections: [
+			beforeYouStartSection(templateData),
 			appellantDetailsSection(templateData),
 			siteDetailsSection(templateData),
 			applicationDetailsSection(templateData),

--- a/appeals/pdf-service-api/src/mappers/appellant-case/sections/appeal-details.section.js
+++ b/appeals/pdf-service-api/src/mappers/appellant-case/sections/appeal-details.section.js
@@ -2,7 +2,6 @@ import { formatSentenceCase } from '../../../lib/nunjucks-filters/index.js';
 
 export function appealDetailsSection(templateData) {
 	const {
-		appealType,
 		appellantProcedurePreference,
 		appellantProcedurePreferenceDetails,
 		appellantProcedurePreferenceDuration,
@@ -12,10 +11,6 @@ export function appealDetailsSection(templateData) {
 	return {
 		heading: 'Appeal details',
 		items: [
-			{
-				key: 'What type of application is your appeal about?',
-				text: formatSentenceCase(appealType, 'Not provided')
-			},
 			{
 				key: 'How would you prefer us to decide your appeal?',
 				text: formatSentenceCase(appellantProcedurePreference, 'Not answered')

--- a/appeals/pdf-service-api/src/mappers/appellant-case/sections/application-details.section.js
+++ b/appeals/pdf-service-api/src/mappers/appellant-case/sections/application-details.section.js
@@ -2,25 +2,11 @@ import { formatDate } from '../../../lib/nunjucks-filters/format-date.js';
 import { formatSentenceCase, formatYesNo } from '../../../lib/nunjucks-filters/index.js';
 
 export function applicationDetailsSection(templateData) {
-	const {
-		localPlanningDepartment,
-		planningApplicationReference,
-		applicationDate,
-		developmentDescription,
-		otherAppeals,
-		applicationDecision,
-		applicationDecisionDate,
-		developmentType
-	} = templateData;
+	const { applicationDate, developmentDescription, otherAppeals, developmentType } = templateData;
 
 	return {
 		heading: 'Application details',
 		items: [
-			{
-				key: 'Which local planning authority (LPA) do you want to appeal against?',
-				html: formatSentenceCase(localPlanningDepartment, 'Not provided')
-			},
-			{ key: 'What is the application reference number?', text: planningApplicationReference },
 			{ key: 'What date did you submit your application?', text: formatDate(applicationDate) },
 			{
 				key: 'Enter the description of development that you submitted in your application',
@@ -29,14 +15,6 @@ export function applicationDetailsSection(templateData) {
 			{
 				key: 'Are there other appeals linked to your development?',
 				text: formatYesNo(otherAppeals?.length > 0)
-			},
-			{
-				key: 'Was your application granted or refused?',
-				text: formatSentenceCase(applicationDecision)
-			},
-			{
-				key: 'What’s the date on the decision letter from the local planning authority?',
-				text: formatDate(applicationDecisionDate)
 			},
 			{ key: 'Development type', text: formatSentenceCase(developmentType, 'Not provided') }
 		]

--- a/appeals/pdf-service-api/src/mappers/appellant-case/sections/before-you-start.section.js
+++ b/appeals/pdf-service-api/src/mappers/appellant-case/sections/before-you-start.section.js
@@ -1,0 +1,42 @@
+import { formatDate } from '../../../lib/nunjucks-filters/format-date.js';
+import { formatSentenceCase, formatYesNo } from '../../../lib/nunjucks-filters/index.js';
+
+export function beforeYouStartSection(templateData) {
+	const {
+		localPlanningDepartment,
+		planningApplicationReference,
+		applicationDate,
+		appealType,
+		appellantCostsAppliedFor,
+		applicationDecision,
+		applicationDecisionDate
+	} = templateData;
+
+	return {
+		heading: 'Before you start',
+		items: [
+			{
+				key: 'Local planning authority',
+				html: formatSentenceCase(localPlanningDepartment, 'Not provided')
+			},
+			{
+				key: 'What type of application is your appeal about?',
+				text: formatSentenceCase(appealType, 'Not provided')
+			},
+			{
+				key: 'Was your application granted or refused?',
+				text: formatSentenceCase(applicationDecision)
+			},
+			{
+				key: 'What’s the date on the decision letter from the local planning authority?',
+				text: formatDate(applicationDecisionDate)
+			},
+			{
+				key: 'Are you claiming costs as part of your appeal?',
+				text: formatYesNo(appellantCostsAppliedFor)
+			},
+			{ key: 'What is the application reference number?', text: planningApplicationReference },
+			{ key: 'What date did you submit your application?', text: formatDate(applicationDate) }
+		]
+	};
+}

--- a/appeals/pdf-service-api/src/mappers/appellant-case/sections/site-details.section.js
+++ b/appeals/pdf-service-api/src/mappers/appellant-case/sections/site-details.section.js
@@ -1,3 +1,4 @@
+import { APPEAL_TYPE } from '@pins/appeals/constants/common.js';
 import {
 	formatAddress,
 	formatSentenceCase,
@@ -11,6 +12,7 @@ function formatArea(area) {
 export function siteDetailsSection(templateData) {
 	const {
 		appealSite,
+		appealType,
 		siteAreaSquareMetres,
 		isGreenBelt,
 		siteOwnership,
@@ -37,7 +39,7 @@ export function siteDetailsSection(templateData) {
 				text: formatSentenceCase(siteOwnership?.knowsOtherLandowners)
 			},
 			// Will only be available for s78
-			...(agriculturalHolding
+			...([APPEAL_TYPE.S78].includes(appealType)
 				? [
 						{
 							key: 'Is the appeal site part of an agricultural holding?',

--- a/appeals/pdf-service-api/src/mappers/appellant-case/sections/upload-documents.section.js
+++ b/appeals/pdf-service-api/src/mappers/appellant-case/sections/upload-documents.section.js
@@ -11,6 +11,7 @@ export function uploadDocumentsSection(templateData) {
 		planningObligation: planningObligationDocuments,
 		ownershipCertificate,
 		appellantCostsApplication,
+		statementCommonGround,
 		designAccessStatement,
 		plansDrawings,
 		newPlansDrawings,
@@ -38,6 +39,7 @@ export function uploadDocumentsSection(templateData) {
 				text: formatSentenceCase(planningObligation?.status, 'Not answered')
 			},
 			{ key: 'Planning obligation', html: formatDocumentData(planningObligationDocuments) },
+			{ key: 'Draft statement of common ground', html: formatDocumentData(statementCommonGround) },
 			{
 				key: 'Separate ownership certificate and agricultural land declaration',
 				html: formatDocumentData(ownershipCertificate)


### PR DESCRIPTION
## Describe your changes
#### Add before you start section to appellant case pdf (a2-4540)

### PDF:
- Add before you start section to appellant case pdf and move some entries 
to this section

### TEST:
- Make sure unit tests pass
- Tested within browser

## Issue ticket number and link

[A2-4540- BO - s78 appellant case PDF to reflect new content/format](https://pins-ds.atlassian.net/browse/A2-4540)
