### PR TITLE
fix(appeals): generate start hearing case email previews on API side

### DIFF
--- a/appeals/api/src/server/endpoints/appeal-timetables/appeal-timetables.routes.js
+++ b/appeals/api/src/server/endpoints/appeal-timetables/appeal-timetables.routes.js
@@ -4,6 +4,7 @@ import { Router as createRouter } from 'express';
 import {
 	getCalculatedAppealTimetable,
 	startAppeal,
+	startAppealNotifyPreview,
 	updateAppealTimetableById
 } from './appeal-timetables.controller.js';
 import { checkAppealTimetableExists } from './appeal-timetables.service.js';
@@ -27,7 +28,7 @@ router.post(
 		}
 		#swagger.requestBody = {
 			in: 'body',
-			description: 'Appeal and optional start date (defaults to the current date, if omitted)',
+			description: 'Appeal and optionally a start date (defaults to the current date, if omitted), procedure type, and hearing start time',
 			schema: { $ref: '#/components/schemas/StartCaseRequest' },
 			required: true
 		}
@@ -41,6 +42,35 @@ router.post(
 	checkAppealExistsByIdAndAddToRequest,
 	createAppealTimetableValidator,
 	asyncHandler(startAppeal)
+);
+
+router.post(
+	'/:appealId/appeal-timetables/notify-preview',
+	/*
+		#swagger.tags = ['Appeal Timetables']
+		#swagger.path = '/appeals/{appealId}/appeal-timetables/notify-preview'
+		#swagger.description = 'Returns the rendered HTML of the emails that would be sent to the relevant parties'
+		#swagger.parameters['azureAdUserId'] = {
+			in: 'header',
+			required: true,
+			example: '434bff4e-8191-4ce0-9a0a-91e5d6cdd882'
+		}
+		#swagger.requestBody = {
+			in: 'body',
+			description: 'Appeal and optionally a start date (defaults to the current date, if omitted), procedure type, and hearing start time',
+			schema: { $ref: '#/components/schemas/StartCaseRequest' },
+			required: true
+		}
+		#swagger.responses[200] = {
+			description: 'Returns the rendered HTML of the emails that would be sent to the relevant parties',
+			schema: { $ref: '#/components/schemas/StartCaseNotifyPreviewResponse' }
+		}
+		#swagger.responses[400] = {}
+		#swagger.responses[404] = {}
+		#swagger.responses[500] = {}
+	 */
+	checkAppealExistsByIdAndAddToRequest,
+	asyncHandler(startAppealNotifyPreview)
 );
 
 router.patch(

--- a/appeals/api/src/server/notify/templates/__tests__/appeal-valid-start-case-s78-lpa-hearing.test.js
+++ b/appeals/api/src/server/notify/templates/__tests__/appeal-valid-start-case-s78-lpa-hearing.test.js
@@ -34,7 +34,7 @@ describe('appeal-valid-start-case-lpa-hearing.md', () => {
 		};
 
 		const expectedContent = [
-			'You have a new Householder appeal against the application 48269/APP/2021/1482.',
+			'You have a new householder appeal against the application 48269/APP/2021/1482.',
 			'',
 			'We will decide the appeal by a hearing. You can tell us if you think a different procedure is more appropriate in the questionnaire.',
 			'',

--- a/appeals/api/src/server/notify/templates/appeal-valid-start-case-s78-lpa-hearing.content.md
+++ b/appeals/api/src/server/notify/templates/appeal-valid-start-case-s78-lpa-hearing.content.md
@@ -1,4 +1,4 @@
-You have a new {{appeal_type}} appeal against the application {{lpa_reference}}.
+You have a new {{appeal_type | lower}} appeal against the application {{lpa_reference}}.
 
 We will decide the appeal by a hearing. You can tell us if you think a different procedure is more appropriate in the questionnaire.
 

--- a/appeals/api/src/server/openapi-types.ts
+++ b/appeals/api/src/server/openapi-types.ts
@@ -1436,6 +1436,17 @@ export interface StartCaseResponse {
 	statementReviewDate?: string;
 }
 
+export interface StartCaseNotifyPreviewResponse {
+	appellant?: {
+		/** @example "Rendered HTML for appellant preview" */
+		renderedHtml?: string;
+	};
+	lpa?: {
+		/** @example "Rendered HTML for LPA preview" */
+		renderedHtml?: string;
+	};
+}
+
 export interface SingleLPAQuestionnaireResponse {
 	affectsListedBuildingDetails?: {
 		/** @example "654321" */

--- a/appeals/api/src/server/openapi.json
+++ b/appeals/api/src/server/openapi.json
@@ -525,7 +525,75 @@
 				},
 				"requestBody": {
 					"in": "body",
-					"description": "Appeal and optional start date (defaults to the current date, if omitted)",
+					"description": "Appeal and optionally a start date (defaults to the current date, if omitted), procedure type, and hearing start time",
+					"required": true,
+					"content": {
+						"application/json": {
+							"schema": {
+								"$ref": "#/components/schemas/StartCaseRequest"
+							}
+						},
+						"application/xml": {
+							"schema": {
+								"$ref": "#/components/schemas/StartCaseRequest"
+							}
+						}
+					}
+				}
+			}
+		},
+		"/appeals/{appealId}/appeal-timetables/notify-preview": {
+			"post": {
+				"tags": ["Appeal Timetables"],
+				"description": "Returns the rendered HTML of the emails that would be sent to the relevant parties",
+				"parameters": [
+					{
+						"name": "appealId",
+						"in": "path",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"name": "azureAdUserId",
+						"in": "header",
+						"required": true,
+						"example": "434bff4e-8191-4ce0-9a0a-91e5d6cdd882",
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "Returns the rendered HTML of the emails that would be sent to the relevant parties",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/StartCaseNotifyPreviewResponse"
+								}
+							},
+							"application/xml": {
+								"schema": {
+									"$ref": "#/components/schemas/StartCaseNotifyPreviewResponse"
+								}
+							}
+						}
+					},
+					"400": {
+						"description": "Bad Request"
+					},
+					"404": {
+						"description": "Not Found"
+					},
+					"500": {
+						"description": "Internal Server Error"
+					}
+				},
+				"requestBody": {
+					"in": "body",
+					"description": "Appeal and optionally a start date (defaults to the current date, if omitted), procedure type, and hearing start time",
 					"required": true,
 					"content": {
 						"application/json": {
@@ -3339,6 +3407,80 @@
 				}
 			},
 			"patch": {
+				"tags": ["Site Visits"],
+				"description": "Updates a single site visit by id",
+				"parameters": [
+					{
+						"name": "appealId",
+						"in": "path",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"name": "siteVisitId",
+						"in": "path",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"name": "azureAdUserId",
+						"in": "header",
+						"required": true,
+						"example": "434bff4e-8191-4ce0-9a0a-91e5d6cdd882",
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "Creates a single site visit by id",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/SiteVisitUpdateRequest"
+								}
+							},
+							"application/xml": {
+								"schema": {
+									"$ref": "#/components/schemas/SiteVisitUpdateRequest"
+								}
+							}
+						}
+					},
+					"400": {
+						"description": "Bad Request"
+					},
+					"404": {
+						"description": "Not Found"
+					},
+					"500": {
+						"description": "Internal Server Error"
+					}
+				},
+				"requestBody": {
+					"in": "body",
+					"description": "Site visit details to create",
+					"required": true,
+					"content": {
+						"application/json": {
+							"schema": {
+								"$ref": "#/components/schemas/SiteVisitUpdateRequest"
+							}
+						},
+						"application/xml": {
+							"schema": {
+								"$ref": "#/components/schemas/SiteVisitUpdateRequest"
+							}
+						}
+					}
+				}
+			},
+			"delete": {
 				"tags": ["Site Visits"],
 				"description": "Updates a single site visit by id",
 				"parameters": [
@@ -9580,6 +9722,32 @@
 				},
 				"xml": {
 					"name": "StartCaseResponse"
+				}
+			},
+			"StartCaseNotifyPreviewResponse": {
+				"type": "object",
+				"properties": {
+					"appellant": {
+						"type": "object",
+						"properties": {
+							"renderedHtml": {
+								"type": "string",
+								"example": "Rendered HTML for appellant preview"
+							}
+						}
+					},
+					"lpa": {
+						"type": "object",
+						"properties": {
+							"renderedHtml": {
+								"type": "string",
+								"example": "Rendered HTML for LPA preview"
+							}
+						}
+					}
+				},
+				"xml": {
+					"name": "StartCaseNotifyPreviewResponse"
 				}
 			},
 			"SingleLPAQuestionnaireResponse": {

--- a/appeals/api/src/server/swagger.js
+++ b/appeals/api/src/server/swagger.js
@@ -556,6 +556,14 @@ export const spec = {
 			lpaQuestionnaireDueDate: '2024-08-11',
 			statementReviewDate: '2024-08-12'
 		},
+		StartCaseNotifyPreviewResponse: {
+			appellant: {
+				renderedHtml: 'Rendered HTML for appellant preview'
+			},
+			lpa: {
+				renderedHtml: 'Rendered HTML for LPA preview'
+			}
+		},
 		SingleLPAQuestionnaireResponse: {
 			affectsListedBuildingDetails: [
 				{

--- a/appeals/web/src/server/appeals/appeal-details/start-case/hearing/__tests__/start-case-hearing.test.js
+++ b/appeals/web/src/server/appeals/appeal-details/start-case/hearing/__tests__/start-case-hearing.test.js
@@ -416,23 +416,6 @@ describe('start case hearing flow', () => {
 
 	describe('GET /start-case/hearing/confirm', () => {
 		it('should render the confirm page when date is known', async () => {
-			const personalisation = {
-				appeal_reference_number: 'APP/Q9999/D/21/351062',
-				lpa_reference: '48269/APP/2021/1482',
-				site_address: '21 The Pavement, Wandsworth, SW4 0HY',
-				appeal_type: 'Planning appeal',
-				local_planning_authority: 'Wiltshire Council',
-				start_date: '1 February 2025',
-				questionnaire_due_date: '1 February 2025',
-				lpa_statement_deadline: '1 March 2025',
-				ip_comments_deadline: '1 April 2025',
-				statement_of_common_ground_due_date: '1 May 2025',
-				hearing_date: '1 February 3025',
-				hearing_time: '12:00pm',
-				procedure_type: 'a hearing',
-				child_appeals: [],
-				team_email_address: 'caseofficers@planninginspectorate.gov.uk'
-			};
 			nock('http://test/').get('/appeals/1/case-team-email').reply(200, {
 				id: 1,
 				email: 'caseofficers@planninginspectorate.gov.uk',
@@ -446,26 +429,14 @@ describe('start case hearing flow', () => {
 					appealType: 'Planning appeal'
 				});
 			nock('http://test/')
-				.get('/appeals/1/appeal-timetables/calculate?procedureType=hearing')
+				.post('/appeals/1/appeal-timetables/notify-preview', {
+					procedureType: 'hearing',
+					hearingStartTime: '3025-02-01T12:00:00.000Z'
+				})
 				.reply(200, {
-					startDate: '2025-02-01T12:00:00.000Z',
-					lpaQuestionnaireDueDate: '2025-02-01T12:00:00.000Z',
-					lpaStatementDueDate: '2025-03-01T12:00:00.000Z',
-					ipCommentsDueDate: '2025-04-01T12:00:00.000Z',
-					statementOfCommonGroundDueDate: '2025-05-01T12:00:00.000Z'
+					appellant: 'Rendered HTML for appellant preview',
+					lpa: 'Rendered HTML for LPA preview'
 				});
-			nock('http://test/')
-				.post(
-					'/appeals/notify-preview/appeal-valid-start-case-s78-appellant-hearing.content.md',
-					personalisation
-				)
-				.reply(200, { renderedHtml: 'Rendered HTML for appellant preview' });
-			nock('http://test/')
-				.post(
-					'/appeals/notify-preview/appeal-valid-start-case-s78-lpa-hearing.content.md',
-					personalisation
-				)
-				.reply(200, { renderedHtml: 'Rendered HTML for LPA preview' });
 
 			await request
 				.post(`${baseUrl}/1/start-case/select-procedure`)
@@ -522,23 +493,6 @@ describe('start case hearing flow', () => {
 		});
 
 		it('should render the confirm page when date is not known', async () => {
-			const personalisation = {
-				appeal_reference_number: 'APP/Q9999/D/21/351062',
-				lpa_reference: '48269/APP/2021/1482',
-				site_address: '21 The Pavement, Wandsworth, SW4 0HY',
-				appeal_type: 'Planning appeal',
-				local_planning_authority: 'Wiltshire Council',
-				start_date: '1 February 2025',
-				questionnaire_due_date: '1 February 2025',
-				lpa_statement_deadline: '1 March 2025',
-				ip_comments_deadline: '1 April 2025',
-				statement_of_common_ground_due_date: '1 May 2025',
-				hearing_date: '',
-				hearing_time: '',
-				procedure_type: 'a hearing',
-				child_appeals: [],
-				team_email_address: 'caseofficers@planninginspectorate.gov.uk'
-			};
 			nock('http://test/').get('/appeals/1/case-team-email').reply(200, {
 				id: 1,
 				email: 'caseofficers@planninginspectorate.gov.uk',
@@ -552,23 +506,13 @@ describe('start case hearing flow', () => {
 					appealType: 'Planning appeal'
 				});
 			nock('http://test/')
-				.get('/appeals/1/appeal-timetables/calculate?procedureType=hearing')
+				.post('/appeals/1/appeal-timetables/notify-preview', {
+					procedureType: 'hearing'
+				})
 				.reply(200, {
-					startDate: '2025-02-01T12:00:00.000Z',
-					lpaQuestionnaireDueDate: '2025-02-01T12:00:00.000Z',
-					lpaStatementDueDate: '2025-03-01T12:00:00.000Z',
-					ipCommentsDueDate: '2025-04-01T12:00:00.000Z',
-					statementOfCommonGroundDueDate: '2025-05-01T12:00:00.000Z'
+					appellant: 'Rendered HTML for appellant preview',
+					lpa: 'Rendered HTML for LPA preview'
 				});
-			nock('http://test/')
-				.post(
-					'/appeals/notify-preview/appeal-valid-start-case-s78-appellant.content.md',
-					personalisation
-				)
-				.reply(200, { renderedHtml: 'Rendered HTML for appellant preview' });
-			nock('http://test/')
-				.post('/appeals/notify-preview/appeal-valid-start-case-s78-lpa.content.md', personalisation)
-				.reply(200, { renderedHtml: 'Rendered HTML for LPA preview' });
 
 			// Set up the session values
 			await request

--- a/appeals/web/src/server/appeals/appeal-details/start-case/start-case.service.js
+++ b/appeals/web/src/server/appeals/appeal-details/start-case/start-case.service.js
@@ -42,6 +42,39 @@ export async function setStartDate(
 }
 
 /**
+ *
+ * @param {import('got').Got} apiClient
+ * @param {string} appealId
+ * @param {string} [startDate]
+ * @param {string} [procedureType]
+ * @param {string} [hearingStartTime]
+ * @returns {Promise<{appellant?: string, lpa?: string}>}
+ */
+export async function getStartCaseNotifyPreviews(
+	apiClient,
+	appealId,
+	startDate,
+	procedureType,
+	hearingStartTime
+) {
+	const result = await apiClient
+		.post(`appeals/${appealId}/appeal-timetables/notify-preview`, {
+			json: {
+				...(startDate && { startDate }),
+				...(procedureType && { procedureType }),
+				...(hearingStartTime && { hearingStartTime })
+			}
+		})
+		.json();
+
+	if (result.error) {
+		throw new Error(result.error);
+	}
+
+	return result;
+}
+
+/**
  * @param {import('got').Got} apiClient
  * @param {string} appealId
  * @param {string} [procedureType]


### PR DESCRIPTION
## Describe your changes

There were discrepancies in the formatting of the preview emails vs. the actualy emails that got sent out. I have added an API enpoint to generate the emails based on the same data that sent when starting a case, to make sure that we get the same result.

## Issue ticket number and link

[A2-4273](https://pins-ds.atlassian.net/browse/A2-4273)


[A2-4273]: https://pins-ds.atlassian.net/browse/A2-4273?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ