### PR TITLE
fix(appeals): add lead in brackets after lead appeal in notify (a2-4561)

### DIFF
--- a/appeals/api/src/server/notify/templates/__tests__/notify-decision-is-allowed-split-dismissed-appellant.test.js
+++ b/appeals/api/src/server/notify/templates/__tests__/notify-decision-is-allowed-split-dismissed-appellant.test.js
@@ -80,7 +80,7 @@ describe('decision-is-allowed-split-dismissed-appellant.md', () => {
 
 		const expectedContent = expectedContentRows([
 			'We have made a decision on the following appeals:',
-			'- ABC45678',
+			'- ABC45678 (lead)',
 			'- CHILD123',
 			'- CHILD456',
 			'- CHILD789'

--- a/appeals/api/src/server/notify/templates/__tests__/notify-decision-is-allowed-split-dismissed-lpa.test.js
+++ b/appeals/api/src/server/notify/templates/__tests__/notify-decision-is-allowed-split-dismissed-lpa.test.js
@@ -80,7 +80,7 @@ describe('decision-is-allowed-split-dismissed-lpa.md', () => {
 
 		const expectedContent = expectedContentRows([
 			'We have made a decision on the following appeals:',
-			'- ABC45678',
+			'- ABC45678 (lead)',
 			'- CHILD123',
 			'- CHILD456',
 			'- CHILD789'

--- a/appeals/api/src/server/notify/templates/decision-is-allowed-split-dismissed-appellant.content.md
+++ b/appeals/api/src/server/notify/templates/decision-is-allowed-split-dismissed-appellant.content.md
@@ -5,7 +5,7 @@
 {%- if child_appeals.length > 1 %}
 
 We have made a decision on the following appeals:
-- {{ appeal_reference_number }}
+- {{ appeal_reference_number }} (lead)
   {%- for child_appeal in child_appeals %}
 - {{ child_appeal }}
   {%- endfor %}

--- a/appeals/api/src/server/notify/templates/decision-is-allowed-split-dismissed-lpa.content.md
+++ b/appeals/api/src/server/notify/templates/decision-is-allowed-split-dismissed-lpa.content.md
@@ -5,7 +5,7 @@
 {%- if child_appeals.length > 1 %}
 
 We have made a decision on the following appeals:
-- {{ appeal_reference_number }}
+- {{ appeal_reference_number }} (lead)
 {%- for child_appeal in child_appeals %}
 - {{ child_appeal }}
 {%- endfor %}


### PR DESCRIPTION
## Describe your changes
#### Add lead in brackets after lead appeal in notify (a2-4561)

### API:
- Update notifiy templates and tests to add (lead) to the lead appeal in the list of appeals

### TEST:
- Fixed unit tests for above
- Make sure all unit tests pass

## Issue ticket number and link

[A2-4561 - Notify - Appeal ref missing '(lead)'](https://pins-ds.atlassian.net/browse/A2-4561)
