### PR TITLE
fix(appeals): issue with malformed notify template name in timetable

### DIFF
--- a/appeals/api/src/server/endpoints/appeal-timetables/appeal-timetables.service.js
+++ b/appeals/api/src/server/endpoints/appeal-timetables/appeal-timetables.service.js
@@ -42,6 +42,7 @@ import {
 	APPEAL_CASE_TYPE
 } from '@planning-inspectorate/data-model';
 import { mapValues } from 'lodash-es';
+
 const environment = loadEnvironment(process.env.NODE_ENV);
 
 /** @typedef {import('@pins/appeals.api').Schema.Appeal} Appeal */
@@ -71,6 +72,22 @@ const checkAppealTimetableExists = async (req, res, next) => {
 };
 
 /**
+ * Map appeal type to template value
+ * @param {string | undefined | null} appealType
+ * @returns {string}
+ */
+const appealTypeMap = (appealType) => {
+	switch (appealType) {
+		case 'W':
+			return '-s78-';
+		case 'Y':
+			return '-s78-';
+		default:
+			return '-';
+	}
+};
+
+/**
  *
  * @param {Appeal} appeal
  * @param {string} startDate
@@ -92,13 +109,6 @@ const getStartCaseNotifyParams = async (
 	procedureType,
 	hearingStartTime
 ) => {
-	/** @type {Record<string, string>} */
-	const appealTypeMap = {
-		D: '-',
-		W: '-s78-',
-		Y: '-s78-',
-		ZP: '-'
-	};
 	const hearingSuffix = hearingStartTime ? '-hearing' : '';
 
 	const { type = '', key: appealTypeKey = 'D' } = appeal.appealType || {};
@@ -106,11 +116,11 @@ const getStartCaseNotifyParams = async (
 
 	const appellantTemplate = appeal.caseStartedDate
 		? 'appeal-start-date-change-appellant'
-		: `appeal-valid-start-case${[appealTypeMap[appealTypeKey]]}appellant${hearingSuffix}`;
+		: `appeal-valid-start-case${[appealTypeMap(appealTypeKey)]}appellant${hearingSuffix}`;
 
 	const lpaTemplate = appeal.caseStartedDate
 		? 'appeal-start-date-change-lpa'
-		: `appeal-valid-start-case${[appealTypeMap[appealTypeKey]]}lpa${hearingSuffix}`;
+		: `appeal-valid-start-case${[appealTypeMap(appealTypeKey)]}lpa${hearingSuffix}`;
 
 	const appellantEmail = appeal.appellant?.email || appeal.agent?.email;
 	const lpaEmail = appeal.lpa?.email || '';


### PR DESCRIPTION
## Describe your changes

I had an issue where the notify template names for starting an appeal were malformed and caused the back office to crash while testing locally.  This is because the appeal type did not exist in the mapping object used to build the template name.

This caused a template name of "appeal-valid-start-caseappellant" instead of the required "appeal-valid-start-case-appellant"

This fix will always build an existing template for s78 or otherwise.