### PR TITLE
fix(infrastructure): adding count condition for advanced threat protection

### DIFF
--- a/infrastructure/database-monitoring.tf
+++ b/infrastructure/database-monitoring.tf
@@ -46,8 +46,14 @@ resource "azurerm_storage_container" "sql_server" {
   container_access_type = "private"
 }
 
+moved {
+  from = azurerm_advanced_threat_protection.sql_server_storage
+  to   = azurerm_advanced_threat_protection.sql_server_storage[0]
+}
+
 # Advanced Threat Protection is skipped as classic plan protection is deprecated. New one doesn't have a specific resource block
 resource "azurerm_advanced_threat_protection" "sql_server_storage" {
+  count              = var.environment != "staging" ? 1 : 0
   target_resource_id = azurerm_storage_account.sql_server.id
   enabled            = true
 }


### PR DESCRIPTION
## Describe your changes


As the Azure advanced threat protection is deprecated by Azure, It cannot be deployed to staging environment. Commenting or removing the terraform lines would delete already existing defenders in other environment. 

Hence adding a condition to not deploy if the environment is staging


<!--
    Please include a summary of the change along with any relevant context.
    List any dependencies that are required for this change.
-->

## Issue ticket number and link

[Ticket](<!--Paste your ticket link here-->)
