### PR TITLE
test(test/e2e): start hearing cases

### DIFF
--- a/appeals/e2e/cypress/e2e/back-office-appeals/hearing.spec.js
+++ b/appeals/e2e/cypress/e2e/back-office-appeals/hearing.spec.js
@@ -486,7 +486,7 @@ describe('Setup hearing and add hearing estimates', () => {
 		caseDetailsPage.verifyTimeTableRows(rowsWithNoObligationPlanning);
 
 		// Add planning obligation
-		cy.updateAppealDetails(caseRef, { planningObligation: true });
+		cy.updateAppealDetailsViaApi(caseRef, { planningObligation: true });
 		cy.getBusinessActualDate(currentDate, 1).then((date) => {
 			cy.updateTimeTableDetails(caseRef, { planningObligationDueDate: date });
 		});

--- a/appeals/e2e/cypress/page_objects/cyaSection.js
+++ b/appeals/e2e/cypress/page_objects/cyaSection.js
@@ -4,7 +4,10 @@ import { CaseDetailsPage } from './caseDetailsPage.js';
 export class CYASection extends CaseDetailsPage {
 	// S E L E C T O R S
 
-	selectors = {};
+	selectors = {
+		previewEmailAppellant: 'preview-email-to-appellant',
+		previewEmailLpa: 'preview-email-to-lpa'
+	};
 
 	// E L E M E N T S
 
@@ -12,6 +15,21 @@ export class CYASection extends CaseDetailsPage {
 
 	cyaSectionFields = {
 		address: 'Address of where the inquiry will take place'
+	};
+
+	previewEmailSummary = {
+		appellant: 'Preview email to appellant',
+		lpa: 'Preview email to LPA'
+	};
+
+	previewEmails = {
+		appellant: () => cy.getByData(this.selectors.previewEmailAppellant),
+		lpa: () => cy.getByData(this.selectors.previewEmailLpa)
+	};
+
+	fileUploaderElements = {
+		uploadFile: () => cy.getByData(this.selectors.uploadFile),
+		uploadedFiles: () => cy.get(this.selectors.uploadedFileRows)
 	};
 
 	// A C T I O N S
@@ -22,5 +40,35 @@ export class CYASection extends CaseDetailsPage {
 
 	verifyAnswerUpdated(fieldValue) {
 		this.verifyCheckYourAnswers(fieldValue.field, fieldValue.value);
+	}
+
+	verifyPreviewEmail(emailType, isDateAndTime = false, dateTimeValues = null) {
+		if (!this.previewEmails[emailType]) {
+			throw new Error(`Invalid email type: ${emailType}. Use 'appellant' or 'lpa'.`);
+		}
+
+		const expectedText = this.previewEmailSummary[emailType];
+
+		// Store the element with alias for reuse
+		this.previewEmails[emailType]().as('emailDetails');
+
+		cy.get('@emailDetails').then(($el) => {
+			// Initial state - collapsed
+			cy.wrap($el).should('not.have.attr', 'open');
+
+			// Expand and verify
+			cy.wrap($el).find('span').click();
+			cy.wrap($el).should('have.attr', 'open');
+			cy.wrap($el).find('.govuk-details__text').should('be.visible');
+			cy.wrap($el).find('.govuk-details__summary-text').should('contain', expectedText);
+			if (isDateAndTime) {
+				cy.wrap($el).find('.govuk-details__text').should('contain', dateTimeValues.date);
+				cy.wrap($el).find('.govuk-details__text').should('contain', dateTimeValues.time);
+			}
+
+			// Collapse and verify
+			cy.wrap($el).find('span').click();
+			cy.wrap($el).should('not.have.attr', 'open');
+		});
 	}
 }

--- a/appeals/e2e/cypress/support/appealsApiClient.js
+++ b/appeals/e2e/cypress/support/appealsApiClient.js
@@ -420,5 +420,25 @@ export const appealsApiClient = {
 		} catch {
 			return false;
 		}
+	},
+
+	async assignCaseOfficer(appealId) {
+		try {
+			const url = `${baseUrl}appeals/${appealId}`;
+			const response = await fetch(url, {
+				method: 'PATCH',
+				headers: {
+					'Content-Type': 'application/json',
+					azureAdUserId: '434bff4e-8191-4ce0-9a0a-91e5d6cdd882'
+				},
+				body: JSON.stringify({
+					caseOfficer: '13de469c-8de6-4908-97cd-330ea73df618'
+				})
+			});
+			expect(response.status).eq(200);
+			return await response.json();
+		} catch {
+			return false;
+		}
 	}
 };

--- a/appeals/e2e/cypress/support/commands.js
+++ b/appeals/e2e/cypress/support/commands.js
@@ -253,7 +253,7 @@ Cypress.Commands.add('checkNotifySent', (reference, expectedNotifies) => {
 	});
 });
 
-Cypress.Commands.add('updateAppealDetails', (reference, caseDetails) => {
+Cypress.Commands.add('updateAppealDetailsViaApi', (reference, caseDetails) => {
 	return cy.wrap(null).then(async () => {
 		const details = await appealsApiClient.loadCaseDetails(reference);
 		const appealId = details.appealId;
@@ -309,5 +309,13 @@ Cypress.Commands.add('deleteEstimateViaApi', (procedureType, reference) => {
 		const details = await appealsApiClient.loadCaseDetails(reference);
 		const appealId = await details.appealId;
 		return await appealsApiClient.deleteEstimate(procedureType, appealId);
+	});
+});
+
+Cypress.Commands.add('assignCaseOfficerViaApi', (reference) => {
+	return cy.wrap(null).then(async () => {
+		const details = await appealsApiClient.loadCaseDetails(reference);
+		const appealId = await details.appealId;
+		return await appealsApiClient.assignCaseOfficer(appealId);
 	});
 });

--- a/appeals/e2e/cypress/support/utils/format.js
+++ b/appeals/e2e/cypress/support/utils/format.js
@@ -24,27 +24,34 @@ export function formatObjectAsString(object, seperator = '') {
 
 /**
  * Takes a date object and returns formatted date and time
- * @param {*} date Date to format
- * @returns formatted date and time
+ * @param {Date} date - Date to format
+ * @param {boolean} isOrdinal - Whether to use ordinal format (short month, 24-hour time)
+ * @returns {Object} Formatted date and time
+ * @throws {Error} When invalid date object is provided
  */
-export function formatDateAndTime(date) {
+export function formatDateAndTime(date, isOrdinal = false) {
 	if (!(date instanceof Date)) {
 		throw new Error('Invalid date object');
 	}
 
-	// Format date (e.g., "22 May 2025")
-	const formattedDate = new Intl.DateTimeFormat('en-GB', {
+	// Set format options based on ordinal flag
+	const dateOptions = {
 		day: 'numeric',
-		month: 'long',
+		month: isOrdinal ? 'short' : 'long',
 		year: 'numeric'
-	}).format(date);
+	};
 
-	// Format time (e.g., "2:31am")
-	const formattedTime = new Intl.DateTimeFormat('en-GB', {
+	const timeOptions = {
 		hour: 'numeric',
 		minute: 'numeric',
-		hour12: true
-	})
+		hour12: !isOrdinal
+	};
+
+	// Format date (e.g., "22 May 2025" or "22 Oct 2025")
+	const formattedDate = new Intl.DateTimeFormat('en-GB', dateOptions).format(date);
+
+	// Format time (e.g., "2:31am" or "14:31")
+	const formattedTime = new Intl.DateTimeFormat('en-GB', timeOptions)
 		.format(date)
 		.toLowerCase()
 		.replace(' ', '');


### PR DESCRIPTION
## Describe your changes

**What's Added:**
- Cypress tests for hearing case initiation with optional hearing scheduling
- Email preview validation on Check Your Answers page
- Case officer assignment via API
- Case validation via Api
- Enhanced formatDateAndTime function with standard/ordinal format support
- Notify email verification for household and planning appeal case starts


**No breaking changes.**

## Issue ticket number and link

[Ticket](https://pins-ds.atlassian.net.mcas.ms/browse/A2-4273)
