### PR TITLE
[test(test/e2e)] - adding wait for virus scan to document correspondance test 

### DIFF
--- a/appeals/e2e/cypress/e2e/back-office-appeals/manageCorrespondence.spec.js
+++ b/appeals/e2e/cypress/e2e/back-office-appeals/manageCorrespondence.spec.js
@@ -28,6 +28,7 @@ describe('Manage correspondence', () => {
 			caseDetailsPage.clickButtonByText('Confirm');
 			caseDetailsPage.validateBannerMessage('Success', 'Cross-team correspondence added');
 			caseDetailsPage.clickManageCrossTeamCorrespondence();
+			cy.reloadUntilVirusCheckComplete();
 			caseDetailsPage.clickLinkByText('View and edit');
 			caseDetailsPage.clickButtonByText('Upload a new version');
 			caseDetailsPage.uploadSampleFile(sampleFiles.document2);
@@ -55,6 +56,7 @@ describe('Manage correspondence', () => {
 			caseDetailsPage.clickButtonByText('Confirm');
 			caseDetailsPage.validateBannerMessage('Success', 'Inspector correspondence added');
 			caseDetailsPage.clickManageInspectorCorrespondence();
+			cy.reloadUntilVirusCheckComplete();
 			caseDetailsPage.clickLinkByText('View and edit');
 			caseDetailsPage.clickButtonByText('Remove current version');
 			caseDetailsPage.selectRadioButtonByValue('Yes');


### PR DESCRIPTION
## Describe your changes

Very similar to https://github.com/Planning-Inspectorate/appeals-back-office/pull/2165 - in this case for `manageCorrespondence.spec` tests, which failed in last nightly run 

## Issue ticket number and link

*{Is no ticket - fix}* 