### PR TITLE
feat(web) a2-4175 case history use 12hr clock for times

### DIFF
--- a/appeals/web/src/server/appeals/appeal-details/audit/__tests__/__snapshots__/audit.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/audit/__tests__/__snapshots__/audit.test.js.snap
@@ -147,7 +147,7 @@ exports[`audit GET /:appealId/audit should render the case history page with a r
                     </tr>
                     <tr class="govuk-table__row">
                         <td class="govuk-table__cell">1 October 2024
-                            <br><span>11:00</span>
+                            <br><span>11:00am</span>
                         </td>
                         <td class="govuk-table__cell">Case note added:
                             <br>A case note you should see.</td>
@@ -155,7 +155,7 @@ exports[`audit GET /:appealId/audit should render the case history page with a r
                     </tr>
                     <tr class="govuk-table__row">
                         <td class="govuk-table__cell">1 October 2024
-                            <br><span>11:00</span>
+                            <br><span>11:00am</span>
                         </td>
                         <td class="govuk-table__cell">Case note added:
                             <br>A case note you should see.</td>

--- a/appeals/web/src/server/appeals/appeal-details/audit/audit.controller.js
+++ b/appeals/web/src/server/appeals/appeal-details/audit/audit.controller.js
@@ -2,7 +2,11 @@ import nunjucksEnvironments from '#app/config/nunjucks.js';
 import { getAppealCaseNotes } from '#appeals/appeal-details/case-notes/case-notes.service.js';
 import config from '#environment/config.js';
 import { appealShortReference } from '#lib/appeals-formatter.js';
-import { dateISOStringToDisplayDate, dateISOStringToDisplayTime24hr } from '#lib/dates.js';
+import {
+	dateISOStringToDisplayDate,
+	dateISOStringToDisplayTime12hr,
+	dateISOStringToDisplayTime24hr
+} from '#lib/dates.js';
 import { utcToZonedTime } from 'date-fns-tz';
 import * as interestedPartyCommentsService from '../representations/interested-party-comments/interested-party-comments.service.js';
 import { mapMessageContent, tryMapUsers } from './audit.mapper.js';
@@ -77,7 +81,7 @@ export const renderAudit = async (request, response) => {
 			return {
 				dateTime: createdAt.getTime(),
 				date: dateISOStringToDisplayDate(note.createdAt),
-				time: dateISOStringToDisplayTime24hr(note.createdAt),
+				time: dateISOStringToDisplayTime12hr(note.createdAt),
 				details: 'Case note added: <br>' + note.comment,
 				user: await tryMapUsers(note.azureAdUserId, request.session)
 			};


### PR DESCRIPTION
## Describe your changes

Changed auditController file to make use of the dateISOStringToDisplay12hr rather than the 24hr version which will add in the am/pm as required from the ticket

Screenshot of changes

<img width="1049" height="629" alt="Screenshot 2025-10-03 at 11 34 10" src="https://github.com/user-attachments/assets/391410a2-b693-493d-8e48-58062575d969" />

## Issue ticket number and link

[Ticket](<https://pins-ds.atlassian.net/browse/A2-4175>)
