### PR TITLE
feat(appeals): add resubmission invalid reason and filter for standar…

### DIFF
--- a/appeals/api/src/database/seed/data-static.js
+++ b/appeals/api/src/database/seed/data-static.js
@@ -334,6 +334,11 @@ export const appellantCaseInvalidReasons = [
 		id: 4,
 		name: 'Other reason',
 		hasText: true
+	},
+	{
+		id: 5,
+		name: 'Wrong appeal type',
+		hasText: false
 	}
 ];
 

--- a/appeals/api/src/server/endpoints/change-appeal-type/__tests__/change-appeal-type.test.js
+++ b/appeals/api/src/server/endpoints/change-appeal-type/__tests__/change-appeal-type.test.js
@@ -144,9 +144,9 @@ const appealsWithInvalidStatus = [
 	}
 ];
 const mockInvalidReason = {
-	id: 4,
-	name: 'Other reason',
-	hasText: true
+	id: 5,
+	name: 'Wrong appeal type',
+	hasText: false
 };
 
 describe('appeal change type resubmit routes', () => {
@@ -338,18 +338,6 @@ describe('appeal resubmit mark invalid type routes', () => {
 				data: {
 					appellantCaseValidationOutcomeId: appellantCaseValidationOutcomes[0].id
 				}
-			});
-
-			expect(databaseConnector.appellantCaseInvalidReasonText.deleteMany).toHaveBeenCalled();
-
-			expect(databaseConnector.appellantCaseInvalidReasonText.createMany).toHaveBeenCalledWith({
-				data: [
-					{
-						appellantCaseId: 1,
-						appellantCaseInvalidReasonId: mockInvalidReason.id,
-						text: 'Wrong appeal type, resubmission required'
-					}
-				]
 			});
 
 			expect(mockNotifySend).toHaveBeenCalledTimes(1);

--- a/appeals/api/src/server/endpoints/change-appeal-type/change-appeal-type.service.js
+++ b/appeals/api/src/server/endpoints/change-appeal-type/change-appeal-type.service.js
@@ -18,6 +18,7 @@ import {
 	AUDIT_TRAIL_APPEAL_TYPE_UPDATED,
 	AUDIT_TRAIL_HORIZON_REFERENCE_UPDATED,
 	AUDIT_TRAIL_SUBMISSION_INVALID,
+	CHANGE_APPEAL_TYPE_INVALID_REASON,
 	VALIDATION_OUTCOME_INVALID
 } from '@pins/appeals/constants/support.js';
 import { addDays, setTimeInTimeZone } from '@pins/appeals/utils/business-days.js';
@@ -115,7 +116,7 @@ const resubmitAndMarkInvalid = async (
 
 	const invalidReason = await commonRepository.getLookupListValueByName(
 		'appellantCaseInvalidReason',
-		'Other reason'
+		CHANGE_APPEAL_TYPE_INVALID_REASON
 	);
 
 	Promise.all([
@@ -133,7 +134,7 @@ const resubmitAndMarkInvalid = async (
 			appealId,
 			appellantCaseId,
 			validationOutcomeId: invalidOutcome.id,
-			invalidReasons: [{ id: invalidReason.id, text: ['Wrong appeal type, resubmission required'] }]
+			invalidReasons: [{ id: invalidReason.id, text: [] }]
 		}),
 		await transitionState(appealId, azureAdUserId, VALIDATION_OUTCOME_INVALID)
 	]);

--- a/appeals/web/src/server/appeals/appeal-details/appellant-case/appellant-case.controller.js
+++ b/appeals/web/src/server/appeals/appeal-details/appellant-case/appellant-case.controller.js
@@ -5,6 +5,7 @@ import { objectContainsAllKeys } from '#lib/object-utilities.js';
 import { addNotificationBannerToSession } from '#lib/session-utilities.js';
 import { capitalizeFirstLetter } from '#lib/string-utilities.js';
 import { getBackLinkUrlFromQuery, stripQueryString } from '#lib/url-utilities.js';
+import { CHANGE_APPEAL_TYPE_INVALID_REASON } from '@pins/appeals/constants/support.js';
 import { capitalize } from 'lodash-es';
 import {
 	postChangeDocumentDetails,
@@ -94,14 +95,19 @@ const renderCheckAndConfirm = async (request, response) => {
 				request.apiClient,
 				webAppellantCaseReviewOutcome.validationOutcome
 			);
-		if (!reasonOptions) {
+
+		const filteredReasonOptions = reasonOptions.filter(
+			(reason) => reason.name !== CHANGE_APPEAL_TYPE_INVALID_REASON
+		);
+
+		if (!filteredReasonOptions) {
 			throw new Error('error retrieving invalid reason options');
 		}
 
 		const mappedPageContent = checkAndConfirmPage(
 			currentAppeal.appealId,
 			currentAppeal.appealReference,
-			reasonOptions,
+			filteredReasonOptions,
 			webAppellantCaseReviewOutcome.validationOutcome,
 			request.session,
 			webAppellantCaseReviewOutcome.reasons,

--- a/appeals/web/src/server/appeals/appeal-details/invalid-appeal/invalid-appeal.controller.js
+++ b/appeals/web/src/server/appeals/appeal-details/invalid-appeal/invalid-appeal.controller.js
@@ -6,6 +6,7 @@ import { renderCheckYourAnswersComponent } from '#lib/mappers/components/page-co
 import { objectContainsAllKeys } from '#lib/object-utilities.js';
 import { addBackLinkQueryToUrl } from '#lib/url-utilities.js';
 import { getNotValidReasonsTextFromRequestBody } from '#lib/validation-outcome-reasons-formatter.js';
+import { CHANGE_APPEAL_TYPE_INVALID_REASON } from '@pins/appeals/constants/support.js';
 import { mapInvalidOrIncompleteReasonOptionsToCheckboxItemParameters } from '../appellant-case/appellant-case.mapper.js';
 import * as appellantCaseService from '../appellant-case/appellant-case.service.js';
 import {
@@ -62,10 +63,14 @@ const renderInvalidReason = async (request, response) => {
 		delete request.session.webAppellantCaseReviewOutcome;
 	}
 
-	if (invalidReasonOptions) {
+	const filteredReasonOptions = invalidReasonOptions.filter(
+		(reason) => reason.name !== CHANGE_APPEAL_TYPE_INVALID_REASON
+	);
+
+	if (filteredReasonOptions) {
 		const mappedInvalidReasonOptions = mapInvalidOrIncompleteReasonOptionsToCheckboxItemParameters(
 			'invalid',
-			invalidReasonOptions,
+			filteredReasonOptions,
 			body,
 			request.session.webAppellantCaseReviewOutcome,
 			appellantCaseResponse.validation,
@@ -176,12 +181,17 @@ export const getCheckPage = async (request, response) => {
 				request.apiClient,
 				webAppellantCaseReviewOutcome.validationOutcome
 			);
-		if (!reasonOptions) {
+
+		const filteredReasonOptions = reasonOptions.filter(
+			(reason) => reason.name !== CHANGE_APPEAL_TYPE_INVALID_REASON
+		);
+
+		if (!filteredReasonOptions) {
 			throw new Error('error retrieving invalid reason options');
 		}
 
 		const invalidReasons = buildRejectionReasons(
-			reasonOptions,
+			filteredReasonOptions,
 			webAppellantCaseReviewOutcome.reasons,
 			webAppellantCaseReviewOutcome.reasonsText
 		);

--- a/packages/appeals/constants/support.js
+++ b/packages/appeals/constants/support.js
@@ -14,6 +14,8 @@ export const CASE_OUTCOME_DISMISSED = 'dismissed';
 export const CASE_OUTCOME_SPLIT_DECISION = 'split decision';
 export const CASE_OUTCOME_INVALID = 'invalid';
 
+export const CHANGE_APPEAL_TYPE_INVALID_REASON = 'Wrong appeal type';
+
 export const DECISION_TYPE_INSPECTOR = 'inspector-decision';
 export const DECISION_TYPE_APPELLANT_COSTS = 'appellant-costs-decision';
 export const DECISION_TYPE_LPA_COSTS = 'lpa-costs-decision';


### PR DESCRIPTION
…d invalid routes

Adds a new Invalid Reason - this is used when invalidating an appeal where the appeal type is to be changed and the appeal resubmitted.  This invalid reason will not appeal in the existing invalid appeal routes (i.e. as an option on validation) so is filtered out for display.

## Issue ticket number and link

[Ticket](https://pins-ds.atlassian.net/browse/A2-4573)
