### PR TITLE
fix(web) A2-4234 update heading for cancel site visit confirmation

### DIFF
--- a/appeals/web/src/server/appeals/appeal-details/site-visit/__tests__/__snapshots__/site-visit.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/site-visit/__tests__/__snapshots__/site-visit.test.js.snap
@@ -4,7 +4,7 @@ exports[`site-visit GET /site-visit/delete should render the manage visit page 1
 "<main class="govuk-main-wrapper" id="main-content">
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Appeal 351062</span>
-            <h1 class="govuk-heading-l">Cancel the site visit</h1>
+            <h1 class="govuk-heading-l">Confirm that you want to cancel the site visit</h1>
         </div>
     </div>
     <div class="govuk-grid-row">

--- a/appeals/web/src/server/appeals/appeal-details/site-visit/__tests__/site-visit.test.js
+++ b/appeals/web/src/server/appeals/appeal-details/site-visit/__tests__/site-visit.test.js
@@ -1229,7 +1229,7 @@ describe('site-visit', () => {
 			const element = parseHtml(response.text);
 
 			expect(element.innerHTML).toMatchSnapshot();
-			expect(element.innerHTML).toContain('Cancel the site visit</h1>');
+			expect(element.innerHTML).toContain('Confirm that you want to cancel the site visit</h1>');
 			expect(element.innerHTML).toContain('Preview email to appellant</span>');
 			expect(element.innerHTML).toContain('Preview email to LPA</span>');
 			expect(element.innerHTML).toContain('Cancel site visit</button>');

--- a/appeals/web/src/server/appeals/appeal-details/site-visit/site-visit.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/site-visit/site-visit.mapper.js
@@ -618,7 +618,7 @@ export const cancelSiteVisitPage = (appealDetails, emailTemplate) => {
 		title: 'Confirm that you want to cancel the site visit',
 		backLinkUrl: `/appeals-service/appeal-details/${appealDetails.appealId}`,
 		preHeading: `Appeal ${appealShortReference(appealDetails.appealReference)}`,
-		heading: 'Cancel the site visit',
+		heading: 'Confirm that you want to cancel the site visit',
 		submitButtonProperties: {},
 		submitButtonText: 'Cancel site visit',
 		postPageComponents: [


### PR DESCRIPTION
## Describe your changes
Changed H1 string to match acceptance criteria of ticket and updated test/snapshots

<img width="1384" height="694" alt="Screenshot 2025-10-06 at 14 47 48" src="https://github.com/user-attachments/assets/7dd0ac33-22aa-4885-a16b-e7d44d5bd4d8" />


## Issue ticket number and link

[Ticket](https://pins-ds.atlassian.net/browse/A2-4234)
