### PR TITLE
test(appeals): cy command for deleting cases

### DIFF
--- a/appeals/e2e/cypress/support/appealsApiClient.js
+++ b/appeals/e2e/cypress/support/appealsApiClient.js
@@ -440,5 +440,24 @@ export const appealsApiClient = {
 		} catch {
 			return false;
 		}
+	},
+
+	async deleteAppeals(appealId) {
+		try {
+			const url = `${baseUrl}appeals/delete-appeals`;
+			const response = await fetch(url, {
+				method: 'DELETE',
+				headers: {
+					'Content-Type': 'application/json',
+					azureAdUserId: '434bff4e-8191-4ce0-9a0a-91e5d6cdd882'
+				},
+				body: JSON.stringify({
+					appealIds: appealId
+				})
+			});
+			expect(response.status).eq(200);
+		} catch {
+			return false;
+		}
 	}
 };

--- a/appeals/e2e/cypress/support/commands.js
+++ b/appeals/e2e/cypress/support/commands.js
@@ -319,3 +319,20 @@ Cypress.Commands.add('assignCaseOfficerViaApi', (reference) => {
 		return await appealsApiClient.assignCaseOfficer(appealId);
 	});
 });
+
+Cypress.Commands.add('deleteAppeals', (reference) => {
+	return cy.wrap(null).then(async () => {
+		const appealRefs = [].concat(reference);
+
+		const appealsArray = [];
+
+		for (const appeal of appealRefs) {
+			const details = await appealsApiClient.loadCaseDetails(appeal);
+			const appealId = details.appealId;
+			appealsArray.push(appealId);
+		}
+
+		cy.log(`Deleting cases ${appealsArray}`);
+		return await appealsApiClient.deleteAppeals(appealsArray);
+	});
+});


### PR DESCRIPTION
## Describe your changes

Added a cy command that allows you to delete an appeal. Useful for cleanup after running automation tests

## Issue ticket number and link

[A2-4677](https://pins-ds.atlassian.net/browse/A2-4677)
