### PR TITLE
Fix/4155 rejected ip comments

### DIFF
--- a/appeals/web/src/server/app/components/__tests__/file.test.js
+++ b/appeals/web/src/server/app/components/__tests__/file.test.js
@@ -1,0 +1,412 @@
+// @ts-nocheck
+import { getRepresentationAttachments } from '#appeals/appeal-documents/appeal.documents.service.js';
+import { jest } from '@jest/globals';
+import { getRepresentationAttachmentFullNames } from '../file-downloader.component.js';
+
+describe('getRepresentationAttachments', () => {
+	let mockApiClient;
+
+	beforeEach(() => {
+		jest.clearAllMocks();
+		mockApiClient = {
+			get: jest.fn()
+		};
+	});
+
+	it('should successfully fetch representation attachments', async () => {
+		const mockResponse = {
+			itemCount: 2,
+			items: [
+				{ id: 1, representationType: 'comment' },
+				{ id: 2, representationType: 'appellant_statement' }
+			]
+		};
+
+		mockApiClient.get.mockReturnValue({
+			json: jest.fn().mockResolvedValue(mockResponse)
+		});
+
+		const result = await getRepresentationAttachments(mockApiClient, '12345');
+
+		expect(mockApiClient.get).toHaveBeenCalledWith('appeals/12345/reps');
+		expect(result).toEqual(mockResponse);
+	});
+});
+
+describe('getRepresentationAttachmentFullNames', () => {
+	let mockApiClient;
+
+	beforeEach(() => {
+		jest.clearAllMocks();
+		mockApiClient = {
+			get: jest.fn()
+		};
+	});
+
+	it('should process valid comment representations with attachments', async () => {
+		const mockRepresentations = {
+			items: [
+				{
+					id: 359,
+					status: 'valid',
+					representationType: 'comment',
+					attachments: [
+						{
+							documentVersion: {
+								document: {
+									guid: 'dd2c2fdf-126a-4059-be21-ba2e90024965',
+									name: 'lorem.pdf'
+								}
+							}
+						}
+					]
+				}
+			]
+		};
+
+		mockApiClient.get.mockReturnValue({
+			json: jest.fn().mockResolvedValue(mockRepresentations)
+		});
+
+		const result = await getRepresentationAttachmentFullNames(mockApiClient, '12345');
+
+		expect(result).toEqual({
+			'dd2c2fdf-126a-4059-be21-ba2e90024965':
+				'Representations/Interested party comments/Accepted/Comment 1/lorem.pdf'
+		});
+	});
+
+	it('should skip invalid comment representations', async () => {
+		const mockRepresentations = {
+			items: [
+				{
+					id: 355,
+					status: 'invalid',
+					representationType: 'comment',
+					attachments: [
+						{
+							documentVersion: {
+								document: {
+									guid: 'guid-1',
+									name: 'test.pdf'
+								}
+							}
+						}
+					]
+				}
+			]
+		};
+
+		mockApiClient.get.mockReturnValue({
+			json: jest.fn().mockResolvedValue(mockRepresentations)
+		});
+
+		const result = await getRepresentationAttachmentFullNames(mockApiClient, '12345');
+
+		expect(result).toEqual({});
+	});
+
+	it('should handle multiple valid comments with unique folder names', async () => {
+		const mockRepresentations = {
+			items: [
+				{
+					id: 359,
+					status: 'valid',
+					representationType: 'comment',
+					attachments: [
+						{
+							documentVersion: {
+								document: {
+									guid: 'guid-1',
+									name: 'file1.pdf'
+								}
+							}
+						}
+					]
+				},
+				{
+					id: 358,
+					status: 'valid',
+					representationType: 'comment',
+					attachments: [
+						{
+							documentVersion: {
+								document: {
+									guid: 'guid-2',
+									name: 'file2.pdf'
+								}
+							}
+						}
+					]
+				}
+			]
+		};
+
+		mockApiClient.get.mockReturnValue({
+			json: jest.fn().mockResolvedValue(mockRepresentations)
+		});
+
+		const result = await getRepresentationAttachmentFullNames(mockApiClient, '12345');
+
+		expect(result).toEqual({
+			'guid-1': 'Representations/Interested party comments/Accepted/Comment 1/file1.pdf',
+			'guid-2': 'Representations/Interested party comments/Accepted/Comment 2/file2.pdf'
+		});
+	});
+
+	it('should handle awaiting_review status comments', async () => {
+		const mockRepresentations = {
+			items: [
+				{
+					id: 362,
+					status: 'awaiting_review',
+					representationType: 'comment',
+					attachments: [
+						{
+							documentVersion: {
+								document: {
+									guid: '600dddb1-2f93-4872-bac5-9885fdcf8532',
+									name: 'image.png'
+								}
+							}
+						}
+					]
+				}
+			]
+		};
+
+		mockApiClient.get.mockReturnValue({
+			json: jest.fn().mockResolvedValue(mockRepresentations)
+		});
+
+		const result = await getRepresentationAttachmentFullNames(mockApiClient, '12345');
+
+		expect(result).toEqual({
+			'600dddb1-2f93-4872-bac5-9885fdcf8532':
+				'Representations/Interested party comments/Awaiting review/Comment 1/image.png'
+		});
+	});
+
+	it('should handle non-comment representation types', async () => {
+		const mockRepresentations = {
+			items: [
+				{
+					id: 137,
+					status: 'awaiting_review',
+					representationType: 'appellant_statement',
+					attachments: [
+						{
+							documentVersion: {
+								document: {
+									guid: 'guid-statement',
+									name: 'statement.pdf'
+								}
+							}
+						}
+					]
+				}
+			]
+		};
+
+		mockApiClient.get.mockReturnValue({
+			json: jest.fn().mockResolvedValue(mockRepresentations)
+		});
+
+		const result = await getRepresentationAttachmentFullNames(mockApiClient, '12345');
+
+		expect(result).toEqual({
+			'guid-statement': 'Representations/Appellant statement/statement.pdf'
+		});
+	});
+
+	it('should replace "Lpa" with "LPA" in representation type', async () => {
+		const mockRepresentations = {
+			items: [
+				{
+					id: 140,
+					status: 'valid',
+					representationType: 'lpa_statement',
+					attachments: [
+						{
+							documentVersion: {
+								document: {
+									guid: 'guid-lpa',
+									name: 'lpa-doc.pdf'
+								}
+							}
+						}
+					]
+				}
+			]
+		};
+
+		mockApiClient.get.mockReturnValue({
+			json: jest.fn().mockResolvedValue(mockRepresentations)
+		});
+
+		const result = await getRepresentationAttachmentFullNames(mockApiClient, '12345');
+
+		expect(result).toEqual({
+			'guid-lpa': 'Representations/LPA statement/lpa-doc.pdf'
+		});
+	});
+
+	it('should handle representations with multiple attachments', async () => {
+		const mockRepresentations = {
+			items: [
+				{
+					id: 359,
+					status: 'valid',
+					representationType: 'comment',
+					attachments: [
+						{
+							documentVersion: {
+								document: {
+									guid: 'guid-1',
+									name: 'file1.pdf'
+								}
+							}
+						},
+						{
+							documentVersion: {
+								document: {
+									guid: 'guid-2',
+									name: 'file2.pdf'
+								}
+							}
+						}
+					]
+				}
+			]
+		};
+
+		mockApiClient.get.mockReturnValue({
+			json: jest.fn().mockResolvedValue(mockRepresentations)
+		});
+
+		const result = await getRepresentationAttachmentFullNames(mockApiClient, '12345');
+
+		expect(result).toEqual({
+			'guid-1': 'Representations/Interested party comments/Accepted/Comment 1/file1.pdf',
+			'guid-2': 'Representations/Interested party comments/Accepted/Comment 1/file2.pdf'
+		});
+	});
+
+	it('should handle empty representations list', async () => {
+		const mockRepresentations = {
+			items: []
+		};
+
+		mockApiClient.get.mockReturnValue({
+			json: jest.fn().mockResolvedValue(mockRepresentations)
+		});
+
+		const result = await getRepresentationAttachmentFullNames(mockApiClient, '12345');
+
+		expect(result).toEqual({});
+	});
+
+	it('should handle representations with no attachments', async () => {
+		const mockRepresentations = {
+			items: [
+				{
+					id: 137,
+					status: 'awaiting_review',
+					representationType: 'appellant_statement',
+					attachments: []
+				}
+			]
+		};
+
+		mockApiClient.get.mockReturnValue({
+			json: jest.fn().mockResolvedValue(mockRepresentations)
+		});
+
+		const result = await getRepresentationAttachmentFullNames(mockApiClient, '12345');
+
+		expect(result).toEqual({});
+	});
+
+	it('should handle mixed statuses for comments correctly', async () => {
+		const mockRepresentations = {
+			items: [
+				{
+					id: 1,
+					status: 'valid',
+					representationType: 'comment',
+					attachments: [
+						{
+							documentVersion: {
+								document: { guid: 'guid-valid-1', name: 'valid1.pdf' }
+							}
+						}
+					]
+				},
+				{
+					id: 2,
+					status: 'invalid',
+					representationType: 'comment',
+					attachments: [
+						{
+							documentVersion: {
+								document: { guid: 'guid-invalid', name: 'invalid.pdf' }
+							}
+						}
+					]
+				},
+				{
+					id: 3,
+					status: 'valid',
+					representationType: 'comment',
+					attachments: [
+						{
+							documentVersion: {
+								document: { guid: 'guid-valid-2', name: 'valid2.pdf' }
+							}
+						}
+					]
+				},
+				{
+					id: 4,
+					status: 'awaiting_review',
+					representationType: 'comment',
+					attachments: [
+						{
+							documentVersion: {
+								document: { guid: 'guid-awaiting', name: 'awaiting.pdf' }
+							}
+						}
+					]
+				}
+			]
+		};
+
+		mockApiClient.get.mockReturnValue({
+			json: jest.fn().mockResolvedValue(mockRepresentations)
+		});
+
+		const result = await getRepresentationAttachmentFullNames(mockApiClient, '12345');
+
+		expect(result).toEqual({
+			'guid-valid-1': 'Representations/Interested party comments/Accepted/Comment 1/valid1.pdf',
+			'guid-valid-2': 'Representations/Interested party comments/Accepted/Comment 2/valid2.pdf',
+			'guid-awaiting':
+				'Representations/Interested party comments/Awaiting review/Comment 1/awaiting.pdf'
+		});
+		expect(result['guid-invalid']).toBeUndefined();
+	});
+
+	it('should handle undefined or null items gracefully', async () => {
+		const mockRepresentations = {
+			items: undefined
+		};
+
+		mockApiClient.get.mockReturnValue({
+			json: jest.fn().mockResolvedValue(mockRepresentations)
+		});
+
+		const result = await getRepresentationAttachmentFullNames(mockApiClient, '12345');
+
+		expect(result).toEqual({});
+	});
+});

--- a/appeals/web/src/server/app/components/file-downloader.component.js
+++ b/appeals/web/src/server/app/components/file-downloader.component.js
@@ -307,6 +307,9 @@ export const getBulkDocumentDownload = async (
  * @param {string} filename
  * @returns {*}
  */
+// @ts-ignore
+// @ts-ignore
+// @ts-ignore
 const buildZipFileName = (caseId, filename) => {
 	const timestampTokens = new Date().toISOString().split('T');
 	const dateString = timestampTokens[0].replaceAll('-', '');
@@ -322,18 +325,25 @@ const buildZipFileName = (caseId, filename) => {
  * @param {string} caseId
  * @returns {Promise<*>}
  */
-const getRepresentationAttachmentFullNames = async (apiClient, caseId) => {
+
+export const getRepresentationAttachmentFullNames = async (apiClient, caseId) => {
 	const representations = await getRepresentationAttachments(apiClient, caseId);
 	const fullAttachmentNames = {};
 	const statusCounts = {};
+
 	// @ts-ignore
 	representations?.items?.forEach((representation) => {
+		// Skip comments with invalid status
+		if (representation.representationType === 'comment' && representation.status === 'invalid') {
+			return; // Skip this representation
+		}
 		let representationStatus = representation.status;
 		if (representation.status === 'valid') {
 			representationStatus = 'accepted';
 		} else if (representation.status === 'invalid') {
 			representationStatus = 'rejected';
 		}
+
 		// Keep a count of each representation type and status so that we can give each ip comment a unique folder name
 		const statusCountKey = `${representation.representationType}-${representation.status}`;
 		// @ts-ignore
@@ -341,6 +351,7 @@ const getRepresentationAttachmentFullNames = async (apiClient, caseId) => {
 			// @ts-ignore
 			statusCounts[statusCountKey] = 0;
 		}
+
 		const representationType =
 			representation.representationType === 'comment'
 				? `Interested party comments/${toSentenceCase(
@@ -348,6 +359,7 @@ const getRepresentationAttachmentFullNames = async (apiClient, caseId) => {
 						// @ts-ignore
 				  )}/Comment ${++statusCounts[statusCountKey]}`
 				: toSentenceCase(representation.representationType).replace('Lpa', 'LPA');
+
 		// @ts-ignore
 		representation.attachments.forEach((attachment) => {
 			const { document } = attachment.documentVersion || {};
@@ -370,27 +382,60 @@ export const getBulkFileInfo = async (apiClient, caseId) => {
 		apiClient,
 		caseId
 	);
+	// @ts-ignore
 	const folders = await getAllCaseFolders(apiClient, caseId);
-	return folders
-		?.filter(
-			(folder) => folder.documents?.length && !folder.path.startsWith(APPEAL_CASE_STAGE.INTERNAL)
-		)
-		.flatMap((folder) => {
-			const folderPath = folder.path
-				.split('/')
-				.map((folderName) => camelCaseToWords(folderName.trim()).replace('Lpa', 'LPA'))
-				.join('/');
-			return folder.documents.map((document) => {
-				const { blobStorageContainer, blobStoragePath, documentURI } =
-					document.latestDocumentVersion;
-				return {
-					fullName:
-						// @ts-ignore
-						representationAttachmentFullNames[document.guid] || `${folderPath}/${document.name}`,
-					blobStorageContainer,
-					blobStoragePath,
-					documentURI
-				};
-			});
-		});
+
+	return (
+		folders
+			?.filter(
+				// @ts-ignore
+				(folder) => folder.documents?.length && !folder.path.startsWith(APPEAL_CASE_STAGE.INTERNAL)
+			)
+			// @ts-ignore
+			.flatMap((folder) => {
+				const folderPath = folder.path
+					.split('/')
+					// @ts-ignore
+					.map((folderName) => camelCaseToWords(folderName.trim()).replace('Lpa', 'LPA'))
+					.join('/');
+
+				// @ts-ignore
+				return folder.documents
+					.map((document) => {
+						const { blobStorageContainer, blobStoragePath, documentURI } =
+							document.latestDocumentVersion;
+
+						// If this is in Representation Attachments folder, only include if it's mapped
+						if (folderPath === 'Representation/Representation Attachments') {
+							// @ts-ignore
+							if (representationAttachmentFullNames[document.guid]) {
+								return {
+									// @ts-ignore
+									fullName: representationAttachmentFullNames[document.guid],
+									blobStorageContainer,
+									blobStoragePath,
+									documentURI
+								};
+							} else {
+								// Skip unmapped representation attachments
+								// @ts-ignore
+
+								return null;
+							}
+						} else {
+							// For other folders, include all documents
+							return {
+								// @ts-ignore
+								fullName:
+									representationAttachmentFullNames[document.guid] ||
+									`${folderPath}/${document.name}`,
+								blobStorageContainer,
+								blobStoragePath,
+								documentURI
+							};
+						}
+					})
+					.filter(Boolean); // Remove null entries
+			})
+	);
 };

--- a/appeals/web/src/server/app/components/file-downloader.component.js
+++ b/appeals/web/src/server/app/components/file-downloader.component.js
@@ -427,6 +427,7 @@ export const getBulkFileInfo = async (apiClient, caseId) => {
 							return {
 								// @ts-ignore
 								fullName:
+									// @ts-ignore
 									representationAttachmentFullNames[document.guid] ||
 									`${folderPath}/${document.name}`,
 								blobStorageContainer,


### PR DESCRIPTION
## Describe your changes

###    Attachments to rejected IP comments are still available in the case ZIP file
Modified the getRepresentationAttachmentFullNames and getBulkFileInfo function to ensure that Interested Parties comment that are invalid or rejected are not added to the ZIP file when it is downloaded.

## Issue ticket number and link

[[Ticket](<!--Paste your ticket link here-->)](https://pins-ds.atlassian.net/browse/A2-4155)
