### PR TITLE
test(appeals): updating api command names and creating new command files

### DIFF
--- a/appeals/e2e/cypress/e2e/back-office-appeals/changeAppealProcedureType.spec.js
+++ b/appeals/e2e/cypress/e2e/back-office-appeals/changeAppealProcedureType.spec.js
@@ -254,7 +254,7 @@ describe('change appeal procedure types', () => {
 		caseDetailsPage.checkStatusOfCase('LPA questionnaire', 0);
 
 		// Add planning obligation
-		cy.updateAppealDetailsViaApi(caseObj, { planningObligation: true });
+		cy.updateAppealDetails(caseObj, { planningObligation: true });
 		cy.getBusinessActualDate(currentDate, 1).then((date) => {
 			cy.updateTimeTableDetails(caseObj, { planningObligationDueDate: date });
 		});
@@ -337,7 +337,7 @@ describe('change appeal procedure types', () => {
 			caseObj = ref;
 			appeal = caseObj;
 			cy.addLpaqSubmissionToCase(caseObj);
-			cy.assignCaseOfficerViaApi(caseObj);
+			cy.assignCaseOfficer(caseObj);
 			happyPathHelper.viewCaseDetails(caseObj);
 			caseDetailsPage.checkStatusOfCase('Validation', 0);
 			happyPathHelper.reviewAppellantCase(caseObj);

--- a/appeals/e2e/cypress/e2e/back-office-appeals/hearing.spec.js
+++ b/appeals/e2e/cypress/e2e/back-office-appeals/hearing.spec.js
@@ -492,7 +492,7 @@ describe('Setup hearing and add hearing estimates', () => {
 		caseDetailsPage.verifyTimeTableRows(rowsWithNoObligationPlanning);
 
 		// Add planning obligation
-		cy.updateAppealDetailsViaApi(caseObj, { planningObligation: true });
+		cy.updateAppealDetails(caseObj, { planningObligation: true });
 		cy.getBusinessActualDate(currentDate, 1).then((date) => {
 			cy.updateTimeTableDetails(caseObj, { planningObligationDueDate: date });
 		});

--- a/appeals/e2e/cypress/e2e/back-office-appeals/inquiry.spec.js
+++ b/appeals/e2e/cypress/e2e/back-office-appeals/inquiry.spec.js
@@ -135,11 +135,11 @@ const setupTestCase = () => {
 		happyPathHelper.viewCaseDetails(caseObj);
 
 		// Assign Case Officer Via API
-		cy.assignCaseOfficerViaApi(caseObj);
+		cy.assignCaseOfficer(caseObj);
 
 		// Validate Appeal Via API
 		cy.getBusinessActualDate(new Date(), 0).then((date) => {
-			cy.updateAppealDetailsViaApi(caseObj, { validationOutcome: 'valid', validAt: date });
+			cy.updateAppealDetails(caseObj, { validationOutcome: 'valid', validAt: date });
 		});
 
 		cy.reload();
@@ -197,7 +197,7 @@ it('Can update inquiry date', () => {
 	// Setup: Add inquiry via API
 	cy.getBusinessActualDate(new Date(), 28).then((inquiryDate) => {
 		inquiryDate.setHours(14);
-		cy.addInquiryViaApi(caseObj, inquiryDate);
+		cy.addInquiry(caseObj, inquiryDate);
 
 		// find case and open inquiry section
 		cy.visit(urlPaths.appealsList);
@@ -229,7 +229,7 @@ it('Can update inquiry time', () => {
 	// Setup: Add inquiry via API
 	cy.getBusinessActualDate(new Date(), 28).then((inquiryDate) => {
 		inquiryDate.setHours(14);
-		cy.addInquiryViaApi(caseObj, inquiryDate);
+		cy.addInquiry(caseObj, inquiryDate);
 
 		// find case and open inquiry section
 		cy.visit(urlPaths.appealsList);
@@ -260,7 +260,7 @@ it('Can update inquiry time', () => {
 it('Can update inquiry estimated days when already set - using do you know link', () => {
 	// Setup: Add inquiry via API
 	cy.getBusinessActualDate(new Date(), 28).then((inquiryDate) => {
-		cy.addInquiryViaApi(caseObj, inquiryDate);
+		cy.addInquiry(caseObj, inquiryDate);
 
 		// find case and open inquiry section
 		cy.visit(urlPaths.appealsList);
@@ -293,7 +293,7 @@ it('Can update inquiry estimated days when already set - using do you know link'
 it('Can update inquiry estimated days when already set - using estimated days link', () => {
 	// Setup: Add inquiry via API
 	cy.getBusinessActualDate(new Date(), 28).then((inquiryDate) => {
-		cy.addInquiryViaApi(caseObj, inquiryDate);
+		cy.addInquiry(caseObj, inquiryDate);
 
 		// find case and open inquiry section
 		cy.visit(urlPaths.appealsList);
@@ -325,7 +325,7 @@ it('Can update inquiry estimated days when not already set', () => {
 	// Setup: Add inquiry via API
 	cy.getBusinessActualDate(new Date(), 28).then((inquiryDate) => {
 		// setting estimate days to '0' has effect of 'No' in inquiry UI
-		cy.addInquiryViaApi(caseObj, inquiryDate, { estimatedDays: '0' });
+		cy.addInquiry(caseObj, inquiryDate, { estimatedDays: '0' });
 
 		// find case and open inquiry section
 		cy.visit(urlPaths.appealsList);
@@ -358,7 +358,7 @@ it('Can update inquiry estimated days when not already set', () => {
 it('Can update inquiry address', () => {
 	// Setup: Add inquiry via API
 	cy.getBusinessActualDate(new Date(), 28).then((inquiryDate) => {
-		cy.addInquiryViaApi(caseObj, inquiryDate);
+		cy.addInquiry(caseObj, inquiryDate);
 
 		// find case and open inquiry section
 		cy.visit(urlPaths.appealsList);
@@ -385,7 +385,7 @@ it('Can update inquiry address', () => {
 it('Can update answer from CYA page - change address', () => {
 	// Setup: Add inquiry via API
 	cy.getBusinessActualDate(new Date(), 28).then((inquiryDate) => {
-		cy.addInquiryViaApi(caseObj, inquiryDate);
+		cy.addInquiry(caseObj, inquiryDate);
 
 		// find case and open inquiry section
 		cy.visit(urlPaths.appealsList);
@@ -416,7 +416,7 @@ it('Can update answer from CYA page - change address', () => {
 it('Can add rule 6 party', () => {
 	// Setup: Add inquiry via API
 	cy.getBusinessActualDate(new Date(), 28).then((inquiryDate) => {
-		cy.addInquiryViaApi(caseObj, inquiryDate);
+		cy.addInquiry(caseObj, inquiryDate);
 
 		// find case and open inquiry section
 		cy.visit(urlPaths.appealsList);
@@ -481,7 +481,7 @@ it('Can add rule 6 party', () => {
 it('Validates rule 6 party name and email address', () => {
 	// Setup: Add inquiry via API
 	cy.getBusinessActualDate(new Date(), 28).then((inquiryDate) => {
-		cy.addInquiryViaApi(caseObj, inquiryDate);
+		cy.addInquiry(caseObj, inquiryDate);
 
 		// find case and open inquiry section
 		cy.visit(urlPaths.appealsList);
@@ -514,7 +514,7 @@ it('Validates rule 6 party name and email address', () => {
 
 it('should not accept invalid input - inquiry Estimate', () => {
 	cy.getBusinessActualDate(new Date(), 28).then((inquiryDate) => {
-		cy.addInquiryViaApi(caseObj, inquiryDate);
+		cy.addInquiry(caseObj, inquiryDate);
 	});
 
 	cy.visit(urlPaths.appealsList);
@@ -549,7 +549,7 @@ it('should not accept invalid input - inquiry Estimate', () => {
 it('should add inquiry Estimates', () => {
 	// Setup: Add inquiry via API
 	cy.getBusinessActualDate(new Date(), 28).then((inquiryDate) => {
-		cy.addInquiryViaApi(caseObj, inquiryDate);
+		cy.addInquiry(caseObj, inquiryDate);
 	});
 
 	cy.visit(urlPaths.appealsList);
@@ -607,7 +607,7 @@ it('should add inquiry Estimates', () => {
 it('should update inquiry timetable dates from case details page', () => {
 	inquirySectionPage.setupTimetableDates().then(({ currentDate, ...timeTable }) => {
 		// Setup initial timetable
-		cy.addInquiryViaApi(caseObj, currentDate, timeTable);
+		cy.addInquiry(caseObj, currentDate, timeTable);
 
 		// find case and open inquiry section
 		cy.visit(urlPaths.appealsList);
@@ -671,7 +671,7 @@ it('should update inquiry timetable dates from case details page', () => {
 it('should validate inquiry timetable chronology', () => {
 	inquirySectionPage.setupTimetableDates().then(({ currentDate, ...timeTable }) => {
 		// Setup initial timetable
-		cy.addInquiryViaApi(caseObj, currentDate, timeTable);
+		cy.addInquiry(caseObj, currentDate, timeTable);
 
 		// find case and open inquiry section
 		cy.visit(urlPaths.appealsList);
@@ -712,7 +712,7 @@ it('should validate inquiry timetable chronology', () => {
 it('should show business day validation errors for all timetable fields', () => {
 	inquirySectionPage.setupTimetableDates().then(({ currentDate, ...timeTable }) => {
 		// Setup initial timetable
-		cy.addInquiryViaApi(caseObj, currentDate, timeTable);
+		cy.addInquiry(caseObj, currentDate, timeTable);
 
 		// find case and open inquiry section
 		cy.visit(urlPaths.appealsList);
@@ -760,7 +760,7 @@ it.only('should progress to evidence stage with no statements or IP comments', (
 	inquirySectionPage.setupTimetableDates().then(({ currentDate, ...timeTable }) => {
 		cy.visit(urlPaths.appealsList);
 		listCasesPage.clickAppealByRef(caseObj);
-		cy.addInquiryViaApi(caseObj, currentDate, timeTable);
+		cy.addInquiry(caseObj, currentDate, timeTable);
 		cy.addLpaqSubmissionToCase(caseObj);
 		cy.reviewLpaqSubmission(caseObj);
 		caseDetailsPage.checkStatusOfCase('Statements', 0);
@@ -808,17 +808,17 @@ it('should progress to evidence stage after sharing statements and IP comments',
 	inquirySectionPage.setupTimetableDates().then(({ currentDate, ...timeTable }) => {
 		cy.visit(urlPaths.appealsList);
 		listCasesPage.clickAppealByRef(caseObj);
-		cy.addInquiryViaApi(caseObj, currentDate, timeTable);
+		cy.addInquiry(caseObj, currentDate, timeTable);
 		cy.addLpaqSubmissionToCase(caseObj);
 		cy.reviewLpaqSubmission(caseObj);
 		caseDetailsPage.checkStatusOfCase('Statements', 0);
 
 		// Add & Review statement & IP comment Via Api
 		cy.addRepresentation(caseObj, 'lpaStatement', null);
-		cy.reviewStatementViaApi(caseObj);
+		cy.reviewStatement(caseObj);
 
 		cy.addRepresentation(caseObj, 'interestedPartyComment', null);
-		cy.reviewIpCommentsViaApi(caseObj);
+		cy.reviewIpComments(caseObj);
 
 		cy.simulateStatementsDeadlineElapsed(caseObj);
 
@@ -851,20 +851,20 @@ it('should complete LPA/Appellant POE and progress to awaiting inquiry', () => {
 	inquirySectionPage.setupTimetableDates().then(({ currentDate, ...timeTable }) => {
 		cy.visit(urlPaths.appealsList);
 		listCasesPage.clickAppealByRef(caseObj);
-		cy.addInquiryViaApi(caseObj, currentDate, timeTable);
+		cy.addInquiry(caseObj, currentDate, timeTable);
 		cy.addLpaqSubmissionToCase(caseObj);
 		cy.reviewLpaqSubmission(caseObj);
 
 		// Add & Review statement & IP comment Via Api
 		cy.addRepresentation(caseObj, 'lpaStatement', null);
-		cy.reviewStatementViaApi(caseObj);
+		cy.reviewStatement(caseObj);
 
 		cy.addRepresentation(caseObj, 'interestedPartyComment', null);
-		cy.reviewIpCommentsViaApi(caseObj);
+		cy.reviewIpComments(caseObj);
 
 		cy.simulateStatementsDeadlineElapsed(caseObj);
 
-		cy.shareCommentsAndStatementsViaApi(caseObj);
+		cy.shareCommentsAndStatements(caseObj);
 
 		caseDetailsPage.checkStatusOfCase('Evidence', 0);
 
@@ -968,20 +968,20 @@ it('should complete inquiry appeal to decision`', () => {
 	inquirySectionPage.setupTimetableDates().then(({ currentDate, ...timeTable }) => {
 		cy.visit(urlPaths.appealsList);
 		listCasesPage.clickAppealByRef(caseObj);
-		cy.addInquiryViaApi(caseObj, currentDate, timeTable);
+		cy.addInquiry(caseObj, currentDate, timeTable);
 		cy.addLpaqSubmissionToCase(caseObj);
 		cy.reviewLpaqSubmission(caseObj);
 
 		// Add & Review statement & IP comment Via Api
 		cy.addRepresentation(caseObj, 'lpaStatement', null);
-		cy.reviewStatementViaApi(caseObj);
+		cy.reviewStatement(caseObj);
 
 		cy.addRepresentation(caseObj, 'interestedPartyComment', null);
-		cy.reviewIpCommentsViaApi(caseObj);
+		cy.reviewIpComments(caseObj);
 
 		cy.simulateStatementsDeadlineElapsed(caseObj);
 
-		cy.shareCommentsAndStatementsViaApi(caseObj);
+		cy.shareCommentsAndStatements(caseObj);
 
 		caseDetailsPage.checkStatusOfCase('Evidence', 0);
 
@@ -1040,20 +1040,20 @@ it('should display the correct status tags when removing inquiry address', () =>
 	inquirySectionPage.setupTimetableDates().then(({ currentDate, ...timeTable }) => {
 		cy.visit(urlPaths.appealsList);
 		listCasesPage.clickAppealByRef(caseObj);
-		cy.addInquiryViaApi(caseObj, currentDate, timeTable);
+		cy.addInquiry(caseObj, currentDate, timeTable);
 		cy.addLpaqSubmissionToCase(caseObj);
 		cy.reviewLpaqSubmission(caseObj);
 
 		// Add & Review statement & IP comment Via Api
 		cy.addRepresentation(caseObj, 'lpaStatement', null);
-		cy.reviewStatementViaApi(caseObj);
+		cy.reviewStatement(caseObj);
 
 		cy.addRepresentation(caseObj, 'interestedPartyComment', null);
-		cy.reviewIpCommentsViaApi(caseObj);
+		cy.reviewIpComments(caseObj);
 
 		cy.simulateStatementsDeadlineElapsed(caseObj);
 
-		cy.shareCommentsAndStatementsViaApi(caseObj);
+		cy.shareCommentsAndStatements(caseObj);
 
 		// Verify evidence tag
 		caseDetailsPage.checkStatusOfCase('Evidence', 0);

--- a/appeals/e2e/cypress/e2e/back-office-appeals/linkAppeals.spec.js
+++ b/appeals/e2e/cypress/e2e/back-office-appeals/linkAppeals.spec.js
@@ -50,7 +50,7 @@ describe('Link appeals', () => {
 			cy.createCase({ caseType: 'W' }).then((childCaseObj) => {
 				cases = [leadCaseObj, childCaseObj];
 
-				cy.assignCaseOfficerViaApi(leadCaseObj);
+				cy.assignCaseOfficer(leadCaseObj);
 				happyPathHelper.viewCaseDetails(leadCaseObj);
 
 				//link appeal
@@ -79,7 +79,7 @@ describe('Link appeals', () => {
 			cy.createCase().then((childCaseObj) => {
 				cases = [leadCaseObj, childCaseObj];
 
-				cy.assignCaseOfficerViaApi(childCaseObj);
+				cy.assignCaseOfficer(childCaseObj);
 				happyPathHelper.viewCaseDetails(childCaseObj);
 
 				//link appeal
@@ -109,7 +109,7 @@ describe('Link appeals', () => {
 				cy.createCase({ caseType: 'W' }).then((childCaseObj2) => {
 					cases = [leadCaseObj, childCaseObj1, childCaseObj2];
 
-					cy.assignCaseOfficerViaApi(leadCaseObj);
+					cy.assignCaseOfficer(leadCaseObj);
 					happyPathHelper.viewCaseDetails(leadCaseObj);
 					happyPathHelper.addLinkedAppeal(leadCaseObj, childCaseObj1);
 					caseDetailsPage.checkStatusOfCase('Lead', 1);
@@ -127,7 +127,7 @@ describe('Link appeals', () => {
 			cy.createCase({ caseType: 'W' }).then((childCaseObj) => {
 				cases = [leadCaseObj, childCaseObj];
 
-				cy.assignCaseOfficerViaApi(leadCaseObj);
+				cy.assignCaseOfficer(leadCaseObj);
 				happyPathHelper.viewCaseDetails(leadCaseObj);
 
 				//link appeal
@@ -148,7 +148,7 @@ describe('Hidden elements', () => {
 			cy.createCase({ caseType: 'W' }).then((childCaseObj) => {
 				cases = [leadCaseObj, childCaseObj];
 
-				cy.assignCaseOfficerViaApi(leadCaseObj);
+				cy.assignCaseOfficer(leadCaseObj);
 				happyPathHelper.viewCaseDetails(leadCaseObj);
 
 				//link appeal
@@ -173,13 +173,13 @@ describe('Hidden elements', () => {
 				cases = [leadCaseObj, childCaseObj];
 
 				//child appeal
-				cy.assignCaseOfficerViaApi(childCaseObj);
+				cy.assignCaseOfficer(childCaseObj);
 				happyPathHelper.viewCaseDetails(childCaseObj);
 				happyPathHelper.reviewAppellantCase(childCaseObj);
 				caseDetailsPage.verifyLinkExists('Cancel appeal', true);
 
 				//lead appeal
-				cy.assignCaseOfficerViaApi(leadCaseObj);
+				cy.assignCaseOfficer(leadCaseObj);
 				happyPathHelper.viewCaseDetails(leadCaseObj);
 				caseDetailsPage.verifyLinkExists('Cancel appeal', true);
 				happyPathHelper.addLinkedAppeal(leadCaseObj, childCaseObj);
@@ -201,12 +201,12 @@ describe('Hidden elements', () => {
 				cases = [leadCaseObj, childCaseObj];
 
 				//child appeal
-				cy.assignCaseOfficerViaApi(childCaseObj);
+				cy.assignCaseOfficer(childCaseObj);
 				happyPathHelper.viewCaseDetails(childCaseObj);
 				happyPathHelper.reviewAppellantCase(childCaseObj);
 
 				//lead appeal
-				cy.assignCaseOfficerViaApi(leadCaseObj);
+				cy.assignCaseOfficer(leadCaseObj);
 				happyPathHelper.viewCaseDetails(leadCaseObj);
 				happyPathHelper.addLinkedAppeal(leadCaseObj, childCaseObj);
 				happyPathHelper.reviewAppellantCase(leadCaseObj);
@@ -233,12 +233,12 @@ describe('Net residences', () => {
 				});
 
 				//child appeal
-				cy.assignCaseOfficerViaApi(childCaseObj);
+				cy.assignCaseOfficer(childCaseObj);
 				happyPathHelper.viewCaseDetails(childCaseObj);
 				happyPathHelper.reviewAppellantCase(childCaseObj);
 
 				//lead appeal
-				cy.assignCaseOfficerViaApi(leadCaseObj);
+				cy.assignCaseOfficer(leadCaseObj);
 				happyPathHelper.viewCaseDetails(leadCaseObj);
 				happyPathHelper.reviewAppellantCase(leadCaseObj);
 				happyPathHelper.addLinkedAppeal(leadCaseObj, childCaseObj);
@@ -270,12 +270,12 @@ describe('Net residences', () => {
 				});
 
 				//child appeal
-				cy.assignCaseOfficerViaApi(childCaseObj);
+				cy.assignCaseOfficer(childCaseObj);
 				happyPathHelper.viewCaseDetails(childCaseObj);
 				happyPathHelper.reviewAppellantCase(childCaseObj);
 
 				//lead appeal
-				cy.assignCaseOfficerViaApi(leadCaseObj);
+				cy.assignCaseOfficer(leadCaseObj);
 				happyPathHelper.viewCaseDetails(leadCaseObj);
 				happyPathHelper.reviewAppellantCase(leadCaseObj);
 				happyPathHelper.addLinkedAppeal(leadCaseObj, childCaseObj);
@@ -312,12 +312,12 @@ describe('Net residences', () => {
 				});
 
 				//child appeal
-				cy.assignCaseOfficerViaApi(childCaseObj);
+				cy.assignCaseOfficer(childCaseObj);
 				happyPathHelper.viewCaseDetails(childCaseObj);
 				happyPathHelper.reviewAppellantCase(childCaseObj);
 
 				//lead appeal
-				cy.assignCaseOfficerViaApi(leadCaseObj);
+				cy.assignCaseOfficer(leadCaseObj);
 				happyPathHelper.viewCaseDetails(leadCaseObj);
 				happyPathHelper.reviewAppellantCase(leadCaseObj);
 				happyPathHelper.addLinkedAppeal(leadCaseObj, childCaseObj);
@@ -355,12 +355,12 @@ describe('Timetable', () => {
 				});
 
 				//child appeal
-				cy.assignCaseOfficerViaApi(childCaseObj);
+				cy.assignCaseOfficer(childCaseObj);
 				happyPathHelper.viewCaseDetails(childCaseObj);
 				happyPathHelper.reviewAppellantCase(childCaseObj);
 
 				//lead appeal
-				cy.assignCaseOfficerViaApi(leadCaseObj);
+				cy.assignCaseOfficer(leadCaseObj);
 				happyPathHelper.viewCaseDetails(leadCaseObj);
 				happyPathHelper.addLinkedAppeal(leadCaseObj, childCaseObj);
 				happyPathHelper.reviewAppellantCase(leadCaseObj);
@@ -394,12 +394,12 @@ describe('Timetable', () => {
 				});
 
 				//child appeal
-				cy.assignCaseOfficerViaApi(childCaseObj);
+				cy.assignCaseOfficer(childCaseObj);
 				happyPathHelper.viewCaseDetails(childCaseObj);
 				happyPathHelper.reviewAppellantCase(childCaseObj);
 
 				//lead appeal
-				cy.assignCaseOfficerViaApi(leadCaseObj);
+				cy.assignCaseOfficer(leadCaseObj);
 				happyPathHelper.viewCaseDetails(leadCaseObj);
 				happyPathHelper.addLinkedAppeal(leadCaseObj, childCaseObj);
 				happyPathHelper.reviewAppellantCase(leadCaseObj);
@@ -444,11 +444,11 @@ describe('Site visit', () => {
 					cy.addLpaqSubmissionToCase(caseObj);
 				});
 
-				cy.assignCaseOfficerViaApi(childCaseObj);
+				cy.assignCaseOfficer(childCaseObj);
 				happyPathHelper.viewCaseDetails(childCaseObj);
 				happyPathHelper.reviewAppellantCase(childCaseObj);
 
-				cy.assignCaseOfficerViaApi(leadCaseObj);
+				cy.assignCaseOfficer(leadCaseObj);
 				happyPathHelper.viewCaseDetails(leadCaseObj);
 
 				//link appeals
@@ -573,12 +573,12 @@ describe('Issue Decision', () => {
 					});
 
 					children.forEach((childCaseObj) => {
-						cy.assignCaseOfficerViaApi(childCaseObj);
+						cy.assignCaseOfficer(childCaseObj);
 						happyPathHelper.viewCaseDetails(childCaseObj);
 						happyPathHelper.reviewAppellantCase(childCaseObj);
 					});
 
-					cy.assignCaseOfficerViaApi(leadCaseObj);
+					cy.assignCaseOfficer(leadCaseObj);
 					happyPathHelper.viewCaseDetails(leadCaseObj);
 
 					//link appeals
@@ -682,12 +682,12 @@ describe('Issue Decision', () => {
 					});
 
 					children.forEach((childCaseObj) => {
-						cy.assignCaseOfficerViaApi(childCaseObj);
+						cy.assignCaseOfficer(childCaseObj);
 						happyPathHelper.viewCaseDetails(childCaseObj);
 						happyPathHelper.reviewAppellantCase(childCaseObj);
 					});
 
-					cy.assignCaseOfficerViaApi(leadCaseObj);
+					cy.assignCaseOfficer(leadCaseObj);
 					happyPathHelper.viewCaseDetails(leadCaseObj);
 
 					//link appeals
@@ -797,12 +797,12 @@ describe('Issue Decision', () => {
 					});
 
 					children.forEach((childCaseObj) => {
-						cy.assignCaseOfficerViaApi(childCaseObj);
+						cy.assignCaseOfficer(childCaseObj);
 						happyPathHelper.viewCaseDetails(childCaseObj);
 						happyPathHelper.reviewAppellantCase(childCaseObj);
 					});
 
-					cy.assignCaseOfficerViaApi(leadCaseObj);
+					cy.assignCaseOfficer(leadCaseObj);
 					happyPathHelper.viewCaseDetails(leadCaseObj);
 
 					//link appeals
@@ -908,14 +908,14 @@ describe('Unhappy path', () => {
 				cy.createCase({ caseType: 'W' }).then((childCaseObj) => {
 					cases = [leadCaseObj1, leadCaseObj2, childCaseObj];
 
-					cy.assignCaseOfficerViaApi(leadCaseObj1);
+					cy.assignCaseOfficer(leadCaseObj1);
 					happyPathHelper.viewCaseDetails(leadCaseObj1);
 
 					happyPathHelper.addLinkedAppeal(leadCaseObj1, childCaseObj);
 					caseDetailsPage.checkStatusOfCase('Lead', 1);
 
 					//2nd lead case
-					cy.assignCaseOfficerViaApi(leadCaseObj2);
+					cy.assignCaseOfficer(leadCaseObj2);
 					happyPathHelper.viewCaseDetails(leadCaseObj2);
 
 					//link appeal
@@ -935,14 +935,14 @@ describe('Unhappy path', () => {
 					cy.createCase({ caseType: 'W' }).then((childCaseObj2) => {
 						cases = [leadCaseObj1, leadCaseObj2, childCaseObj1, childCaseObj2];
 
-						cy.assignCaseOfficerViaApi(leadCaseObj1);
+						cy.assignCaseOfficer(leadCaseObj1);
 						happyPathHelper.viewCaseDetails(leadCaseObj1);
 
 						happyPathHelper.addLinkedAppeal(leadCaseObj1, childCaseObj1);
 						caseDetailsPage.checkStatusOfCase('Lead', 1);
 
 						//2nd lead case
-						cy.assignCaseOfficerViaApi(leadCaseObj2);
+						cy.assignCaseOfficer(leadCaseObj2);
 						happyPathHelper.viewCaseDetails(leadCaseObj2);
 
 						happyPathHelper.addLinkedAppeal(leadCaseObj2, childCaseObj2);
@@ -970,14 +970,14 @@ describe('Unhappy path', () => {
 					cy.createCase({ caseType: 'W' }).then((childCaseObj2) => {
 						cases = [leadCaseObj1, leadCaseObj2, childCaseObj1, childCaseObj2];
 
-						cy.assignCaseOfficerViaApi(leadCaseObj1);
+						cy.assignCaseOfficer(leadCaseObj1);
 						happyPathHelper.viewCaseDetails(leadCaseObj1);
 
 						happyPathHelper.addLinkedAppeal(leadCaseObj1, childCaseObj1);
 						caseDetailsPage.checkStatusOfCase('Lead', 1);
 
 						//2nd lead case
-						cy.assignCaseOfficerViaApi(leadCaseObj2);
+						cy.assignCaseOfficer(leadCaseObj2);
 						happyPathHelper.viewCaseDetails(leadCaseObj2);
 						happyPathHelper.addLinkedAppeal(leadCaseObj2, childCaseObj2);
 						caseDetailsPage.checkStatusOfCase('Lead', 1);
@@ -997,7 +997,7 @@ describe('Unhappy path', () => {
 				cases = [leadCaseObj, childCaseObj];
 
 				cy.addLpaqSubmissionToCase(leadCaseObj);
-				cy.assignCaseOfficerViaApi(leadCaseObj);
+				cy.assignCaseOfficer(leadCaseObj);
 				happyPathHelper.viewCaseDetails(leadCaseObj);
 				happyPathHelper.reviewAppellantCase(leadCaseObj);
 				happyPathHelper.startS78Case(leadCaseObj, 'written');
@@ -1017,7 +1017,7 @@ describe('Unhappy path', () => {
 				cases = [leadCaseObj, childCaseObj];
 
 				cy.addLpaqSubmissionToCase(childCaseObj);
-				cy.assignCaseOfficerViaApi(childCaseObj);
+				cy.assignCaseOfficer(childCaseObj);
 				happyPathHelper.viewCaseDetails(childCaseObj);
 				happyPathHelper.reviewAppellantCase(childCaseObj);
 				happyPathHelper.startS78Case(childCaseObj, 'written');

--- a/appeals/e2e/cypress/e2e/back-office-appeals/manageDocsAppellant.spec.js
+++ b/appeals/e2e/cypress/e2e/back-office-appeals/manageDocsAppellant.spec.js
@@ -34,7 +34,7 @@ describe('manage docs on appellant case', () => {
 
 	const setupInquiry = (caseObj, inquiryDate) => {
 		// require case to be started as inquiry to access appellant POE evidence e.g.
-		cy.addInquiryViaApi(caseObj, inquiryDate);
+		cy.addInquiry(caseObj, inquiryDate);
 		happyPathHelper.assignCaseOfficer(caseObj);
 		happyPathHelper.reviewAppellantCase(caseObj);
 		happyPathHelper.startS78InquiryCase(caseObj, 'inquiry');

--- a/appeals/e2e/cypress/e2e/back-office-appeals/manageDocsLpa.spec.js
+++ b/appeals/e2e/cypress/e2e/back-office-appeals/manageDocsLpa.spec.js
@@ -34,7 +34,7 @@ describe('Manage docs on lpa case', () => {
 
 	const setupInquiry = (caseObj, inquiryDate) => {
 		// require case to be started as inquiry to access appellant POE evidence e.g.
-		cy.addInquiryViaApi(caseObj, inquiryDate);
+		cy.addInquiry(caseObj, inquiryDate);
 		happyPathHelper.assignCaseOfficer(caseObj);
 		happyPathHelper.reviewAppellantCase(caseObj);
 		happyPathHelper.startS78InquiryCase(caseObj, 'inquiry');

--- a/appeals/e2e/cypress/e2e/back-office-appeals/startCase.spec.js
+++ b/appeals/e2e/cypress/e2e/back-office-appeals/startCase.spec.js
@@ -101,7 +101,7 @@ describe('Start case', () => {
 			appeal = caseObj;
 
 			// Assign Case Officer Via API
-			cy.assignCaseOfficerViaApi(caseObj);
+			cy.assignCaseOfficer(caseObj);
 
 			// Validate Appeal Via API
 			cy.validateAppeal(caseObj);
@@ -123,7 +123,7 @@ describe('Start case', () => {
 			appeal = caseObj;
 
 			// Assign Case Officer Via API
-			cy.assignCaseOfficerViaApi(caseObj);
+			cy.assignCaseOfficer(caseObj);
 
 			// Validate Appeal Via API
 			cy.validateAppeal(caseObj);
@@ -146,7 +146,7 @@ describe('Start case', () => {
 			appeal = caseObj;
 
 			// Assign Case Officer Via API
-			cy.assignCaseOfficerViaApi(caseObj);
+			cy.assignCaseOfficer(caseObj);
 
 			// Validate Appeal Via API
 			cy.validateAppeal(caseObj);
@@ -170,7 +170,7 @@ describe('Start case', () => {
 			happyPathHelper.viewCaseDetails(caseObj);
 
 			// Assign Case Officer Via API
-			cy.assignCaseOfficerViaApi(caseObj);
+			cy.assignCaseOfficer(caseObj);
 
 			// Validate Appeal Via API
 			cy.validateAppeal(caseObj);
@@ -199,7 +199,7 @@ describe('Start case', () => {
 			happyPathHelper.viewCaseDetails(caseObj);
 
 			// Assign Case Officer Via API
-			cy.assignCaseOfficerViaApi(caseObj);
+			cy.assignCaseOfficer(caseObj);
 
 			// Validate Appeal Via API
 			cy.validateAppeal(caseObj);
@@ -236,7 +236,7 @@ describe('Start case', () => {
 			happyPathHelper.viewCaseDetails(caseObj);
 
 			// Assign Case Officer Via API
-			cy.assignCaseOfficerViaApi(caseObj);
+			cy.assignCaseOfficer(caseObj);
 
 			// Validate Appeal Via API
 			cy.validateAppeal(caseObj);
@@ -295,7 +295,7 @@ describe('Start case', () => {
 			happyPathHelper.viewCaseDetails(caseObj);
 
 			// Assign Case Officer Via API
-			cy.assignCaseOfficerViaApi(caseObj);
+			cy.assignCaseOfficer(caseObj);
 
 			// Validate Appeal Via API
 			cy.validateAppeal(caseObj);

--- a/appeals/e2e/cypress/e2e/back-office-test-data-generation/createAdvertisementAppeal.spec.js
+++ b/appeals/e2e/cypress/e2e/back-office-test-data-generation/createAdvertisementAppeal.spec.js
@@ -36,13 +36,13 @@ describe('Create advertisement application', () => {
 
 			// Assign Case Officer Via API
 			if (testCaseConfig.assignCaseOfficer) {
-				cy.assignCaseOfficerViaApi(caseObj);
+				cy.assignCaseOfficer(caseObj);
 			}
 
 			// Validate Appeal Via API
 			if (testCaseConfig.validateAppeal) {
 				cy.getBusinessActualDate(new Date(), 0).then((date) => {
-					cy.updateAppealDetailsViaApi(caseObj, { validationOutcome: 'valid', validAt: date });
+					cy.updateAppealDetails(caseObj, { validationOutcome: 'valid', validAt: date });
 				});
 			}
 

--- a/appeals/e2e/cypress/e2e/back-office-test-data-generation/createCASAdvertAppeal.spec.js
+++ b/appeals/e2e/cypress/e2e/back-office-test-data-generation/createCASAdvertAppeal.spec.js
@@ -36,13 +36,13 @@ describe('Create CAS advert application', () => {
 
 			// Assign Case Officer Via API
 			if (testCaseConfig.assignCaseOfficer) {
-				cy.assignCaseOfficerViaApi(caseObj);
+				cy.assignCaseOfficer(caseObj);
 			}
 
 			// Validate Appeal Via API
 			if (testCaseConfig.validateAppeal) {
 				cy.getBusinessActualDate(new Date(), 0).then((date) => {
-					cy.updateAppealDetailsViaApi(caseObj, { validationOutcome: 'valid', validAt: date });
+					cy.updateAppealDetails(caseObj, { validationOutcome: 'valid', validAt: date });
 				});
 			}
 

--- a/appeals/e2e/cypress/e2e/back-office-test-data-generation/createCASPlanningAppeal.spec.js
+++ b/appeals/e2e/cypress/e2e/back-office-test-data-generation/createCASPlanningAppeal.spec.js
@@ -46,13 +46,13 @@ describe('Create CAS planning application', () => {
 
 			// Assign Case Officer Via API
 			if (testCaseConfig.assignCaseOfficer) {
-				cy.assignCaseOfficerViaApi(caseObj);
+				cy.assignCaseOfficer(caseObj);
 			}
 
 			// Validate Appeal Via API
 			if (testCaseConfig.validateAppeal) {
 				cy.getBusinessActualDate(new Date(), 0).then((date) => {
-					cy.updateAppealDetailsViaApi(caseObj, { validationOutcome: 'valid', validAt: date });
+					cy.updateAppealDetails(caseObj, { validationOutcome: 'valid', validAt: date });
 				});
 			}
 

--- a/appeals/e2e/cypress/e2e/back-office-test-data-generation/createHouseholderAppeal.spec.js
+++ b/appeals/e2e/cypress/e2e/back-office-test-data-generation/createHouseholderAppeal.spec.js
@@ -37,13 +37,13 @@ describe('Create householder application', () => {
 
 			// Assign Case Officer Via API
 			if (testCaseConfig.assignCaseOfficer) {
-				cy.assignCaseOfficerViaApi(caseObj);
+				cy.assignCaseOfficer(caseObj);
 			}
 
 			// Validate Appeal Via API
 			if (testCaseConfig.validateAppeal) {
 				cy.getBusinessActualDate(new Date(), 0).then((date) => {
-					cy.updateAppealDetailsViaApi(caseObj, { validationOutcome: 'valid', validAt: date });
+					cy.updateAppealDetails(caseObj, { validationOutcome: 'valid', validAt: date });
 				});
 			}
 
@@ -51,7 +51,7 @@ describe('Create householder application', () => {
 			if (testCaseConfig.addInquiry) {
 				inquirySectionPage.setupTimetableDates().then(({ currentDate, ...timeTable }) => {
 					// Set up inquiry case with LPA questionnaire
-					cy.addInquiryViaApi(caseObj, currentDate, timeTable);
+					cy.addInquiry(caseObj, currentDate, timeTable);
 				});
 			}
 
@@ -61,7 +61,7 @@ describe('Create householder application', () => {
 					// Set up hearing case
 					cy.addHearingDetails(caseObj, date);
 				});
-				cy.setupHearingViaApi(caseObj);
+				cy.setupHearing(caseObj);
 			}
 
 			// add lpaq

--- a/appeals/e2e/cypress/e2e/back-office-test-data-generation/createListedBuildingAppeal.spec.js
+++ b/appeals/e2e/cypress/e2e/back-office-test-data-generation/createListedBuildingAppeal.spec.js
@@ -37,13 +37,13 @@ describe('Create listed building application', () => {
 
 			// Assign Case Officer Via API
 			if (testCaseConfig.assignCaseOfficer) {
-				cy.assignCaseOfficerViaApi(caseObj);
+				cy.assignCaseOfficer(caseObj);
 			}
 
 			// Validate Appeal Via API
 			if (testCaseConfig.validateAppeal) {
 				cy.getBusinessActualDate(new Date(), 0).then((date) => {
-					cy.updateAppealDetailsViaApi(caseObj, { validationOutcome: 'valid', validAt: date });
+					cy.updateAppealDetails(caseObj, { validationOutcome: 'valid', validAt: date });
 				});
 			}
 
@@ -51,7 +51,7 @@ describe('Create listed building application', () => {
 			if (testCaseConfig.addInquiry) {
 				inquirySectionPage.setupTimetableDates().then(({ currentDate, ...timeTable }) => {
 					// Set up inquiry case with LPA questionnaire
-					cy.addInquiryViaApi(caseObj, currentDate, timeTable);
+					cy.addInquiry(caseObj, currentDate, timeTable);
 				});
 			}
 
@@ -61,7 +61,7 @@ describe('Create listed building application', () => {
 					// Set up hearing case
 					cy.addHearingDetails(caseObj, date);
 				});
-				cy.setupHearingViaApi(caseObj);
+				cy.setupHearing(caseObj);
 			}
 
 			// add lpaq

--- a/appeals/e2e/cypress/e2e/back-office-test-data-generation/createPlanningApplicationAppeal.spec.js
+++ b/appeals/e2e/cypress/e2e/back-office-test-data-generation/createPlanningApplicationAppeal.spec.js
@@ -44,13 +44,13 @@ describe('Create planning application', () => {
 
 			// Assign Case Officer Via API
 			if (testCaseConfig.assignCaseOfficer) {
-				cy.assignCaseOfficerViaApi(caseObj);
+				cy.assignCaseOfficer(caseObj);
 			}
 
 			// Validate Appeal Via API
 			if (testCaseConfig.validateAppeal) {
 				cy.getBusinessActualDate(new Date(), 0).then((date) => {
-					cy.updateAppealDetailsViaApi(caseObj, { validationOutcome: 'valid', validAt: date });
+					cy.updateAppealDetails(caseObj, { validationOutcome: 'valid', validAt: date });
 				});
 			}
 
@@ -58,7 +58,7 @@ describe('Create planning application', () => {
 			if (testCaseConfig.addInquiry) {
 				inquirySectionPage.setupTimetableDates().then(({ currentDate, ...timeTable }) => {
 					// Set up inquiry case with LPA questionnaire
-					cy.addInquiryViaApi(caseObj, currentDate, timeTable);
+					cy.addInquiry(caseObj, currentDate, timeTable);
 				});
 			}
 
@@ -68,7 +68,7 @@ describe('Create planning application', () => {
 					// Set up hearing case
 					cy.addHearingDetails(caseObj, date);
 				});
-				cy.setupHearingViaApi(caseObj);
+				cy.setupHearing(caseObj);
 			}
 
 			// add lpaq

--- a/appeals/e2e/cypress/support/commands/authentication.js
+++ b/appeals/e2e/cypress/support/commands/authentication.js
@@ -1,0 +1,162 @@
+// @ts-nocheck
+import { BrowserAuthData } from '../../fixtures/browser-auth-data';
+
+// const cookiesToSet = ['domain', 'expiry', 'httpOnly', 'path', 'secure'];
+// Pick a stable auth cookie name if you know it; regex is a safe default.
+const AUTH_COOKIE_MATCH = /(Auth|\.AspNetCore|idsrv|x-ms-)/i;
+
+function assertAuthCookiesExist() {
+	cy.getCookies().then((cookies) => {
+		const ok = cookies.some((c) => AUTH_COOKIE_MATCH.test(c.name));
+		expect(ok, 'at least one auth cookie present').to.be.true;
+	});
+}
+
+// Checks we are authenticated by probing a known auth-only page.
+// Adjust PATH if your app uses a different landing route.
+function assertAuthenticated() {
+	const PATH = '/appeals-service/personal-list';
+
+	cy.request({
+		url: PATH,
+		failOnStatusCode: false, // don't fail the test on 302/404
+		followRedirect: false // so we can inspect Location header
+	}).then((res) => {
+		const location = res.headers?.location || '';
+
+		// Not bounced to Azure AD
+		expect(location, 'not redirected to AAD').not.to.include('login.microsoftonline.com');
+
+		// SPA backends may return 404 for client-routed paths; accept it.
+		// 200 = served page, 302 = in-app redirect, 404 = SPA not SSR'd but still auth OK
+		expect(res.status, 'authenticated status').to.be.oneOf([200, 302, 404]);
+	});
+}
+
+// LOGIN AND AUTHENTICATION
+
+Cypress.Commands.add('clearCookiesFiles', () => {
+	cy.task('ClearAllCookies').then((cleared) => {
+		console.log(cleared);
+	});
+});
+
+Cypress.Commands.add('deleteDownloads', () => {
+	cy.task('DeleteDownloads');
+});
+
+Cypress.Commands.add('deleteUnwantedFixtures', () => {
+	cy.task('DeleteUnwantedFixtures');
+});
+
+Cypress.Commands.add('validateDownloadedFile', (fileName) => {
+	cy.task('ValidateDownloadedFile', fileName).then((success) => {
+		if (success) {
+			expect(success).to.be.true;
+		} else {
+			throw new Error(
+				`${fileName} was not found. The file was either not downloaded or the file name is not correct.`
+			);
+		}
+	});
+});
+
+Cypress.Commands.add('login', (user) => {
+	cy.loginSession(user);
+});
+
+Cypress.Commands.add('loginWithPuppeteer', (user) => {
+	const config = {
+		username: user.email,
+		password: Cypress.env('PASSWORD'),
+		loginUrl: Cypress.config('baseUrl'),
+		id: user.id
+	};
+
+	cy.task('AzureSignIn', config).then((cookies) => {
+		cy.clearCookies();
+		cookies.forEach((cookie) => {
+			cy.setCookie(cookie.name, cookie.value, {
+				domain: cookie.domain,
+				expiry: cookie.expires,
+				httpOnly: cookie.httpOnly,
+				path: cookie.path,
+				secure: cookie.secure,
+				log: false
+			});
+		});
+
+		// Bind cookies to the app origin and verify we’re authenticated
+		cy.visit('/');
+		assertAuthenticated();
+	});
+
+	return;
+});
+
+Cypress.Commands.add('loginSession', (user) => {
+	if (!user?.id || !user?.email) {
+		throw new Error('loginSession: user must be an object with { id, email }');
+	}
+
+	const sessionKey = `azure:${Cypress.config('baseUrl')}:${user.id}`;
+
+	cy.session(
+		sessionKey,
+		() => {
+			cy.task('CookiesFileExists', user.id).then((exists) => {
+				if (!exists) {
+					cy.log(`No cookie file for ${user.id} → performing Azure sign-in`);
+					cy.loginWithPuppeteer(user);
+				} else {
+					cy.log(`Using cookie file for ${user.id}`);
+					setLocalCookies(user.id);
+				}
+			});
+		},
+		{
+			cacheAcrossSpecs: true,
+			validate() {
+				assertAuthenticated();
+			}
+		}
+	);
+});
+
+export function setLocalCookies(userId) {
+	cy.readFile(
+		`${BrowserAuthData.BrowserAuthDataFolder}/${userId}-${BrowserAuthData.CookiesFile}`
+	).then((data) => {
+		cy.clearCookies();
+		data.forEach((cookie) => {
+			cy.setCookie(cookie.name, cookie.value, {
+				domain: cookie.domain,
+				expiry: cookie.expires,
+				httpOnly: cookie.httpOnly,
+				path: cookie.path,
+				secure: cookie.secure,
+				log: false
+			});
+		});
+
+		// Bind cookies and verify auth
+		cy.visit('/');
+		assertAuthenticated();
+	});
+}
+
+Cypress.Commands.add('setCurrentCookies', (cookies) => {
+	cy.clearCookies();
+	cookies.forEach((cookie) => {
+		cy.setCookie(cookie.name, cookie.value, {
+			domain: cookie.domain,
+			expiry: cookie.expiry,
+			httpOnly: cookie.httpOnly,
+			path: cookie.path,
+			secure: cookie.secure
+		});
+	});
+
+	cy.visit('/');
+	assertAuthenticated();
+});

--- a/appeals/e2e/cypress/support/commands/utils.js
+++ b/appeals/e2e/cypress/support/commands/utils.js
@@ -1,0 +1,95 @@
+// @ts-nocheck
+import { appealsApiClient } from '../appealsApiClient';
+
+// HELPER FUNCTIONS
+
+Cypress.Commands.add('reloadUntilVirusCheckComplete', () => {
+	cy.reload();
+});
+
+Cypress.Commands.add('reloadUntilVirusCheckComplete', () => {
+	cy.reload();
+});
+
+Cypress.Commands.add('getByData', (value) => {
+	return cy.get(`[data-cy="${value}"]`);
+});
+
+Cypress.Commands.add('elementExists', (selector) => {
+	return cy.get('body').then(($body) => {
+		const hasElement = $body.find(selector).length > 0;
+		return cy.wrap(hasElement);
+	});
+});
+
+Cypress.Commands.add('selectReasonOption', (optionLabel = null) => {
+	return cy.get('input[type="checkbox"]').then(($checkboxes) => {
+		// Helper function to get label text for a checkbox
+		const getLabelText = (checkbox) => Cypress.$(checkbox).siblings('label').text().trim();
+
+		// Filter checkboxes based on the selection logic
+		const targetCheckbox =
+			optionLabel === 'Other reason'
+				? $checkboxes.filter((i, elem) => getLabelText(elem) === 'Other reason')[0]
+				: $checkboxes.filter((i, elem) => getLabelText(elem) !== 'Other reason')[
+						Math.floor(
+							Math.random() *
+								$checkboxes.filter((i, elem) => getLabelText(elem) !== 'Other reason').length
+						)
+				  ];
+
+		// Validate target checkbox exists
+		if (!targetCheckbox) {
+			throw new Error(
+				optionLabel === 'Other reason'
+					? 'Checkbox with label "Other reason" not found'
+					: 'No eligible checkboxes available (excluding "Other reason")'
+			);
+		}
+
+		// Select checkbox and return label text
+		const selectedLabelText = getLabelText(targetCheckbox);
+		cy.wrap(targetCheckbox).click().should('be.checked');
+
+		return cy.wrap(selectedLabelText);
+	});
+});
+
+Cypress.Commands.add('checkNotifySent', (caseObj, expectedNotifies) => {
+	// ensure input is always an array
+	const expected = [].concat(expectedNotifies);
+
+	expected.forEach(({ template, recipient }) => {
+		expect(
+			typeof template === 'string' && template.trim() !== '',
+			`notify template should be provided: "${template}"`
+		).to.be.true;
+
+		expect(
+			typeof recipient === 'string' && recipient.trim() !== '',
+			`notify recipient should be provided: "${recipient}"`
+		).to.be.true;
+	});
+
+	return cy.wrap(null).then(async () => {
+		// returns an array of email objects sent for the given appeal
+		const sentNotifies = await appealsApiClient.getNotifyEmails(caseObj.reference);
+
+		// filter for expected notifies that were NOT found in the sent notfies array
+		const missingNotifies = expected.filter(
+			(expectedNotify) =>
+				!sentNotifies.some(
+					(sentNotifies) =>
+						sentNotifies.template === expectedNotify.template &&
+						sentNotifies.recipient === expectedNotify.recipient
+				)
+		);
+
+		// error message detail
+		const missingDetails = missingNotifies
+			.map((notify) => `(Template: ${notify.template}, Recipient: ${notify.recipient})`)
+			.join('; ');
+
+		expect(missingNotifies, `Missing notifies: ${missingDetails}`).to.be.empty;
+	});
+});

--- a/appeals/e2e/cypress/support/e2e.js
+++ b/appeals/e2e/cypress/support/e2e.js
@@ -18,7 +18,9 @@
 
 // Import commands.js using ES2015 syntax:
 import registerCypressGrep from '@cypress/grep';
-import './commands';
+import './commands/api';
+import './commands/authentication';
+import './commands/utils';
 registerCypressGrep();
 
 after(() => {

--- a/appeals/e2e/cypress/support/happyPathHelper.js
+++ b/appeals/e2e/cypress/support/happyPathHelper.js
@@ -505,8 +505,8 @@ export const happyPathHelper = {
 
 	updateCase(caseObj, currentStatus, targetStatus, appealType, procedureType = 'written') {
 		const baseActions = {
-			[STATUSES.ASSIGN_CASE_OFFICER]: (c) => cy.assignCaseOfficerViaApi(c),
-			[STATUSES.VALIDATION]: (c) => cy.updateAppealDetailsViaApi(c, { validationOutcome: 'valid' }),
+			[STATUSES.ASSIGN_CASE_OFFICER]: (c) => cy.assignCaseOfficer(c),
+			[STATUSES.VALIDATION]: (c) => cy.updateAppealDetails(c, { validationOutcome: 'valid' }),
 			[STATUSES.READY_TO_START]: (c, appealType, procedureType) => cy.startAppeal(c),
 			[STATUSES.LPA_QUESTIONNAIRE]: (c) => {
 				cy.addLpaqSubmissionToCase(c);
@@ -514,19 +514,19 @@ export const happyPathHelper = {
 			},
 			[STATUSES.STATEMENTS]: (c) => {
 				cy.addRepresentation(c, 'lpaStatement', null);
-				cy.reviewStatementViaApi(c);
+				cy.reviewStatement(c);
 				cy.simulateStatementsDeadlineElapsed(c);
-				cy.shareCommentsAndStatementsViaApi(c);
+				cy.shareCommentsAndStatements(c);
 			},
 			[STATUSES.FINAL_COMMENTS]: (c) => {
 				cy.addRepresentation(c, 'lpaFinalComment', null);
-				cy.reviewLpaFinalCommentsViaApi(c);
+				cy.reviewLpaFinalComments(c);
 				cy.simulateFinalCommentsDeadlineElapsed(c);
-				cy.shareCommentsAndStatementsViaApi(c);
+				cy.shareCommentsAndStatements(c);
 			},
-			[STATUSES.EVENT_READY_TO_SETUP]: (c) => cy.setupSiteVisitViaAPI(c),
+			[STATUSES.EVENT_READY_TO_SETUP]: (c) => cy.setupSiteVisit(c),
 			[STATUSES.AWAITING_EVENT]: (c) => cy.simulateSiteVisit(c),
-			[STATUSES.ISSUE_DECISION]: (c) => cy.issueDecisionViaApi(c)
+			[STATUSES.ISSUE_DECISION]: (c) => cy.issueDecision(c)
 		};
 
 		const flow = FLOWS[appealType];


### PR DESCRIPTION
## Describe your changes

In this PR am **making some changes to the cypress commands setup** 

**Renaming api commands** 
Have renamed the api commands to remove the `viaApi` from some names, as was causing some confusion, and also some inconsistency! 

**New command files**
The existing `commands.js` file was getting quite large and bit difficult to follow, as different types of command were mixed up, i.e. trying to keep track of what api commands we have 
as such have moved them into separate files, for clarity and to make it easier to find command that are looking for! 

- commands/api.js - commands relating to api client (hearing, inquiry etc.) 
- commands/authentication.js - commands relating to authentication, login etc. 
- commands/utils.js - helper commands (e.g. find elements) 

These are now each imported into the e2e.js file            

## Issue ticket number and link

https://pins-ds.atlassian.net/browse/A2-7731 
