### PR TITLE
fix(appeals): display add cta when decision letter date not entered (A2-5642)

### DIFF
--- a/appeals/web/src/server/appeals/appeal-details/appellant-case/__tests__/__snapshots__/appellant-case.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/appellant-case/__tests__/__snapshots__/appellant-case.test.js.snap
@@ -99,7 +99,7 @@ exports[`appellant-case GET /appellant-case notification banners should render a
                         <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> What’s the date on the decision letter from the local planning authority?​</dt>
                             <dd                             class="govuk-summary-list__value">No data</dd>
                                 <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/application-decision-date/change"
-                                    data-cy="change-application-decision-date">Change<span class="govuk-visually-hidden"> What’s the date on the decision letter from the local planning authority?​ (Before you start)</span></a>
+                                    data-cy="add-application-decision-date">Add<span class="govuk-visually-hidden"> What’s the date on the decision letter from the local planning authority?​ (Before you start)</span></a>
                                 </dd>
                         </div>
                         <div class="govuk-summary-list__row govuk-summary-list__row--no-actions"><dt class="govuk-summary-list__key"> Are you claiming costs as part of your appeal?</dt>
@@ -397,7 +397,7 @@ exports[`appellant-case GET /appellant-case notification banners should render a
                         <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> What’s the date on the decision letter from the local planning authority?​</dt>
                             <dd                             class="govuk-summary-list__value">No data</dd>
                                 <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/application-decision-date/change"
-                                    data-cy="change-application-decision-date">Change<span class="govuk-visually-hidden"> What’s the date on the decision letter from the local planning authority?​ (Before you start)</span></a>
+                                    data-cy="add-application-decision-date">Add<span class="govuk-visually-hidden"> What’s the date on the decision letter from the local planning authority?​ (Before you start)</span></a>
                                 </dd>
                         </div>
                         <div class="govuk-summary-list__row govuk-summary-list__row--no-actions"><dt class="govuk-summary-list__key"> Are you claiming costs as part of your appeal?</dt>
@@ -737,7 +737,7 @@ exports[`appellant-case GET /appellant-case notification banners should render a
                         <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> What’s the date on the decision letter from the local planning authority?​</dt>
                             <dd                             class="govuk-summary-list__value">No data</dd>
                                 <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/application-decision-date/change"
-                                    data-cy="change-application-decision-date">Change<span class="govuk-visually-hidden"> What’s the date on the decision letter from the local planning authority?​ (Before you start)</span></a>
+                                    data-cy="add-application-decision-date">Add<span class="govuk-visually-hidden"> What’s the date on the decision letter from the local planning authority?​ (Before you start)</span></a>
                                 </dd>
                         </div>
                         <div class="govuk-summary-list__row govuk-summary-list__row--no-actions"><dt class="govuk-summary-list__key"> Are you claiming costs as part of your appeal?</dt>
@@ -1048,7 +1048,7 @@ exports[`appellant-case GET /appellant-case notification banners should render a
                         <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> What’s the date on the decision letter from the local planning authority?​</dt>
                             <dd                             class="govuk-summary-list__value">No data</dd>
                                 <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/application-decision-date/change"
-                                    data-cy="change-application-decision-date">Change<span class="govuk-visually-hidden"> What’s the date on the decision letter from the local planning authority?​ (Before you start)</span></a>
+                                    data-cy="add-application-decision-date">Add<span class="govuk-visually-hidden"> What’s the date on the decision letter from the local planning authority?​ (Before you start)</span></a>
                                 </dd>
                         </div>
                         <div class="govuk-summary-list__row govuk-summary-list__row--no-actions"><dt class="govuk-summary-list__key"> Are you claiming costs as part of your appeal?</dt>
@@ -1491,7 +1491,7 @@ exports[`appellant-case GET /appellant-case should render review outcome form fi
                         <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> What’s the date on the decision letter from the local planning authority?​</dt>
                             <dd                             class="govuk-summary-list__value">No data</dd>
                                 <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/appellant-case/application-decision-date/change"
-                                    data-cy="change-application-decision-date">Change<span class="govuk-visually-hidden"> What’s the date on the decision letter from the local planning authority?​ (Before you start)</span></a>
+                                    data-cy="add-application-decision-date">Add<span class="govuk-visually-hidden"> What’s the date on the decision letter from the local planning authority?​ (Before you start)</span></a>
                                 </dd>
                         </div>
                         <div class="govuk-summary-list__row govuk-summary-list__row--no-actions"><dt class="govuk-summary-list__key"> Are you claiming costs as part of your appeal?</dt>
@@ -1801,7 +1801,7 @@ exports[`appellant-case GET /appellant-case should render the appellant case pag
                         <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> What’s the date on the decision letter from the local planning authority?​</dt>
                             <dd                             class="govuk-summary-list__value">No data</dd>
                                 <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/application-decision-date/change"
-                                    data-cy="change-application-decision-date">Change<span class="govuk-visually-hidden"> What’s the date on the decision letter from the local planning authority?​ (Before you start)</span></a>
+                                    data-cy="add-application-decision-date">Add<span class="govuk-visually-hidden"> What’s the date on the decision letter from the local planning authority?​ (Before you start)</span></a>
                                 </dd>
                         </div>
                         <div class="govuk-summary-list__row govuk-summary-list__row--no-actions"><dt class="govuk-summary-list__key"> Are you claiming costs as part of your appeal?</dt>
@@ -2072,7 +2072,7 @@ exports[`appellant-case GET /appellant-case should render the appellant case pag
                         <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> What’s the date on the decision letter from the local planning authority?​</dt>
                             <dd                             class="govuk-summary-list__value">No data</dd>
                                 <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/appellant-case/application-decision-date/change"
-                                    data-cy="change-application-decision-date">Change<span class="govuk-visually-hidden"> What’s the date on the decision letter from the local planning authority?​ (Before you start)</span></a>
+                                    data-cy="add-application-decision-date">Add<span class="govuk-visually-hidden"> What’s the date on the decision letter from the local planning authority?​ (Before you start)</span></a>
                                 </dd>
                         </div>
                         <div class="govuk-summary-list__row govuk-summary-list__row--no-actions"><dt class="govuk-summary-list__key"> Are you claiming costs as part of your appeal?</dt>
@@ -2328,7 +2328,7 @@ exports[`appellant-case GET /appellant-case should render the appellant case pag
                         <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> What’s the date on the decision letter from the local planning authority?​</dt>
                             <dd                             class="govuk-summary-list__value">No data</dd>
                                 <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/appellant-case/application-decision-date/change"
-                                    data-cy="change-application-decision-date">Change<span class="govuk-visually-hidden"> What’s the date on the decision letter from the local planning authority?​ (Before you start)</span></a>
+                                    data-cy="add-application-decision-date">Add<span class="govuk-visually-hidden"> What’s the date on the decision letter from the local planning authority?​ (Before you start)</span></a>
                                 </dd>
                         </div>
                         <div class="govuk-summary-list__row govuk-summary-list__row--no-actions"><dt class="govuk-summary-list__key"> Are you claiming costs as part of your appeal?</dt>
@@ -3074,7 +3074,7 @@ exports[`appellant-case GET /appellant-case should render the appellant case pag
                         <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> What’s the date on the decision letter from the local planning authority?​</dt>
                             <dd                             class="govuk-summary-list__value">No data</dd>
                                 <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/appellant-case/application-decision-date/change"
-                                    data-cy="change-application-decision-date">Change<span class="govuk-visually-hidden"> What’s the date on the decision letter from the local planning authority?​ (3. Grounds and facts)</span></a>
+                                    data-cy="add-application-decision-date">Add<span class="govuk-visually-hidden"> What’s the date on the decision letter from the local planning authority?​ (3. Grounds and facts)</span></a>
                                 </dd>
                         </div>
                         <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> When was the appeal decision?</dt>
@@ -3494,7 +3494,7 @@ exports[`appellant-case GET /appellant-case should render the appellant case pag
                         <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> What’s the date on the decision letter from the local planning authority?​</dt>
                             <dd                             class="govuk-summary-list__value">No data</dd>
                                 <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/appellant-case/application-decision-date/change"
-                                    data-cy="change-application-decision-date">Change<span class="govuk-visually-hidden"> What’s the date on the decision letter from the local planning authority?​ (3. Grounds and facts)</span></a>
+                                    data-cy="add-application-decision-date">Add<span class="govuk-visually-hidden"> What’s the date on the decision letter from the local planning authority?​ (3. Grounds and facts)</span></a>
                                 </dd>
                         </div>
                         <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> When was the appeal decision?</dt>
@@ -3724,7 +3724,7 @@ exports[`appellant-case GET /appellant-case should render the appellant case pag
                         <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> What’s the date on the decision letter from the local planning authority?​</dt>
                             <dd                             class="govuk-summary-list__value">No data</dd>
                                 <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/appellant-case/application-decision-date/change"
-                                    data-cy="change-application-decision-date">Change<span class="govuk-visually-hidden"> What’s the date on the decision letter from the local planning authority?​ (Before you start)</span></a>
+                                    data-cy="add-application-decision-date">Add<span class="govuk-visually-hidden"> What’s the date on the decision letter from the local planning authority?​ (Before you start)</span></a>
                                 </dd>
                         </div>
                         <div class="govuk-summary-list__row govuk-summary-list__row--no-actions"><dt class="govuk-summary-list__key"> Are you claiming costs as part of your appeal?</dt>
@@ -4095,7 +4095,7 @@ exports[`appellant-case GET /appellant-case should render the appellant case pag
                         <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> What’s the date on the decision letter from the local planning authority?​</dt>
                             <dd                             class="govuk-summary-list__value">No data</dd>
                                 <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/application-decision-date/change"
-                                    data-cy="change-application-decision-date">Change<span class="govuk-visually-hidden"> What’s the date on the decision letter from the local planning authority?​ (Before you start)</span></a>
+                                    data-cy="add-application-decision-date">Add<span class="govuk-visually-hidden"> What’s the date on the decision letter from the local planning authority?​ (Before you start)</span></a>
                                 </dd>
                         </div>
                         <div class="govuk-summary-list__row govuk-summary-list__row--no-actions"><dt class="govuk-summary-list__key"> Are you claiming costs as part of your appeal?</dt>
@@ -4548,7 +4548,7 @@ exports[`appellant-case GET /appellant-case should render the appellant case pag
                         <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> What’s the date on the decision letter from the local planning authority?​</dt>
                             <dd                             class="govuk-summary-list__value">No data</dd>
                                 <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/appellant-case/application-decision-date/change"
-                                    data-cy="change-application-decision-date">Change<span class="govuk-visually-hidden"> What’s the date on the decision letter from the local planning authority?​ (3. Grounds and facts)</span></a>
+                                    data-cy="add-application-decision-date">Add<span class="govuk-visually-hidden"> What’s the date on the decision letter from the local planning authority?​ (3. Grounds and facts)</span></a>
                                 </dd>
                         </div>
                         <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> When was the appeal decision?</dt>
@@ -4817,7 +4817,7 @@ exports[`appellant-case GET /appellant-case should render the appellant case pag
                         <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> What’s the date on the decision letter from the local planning authority?​</dt>
                             <dd                             class="govuk-summary-list__value">No data</dd>
                                 <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/3/appellant-case/application-decision-date/change"
-                                    data-cy="change-application-decision-date">Change<span class="govuk-visually-hidden"> What’s the date on the decision letter from the local planning authority?​ (Before you start)</span></a>
+                                    data-cy="add-application-decision-date">Add<span class="govuk-visually-hidden"> What’s the date on the decision letter from the local planning authority?​ (Before you start)</span></a>
                                 </dd>
                         </div>
                         <div class="govuk-summary-list__row govuk-summary-list__row--no-actions"><dt class="govuk-summary-list__key"> Are you claiming costs as part of your appeal?</dt>
@@ -5173,7 +5173,7 @@ exports[`appellant-case GET /appellant-case should render the appellant case pag
                         <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> What’s the date on the decision letter from the local planning authority?​</dt>
                             <dd                             class="govuk-summary-list__value">No data</dd>
                                 <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/appellant-case/application-decision-date/change"
-                                    data-cy="change-application-decision-date">Change<span class="govuk-visually-hidden"> What’s the date on the decision letter from the local planning authority?​ (Before you start)</span></a>
+                                    data-cy="add-application-decision-date">Add<span class="govuk-visually-hidden"> What’s the date on the decision letter from the local planning authority?​ (Before you start)</span></a>
                                 </dd>
                         </div>
                         <div class="govuk-summary-list__row govuk-summary-list__row--no-actions"><dt class="govuk-summary-list__key"> Are you claiming costs as part of your appeal?</dt>
@@ -5466,7 +5466,7 @@ exports[`appellant-case GET /appellant-case should render the appellant case pag
                         <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> What’s the date on the decision letter from the local planning authority?​</dt>
                             <dd                             class="govuk-summary-list__value">No data</dd>
                                 <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/appellant-case/application-decision-date/change"
-                                    data-cy="change-application-decision-date">Change<span class="govuk-visually-hidden"> What’s the date on the decision letter from the local planning authority?​ (Before you start)</span></a>
+                                    data-cy="add-application-decision-date">Add<span class="govuk-visually-hidden"> What’s the date on the decision letter from the local planning authority?​ (Before you start)</span></a>
                                 </dd>
                         </div>
                         <div class="govuk-summary-list__row govuk-summary-list__row--no-actions"><dt class="govuk-summary-list__key"> Are you claiming costs as part of your appeal?</dt>
@@ -5771,7 +5771,7 @@ exports[`appellant-case GET /appellant-case should render the appellant case pag
                         <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> What’s the date on the decision letter from the local planning authority?​</dt>
                             <dd                             class="govuk-summary-list__value">No data</dd>
                                 <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/appellant-case/application-decision-date/change"
-                                    data-cy="change-application-decision-date">Change<span class="govuk-visually-hidden"> What’s the date on the decision letter from the local planning authority?​ (Before you start)</span></a>
+                                    data-cy="add-application-decision-date">Add<span class="govuk-visually-hidden"> What’s the date on the decision letter from the local planning authority?​ (Before you start)</span></a>
                                 </dd>
                         </div>
                         <div class="govuk-summary-list__row govuk-summary-list__row--no-actions"><dt class="govuk-summary-list__key"> Are you claiming costs as part of your appeal?</dt>
@@ -9328,7 +9328,7 @@ exports[`appellant-case POST /appellant-case should re-render the appellant case
                         <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> What’s the date on the decision letter from the local planning authority?​</dt>
                             <dd                             class="govuk-summary-list__value">No data</dd>
                                 <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/application-decision-date/change"
-                                    data-cy="change-application-decision-date">Change<span class="govuk-visually-hidden"> What’s the date on the decision letter from the local planning authority?​ (Before you start)</span></a>
+                                    data-cy="add-application-decision-date">Add<span class="govuk-visually-hidden"> What’s the date on the decision letter from the local planning authority?​ (Before you start)</span></a>
                                 </dd>
                         </div>
                         <div class="govuk-summary-list__row govuk-summary-list__row--no-actions"><dt class="govuk-summary-list__key"> Are you claiming costs as part of your appeal?</dt>

--- a/appeals/web/src/server/lib/mappers/data/appellant-case/submappers/application-decision-date.js
+++ b/appeals/web/src/server/lib/mappers/data/appellant-case/submappers/application-decision-date.js
@@ -7,6 +7,7 @@ export const mapApplicationDecisionDate = ({
 	currentRoute,
 	userHasUpdateCase
 }) =>
+	// @ts-ignore
 	textSummaryListItem({
 		id: 'application-decision-date',
 		text:
@@ -15,5 +16,6 @@ export const mapApplicationDecisionDate = ({
 				: 'What’s the date on the decision letter from the local planning authority?​',
 		value: dateISOStringToDisplayDate(appellantCaseData.applicationDecisionDate, 'No data'),
 		link: `${currentRoute}/application-decision-date/change`,
-		editable: userHasUpdateCase && !appellantCaseData.isEnforcementChild
+		editable: userHasUpdateCase && !appellantCaseData.isEnforcementChild,
+		actionText: appellantCaseData.applicationDecisionDate ? 'Change' : 'Add'
 	});


### PR DESCRIPTION
## Describe your changes

#### BO Enforcement - Appellant case - display add cta when decision letter date not entered (A2-5642)

### WEB:
- Display the add cta when decision letter date not entered
- Update tests

## Issue ticket number and link
- [Ticket: BO Enforcement - Appellant case - Grounds and facts - What is the date on the decision letter from the local planning authority? change screen (A2-5642)](https://pins-ds.atlassian.net/browse/A2-5642)
