### PR TITLE
chore(appeals): performance todos and deprecations

### DIFF
--- a/appeals/api/src/server/endpoints/appeal-details/__tests__/appeals-details.test.js
+++ b/appeals/api/src/server/endpoints/appeal-details/__tests__/appeals-details.test.js
@@ -306,7 +306,7 @@ describe('Appeal detail routes', () => {
 				});
 
 				const response = await request
-					.get(`/appeals/${mocks.householdAppeal.id}?include=all`)
+					.get(`/appeals/${mocks.householdAppeal.id}`)
 					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(200);
@@ -326,7 +326,7 @@ describe('Appeal detail routes', () => {
 				});
 
 				const response = await request
-					.get(`/appeals/${fullPlanningAppeal.id}?include=all`)
+					.get(`/appeals/${fullPlanningAppeal.id}`)
 					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(200);
@@ -348,9 +348,7 @@ describe('Appeal detail routes', () => {
 				// @ts-ignore
 				databaseConnector.appeal.findUnique.mockResolvedValue(null);
 
-				const response = await request
-					.get('/appeals/3?include=all')
-					.set('azureAdUserId', azureAdUserId);
+				const response = await request.get('/appeals/3').set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(404);
 				expect(response.body).toEqual({
@@ -380,7 +378,7 @@ describe('Appeal detail routes', () => {
 				});
 
 				const response = await request
-					.get(`/appeals/${fullPlanningAppeal.id}?include=all`)
+					.get(`/appeals/${fullPlanningAppeal.id}`)
 					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(200);
@@ -414,7 +412,7 @@ describe('Appeal detail routes', () => {
 				});
 
 				const response = await request
-					.get(`/appeals/${fullPlanningAppeal.id}?include=all`)
+					.get(`/appeals/${fullPlanningAppeal.id}`)
 					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(200);
@@ -448,7 +446,7 @@ describe('Appeal detail routes', () => {
 				});
 
 				const response = await request
-					.get(`/appeals/${fullPlanningAppeal.id}?include=all`)
+					.get(`/appeals/${fullPlanningAppeal.id}`)
 					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(200);

--- a/appeals/api/src/server/endpoints/appeal-details/__tests__/appeals-details.test.js
+++ b/appeals/api/src/server/endpoints/appeal-details/__tests__/appeals-details.test.js
@@ -308,7 +308,7 @@ describe('Appeal detail routes', () => {
 				});
 
 				const response = await request
-					.get(`/appeals/${mocks.householdAppeal.id}?include=all`)
+					.get(`/appeals/${mocks.householdAppeal.id}`)
 					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(200);
@@ -328,7 +328,7 @@ describe('Appeal detail routes', () => {
 				});
 
 				const response = await request
-					.get(`/appeals/${fullPlanningAppeal.id}?include=all`)
+					.get(`/appeals/${fullPlanningAppeal.id}`)
 					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(200);
@@ -382,7 +382,7 @@ describe('Appeal detail routes', () => {
 				});
 
 				const response = await request
-					.get(`/appeals/${fullPlanningAppeal.id}?include=all`)
+					.get(`/appeals/${fullPlanningAppeal.id}`)
 					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(200);
@@ -416,7 +416,7 @@ describe('Appeal detail routes', () => {
 				});
 
 				const response = await request
-					.get(`/appeals/${fullPlanningAppeal.id}?include=all`)
+					.get(`/appeals/${fullPlanningAppeal.id}`)
 					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(200);
@@ -450,7 +450,7 @@ describe('Appeal detail routes', () => {
 				});
 
 				const response = await request
-					.get(`/appeals/${fullPlanningAppeal.id}?include=all`)
+					.get(`/appeals/${fullPlanningAppeal.id}`)
 					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(200);

--- a/appeals/api/src/server/endpoints/appeal-details/appeal-details.routes.js
+++ b/appeals/api/src/server/endpoints/appeal-details/appeal-details.routes.js
@@ -85,7 +85,19 @@ router.patch(
 		#swagger.responses[500] = {}
 	 */
 	patchAppealValidator,
-	asyncHandler(checkAppealExistsByIdAndAddPartialToRequest([])),
+	asyncHandler(
+		checkAppealExistsByIdAndAddPartialToRequest([
+			'address',
+			'agent',
+			'appealType',
+			'appellant',
+			'appellantCase',
+			'childAppeals',
+			'inspector',
+			'lpa',
+			'parentAppeals'
+		])
+	),
 	asyncHandler(controller.updateAppealById)
 );
 

--- a/appeals/api/src/server/endpoints/appeal-timetables/appeal-timetables.controller.js
+++ b/appeals/api/src/server/endpoints/appeal-timetables/appeal-timetables.controller.js
@@ -147,9 +147,11 @@ const updateAppealTimetableById = async (req, res) => {
 			await Promise.all(
 				// @ts-ignore
 				appeal.childAppeals.map(async (childAppeal) => {
+					// TODO: performance
+					// is returning all data in a loop, return only needed data
 					const child =
 						childAppeal.child ||
-						(await appealRepository.getAppealById(Number(childAppeal.childId)));
+						(await appealRepository.deprecatedGetAppealById(Number(childAppeal.childId)));
 					if (child) {
 						return updateAppealTimetable(child, body, notifyClient, azureAdUserId, true);
 					}

--- a/appeals/api/src/server/endpoints/appeal-timetables/appeal-timetables.controller.js
+++ b/appeals/api/src/server/endpoints/appeal-timetables/appeal-timetables.controller.js
@@ -154,9 +154,11 @@ const updateAppealTimetableById = async (req, res) => {
 			await Promise.all(
 				// @ts-ignore
 				appeal.childAppeals.map(async (childAppeal) => {
+					// TODO: performance
+					// is returning all data in a loop, return only needed data
 					const child =
 						childAppeal.child ||
-						(await appealRepository.getAppealById(Number(childAppeal.childId)));
+						(await appealRepository.deprecatedGetAppealById(Number(childAppeal.childId)));
 					if (child) {
 						return updateAppealTimetable(child, body, notifyClient, azureAdUserId, true);
 					}

--- a/appeals/api/src/server/endpoints/appellant-cases/appellant-cases.service.js
+++ b/appeals/api/src/server/endpoints/appellant-cases/appellant-cases.service.js
@@ -255,7 +255,9 @@ export const updateAppellantCaseValidationOutcome = async (
 		azureAdUserId
 	});
 
-	const updatedAppeal = await appealRepository.getAppealById(Number(appealId));
+	// TODO: performance
+	// is returning all data, return only needed data
+	const updatedAppeal = await appealRepository.deprecatedGetAppealById(Number(appealId));
 
 	if (isOutcomeValid(validationOutcome.name)) {
 		const latestDocumentVersionsUpdated = await documentRepository.setRedactionStatusOnValidation(

--- a/appeals/api/src/server/endpoints/decision/decision.controller.js
+++ b/appeals/api/src/server/endpoints/decision/decision.controller.js
@@ -54,7 +54,11 @@ export const postInspectorDecision = async (req, res) => {
 				switch (decisionType) {
 					case DECISION_TYPE_INSPECTOR: {
 						if (isChildAppeal) {
-							const childAppeal = await appealRepository.getAppealById(Number(decisionAppealId));
+							// TODO: performance
+							// is returning all data, return only needed data
+							const childAppeal = await appealRepository.deprecatedGetAppealById(
+								Number(decisionAppealId)
+							);
 
 							if (childAppeal) {
 								return publishChildDecision(

--- a/appeals/api/src/server/endpoints/decision/decision.controller.js
+++ b/appeals/api/src/server/endpoints/decision/decision.controller.js
@@ -84,7 +84,11 @@ export const postInspectorDecision = async (req, res) => {
 				switch (decisionType) {
 					case DECISION_TYPE_INSPECTOR: {
 						if (isChildAppeal) {
-							const childAppeal = await appealRepository.getAppealById(Number(decisionAppealId));
+							// TODO: performance
+							// is returning all data, return only needed data
+							const childAppeal = await appealRepository.deprecatedGetAppealById(
+								Number(decisionAppealId)
+							);
 
 							if (childAppeal) {
 								return publishChildDecision(

--- a/appeals/api/src/server/endpoints/integrations/integrations.controller.js
+++ b/appeals/api/src/server/endpoints/integrations/integrations.controller.js
@@ -209,7 +209,9 @@ export const importAppeal = async (req, res) => {
 
 		const [parentAppeal, ...childAppeals] = await Promise.all(
 			[parentResult, ...childResults].map(async (caseData) => {
-				return appealRepository.getAppealById(caseData.id);
+				// TODO: performance
+				// is returning all data in a loop, return only needed data
+				return appealRepository.deprecatedGetAppealById(caseData.id);
 			})
 		);
 

--- a/appeals/api/src/server/endpoints/integrations/integrations.controller.js
+++ b/appeals/api/src/server/endpoints/integrations/integrations.controller.js
@@ -206,7 +206,9 @@ export const importAppeal = async (req, res) => {
 
 		const [parentAppeal, ...childAppeals] = await Promise.all(
 			[parentResult, ...childResults].map(async (caseData) => {
-				return appealRepository.getAppealById(caseData.id);
+				// TODO: performance
+				// is returning all data in a loop, return only needed data
+				return appealRepository.deprecatedGetAppealById(caseData.id);
 			})
 		);
 

--- a/appeals/api/src/server/endpoints/link-appeals/link-appeals.service.js
+++ b/appeals/api/src/server/endpoints/link-appeals/link-appeals.service.js
@@ -386,14 +386,20 @@ export const updateAppealStatusIfRequired = async (
 	previousLeadAppealId,
 	azureAdUserId
 ) => {
-	const leadAppeal = leadAppealId ? await appealRepository.getAppealById(leadAppealId) : null;
+	// TODO: performance
+	// is returning all data, return only needed data
+	const leadAppeal = leadAppealId
+		? await appealRepository.deprecatedGetAppealById(leadAppealId)
+		: null;
 
 	if (!leadAppeal) {
 		throw new Error('Lead appeal not found');
 	}
 
+	// TODO: performance
+	// is returning all data, return only needed data
 	const unlinkedAppeal = unlinkedAppealId
-		? await appealRepository.getAppealById(unlinkedAppealId)
+		? await appealRepository.deprecatedGetAppealById(unlinkedAppealId)
 		: null;
 
 	const { appellantCaseValidationOutcome: leadAppealAppellantCaseOutcome } =

--- a/appeals/api/src/server/endpoints/link-appeals/link-appeals.service.js
+++ b/appeals/api/src/server/endpoints/link-appeals/link-appeals.service.js
@@ -442,14 +442,20 @@ export const updateAppealStatusIfRequired = async (
 	previousLeadAppealId,
 	azureAdUserId
 ) => {
-	const leadAppeal = leadAppealId ? await appealRepository.getAppealById(leadAppealId) : null;
+	// TODO: performance
+	// is returning all data, return only needed data
+	const leadAppeal = leadAppealId
+		? await appealRepository.deprecatedGetAppealById(leadAppealId)
+		: null;
 
 	if (!leadAppeal) {
 		throw new Error('Lead appeal not found');
 	}
 
+	// TODO: performance
+	// is returning all data, return only needed data
 	const unlinkedAppeal = unlinkedAppealId
-		? await appealRepository.getAppealById(unlinkedAppealId)
+		? await appealRepository.deprecatedGetAppealById(unlinkedAppealId)
 		: null;
 
 	const { appellantCaseValidationOutcome: leadAppealAppellantCaseOutcome } =

--- a/appeals/api/src/server/endpoints/linkable-appeals/linkable-appeal.service.js
+++ b/appeals/api/src/server/endpoints/linkable-appeals/linkable-appeal.service.js
@@ -22,7 +22,9 @@ const linkableCaseStatuses = [
  * @returns {Promise<import('@pins/appeals.api').Appeals.LinkableAppealSummary>}
  */
 export const getLinkableAppealSummaryByCaseReference = async (appealReference, linkableType) => {
-	let appeal = await appealRepository.getAppealByAppealReference(appealReference);
+	// TODO: performance
+	// is returning all data, return only needed data
+	let appeal = await appealRepository.deprecatedGetAppealByAppealReference(appealReference);
 	if (!appeal) {
 		logger.debug('Case not found in BO, now trying to query Horizon');
 		const horizonAppeal = await getAppealFromHorizon(appealReference).catch((error) => {

--- a/appeals/api/src/server/endpoints/lpa-questionnaires/lpa-questionnaires.service.js
+++ b/appeals/api/src/server/endpoints/lpa-questionnaires/lpa-questionnaires.service.js
@@ -156,7 +156,9 @@ const updateLPAQuestionnaireValidationOutcome = async (
 		await sendLpaqCompleteEmailToAppellant(notifyClient, appeal, siteAddress, azureAdUserId);
 	}
 
-	const updatedAppeal = await appealRepository.getAppealById(Number(appealId));
+	// TODO: performance
+	// is returning all data, return only needed data
+	const updatedAppeal = await appealRepository.deprecatedGetAppealById(Number(appealId));
 	if (updatedAppeal) {
 		const { lpaQuestionnaire: updatedLpaQuestionnaire } = updatedAppeal;
 

--- a/appeals/api/src/server/endpoints/site-visits/__tests__/site-visits.test.js
+++ b/appeals/api/src/server/endpoints/site-visits/__tests__/site-visits.test.js
@@ -1227,9 +1227,7 @@ describe('site visit routes', () => {
 				// @ts-ignore
 				databaseConnector.appeal.findUnique.mockResolvedValue(null);
 
-				const response = await request
-					.get('/appeals/3?include=all')
-					.set('azureAdUserId', azureAdUserId);
+				const response = await request.get('/appeals/3').set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(404);
 				expect(response.body).toEqual({

--- a/appeals/api/src/server/middleware/check-appeal-exists-and-add-to-request.js
+++ b/appeals/api/src/server/middleware/check-appeal-exists-and-add-to-request.js
@@ -17,7 +17,9 @@ export const checkAppealExistsByCaseReferenceAndAddToRequest = async (req, res, 
 		params: { caseReference }
 	} = req;
 
-	const appeal = await appealRepository.getAppealByAppealReference(caseReference);
+	// TODO: performance
+	// is returning all data, return only needed data
+	const appeal = await appealRepository.deprecatedGetAppealByAppealReference(caseReference);
 
 	if (!appeal || !isAppealTypeEnabled(appeal.appealType?.key || '')) {
 		return res.status(404).send({ errors: { caseReference: ERROR_NOT_FOUND } });
@@ -61,12 +63,18 @@ export const checkAppealExistsByIdAndAddPartialToRequest =
 			includeDetails = true;
 		}
 
-		const appeal = await appealRepository.getAppealById(
-			Number(appealId),
-			includeDetails,
-			getAppealKeys,
-			selectAppealTypeKey
-		);
+		let appeal;
+
+		if (includeDetails && !selectAppealTypeKey) {
+			appeal = await appealRepository.deprecatedGetAppealById(Number(appealId));
+		} else {
+			appeal = await appealRepository.getAppealById(
+				Number(appealId),
+				includeDetails,
+				getAppealKeys,
+				selectAppealTypeKey
+			);
+		}
 
 		if (!appeal || !isAppealTypeEnabled(appeal.appealType?.key || '')) {
 			return res.status(404).send({ errors: { appealId: ERROR_NOT_FOUND } });

--- a/appeals/api/src/server/repositories/__tests__/appeal.repository.test.js
+++ b/appeals/api/src/server/repositories/__tests__/appeal.repository.test.js
@@ -2,9 +2,10 @@
 import { appealDetailsInclude, buildAppealInclude } from '../appeal.repository.js';
 
 describe('buildAppealInclude', () => {
-	it('returns full appealDetailsInclude when selectedKeys is empty and includeDetails = true', () => {
-		const result = buildAppealInclude([], true);
-		expect(result).toBe(appealDetailsInclude);
+	it('throws error when selectedKeys is empty and selectAppealTypeKey is not provided', () => {
+		expect(() => buildAppealInclude([], true)).toThrow(
+			'Must provide at least one: selectedKeys or selectAppealTypeKey'
+		);
 	});
 
 	it('returns null when selectedKeys is empty and includeDetails = false', () => {

--- a/appeals/api/src/server/repositories/appeal-lists.repository.js
+++ b/appeals/api/src/server/repositories/appeal-lists.repository.js
@@ -69,6 +69,8 @@ const getAllAppeals = async (
 
 	const appeals = await databaseConnector.appeal.findMany({
 		where,
+		// TODO: performance
+		// use selects not include to only return the data needed for the appeals list
 		include: {
 			address: true,
 			appealStatus: {
@@ -201,6 +203,9 @@ const getAppealsWithoutIncludes = async (
 		appellantProcedurePreferencePreFilter
 	);
 
+	// TODO: performance
+	// gets all appeals, performance will get worse over time
+	// only used for filtering the filters
 	return databaseConnector.appeal.findMany({ where });
 };
 
@@ -511,6 +516,10 @@ const getAppealsStatusesInNationalList = async () => {
 			status: true
 		},
 		distinct: ['status']
+		// TODO: performance
+		// Prisma Client's distinct option does not use SQL SELECT DISTINCT. Instead, distinct uses:
+		// A SELECT query + In-memory post-processing to select distinct
+		// this will get worse over time
 	});
 
 	return results.map((result) => result.status);

--- a/appeals/api/src/server/repositories/appeal.repository.js
+++ b/appeals/api/src/server/repositories/appeal.repository.js
@@ -380,8 +380,7 @@ export const buildAppealInclude = (
 	}
 
 	if (!selectedKeys.length && !selectAppealTypeKey) {
-		// Return everything if no keys are selected
-		return appealDetailsInclude;
+		throw new Error('Must provide at least one: selectedKeys or selectAppealTypeKey');
 	}
 
 	/** @type {Partial<import('#db-client/models.ts').AppealInclude>} */
@@ -428,6 +427,25 @@ const getAppealById = async (id, includeDetails = true, selectedKeys = [], selec
 };
 
 /**
+ * @deprecated too inefficient do not use, use getAppealById with specific includes only
+ * @description DO NOT USE. Gets an appeal and all it's related entities
+ * @param {number} id
+ * @returns {Promise<Appeal|undefined>}
+ */
+const deprecatedGetAppealById = async (id) => {
+	const appeal = await databaseConnector.appeal.findUnique({
+		where: {
+			id
+		},
+		include: appealDetailsInclude
+	});
+	if (appeal) {
+		// @ts-ignore
+		return appeal;
+	}
+};
+
+/**
  * @param {number} id
  * @returns {Promise<AppealType|undefined>}
  */
@@ -446,11 +464,11 @@ const getAppealTypeById = async (id) => {
 };
 
 /**
- *
+ * @deprecated too inefficient, use getAppealById with specific includes only
  * @param {string} appealReference
  * @returns {Promise<Appeal|undefined|null>}
  */
-const getAppealByAppealReference = async (appealReference) => {
+const deprecatedGetAppealByAppealReference = async (appealReference) => {
 	const appeal = await databaseConnector.appeal.findUnique({
 		where: {
 			reference: appealReference
@@ -939,8 +957,9 @@ export default {
 	getLinkedAppeals,
 	getLinkedAppealsById,
 	getAppealById,
+	deprecatedGetAppealById,
 	getAppealTypeById,
-	getAppealByAppealReference,
+	deprecatedGetAppealByAppealReference,
 	getAppealIdList,
 	updateAppealById,
 	setAppealDecision,

--- a/appeals/api/src/server/repositories/personal-list.repository.js
+++ b/appeals/api/src/server/repositories/personal-list.repository.js
@@ -79,6 +79,8 @@ const getPersonalList = async (userId, pageNumber, pageSize, status, leadAppealI
 	return databaseConnector.$transaction(async (tx) => {
 		const personalList = await tx.personalList.findMany({
 			where: where({ status, leadAppealId }),
+			// TODO: performance
+			// use selects not include to only return the data needed for the personal list
 			include: {
 				appeal: {
 					include: {

--- a/appeals/api/src/server/state/transition-state.js
+++ b/appeals/api/src/server/state/transition-state.js
@@ -37,7 +37,9 @@ import createStateMachine from './create-state-machine.js';
  * @param {string} trigger
  */
 const transitionState = async (appealId, azureAdUserId, trigger) => {
-	const appeal = await appealRepository.getAppealById(appealId);
+	// TODO: performance
+	// is returning all data, return only needed data
+	const appeal = await appealRepository.deprecatedGetAppealById(appealId);
 
 	if (!appeal) {
 		throw new Error(`no appeal exists with ID: ${appealId}`);

--- a/appeals/api/src/server/utils/update-personal-list.js
+++ b/appeals/api/src/server/utils/update-personal-list.js
@@ -13,7 +13,9 @@ import { APPEAL_CASE_STATUS } from '@planning-inspectorate/data-model';
  * @returns {Promise<void>}
  */
 export const updatePersonalList = async (appealId) => {
-	const appeal = await appealRepository.getAppealById(appealId);
+	// TODO: performance
+	// is returning all data, return only needed data
+	const appeal = await appealRepository.deprecatedGetAppealById(appealId);
 	if (!appeal) {
 		return;
 	}
@@ -36,7 +38,11 @@ export const updatePersonalList = async (appealId) => {
 			linkType = 'parent';
 		}
 		if (!dueDate && linkedAppeals[0]?.parentId) {
-			const parentAppeal = await appealRepository.getAppealById(linkedAppeals[0].parentId);
+			// TODO: performance
+			// is returning all data, return only needed data
+			const parentAppeal = await appealRepository.deprecatedGetAppealById(
+				linkedAppeals[0].parentId
+			);
 			if (!parentAppeal) {
 				dueDate = null;
 			} else {

--- a/appeals/web/src/server/appeals/appeal-details/__tests__/appeal-details.test.js
+++ b/appeals/web/src/server/appeals/appeal-details/__tests__/appeal-details.test.js
@@ -411,7 +411,7 @@ describe('appeal-details', () => {
 						.reply(200, appealData)
 						.persist();
 					nock('http://test/')
-						.patch(`/appeals/${appealData.appealId}?include=all`)
+						.patch(`/appeals/${appealData.appealId}`)
 						.reply(200, {
 							...appealData,
 							caseOfficer: 'updatedCaseOfficerId'
@@ -452,13 +452,13 @@ describe('appeal-details', () => {
 						.reply(200, appealData)
 						.persist();
 					nock('http://test/')
-						.patch(`/appeals/${appealData.appealId}?include=all`)
+						.patch(`/appeals/${appealData.appealId}`)
 						.reply(200, {
 							...appealData,
 							inspector: 'updatedInspectorId'
 						});
 					nock('http://test/')
-						.get(`/appeals/${appealData.appealId}/case-notes`)
+						.get(`/appeals/${appealData.appealId}/case-notes?include=all`)
 						.reply(200, caseNotes);
 
 					await request
@@ -1929,7 +1929,7 @@ describe('appeal-details', () => {
 						.reply(200, appealInValidationStatus)
 						.persist();
 					nock('http://test/')
-						.patch(`/appeals/${appealId}?include=all`)
+						.patch(`/appeals/${appealId}`)
 						.reply(200, {
 							...appealInValidationStatus,
 							caseOfficer: 'updatedCaseOfficerId'

--- a/appeals/web/src/server/appeals/appeal-details/appeal-details.middleware.js
+++ b/appeals/web/src/server/appeals/appeal-details/appeal-details.middleware.js
@@ -1,5 +1,8 @@
 import { areIdParamsValid } from '#lib/validators/id-param.validator.js';
-import { getAppealDetailsFromId } from './appeal-details.service.js';
+import {
+	deprecatedGetAppealDetailsFromId,
+	getAppealDetailsFromId
+} from './appeal-details.service.js';
 
 /**
  * @deprecated too inefficient, use validateAppealWithInclude
@@ -15,7 +18,9 @@ export const validateAppeal = async (req, res, next) => {
 	}
 
 	try {
-		const appeal = await getAppealDetailsFromId(req.apiClient, appealId || caseId);
+		// TODO: performance
+		// is returning all data, return only needed data
+		const appeal = await deprecatedGetAppealDetailsFromId(req.apiClient, appealId || caseId);
 		if (!appeal) {
 			return res.status(404).render('app/404.njk');
 		}

--- a/appeals/web/src/server/appeals/appeal-details/appeal-details.service.js
+++ b/appeals/web/src/server/appeals/appeal-details/appeal-details.service.js
@@ -6,9 +6,23 @@
  * @returns {Promise<import('./appeal-details.types.js').WebAppeal>}
  */
 export function getAppealDetailsFromId(apiClient, appealId, include) {
-	const url = include
-		? `appeals/${appealId}?include=${include}`
-		: `appeals/${appealId}?include=all`;
+	if (include === 'all') {
+		throw new Error('include=all is not allowed, select only the keys needed');
+	}
+
+	const url = include ? `appeals/${appealId}?include=${include}` : `appeals/${appealId}`;
+
+	return apiClient.get(url).json();
+}
+
+/**
+ * @deprecated Inefficient use getAppealDetailsFromId and select only the data needed
+ * @param {import('got').Got} apiClient
+ * @param {string} appealId
+ * @returns {Promise<import('./appeal-details.types.js').WebAppeal>}
+ */
+export function deprecatedGetAppealDetailsFromId(apiClient, appealId) {
+	const url = `appeals/${appealId}?include=all`;
 
 	return apiClient.get(url).json();
 }

--- a/appeals/web/src/server/appeals/appeal-details/appeal-details.service.js
+++ b/appeals/web/src/server/appeals/appeal-details/appeal-details.service.js
@@ -10,7 +10,10 @@ export function getAppealDetailsFromId(apiClient, appealId, include) {
 		throw new Error('include=all is not allowed, select only the keys needed');
 	}
 
-	const url = include ? `appeals/${appealId}?include=${include}` : `appeals/${appealId}`;
+	const encodedAppealId = encodeURIComponent(appealId);
+	const url = include
+		? `appeals/${encodedAppealId}?include=${include}`
+		: `appeals/${encodedAppealId}`;
 
 	return apiClient.get(url).json();
 }
@@ -22,7 +25,8 @@ export function getAppealDetailsFromId(apiClient, appealId, include) {
  * @returns {Promise<import('./appeal-details.types.js').WebAppeal>}
  */
 export function deprecatedGetAppealDetailsFromId(apiClient, appealId) {
-	const url = `appeals/${appealId}?include=all`;
+	const encodedAppealId = encodeURIComponent(appealId);
+	const url = `appeals/${encodedAppealId}?include=all`;
 
 	return apiClient.get(url).json();
 }
@@ -38,8 +42,9 @@ export function setEnvironmentalImpactAssessmentScreening(
 	appealId,
 	eiaScreeningRequired
 ) {
+	const encodedAppealId = encodeURIComponent(appealId);
 	return apiClient
-		.patch(`appeals/${appealId}/eia-screening-required`, {
+		.patch(`appeals/${encodedAppealId}/eia-screening-required`, {
 			json: { eiaScreeningRequired }
 		})
 		.json();

--- a/appeals/web/src/server/appeals/appeal-details/assign-user/__tests__/assign-user.test.js
+++ b/appeals/web/src/server/appeals/appeal-details/assign-user/__tests__/assign-user.test.js
@@ -158,9 +158,7 @@ describe('assign-user', () => {
 
 	describe('POST /assign-case-officer/check-details', () => {
 		it('should redirect to the case details page when user clicks on "Assign case officer"', async () => {
-			nock('http://test/')
-				.patch('/appeals/1?include=all')
-				.reply(200, { caseOfficer: 'updatedCaseOfficerId' });
+			nock('http://test/').patch('/appeals/1').reply(200, { caseOfficer: 'updatedCaseOfficerId' });
 			await request.post(`${baseUrl}/assign-inspector/search-inspector`).send({
 				user: '{"id": "923ac03b-9031-4cf4-8b17-348c274321f9", "name": "Smith, John", "email": "John.Smith@planninginspectorate.gov.uk"}'
 			});
@@ -230,9 +228,7 @@ describe('assign-user', () => {
 
 	describe('POST /assign-inspector/check-details', () => {
 		it('should redirect to the case details page when user clicks on "Assign inspector"', async () => {
-			nock('http://test/')
-				.patch('/appeals/1?include=all')
-				.reply(200, { caseOfficer: 'updatedCaseOfficerId' });
+			nock('http://test/').patch('/appeals/1').reply(200, { caseOfficer: 'updatedCaseOfficerId' });
 			await request.post(`${baseUrl}/assign-inspector/search-inspector`).send({
 				user: '{"id": "923ac03b-9031-4cf4-8b17-348c274321f9", "name": "Smith, John", "email": "John.Smith@planninginspectorate.gov.uk"}'
 			});
@@ -243,9 +239,7 @@ describe('assign-user', () => {
 		});
 
 		it('should redirect to the case details page when user clicks on "Unassign inspector"', async () => {
-			nock('http://test/')
-				.patch('/appeals/1?include=all')
-				.reply(200, { caseOfficer: 'updatedCaseOfficerId' });
+			nock('http://test/').patch('/appeals/1').reply(200, { caseOfficer: 'updatedCaseOfficerId' });
 			await request.post(`${baseUrl}/assign-inspector/search-inspector`).send({
 				user: '{"id": "0", "name": "Remove", "email": "Remove"}'
 			});

--- a/appeals/web/src/server/appeals/appeal-details/assign-user/assign-user.service.js
+++ b/appeals/web/src/server/appeals/appeal-details/assign-user/assign-user.service.js
@@ -33,7 +33,7 @@ export async function setAppealAssignee(apiClient, appealId, assigneeUser, isIns
 	} else {
 		userJson = { caseOfficerId: assigneeUserId, caseOfficerName: assigneeUser.name };
 	}
-	return apiClient.patch(`appeals/${appealId}?include=all`, { json: userJson }).json();
+	return apiClient.patch(`appeals/${appealId}`, { json: userJson }).json();
 }
 
 /**


### PR DESCRIPTION
## Describe your changes

This PR attempts to stop new uses of the inefficient calls that return all data for an appeal
- renames some deprecated functions so that they are more obvious to spot in PR review
- patch appeal-details was using ?include=all which is deprecated and unnecessary, the response isn't used, so the endpoint itself can decide on which lookups are needed
- added comments for some performance issues, tickets exist as well
- encoded uri based on github suggestion - unrelated to my changes so left in a separate commit

## Issue ticket number and link

[Ticket](https://pins-ds.atlassian.net/browse/A2-7612)
