### PR TITLE
feat(appeals): add stored procedure for setting personal list entries and integration tests (A2-6158)

### DIFF
--- a/appeals/api/jest.config.js
+++ b/appeals/api/jest.config.js
@@ -3,6 +3,7 @@ export default {
 	moduleNameMapper: { '^uuid$': 'uuid' },
 	globalSetup: './global-setup.js',
 	setupFilesAfterEnv: ['<rootDir>/setup-tests.js'],
+	testPathIgnorePatterns: ['<rootDir>/src/server/tests/stored-procedures/'],
 	coverageThreshold: {
 		global: {
 			branches: 50,

--- a/appeals/api/jest.stored-procedures.config.js
+++ b/appeals/api/jest.stored-procedures.config.js
@@ -1,0 +1,9 @@
+export default {
+	transform: {},
+	moduleNameMapper: { '^uuid$': 'uuid' },
+	globalSetup: './stored-procedures.global-setup.js',
+	globalTeardown: './stored-procedures.global-teardown.js',
+	setupFiles: ['<rootDir>/stored-procedures.setup.js'],
+	testMatch: ['<rootDir>/src/server/tests/stored-procedures/**/*.integration.test.js'],
+	testTimeout: 180000
+};

--- a/appeals/api/package.json
+++ b/appeals/api/package.json
@@ -15,6 +15,7 @@
 		"test": "npm run prisma-generate && cross-env NODE_ENV=test NODE_OPTIONS=\"--experimental-vm-modules --expose-gc\" npx jest --logHeapUsage --ci",
 		"test:updateSnapshot": "npm run prisma-generate && cross-env NODE_ENV=test NODE_OPTIONS=\"--experimental-vm-modules --expose-gc\" npx jest --logHeapUsage --updateSnapshot",
 		"test:cov": "npm run prisma-generate && cross-env NODE_ENV=test NODE_OPTIONS=\"--experimental-vm-modules --expose-gc\" npx jest --forceExit --logHeapUsage --ci --coverage",
+		"test:stored-procedures": "npm run prisma-generate && cross-env NODE_ENV=test NODE_OPTIONS=\"--experimental-vm-modules --expose-gc\" npx jest --config jest.stored-procedures.config.js --runInBand",
 		"test:watch": "npm run test -- --watch",
 		"dev": "npm run prisma-generate && nodemon --experimental-json-modules -e js ./src/server.js",
 		"start": "node ./src/server.js",
@@ -95,6 +96,7 @@
 		"stream-chain": "^3.4.0",
 		"stream-json": "^1.9.1",
 		"supertest": "7.0.0",
+		"testcontainers": "^11.7.3",
 		"swagger-autogen": "^2.21.4",
 		"swagger-typescript-api": "^13.2.16"
 	},

--- a/appeals/api/src/database/migrations/20260320113501_add_procedure_sp_set_personal_list/migration.sql
+++ b/appeals/api/src/database/migrations/20260320113501_add_procedure_sp_set_personal_list/migration.sql
@@ -1,0 +1,329 @@
+-- Populates thePersonalList for all appeals or a specific one.
+CREATE OR ALTER PROCEDURE dbo.spSetPersonalList
+	(
+                @appealId                       AS INT = NULL,
+                @isNetResidentsAppealType       AS BIT = 0
+        )
+AS
+BEGIN
+	SET NOCOUNT ON;
+
+    DECLARE @STATE_TARGET_READY_TO_START INT = 5,
+	        @STATE_TARGET_LPA_QUESTIONNAIRE_DUE INT = 10,
+	        @STATE_TARGET_ASSIGN_CASE_OFFICER INT = 15,
+	        @STATE_TARGET_ISSUE_DETERMINATION INT = 30,
+	        @STATE_TARGET_ISSUE_DETERMINATION_AFTER_SITE_VISIT INT = 40,
+	        @STATE_TARGET_STATEMENT_REVIEW INT = 55,
+	        @STATE_TARGET_FINAL_COMMENT_REVIEW INT = 60;
+
+    DECLARE @parentId INT = NULL;
+
+    -- Create temp table to store the data we need to create the personal list table   
+	CREATE TABLE #personal 
+	(
+                appealId                            INT             NOT NULL,
+                parentAppealId                      INT             NULL,
+                caseCreatedDate                     DATETIME2       NOT NULL,
+                caseExtensionDate                   DATETIME2       NULL,
+
+                -- AppealStatus
+                status                              NVARCHAR(1000)  NULL,
+                statusCreatedAt                     DATETIME2       NULL,
+
+                -- Flags
+                completeOrWithdrawn                 BIT             NOT NULL    DEFAULT 0,
+                isParentAppeal                      BIT             NOT NULL    DEFAULT 0,
+                isChildAppeal                       BIT             NOT NULL    DEFAULT 0,
+                dueDate                             DATETIME2       NULL,
+
+                -- appellantCase
+                appellantCaseValidationOutcomeName  BIT             NOT NULL        DEFAULT 0,
+                numberOfResidencesNetChange         INT             NOT NULL        DEFAULT 0,
+
+                -- appealTimetable
+                lpaQuestionnaireDueDate             DATETIME2       NULL,
+                ipCommentsDueDate                   DATETIME2       NULL,
+                lpaStatementDueDate                 DATETIME2       NULL,
+                appellantStatementDueDate           DATETIME2       NULL,
+                proofOfEvidenceAndWitnessesDueDate  DATETIME2       NULL,
+                finalCommentsDueDate                DATETIME2       NULL,
+
+                -- procedureType
+                procedureTypeKey                    NVARCHAR(1000)  NULL, 
+
+                -- hearing
+                hearingStartTime                    DATETIME2       NULL,
+
+                -- inquiry
+                inquiryStartTime                    DATETIME2       NULL,
+                estimatedDays                       INT             NULL,
+
+                -- SiteVisit
+                siteVisitEndTime                    DATETIME2       NULL,
+                siteVisitDate                       DATETIME2       NULL,
+
+                -- Costs
+                appellantCostsApplication           INT             NOT NULL      DEFAULT(0),
+                appellantCostsWithdrawal            INT             NOT NULL      DEFAULT(0),
+                appellantCostsCorrespondence        INT             NOT NULL      DEFAULT(0),
+                lpaCostsApplication                 INT             NOT NULL      DEFAULT(0),
+                lpaCostsWithdrawal                  INT             NOT NULL      DEFAULT(0),
+                lpaCostsCorrespondence              INT             NOT NULL      DEFAULT(0),
+                lpaCostsDecisionLetter              INT             NOT NULL      DEFAULT(0),
+                awaitingLpaCostsDecision            INT             NOT NULL      DEFAULT(0),
+     
+                awaitingAppellantCostsDecision      BIT             NOT NULL      DEFAULT(0),
+                appellantCostsDecisionLetter        INT             NOT NULL      DEFAULT(0),
+
+		PRIMARY KEY (appealId)
+	);
+
+    IF @appealId IS NULL 
+    BEGIN
+            -- Insert the appeals
+            INSERT INTO #personal (appealId, caseCreatedDate, caseExtensionDate, procedureTypeKey ) 
+            SELECT  ap.id, ap.caseCreatedDate, ap.caseExtensionDate, pt.[key]
+            FROM    Appeal ap
+                    LEFT OUTER JOIN ProcedureType pt ON ap.procedureTypeId = pt.id;
+    END
+    ELSE
+    BEGIN
+            -- Change: the procedure now accepts Appeal.id directly, so linked lookups use parentId/childId instead of parentRef/childRef.
+            SELECT  @parentId = parentId FROM AppealRelationship WHERE parentId = @appealId OR childId = @appealId;
+
+            IF @parentId IS NULL
+            BEGIN
+                    -- Change: if the appeal is not linked, refresh just the standalone appeal that matches the supplied appeal id.
+                    INSERT INTO #personal (appealId, caseCreatedDate, caseExtensionDate, procedureTypeKey ) 
+                    SELECT  ap.id, ap.caseCreatedDate, ap.caseExtensionDate, pt.[key]
+                    FROM    Appeal ap
+                            LEFT OUTER JOIN ProcedureType pt ON ap.procedureTypeId = pt.id
+                    WHERE   ap.id = @appealId;
+            END
+            ELSE
+            BEGIN
+                    -- Existing linked behaviour: refresh the parent appeal and all children in that linked set, keyed by Appeal.id.
+                    INSERT INTO #personal (appealId, caseCreatedDate, caseExtensionDate, procedureTypeKey ) 
+                    SELECT  ap.id, ap.caseCreatedDate, ap.caseExtensionDate, pt.[key]
+                    FROM    Appeal ap
+                            LEFT OUTER JOIN ProcedureType pt ON ap.procedureTypeId = pt.id
+                    WHERE   ap.id = @parentId
+                    UNION ALL
+                    SELECT  ap.id, ap.caseCreatedDate, ap.caseExtensionDate, pt.[key]
+                    FROM    Appeal ap
+                            LEFT OUTER JOIN ProcedureType pt ON ap.procedureTypeId = pt.id
+                            INNER JOIN AppealRelationship ar ON ap.id = ar.childId AND parentId = @parentId;
+            END
+    END;
+
+    -- Add the appeal statuses to the temp table
+    UPDATE  #personal
+    SET     status = st.status,
+            statusCreatedAt = st.createdAt
+    FROM    #personal p 
+            INNER JOIN AppealStatus st ON p.appealId = st.appealId AND valid = 1;
+
+    -- Set the complete / withdrawn flag
+    UPDATE  #personal
+    SET     completeOrWithdrawn = CASE WHEN status = 'complete' OR status = 'withdrawn' THEN 1 ELSE 0 END;
+
+    -- Set the linked appeal flags
+    UPDATE  #personal
+    SET     parentAppealId = art.parentAppealId,
+            isParentAppeal = art.parentAppeal,
+            isChildAppeal = art.childAppeal
+    FROM    #personal p 
+            INNER JOIN ( 
+                    SELECT DISTINCT p.appealId, 
+                                    CASE WHEN p.appealId = ar.parentId THEN 1 ELSE 0 END as parentAppeal, 
+                                    CASE WHEN p.appealId = ar.childId THEN 1 ELSE 0 END AS childAppeal,
+                                    CASE WHEN p.appealId = ar.childId THEN ar.parentId ELSE ar.parentId END AS parentAppealId
+                    FROM    AppealRelationship ar 
+                            INNER JOIN #personal p ON p.appealId = ar.parentId OR p.appealId = ar.childId
+                    WHERE   ar.type = 'linked'
+            ) art ON  p.appealId = art.appealId;
+
+    -- Timetables
+    UPDATE  #personal
+    SET     lpaQuestionnaireDueDate             = tm.lpaQuestionnaireDueDate,
+            ipCommentsDueDate                   = tm.ipCommentsDueDate,
+            appellantStatementDueDate           = tm.appellantStatementDueDate,
+            proofOfEvidenceAndWitnessesDueDate  = tm.proofOfEvidenceAndWitnessesDueDate,
+            finalCommentsDueDate                = tm.finalCommentsDueDate
+    FROM    #personal p 
+            INNER JOIN AppealTimetable tm ON p.appealId = tm.appealId;
+
+    -- AppellantCase
+    UPDATE  #personal
+    SET     appellantCaseValidationOutcomeName  = 1,
+            numberOfResidencesNetChange = ISNULL(ac.numberOfResidencesNetChange, 0)
+    FROM    #personal p 
+            INNER JOIN AppellantCase ac ON p.appealId = ac.appealId
+            INNER JOIN appellantCaseValidationOutcome acvo  ON      ac.appellantCaseValidationOutcomeId = acvo.id
+                                                            AND     acvo.name = 'invalid';
+                                                            
+    -- SiteVisit
+    UPDATE  #personal
+    SET     siteVisitEndTime             = sv.visitEndTime,
+            siteVisitDate                = sv.visitDate
+    FROM    #personal p 
+            INNER JOIN SiteVisit sv ON p.appealId = sv.appealId;
+
+    -- Hearing
+    UPDATE  #personal
+    SET     hearingStartTime             = h.hearingStartTime
+    FROM    #personal p 
+            INNER JOIN Hearing h ON p.appealId = h.appealId;
+
+    -- Inquiry
+    UPDATE  #personal
+    SET     inquiryStartTime             = i.inquiryStartTime,
+            estimatedDays                = i.estimatedDays
+    FROM    #personal p 
+            INNER JOIN Inquiry i ON p.appealId = i.appealId;
+
+    -- COSTS
+    UPDATE  #personal
+    SET     appellantCostsApplication    = appellantCostsApplication    + CASE WHEN fd.costsType = 'appellantCostsApplication' THEN fd.documentCount ELSE 0 END,
+            appellantCostsWithdrawal     = appellantCostsWithdrawal     + CASE WHEN fd.costsType = 'appellantCostsWithdrawal' THEN fd.documentCount ELSE 0 END,
+            appellantCostsCorrespondence = appellantCostsCorrespondence + CASE WHEN fd.costsType = 'appellantCostsCorrespondence' THEN fd.documentCount ELSE 0 END,
+            lpaCostsApplication          = lpaCostsApplication          + CASE WHEN fd.costsType = 'lpaCostsApplication' THEN fd.documentCount ELSE 0 END,
+            lpaCostsWithdrawal           = lpaCostsWithdrawal           + CASE WHEN fd.costsType = 'lpaCostsWithdrawal' THEN fd.documentCount ELSE 0 END,
+            lpaCostsCorrespondence       = lpaCostsCorrespondence       + CASE WHEN fd.costsType = 'lpaCostsCorrespondence' THEN fd.documentCount ELSE 0 END,
+            appellantCostsDecisionLetter = appellantCostsDecisionLetter + CASE WHEN fd.costsType = 'appellantCostsDecisionLetter' THEN fd.documentCount ELSE 0 END,
+            lpaCostsDecisionLetter       = lpaCostsDecisionLetter       + CASE WHEN fd.costsType = 'lpaCostsDecisionLetter' THEN fd.documentCount ELSE 0 END
+    FROM    #personal p 
+            INNER JOIN ( 
+                    SELECT  f.caseId,
+                            REPLACE(f.path, 'costs/', '') AS costsType,
+                            COUNT(d.guid) AS documentCount
+                    FROM    Folder AS f
+                            LEFT JOIN Document AS d ON  d.folderId = f.id
+                                                    AND d.isDeleted = 0
+                    WHERE   f.path LIKE 'costs/%'        -- only folders under 'costs/'
+                    GROUP BY f.caseId, f.path
+            ) fd ON  p.appealId = fd.caseId;
+
+    UPDATE  #personal
+    SET     awaitingAppellantCostsDecision = CASE WHEN appellantCostsDecisionLetter = 0 AND appellantCostsApplication > appellantCostsWithdrawal THEN 1 ELSE 0 END,
+            awaitingLpaCostsDecision       = CASE WHEN lpaCostsDecisionLetter = 0 AND lpaCostsApplication > lpaCostsWithdrawal THEN 1 ELSE 0 END;
+
+    --
+    -- CalculateDueDate
+    --
+
+    UPDATE  #personal
+    SET     dueDate = CASE  WHEN appellantCaseValidationOutcomeName = 1 AND caseExtensionDate IS NOT NULL
+                            THEN caseExtensionDate
+                            ELSE DATEADD(day, @STATE_TARGET_READY_TO_START, caseCreatedDate) END
+    WHERE   status = 'ready_to_start';
+
+    UPDATE  #personal
+    SET     dueDate = CASE  WHEN lpaQuestionnaireDueDate IS NOT NULL
+                            THEN lpaQuestionnaireDueDate
+                            ELSE DATEADD(day, @STATE_TARGET_LPA_QUESTIONNAIRE_DUE, caseCreatedDate) END
+    WHERE   status = 'lpa_questionnaire';
+
+    UPDATE  #personal
+    SET     dueDate = DATEADD(day, @STATE_TARGET_ASSIGN_CASE_OFFICER, caseCreatedDate)
+    WHERE   status = 'assign_case_officer';
+
+    UPDATE  #personal
+    SET     dueDate = CASE WHEN caseExtensionDate IS NULL THEN caseCreatedDate ELSE caseExtensionDate END
+    WHERE   status = 'validation';
+
+    -- IssueDetermination TODO
+    UPDATE  #personal
+    SET     dueDate = CASE  WHEN siteVisitDate IS NOT NULL AND siteVisitEndTime IS NOT NULL THEN ( SELECT businessDate FROM NextBusinessDate WHERE currentDate = CONVERT(DATE, siteVisitEndTime) AND noBusinessDays = 40 )
+                            WHEN siteVisitDate IS NOT NULL THEN ( SELECT businessDate FROM NextBusinessDate WHERE currentDate = CONVERT(DATE, siteVisitDate) AND noBusinessDays = 5 )
+                            ELSE ( SELECT businessDate FROM NextBusinessDate WHERE currentDate = CONVERT(DATE, caseCreatedDate) AND noBusinessDays = 30 )
+                    END
+    WHERE   status = 'issue_determination';
+
+    SELECT p.appealId, siteVisitEndTime, CONVERT(DATE, siteVisitEndTime) as conSiteVisitEndTime, nbd.*
+    FROM   #personal p 
+           LEFT OUTER  JOIN NextBusinessDate nbd ON nbd.currentDate = CONVERT(DATE, siteVisitEndTime)
+    WHERE  p.appealId = 102;
+    
+
+    -- Complete 
+    UPDATE  #personal
+    SET     dueDate = CASE  WHEN awaitingAppellantCostsDecision IS NOT NULL OR awaitingLpaCostsDecision IS NOT NULL THEN ( SELECT businessDate FROM NextBusinessDate WHERE currentDate = statusCreatedAt AND noBusinessDays = 5 )
+                            WHEN numberOfResidencesNetChange IS NULL AND @isNetResidentsAppealType = 1 AND isChildAppeal = 1 THEN GETDATE()
+                    END
+    WHERE   status = 'complete';
+
+    UPDATE  #personal
+    SET     dueDate = CASE  WHEN lpaStatementDueDate IS NOT NULL AND ipCommentsDueDate IS NOT NULL AND lpaStatementDueDate < ipCommentsDueDate          THEN lpaStatementDueDate
+                            WHEN lpaStatementDueDate IS NOT NULL AND ipCommentsDueDate IS NOT NULL AND lpaStatementDueDate >= ipCommentsDueDate         THEN ipCommentsDueDate
+                            WHEN lpaStatementDueDate IS NOT NULL THEN lpaStatementDueDate
+                            WHEN ipCommentsDueDate IS NOT NULL THEN ipCommentsDueDate
+                            WHEN appellantStatementDueDate IS NOT NULL THEN appellantStatementDueDate
+                            ELSE DATEADD(day, @STATE_TARGET_STATEMENT_REVIEW, caseCreatedDate) END
+    WHERE   status = 'statements';
+
+    UPDATE  #personal
+    SET     dueDate = CASE  WHEN proofOfEvidenceAndWitnessesDueDate IS NOT NULL THEN proofOfEvidenceAndWitnessesDueDate
+                            ELSE NULL END
+    WHERE   status = 'evidence';
+
+    UPDATE  #personal
+    SET     dueDate = CASE  WHEN finalCommentsDueDate IS NOT NULL
+                            THEN finalCommentsDueDate
+                            ELSE DATEADD(day, @STATE_TARGET_FINAL_COMMENT_REVIEW, caseCreatedDate) END
+    WHERE   status = 'final_comments';
+
+    UPDATE  #personal
+    SET     dueDate = CASE  WHEN procedureTypeKey = 'hearing' THEN hearingStartTime
+                            WHEN procedureTypeKey = 'inquiry' THEN  
+                                    CASE WHEN inquiryStartTime IS NOT NULL THEN DATEADD(day, ISNULL(estimatedDays, 0), inquiryStartTime) END
+                            ELSE siteVisitDate END
+    WHERE   status = 'awaiting_event';
+
+    UPDATE  #personal
+    SET     dueDate = CASE  WHEN finalCommentsDueDate IS NOT NULL THEN finalCommentsDueDate
+                            WHEN lpaQuestionnaireDueDate IS NOT NULL THEN lpaQuestionnaireDueDate
+                            ELSE CAST('1970-01-01T00:00:00.000' AS datetime2) END
+    WHERE   status = 'event';
+
+    -- 5 business days to be added NOT 5 days
+    UPDATE  #personal
+    SET     dueDate = DATEADD(day, 5, statusCreatedAt)
+    WHERE   status = 'awaiting_transfer'
+    AND     statusCreatedAt IS NOT NULL;
+
+    -- 5 busioness days to be added NOT 5 days
+    UPDATE  #personal
+    SET     dueDate = CASE  WHEN awaitingAppellantCostsDecision IS NOT NULL OR awaitingLpaCostsDecision IS NOT NULL THEN DATEADD(day, 5, statusCreatedAt) END
+    WHERE   status = 'withdrawn';
+
+    UPDATE  p1
+    SET     dueDate = p2.dueDate
+    FROM    #personal p1 
+            INNER JOIN #personal p2 ON p2.isParentAppeal = 1 AND p1.parentAppealId = p2.appealId;
+
+    ;WITH SourceData AS
+    (
+    	SELECT	appealId, 
+            CASE WHEN isParentAppeal = 1 THEN 'parent'
+                    WHEN isChildAppeal = 1 THEN 'child'
+                    ELSE NULL
+            END AS linkType,
+            parentAppealId AS leadAppealId,
+            duedate
+	FROM	#personal
+    )
+
+    MERGE PersonalList AS target
+    USING SourceData AS source
+        ON target.appealId = source.appealId
+    WHEN MATCHED THEN
+        UPDATE SET
+            target.linkType     = source.linkType,
+            target.leadAppealId = source.leadAppealId,
+            target.dueDate      = source.dueDate
+    WHEN NOT MATCHED BY TARGET THEN
+        INSERT (appealId, linkType, leadAppealId, dueDate)
+        VALUES (source.appealId, source.linkType, source.leadAppealId, source.dueDate);
+
+END;

--- a/appeals/api/src/database/migrations/20260320113501_add_procedure_sp_set_personal_list/migration.sql
+++ b/appeals/api/src/database/migrations/20260320113501_add_procedure_sp_set_personal_list/migration.sql
@@ -40,6 +40,10 @@ BEGIN
 		@STATUS_VALIDATION NVARCHAR(1000) = 'validation',
 		@STATUS_WITHDRAWN NVARCHAR(1000) = 'withdrawn';
 
+	DECLARE @VALIDATION_OUTCOME_VALID INT =  (SELECT id FROM AppellantCaseValidationOutcome WHERE name='Valid'),
+		@VALIDATION_OUTCOME_INVALID INT =  (SELECT id FROM AppellantCaseValidationOutcome WHERE name='Invalid'),
+		@VALIDATION_OUTCOME_INCOMPLETE INT =  (SELECT id FROM AppellantCaseValidationOutcome WHERE name='Incomplete');
+
 
 	-- Create temp table to store the data we need to create the personal list table
 	CREATE TABLE #personal
@@ -63,8 +67,8 @@ BEGIN
 		dueDate                             DATETIME2       NULL,
 
 		-- appellantCase
-		appellantCaseValidationOutcomeName  BIT             NOT NULL        DEFAULT 0,
-		numberOfResidencesNetChange         INT             NOT NULL        DEFAULT 0,
+		appellantCaseValidationOutcomeId	INT             NULL,
+		numberOfResidencesNetChange         INT             NULL,
 
 		-- appealTimetable
 		lpaQuestionnaireDueDate             DATETIME2       NULL,
@@ -112,14 +116,14 @@ BEGIN
 			INSERT INTO #personal (appealId, caseCreatedDate, caseExtensionDate, procedureTypeKey, appealTypeId )
 			SELECT  ap.id, ap.caseCreatedDate, ap.caseExtensionDate, pt.[key], ap.appealTypeId
 			FROM    Appeal ap
-						LEFT OUTER JOIN ProcedureType pt ON ap.procedureTypeId = pt.id;
+					LEFT OUTER JOIN ProcedureType pt ON ap.procedureTypeId = pt.id;
 		END
 	ELSE
 		BEGIN
 			-- Change: the procedure now accepts Appeal.id directly, so linked lookups use parentId/childId instead of parentRef/childRef.
 			-- only get type linked appeals (not related)
 			SELECT  @parentId = parentId FROM AppealRelationship WHERE (parentId = @appealId OR childId = @appealId)
-			                                                       AND type = 'linked';
+					AND type = 'linked';
 
 			IF @parentId IS NULL
 				BEGIN
@@ -127,7 +131,7 @@ BEGIN
 					INSERT INTO #personal (appealId, caseCreatedDate, caseExtensionDate, procedureTypeKey, appealTypeId )
 					SELECT  ap.id, ap.caseCreatedDate, ap.caseExtensionDate, pt.[key], ap.appealTypeId
 					FROM    Appeal ap
-								LEFT OUTER JOIN ProcedureType pt ON ap.procedureTypeId = pt.id
+							LEFT OUTER JOIN ProcedureType pt ON ap.procedureTypeId = pt.id
 					WHERE   ap.id = @appealId;
 				END
 			ELSE
@@ -136,13 +140,13 @@ BEGIN
 					INSERT INTO #personal (appealId, caseCreatedDate, caseExtensionDate, procedureTypeKey, appealTypeId )
 					SELECT  ap.id, ap.caseCreatedDate, ap.caseExtensionDate, pt.[key], ap.appealTypeId
 					FROM    Appeal ap
-								LEFT OUTER JOIN ProcedureType pt ON ap.procedureTypeId = pt.id
+							LEFT OUTER JOIN ProcedureType pt ON ap.procedureTypeId = pt.id
 					WHERE   ap.id = @parentId
 					UNION ALL
 					SELECT  ap.id, ap.caseCreatedDate, ap.caseExtensionDate, pt.[key], ap.appealTypeId
 					FROM    Appeal ap
-								LEFT OUTER JOIN ProcedureType pt ON ap.procedureTypeId = pt.id
-						        INNER JOIN AppealRelationship ar ON ap.id = ar.childId AND parentId = @parentId;
+							LEFT OUTER JOIN ProcedureType pt ON ap.procedureTypeId = pt.id
+						    INNER JOIN AppealRelationship ar ON ap.id = ar.childId AND parentId = @parentId;
 				END
 		END;
 
@@ -151,7 +155,7 @@ BEGIN
 	SET     status = st.status,
 	        statusCreatedAt = st.createdAt
 	FROM    #personal p
-				INNER JOIN AppealStatus st ON p.appealId = st.appealId AND valid = 1;
+			INNER JOIN AppealStatus st ON p.appealId = st.appealId AND valid = 1;
 
 	-- Set the complete / withdrawn flag
 	UPDATE  #personal
@@ -163,15 +167,15 @@ BEGIN
 	        isParentAppeal = art.parentAppeal,
 	        isChildAppeal = art.childAppeal
 	FROM    #personal p
-				INNER JOIN (
-		SELECT DISTINCT p.appealId,
-		                CASE WHEN p.appealId = ar.parentId THEN 1 ELSE 0 END as parentAppeal,
-		                CASE WHEN p.appealId = ar.childId THEN 1 ELSE 0 END AS childAppeal,
-		                CASE WHEN p.appealId = ar.childId THEN ar.parentId ELSE ar.parentId END AS parentAppealId
-		FROM    AppealRelationship ar
-					INNER JOIN #personal p ON p.appealId = ar.parentId OR p.appealId = ar.childId
-		WHERE   ar.type = 'linked'
-	) art ON  p.appealId = art.appealId;
+			INNER JOIN (
+				SELECT DISTINCT p.appealId,
+								CASE WHEN p.appealId = ar.parentId THEN 1 ELSE 0 END as parentAppeal,
+								CASE WHEN p.appealId = ar.childId THEN 1 ELSE 0 END AS childAppeal,
+								CASE WHEN p.appealId = ar.childId THEN ar.parentId ELSE ar.parentId END AS parentAppealId
+				FROM    AppealRelationship ar
+						INNER JOIN #personal p ON p.appealId = ar.parentId OR p.appealId = ar.childId
+				WHERE   ar.type = 'linked'
+			) art ON  p.appealId = art.appealId;
 
 	-- Timetables
 	UPDATE  #personal
@@ -182,43 +186,41 @@ BEGIN
 	        finalCommentsDueDate                = tm.finalCommentsDueDate,
 	        lpaStatementDueDate					= tm.lpaStatementDueDate
 	FROM    #personal p
-				INNER JOIN AppealTimetable tm ON p.appealId = tm.appealId;
+			INNER JOIN AppealTimetable tm ON p.appealId = tm.appealId;
 
 	-- AppellantCase
 	UPDATE  #personal
-	SET     appellantCaseValidationOutcomeName  = 1,
-	        numberOfResidencesNetChange = ISNULL(ac.numberOfResidencesNetChange, 0)
+	SET     appellantCaseValidationOutcomeId  = ac.appellantCaseValidationOutcomeId,
+	        numberOfResidencesNetChange = ac.numberOfResidencesNetChange
 	FROM    #personal p
-				INNER JOIN AppellantCase ac ON p.appealId = ac.appealId
-		        INNER JOIN appellantCaseValidationOutcome acvo  ON      ac.appellantCaseValidationOutcomeId = acvo.id
-		AND     acvo.name = 'invalid';
+			INNER JOIN AppellantCase ac ON p.appealId = ac.appealId;
 
 	-- SiteVisit
 	UPDATE  #personal
 	SET     siteVisitEndTime             = sv.visitEndTime,
 	        siteVisitDate                = sv.visitDate
 	FROM    #personal p
-				INNER JOIN SiteVisit sv ON p.appealId = sv.appealId;
+			INNER JOIN SiteVisit sv ON p.appealId = sv.appealId;
 
 	-- Hearing
 	UPDATE  #personal
 	SET     hearingStartTime             = h.hearingStartTime
 	FROM    #personal p
-				INNER JOIN Hearing h ON p.appealId = h.appealId;
+			INNER JOIN Hearing h ON p.appealId = h.appealId;
 
 	-- Inquiry
 	UPDATE  #personal
 	SET     inquiryStartTime             = i.inquiryStartTime,
 	        estimatedDays                = i.estimatedDays
 	FROM    #personal p
-				INNER JOIN Inquiry i ON p.appealId = i.appealId;
+			INNER JOIN Inquiry i ON p.appealId = i.appealId;
 
 
 	-- Enforcement only - ground A Due Date
 	UPDATE  #personal
 	SET     groundAFeeReceiptDueDate     = enao.groundAFeeReceiptDueDate
 	FROM    #personal p
-				INNER JOIN EnforcementNoticeAppealOutcome enao ON enao.appealId = p.appealId
+			INNER JOIN EnforcementNoticeAppealOutcome enao ON enao.appealId = p.appealId
 	WHERE enao.groundAFeeReceiptDueDate IS NOT NULL
 	;
 
@@ -234,24 +236,24 @@ BEGIN
 	        appellantCostsDecisionLetter = appellantCostsDecisionLetter + fd.ctr_appellantCostsDecisionLetter,
 	        lpaCostsDecisionLetter       = lpaCostsDecisionLetter       + fd.ctr_lpaCostsDecisionLetter
 	FROM    #personal p
-				INNER JOIN (
-		SELECT  f.caseId,
-		        SUM(CASE WHEN f.path = 'costs/appellantCostsApplication'    THEN dc.documentCount ELSE 0 END) AS ctr_appellantCostsApplication,
-		        SUM(CASE WHEN f.path = 'costs/appellantCostsWithdrawal'     THEN dc.documentCount ELSE 0 END) AS ctr_appellantCostsWithdrawal,
-		        SUM(CASE WHEN f.path = 'costs/lpaCostsApplication'          THEN dc.documentCount ELSE 0 END) AS ctr_lpaCostsApplication,
-		        SUM(CASE WHEN f.path = 'costs/lpaCostsWithdrawal'           THEN dc.documentCount ELSE 0 END) AS ctr_lpaCostsWithdrawal,
-		        SUM(CASE WHEN f.path = 'costs/appellantCostsDecisionLetter' THEN dc.documentCount ELSE 0 END) AS ctr_appellantCostsDecisionLetter,
-		        SUM(CASE WHEN f.path = 'costs/lpaCostsDecisionLetter'       THEN dc.documentCount ELSE 0 END) AS ctr_lpaCostsDecisionLetter
-		FROM    Folder AS f
-					LEFT JOIN (
-			SELECT  folderId, COUNT(guid) AS documentCount
-			FROM    Document
-			WHERE   isDeleted = 0
-			GROUP BY folderId
-		) dc ON dc.folderId = f.id
-		WHERE   f.path LIKE 'costs/%'
-		GROUP BY f.caseId
-	) fd ON p.appealId = fd.caseId;
+			INNER JOIN (
+				SELECT  f.caseId,
+						SUM(CASE WHEN f.path = 'costs/appellantCostsApplication'    THEN dc.documentCount ELSE 0 END) AS ctr_appellantCostsApplication,
+						SUM(CASE WHEN f.path = 'costs/appellantCostsWithdrawal'     THEN dc.documentCount ELSE 0 END) AS ctr_appellantCostsWithdrawal,
+						SUM(CASE WHEN f.path = 'costs/lpaCostsApplication'          THEN dc.documentCount ELSE 0 END) AS ctr_lpaCostsApplication,
+						SUM(CASE WHEN f.path = 'costs/lpaCostsWithdrawal'           THEN dc.documentCount ELSE 0 END) AS ctr_lpaCostsWithdrawal,
+						SUM(CASE WHEN f.path = 'costs/appellantCostsDecisionLetter' THEN dc.documentCount ELSE 0 END) AS ctr_appellantCostsDecisionLetter,
+						SUM(CASE WHEN f.path = 'costs/lpaCostsDecisionLetter'       THEN dc.documentCount ELSE 0 END) AS ctr_lpaCostsDecisionLetter
+				FROM    Folder AS f
+						LEFT JOIN (
+							SELECT  folderId, COUNT(guid) AS documentCount
+							FROM    Document
+							WHERE   isDeleted = 0
+							GROUP BY folderId
+						) dc ON dc.folderId = f.id
+				WHERE   f.path LIKE 'costs/%'
+				GROUP BY f.caseId
+			) fd ON p.appealId = fd.caseId;
 
 	UPDATE  #personal
 	SET     awaitingAppellantCostsDecision = CASE WHEN appellantCostsDecisionLetter = 0 AND appellantCostsApplication > appellantCostsWithdrawal THEN 1 ELSE 0 END,
@@ -263,15 +265,15 @@ BEGIN
 
 	-- ready to start
 	UPDATE  #personal
-	SET     dueDate = CASE  WHEN appellantCaseValidationOutcomeName = 1 AND caseExtensionDate IS NOT NULL
-								THEN caseExtensionDate
+	SET     dueDate = CASE  WHEN appellantCaseValidationOutcomeId = @VALIDATION_OUTCOME_INCOMPLETE AND caseExtensionDate IS NOT NULL
+							THEN caseExtensionDate
 	                        ELSE DATEADD(day, @STATE_TARGET_READY_TO_START, caseCreatedDate) END
 	WHERE   status = @STATUS_READY_TO_START;
 
 	-- lpa questionnaire
 	UPDATE  #personal
 	SET     dueDate = CASE  WHEN lpaQuestionnaireDueDate IS NOT NULL
-								THEN lpaQuestionnaireDueDate
+							THEN lpaQuestionnaireDueDate
 	                        ELSE DATEADD(day, @STATE_TARGET_LPA_QUESTIONNAIRE_DUE, caseCreatedDate) END
 	WHERE   status = @STATUS_LPA_QUESTIONNAIRE;
 
@@ -283,9 +285,9 @@ BEGIN
 	-- validation
 	UPDATE  #personal
 	SET     dueDate = CASE	WHEN appealTypeId = @APPEAL_TYPE_ENFORCEMENT AND groundAFeeReceiptDueDate IS NOT NULL AND caseExtensionDate IS NOT NULL THEN
-								  CASE WHEN groundAFeeReceiptDueDate < caseExtensionDate THEN groundAFeeReceiptDueDate ELSE caseExtensionDate END
-	                          WHEN caseExtensionDate IS NULL THEN caseCreatedDate
-	                          ELSE caseExtensionDate END
+								CASE WHEN groundAFeeReceiptDueDate < caseExtensionDate THEN groundAFeeReceiptDueDate ELSE caseExtensionDate END
+	                        WHEN caseExtensionDate IS NULL THEN caseCreatedDate
+	                        ELSE caseExtensionDate END
 	WHERE   status = @STATUS_VALIDATION;
 
 
@@ -293,10 +295,10 @@ BEGIN
 	-- Note that businessDate is a date field with no time element, so we need to add the time part from the relevant visit date
 	UPDATE  #personal
 	SET     dueDate = CASE  WHEN siteVisitDate IS NOT NULL AND siteVisitEndTime IS NOT NULL THEN (
-		SELECT DATEADD(MILLISECOND, DATEDIFF(MILLISECOND, CAST(CAST(siteVisitEndTime AS DATE) AS DATETIME2), siteVisitEndTime), CAST(businessDate AS DATETIME2))
-		FROM NextBusinessDate
-		WHERE currentDate = CONVERT(DATE, siteVisitEndTime) AND noBusinessDays = @STATE_TARGET_ISSUE_DETERMINATION_AFTER_SITE_VISIT
-	)
+								SELECT DATEADD(MILLISECOND, DATEDIFF(MILLISECOND, CAST(CAST(siteVisitEndTime AS DATE) AS DATETIME2), siteVisitEndTime), CAST(businessDate AS DATETIME2))
+								FROM NextBusinessDate
+								WHERE currentDate = CONVERT(DATE, siteVisitEndTime) AND noBusinessDays = @STATE_TARGET_ISSUE_DETERMINATION_AFTER_SITE_VISIT
+							)
 	                        WHEN siteVisitDate IS NOT NULL THEN (
 								SELECT DATEADD(MILLISECOND, DATEDIFF(MILLISECOND, CAST(CAST(siteVisitDate AS DATE) AS DATETIME2), siteVisitDate), CAST(businessDate AS DATETIME2))
 		                        FROM NextBusinessDate
@@ -307,7 +309,7 @@ BEGIN
 		                        FROM NextBusinessDate
 		                        WHERE currentDate = CONVERT(DATE, caseCreatedDate) AND noBusinessDays = @STATE_TARGET_ISSUE_DETERMINATION
 							)
-		END
+					END
 	WHERE   status = @STATUS_ISSUE_DETERMINATION;
 
 
@@ -315,12 +317,12 @@ BEGIN
 	-- Note that businessDate is a date field with no time element, so we need to add the time part from the statusCreatedAt date
 	UPDATE  #personal
 	SET     dueDate = CASE  WHEN awaitingAppellantCostsDecision =1 OR awaitingLpaCostsDecision =1 THEN (
-		SELECT DATEADD(MILLISECOND, DATEDIFF(MILLISECOND, CAST(CAST(statusCreatedAt AS DATE) AS DATETIME2), statusCreatedAt), CAST(businessDate AS DATETIME2))
-		FROM NextBusinessDate
-		WHERE currentDate = CONVERT(DATE, statusCreatedAt) AND noBusinessDays = @STATE_TARGET_5_BUSINESS_DAYS )
-	                        WHEN numberOfResidencesNetChange =0 AND appealTypeId IN (@APPEAL_TYPE_S78, @APPEAL_TYPE_PLANNED_LISTED_BUILDING) AND isChildAppeal = 0 THEN GETDATE()
-	                        ELSE NULL
-		END
+								SELECT DATEADD(MILLISECOND, DATEDIFF(MILLISECOND, CAST(CAST(statusCreatedAt AS DATE) AS DATETIME2), statusCreatedAt), CAST(businessDate AS DATETIME2))
+								FROM NextBusinessDate
+								WHERE currentDate = CONVERT(DATE, statusCreatedAt) AND noBusinessDays = @STATE_TARGET_5_BUSINESS_DAYS )
+							WHEN numberOfResidencesNetChange IS NULL AND appealTypeId IN (@APPEAL_TYPE_S78, @APPEAL_TYPE_PLANNED_LISTED_BUILDING) AND isChildAppeal = 0 THEN GETDATE()
+							ELSE NULL
+					END
 	WHERE   status = @STATUS_COMPLETE;
 
 	-- statements
@@ -342,7 +344,7 @@ BEGIN
 	-- final comments
 	UPDATE  #personal
 	SET     dueDate = CASE  WHEN finalCommentsDueDate IS NOT NULL
-								THEN finalCommentsDueDate
+							THEN finalCommentsDueDate
 	                        ELSE DATEADD(day, @STATE_TARGET_FINAL_COMMENT_REVIEW, caseCreatedDate) END
 	WHERE   status = @STATUS_FINAL_COMMENTS;
 
@@ -367,44 +369,44 @@ BEGIN
 	                   FROM NextBusinessDate
 	                   WHERE currentDate = CONVERT(DATE, statusCreatedAt) AND noBusinessDays = @STATE_TARGET_5_BUSINESS_DAYS )
 	WHERE   status = @STATUS_AWAITING_TRANSFER
-	  AND     statusCreatedAt IS NOT NULL;
+	AND     statusCreatedAt IS NOT NULL;
 
 	-- withdrawn - add 5 business days
 	UPDATE  #personal
 	SET     dueDate = CASE  WHEN awaitingAppellantCostsDecision =1 OR awaitingLpaCostsDecision =1 THEN (
-		SELECT DATEADD(MILLISECOND, DATEDIFF(MILLISECOND, CAST(CAST(statusCreatedAt AS DATE) AS DATETIME2), statusCreatedAt), CAST(businessDate AS DATETIME2))
-		FROM NextBusinessDate
-		WHERE currentDate = CONVERT(DATE, statusCreatedAt) AND noBusinessDays = @STATE_TARGET_5_BUSINESS_DAYS )
-	                        ELSE NULL
-		END
+								SELECT DATEADD(MILLISECOND, DATEDIFF(MILLISECOND, CAST(CAST(statusCreatedAt AS DATE) AS DATETIME2), statusCreatedAt), CAST(businessDate AS DATETIME2))
+								FROM NextBusinessDate
+								WHERE currentDate = CONVERT(DATE, statusCreatedAt) AND noBusinessDays = @STATE_TARGET_5_BUSINESS_DAYS )
+							ELSE NULL
+							END
 	WHERE   status = @STATUS_WITHDRAWN;
 
 	-- Finally update the PersonalList table
 	UPDATE  p1
 	SET     dueDate = p2.dueDate
 	FROM    #personal p1
-				INNER JOIN #personal p2 ON p2.isParentAppeal = 1 AND p1.parentAppealId = p2.appealId;
+			INNER JOIN #personal p2 ON p2.isParentAppeal = 1 AND p1.parentAppealId = p2.appealId;
 
 	;WITH SourceData AS
-		(
+	(
 		SELECT	appealId,
-		          CASE WHEN isParentAppeal = 1 THEN 'parent'
-		               WHEN isChildAppeal = 1 THEN 'child'
-		               ELSE NULL
-					  END AS linkType,
-		          parentAppealId AS leadAppealId,
-		          duedate
+			CASE WHEN isParentAppeal = 1 THEN 'parent'
+					WHEN isChildAppeal = 1 THEN 'child'
+					ELSE NULL
+			END AS linkType,
+			parentAppealId AS leadAppealId,
+			duedate
 		FROM	#personal
-		)
+	)
 
-		MERGE PersonalList AS target
+	MERGE PersonalList AS target
 	USING SourceData AS source
-	ON target.appealId = source.appealId
+		ON target.appealId = source.appealId
 	WHEN MATCHED THEN
 		UPDATE SET
-				   target.linkType     = source.linkType,
-			       target.leadAppealId = source.leadAppealId,
-			       target.dueDate      = source.dueDate
+			target.linkType     = source.linkType,
+			target.leadAppealId = source.leadAppealId,
+			target.dueDate      = source.dueDate
 	WHEN NOT MATCHED BY TARGET THEN
 		INSERT (appealId, linkType, leadAppealId, dueDate)
 		VALUES (source.appealId, source.linkType, source.leadAppealId, source.dueDate);

--- a/appeals/api/src/database/migrations/20260320113501_add_procedure_sp_set_personal_list/migration.sql
+++ b/appeals/api/src/database/migrations/20260320113501_add_procedure_sp_set_personal_list/migration.sql
@@ -171,7 +171,7 @@ BEGIN
 				SELECT DISTINCT p.appealId,
 								CASE WHEN p.appealId = ar.parentId THEN 1 ELSE 0 END as parentAppeal,
 								CASE WHEN p.appealId = ar.childId THEN 1 ELSE 0 END AS childAppeal,
-								CASE WHEN p.appealId = ar.childId THEN ar.parentId ELSE ar.parentId END AS parentAppealId
+								ar.parentId AS parentAppealId
 				FROM    AppealRelationship ar
 						INNER JOIN #personal p ON p.appealId = ar.parentId OR p.appealId = ar.childId
 				WHERE   ar.type = 'linked'

--- a/appeals/api/src/database/migrations/20260320113501_add_procedure_sp_set_personal_list/migration.sql
+++ b/appeals/api/src/database/migrations/20260320113501_add_procedure_sp_set_personal_list/migration.sql
@@ -223,24 +223,35 @@ BEGIN
 	;
 
 	-- COSTS
+	-- Note: Use conditional aggregation inside the subquery so there is exactly one row per caseId with 6 separate columns:
+	--		 This avoids the JOIN table to multiple rows in a SQL Server UPDATE, only one of the matching rows is applied (the "last one wins" — but which row is picked is non-deterministic).
+	--		 This method ensures that all 6 values correctly get totalled
 	UPDATE  #personal
-	SET     appellantCostsApplication    = appellantCostsApplication    + CASE WHEN fd.costsType = 'appellantCostsApplication' THEN fd.documentCount ELSE 0 END,
-	        appellantCostsWithdrawal     = appellantCostsWithdrawal     + CASE WHEN fd.costsType = 'appellantCostsWithdrawal' THEN fd.documentCount ELSE 0 END,
-	        lpaCostsApplication          = lpaCostsApplication          + CASE WHEN fd.costsType = 'lpaCostsApplication' THEN fd.documentCount ELSE 0 END,
-	        lpaCostsWithdrawal           = lpaCostsWithdrawal           + CASE WHEN fd.costsType = 'lpaCostsWithdrawal' THEN fd.documentCount ELSE 0 END,
-	        appellantCostsDecisionLetter = appellantCostsDecisionLetter + CASE WHEN fd.costsType = 'appellantCostsDecisionLetter' THEN fd.documentCount ELSE 0 END,
-	        lpaCostsDecisionLetter       = lpaCostsDecisionLetter       + CASE WHEN fd.costsType = 'lpaCostsDecisionLetter' THEN fd.documentCount ELSE 0 END
+	SET     appellantCostsApplication    = appellantCostsApplication    + fd.ctr_appellantCostsApplication,
+	        appellantCostsWithdrawal     = appellantCostsWithdrawal     + fd.ctr_appellantCostsWithdrawal,
+	        lpaCostsApplication          = lpaCostsApplication          + fd.ctr_lpaCostsApplication,
+	        lpaCostsWithdrawal           = lpaCostsWithdrawal           + fd.ctr_lpaCostsWithdrawal,
+	        appellantCostsDecisionLetter = appellantCostsDecisionLetter + fd.ctr_appellantCostsDecisionLetter,
+	        lpaCostsDecisionLetter       = lpaCostsDecisionLetter       + fd.ctr_lpaCostsDecisionLetter
 	FROM    #personal p
 				INNER JOIN (
 		SELECT  f.caseId,
-		        REPLACE(f.path, 'costs/', '') AS costsType,
-		        COUNT(d.guid) AS documentCount
+		        SUM(CASE WHEN f.path = 'costs/appellantCostsApplication'    THEN dc.documentCount ELSE 0 END) AS ctr_appellantCostsApplication,
+		        SUM(CASE WHEN f.path = 'costs/appellantCostsWithdrawal'     THEN dc.documentCount ELSE 0 END) AS ctr_appellantCostsWithdrawal,
+		        SUM(CASE WHEN f.path = 'costs/lpaCostsApplication'          THEN dc.documentCount ELSE 0 END) AS ctr_lpaCostsApplication,
+		        SUM(CASE WHEN f.path = 'costs/lpaCostsWithdrawal'           THEN dc.documentCount ELSE 0 END) AS ctr_lpaCostsWithdrawal,
+		        SUM(CASE WHEN f.path = 'costs/appellantCostsDecisionLetter' THEN dc.documentCount ELSE 0 END) AS ctr_appellantCostsDecisionLetter,
+		        SUM(CASE WHEN f.path = 'costs/lpaCostsDecisionLetter'       THEN dc.documentCount ELSE 0 END) AS ctr_lpaCostsDecisionLetter
 		FROM    Folder AS f
-					LEFT JOIN Document AS d ON  d.folderId = f.id
-			AND d.isDeleted = 0
-		WHERE   f.path LIKE 'costs/%'        -- only folders under 'costs/'
-		GROUP BY f.caseId, f.path
-	) fd ON  p.appealId = fd.caseId;
+					LEFT JOIN (
+			SELECT  folderId, COUNT(guid) AS documentCount
+			FROM    Document
+			WHERE   isDeleted = 0
+			GROUP BY folderId
+		) dc ON dc.folderId = f.id
+		WHERE   f.path LIKE 'costs/%'
+		GROUP BY f.caseId
+	) fd ON p.appealId = fd.caseId;
 
 	UPDATE  #personal
 	SET     awaitingAppellantCostsDecision = CASE WHEN appellantCostsDecisionLetter = 0 AND appellantCostsApplication > appellantCostsWithdrawal THEN 1 ELSE 0 END,

--- a/appeals/api/src/database/stored-procedures/spPopulateCalendarDates.sql
+++ b/appeals/api/src/database/stored-procedures/spPopulateCalendarDates.sql
@@ -1,0 +1,55 @@
+-- Stored Procedure: spPopulateCalendarDates
+-- This stored procedure populates the CalendarDate table with a record for each date, indicating whether it is a weekend or a bank holiday.
+-- It is used to identify Business Days for the purpose of calculating deadlines and other date-related logic in the application.
+CREATE OR ALTER PROCEDURE dbo.spPopulateCalendarDates
+AS
+BEGIN
+	SET NOCOUNT ON;
+
+	-- Ensure consistent weekday numbering (Sunday=1, Saturday=7)
+	SET DATEFIRST 7;
+
+	DECLARE @StartDate DATE = '2025-01-01';
+	DECLARE @EndDate   DATE = DATEADD(YEAR, 1, CAST(GETDATE() AS DATE));
+
+	;WITH DateSeries AS
+			  (
+				  SELECT @StartDate AS DateValue
+			      UNION ALL
+			      SELECT DATEADD(DAY, 1, DateValue)
+			      FROM DateSeries
+			      WHERE DateValue < @EndDate
+			  )
+	 INSERT INTO dbo.CalendarDate
+	 (
+		 currentDate,
+		 isWeekend,
+		 isBankHoliday
+	 )
+	 SELECT
+		 d.DateValue,
+		 CASE
+			 WHEN DATEPART(WEEKDAY, d.DateValue) IN (1, 7) THEN 1
+			 ELSE 0
+			 END AS isWeekend,
+		 0 AS isBankHoliday
+	 FROM DateSeries d
+	 WHERE NOT EXISTS
+			   (
+				   SELECT 1
+			       FROM dbo.CalendarDate c
+			       WHERE c.currentDate = d.DateValue
+			   )
+	 OPTION (MAXRECURSION 32767);
+
+	UPDATE CalendarDate
+	SET    isBankHoliday = 0
+	WHERE  isBankHoliday = 1;
+
+	-- Update the InvalidReasonsSelected
+	UPDATE CalendarDate
+	SET    isBankHoliday = 1
+	FROM   CalendarDate cal
+			   INNER JOIN BankHoliday bh ON cal.currentDate = bh.bankHolidayDate;
+
+END;

--- a/appeals/api/src/database/stored-procedures/spPopulateNextBusinessDates.sql
+++ b/appeals/api/src/database/stored-procedures/spPopulateNextBusinessDates.sql
@@ -1,0 +1,51 @@
+-- Stored Procedure to populate the NextBusinessDate for each date in the CalendarDate table for the number of business dates.
+-- Used to calculate the next business date for a given number of business days from a specific date, taking into account weekends and bank holidays.
+CREATE OR ALTER PROCEDURE dbo.spPopulateNextBusinessDates
+@BusinessDays INT
+AS
+BEGIN
+	SET NOCOUNT ON;
+
+	;WITH BusinessDates AS
+		(
+		SELECT
+			CAST(currentDate AS date) AS businessDate
+		FROM CalendarDate
+		WHERE isWeekend = 0
+		  AND isBankHoliday = 0
+		),
+		RankedBusinessDates AS
+			(
+			SELECT
+				CAST(c.currentDate AS date) AS currentDate,
+				CAST(@BusinessDays AS int) AS noBusinessDays,
+				b.businessDate AS businessDate,
+				ROW_NUMBER() OVER
+					(
+					PARTITION BY CAST(c.currentDate AS date)
+					ORDER BY b.businessDate
+					) AS rn
+			FROM CalendarDate c
+					 INNER JOIN BusinessDates b
+								ON b.businessDate > CAST(c.currentDate AS date)
+			),
+		FinalResult AS
+			(
+			SELECT
+				currentDate,
+				noBusinessDays,
+				businessDate
+			FROM RankedBusinessDates
+			WHERE rn = CAST(@BusinessDays AS int)
+			)
+		MERGE NextBusinessDate AS tgt
+	USING FinalResult AS src
+	ON tgt.currentDate = src.currentDate
+		AND tgt.noBusinessDays = src.noBusinessDays
+	WHEN MATCHED THEN
+		UPDATE SET tgt.businessDate = src.businessDate
+	WHEN NOT MATCHED THEN
+		INSERT (currentDate, noBusinessDays, businessDate)
+		VALUES (src.currentDate, src.noBusinessDays, src.businessDate);
+
+END;

--- a/appeals/api/src/database/stored-procedures/spSetPersonalList.sql
+++ b/appeals/api/src/database/stored-procedures/spSetPersonalList.sql
@@ -171,7 +171,7 @@ BEGIN
 				SELECT DISTINCT p.appealId,
 								CASE WHEN p.appealId = ar.parentId THEN 1 ELSE 0 END as parentAppeal,
 								CASE WHEN p.appealId = ar.childId THEN 1 ELSE 0 END AS childAppeal,
-								CASE WHEN p.appealId = ar.childId THEN ar.parentId ELSE ar.parentId END AS parentAppealId
+								ar.parentId AS parentAppealId
 				FROM    AppealRelationship ar
 						INNER JOIN #personal p ON p.appealId = ar.parentId OR p.appealId = ar.childId
 				WHERE   ar.type = 'linked'

--- a/appeals/api/src/database/stored-procedures/spSetPersonalList.sql
+++ b/appeals/api/src/database/stored-procedures/spSetPersonalList.sql
@@ -40,6 +40,10 @@ BEGIN
 		@STATUS_VALIDATION NVARCHAR(1000) = 'validation',
 		@STATUS_WITHDRAWN NVARCHAR(1000) = 'withdrawn';
 
+	DECLARE @VALIDATION_OUTCOME_VALID INT =  (SELECT id FROM AppellantCaseValidationOutcome WHERE name='Valid'),
+		@VALIDATION_OUTCOME_INVALID INT =  (SELECT id FROM AppellantCaseValidationOutcome WHERE name='Invalid'),
+		@VALIDATION_OUTCOME_INCOMPLETE INT =  (SELECT id FROM AppellantCaseValidationOutcome WHERE name='Incomplete');
+
 
 	-- Create temp table to store the data we need to create the personal list table
 	CREATE TABLE #personal
@@ -63,8 +67,8 @@ BEGIN
 		dueDate                             DATETIME2       NULL,
 
 		-- appellantCase
-		appellantCaseValidationOutcomeName  BIT             NOT NULL        DEFAULT 0,
-		numberOfResidencesNetChange         INT             NOT NULL        DEFAULT 0,
+		appellantCaseValidationOutcomeId	INT             NULL,
+		numberOfResidencesNetChange         INT             NULL,
 
 		-- appealTimetable
 		lpaQuestionnaireDueDate             DATETIME2       NULL,
@@ -112,14 +116,14 @@ BEGIN
 			INSERT INTO #personal (appealId, caseCreatedDate, caseExtensionDate, procedureTypeKey, appealTypeId )
 			SELECT  ap.id, ap.caseCreatedDate, ap.caseExtensionDate, pt.[key], ap.appealTypeId
 			FROM    Appeal ap
-						LEFT OUTER JOIN ProcedureType pt ON ap.procedureTypeId = pt.id;
+					LEFT OUTER JOIN ProcedureType pt ON ap.procedureTypeId = pt.id;
 		END
 	ELSE
 		BEGIN
 			-- Change: the procedure now accepts Appeal.id directly, so linked lookups use parentId/childId instead of parentRef/childRef.
 			-- only get type linked appeals (not related)
 			SELECT  @parentId = parentId FROM AppealRelationship WHERE (parentId = @appealId OR childId = @appealId)
-			                                                       AND type = 'linked';
+					AND type = 'linked';
 
 			IF @parentId IS NULL
 				BEGIN
@@ -127,7 +131,7 @@ BEGIN
 					INSERT INTO #personal (appealId, caseCreatedDate, caseExtensionDate, procedureTypeKey, appealTypeId )
 					SELECT  ap.id, ap.caseCreatedDate, ap.caseExtensionDate, pt.[key], ap.appealTypeId
 					FROM    Appeal ap
-								LEFT OUTER JOIN ProcedureType pt ON ap.procedureTypeId = pt.id
+							LEFT OUTER JOIN ProcedureType pt ON ap.procedureTypeId = pt.id
 					WHERE   ap.id = @appealId;
 				END
 			ELSE
@@ -136,13 +140,13 @@ BEGIN
 					INSERT INTO #personal (appealId, caseCreatedDate, caseExtensionDate, procedureTypeKey, appealTypeId )
 					SELECT  ap.id, ap.caseCreatedDate, ap.caseExtensionDate, pt.[key], ap.appealTypeId
 					FROM    Appeal ap
-								LEFT OUTER JOIN ProcedureType pt ON ap.procedureTypeId = pt.id
+							LEFT OUTER JOIN ProcedureType pt ON ap.procedureTypeId = pt.id
 					WHERE   ap.id = @parentId
 					UNION ALL
 					SELECT  ap.id, ap.caseCreatedDate, ap.caseExtensionDate, pt.[key], ap.appealTypeId
 					FROM    Appeal ap
-								LEFT OUTER JOIN ProcedureType pt ON ap.procedureTypeId = pt.id
-						        INNER JOIN AppealRelationship ar ON ap.id = ar.childId AND parentId = @parentId;
+							LEFT OUTER JOIN ProcedureType pt ON ap.procedureTypeId = pt.id
+						    INNER JOIN AppealRelationship ar ON ap.id = ar.childId AND parentId = @parentId;
 				END
 		END;
 
@@ -151,7 +155,7 @@ BEGIN
 	SET     status = st.status,
 	        statusCreatedAt = st.createdAt
 	FROM    #personal p
-				INNER JOIN AppealStatus st ON p.appealId = st.appealId AND valid = 1;
+			INNER JOIN AppealStatus st ON p.appealId = st.appealId AND valid = 1;
 
 	-- Set the complete / withdrawn flag
 	UPDATE  #personal
@@ -163,15 +167,15 @@ BEGIN
 	        isParentAppeal = art.parentAppeal,
 	        isChildAppeal = art.childAppeal
 	FROM    #personal p
-				INNER JOIN (
-		SELECT DISTINCT p.appealId,
-		                CASE WHEN p.appealId = ar.parentId THEN 1 ELSE 0 END as parentAppeal,
-		                CASE WHEN p.appealId = ar.childId THEN 1 ELSE 0 END AS childAppeal,
-		                CASE WHEN p.appealId = ar.childId THEN ar.parentId ELSE ar.parentId END AS parentAppealId
-		FROM    AppealRelationship ar
-					INNER JOIN #personal p ON p.appealId = ar.parentId OR p.appealId = ar.childId
-		WHERE   ar.type = 'linked'
-	) art ON  p.appealId = art.appealId;
+			INNER JOIN (
+				SELECT DISTINCT p.appealId,
+								CASE WHEN p.appealId = ar.parentId THEN 1 ELSE 0 END as parentAppeal,
+								CASE WHEN p.appealId = ar.childId THEN 1 ELSE 0 END AS childAppeal,
+								CASE WHEN p.appealId = ar.childId THEN ar.parentId ELSE ar.parentId END AS parentAppealId
+				FROM    AppealRelationship ar
+						INNER JOIN #personal p ON p.appealId = ar.parentId OR p.appealId = ar.childId
+				WHERE   ar.type = 'linked'
+			) art ON  p.appealId = art.appealId;
 
 	-- Timetables
 	UPDATE  #personal
@@ -182,43 +186,41 @@ BEGIN
 	        finalCommentsDueDate                = tm.finalCommentsDueDate,
 	        lpaStatementDueDate					= tm.lpaStatementDueDate
 	FROM    #personal p
-				INNER JOIN AppealTimetable tm ON p.appealId = tm.appealId;
+			INNER JOIN AppealTimetable tm ON p.appealId = tm.appealId;
 
 	-- AppellantCase
 	UPDATE  #personal
-	SET     appellantCaseValidationOutcomeName  = 1,
-	        numberOfResidencesNetChange = ISNULL(ac.numberOfResidencesNetChange, 0)
+	SET     appellantCaseValidationOutcomeId  = ac.appellantCaseValidationOutcomeId,
+	        numberOfResidencesNetChange = ac.numberOfResidencesNetChange
 	FROM    #personal p
-				INNER JOIN AppellantCase ac ON p.appealId = ac.appealId
-		        INNER JOIN appellantCaseValidationOutcome acvo  ON      ac.appellantCaseValidationOutcomeId = acvo.id
-		AND     acvo.name = 'invalid';
+			INNER JOIN AppellantCase ac ON p.appealId = ac.appealId;
 
 	-- SiteVisit
 	UPDATE  #personal
 	SET     siteVisitEndTime             = sv.visitEndTime,
 	        siteVisitDate                = sv.visitDate
 	FROM    #personal p
-				INNER JOIN SiteVisit sv ON p.appealId = sv.appealId;
+			INNER JOIN SiteVisit sv ON p.appealId = sv.appealId;
 
 	-- Hearing
 	UPDATE  #personal
 	SET     hearingStartTime             = h.hearingStartTime
 	FROM    #personal p
-				INNER JOIN Hearing h ON p.appealId = h.appealId;
+			INNER JOIN Hearing h ON p.appealId = h.appealId;
 
 	-- Inquiry
 	UPDATE  #personal
 	SET     inquiryStartTime             = i.inquiryStartTime,
 	        estimatedDays                = i.estimatedDays
 	FROM    #personal p
-				INNER JOIN Inquiry i ON p.appealId = i.appealId;
+			INNER JOIN Inquiry i ON p.appealId = i.appealId;
 
 
 	-- Enforcement only - ground A Due Date
 	UPDATE  #personal
 	SET     groundAFeeReceiptDueDate     = enao.groundAFeeReceiptDueDate
 	FROM    #personal p
-				INNER JOIN EnforcementNoticeAppealOutcome enao ON enao.appealId = p.appealId
+			INNER JOIN EnforcementNoticeAppealOutcome enao ON enao.appealId = p.appealId
 	WHERE enao.groundAFeeReceiptDueDate IS NOT NULL
 	;
 
@@ -234,24 +236,24 @@ BEGIN
 	        appellantCostsDecisionLetter = appellantCostsDecisionLetter + fd.ctr_appellantCostsDecisionLetter,
 	        lpaCostsDecisionLetter       = lpaCostsDecisionLetter       + fd.ctr_lpaCostsDecisionLetter
 	FROM    #personal p
-				INNER JOIN (
-		SELECT  f.caseId,
-		        SUM(CASE WHEN f.path = 'costs/appellantCostsApplication'    THEN dc.documentCount ELSE 0 END) AS ctr_appellantCostsApplication,
-		        SUM(CASE WHEN f.path = 'costs/appellantCostsWithdrawal'     THEN dc.documentCount ELSE 0 END) AS ctr_appellantCostsWithdrawal,
-		        SUM(CASE WHEN f.path = 'costs/lpaCostsApplication'          THEN dc.documentCount ELSE 0 END) AS ctr_lpaCostsApplication,
-		        SUM(CASE WHEN f.path = 'costs/lpaCostsWithdrawal'           THEN dc.documentCount ELSE 0 END) AS ctr_lpaCostsWithdrawal,
-		        SUM(CASE WHEN f.path = 'costs/appellantCostsDecisionLetter' THEN dc.documentCount ELSE 0 END) AS ctr_appellantCostsDecisionLetter,
-		        SUM(CASE WHEN f.path = 'costs/lpaCostsDecisionLetter'       THEN dc.documentCount ELSE 0 END) AS ctr_lpaCostsDecisionLetter
-		FROM    Folder AS f
-					LEFT JOIN (
-			SELECT  folderId, COUNT(guid) AS documentCount
-			FROM    Document
-			WHERE   isDeleted = 0
-			GROUP BY folderId
-		) dc ON dc.folderId = f.id
-		WHERE   f.path LIKE 'costs/%'
-		GROUP BY f.caseId
-	) fd ON p.appealId = fd.caseId;
+			INNER JOIN (
+				SELECT  f.caseId,
+						SUM(CASE WHEN f.path = 'costs/appellantCostsApplication'    THEN dc.documentCount ELSE 0 END) AS ctr_appellantCostsApplication,
+						SUM(CASE WHEN f.path = 'costs/appellantCostsWithdrawal'     THEN dc.documentCount ELSE 0 END) AS ctr_appellantCostsWithdrawal,
+						SUM(CASE WHEN f.path = 'costs/lpaCostsApplication'          THEN dc.documentCount ELSE 0 END) AS ctr_lpaCostsApplication,
+						SUM(CASE WHEN f.path = 'costs/lpaCostsWithdrawal'           THEN dc.documentCount ELSE 0 END) AS ctr_lpaCostsWithdrawal,
+						SUM(CASE WHEN f.path = 'costs/appellantCostsDecisionLetter' THEN dc.documentCount ELSE 0 END) AS ctr_appellantCostsDecisionLetter,
+						SUM(CASE WHEN f.path = 'costs/lpaCostsDecisionLetter'       THEN dc.documentCount ELSE 0 END) AS ctr_lpaCostsDecisionLetter
+				FROM    Folder AS f
+						LEFT JOIN (
+							SELECT  folderId, COUNT(guid) AS documentCount
+							FROM    Document
+							WHERE   isDeleted = 0
+							GROUP BY folderId
+						) dc ON dc.folderId = f.id
+				WHERE   f.path LIKE 'costs/%'
+				GROUP BY f.caseId
+			) fd ON p.appealId = fd.caseId;
 
 	UPDATE  #personal
 	SET     awaitingAppellantCostsDecision = CASE WHEN appellantCostsDecisionLetter = 0 AND appellantCostsApplication > appellantCostsWithdrawal THEN 1 ELSE 0 END,
@@ -263,15 +265,15 @@ BEGIN
 
 	-- ready to start
 	UPDATE  #personal
-	SET     dueDate = CASE  WHEN appellantCaseValidationOutcomeName = 1 AND caseExtensionDate IS NOT NULL
-								THEN caseExtensionDate
+	SET     dueDate = CASE  WHEN appellantCaseValidationOutcomeId = @VALIDATION_OUTCOME_INCOMPLETE AND caseExtensionDate IS NOT NULL
+							THEN caseExtensionDate
 	                        ELSE DATEADD(day, @STATE_TARGET_READY_TO_START, caseCreatedDate) END
 	WHERE   status = @STATUS_READY_TO_START;
 
 	-- lpa questionnaire
 	UPDATE  #personal
 	SET     dueDate = CASE  WHEN lpaQuestionnaireDueDate IS NOT NULL
-								THEN lpaQuestionnaireDueDate
+							THEN lpaQuestionnaireDueDate
 	                        ELSE DATEADD(day, @STATE_TARGET_LPA_QUESTIONNAIRE_DUE, caseCreatedDate) END
 	WHERE   status = @STATUS_LPA_QUESTIONNAIRE;
 
@@ -283,9 +285,9 @@ BEGIN
 	-- validation
 	UPDATE  #personal
 	SET     dueDate = CASE	WHEN appealTypeId = @APPEAL_TYPE_ENFORCEMENT AND groundAFeeReceiptDueDate IS NOT NULL AND caseExtensionDate IS NOT NULL THEN
-								  CASE WHEN groundAFeeReceiptDueDate < caseExtensionDate THEN groundAFeeReceiptDueDate ELSE caseExtensionDate END
-	                          WHEN caseExtensionDate IS NULL THEN caseCreatedDate
-	                          ELSE caseExtensionDate END
+								CASE WHEN groundAFeeReceiptDueDate < caseExtensionDate THEN groundAFeeReceiptDueDate ELSE caseExtensionDate END
+	                        WHEN caseExtensionDate IS NULL THEN caseCreatedDate
+	                        ELSE caseExtensionDate END
 	WHERE   status = @STATUS_VALIDATION;
 
 
@@ -293,10 +295,10 @@ BEGIN
 	-- Note that businessDate is a date field with no time element, so we need to add the time part from the relevant visit date
 	UPDATE  #personal
 	SET     dueDate = CASE  WHEN siteVisitDate IS NOT NULL AND siteVisitEndTime IS NOT NULL THEN (
-		SELECT DATEADD(MILLISECOND, DATEDIFF(MILLISECOND, CAST(CAST(siteVisitEndTime AS DATE) AS DATETIME2), siteVisitEndTime), CAST(businessDate AS DATETIME2))
-		FROM NextBusinessDate
-		WHERE currentDate = CONVERT(DATE, siteVisitEndTime) AND noBusinessDays = @STATE_TARGET_ISSUE_DETERMINATION_AFTER_SITE_VISIT
-	)
+								SELECT DATEADD(MILLISECOND, DATEDIFF(MILLISECOND, CAST(CAST(siteVisitEndTime AS DATE) AS DATETIME2), siteVisitEndTime), CAST(businessDate AS DATETIME2))
+								FROM NextBusinessDate
+								WHERE currentDate = CONVERT(DATE, siteVisitEndTime) AND noBusinessDays = @STATE_TARGET_ISSUE_DETERMINATION_AFTER_SITE_VISIT
+							)
 	                        WHEN siteVisitDate IS NOT NULL THEN (
 								SELECT DATEADD(MILLISECOND, DATEDIFF(MILLISECOND, CAST(CAST(siteVisitDate AS DATE) AS DATETIME2), siteVisitDate), CAST(businessDate AS DATETIME2))
 		                        FROM NextBusinessDate
@@ -307,7 +309,7 @@ BEGIN
 		                        FROM NextBusinessDate
 		                        WHERE currentDate = CONVERT(DATE, caseCreatedDate) AND noBusinessDays = @STATE_TARGET_ISSUE_DETERMINATION
 							)
-		END
+					END
 	WHERE   status = @STATUS_ISSUE_DETERMINATION;
 
 
@@ -315,12 +317,12 @@ BEGIN
 	-- Note that businessDate is a date field with no time element, so we need to add the time part from the statusCreatedAt date
 	UPDATE  #personal
 	SET     dueDate = CASE  WHEN awaitingAppellantCostsDecision =1 OR awaitingLpaCostsDecision =1 THEN (
-		SELECT DATEADD(MILLISECOND, DATEDIFF(MILLISECOND, CAST(CAST(statusCreatedAt AS DATE) AS DATETIME2), statusCreatedAt), CAST(businessDate AS DATETIME2))
-		FROM NextBusinessDate
-		WHERE currentDate = CONVERT(DATE, statusCreatedAt) AND noBusinessDays = @STATE_TARGET_5_BUSINESS_DAYS )
-	                        WHEN numberOfResidencesNetChange =0 AND appealTypeId IN (@APPEAL_TYPE_S78, @APPEAL_TYPE_PLANNED_LISTED_BUILDING) AND isChildAppeal = 0 THEN GETDATE()
-	                        ELSE NULL
-		END
+								SELECT DATEADD(MILLISECOND, DATEDIFF(MILLISECOND, CAST(CAST(statusCreatedAt AS DATE) AS DATETIME2), statusCreatedAt), CAST(businessDate AS DATETIME2))
+								FROM NextBusinessDate
+								WHERE currentDate = CONVERT(DATE, statusCreatedAt) AND noBusinessDays = @STATE_TARGET_5_BUSINESS_DAYS )
+							WHEN numberOfResidencesNetChange IS NULL AND appealTypeId IN (@APPEAL_TYPE_S78, @APPEAL_TYPE_PLANNED_LISTED_BUILDING) AND isChildAppeal = 0 THEN GETDATE()
+							ELSE NULL
+					END
 	WHERE   status = @STATUS_COMPLETE;
 
 	-- statements
@@ -342,7 +344,7 @@ BEGIN
 	-- final comments
 	UPDATE  #personal
 	SET     dueDate = CASE  WHEN finalCommentsDueDate IS NOT NULL
-								THEN finalCommentsDueDate
+							THEN finalCommentsDueDate
 	                        ELSE DATEADD(day, @STATE_TARGET_FINAL_COMMENT_REVIEW, caseCreatedDate) END
 	WHERE   status = @STATUS_FINAL_COMMENTS;
 
@@ -367,44 +369,44 @@ BEGIN
 	                   FROM NextBusinessDate
 	                   WHERE currentDate = CONVERT(DATE, statusCreatedAt) AND noBusinessDays = @STATE_TARGET_5_BUSINESS_DAYS )
 	WHERE   status = @STATUS_AWAITING_TRANSFER
-	  AND     statusCreatedAt IS NOT NULL;
+	AND     statusCreatedAt IS NOT NULL;
 
 	-- withdrawn - add 5 business days
 	UPDATE  #personal
 	SET     dueDate = CASE  WHEN awaitingAppellantCostsDecision =1 OR awaitingLpaCostsDecision =1 THEN (
-		SELECT DATEADD(MILLISECOND, DATEDIFF(MILLISECOND, CAST(CAST(statusCreatedAt AS DATE) AS DATETIME2), statusCreatedAt), CAST(businessDate AS DATETIME2))
-		FROM NextBusinessDate
-		WHERE currentDate = CONVERT(DATE, statusCreatedAt) AND noBusinessDays = @STATE_TARGET_5_BUSINESS_DAYS )
-	                        ELSE NULL
-		END
+								SELECT DATEADD(MILLISECOND, DATEDIFF(MILLISECOND, CAST(CAST(statusCreatedAt AS DATE) AS DATETIME2), statusCreatedAt), CAST(businessDate AS DATETIME2))
+								FROM NextBusinessDate
+								WHERE currentDate = CONVERT(DATE, statusCreatedAt) AND noBusinessDays = @STATE_TARGET_5_BUSINESS_DAYS )
+							ELSE NULL
+							END
 	WHERE   status = @STATUS_WITHDRAWN;
 
 	-- Finally update the PersonalList table
 	UPDATE  p1
 	SET     dueDate = p2.dueDate
 	FROM    #personal p1
-				INNER JOIN #personal p2 ON p2.isParentAppeal = 1 AND p1.parentAppealId = p2.appealId;
+			INNER JOIN #personal p2 ON p2.isParentAppeal = 1 AND p1.parentAppealId = p2.appealId;
 
 	;WITH SourceData AS
-		(
+	(
 		SELECT	appealId,
-		          CASE WHEN isParentAppeal = 1 THEN 'parent'
-		               WHEN isChildAppeal = 1 THEN 'child'
-		               ELSE NULL
+				  CASE WHEN isParentAppeal = 1 THEN 'parent'
+					   WHEN isChildAppeal = 1 THEN 'child'
+					   ELSE NULL
 					  END AS linkType,
-		          parentAppealId AS leadAppealId,
-		          duedate
+				  parentAppealId AS leadAppealId,
+				  duedate
 		FROM	#personal
-		)
+	)
 
-		MERGE PersonalList AS target
+	MERGE PersonalList AS target
 	USING SourceData AS source
-	ON target.appealId = source.appealId
+		ON target.appealId = source.appealId
 	WHEN MATCHED THEN
 		UPDATE SET
-				   target.linkType     = source.linkType,
-			       target.leadAppealId = source.leadAppealId,
-			       target.dueDate      = source.dueDate
+			target.linkType     = source.linkType,
+			target.leadAppealId = source.leadAppealId,
+			target.dueDate      = source.dueDate
 	WHEN NOT MATCHED BY TARGET THEN
 		INSERT (appealId, linkType, leadAppealId, dueDate)
 		VALUES (source.appealId, source.linkType, source.leadAppealId, source.dueDate);

--- a/appeals/api/src/database/stored-procedures/spSetPersonalList.sql
+++ b/appeals/api/src/database/stored-procedures/spSetPersonalList.sql
@@ -1,8 +1,8 @@
 -- Populates the PersonalList for all appeals or a specific one.
 CREATE OR ALTER PROCEDURE dbo.spSetPersonalList
-(
-	@appealId                       AS INT = NULL
-)
+	(
+                @appealId                       AS INT = NULL
+    )
 AS
 BEGIN
 	SET NOCOUNT ON;

--- a/appeals/api/src/database/stored-procedures/spSetPersonalList.sql
+++ b/appeals/api/src/database/stored-procedures/spSetPersonalList.sql
@@ -223,24 +223,35 @@ BEGIN
 	;
 
 	-- COSTS
+	-- Note: Use conditional aggregation inside the subquery so there is exactly one row per caseId with 6 separate columns:
+	--		 This avoids the JOIN table to multiple rows in a SQL Server UPDATE, only one of the matching rows is applied (the "last one wins" — but which row is picked is non-deterministic).
+	--		 This method ensures that all 6 values correctly get totalled
 	UPDATE  #personal
-	SET     appellantCostsApplication    = appellantCostsApplication    + CASE WHEN fd.costsType = 'appellantCostsApplication' THEN fd.documentCount ELSE 0 END,
-	        appellantCostsWithdrawal     = appellantCostsWithdrawal     + CASE WHEN fd.costsType = 'appellantCostsWithdrawal' THEN fd.documentCount ELSE 0 END,
-	        lpaCostsApplication          = lpaCostsApplication          + CASE WHEN fd.costsType = 'lpaCostsApplication' THEN fd.documentCount ELSE 0 END,
-	        lpaCostsWithdrawal           = lpaCostsWithdrawal           + CASE WHEN fd.costsType = 'lpaCostsWithdrawal' THEN fd.documentCount ELSE 0 END,
-	        appellantCostsDecisionLetter = appellantCostsDecisionLetter + CASE WHEN fd.costsType = 'appellantCostsDecisionLetter' THEN fd.documentCount ELSE 0 END,
-	        lpaCostsDecisionLetter       = lpaCostsDecisionLetter       + CASE WHEN fd.costsType = 'lpaCostsDecisionLetter' THEN fd.documentCount ELSE 0 END
+	SET     appellantCostsApplication    = appellantCostsApplication    + fd.ctr_appellantCostsApplication,
+	        appellantCostsWithdrawal     = appellantCostsWithdrawal     + fd.ctr_appellantCostsWithdrawal,
+	        lpaCostsApplication          = lpaCostsApplication          + fd.ctr_lpaCostsApplication,
+	        lpaCostsWithdrawal           = lpaCostsWithdrawal           + fd.ctr_lpaCostsWithdrawal,
+	        appellantCostsDecisionLetter = appellantCostsDecisionLetter + fd.ctr_appellantCostsDecisionLetter,
+	        lpaCostsDecisionLetter       = lpaCostsDecisionLetter       + fd.ctr_lpaCostsDecisionLetter
 	FROM    #personal p
 				INNER JOIN (
 		SELECT  f.caseId,
-		        REPLACE(f.path, 'costs/', '') AS costsType,
-		        COUNT(d.guid) AS documentCount
+		        SUM(CASE WHEN f.path = 'costs/appellantCostsApplication'    THEN dc.documentCount ELSE 0 END) AS ctr_appellantCostsApplication,
+		        SUM(CASE WHEN f.path = 'costs/appellantCostsWithdrawal'     THEN dc.documentCount ELSE 0 END) AS ctr_appellantCostsWithdrawal,
+		        SUM(CASE WHEN f.path = 'costs/lpaCostsApplication'          THEN dc.documentCount ELSE 0 END) AS ctr_lpaCostsApplication,
+		        SUM(CASE WHEN f.path = 'costs/lpaCostsWithdrawal'           THEN dc.documentCount ELSE 0 END) AS ctr_lpaCostsWithdrawal,
+		        SUM(CASE WHEN f.path = 'costs/appellantCostsDecisionLetter' THEN dc.documentCount ELSE 0 END) AS ctr_appellantCostsDecisionLetter,
+		        SUM(CASE WHEN f.path = 'costs/lpaCostsDecisionLetter'       THEN dc.documentCount ELSE 0 END) AS ctr_lpaCostsDecisionLetter
 		FROM    Folder AS f
-					LEFT JOIN Document AS d ON  d.folderId = f.id
-			AND d.isDeleted = 0
-		WHERE   f.path LIKE 'costs/%'        -- only folders under 'costs/'
-		GROUP BY f.caseId, f.path
-	) fd ON  p.appealId = fd.caseId;
+					LEFT JOIN (
+			SELECT  folderId, COUNT(guid) AS documentCount
+			FROM    Document
+			WHERE   isDeleted = 0
+			GROUP BY folderId
+		) dc ON dc.folderId = f.id
+		WHERE   f.path LIKE 'costs/%'
+		GROUP BY f.caseId
+	) fd ON p.appealId = fd.caseId;
 
 	UPDATE  #personal
 	SET     awaitingAppellantCostsDecision = CASE WHEN appellantCostsDecisionLetter = 0 AND appellantCostsApplication > appellantCostsWithdrawal THEN 1 ELSE 0 END,

--- a/appeals/api/src/database/stored-procedures/stored-procedures.md
+++ b/appeals/api/src/database/stored-procedures/stored-procedures.md
@@ -1,0 +1,7 @@
+## Stored Procedures
+
+This is the folder where we will keep our version-controlled stored procedure SQL scripts.
+
+To change these scripts, amend them here and then create a new manual prisma migration file in a prisma migration folder, and copy that script into it.
+
+For more details, see the main documentation on [stored procedures](/docs/database.md#stored-procedures).

--- a/appeals/api/src/database/stored-procedures/stored-procedures.md
+++ b/appeals/api/src/database/stored-procedures/stored-procedures.md
@@ -4,7 +4,7 @@ This is the folder where we will keep our version-controlled stored procedure SQ
 
 To change these scripts, amend them here and then create a new manual prisma migration file in a prisma migration folder, and copy that script into it.
 
-For more details, see the main documentation on [stored procedures](/docs/database.md#stored-procedures).
+For more details, see the main documentation on [stored procedures](/docs/database.md).
 
 
 # Current Stored Procedures

--- a/appeals/api/src/database/stored-procedures/stored-procedures.md
+++ b/appeals/api/src/database/stored-procedures/stored-procedures.md
@@ -1,7 +1,26 @@
-## Stored Procedures
+# Stored Procedures
 
 This is the folder where we will keep our version-controlled stored procedure SQL scripts.
 
 To change these scripts, amend them here and then create a new manual prisma migration file in a prisma migration folder, and copy that script into it.
 
 For more details, see the main documentation on [stored procedures](/docs/database.md#stored-procedures).
+
+
+# Current Stored Procedures
+
+## spPopulateCalendarDates.sql
+This stored procedure populates the CalendarDate table with a record for each date, indicating whether it is a weekend or a bank holiday.
+It is used to identify Business Days for the purpose of calculating deadlines and other date-related logic in the application.
+Called from the scheduled jobs Function App in update-bank-holidays.
+
+## spPopulateNextBusinessDates.sql
+Stored Procedure to populate the NextBusinessDate for each date in the CalendarDate table for the number of business dates.
+Used to calculate the next business date for a given number of business days from a specific date, taking into account weekends and bank holidays.
+Called from the scheduled jobs Function App in update-bank-holidays.
+
+## spPersonalList.sql
+Populates the PersonalList table with the next Due Date for each appeal - used on User Personal List dashboard.
+Updated when appeal stage transitions occur.  
+Can be called for a single appealId, or to update the table for all appeals. 
+

--- a/appeals/api/src/server/endpoints/appeal-details/appeal-details.controller.js
+++ b/appeals/api/src/server/endpoints/appeal-details/appeal-details.controller.js
@@ -4,7 +4,7 @@ import { contextEnum } from '#mappers/context-enum.js';
 import { isParentAppeal } from '#utils/is-linked-appeal.js';
 import { getChildAppeals } from '#utils/link-appeals.js';
 import logger from '#utils/logger.js';
-import { updatePersonalList } from '#utils/update-personal-list.js';
+import { setPersonalList } from '#utils/update-personal-list.js';
 import { ERROR_FAILED_TO_SAVE_DATA } from '@pins/appeals/constants/support.js';
 import { SERVICE_USER_TYPE } from '@planning-inspectorate/data-model';
 import { appealDetailService } from './appeal-details.service.js';
@@ -96,7 +96,7 @@ const updateAppealById = async (req, res) => {
 				azureAdUserId
 			);
 		}
-		await updatePersonalList(appealId);
+		await setPersonalList({ appealId });
 		// broadcast any changes
 		await broadcasters.broadcastAppeal(appeal.id);
 

--- a/appeals/api/src/server/endpoints/appeal-details/appeal-details.controller.js
+++ b/appeals/api/src/server/endpoints/appeal-details/appeal-details.controller.js
@@ -98,7 +98,7 @@ const updateAppealById = async (req, res) => {
 		}
 		await setPersonalList({ appealId });
 		// broadcast any changes
-		await broadcasters.broadcastAppeal(appeal.id);
+		await broadcasters.broadcastAppeal(appealId);
 
 		// if an assignment change, also assign to linked/child appeals
 		if (isAssignmentChange && isParentAppeal(appeal)) {

--- a/appeals/api/src/server/endpoints/appeal-timetables/appeal-timetables.service.js
+++ b/appeals/api/src/server/endpoints/appeal-timetables/appeal-timetables.service.js
@@ -13,7 +13,7 @@ import { getChildEnforcementsWithGrounds } from '#utils/link-appeals.js';
 import logger from '#utils/logger.js';
 import stringTokenReplacement from '#utils/string-token-replacement.js';
 import { trimAppealType } from '#utils/string-utils.js';
-import { updatePersonalList } from '#utils/update-personal-list.js';
+import { setPersonalList } from '#utils/update-personal-list.js';
 import {
 	PROCEDURE_TYPE_ID_MAP,
 	PROCEDURE_TYPE_KEY,

--- a/appeals/api/src/server/endpoints/appeal-timetables/appeal-timetables.service.js
+++ b/appeals/api/src/server/endpoints/appeal-timetables/appeal-timetables.service.js
@@ -628,7 +628,7 @@ const updateAppealTimetable = async (
 	);
 
 	if (result) {
-		await updatePersonalList(appeal.id);
+		await setPersonalList(appeal.id);
 
 		if (!isChildAppeal) {
 			let details = 'Timetable updated:';

--- a/appeals/api/src/server/endpoints/appeal-timetables/appeal-timetables.service.js
+++ b/appeals/api/src/server/endpoints/appeal-timetables/appeal-timetables.service.js
@@ -628,7 +628,7 @@ const updateAppealTimetable = async (
 	);
 
 	if (result) {
-		await setPersonalList(appeal.id);
+		await setPersonalList({ appealId: appeal.id });
 
 		if (!isChildAppeal) {
 			let details = 'Timetable updated:';

--- a/appeals/api/src/server/endpoints/appellant-cases/appellant-cases.controller.js
+++ b/appeals/api/src/server/endpoints/appellant-cases/appellant-cases.controller.js
@@ -4,8 +4,8 @@ import { createAuditTrail } from '#endpoints/audit-trails/audit-trails.service.j
 import { broadcasters } from '#endpoints/integrations/integrations.broadcasters.js';
 import { contextEnum } from '#mappers/context-enum.js';
 import logger from '#utils/logger.js';
+import { setPersonalList } from '#utils/update-personal-list.js';
 import stringTokenReplacement from '#utils/string-token-replacement.js';
-import { updatePersonalList } from '#utils/update-personal-list.js';
 import { APPEAL_TYPE } from '@pins/appeals/constants/common.js';
 import * as CONSTANTS from '@pins/appeals/constants/support.js';
 import {
@@ -206,7 +206,7 @@ const updateAppellantCaseById = async (req, res) => {
 					appeal
 				);
 
-		await updatePersonalList(appeal.id);
+		await setPersonalList(appeal.id);
 
 		const auditTrailDetail = renderAuditTrailDetail(body);
 

--- a/appeals/api/src/server/endpoints/appellant-cases/appellant-cases.controller.js
+++ b/appeals/api/src/server/endpoints/appellant-cases/appellant-cases.controller.js
@@ -4,8 +4,8 @@ import { createAuditTrail } from '#endpoints/audit-trails/audit-trails.service.j
 import { broadcasters } from '#endpoints/integrations/integrations.broadcasters.js';
 import { contextEnum } from '#mappers/context-enum.js';
 import logger from '#utils/logger.js';
-import { setPersonalList } from '#utils/update-personal-list.js';
 import stringTokenReplacement from '#utils/string-token-replacement.js';
+import { setPersonalList } from '#utils/update-personal-list.js';
 import { APPEAL_TYPE } from '@pins/appeals/constants/common.js';
 import * as CONSTANTS from '@pins/appeals/constants/support.js';
 import {
@@ -206,7 +206,7 @@ const updateAppellantCaseById = async (req, res) => {
 					appeal
 				);
 
-		await setPersonalList(appeal.id);
+		await setPersonalList({ appealId: appeal.id });
 
 		const auditTrailDetail = renderAuditTrailDetail(body);
 

--- a/appeals/api/src/server/endpoints/cancel/__tests__/cancel.test.js
+++ b/appeals/api/src/server/endpoints/cancel/__tests__/cancel.test.js
@@ -15,6 +15,8 @@ describe('cancel routes', () => {
 			id: 1,
 			name: 'Invalid'
 		});
+		// Mock $executeRawUnsafe for updating PersonalList
+		databaseConnector.$executeRawUnsafe = jest.fn().mockResolvedValue();
 	});
 
 	afterEach(() => {
@@ -73,7 +75,11 @@ describe('cancel routes', () => {
 					templateName: 'appeal-cancelled-enforcement-notice-withdrawn'
 				})
 			);
-			expect(databaseConnector.personalList.upsert).toHaveBeenCalled();
+			// Assert $executeRawUnsafe was called to update personalList
+			expect(databaseConnector.$executeRawUnsafe).toHaveBeenCalledTimes(1);
+			expect(databaseConnector.$executeRawUnsafe).toHaveBeenCalledWith(
+				expect.stringContaining('EXEC dbo.spSetPersonalList')
+			);
 			expect(mockBroadcasters.broadcastAppeal).toHaveBeenCalledWith(enforcementNoticeAppeal.id);
 		});
 		test('cancels the appeal and returns the appeal when dryRun is not set and there are child appeals', async () => {
@@ -119,7 +125,11 @@ describe('cancel routes', () => {
 					templateName: 'appeal-cancelled-enforcement-notice-withdrawn'
 				})
 			);
-			expect(databaseConnector.personalList.upsert).toHaveBeenCalled();
+			// Assert $executeRawUnsafe was called to update personalList
+			expect(databaseConnector.$executeRawUnsafe).toHaveBeenCalledTimes(1);
+			expect(databaseConnector.$executeRawUnsafe).toHaveBeenCalledWith(
+				expect.stringContaining('EXEC dbo.spSetPersonalList')
+			);
 			expect(mockBroadcasters.broadcastAppeal).toHaveBeenCalledWith(enforcementNoticeAppeal.id);
 			expect(mockBroadcasters.broadcastAppeal).toHaveBeenCalledWith(100);
 		});

--- a/appeals/api/src/server/endpoints/decision/decision.service.js
+++ b/appeals/api/src/server/endpoints/decision/decision.service.js
@@ -14,7 +14,7 @@ import { getEnforcementReference } from '#utils/get-enforcement-reference.js';
 import logger from '#utils/logger.js';
 import stringTokenReplacement from '#utils/string-token-replacement.js';
 import { trimAppealType } from '#utils/string-utils.js';
-import { updatePersonalList } from '#utils/update-personal-list.js';
+import { setPersonalList } from '#utils/update-personal-list.js';
 import { FEATURE_FLAG_NAMES, FEEDBACK_FORM_LINKS } from '@pins/appeals/constants/common.js';
 import {
 	AUDIT_TRAIL_APPELLANT_COSTS_DECISION_ISSUED,
@@ -381,7 +381,7 @@ export const publishCostsDecision = async (
 	}
 	const { recipientEmailTemplate, lpaEmailTemplate, auditTrailDetails } = costDecisionDetails;
 
-	await updatePersonalList(appeal.id);
+	await setPersonalList({ appealId: appeal.id });
 
 	if (!skipNotifies) {
 		const enforcementReference = await getEnforcementReference(appeal);

--- a/appeals/api/src/server/endpoints/documents/documents.controller.js
+++ b/appeals/api/src/server/endpoints/documents/documents.controller.js
@@ -26,7 +26,7 @@ import lpaQuestionnaireRepository from '#repositories/lpa-questionnaire.reposito
 import { getPageCount } from '#utils/database-pagination.js';
 import logger from '#utils/logger.js';
 import stringTokenReplacement from '#utils/string-token-replacement.js';
-import { updatePersonalList } from '#utils/update-personal-list.js';
+import { setPersonalList } from '#utils/update-personal-list.js';
 import { EventType } from '@pins/event-client';
 import { APPEAL_DOCUMENT_TYPE } from '@planning-inspectorate/data-model';
 import { addWeeks, format } from 'date-fns';
@@ -140,7 +140,7 @@ export const addDocuments = async (req, res) => {
 			);
 		}
 
-		await updatePersonalList(appeal.id);
+		await setPersonalList({ appealId: appeal.id });
 
 		const auditTrails = await Promise.all(
 			documentInfo.documents.filter(Boolean).map(async (document) => {

--- a/appeals/api/src/server/endpoints/link-appeals/link-appeals.controller.js
+++ b/appeals/api/src/server/endpoints/link-appeals/link-appeals.controller.js
@@ -15,7 +15,7 @@ import { isChildAppeal, isLinkedAppeal, isParentAppeal } from '#utils/is-linked-
 import { getChildAppeals, getLeadAppeal } from '#utils/link-appeals.js';
 import { formatHorizonGetCaseData } from '#utils/mapping/map-horizon.js';
 import stringTokenReplacement from '#utils/string-token-replacement.js';
-import { updatePersonalList } from '#utils/update-personal-list.js';
+import { setPersonalList } from '#utils/update-personal-list.js';
 import { logger } from '@azure/identity';
 import {
 	AUDIT_TRAIL_APPEAL_LINK_ADDED,
@@ -162,9 +162,9 @@ export const linkAppeal = async (req, res) => {
 	const lpaEmail = currentAppeal.lpa?.email || '';
 
 	await Promise.all([
-		await updatePersonalList(parentAppeal.id),
+		await setPersonalList({ appealId: parentAppeal.id }),
 
-		await updatePersonalList(childAppeal.id),
+		await setPersonalList({ appealId: childAppeal.id }),
 
 		notifySend({
 			templateName: 'link-appeal',
@@ -517,7 +517,7 @@ export const updateLinkedAppeals = async (req, res) => {
 					// @ts-ignore
 					unlinkChildAppeal(appealToUnlink),
 					// @ts-ignore
-					updatePersonalList(appealToUnlink.id)
+					setPersonalList({ appealId: appealToUnlink.id })
 				]);
 
 				if (currentLead?.id && appealToUnlink?.reference) {
@@ -541,7 +541,7 @@ export const updateLinkedAppeals = async (req, res) => {
 		}
 
 		// Refresh the personal list for the lead
-		await updatePersonalList(appealToReplaceLead?.id || currentLead?.id);
+		await setPersonalList({ appealId: appealToReplaceLead?.id || currentLead?.id });
 
 		if (currentLead?.id && appealToReplaceLead?.reference) {
 			await Promise.allSettled(

--- a/appeals/api/src/server/endpoints/site-visits/site-visits.service.js
+++ b/appeals/api/src/server/endpoints/site-visits/site-visits.service.js
@@ -21,7 +21,7 @@ import { notifySend } from '#notify/notify-send.js';
 import appealRepository from '#repositories/appeal.repository.js';
 import { getEnforcementReference } from '#utils/get-enforcement-reference.js';
 import logger from '#utils/logger.js';
-import { updatePersonalList } from '#utils/update-personal-list.js';
+import { setPersonalList } from '#utils/update-personal-list.js';
 import { DEFAULT_TIMEZONE } from '@pins/appeals/constants/dates.js';
 import { AUDIT_TRAIL_SITE_VISIT_CANCELLED } from '@pins/appeals/constants/support.js';
 import { addDays } from '@pins/appeals/utils/business-days.js';
@@ -224,7 +224,7 @@ const updateSiteVisit = async (
 
 		const siteVisits = await siteVisitRepository.getSiteVisitByAppealId(appealIdsToUpdate);
 
-		await updatePersonalList(appealId);
+		await setPersonalList({ appealId });
 
 		if (updateSiteVisitData.visitType) {
 			await createAuditTrail({

--- a/appeals/api/src/server/state/__tests__/transition-state.test.js
+++ b/appeals/api/src/server/state/__tests__/transition-state.test.js
@@ -80,7 +80,7 @@ describe('transitionState', () => {
 			// @ts-ignore
 			databaseConnector.appealRelationship.findMany.mockResolvedValue([]);
 			// @ts-ignore
-			databaseConnector.personalList.upsert.mockResolvedValue({});
+			databaseConnector.$executeRawUnsafe.mockResolvedValue({});
 			// @ts-ignore
 			databaseConnector.appealStatus.update.mockResolvedValue({});
 		});
@@ -119,7 +119,7 @@ describe('transitionState', () => {
 
 				expect(databaseConnector.appealStatus.create).toHaveBeenCalledTimes(expectCreate ? 1 : 0);
 
-				expect(databaseConnector.personalList.upsert).toHaveBeenCalledTimes(1);
+				expect(databaseConnector.$executeRawUnsafe).toHaveBeenCalledTimes(1);
 				expect(result).toEqual(expectUpdate);
 			}
 		);
@@ -148,13 +148,14 @@ describe('transitionState', () => {
 				.spyOn(appealStatusRepository, 'updateAppealStatusByAppealId')
 				.mockImplementation(jest.fn());
 			jest.spyOn(appealStatusRepository, 'rollBackAppealStatusTo').mockImplementation(jest.fn());
-			databaseConnector.personalList.upsert.mockResolvedValue({});
-		});
+			// @ts-ignore
+			databaseConnector.$executeRawUnsafe = jest.fn().mockResolvedValue({});
+		};);
 		test('does not update status but updates personal list', async () => {
 			const result = await transitionState(22, 'user-xyz', VALIDATION_OUTCOME_INCOMPLETE);
 			expect(appealStatusRepository.updateAppealStatusByAppealId).not.toHaveBeenCalled();
 			expect(appealStatusRepository.rollBackAppealStatusTo).not.toHaveBeenCalled();
-			expect(databaseConnector.personalList.upsert).toHaveBeenCalled();
+			expect(databaseConnector.$executeRawUnsafe).toHaveBeenCalled();
 			expect(result).toEqual(false);
 		});
 
@@ -403,14 +404,14 @@ describe('transitionState', () => {
 
 				const result = await transitionState(11, 'user-123', VALIDATION_OUTCOME_VALID);
 
-				expect(databaseConnector.personalList.upsert).not.toHaveBeenCalled();
+				expect(databaseConnector.$executeRawUnsafe).not.toHaveBeenCalled();
 				expect(result).toEqual(true);
 			});
 
 			test('updates personal list for non-child appeals', async () => {
 				const result = await transitionState(11, 'user-123', VALIDATION_OUTCOME_VALID);
 
-				expect(databaseConnector.personalList.upsert).toHaveBeenCalled();
+				expect(databaseConnector.$executeRawUnsafe).toHaveBeenCalled();
 				expect(result).toEqual(true);
 			});
 		});

--- a/appeals/api/src/server/state/__tests__/transition-state.test.js
+++ b/appeals/api/src/server/state/__tests__/transition-state.test.js
@@ -120,6 +120,9 @@ describe('transitionState', () => {
 				expect(databaseConnector.appealStatus.create).toHaveBeenCalledTimes(expectCreate ? 1 : 0);
 
 				expect(databaseConnector.$executeRawUnsafe).toHaveBeenCalledTimes(1);
+				expect(databaseConnector.$executeRawUnsafe).toHaveBeenCalledWith(
+					expect.stringContaining('EXEC dbo.spSetPersonalList')
+				);
 				expect(result).toEqual(expectUpdate);
 			}
 		);
@@ -150,12 +153,15 @@ describe('transitionState', () => {
 			jest.spyOn(appealStatusRepository, 'rollBackAppealStatusTo').mockImplementation(jest.fn());
 			// @ts-ignore
 			databaseConnector.$executeRawUnsafe = jest.fn().mockResolvedValue({});
-		};);
+		});
 		test('does not update status but updates personal list', async () => {
 			const result = await transitionState(22, 'user-xyz', VALIDATION_OUTCOME_INCOMPLETE);
 			expect(appealStatusRepository.updateAppealStatusByAppealId).not.toHaveBeenCalled();
 			expect(appealStatusRepository.rollBackAppealStatusTo).not.toHaveBeenCalled();
 			expect(databaseConnector.$executeRawUnsafe).toHaveBeenCalled();
+			expect(databaseConnector.$executeRawUnsafe).toHaveBeenCalledWith(
+				expect.stringContaining('EXEC dbo.spSetPersonalList')
+			);
 			expect(result).toEqual(false);
 		});
 
@@ -412,6 +418,9 @@ describe('transitionState', () => {
 				const result = await transitionState(11, 'user-123', VALIDATION_OUTCOME_VALID);
 
 				expect(databaseConnector.$executeRawUnsafe).toHaveBeenCalled();
+				expect(databaseConnector.$executeRawUnsafe).toHaveBeenCalledWith(
+					expect.stringContaining('EXEC dbo.spSetPersonalList')
+				);
 				expect(result).toEqual(true);
 			});
 		});

--- a/appeals/api/src/server/state/transition-state.js
+++ b/appeals/api/src/server/state/transition-state.js
@@ -7,7 +7,7 @@ import { currentStatus } from '#utils/current-status.js';
 import { isChildAppeal } from '#utils/is-linked-appeal.js';
 import logger from '#utils/logger.js';
 import stringTokenReplacement from '#utils/string-token-replacement.js';
-import { updatePersonalList } from '#utils/update-personal-list.js';
+import { setPersonalList } from '#utils/update-personal-list.js';
 import {
 	APPEAL_REPRESENTATION_STATUS,
 	APPEAL_REPRESENTATION_TYPE
@@ -101,7 +101,7 @@ const transitionState = async (appealId, azureAdUserId, trigger) => {
 	if (newState === currentState) {
 		stateMachineService.stop();
 		if (!isChildAppeal(appeal)) {
-			await updatePersonalList(appealId);
+			await setPersonalList({ appealId });
 		}
 		return false;
 	}
@@ -166,7 +166,7 @@ const transitionState = async (appealId, azureAdUserId, trigger) => {
 	}
 
 	if (!isChildAppeal(appeal)) {
-		await updatePersonalList(appealId);
+		await setPersonalList({ appealId });
 	}
 
 	stateMachineService.stop();

--- a/appeals/api/src/server/tests/stored-procedures/set-personal-list.integration.test.js
+++ b/appeals/api/src/server/tests/stored-procedures/set-personal-list.integration.test.js
@@ -1,0 +1,312 @@
+import {
+	createStoredProcedureTestPrismaClient,
+	executeSpSetPersonalList
+} from '#tests/stored-procedures/test-database.js';
+
+describe.skip('spSetPersonalList stored procedure', () => {
+	const testLpaCode = 'SPT1';
+	const invalidOutcomeName = 'Invalid';
+
+	/** @type {import('#db-client/client.js').PrismaClient} */
+	let prisma;
+	/** @type {number[]} */
+	let createdAppealIds = [];
+	/** @type {number} */
+	let lpaId;
+	/** @type {number} */
+	let invalidOutcomeId;
+
+	beforeAll(async () => {
+		prisma = createStoredProcedureTestPrismaClient();
+
+		const lpa = await prisma.lPA.upsert({
+			where: { lpaCode: testLpaCode },
+			update: {
+				name: 'Stored procedure test LPA',
+				email: 'stored-procedure-tests@example.com'
+			},
+			create: {
+				lpaCode: testLpaCode,
+				name: 'Stored procedure test LPA',
+				email: 'stored-procedure-tests@example.com'
+			}
+		});
+
+		const invalidOutcome = await prisma.appellantCaseValidationOutcome.upsert({
+			where: { name: invalidOutcomeName },
+			update: {},
+			create: { name: invalidOutcomeName }
+		});
+
+		lpaId = lpa.id;
+		invalidOutcomeId = invalidOutcome.id;
+	});
+
+	afterEach(async () => {
+		if (!createdAppealIds.length) {
+			return;
+		}
+
+		const appealIds = [...createdAppealIds];
+		createdAppealIds = [];
+
+		await prisma.personalList.deleteMany({
+			where: { appealId: { in: appealIds } }
+		});
+		await prisma.appealRelationship.deleteMany({
+			where: {
+				OR: [{ parentId: { in: appealIds } }, { childId: { in: appealIds } }]
+			}
+		});
+		await prisma.appealStatus.deleteMany({
+			where: { appealId: { in: appealIds } }
+		});
+		await prisma.appellantCase.deleteMany({
+			where: { appealId: { in: appealIds } }
+		});
+		await prisma.appeal.deleteMany({
+			where: { id: { in: appealIds } }
+		});
+	});
+
+	afterAll(async () => {
+		await prisma?.$disconnect();
+	});
+
+	/**
+	 * @param {{
+	 * 	reference: number,
+	 * 	caseCreatedDate: Date,
+	 * 	status: string,
+	 * 	caseExtensionDate?: Date
+	 * }} appealData
+	 */
+	const createAppeal = async ({ reference, caseCreatedDate, status, caseExtensionDate }) => {
+		const appeal = await prisma.appeal.create({
+			data: {
+				reference: String(reference),
+				lpaId,
+				caseCreatedDate,
+				caseUpdatedDate: caseCreatedDate,
+				...(caseExtensionDate ? { caseExtensionDate } : {})
+			}
+		});
+
+		createdAppealIds.push(appeal.id);
+
+		await prisma.appealStatus.create({
+			data: {
+				appealId: appeal.id,
+				status,
+				valid: true,
+				createdAt: caseCreatedDate
+			}
+		});
+
+		return appeal;
+	};
+
+	test('uses the extension date for invalid ready-to-start appeals', async () => {
+		const caseCreatedDate = new Date('2026-04-01T09:00:00.000Z');
+		const caseExtensionDate = new Date('2026-04-14T09:00:00.000Z');
+		const appeal = await createAppeal({
+			reference: 920001,
+			caseCreatedDate,
+			caseExtensionDate,
+			status: 'ready_to_start'
+		});
+
+		await prisma.appellantCase.create({
+			data: {
+				appealId: appeal.id,
+				appellantCaseValidationOutcomeId: invalidOutcomeId,
+				caseSubmittedDate: caseCreatedDate
+			}
+		});
+
+		await executeSpSetPersonalList(prisma);
+
+		const personalListEntry = await prisma.personalList.findUnique({
+			where: { appealId: appeal.id }
+		});
+
+		const dueDate = personalListEntry?.dueDate?.toISOString();
+
+		expect(personalListEntry).not.toBeNull();
+		expect(personalListEntry).toMatchObject({
+			appealId: appeal.id,
+			linkType: null,
+			leadAppealId: null
+		});
+		expect(dueDate).toBe(caseExtensionDate.toISOString());
+	});
+
+	test('recreates personal list entries for all appeals when called with a null reference', async () => {
+		const firstAppeal = await createAppeal({
+			reference: 920201,
+			caseCreatedDate: new Date('2026-05-01T00:00:00.000Z'),
+			status: 'assign_case_officer'
+		});
+		const secondAppeal = await createAppeal({
+			reference: 920202,
+			caseCreatedDate: new Date('2026-05-10T00:00:00.000Z'),
+			status: 'ready_to_start'
+		});
+
+		await executeSpSetPersonalList(prisma);
+
+		let entries = await prisma.personalList.findMany({
+			where: { appealId: { in: [firstAppeal.id, secondAppeal.id] } },
+			orderBy: { appealId: 'asc' }
+		});
+
+		expect(entries).toHaveLength(2);
+		expect(entries.map((entry) => entry.appealId)).toEqual([firstAppeal.id, secondAppeal.id]);
+
+		await prisma.personalList.deleteMany({
+			where: { appealId: { in: [firstAppeal.id, secondAppeal.id] } }
+		});
+
+		expect(
+			await prisma.personalList.count({
+				where: { appealId: { in: [firstAppeal.id, secondAppeal.id] } }
+			})
+		).toBe(0);
+
+		await executeSpSetPersonalList(prisma);
+
+		entries = await prisma.personalList.findMany({
+			where: { appealId: { in: [firstAppeal.id, secondAppeal.id] } },
+			orderBy: { appealId: 'asc' }
+		});
+
+		expect(entries).toHaveLength(2);
+		expect(entries.map((entry) => entry.appealId)).toEqual([firstAppeal.id, secondAppeal.id]);
+		expect(entries.map((entry) => entry.dueDate?.toISOString())).toEqual([
+			'2026-05-16T00:00:00.000Z',
+			'2026-05-15T00:00:00.000Z'
+		]);
+	});
+
+	test('creates an entry for a standalone appeal when called with that appeal id', async () => {
+		const standaloneAppeal = await createAppeal({
+			reference: 920250,
+			caseCreatedDate: new Date('2026-05-20T00:00:00.000Z'),
+			status: 'assign_case_officer'
+		});
+
+		await executeSpSetPersonalList(prisma, { appealId: standaloneAppeal.id });
+
+		const personalListEntry = await prisma.personalList.findUnique({
+			where: { appealId: standaloneAppeal.id }
+		});
+
+		expect(personalListEntry).not.toBeNull();
+		expect(personalListEntry).toMatchObject({
+			appealId: standaloneAppeal.id,
+			linkType: null,
+			leadAppealId: null
+		});
+		expect(personalListEntry?.dueDate?.toISOString()).toBe('2026-06-04T00:00:00.000Z');
+	});
+
+	test('creates entries for the supplied linked appeal set and not for unrelated appeals', async () => {
+		const parentAppeal = await createAppeal({
+			reference: 920301,
+			caseCreatedDate: new Date('2026-06-01T00:00:00.000Z'),
+			status: 'assign_case_officer'
+		});
+		const childAppeal = await createAppeal({
+			reference: 920302,
+			caseCreatedDate: new Date('2026-06-03T00:00:00.000Z'),
+			status: 'ready_to_start'
+		});
+		const unaffectedAppeal = await createAppeal({
+			reference: 920303,
+			caseCreatedDate: new Date('2026-06-05T00:00:00.000Z'),
+			status: 'ready_to_start'
+		});
+
+		await prisma.appealRelationship.create({
+			data: {
+				type: 'linked',
+				parentRef: parentAppeal.reference,
+				childRef: childAppeal.reference,
+				parentId: parentAppeal.id,
+				childId: childAppeal.id
+			}
+		});
+
+		await executeSpSetPersonalList(prisma, { appealId: childAppeal.id });
+
+		const [parentEntry, childEntry, unaffectedEntry] = await Promise.all([
+			prisma.personalList.findUnique({ where: { appealId: parentAppeal.id } }),
+			prisma.personalList.findUnique({ where: { appealId: childAppeal.id } }),
+			prisma.personalList.findUnique({ where: { appealId: unaffectedAppeal.id } })
+		]);
+
+		expect(parentEntry).not.toBeNull();
+		expect(parentEntry).toMatchObject({
+			appealId: parentAppeal.id,
+			linkType: 'parent',
+			leadAppealId: parentAppeal.id
+		});
+		expect(childEntry).not.toBeNull();
+		expect(childEntry).toMatchObject({
+			appealId: childAppeal.id,
+			linkType: 'child',
+			leadAppealId: parentAppeal.id
+		});
+		expect(unaffectedEntry).toBeNull();
+	});
+
+	test('updates linked parent and child entries when called with a linked appeal id', async () => {
+		const parentCreatedDate = new Date('2026-03-01T00:00:00.000Z');
+		const childCreatedDate = new Date('2026-04-01T00:00:00.000Z');
+		const parentAppeal = await createAppeal({
+			reference: 920101,
+			caseCreatedDate: parentCreatedDate,
+			status: 'assign_case_officer'
+		});
+		const childAppeal = await createAppeal({
+			reference: 920102,
+			caseCreatedDate: childCreatedDate,
+			status: 'ready_to_start'
+		});
+
+		await prisma.appealRelationship.create({
+			data: {
+				type: 'linked',
+				parentRef: parentAppeal.reference,
+				childRef: childAppeal.reference,
+				parentId: parentAppeal.id,
+				childId: childAppeal.id
+			}
+		});
+
+		await executeSpSetPersonalList(prisma, { appealId: childAppeal.id });
+
+		const [parentEntry, childEntry] = await Promise.all([
+			prisma.personalList.findUnique({ where: { appealId: parentAppeal.id } }),
+			prisma.personalList.findUnique({ where: { appealId: childAppeal.id } })
+		]);
+		const parentDueDate = parentEntry?.dueDate?.toISOString();
+		const childDueDate = childEntry?.dueDate?.toISOString();
+
+		expect(parentEntry).not.toBeNull();
+		expect(childEntry).not.toBeNull();
+		expect(parentEntry).toMatchObject({
+			appealId: parentAppeal.id,
+			linkType: 'parent',
+			leadAppealId: parentAppeal.id
+		});
+		expect(childEntry).toMatchObject({
+			appealId: childAppeal.id,
+			linkType: 'child',
+			leadAppealId: parentAppeal.id
+		});
+		expect(parentDueDate).toBe('2026-03-16T00:00:00.000Z');
+		expect(childDueDate).toBe(parentDueDate);
+		expect(childDueDate).not.toBe('2026-04-06T00:00:00.000Z');
+	});
+});

--- a/appeals/api/src/server/tests/stored-procedures/set-personal-list.integration.test.js
+++ b/appeals/api/src/server/tests/stored-procedures/set-personal-list.integration.test.js
@@ -3,7 +3,7 @@ import {
 	executeSpSetPersonalList
 } from '#tests/stored-procedures/test-database.js';
 
-describe.skip('spSetPersonalList stored procedure', () => {
+describe('spSetPersonalList stored procedure', () => {
 	const testLpaCode = 'SPT1';
 	const invalidOutcomeName = 'Invalid';
 

--- a/appeals/api/src/server/tests/stored-procedures/test-database.js
+++ b/appeals/api/src/server/tests/stored-procedures/test-database.js
@@ -1,0 +1,307 @@
+import { PrismaClient } from '#db-client/client.js';
+import { PrismaMssql } from '@prisma/adapter-mssql';
+import { spawnSync } from 'node:child_process';
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { GenericContainer, Wait } from 'testcontainers';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const apiRoot = path.resolve(__dirname, '../../../..');
+const storedProcedureStatePath = path.join(
+	tmpdir(),
+	'appeals-api-stored-procedure-test-database.json'
+);
+const storedProcedureSqlPath = path.join(
+	apiRoot,
+	'src/database/migrations/20260320113501_add_procedure_sp_set_personal_list/migration.sql'
+);
+
+const sqlEdgeImage = 'mcr.microsoft.com/azure-sql-edge:latest';
+const sqlEdgePort = 1433;
+const sqlEdgeDatabaseName = 'pins_stored_procedures_test';
+const sqlEdgeUsername = 'sa';
+const sqlEdgePassword = 'PinsStoredProcTest!234';
+
+/**
+ * @param {string} connectionString
+ * @returns {PrismaClient}
+ */
+const createPrismaClientForConnection = (connectionString) =>
+	new PrismaClient({
+		adapter: new PrismaMssql(connectionString),
+		transactionOptions: {
+			maxWait: 2000,
+			timeout: 20000
+		}
+	});
+
+/**
+ * @param {{host: string, port: number, databaseName: string}} param0
+ * @returns {string}
+ */
+export const buildSqlServerConnectionString = ({ host, port, databaseName }) =>
+	`sqlserver://${host}:${port};database=${databaseName};user=${sqlEdgeUsername};password=${sqlEdgePassword};trustServerCertificate=true`;
+
+/**
+ * @param {number} ms
+ * @returns {Promise<void>}
+ */
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+/**
+ * @param {unknown} error
+ * @returns {string}
+ */
+const getErrorMessage = (error) => {
+	if (error instanceof Error) {
+		return error.message;
+	}
+
+	if (
+		error &&
+		typeof error === 'object' &&
+		'message' in error &&
+		typeof error.message === 'string'
+	) {
+		return error.message;
+	}
+
+	return 'unknown error';
+};
+
+export const assertSpSetPersonalListProcedureExists = () => {
+	if (!existsSync(storedProcedureSqlPath)) {
+		throw new Error(
+			`spSetPersonalList SQL file was not found at ${storedProcedureSqlPath}. The stored procedure must exist in-repo for these tests to run.`
+		);
+	}
+
+	return storedProcedureSqlPath;
+};
+
+/**
+ * @returns {{
+ * 	containerId: string,
+ * 	host: string,
+ * 	port: number,
+ * 	databaseName: string,
+ * 	connectionString: string
+ * } | null}
+ */
+export const loadStoredProcedureTestState = () => {
+	if (!existsSync(storedProcedureStatePath)) {
+		return null;
+	}
+
+	return JSON.parse(readFileSync(storedProcedureStatePath, 'utf8'));
+};
+
+/**
+ * @param {{
+ * 	containerId: string,
+ * 	host: string,
+ * 	port: number,
+ * 	databaseName: string,
+ * 	connectionString: string
+ * }} state
+ */
+const saveStoredProcedureTestState = (state) => {
+	mkdirSync(path.dirname(storedProcedureStatePath), { recursive: true });
+	writeFileSync(storedProcedureStatePath, JSON.stringify(state), 'utf8');
+};
+
+const removeStoredProcedureTestState = () => {
+	rmSync(storedProcedureStatePath, { force: true });
+};
+
+/**
+ * @param {{
+ * 	containerId: string,
+ * 	host: string,
+ * 	port: number,
+ * 	databaseName: string,
+ * 	connectionString: string
+ * } | null} state
+ */
+export const applyStoredProcedureTestEnvironment = (state) => {
+	if (!state) {
+		return;
+	}
+
+	process.env.DATABASE_URL = state.connectionString;
+	process.env.STORED_PROCEDURE_TEST_DATABASE_URL = state.connectionString;
+	process.env.STORED_PROCEDURE_TEST_DATABASE_NAME = state.databaseName;
+	process.env.STORED_PROCEDURE_TEST_DATABASE_HOST = state.host;
+	process.env.STORED_PROCEDURE_TEST_DATABASE_PORT = String(state.port);
+};
+
+/**
+ * @param {string} masterConnectionString
+ * @returns {Promise<void>}
+ */
+const waitForSqlServer = async (masterConnectionString) => {
+	/** @type {unknown} */
+	let lastError;
+
+	for (let attempt = 0; attempt < 60; attempt++) {
+		const prisma = createPrismaClientForConnection(masterConnectionString);
+
+		try {
+			await prisma.$queryRaw`SELECT 1`;
+			return;
+		} catch (error) {
+			lastError = error;
+			await sleep(2000);
+		} finally {
+			await prisma.$disconnect().catch(() => undefined);
+		}
+	}
+
+	throw new Error(`SQL Server did not become ready in time: ${getErrorMessage(lastError)}`);
+};
+
+/**
+ * @param {string} masterConnectionString
+ * @returns {Promise<void>}
+ */
+const ensureTestDatabaseExists = async (masterConnectionString) => {
+	const prisma = createPrismaClientForConnection(masterConnectionString);
+
+	try {
+		await prisma.$executeRawUnsafe(
+			`IF DB_ID(N'${sqlEdgeDatabaseName}') IS NULL CREATE DATABASE [${sqlEdgeDatabaseName}]`
+		);
+	} finally {
+		await prisma.$disconnect();
+	}
+};
+
+/**
+ * @param {string} connectionString
+ */
+const runPrismaMigrations = (connectionString) => {
+	const result = spawnSync(
+		'npx',
+		['prisma', 'migrate', 'deploy', '--schema', 'src/database/schema.prisma'],
+		{
+			cwd: apiRoot,
+			encoding: 'utf8',
+			env: {
+				...process.env,
+				DATABASE_URL: connectionString
+			}
+		}
+	);
+
+	if (result.status !== 0) {
+		throw new Error(
+			['Failed to run Prisma migrations for stored procedure tests.', result.stdout, result.stderr]
+				.filter(Boolean)
+				.join('\n')
+		);
+	}
+};
+
+export const bootstrapStoredProcedureTestDatabase = async () => {
+	assertSpSetPersonalListProcedureExists();
+
+	let container = new GenericContainer(sqlEdgeImage)
+		.withEnvironment({
+			ACCEPT_EULA: '1',
+			MSSQL_SA_PASSWORD: sqlEdgePassword
+		})
+		.withExposedPorts(sqlEdgePort)
+		.withWaitStrategy(Wait.forLogMessage(/SQL Server is now ready for client connections/i))
+		.withStartupTimeout(180000);
+
+	if (typeof container.withPlatform === 'function') {
+		container = container.withPlatform('linux/amd64');
+	}
+
+	const startedContainer = await container.start();
+	const state = {
+		containerId: startedContainer.getId(),
+		host: startedContainer.getHost(),
+		port: startedContainer.getMappedPort(sqlEdgePort),
+		databaseName: sqlEdgeDatabaseName,
+		connectionString: buildSqlServerConnectionString({
+			host: startedContainer.getHost(),
+			port: startedContainer.getMappedPort(sqlEdgePort),
+			databaseName: sqlEdgeDatabaseName
+		})
+	};
+
+	const masterConnectionString = buildSqlServerConnectionString({
+		host: state.host,
+		port: state.port,
+		databaseName: 'master'
+	});
+
+	await waitForSqlServer(masterConnectionString);
+	await ensureTestDatabaseExists(masterConnectionString);
+	runPrismaMigrations(state.connectionString);
+	saveStoredProcedureTestState(state);
+	applyStoredProcedureTestEnvironment(state);
+
+	return state;
+};
+
+export const stopStoredProcedureTestDatabase = async () => {
+	const state = loadStoredProcedureTestState();
+
+	if (!state?.containerId) {
+		removeStoredProcedureTestState();
+		return;
+	}
+
+	const result = spawnSync('docker', ['rm', '-f', state.containerId], {
+		encoding: 'utf8'
+	});
+
+	removeStoredProcedureTestState();
+
+	if (
+		result.status !== 0 &&
+		!result.stderr.includes('No such container') &&
+		!result.stderr.includes('is not running')
+	) {
+		throw new Error(
+			[`Failed to stop SQL Edge test container ${state.containerId}.`, result.stdout, result.stderr]
+				.filter(Boolean)
+				.join('\n')
+		);
+	}
+};
+
+export const createStoredProcedureTestPrismaClient = () => {
+	const state = loadStoredProcedureTestState();
+
+	if (!state?.connectionString) {
+		throw new Error(
+			`Stored procedure test database state was not found at ${storedProcedureStatePath}.`
+		);
+	}
+
+	return createPrismaClientForConnection(state.connectionString);
+};
+
+/**
+ * @param {PrismaClient} prisma
+ * @param {{appealId?: number | null, isNetResidentsAppealType?: boolean}} [options]
+ */
+export const executeSpSetPersonalList = async (
+	prisma,
+	{ appealId = null, isNetResidentsAppealType = false } = {}
+) => {
+	const parsedAppealId = appealId === null ? null : Number(appealId);
+
+	if (appealId !== null && Number.isNaN(parsedAppealId)) {
+		throw new Error(`spSetPersonalList appealId must be numeric. Received: ${appealId}`);
+	}
+
+	return prisma.$queryRawUnsafe(
+		`EXEC dbo.spSetPersonalList @appealId = ${parsedAppealId === null ? 'NULL' : parsedAppealId}, @isNetResidentsAppealType = ${isNetResidentsAppealType ? 1 : 0};`
+	);
+};

--- a/appeals/api/src/server/tests/stored-procedures/test-database.js
+++ b/appeals/api/src/server/tests/stored-procedures/test-database.js
@@ -289,12 +289,9 @@ export const createStoredProcedureTestPrismaClient = () => {
 
 /**
  * @param {PrismaClient} prisma
- * @param {{appealId?: number | null, isNetResidentsAppealType?: boolean}} [options]
+ * @param {{appealId?: number | null}} [options]
  */
-export const executeSpSetPersonalList = async (
-	prisma,
-	{ appealId = null, isNetResidentsAppealType = false } = {}
-) => {
+export const executeSpSetPersonalList = async (prisma, { appealId = null } = {}) => {
 	const parsedAppealId = appealId === null ? null : Number(appealId);
 
 	if (appealId !== null && Number.isNaN(parsedAppealId)) {
@@ -302,6 +299,6 @@ export const executeSpSetPersonalList = async (
 	}
 
 	return prisma.$queryRawUnsafe(
-		`EXEC dbo.spSetPersonalList @appealId = ${parsedAppealId === null ? 'NULL' : parsedAppealId}, @isNetResidentsAppealType = ${isNetResidentsAppealType ? 1 : 0};`
+		`EXEC dbo.spSetPersonalList @appealId = ${parsedAppealId === null ? 'NULL' : parsedAppealId};`
 	);
 };

--- a/appeals/api/src/server/utils/link-appeals.js
+++ b/appeals/api/src/server/utils/link-appeals.js
@@ -3,7 +3,7 @@ import { broadcasters } from '#endpoints/integrations/integrations.broadcasters.
 import appealRepository from '#repositories/appeal.repository.js';
 import { isParentAppeal } from '#utils/is-linked-appeal.js';
 import stringTokenReplacement from '#utils/string-token-replacement.js';
-import { updatePersonalList } from '#utils/update-personal-list.js';
+import { setPersonalList } from '#utils/update-personal-list.js';
 import {
 	AUDIT_TRAIL_APPEAL_LINK_ADDED,
 	CASE_RELATIONSHIP_LINKED
@@ -60,9 +60,9 @@ export const linkAppeals = async (azureAdUserId, parentAppeal, childAppeal) => {
 	await appealRepository.linkAppeal(relationship);
 
 	await Promise.all([
-		await updatePersonalList(relationship.parentId),
+		await setPersonalList({ appealId: relationship.parentId }),
 
-		await updatePersonalList(relationship.childId),
+		await setPersonalList({ appealId: relationship.childId }),
 
 		createAuditTrail({
 			appealId: relationship.parentId,

--- a/appeals/api/src/server/utils/update-personal-list.js
+++ b/appeals/api/src/server/utils/update-personal-list.js
@@ -1,11 +1,8 @@
 import appealRepository from '#repositories/appeal.repository.js';
-import personalListRepository from '#repositories/personal-list.repository.js';
-import { calculateDueDate } from '#utils/calculate-due-date.js';
-import { currentStatus } from '#utils/current-status.js';
-import { formatCostsDecision } from '#utils/format-costs-decision.js';
+import { databaseConnector } from '#utils/database-connector.js';
+import { isFeatureActive } from '#utils/feature-flags.js';
 import logger from '#utils/logger.js';
-import { CASE_RELATIONSHIP_LINKED } from '@pins/appeals/constants/support.js';
-import { APPEAL_CASE_STATUS } from '@planning-inspectorate/data-model';
+import { APPEAL_TYPE, FEATURE_FLAG_NAMES } from '@pins/appeals/constants/common.js';
 
 /**
  * Updates the PersonalList for the specified appeal
@@ -13,87 +10,44 @@ import { APPEAL_CASE_STATUS } from '@planning-inspectorate/data-model';
  * @returns {Promise<void>}
  */
 export const updatePersonalList = async (appealId) => {
-	// TODO: performance
-	// is returning all data, return only needed data
-	const appeal = await appealRepository.deprecatedGetAppealById(appealId);
-	if (!appeal) {
-		return;
-	}
-
-	const appealStatus = currentStatus(appeal);
-	const appealIsCompleteOrWithdrawn =
-		appealStatus === APPEAL_CASE_STATUS.COMPLETE || appealStatus === APPEAL_CASE_STATUS.WITHDRAWN;
-	const costsDecision = appealIsCompleteOrWithdrawn ? await formatCostsDecision(appeal) : null;
-
-	let dueDate = await calculateDueDate(appeal, costsDecision);
-	let linkType = null;
-	const linkedAppeals = await appealRepository.getLinkedAppeals(
-		appeal.reference,
-		CASE_RELATIONSHIP_LINKED
-	);
-	if (linkedAppeals?.length) {
-		if (linkedAppeals.some((linkedAppeal) => linkedAppeal.childId === appeal.id)) {
-			return; // Do not update children here as their parent should display the correct date
-		} else if (linkedAppeals.some((linkedAppeal) => linkedAppeal.parentId === appeal.id)) {
-			linkType = 'parent';
-		}
-		if (!dueDate && linkedAppeals[0]?.parentId) {
-			// TODO: performance
-			// is returning all data, return only needed data
-			const parentAppeal = await appealRepository.deprecatedGetAppealById(
-				linkedAppeals[0].parentId
-			);
-			if (!parentAppeal) {
-				dueDate = null;
-			} else {
-				const costsDecision =
-					currentStatus(parentAppeal) === APPEAL_CASE_STATUS.COMPLETE
-						? await formatCostsDecision(parentAppeal)
-						: null;
-				dueDate = await calculateDueDate(parentAppeal, costsDecision);
-			}
-		}
-	}
-	const personalListEntry = {
-		appealId: appeal.id,
-		dueDate,
-		linkType,
-		leadAppealId: linkType === 'parent' ? appeal.id : null
-	};
-
-	await performUpdate(personalListEntry);
-
-	if (linkType === 'parent') {
-		await Promise.all(
-			linkedAppeals.map(async (linkedAppeal) => {
-				if (linkedAppeal.childId) {
-					await performUpdate({
-						appealId: linkedAppeal.childId,
-						dueDate,
-						linkType: 'child',
-						leadAppealId: linkedAppeal.parentId
-					});
-				}
-			})
-		);
-	}
+	await setPersonalList({ appealId });
 };
 
 /**
- *
- * @param {{ appealId: number, dueDate: Date | null | undefined, linkType: string | null, leadAppealId: number | null }} personalListEntry
+ * @param {string | null | undefined} appealType
+ * @returns {boolean}
  */
-async function performUpdate(personalListEntry) {
-	const { appealId, dueDate = null, linkType = null, leadAppealId = null } = personalListEntry;
+const isNetResidencesAppealType = (appealType) => {
+	return (
+		(isFeatureActive(FEATURE_FLAG_NAMES.NET_RESIDENCE) && appealType === APPEAL_TYPE.S78) ||
+		(isFeatureActive(FEATURE_FLAG_NAMES.NET_RESIDENCE_S20) &&
+			appealType === APPEAL_TYPE.PLANNED_LISTED_BUILDING)
+	);
+};
 
-	// @ts-ignore
-	return personalListRepository.upsertPersonalListEntry({
-		appealId,
-		dueDate,
-		linkType,
-		leadAppealId
-	});
-}
+/**
+ * Executes the spSetPersonalList stored procedure.
+ * @param {{appealId?: number | null, isNetResidentsAppealType?: boolean}} [options]
+ * @returns {Promise<void>}
+ */
+export const setPersonalList = async ({ appealId = null, isNetResidentsAppealType } = {}) => {
+	const parsedAppealId = appealId === null ? null : Number(appealId);
+
+	if (appealId !== null && Number.isNaN(parsedAppealId)) {
+		throw new Error(`spSetPersonalList appealId must be numeric. Received: ${appealId}`);
+	}
+
+	let resolvedIsNetResidentsAppealType = Boolean(isNetResidentsAppealType);
+
+	if (typeof isNetResidentsAppealType === 'undefined' && parsedAppealId !== null) {
+		const appealType = await appealRepository.getAppealTypeById(parsedAppealId);
+		resolvedIsNetResidentsAppealType = isNetResidencesAppealType(appealType?.type);
+	}
+
+	await databaseConnector.$executeRawUnsafe(
+		`EXEC dbo.spSetPersonalList @appealId = ${parsedAppealId === null ? 'NULL' : parsedAppealId}, @isNetResidentsAppealType = ${resolvedIsNetResidentsAppealType ? 1 : 0};`
+	);
+};
 
 /**
  * Sleep for a specified number of milliseconds
@@ -111,14 +65,20 @@ function sleep(ms) {
  */
 export async function refreshPersonalList(forceFullRefresh = false) {
 	try {
-		const appealsWithoutPersonalListEntry =
-			await appealRepository.getAppealIdList(!forceFullRefresh);
+		if (forceFullRefresh) {
+			logger.info(`PersonalList full refresh starting`);
+			await setPersonalList();
+			logger.info(`PersonalList full refresh complete`);
+			return;
+		}
+
+		const appealsWithoutPersonalListEntry = await appealRepository.getAppealIdList(true);
 		if (appealsWithoutPersonalListEntry.length > 0) {
 			logger.info(
 				`PersonalList will be refreshed for ${appealsWithoutPersonalListEntry.length} appeals`
 			);
 			for (const appeal of appealsWithoutPersonalListEntry) {
-				await updatePersonalList(appeal.id);
+				await setPersonalList({ appealId: appeal.id });
 				await sleep(5); // sleep for 5 milliseconds
 			}
 			logger.info(`PersonalList refresh complete`);

--- a/appeals/api/src/server/utils/update-personal-list.js
+++ b/appeals/api/src/server/utils/update-personal-list.js
@@ -1,8 +1,6 @@
 import appealRepository from '#repositories/appeal.repository.js';
 import { databaseConnector } from '#utils/database-connector.js';
-import { isFeatureActive } from '#utils/feature-flags.js';
 import logger from '#utils/logger.js';
-import { APPEAL_TYPE, FEATURE_FLAG_NAMES } from '@pins/appeals/constants/common.js';
 
 /**
  * Updates the PersonalList for the specified appeal
@@ -14,38 +12,19 @@ export const updatePersonalList = async (appealId) => {
 };
 
 /**
- * @param {string | null | undefined} appealType
- * @returns {boolean}
- */
-const isNetResidencesAppealType = (appealType) => {
-	return (
-		(isFeatureActive(FEATURE_FLAG_NAMES.NET_RESIDENCE) && appealType === APPEAL_TYPE.S78) ||
-		(isFeatureActive(FEATURE_FLAG_NAMES.NET_RESIDENCE_S20) &&
-			appealType === APPEAL_TYPE.PLANNED_LISTED_BUILDING)
-	);
-};
-
-/**
  * Executes the spSetPersonalList stored procedure.
- * @param {{appealId?: number | null, isNetResidentsAppealType?: boolean}} [options]
+ * @param {{appealId?: number | null}} [options]
  * @returns {Promise<void>}
  */
-export const setPersonalList = async ({ appealId = null, isNetResidentsAppealType } = {}) => {
+export const setPersonalList = async ({ appealId = null } = {}) => {
 	const parsedAppealId = appealId === null ? null : Number(appealId);
 
 	if (appealId !== null && Number.isNaN(parsedAppealId)) {
 		throw new Error(`spSetPersonalList appealId must be numeric. Received: ${appealId}`);
 	}
 
-	let resolvedIsNetResidentsAppealType = Boolean(isNetResidentsAppealType);
-
-	if (typeof isNetResidentsAppealType === 'undefined' && parsedAppealId !== null) {
-		const appealType = await appealRepository.getAppealTypeById(parsedAppealId);
-		resolvedIsNetResidentsAppealType = isNetResidencesAppealType(appealType?.type);
-	}
-
 	await databaseConnector.$executeRawUnsafe(
-		`EXEC dbo.spSetPersonalList @appealId = ${parsedAppealId === null ? 'NULL' : parsedAppealId}, @isNetResidentsAppealType = ${resolvedIsNetResidentsAppealType ? 1 : 0};`
+		`EXEC dbo.spSetPersonalList @appealId = ${parsedAppealId === null ? 'NULL' : parsedAppealId};`
 	);
 };
 

--- a/appeals/api/stored-procedures.global-setup.js
+++ b/appeals/api/stored-procedures.global-setup.js
@@ -1,0 +1,6 @@
+import { bootstrapStoredProcedureTestDatabase } from '#tests/stored-procedures/test-database.js';
+
+export default async () => {
+	process.env.TZ = 'UTC';
+	await bootstrapStoredProcedureTestDatabase();
+};

--- a/appeals/api/stored-procedures.global-teardown.js
+++ b/appeals/api/stored-procedures.global-teardown.js
@@ -1,0 +1,5 @@
+import { stopStoredProcedureTestDatabase } from '#tests/stored-procedures/test-database.js';
+
+export default async () => {
+	await stopStoredProcedureTestDatabase();
+};

--- a/appeals/api/stored-procedures.setup.js
+++ b/appeals/api/stored-procedures.setup.js
@@ -1,0 +1,7 @@
+import {
+	applyStoredProcedureTestEnvironment,
+	loadStoredProcedureTestState
+} from '#tests/stored-procedures/test-database.js';
+
+process.env.TZ = 'UTC';
+applyStoredProcedureTestEnvironment(loadStoredProcedureTestState());

--- a/docs/database.md
+++ b/docs/database.md
@@ -1,0 +1,35 @@
+# Stored Procedures
+
+Prisma does not explicitly handle stored procedures in the schema file.
+However, you can still use stored procedures in your database and call them from your application code using raw SQL queries.
+
+We can create and modify stored procedures by manually making migration SQL in the database/migrations folder.
+
+However, to modify a stored procedure, we would need to make a new migration with the
+updated SQL for the stored procedure. In git this would of course be a separate file - and so we would
+lose the benefits of git versioning on that file. We would like to be able to see the changes on a single SQL script file.
+
+To achieve this we will do the following:
+
+1. keep our version-controlled stored procedure SQL scripts in a separate folder, e.g. `database/stored-procedures/`.
+
+## Creating a new stored procedure:
+
+2. create a new SQL script in the `database/stored-procedures/` folder with the SQL for the new stored procedure.
+3. create a new manual prisma migration file in a prisma migration folder, and copy that script into it.
+4. commit as usual to git.
+
+## Modifying an existing stored procedure:
+
+5. make the amendments to the existing stored procedure in the same SQL script in the `database/stored-procedures/` folder.
+6. create a new manual prisma migration file in a prisma migration folder, and copy that script into it.
+7. commit as usual to git.
+
+This will ensure that we can version track the changes using the master in the `database/stored-procedures/` folder.
+
+## Permissions
+
+We will need to also ensure that the SQL user that the API connects to the database as
+has the necessary permissions to execute stored procedures.
+This can be done by either ensuring that that user is in a role that has execute permission,
+or by explicitly granting execute permission to that user for the stored procedures.

--- a/package-lock.json
+++ b/package-lock.json
@@ -108,7 +108,8 @@
 				"stream-json": "^1.9.1",
 				"supertest": "7.0.0",
 				"swagger-autogen": "^2.21.4",
-				"swagger-typescript-api": "^13.2.16"
+				"swagger-typescript-api": "^13.2.16",
+				"testcontainers": "^11.7.3"
 			},
 			"engines": {
 				"node": ">=22 < 23"
@@ -4802,6 +4803,13 @@
 				"esbuild": ">=0.17.0"
 			}
 		},
+		"node_modules/@balena/dockerignore": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/@balena/dockerignore/-/dockerignore-1.0.2.tgz",
+			"integrity": "sha512-wMue2Sy4GAVTk6Ic4tJVcnfdau+gx2EnG7S+uAEe+TWJFqE4YoWN4/H8MSLj4eYJKxGg26lZwboEniNiNwZQ6Q==",
+			"dev": true,
+			"license": "Apache-2.0"
+		},
 		"node_modules/@bcoe/v8-coverage": {
 			"version": "0.2.3",
 			"license": "MIT"
@@ -6535,6 +6543,58 @@
 				"node": ">=14"
 			}
 		},
+		"node_modules/@grpc/grpc-js": {
+			"version": "1.14.3",
+			"resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.14.3.tgz",
+			"integrity": "sha512-Iq8QQQ/7X3Sac15oB6p0FmUg/klxQvXLeileoqrTRGJYLV+/9tubbr9ipz0GKHjmXVsgFPo/+W+2cA8eNcR+XA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@grpc/proto-loader": "^0.8.0",
+				"@js-sdsl/ordered-map": "^4.4.2"
+			},
+			"engines": {
+				"node": ">=12.10.0"
+			}
+		},
+		"node_modules/@grpc/grpc-js/node_modules/@grpc/proto-loader": {
+			"version": "0.8.0",
+			"resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.8.0.tgz",
+			"integrity": "sha512-rc1hOQtjIWGxcxpb9aHAfLpIctjEnsDehj0DAiVfBlmT84uvR0uUtN2hEi/ecvWVjXUGf5qPF4qEgiLOx1YIMQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"lodash.camelcase": "^4.3.0",
+				"long": "^5.0.0",
+				"protobufjs": "^7.5.3",
+				"yargs": "^17.7.2"
+			},
+			"bin": {
+				"proto-loader-gen-types": "build/bin/proto-loader-gen-types.js"
+			},
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/@grpc/proto-loader": {
+			"version": "0.7.15",
+			"resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.7.15.tgz",
+			"integrity": "sha512-tMXdRCfYVixjuFK+Hk0Q1s38gV9zDiDJfWL3h1rv4Qc39oILCu1TRTDt7+fGUI8K4G1Fj125Hx/ru3azECWTyQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"lodash.camelcase": "^4.3.0",
+				"long": "^5.0.0",
+				"protobufjs": "^7.2.5",
+				"yargs": "^17.7.2"
+			},
+			"bin": {
+				"proto-loader-gen-types": "build/bin/proto-loader-gen-types.js"
+			},
+			"engines": {
+				"node": ">=6"
+			}
+		},
 		"node_modules/@hapi/boom": {
 			"version": "10.0.1",
 			"resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-10.0.1.tgz",
@@ -7570,6 +7630,27 @@
 			"resolved": "https://registry.npmjs.org/@js-joda/core/-/core-5.7.0.tgz",
 			"integrity": "sha512-WBu4ULVVxySLLzK1Ppq+OdfP+adRS4ntmDQT915rzDJ++i95gc2jZkM5B6LWEAwN3lGXpfie3yPABozdD3K3Vg=="
 		},
+		"node_modules/@js-sdsl/ordered-map": {
+			"version": "4.4.2",
+			"resolved": "https://registry.npmjs.org/@js-sdsl/ordered-map/-/ordered-map-4.4.2.tgz",
+			"integrity": "sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw==",
+			"dev": true,
+			"license": "MIT",
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/js-sdsl"
+			}
+		},
+		"node_modules/@kwsites/file-exists": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@kwsites/file-exists/-/file-exists-1.1.1.tgz",
+			"integrity": "sha512-m9/5YGR18lIwxSFDwfE3oA7bWuq9kdau6ugN4H2rJeyhFQZcG9AgSHkQtSD15a8WvTgfz9aikZMrKPHvbpqFiw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"debug": "^4.1.1"
+			}
+		},
 		"node_modules/@microsoft/applicationinsights-web-snippet": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-web-snippet/-/applicationinsights-web-snippet-1.0.1.tgz",
@@ -8075,6 +8156,80 @@
 				"react": "^18.0.0 || ^19.0.0",
 				"react-dom": "^18.0.0 || ^19.0.0"
 			}
+		},
+		"node_modules/@protobufjs/aspromise": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+			"integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+			"dev": true,
+			"license": "BSD-3-Clause"
+		},
+		"node_modules/@protobufjs/base64": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+			"integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+			"dev": true,
+			"license": "BSD-3-Clause"
+		},
+		"node_modules/@protobufjs/codegen": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
+			"integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==",
+			"dev": true,
+			"license": "BSD-3-Clause"
+		},
+		"node_modules/@protobufjs/eventemitter": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
+			"integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==",
+			"dev": true,
+			"license": "BSD-3-Clause"
+		},
+		"node_modules/@protobufjs/fetch": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
+			"integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"@protobufjs/aspromise": "^1.1.1",
+				"@protobufjs/inquire": "^1.1.0"
+			}
+		},
+		"node_modules/@protobufjs/float": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+			"integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+			"dev": true,
+			"license": "BSD-3-Clause"
+		},
+		"node_modules/@protobufjs/inquire": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
+			"integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==",
+			"dev": true,
+			"license": "BSD-3-Clause"
+		},
+		"node_modules/@protobufjs/path": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+			"integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+			"dev": true,
+			"license": "BSD-3-Clause"
+		},
+		"node_modules/@protobufjs/pool": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+			"integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+			"dev": true,
+			"license": "BSD-3-Clause"
+		},
+		"node_modules/@protobufjs/utf8": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
+			"integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
+			"dev": true,
+			"license": "BSD-3-Clause"
 		},
 		"node_modules/@puppeteer/browsers": {
 			"version": "2.7.1",
@@ -8756,6 +8911,29 @@
 				"date-fns": "*"
 			}
 		},
+		"node_modules/@types/docker-modem": {
+			"version": "3.0.6",
+			"resolved": "https://registry.npmjs.org/@types/docker-modem/-/docker-modem-3.0.6.tgz",
+			"integrity": "sha512-yKpAGEuKRSS8wwx0joknWxsmLha78wNMe9R2S3UNsVOkZded8UqOrV8KoeDXoXsjndxwyF3eIhyClGbO1SEhEg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/node": "*",
+				"@types/ssh2": "*"
+			}
+		},
+		"node_modules/@types/dockerode": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/@types/dockerode/-/dockerode-4.0.1.tgz",
+			"integrity": "sha512-cmUpB+dPN955PxBEuXE3f6lKO1hHiIGYJA46IVF3BJpNsZGvtBDcRnlrHYHtOH/B6vtDOyl2kZ2ShAu3mgc27Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/docker-modem": "*",
+				"@types/node": "*",
+				"@types/ssh2": "*"
+			}
+		},
 		"node_modules/@types/escape-html": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/@types/escape-html/-/escape-html-1.0.4.tgz",
@@ -9132,6 +9310,36 @@
 			"version": "2.3.3",
 			"resolved": "https://registry.npmjs.org/@types/sizzle/-/sizzle-2.3.3.tgz",
 			"integrity": "sha512-JYM8x9EGF163bEyhdJBpR2QX1R5naCJHC8ucJylJ3w9/CVBaskdQ8WqBf8MmQrd1kRvp/a4TS8HJ+bxzR7ZJYQ=="
+		},
+		"node_modules/@types/ssh2": {
+			"version": "1.15.5",
+			"resolved": "https://registry.npmjs.org/@types/ssh2/-/ssh2-1.15.5.tgz",
+			"integrity": "sha512-N1ASjp/nXH3ovBHddRJpli4ozpk6UdDYIX4RJWFa9L1YKnzdhTlVmiGHm4DZnj/jLbqZpes4aeR30EFGQtvhQQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/node": "^18.11.18"
+			}
+		},
+		"node_modules/@types/ssh2-streams": {
+			"version": "0.1.13",
+			"resolved": "https://registry.npmjs.org/@types/ssh2-streams/-/ssh2-streams-0.1.13.tgz",
+			"integrity": "sha512-faHyY3brO9oLEA0QlcO8N2wT7R0+1sHWZvQ+y3rMLwdY1ZyS1z0W3t65j9PqT4HmQ6ALzNe7RZlNuCNE0wBSWA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/node": "*"
+			}
+		},
+		"node_modules/@types/ssh2/node_modules/@types/node": {
+			"version": "18.19.130",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.130.tgz",
+			"integrity": "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"undici-types": "~5.26.4"
+			}
 		},
 		"node_modules/@types/stack-utils": {
 			"version": "2.0.3",
@@ -10607,6 +10815,13 @@
 				"semver": "bin/semver"
 			}
 		},
+		"node_modules/async-lock": {
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/async-lock/-/async-lock-1.4.1.tgz",
+			"integrity": "sha512-Az2ZTpuytrtqENulXwO3GGv1Bztugx6TT37NIo7imr/Qo0gsYiGtSdBa2B6fsXhTpVZDNfu1Qn3pk531e3q+nQ==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/async-mutex": {
 			"version": "0.5.0",
 			"resolved": "https://registry.npmjs.org/async-mutex/-/async-mutex-0.5.0.tgz",
@@ -11265,6 +11480,16 @@
 			"version": "1.1.2",
 			"license": "MIT"
 		},
+		"node_modules/buildcheck": {
+			"version": "0.0.7",
+			"resolved": "https://registry.npmjs.org/buildcheck/-/buildcheck-0.0.7.tgz",
+			"integrity": "sha512-lHblz4ahamxpTmnsk+MNTRWsjYKv965MwOrSJyeD588rR3Jcu7swE+0wN5F+PbL5cjgu/9ObkhfzEPuofEMwLA==",
+			"dev": true,
+			"optional": true,
+			"engines": {
+				"node": ">=10.0.0"
+			}
+		},
 		"node_modules/builtin-modules": {
 			"version": "3.3.0",
 			"resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-3.3.0.tgz",
@@ -11299,6 +11524,16 @@
 			},
 			"engines": {
 				"node": ">=10.16.0"
+			}
+		},
+		"node_modules/byline": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/byline/-/byline-5.0.0.tgz",
+			"integrity": "sha512-s6webAy+R4SR8XVuJWt2V2rGvhnrhxN+9S15GNuTK3wKPOXFF6RNc+8ug2XhH+2s4f+uudG4kUVYmYOQWL2g0Q==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/bytes": {
@@ -11897,6 +12132,13 @@
 				"camelcase": "^5.0.0",
 				"decamelize": "^1.2.0"
 			}
+		},
+		"node_modules/chownr": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+			"integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+			"dev": true,
+			"license": "ISC"
 		},
 		"node_modules/chrome-trace-event": {
 			"version": "1.0.3",
@@ -12745,6 +12987,21 @@
 				"@types/node": "*",
 				"cosmiconfig": ">=9",
 				"typescript": ">=5"
+			}
+		},
+		"node_modules/cpu-features": {
+			"version": "0.0.10",
+			"resolved": "https://registry.npmjs.org/cpu-features/-/cpu-features-0.0.10.tgz",
+			"integrity": "sha512-9IkYqtX3YHPCzoVg1Py+o9057a3i0fp7S530UWokCSaFVTc7CwXPRiOjRjBQQ18ZCNafx78YfnG+HALxtVmOGA==",
+			"dev": true,
+			"hasInstallScript": true,
+			"optional": true,
+			"dependencies": {
+				"buildcheck": "~0.0.6",
+				"nan": "^2.19.0"
+			},
+			"engines": {
+				"node": ">=10.0.0"
 			}
 		},
 		"node_modules/crc-32": {
@@ -13840,6 +14097,144 @@
 			},
 			"engines": {
 				"node": ">=8"
+			}
+		},
+		"node_modules/docker-compose": {
+			"version": "1.3.2",
+			"resolved": "https://registry.npmjs.org/docker-compose/-/docker-compose-1.3.2.tgz",
+			"integrity": "sha512-FO/Jemn08gf9o9E6qtqOPQpyauwf2rQAzfpoUlMyqNpdaVb0ImR/wXKoutLZKp1tks58F8Z8iR7va7H1ne09cw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"yaml": "^2.2.2"
+			},
+			"engines": {
+				"node": ">= 6.0.0"
+			}
+		},
+		"node_modules/docker-compose/node_modules/yaml": {
+			"version": "2.8.2",
+			"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
+			"integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
+			"dev": true,
+			"license": "ISC",
+			"bin": {
+				"yaml": "bin.mjs"
+			},
+			"engines": {
+				"node": ">= 14.6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/eemeli"
+			}
+		},
+		"node_modules/docker-modem": {
+			"version": "5.0.6",
+			"resolved": "https://registry.npmjs.org/docker-modem/-/docker-modem-5.0.6.tgz",
+			"integrity": "sha512-ens7BiayssQz/uAxGzH8zGXCtiV24rRWXdjNha5V4zSOcxmAZsfGVm/PPFbwQdqEkDnhG+SyR9E3zSHUbOKXBQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"debug": "^4.1.1",
+				"readable-stream": "^3.5.0",
+				"split-ca": "^1.0.1",
+				"ssh2": "^1.15.0"
+			},
+			"engines": {
+				"node": ">= 8.0"
+			}
+		},
+		"node_modules/docker-modem/node_modules/readable-stream": {
+			"version": "3.6.2",
+			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+			"integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"inherits": "^2.0.3",
+				"string_decoder": "^1.1.1",
+				"util-deprecate": "^1.0.1"
+			},
+			"engines": {
+				"node": ">= 6"
+			}
+		},
+		"node_modules/dockerode": {
+			"version": "4.0.9",
+			"resolved": "https://registry.npmjs.org/dockerode/-/dockerode-4.0.9.tgz",
+			"integrity": "sha512-iND4mcOWhPaCNh54WmK/KoSb35AFqPAUWFMffTQcp52uQt36b5uNwEJTSXntJZBbeGad72Crbi/hvDIv6us/6Q==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@balena/dockerignore": "^1.0.2",
+				"@grpc/grpc-js": "^1.11.1",
+				"@grpc/proto-loader": "^0.7.13",
+				"docker-modem": "^5.0.6",
+				"protobufjs": "^7.3.2",
+				"tar-fs": "^2.1.4",
+				"uuid": "^10.0.0"
+			},
+			"engines": {
+				"node": ">= 8.0"
+			}
+		},
+		"node_modules/dockerode/node_modules/readable-stream": {
+			"version": "3.6.2",
+			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+			"integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"inherits": "^2.0.3",
+				"string_decoder": "^1.1.1",
+				"util-deprecate": "^1.0.1"
+			},
+			"engines": {
+				"node": ">= 6"
+			}
+		},
+		"node_modules/dockerode/node_modules/tar-fs": {
+			"version": "2.1.4",
+			"resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
+			"integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"chownr": "^1.1.1",
+				"mkdirp-classic": "^0.5.2",
+				"pump": "^3.0.0",
+				"tar-stream": "^2.1.4"
+			}
+		},
+		"node_modules/dockerode/node_modules/tar-stream": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+			"integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"bl": "^4.0.3",
+				"end-of-stream": "^1.4.1",
+				"fs-constants": "^1.0.0",
+				"inherits": "^2.0.3",
+				"readable-stream": "^3.1.1"
+			},
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/dockerode/node_modules/uuid": {
+			"version": "10.0.0",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
+			"integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
+			"dev": true,
+			"funding": [
+				"https://github.com/sponsors/broofa",
+				"https://github.com/sponsors/ctavan"
+			],
+			"license": "MIT",
+			"bin": {
+				"uuid": "dist/bin/uuid"
 			}
 		},
 		"node_modules/doctrine": {
@@ -16023,6 +16418,13 @@
 				"node": ">= 0.6"
 			}
 		},
+		"node_modules/fs-constants": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+			"integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/fs.realpath": {
 			"version": "1.0.0",
 			"license": "ISC"
@@ -16167,6 +16569,19 @@
 			"dev": true,
 			"engines": {
 				"node": ">=8.0.0"
+			}
+		},
+		"node_modules/get-port": {
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/get-port/-/get-port-7.1.0.tgz",
+			"integrity": "sha512-QB9NKEeDg3xxVwCCwJQ9+xycaz6pBB6iQ76wiWMl1927n0Kir6alPiP+yuiICLLU4jpMe08dXfpebuQppFA2zw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=16"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/get-port-please": {
@@ -20835,6 +21250,13 @@
 				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
+		"node_modules/mkdirp-classic": {
+			"version": "0.5.3",
+			"resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+			"integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/mocha": {
 			"version": "11.1.0",
 			"resolved": "https://registry.npmjs.org/mocha/-/mocha-11.1.0.tgz",
@@ -21264,6 +21686,14 @@
 			"engines": {
 				"node": ">=8.0.0"
 			}
+		},
+		"node_modules/nan": {
+			"version": "2.26.2",
+			"resolved": "https://registry.npmjs.org/nan/-/nan-2.26.2.tgz",
+			"integrity": "sha512-0tTvBTYkt3tdGw22nrAy50x7gpbGCCFH3AFcyS5WiUu7Eu4vWlri1woE6qHBSfy11vksDqkiwjOnlR7WV8G1Hw==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true
 		},
 		"node_modules/nanoid": {
 			"version": "3.3.8",
@@ -23104,10 +23534,53 @@
 				"signal-exit": "^3.0.2"
 			}
 		},
+		"node_modules/properties-reader": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/properties-reader/-/properties-reader-3.0.1.tgz",
+			"integrity": "sha512-WPn+h9RGEExOKdu4bsF4HksG/uzd3cFq3MFtq8PsFeExPse5Ha/VOjQNyHhjboBFwGXGev6muJYTSPAOkROq2g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@kwsites/file-exists": "^1.1.1",
+				"mkdirp": "^3.0.1"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/steveukx/properties?sponsor=1"
+			}
+		},
 		"node_modules/property-expr": {
 			"version": "2.0.6",
 			"resolved": "https://registry.npmjs.org/property-expr/-/property-expr-2.0.6.tgz",
 			"integrity": "sha512-SVtmxhRE/CGkn3eZY1T6pC8Nln6Fr/lu1mKSgRud0eC73whjGfoAogbn78LkD8aFL0zz3bAFerKSnOl7NlErBA=="
+		},
+		"node_modules/protobufjs": {
+			"version": "7.5.4",
+			"resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.4.tgz",
+			"integrity": "sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==",
+			"dev": true,
+			"hasInstallScript": true,
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"@protobufjs/aspromise": "^1.1.2",
+				"@protobufjs/base64": "^1.1.2",
+				"@protobufjs/codegen": "^2.0.4",
+				"@protobufjs/eventemitter": "^1.1.0",
+				"@protobufjs/fetch": "^1.1.0",
+				"@protobufjs/float": "^1.0.2",
+				"@protobufjs/inquire": "^1.1.0",
+				"@protobufjs/path": "^1.1.2",
+				"@protobufjs/pool": "^1.1.0",
+				"@protobufjs/utf8": "^1.1.0",
+				"@types/node": ">=13.7.0",
+				"long": "^5.0.0"
+			},
+			"engines": {
+				"node": ">=12.0.0"
+			}
 		},
 		"node_modules/proxy-addr": {
 			"version": "2.0.7",
@@ -25261,6 +25734,13 @@
 				"node": "*"
 			}
 		},
+		"node_modules/split-ca": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/split-ca/-/split-ca-1.0.1.tgz",
+			"integrity": "sha512-Q5thBSxp5t8WPTTJQS59LrGqOZqOsrhDGDVm8azCqIBjSBd7nd9o2PM+mDulQQkh8h//4U6hFZnc/mul8t5pWQ==",
+			"dev": true,
+			"license": "ISC"
+		},
 		"node_modules/split2": {
 			"version": "4.1.0",
 			"license": "ISC",
@@ -25282,6 +25762,46 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">= 0.6"
+			}
+		},
+		"node_modules/ssh-remote-port-forward": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/ssh-remote-port-forward/-/ssh-remote-port-forward-1.0.4.tgz",
+			"integrity": "sha512-x0LV1eVDwjf1gmG7TTnfqIzf+3VPRz7vrNIjX6oYLbeCrf/PeVY6hkT68Mg+q02qXxQhrLjB0jfgvhevoCRmLQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/ssh2": "^0.5.48",
+				"ssh2": "^1.4.0"
+			}
+		},
+		"node_modules/ssh-remote-port-forward/node_modules/@types/ssh2": {
+			"version": "0.5.52",
+			"resolved": "https://registry.npmjs.org/@types/ssh2/-/ssh2-0.5.52.tgz",
+			"integrity": "sha512-lbLLlXxdCZOSJMCInKH2+9V/77ET2J6NPQHpFI0kda61Dd1KglJs+fPQBchizmzYSOJBgdTajhPqBO1xxLywvg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/node": "*",
+				"@types/ssh2-streams": "*"
+			}
+		},
+		"node_modules/ssh2": {
+			"version": "1.17.0",
+			"resolved": "https://registry.npmjs.org/ssh2/-/ssh2-1.17.0.tgz",
+			"integrity": "sha512-wPldCk3asibAjQ/kziWQQt1Wh3PgDFpC0XpwclzKcdT1vql6KeYxf5LIt4nlFkUeR8WuphYMKqUA56X4rjbfgQ==",
+			"dev": true,
+			"hasInstallScript": true,
+			"dependencies": {
+				"asn1": "^0.2.6",
+				"bcrypt-pbkdf": "^1.0.2"
+			},
+			"engines": {
+				"node": ">=10.16.0"
+			},
+			"optionalDependencies": {
+				"cpu-features": "~0.0.10",
+				"nan": "^2.23.0"
 			}
 		},
 		"node_modules/sshpk": {
@@ -26407,6 +26927,83 @@
 			},
 			"engines": {
 				"node": ">=8"
+			}
+		},
+		"node_modules/testcontainers": {
+			"version": "11.13.0",
+			"resolved": "https://registry.npmjs.org/testcontainers/-/testcontainers-11.13.0.tgz",
+			"integrity": "sha512-fzTvgOtd6U/esOzgmDatJh79OSK0tU6vjDOJ3B6ICrrJf0dqCWtFdpOr6f/g/KixMxKDTDbszmZYjSORJXsVCQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@balena/dockerignore": "^1.0.2",
+				"@types/dockerode": "^4.0.1",
+				"archiver": "^7.0.1",
+				"async-lock": "^1.4.1",
+				"byline": "^5.0.0",
+				"debug": "^4.4.3",
+				"docker-compose": "^1.3.2",
+				"dockerode": "^4.0.9",
+				"get-port": "^7.1.0",
+				"proper-lockfile": "^4.1.2",
+				"properties-reader": "^3.0.1",
+				"ssh-remote-port-forward": "^1.0.4",
+				"tar-fs": "^3.1.2",
+				"tmp": "^0.2.5",
+				"undici": "^7.24.3"
+			}
+		},
+		"node_modules/testcontainers/node_modules/debug": {
+			"version": "4.4.3",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+			"integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ms": "^2.1.3"
+			},
+			"engines": {
+				"node": ">=6.0"
+			},
+			"peerDependenciesMeta": {
+				"supports-color": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/testcontainers/node_modules/tar-fs": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.1.2.tgz",
+			"integrity": "sha512-QGxxTxxyleAdyM3kpFs14ymbYmNFrfY+pHj7Z8FgtbZ7w2//VAgLMac7sT6nRpIHjppXO2AwwEOg0bPFVRcmXw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"pump": "^3.0.0",
+				"tar-stream": "^3.1.5"
+			},
+			"optionalDependencies": {
+				"bare-fs": "^4.0.1",
+				"bare-path": "^3.0.0"
+			}
+		},
+		"node_modules/testcontainers/node_modules/tmp": {
+			"version": "0.2.5",
+			"resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
+			"integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=14.14"
+			}
+		},
+		"node_modules/testcontainers/node_modules/undici": {
+			"version": "7.24.5",
+			"resolved": "https://registry.npmjs.org/undici/-/undici-7.24.5.tgz",
+			"integrity": "sha512-3IWdCpjgxp15CbJnsi/Y9TCDE7HWVN19j1hmzVhoAkY/+CJx449tVxT5wZc1Gwg8J+P0LWvzlBzxYRnHJ+1i7Q==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=20.18.1"
 			}
 		},
 		"node_modules/text-decoder": {
@@ -31554,6 +32151,12 @@
 				"debug": "4.3.4"
 			}
 		},
+		"@balena/dockerignore": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/@balena/dockerignore/-/dockerignore-1.0.2.tgz",
+			"integrity": "sha512-wMue2Sy4GAVTk6Ic4tJVcnfdau+gx2EnG7S+uAEe+TWJFqE4YoWN4/H8MSLj4eYJKxGg26lZwboEniNiNwZQ6Q==",
+			"dev": true
+		},
 		"@bcoe/v8-coverage": {
 			"version": "0.2.3"
 		},
@@ -32687,6 +33290,42 @@
 			"resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.1.tgz",
 			"integrity": "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA=="
 		},
+		"@grpc/grpc-js": {
+			"version": "1.14.3",
+			"resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.14.3.tgz",
+			"integrity": "sha512-Iq8QQQ/7X3Sac15oB6p0FmUg/klxQvXLeileoqrTRGJYLV+/9tubbr9ipz0GKHjmXVsgFPo/+W+2cA8eNcR+XA==",
+			"dev": true,
+			"requires": {
+				"@grpc/proto-loader": "^0.8.0",
+				"@js-sdsl/ordered-map": "^4.4.2"
+			},
+			"dependencies": {
+				"@grpc/proto-loader": {
+					"version": "0.8.0",
+					"resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.8.0.tgz",
+					"integrity": "sha512-rc1hOQtjIWGxcxpb9aHAfLpIctjEnsDehj0DAiVfBlmT84uvR0uUtN2hEi/ecvWVjXUGf5qPF4qEgiLOx1YIMQ==",
+					"dev": true,
+					"requires": {
+						"lodash.camelcase": "^4.3.0",
+						"long": "^5.0.0",
+						"protobufjs": "^7.5.3",
+						"yargs": "^17.7.2"
+					}
+				}
+			}
+		},
+		"@grpc/proto-loader": {
+			"version": "0.7.15",
+			"resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.7.15.tgz",
+			"integrity": "sha512-tMXdRCfYVixjuFK+Hk0Q1s38gV9zDiDJfWL3h1rv4Qc39oILCu1TRTDt7+fGUI8K4G1Fj125Hx/ru3azECWTyQ==",
+			"dev": true,
+			"requires": {
+				"lodash.camelcase": "^4.3.0",
+				"long": "^5.0.0",
+				"protobufjs": "^7.2.5",
+				"yargs": "^17.7.2"
+			}
+		},
 		"@hapi/boom": {
 			"version": "10.0.1",
 			"resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-10.0.1.tgz",
@@ -33461,6 +34100,21 @@
 			"resolved": "https://registry.npmjs.org/@js-joda/core/-/core-5.7.0.tgz",
 			"integrity": "sha512-WBu4ULVVxySLLzK1Ppq+OdfP+adRS4ntmDQT915rzDJ++i95gc2jZkM5B6LWEAwN3lGXpfie3yPABozdD3K3Vg=="
 		},
+		"@js-sdsl/ordered-map": {
+			"version": "4.4.2",
+			"resolved": "https://registry.npmjs.org/@js-sdsl/ordered-map/-/ordered-map-4.4.2.tgz",
+			"integrity": "sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw==",
+			"dev": true
+		},
+		"@kwsites/file-exists": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@kwsites/file-exists/-/file-exists-1.1.1.tgz",
+			"integrity": "sha512-m9/5YGR18lIwxSFDwfE3oA7bWuq9kdau6ugN4H2rJeyhFQZcG9AgSHkQtSD15a8WvTgfz9aikZMrKPHvbpqFiw==",
+			"dev": true,
+			"requires": {
+				"debug": "^4.1.1"
+			}
+		},
 		"@microsoft/applicationinsights-web-snippet": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-web-snippet/-/applicationinsights-web-snippet-1.0.1.tgz",
@@ -33673,6 +34327,7 @@
 				"swagger-autogen": "^2.21.4",
 				"swagger-typescript-api": "^13.2.16",
 				"swagger-ui-express": "^5.0.1",
+				"testcontainers": "^11.7.3",
 				"xstate": "4.32.1"
 			},
 			"dependencies": {
@@ -35252,6 +35907,70 @@
 			"devOptional": true,
 			"requires": {}
 		},
+		"@protobufjs/aspromise": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+			"integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+			"dev": true
+		},
+		"@protobufjs/base64": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+			"integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+			"dev": true
+		},
+		"@protobufjs/codegen": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
+			"integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==",
+			"dev": true
+		},
+		"@protobufjs/eventemitter": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
+			"integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==",
+			"dev": true
+		},
+		"@protobufjs/fetch": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
+			"integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
+			"dev": true,
+			"requires": {
+				"@protobufjs/aspromise": "^1.1.1",
+				"@protobufjs/inquire": "^1.1.0"
+			}
+		},
+		"@protobufjs/float": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+			"integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+			"dev": true
+		},
+		"@protobufjs/inquire": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
+			"integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==",
+			"dev": true
+		},
+		"@protobufjs/path": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+			"integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+			"dev": true
+		},
+		"@protobufjs/pool": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+			"integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+			"dev": true
+		},
+		"@protobufjs/utf8": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
+			"integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
+			"dev": true
+		},
 		"@puppeteer/browsers": {
 			"version": "2.7.1",
 			"resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.7.1.tgz",
@@ -35736,6 +36455,27 @@
 				"date-fns": "*"
 			}
 		},
+		"@types/docker-modem": {
+			"version": "3.0.6",
+			"resolved": "https://registry.npmjs.org/@types/docker-modem/-/docker-modem-3.0.6.tgz",
+			"integrity": "sha512-yKpAGEuKRSS8wwx0joknWxsmLha78wNMe9R2S3UNsVOkZded8UqOrV8KoeDXoXsjndxwyF3eIhyClGbO1SEhEg==",
+			"dev": true,
+			"requires": {
+				"@types/node": "*",
+				"@types/ssh2": "*"
+			}
+		},
+		"@types/dockerode": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/@types/dockerode/-/dockerode-4.0.1.tgz",
+			"integrity": "sha512-cmUpB+dPN955PxBEuXE3f6lKO1hHiIGYJA46IVF3BJpNsZGvtBDcRnlrHYHtOH/B6vtDOyl2kZ2ShAu3mgc27Q==",
+			"dev": true,
+			"requires": {
+				"@types/docker-modem": "*",
+				"@types/node": "*",
+				"@types/ssh2": "*"
+			}
+		},
 		"@types/escape-html": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/@types/escape-html/-/escape-html-1.0.4.tgz",
@@ -36089,6 +36829,35 @@
 			"version": "2.3.3",
 			"resolved": "https://registry.npmjs.org/@types/sizzle/-/sizzle-2.3.3.tgz",
 			"integrity": "sha512-JYM8x9EGF163bEyhdJBpR2QX1R5naCJHC8ucJylJ3w9/CVBaskdQ8WqBf8MmQrd1kRvp/a4TS8HJ+bxzR7ZJYQ=="
+		},
+		"@types/ssh2": {
+			"version": "1.15.5",
+			"resolved": "https://registry.npmjs.org/@types/ssh2/-/ssh2-1.15.5.tgz",
+			"integrity": "sha512-N1ASjp/nXH3ovBHddRJpli4ozpk6UdDYIX4RJWFa9L1YKnzdhTlVmiGHm4DZnj/jLbqZpes4aeR30EFGQtvhQQ==",
+			"dev": true,
+			"requires": {
+				"@types/node": "^18.11.18"
+			},
+			"dependencies": {
+				"@types/node": {
+					"version": "18.19.130",
+					"resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.130.tgz",
+					"integrity": "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==",
+					"dev": true,
+					"requires": {
+						"undici-types": "~5.26.4"
+					}
+				}
+			}
+		},
+		"@types/ssh2-streams": {
+			"version": "0.1.13",
+			"resolved": "https://registry.npmjs.org/@types/ssh2-streams/-/ssh2-streams-0.1.13.tgz",
+			"integrity": "sha512-faHyY3brO9oLEA0QlcO8N2wT7R0+1sHWZvQ+y3rMLwdY1ZyS1z0W3t65j9PqT4HmQ6ALzNe7RZlNuCNE0wBSWA==",
+			"dev": true,
+			"requires": {
+				"@types/node": "*"
+			}
 		},
 		"@types/stack-utils": {
 			"version": "2.0.3",
@@ -37113,6 +37882,12 @@
 				}
 			}
 		},
+		"async-lock": {
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/async-lock/-/async-lock-1.4.1.tgz",
+			"integrity": "sha512-Az2ZTpuytrtqENulXwO3GGv1Bztugx6TT37NIo7imr/Qo0gsYiGtSdBa2B6fsXhTpVZDNfu1Qn3pk531e3q+nQ==",
+			"dev": true
+		},
 		"async-mutex": {
 			"version": "0.5.0",
 			"resolved": "https://registry.npmjs.org/async-mutex/-/async-mutex-0.5.0.tgz",
@@ -37563,6 +38338,13 @@
 		"buffer-from": {
 			"version": "1.1.2"
 		},
+		"buildcheck": {
+			"version": "0.0.7",
+			"resolved": "https://registry.npmjs.org/buildcheck/-/buildcheck-0.0.7.tgz",
+			"integrity": "sha512-lHblz4ahamxpTmnsk+MNTRWsjYKv965MwOrSJyeD588rR3Jcu7swE+0wN5F+PbL5cjgu/9ObkhfzEPuofEMwLA==",
+			"dev": true,
+			"optional": true
+		},
 		"builtin-modules": {
 			"version": "3.3.0",
 			"resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-3.3.0.tgz",
@@ -37583,6 +38365,12 @@
 			"requires": {
 				"streamsearch": "^1.1.0"
 			}
+		},
+		"byline": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/byline/-/byline-5.0.0.tgz",
+			"integrity": "sha512-s6webAy+R4SR8XVuJWt2V2rGvhnrhxN+9S15GNuTK3wKPOXFF6RNc+8ug2XhH+2s4f+uudG4kUVYmYOQWL2g0Q==",
+			"dev": true
 		},
 		"bytes": {
 			"version": "3.1.2"
@@ -37995,6 +38783,12 @@
 					}
 				}
 			}
+		},
+		"chownr": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+			"integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+			"dev": true
 		},
 		"chrome-trace-event": {
 			"version": "1.0.3",
@@ -38563,6 +39357,17 @@
 			"dev": true,
 			"requires": {
 				"jiti": "^2.6.1"
+			}
+		},
+		"cpu-features": {
+			"version": "0.0.10",
+			"resolved": "https://registry.npmjs.org/cpu-features/-/cpu-features-0.0.10.tgz",
+			"integrity": "sha512-9IkYqtX3YHPCzoVg1Py+o9057a3i0fp7S530UWokCSaFVTc7CwXPRiOjRjBQQ18ZCNafx78YfnG+HALxtVmOGA==",
+			"dev": true,
+			"optional": true,
+			"requires": {
+				"buildcheck": "~0.0.6",
+				"nan": "^2.19.0"
 			}
 		},
 		"crc-32": {
@@ -39288,6 +40093,107 @@
 			"version": "3.0.1",
 			"requires": {
 				"path-type": "^4.0.0"
+			}
+		},
+		"docker-compose": {
+			"version": "1.3.2",
+			"resolved": "https://registry.npmjs.org/docker-compose/-/docker-compose-1.3.2.tgz",
+			"integrity": "sha512-FO/Jemn08gf9o9E6qtqOPQpyauwf2rQAzfpoUlMyqNpdaVb0ImR/wXKoutLZKp1tks58F8Z8iR7va7H1ne09cw==",
+			"dev": true,
+			"requires": {
+				"yaml": "^2.2.2"
+			},
+			"dependencies": {
+				"yaml": {
+					"version": "2.8.2",
+					"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
+					"integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
+					"dev": true
+				}
+			}
+		},
+		"docker-modem": {
+			"version": "5.0.6",
+			"resolved": "https://registry.npmjs.org/docker-modem/-/docker-modem-5.0.6.tgz",
+			"integrity": "sha512-ens7BiayssQz/uAxGzH8zGXCtiV24rRWXdjNha5V4zSOcxmAZsfGVm/PPFbwQdqEkDnhG+SyR9E3zSHUbOKXBQ==",
+			"dev": true,
+			"requires": {
+				"debug": "^4.1.1",
+				"readable-stream": "^3.5.0",
+				"split-ca": "^1.0.1",
+				"ssh2": "^1.15.0"
+			},
+			"dependencies": {
+				"readable-stream": {
+					"version": "3.6.2",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+					"integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+					"dev": true,
+					"requires": {
+						"inherits": "^2.0.3",
+						"string_decoder": "^1.1.1",
+						"util-deprecate": "^1.0.1"
+					}
+				}
+			}
+		},
+		"dockerode": {
+			"version": "4.0.9",
+			"resolved": "https://registry.npmjs.org/dockerode/-/dockerode-4.0.9.tgz",
+			"integrity": "sha512-iND4mcOWhPaCNh54WmK/KoSb35AFqPAUWFMffTQcp52uQt36b5uNwEJTSXntJZBbeGad72Crbi/hvDIv6us/6Q==",
+			"dev": true,
+			"requires": {
+				"@balena/dockerignore": "^1.0.2",
+				"@grpc/grpc-js": "^1.11.1",
+				"@grpc/proto-loader": "^0.7.13",
+				"docker-modem": "^5.0.6",
+				"protobufjs": "^7.3.2",
+				"tar-fs": "^2.1.4",
+				"uuid": "^10.0.0"
+			},
+			"dependencies": {
+				"readable-stream": {
+					"version": "3.6.2",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+					"integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+					"dev": true,
+					"requires": {
+						"inherits": "^2.0.3",
+						"string_decoder": "^1.1.1",
+						"util-deprecate": "^1.0.1"
+					}
+				},
+				"tar-fs": {
+					"version": "2.1.4",
+					"resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
+					"integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
+					"dev": true,
+					"requires": {
+						"chownr": "^1.1.1",
+						"mkdirp-classic": "^0.5.2",
+						"pump": "^3.0.0",
+						"tar-stream": "^2.1.4"
+					}
+				},
+				"tar-stream": {
+					"version": "2.2.0",
+					"resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+					"integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+					"dev": true,
+					"requires": {
+						"bl": "^4.0.3",
+						"end-of-stream": "^1.4.1",
+						"fs-constants": "^1.0.0",
+						"inherits": "^2.0.3",
+						"readable-stream": "^3.1.1"
+					}
+				},
+				"uuid": {
+					"version": "10.0.0",
+					"resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
+					"integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
+					"dev": true
+				}
 			}
 		},
 		"doctrine": {
@@ -40763,6 +41669,12 @@
 		"fresh": {
 			"version": "0.5.2"
 		},
+		"fs-constants": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+			"integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+			"dev": true
+		},
 		"fs.realpath": {
 			"version": "1.0.0"
 		},
@@ -40855,6 +41767,12 @@
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/get-package-type/-/get-package-type-0.1.0.tgz",
 			"integrity": "sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==",
+			"dev": true
+		},
+		"get-port": {
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/get-port/-/get-port-7.1.0.tgz",
+			"integrity": "sha512-QB9NKEeDg3xxVwCCwJQ9+xycaz6pBB6iQ76wiWMl1927n0Kir6alPiP+yuiICLLU4jpMe08dXfpebuQppFA2zw==",
 			"dev": true
 		},
 		"get-port-please": {
@@ -44033,6 +44951,12 @@
 			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-3.0.1.tgz",
 			"integrity": "sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg=="
 		},
+		"mkdirp-classic": {
+			"version": "0.5.3",
+			"resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+			"integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+			"dev": true
+		},
 		"mocha": {
 			"version": "11.1.0",
 			"resolved": "https://registry.npmjs.org/mocha/-/mocha-11.1.0.tgz",
@@ -44328,6 +45252,13 @@
 			"requires": {
 				"lru.min": "^1.1.0"
 			}
+		},
+		"nan": {
+			"version": "2.26.2",
+			"resolved": "https://registry.npmjs.org/nan/-/nan-2.26.2.tgz",
+			"integrity": "sha512-0tTvBTYkt3tdGw22nrAy50x7gpbGCCFH3AFcyS5WiUu7Eu4vWlri1woE6qHBSfy11vksDqkiwjOnlR7WV8G1Hw==",
+			"dev": true,
+			"optional": true
 		},
 		"nanoid": {
 			"version": "3.3.8",
@@ -45531,10 +46462,40 @@
 				"signal-exit": "^3.0.2"
 			}
 		},
+		"properties-reader": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/properties-reader/-/properties-reader-3.0.1.tgz",
+			"integrity": "sha512-WPn+h9RGEExOKdu4bsF4HksG/uzd3cFq3MFtq8PsFeExPse5Ha/VOjQNyHhjboBFwGXGev6muJYTSPAOkROq2g==",
+			"dev": true,
+			"requires": {
+				"@kwsites/file-exists": "^1.1.1",
+				"mkdirp": "^3.0.1"
+			}
+		},
 		"property-expr": {
 			"version": "2.0.6",
 			"resolved": "https://registry.npmjs.org/property-expr/-/property-expr-2.0.6.tgz",
 			"integrity": "sha512-SVtmxhRE/CGkn3eZY1T6pC8Nln6Fr/lu1mKSgRud0eC73whjGfoAogbn78LkD8aFL0zz3bAFerKSnOl7NlErBA=="
+		},
+		"protobufjs": {
+			"version": "7.5.4",
+			"resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.4.tgz",
+			"integrity": "sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==",
+			"dev": true,
+			"requires": {
+				"@protobufjs/aspromise": "^1.1.2",
+				"@protobufjs/base64": "^1.1.2",
+				"@protobufjs/codegen": "^2.0.4",
+				"@protobufjs/eventemitter": "^1.1.0",
+				"@protobufjs/fetch": "^1.1.0",
+				"@protobufjs/float": "^1.0.2",
+				"@protobufjs/inquire": "^1.1.0",
+				"@protobufjs/path": "^1.1.2",
+				"@protobufjs/pool": "^1.1.0",
+				"@protobufjs/utf8": "^1.1.0",
+				"@types/node": ">=13.7.0",
+				"long": "^5.0.0"
+			}
 		},
 		"proxy-addr": {
 			"version": "2.0.7",
@@ -47121,6 +48082,12 @@
 				"through": "2"
 			}
 		},
+		"split-ca": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/split-ca/-/split-ca-1.0.1.tgz",
+			"integrity": "sha512-Q5thBSxp5t8WPTTJQS59LrGqOZqOsrhDGDVm8azCqIBjSBd7nd9o2PM+mDulQQkh8h//4U6hFZnc/mul8t5pWQ==",
+			"dev": true
+		},
 		"split2": {
 			"version": "4.1.0"
 		},
@@ -47135,6 +48102,40 @@
 			"resolved": "https://registry.npmjs.org/sqlstring/-/sqlstring-2.3.3.tgz",
 			"integrity": "sha512-qC9iz2FlN7DQl3+wjwn3802RTyjCx7sDvfQEXchwa6CWOx07/WVfh91gBmQ9fahw8snwGEWU3xGzOt4tFyHLxg==",
 			"devOptional": true
+		},
+		"ssh-remote-port-forward": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/ssh-remote-port-forward/-/ssh-remote-port-forward-1.0.4.tgz",
+			"integrity": "sha512-x0LV1eVDwjf1gmG7TTnfqIzf+3VPRz7vrNIjX6oYLbeCrf/PeVY6hkT68Mg+q02qXxQhrLjB0jfgvhevoCRmLQ==",
+			"dev": true,
+			"requires": {
+				"@types/ssh2": "^0.5.48",
+				"ssh2": "^1.4.0"
+			},
+			"dependencies": {
+				"@types/ssh2": {
+					"version": "0.5.52",
+					"resolved": "https://registry.npmjs.org/@types/ssh2/-/ssh2-0.5.52.tgz",
+					"integrity": "sha512-lbLLlXxdCZOSJMCInKH2+9V/77ET2J6NPQHpFI0kda61Dd1KglJs+fPQBchizmzYSOJBgdTajhPqBO1xxLywvg==",
+					"dev": true,
+					"requires": {
+						"@types/node": "*",
+						"@types/ssh2-streams": "*"
+					}
+				}
+			}
+		},
+		"ssh2": {
+			"version": "1.17.0",
+			"resolved": "https://registry.npmjs.org/ssh2/-/ssh2-1.17.0.tgz",
+			"integrity": "sha512-wPldCk3asibAjQ/kziWQQt1Wh3PgDFpC0XpwclzKcdT1vql6KeYxf5LIt4nlFkUeR8WuphYMKqUA56X4rjbfgQ==",
+			"dev": true,
+			"requires": {
+				"asn1": "^0.2.6",
+				"bcrypt-pbkdf": "^1.0.2",
+				"cpu-features": "~0.0.10",
+				"nan": "^2.23.0"
+			}
 		},
 		"sshpk": {
 			"version": "1.18.0",
@@ -47880,6 +48881,64 @@
 				"@istanbuljs/schema": "^0.1.2",
 				"glob": "^7.1.4",
 				"minimatch": "^3.0.4"
+			}
+		},
+		"testcontainers": {
+			"version": "11.13.0",
+			"resolved": "https://registry.npmjs.org/testcontainers/-/testcontainers-11.13.0.tgz",
+			"integrity": "sha512-fzTvgOtd6U/esOzgmDatJh79OSK0tU6vjDOJ3B6ICrrJf0dqCWtFdpOr6f/g/KixMxKDTDbszmZYjSORJXsVCQ==",
+			"dev": true,
+			"requires": {
+				"@balena/dockerignore": "^1.0.2",
+				"@types/dockerode": "^4.0.1",
+				"archiver": "^7.0.1",
+				"async-lock": "^1.4.1",
+				"byline": "^5.0.0",
+				"debug": "^4.4.3",
+				"docker-compose": "^1.3.2",
+				"dockerode": "^4.0.9",
+				"get-port": "^7.1.0",
+				"proper-lockfile": "^4.1.2",
+				"properties-reader": "^3.0.1",
+				"ssh-remote-port-forward": "^1.0.4",
+				"tar-fs": "^3.1.2",
+				"tmp": "^0.2.5",
+				"undici": "^7.24.3"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "4.4.3",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+					"integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+					"dev": true,
+					"requires": {
+						"ms": "^2.1.3"
+					}
+				},
+				"tar-fs": {
+					"version": "3.1.2",
+					"resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.1.2.tgz",
+					"integrity": "sha512-QGxxTxxyleAdyM3kpFs14ymbYmNFrfY+pHj7Z8FgtbZ7w2//VAgLMac7sT6nRpIHjppXO2AwwEOg0bPFVRcmXw==",
+					"dev": true,
+					"requires": {
+						"bare-fs": "^4.0.1",
+						"bare-path": "^3.0.0",
+						"pump": "^3.0.0",
+						"tar-stream": "^3.1.5"
+					}
+				},
+				"tmp": {
+					"version": "0.2.5",
+					"resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
+					"integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
+					"dev": true
+				},
+				"undici": {
+					"version": "7.24.5",
+					"resolved": "https://registry.npmjs.org/undici/-/undici-7.24.5.tgz",
+					"integrity": "sha512-3IWdCpjgxp15CbJnsi/Y9TCDE7HWVN19j1hmzVhoAkY/+CJx449tVxT5wZc1Gwg8J+P0LWvzlBzxYRnHJ+1i7Q==",
+					"dev": true
+				}
 			}
 		},
 		"text-decoder": {


### PR DESCRIPTION
## Describe your changes

This PR creates a stored procedure for setting the personal list. It is called with null to refresh all the personalList entries or with an appealId to refresh one personalList entry.

To test the stored procedure I have added to the integration tests and bootstrapped a Azure SQL database in a docker image . 

I changed the decision letter tests as they run in a Promise.all and the order they are returned in isnt consistent.

Also added the SQL for the existing stored procedures to the database/stored-procedures/ master folder, for consistency, and updated the local readme to list and describe the stored procedures purpose.

## Issue ticket number and link

[Ticket](https://pins-ds.atlassian.net/browse/A2-6158)
