### PR TITLE
feat(appeals): add notify interested parties on appeal decision 

### DIFF
--- a/appeals/api/src/server/endpoints/decision/__tests__/decision.test.js
+++ b/appeals/api/src/server/endpoints/decision/__tests__/decision.test.js
@@ -429,7 +429,7 @@ describe('decision routes', () => {
 					details = details + '\n\n Reason: Because it is.';
 				}
 
-				expect(databaseConnector.auditTrail.create).toHaveBeenNthCalledWith(1, {
+				expect(databaseConnector.auditTrail.create).toHaveBeenCalledWith({
 					data: {
 						appealId: appeal.id,
 						details,
@@ -438,7 +438,7 @@ describe('decision routes', () => {
 					}
 				});
 
-				expect(databaseConnector.auditTrail.create).toHaveBeenNthCalledWith(2, {
+				expect(databaseConnector.auditTrail.create).toHaveBeenCalledWith({
 					data: {
 						appealId: appeal.id,
 						details: AUDIT_TRAIL_APPELLANT_COSTS_DECISION_ISSUED,
@@ -447,7 +447,7 @@ describe('decision routes', () => {
 					}
 				});
 
-				expect(databaseConnector.auditTrail.create).toHaveBeenNthCalledWith(3, {
+				expect(databaseConnector.auditTrail.create).toHaveBeenCalledWith({
 					data: {
 						appealId: appeal.id,
 						details: AUDIT_TRAIL_LPA_COSTS_DECISION_ISSUED,
@@ -456,7 +456,7 @@ describe('decision routes', () => {
 					}
 				});
 
-				expect(databaseConnector.auditTrail.create).toHaveBeenNthCalledWith(4, {
+				expect(databaseConnector.auditTrail.create).toHaveBeenCalledWith({
 					data: {
 						appealId: appeal.id,
 						details: stringTokenReplacement(AUDIT_TRAIL_PROGRESSED_TO_STATUS, [nextState]),
@@ -464,7 +464,6 @@ describe('decision routes', () => {
 						userId: appeal.caseOfficer.id
 					}
 				});
-
 				expect(response.status).toEqual(201);
 			}
 		);
@@ -679,13 +678,12 @@ describe('decision routes', () => {
 			};
 
 			// @ts-ignore
-			databaseConnector.appeal.findUnique
-				.mockResolvedValueOnce(appeal)
-				.mockResolvedValueOnce(child)
-				.mockResolvedValueOnce(appeal)
-				.mockResolvedValueOnce(appeal)
-				.mockResolvedValueOnce(child)
-				.mockResolvedValueOnce(child);
+			databaseConnector.appeal.findUnique.mockImplementation(({ where }) => {
+				if (where?.id === child.id) {
+					return Promise.resolve(child);
+				}
+				return Promise.resolve(appeal);
+			});
 
 			// @ts-ignore
 			databaseConnector.document.findUnique.mockResolvedValue(documentCreated);
@@ -802,8 +800,6 @@ describe('decision routes', () => {
 				recipientEmail: appeal.lpa.email
 			});
 
-			expect(databaseConnector.auditTrail.create).toHaveBeenCalledTimes(4);
-
 			expect(databaseConnector.auditTrail.create).toHaveBeenNthCalledWith(1, {
 				data: {
 					appealId: appeal.id,
@@ -817,8 +813,10 @@ describe('decision routes', () => {
 
 			expect(databaseConnector.auditTrail.create).toHaveBeenNthCalledWith(2, {
 				data: {
-					appealId: appeal.id,
-					details: stringTokenReplacement(AUDIT_TRAIL_PROGRESSED_TO_STATUS, ['complete']),
+					appealId: childAppeal.childId,
+					details: stringTokenReplacement(AUDIT_TRAIL_DECISION_ISSUED, [
+						outcome[0].toUpperCase() + outcome.slice(1)
+					]),
 					loggedAt: expect.any(Date),
 					userId: appeal.caseOfficer.id
 				}
@@ -826,10 +824,8 @@ describe('decision routes', () => {
 
 			expect(databaseConnector.auditTrail.create).toHaveBeenNthCalledWith(3, {
 				data: {
-					appealId: childAppeal.childId,
-					details: stringTokenReplacement(AUDIT_TRAIL_DECISION_ISSUED, [
-						outcome[0].toUpperCase() + outcome.slice(1)
-					]),
+					appealId: appeal.id,
+					details: stringTokenReplacement(AUDIT_TRAIL_PROGRESSED_TO_STATUS, ['complete']),
 					loggedAt: expect.any(Date),
 					userId: appeal.caseOfficer.id
 				}
@@ -1117,6 +1113,65 @@ describe('decision routes', () => {
 		});
 
 		//TODO: Add test for rule 6 party cost comms when the comms are added
+
+		test('returns 200 and sends emails to interested parties when decision is published', async () => {
+			const appeal = {
+				...fullPlanningAppeal,
+				appealStatus: [
+					{
+						status: APPEAL_CASE_STATUS.ISSUE_DETERMINATION,
+						valid: true
+					}
+				]
+			};
+
+			const outcome = 'allowed';
+			databaseConnector.appeal.findUnique.mockResolvedValue(appeal);
+			databaseConnector.document.findUnique.mockResolvedValue(documentCreated);
+			databaseConnector.inspectorDecision.create.mockResolvedValue({});
+
+			databaseConnector.representation.count.mockResolvedValue(2);
+			databaseConnector.representation.findMany.mockResolvedValue([
+				{ represented: { email: 'interested-party1@example.com' } },
+				{ represented: { email: 'interested-party2@example.com' } }
+			]);
+
+			const tenDaysAgo = sub(new Date(), { days: 10 });
+			const withoutWeekends = await recalculateDateIfNotBusinessDay(tenDaysAgo.toISOString());
+			const utcDate = setTimeInTimeZone(withoutWeekends, 0, 0);
+
+			const response = await request
+				.post(`/appeals/${appeal.id}/decision`)
+				.send({
+					decisions: [
+						{
+							decisionType: DECISION_TYPE_INSPECTOR,
+							outcome,
+							documentDate: utcDate.toISOString(),
+							documentGuid: documentCreated.guid
+						}
+					]
+				})
+				.set('azureAdUserId', azureAdUserId);
+
+			expect(mockNotifySend).toHaveBeenCalledTimes(4);
+
+			expect(mockNotifySend).toHaveBeenCalledWith(
+				expect.objectContaining({
+					templateName: 'decision-is-allowed-split-dismissed-interested-party',
+					recipientEmail: 'interested-party1@example.com'
+				})
+			);
+
+			expect(mockNotifySend).toHaveBeenCalledWith(
+				expect.objectContaining({
+					templateName: 'decision-is-allowed-split-dismissed-interested-party',
+					recipientEmail: 'interested-party2@example.com'
+				})
+			);
+
+			expect(response.status).toEqual(201);
+		});
 	});
 
 	describe('sendNewDecisionLetter', () => {

--- a/appeals/api/src/server/endpoints/decision/decision.controller.js
+++ b/appeals/api/src/server/endpoints/decision/decision.controller.js
@@ -19,6 +19,36 @@ import { publishChildDecision, publishCostsDecision, publishDecision } from './d
  * @param {Response} res
  * @returns {Promise<Response>}
  */
+export const postDecisionPreview = async (req, res) => {
+	const { appeal } = req;
+	const { outcome, invalidDecisionReason } = req.body;
+
+	const siteAddress = appeal.address
+		? formatAddressSingleLine(appeal.address)
+		: 'Address not available';
+
+	const azureAdUserId = req.get('azureAdUserId') || '';
+
+	const previews = await publishDecision(
+		appeal,
+		outcome || 'allowed',
+		new Date(),
+		'',
+		req.notifyClient,
+		siteAddress,
+		azureAdUserId,
+		invalidDecisionReason || null,
+		true
+	);
+
+	return res.json(previews);
+};
+
+/**
+ * @param {Request} req
+ * @param {Response} res
+ * @returns {Promise<Response>}
+ */
 export const postInspectorDecision = async (req, res) => {
 	const { appeal } = req;
 	const { decisions } = req.body;

--- a/appeals/api/src/server/endpoints/decision/decision.routes.js
+++ b/appeals/api/src/server/endpoints/decision/decision.routes.js
@@ -1,7 +1,7 @@
 import { checkAppealExistsByIdAndAddPartialToRequest } from '#middleware/check-appeal-exists-and-add-to-request.js';
 import { asyncHandler } from '@pins/express';
 import { Router as createRouter } from 'express';
-import { postInspectorDecision } from './decision.controller.js';
+import { postDecisionPreview, postInspectorDecision } from './decision.controller.js';
 import {
 	getDateValidator,
 	getDecisionsValidator,
@@ -12,6 +12,46 @@ import {
 } from './decision.validator.js';
 
 const router = createRouter();
+
+router.post(
+	'/:appealId/decision/preview',
+	/*
+			#swagger.tags = ['Decision']
+			#swagger.path = '/appeals/{appealId}/decision/preview'
+			#swagger.description = Returns email previews for the decision notification emails
+			#swagger.parameters['azureAdUserId'] = {
+					in: 'header',
+					required: true,
+					example: '434bff4e-8191-4ce0-9a0a-91e5d6cdd882'
+			}
+			#swagger.requestBody = {
+					in: 'body',
+					description: 'Decision preview request',
+					schema: {
+							outcome: 'allowed',
+							invalidDecisionReason: null
+					},
+					required: true
+			}
+			#swagger.responses[200] = {
+					description: 'Returns rendered email previews'
+			}
+			#swagger.responses[400] = {}
+			#swagger.responses[404] = {}
+	 */
+	checkAppealExistsByIdAndAddPartialToRequest([
+		'appealStatus',
+		'address',
+		'appellant',
+		'agent',
+		'lpa',
+		'folders',
+		'appealType',
+		'childAppeals',
+		'appealRule6Parties'
+	]),
+	asyncHandler(postDecisionPreview)
+);
 
 router.post(
 	'/:appealId/decision',

--- a/appeals/api/src/server/endpoints/decision/decision.service.js
+++ b/appeals/api/src/server/endpoints/decision/decision.service.js
@@ -4,7 +4,8 @@ import { getTeamEmailFromAppealId } from '#endpoints/case-team/case-team.service
 import { broadcasters } from '#endpoints/integrations/integrations.broadcasters.js';
 import { duplicateFiles } from '#endpoints/link-appeals/link-appeals.service.js';
 import { getRepresentations } from '#endpoints/representations/representations.service.js';
-import { notifySend } from '#notify/notify-send.js';
+import { generateNotifyPreview } from '#notify/emulate-notify.js';
+import { notifySend, renderTemplate } from '#notify/notify-send.js';
 import appealRepository from '#repositories/appeal.repository.js';
 import appellantCaseRepository from '#repositories/appellant-case.repository.js';
 import transitionState from '#state/transition-state.js';
@@ -82,7 +83,7 @@ const formatIssueDecisionAuditTrail = (outcome, invalidDecisionReason) => {
  * @param {string} siteAddress
  * @param {string} azureAdUserId
  * @param {string|null} [invalidDecisionReason]
- * @returns
+ * @param {boolean} [dryRun=false]
  */
 export const publishDecision = async (
 	appeal,
@@ -92,8 +93,81 @@ export const publishDecision = async (
 	notifyClient,
 	siteAddress,
 	azureAdUserId,
-	invalidDecisionReason = null
+	invalidDecisionReason = null,
+	dryRun = false
 ) => {
+	const { type = '', key: appealTypeKey = APPEAL_CASE_TYPE.D } = appeal.appealType || {};
+	const appealType = trimAppealType(type);
+	const caseTeamEmail = await getTeamEmailFromAppealId(appeal.id);
+
+	const feedbackLinkForAppellant = getFeedbackLinkFromAppealTypeKey(appealTypeKey || '');
+	const feedbackLinkForInterestedParty = FEEDBACK_FORM_LINKS.COMMENT_ON_APPEAL;
+	const feedbackLinkForLPA =
+		appealTypeKey === APPEAL_CASE_TYPE.C || appealTypeKey === APPEAL_CASE_TYPE.F
+			? FEEDBACK_FORM_LINKS.ENFORCEMENT_NOTICE
+			: FEEDBACK_FORM_LINKS.LPA;
+
+	const personalisation = {
+		appeal_reference_number: appeal.reference,
+		lpa_reference: appeal.applicationReference || '',
+		site_address: siteAddress,
+		appeal_type: appealType,
+		...(invalidDecisionReason && { reasons: [invalidDecisionReason] }),
+		...(!invalidDecisionReason && {
+			front_office_url: environment.FRONT_OFFICE_URL || '',
+			decision_date: formatDate(new Date(documentDate || ''), false),
+			child_appeals:
+				appeal.childAppeals
+					?.filter((childAppeal) => childAppeal.type === CASE_RELATIONSHIP_LINKED)
+					.map((childAppeal) => childAppeal.childRef) || []
+		})
+	};
+
+	if (appealTypeKey === APPEAL_CASE_TYPE.C || appealTypeKey === APPEAL_CASE_TYPE.F) {
+		const appellantCase = await appellantCaseRepository.getAppellantCaseByAppealId(appeal.id);
+		// @ts-ignore
+		personalisation.enforcement_reference = appellantCase?.enforcementReference;
+	}
+
+	if (dryRun) {
+		const appellantTemplate = renderTemplate(
+			invalidDecisionReason
+				? 'decision-is-invalid-appellant.content.md'
+				: 'decision-is-allowed-split-dismissed-appellant.content.md',
+			{
+				...personalisation,
+				feedback_link: feedbackLinkForAppellant
+			}
+		);
+		const lpaTemplate = renderTemplate(
+			invalidDecisionReason
+				? 'decision-is-invalid-lpa.content.md'
+				: 'decision-is-allowed-split-dismissed-lpa.content.md',
+			{
+				...personalisation,
+				feedback_link: feedbackLinkForLPA
+			}
+		);
+		const interestedPartyTemplate = renderTemplate(
+			invalidDecisionReason
+				? 'decision-is-invalid-interested-party.content.md'
+				: 'decision-is-allowed-split-dismissed-interested-party.content.md',
+			{
+				...personalisation,
+				feedback_link: FEEDBACK_FORM_LINKS.COMMENT_ON_APPEAL,
+				case_team_email_address: caseTeamEmail
+			}
+		);
+
+		return {
+			previews: {
+				appellant: generateNotifyPreview(appellantTemplate),
+				lpa: generateNotifyPreview(lpaTemplate),
+				interestedParty: generateNotifyPreview(interestedPartyTemplate)
+			}
+		};
+	}
+
 	const result = await appealRepository.setAppealDecision(appeal.id, {
 		documentDate,
 		documentGuid,
@@ -102,142 +176,135 @@ export const publishDecision = async (
 		invalidDecisionReason
 	});
 
-	if (result) {
-		const recipientEmail = appeal.agent?.email || appeal.appellant?.email;
-
-		if (!recipientEmail || !appeal.lpa?.email) {
-			throw new Error(ERROR_NO_RECIPIENT_EMAIL);
-		}
-
-		const hasAppellantCostsDecision = hasCostsDocument(
-			appeal,
-			APPEAL_DOCUMENT_TYPE.APPELLANT_COSTS_DECISION_LETTER
-		);
-
-		const hasLpaCostsDecision = hasCostsDocument(
-			appeal,
-			APPEAL_DOCUMENT_TYPE.LPA_COSTS_DECISION_LETTER
-		);
-
-		const lpaEmail = appeal.lpa?.email || '';
-
-		const nextState =
-			outcome === APPEAL_CASE_DECISION_OUTCOME.INVALID
-				? APPEAL_CASE_STATUS.INVALID
-				: APPEAL_CASE_STATUS.COMPLETE;
-
-		const { type = '', key: appealTypeKey = APPEAL_CASE_TYPE.D } = appeal.appealType || {};
-		const appealType = trimAppealType(type);
-
-		const personalisation = {
-			appeal_reference_number: appeal.reference,
-			lpa_reference: appeal.applicationReference || '',
-			site_address: siteAddress,
-			appeal_type: appealType,
-			...(invalidDecisionReason && { reasons: [invalidDecisionReason] }),
-			...(!invalidDecisionReason && {
-				front_office_url: environment.FRONT_OFFICE_URL || '',
-				decision_date: formatDate(new Date(documentDate || ''), false),
-				child_appeals:
-					appeal.childAppeals
-						?.filter((childAppeal) => childAppeal.type === CASE_RELATIONSHIP_LINKED)
-						.map((childAppeal) => childAppeal.childRef) || []
-			})
-		};
-
-		if (appealTypeKey === APPEAL_CASE_TYPE.C || appealTypeKey === APPEAL_CASE_TYPE.F) {
-			const appellantCase = await appellantCaseRepository.getAppellantCaseByAppealId(appeal.id);
-			// @ts-ignore
-			personalisation.enforcement_reference = appellantCase?.enforcementReference;
-		}
-
-		const feedbackLinkForAppellant = getFeedbackLinkFromAppealTypeKey(appealTypeKey || '');
-
-		if (recipientEmail) {
-			await notifySend({
-				azureAdUserId,
-				templateName: invalidDecisionReason
-					? 'decision-is-invalid-appellant'
-					: 'decision-is-allowed-split-dismissed-appellant',
-				notifyClient,
-				recipientEmail,
-				personalisation: invalidDecisionReason
-					? {
-							...personalisation,
-							has_costs_decision: hasAppellantCostsDecision,
-							feedback_link: feedbackLinkForAppellant
-						}
-					: {
-							...personalisation,
-							feedback_link: feedbackLinkForAppellant
-						}
-			});
-		}
-
-		const feedbackLinkForLPA =
-			appealTypeKey === APPEAL_CASE_TYPE.C || appealTypeKey === APPEAL_CASE_TYPE.F
-				? FEEDBACK_FORM_LINKS.ENFORCEMENT_NOTICE
-				: FEEDBACK_FORM_LINKS.LPA;
-
-		if (lpaEmail) {
-			await notifySend({
-				azureAdUserId,
-				templateName: invalidDecisionReason
-					? 'decision-is-invalid-lpa'
-					: 'decision-is-allowed-split-dismissed-lpa',
-				notifyClient,
-				recipientEmail: lpaEmail,
-				personalisation: invalidDecisionReason
-					? {
-							...personalisation,
-							has_costs_decision: hasLpaCostsDecision,
-							feedback_link: feedbackLinkForLPA
-						}
-					: {
-							...personalisation,
-							feedback_link: feedbackLinkForLPA
-						}
-			});
-		}
-
-		if (appeal.appealRule6Parties && appeal.appealRule6Parties.length > 0) {
-			for (const party of appeal.appealRule6Parties) {
-				if (party.serviceUser?.email) {
-					await notifySend({
-						azureAdUserId,
-						templateName: invalidDecisionReason
-							? 'decision-is-invalid-appellant'
-							: 'decision-is-allowed-split-dismissed-appellant',
-						notifyClient,
-						recipientEmail: party.serviceUser.email,
-						personalisation: invalidDecisionReason
-							? {
-									...personalisation,
-									has_costs_decision: hasAppellantCostsDecision,
-									feedback_link: feedbackLinkForAppellant
-								}
-							: {
-									...personalisation,
-									feedback_link: feedbackLinkForAppellant
-								}
-					});
-				}
-			}
-		}
-
-		await createAuditTrail({
-			appealId: appeal.id,
-			azureAdUserId: azureAdUserId,
-			details: formatIssueDecisionAuditTrail(outcome, invalidDecisionReason)
-		});
-
-		await transitionState(appeal.id, azureAdUserId, nextState);
-		await broadcasters.broadcastAppeal(appeal.id);
-
-		return result;
+	if (!result) {
+		return null;
 	}
 
-	return null;
+	const recipientEmail = appeal.agent?.email || appeal.appellant?.email;
+
+	if (!recipientEmail || !appeal.lpa?.email) {
+		throw new Error(ERROR_NO_RECIPIENT_EMAIL);
+	}
+
+	const hasAppellantCostsDecision = hasCostsDocument(
+		appeal,
+		APPEAL_DOCUMENT_TYPE.APPELLANT_COSTS_DECISION_LETTER
+	);
+
+	const hasLpaCostsDecision = hasCostsDocument(
+		appeal,
+		APPEAL_DOCUMENT_TYPE.LPA_COSTS_DECISION_LETTER
+	);
+
+	const lpaEmail = appeal.lpa?.email || '';
+
+	const representations = await getRepresentations([appeal.id], 1, 1000, {
+		representationType: ['comment']
+	});
+	const interestedPartyEmails = representations?.comments
+		.map((comment) => comment.represented?.email)
+		.filter(Boolean);
+
+	const nextState =
+		outcome === APPEAL_CASE_DECISION_OUTCOME.INVALID
+			? APPEAL_CASE_STATUS.INVALID
+			: APPEAL_CASE_STATUS.COMPLETE;
+
+	if (recipientEmail) {
+		await notifySend({
+			azureAdUserId,
+			templateName: invalidDecisionReason
+				? 'decision-is-invalid-appellant'
+				: 'decision-is-allowed-split-dismissed-appellant',
+			notifyClient,
+			recipientEmail,
+			personalisation: invalidDecisionReason
+				? {
+						...personalisation,
+						has_costs_decision: hasAppellantCostsDecision,
+						feedback_link: feedbackLinkForAppellant
+					}
+				: {
+						...personalisation,
+						feedback_link: feedbackLinkForAppellant
+					}
+		});
+	}
+
+	if (lpaEmail) {
+		await notifySend({
+			azureAdUserId,
+			templateName: invalidDecisionReason
+				? 'decision-is-invalid-lpa'
+				: 'decision-is-allowed-split-dismissed-lpa',
+			notifyClient,
+			recipientEmail: lpaEmail,
+			personalisation: invalidDecisionReason
+				? {
+						...personalisation,
+						has_costs_decision: hasLpaCostsDecision,
+						feedback_link: feedbackLinkForLPA
+					}
+				: {
+						...personalisation,
+						feedback_link: feedbackLinkForLPA
+					}
+		});
+	}
+
+	if (appeal.appealRule6Parties && appeal.appealRule6Parties.length > 0) {
+		for (const party of appeal.appealRule6Parties) {
+			if (party.serviceUser?.email) {
+				await notifySend({
+					azureAdUserId,
+					templateName: invalidDecisionReason
+						? 'decision-is-invalid-appellant'
+						: 'decision-is-allowed-split-dismissed-appellant',
+					notifyClient,
+					recipientEmail: party.serviceUser.email,
+					personalisation: invalidDecisionReason
+						? {
+								...personalisation,
+								has_costs_decision: hasAppellantCostsDecision,
+								feedback_link: feedbackLinkForAppellant
+							}
+						: {
+								...personalisation,
+								feedback_link: feedbackLinkForAppellant
+							}
+				});
+			}
+		}
+	}
+
+	if (interestedPartyEmails.length > 0) {
+		for (const email of interestedPartyEmails) {
+			await notifySend({
+				azureAdUserId,
+				templateName: invalidDecisionReason
+					? 'decision-is-invalid-interested-party'
+					: 'decision-is-allowed-split-dismissed-interested-party',
+				notifyClient,
+				recipientEmail: email,
+				personalisation: {
+					...personalisation,
+					feedback_link: feedbackLinkForInterestedParty,
+					case_team_email_address: caseTeamEmail
+				}
+			});
+		}
+	}
+
+	await createAuditTrail({
+		appealId: appeal.id,
+		azureAdUserId: azureAdUserId,
+		details: formatIssueDecisionAuditTrail(outcome, invalidDecisionReason)
+	});
+
+	await transitionState(appeal.id, azureAdUserId, nextState);
+	await broadcasters.broadcastAppeal(appeal.id);
+
+	return result;
 };
 
 /**

--- a/appeals/api/src/server/notify/templates/__tests__/notify-decision-is-allowed-split-dismissed-interested-party.test.js
+++ b/appeals/api/src/server/notify/templates/__tests__/notify-decision-is-allowed-split-dismissed-interested-party.test.js
@@ -1,0 +1,106 @@
+// @ts-nocheck
+import { notifySend } from '#notify/notify-send.js';
+import { jest } from '@jest/globals';
+
+const interestedPartyEmail = 'interested-party@example.com';
+
+const genericNotifySendData = {
+	doNotMockNotifySend: true,
+	templateName: 'decision-is-allowed-split-dismissed-interested-party',
+	notifyClient: {
+		sendEmail: jest.fn()
+	},
+	recipientEmail: interestedPartyEmail,
+	personalisation: {
+		appeal_reference_number: 'ABC45678',
+		site_address: '10, Test Street',
+		lpa_reference: '12345XYZ',
+		decision_date: '01 January 2021',
+		front_office_url: '/mock-front-office-url',
+		feedback_link: '/mock-feedback-link',
+		case_team_email_address: 'caseofficers@planninginspectorate.gov.uk'
+	}
+};
+
+const expectedContentRows = (replacementRows) => [
+	'# Appeal details',
+	'',
+	'^Appeal reference number: ABC45678',
+	'Address: 10, Test Street',
+	'Planning application reference: 12345XYZ',
+	'',
+	'# Appeal decision',
+	'',
+	...replacementRows,
+	'',
+	'[View the decision letter](/mock-front-office-url/appeals/ABC45678) dated 01 January 2021.',
+	'',
+	'We have informed the appellant and local planning authority about the decision.',
+	'',
+	"# The Planning Inspectorate's role",
+	'',
+	'The Planning Inspectorate cannot change or revoke the decision. Only the High Court can change this decision.',
+	'',
+	'# Feedback',
+	'',
+	'We welcome your feedback on our appeals service. Tell us on this short [feedback form](/mock-feedback-link).',
+	'',
+	'The Planning Inspectorate',
+	'caseofficers@planninginspectorate.gov.uk'
+];
+
+describe('decision-is-allowed-split-dismissed-interested-party.md', () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+	});
+
+	test('should call notify sendEmail with the correct data', async () => {
+		const notifySendData = structuredClone({ ...genericNotifySendData, notifyClient: {} });
+		notifySendData.notifyClient.sendEmail = jest.fn();
+
+		const expectedContent = expectedContentRows(['We have made a decision on this appeal']).join(
+			'\n'
+		);
+
+		await notifySend(notifySendData);
+
+		expect(notifySendData.notifyClient.sendEmail).toHaveBeenCalledWith(
+			{
+				id: 'mock-appeal-generic-id'
+			},
+			interestedPartyEmail,
+			{
+				content: expectedContent,
+				subject: 'Appeal decision: ABC45678'
+			}
+		);
+	});
+
+	test('should call notify sendEmail with the correct data when a linked appeal', async () => {
+		const notifySendData = structuredClone({ ...genericNotifySendData, notifyClient: {} });
+		notifySendData.notifyClient.sendEmail = jest.fn();
+		notifySendData.personalisation.child_appeals = ['CHILD123', 'CHILD456', 'CHILD789'];
+
+		const expectedContent = expectedContentRows([
+			'We have made a decision on the following appeals:',
+			'',
+			'- ABC45678 (lead)',
+			'- CHILD123',
+			'- CHILD456',
+			'- CHILD789'
+		]).join('\n');
+
+		await notifySend(notifySendData);
+
+		expect(notifySendData.notifyClient.sendEmail).toHaveBeenCalledWith(
+			{
+				id: 'mock-appeal-generic-id'
+			},
+			interestedPartyEmail,
+			{
+				content: expectedContent,
+				subject: 'Appeal decision: ABC45678'
+			}
+		);
+	});
+});

--- a/appeals/api/src/server/notify/templates/decision-is-allowed-split-dismissed-interested-party.content.md
+++ b/appeals/api/src/server/notify/templates/decision-is-allowed-split-dismissed-interested-party.content.md
@@ -1,0 +1,30 @@
+{% include 'parts/appeal-details.md' %}
+
+# Appeal decision
+
+{%- if child_appeals.length > 1 %}
+
+We have made a decision on the following appeals:
+
+- {{ appeal_reference_number }} (lead)
+  {%- for child_appeal in child_appeals %}
+- {{ child_appeal }}
+  {%- endfor %}
+  {%- else %}
+
+We have made a decision on this appeal {%- endif %}
+
+[View the decision letter]({{front_office_url}}/appeals/{{appeal_reference_number}}) dated {{decision_date}}.
+
+We have informed the appellant and local planning authority about the decision.
+
+# The Planning Inspectorate's role
+
+The Planning Inspectorate cannot change or revoke the decision. Only the High Court can change this decision.
+
+# Feedback
+
+We welcome your feedback on our appeals service. Tell us on this short [feedback form]({{feedback_link}}).
+
+The Planning Inspectorate
+{{case_team_email_address}}

--- a/appeals/api/src/server/notify/templates/decision-is-allowed-split-dismissed-interested-party.subject.md
+++ b/appeals/api/src/server/notify/templates/decision-is-allowed-split-dismissed-interested-party.subject.md
@@ -1,0 +1,1 @@
+Appeal decision: {{appeal_reference_number}}

--- a/appeals/api/src/server/notify/templates/decision-is-invalid-interested-party.content.md
+++ b/appeals/api/src/server/notify/templates/decision-is-invalid-interested-party.content.md
@@ -1,0 +1,29 @@
+{% include 'parts/appeal-details.md' %}
+
+# Appeal decision
+
+We have reviewed this appeal and decided that it is not valid.
+
+Appeal {{ appeal_reference_number }} is now closed.
+
+We have informed the appellant and local planning authority about the decision.
+
+# Why the appeal is not valid
+
+{% for reason in reasons %}
+
+- {{reason}}
+  {%- endfor %}
+  {% if has_costs_decision %}
+
+# Costs decision
+
+[Sign in to our service]({{front_office_url}}/appeals/{{appeal_reference_number}}) to view the costs decision.
+{% endif %}
+
+# Feedback
+
+This is a new service. Help us improve it and [give your feedback (opens in new tab)]({{feedback_link}}).
+
+The Planning Inspectorate
+{{case_team_email_address}}

--- a/appeals/api/src/server/notify/templates/decision-is-invalid-interested-party.subject.md
+++ b/appeals/api/src/server/notify/templates/decision-is-invalid-interested-party.subject.md
@@ -1,0 +1,1 @@
+Appeal invalid: {{appeal_reference_number}}

--- a/appeals/api/src/server/openapi.json
+++ b/appeals/api/src/server/openapi.json
@@ -2712,6 +2712,61 @@
 				}
 			}
 		},
+		"/appeals/{appealId}/decision/preview": {
+			"post": {
+				"tags": ["Decision"],
+				"description": "Returns email previews for the decision notification emails",
+				"parameters": [
+					{
+						"name": "appealId",
+						"in": "path",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"name": "azureAdUserId",
+						"in": "header",
+						"required": true,
+						"example": "434bff4e-8191-4ce0-9a0a-91e5d6cdd882",
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "Returns rendered email previews"
+					},
+					"400": {
+						"description": "Bad Request"
+					},
+					"404": {
+						"description": "Not Found"
+					}
+				},
+				"requestBody": {
+					"in": "body",
+					"description": "Decision preview request",
+					"required": true,
+					"content": {
+						"application/json": {
+							"schema": {
+								"outcome": "allowed",
+								"invalidDecisionReason": null
+							}
+						},
+						"application/xml": {
+							"schema": {
+								"outcome": "allowed",
+								"invalidDecisionReason": null
+							}
+						}
+					}
+				}
+			}
+		},
 		"/appeals/{appealId}/decision": {
 			"post": {
 				"tags": ["Decision"],

--- a/appeals/web/src/server/appeals/appeal-details/issue-decision/__tests__/__snapshots__/issue-decision.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/issue-decision/__tests__/__snapshots__/issue-decision.test.js.snap
@@ -612,8 +612,43 @@ exports[`issue-decision GET /issue-decision/check-your-appellant-costs-decision 
                             </dd>
                     </div>
                 </dl>
-                <p class="govuk-body">We'll send an email to the appellant and LPA to tell them about the decision.</p>
-                <button                 type="submit" class="govuk-button" data-module="govuk-button">Issue appellant costs decision</button>
+                <div class="govuk-grid-row">
+                    <div class="govuk-grid-column-full">
+                        <details class="govuk-details" data-cy="preview-email-to-appellant">
+                            <summary class="govuk-details__summary"><span class="govuk-details__summary-text"> Preview email to appellant</span>
+                            </summary>
+                            <div class="govuk-details__text">
+                                <p>Appellant email preview</p>
+                            </div>
+                        </details>
+                    </div>
+                </div>
+                <div class="govuk-grid-row">
+                    <div class="govuk-grid-column-full">
+                        <details class="govuk-details" data-cy="preview-email-to-lpa">
+                            <summary class="govuk-details__summary"><span class="govuk-details__summary-text"> Preview email to LPA</span>
+                            </summary>
+                            <div class="govuk-details__text">
+                                <p>LPA email preview</p>
+                            </div>
+                        </details>
+                    </div>
+                </div>
+                <div class="govuk-grid-row">
+                    <div class="govuk-grid-column-full">
+                        <details class="govuk-details" data-cy="preview-email-to-interested-parties">
+                            <summary class="govuk-details__summary"><span class="govuk-details__summary-text"> Preview email to interested parties</span>
+                            </summary>
+                            <div class="govuk-details__text">
+                                <p>Interested party email preview</p>
+                            </div>
+                        </details>
+                    </div>
+                </div>
+                <p class="govuk-body">We'll send an email to the appellant, LPA and any interested parties to
+                    tell them about the decision.</p>
+                <button type="submit" class="govuk-button"
+                data-module="govuk-button">Issue appellant costs decision</button>
             </form>
         </div>
     </div>
@@ -673,8 +708,43 @@ exports[`issue-decision GET /issue-decision/check-your-decision Linked appeals s
                             </dd>
                     </div>
                 </dl>
-                <p class="govuk-body">We'll send an email to the appellant and LPA to tell them about the decision.</p>
-                <button                 type="submit" class="govuk-button" data-module="govuk-button">Issue decision</button>
+                <div class="govuk-grid-row">
+                    <div class="govuk-grid-column-full">
+                        <details class="govuk-details" data-cy="preview-email-to-appellant">
+                            <summary class="govuk-details__summary"><span class="govuk-details__summary-text"> Preview email to appellant</span>
+                            </summary>
+                            <div class="govuk-details__text">
+                                <p>Appellant email preview</p>
+                            </div>
+                        </details>
+                    </div>
+                </div>
+                <div class="govuk-grid-row">
+                    <div class="govuk-grid-column-full">
+                        <details class="govuk-details" data-cy="preview-email-to-lpa">
+                            <summary class="govuk-details__summary"><span class="govuk-details__summary-text"> Preview email to LPA</span>
+                            </summary>
+                            <div class="govuk-details__text">
+                                <p>LPA email preview</p>
+                            </div>
+                        </details>
+                    </div>
+                </div>
+                <div class="govuk-grid-row">
+                    <div class="govuk-grid-column-full">
+                        <details class="govuk-details" data-cy="preview-email-to-interested-parties">
+                            <summary class="govuk-details__summary"><span class="govuk-details__summary-text"> Preview email to interested parties</span>
+                            </summary>
+                            <div class="govuk-details__text">
+                                <p>Interested party email preview</p>
+                            </div>
+                        </details>
+                    </div>
+                </div>
+                <p class="govuk-body">We'll send an email to the appellant, LPA and any interested parties to
+                    tell them about the decision.</p>
+                <button type="submit" class="govuk-button"
+                data-module="govuk-button">Issue decision</button>
             </form>
         </div>
     </div>
@@ -729,8 +799,43 @@ exports[`issue-decision GET /issue-decision/check-your-decision Single appeal sh
                             </dd>
                     </div>
                 </dl>
-                <p class="govuk-body">We'll send an email to the appellant and LPA to tell them about the decision.</p>
-                <button                 type="submit" class="govuk-button" data-module="govuk-button">Issue decision</button>
+                <div class="govuk-grid-row">
+                    <div class="govuk-grid-column-full">
+                        <details class="govuk-details" data-cy="preview-email-to-appellant">
+                            <summary class="govuk-details__summary"><span class="govuk-details__summary-text"> Preview email to appellant</span>
+                            </summary>
+                            <div class="govuk-details__text">
+                                <p>Appellant email preview</p>
+                            </div>
+                        </details>
+                    </div>
+                </div>
+                <div class="govuk-grid-row">
+                    <div class="govuk-grid-column-full">
+                        <details class="govuk-details" data-cy="preview-email-to-lpa">
+                            <summary class="govuk-details__summary"><span class="govuk-details__summary-text"> Preview email to LPA</span>
+                            </summary>
+                            <div class="govuk-details__text">
+                                <p>LPA email preview</p>
+                            </div>
+                        </details>
+                    </div>
+                </div>
+                <div class="govuk-grid-row">
+                    <div class="govuk-grid-column-full">
+                        <details class="govuk-details" data-cy="preview-email-to-interested-parties">
+                            <summary class="govuk-details__summary"><span class="govuk-details__summary-text"> Preview email to interested parties</span>
+                            </summary>
+                            <div class="govuk-details__text">
+                                <p>Interested party email preview</p>
+                            </div>
+                        </details>
+                    </div>
+                </div>
+                <p class="govuk-body">We'll send an email to the appellant, LPA and any interested parties to
+                    tell them about the decision.</p>
+                <button type="submit" class="govuk-button"
+                data-module="govuk-button">Issue decision</button>
             </form>
         </div>
     </div>
@@ -756,8 +861,43 @@ exports[`issue-decision GET /issue-decision/check-your-lpa-costs-decision should
                             </dd>
                     </div>
                 </dl>
-                <p class="govuk-body">We'll send an email to the appellant and LPA to tell them about the decision.</p>
-                <button                 type="submit" class="govuk-button" data-module="govuk-button">Issue LPA costs decision</button>
+                <div class="govuk-grid-row">
+                    <div class="govuk-grid-column-full">
+                        <details class="govuk-details" data-cy="preview-email-to-appellant">
+                            <summary class="govuk-details__summary"><span class="govuk-details__summary-text"> Preview email to appellant</span>
+                            </summary>
+                            <div class="govuk-details__text">
+                                <p>Appellant email preview</p>
+                            </div>
+                        </details>
+                    </div>
+                </div>
+                <div class="govuk-grid-row">
+                    <div class="govuk-grid-column-full">
+                        <details class="govuk-details" data-cy="preview-email-to-lpa">
+                            <summary class="govuk-details__summary"><span class="govuk-details__summary-text"> Preview email to LPA</span>
+                            </summary>
+                            <div class="govuk-details__text">
+                                <p>LPA email preview</p>
+                            </div>
+                        </details>
+                    </div>
+                </div>
+                <div class="govuk-grid-row">
+                    <div class="govuk-grid-column-full">
+                        <details class="govuk-details" data-cy="preview-email-to-interested-parties">
+                            <summary class="govuk-details__summary"><span class="govuk-details__summary-text"> Preview email to interested parties</span>
+                            </summary>
+                            <div class="govuk-details__text">
+                                <p>Interested party email preview</p>
+                            </div>
+                        </details>
+                    </div>
+                </div>
+                <p class="govuk-body">We'll send an email to the appellant, LPA and any interested parties to
+                    tell them about the decision.</p>
+                <button type="submit" class="govuk-button"
+                data-module="govuk-button">Issue LPA costs decision</button>
             </form>
         </div>
     </div>

--- a/appeals/web/src/server/appeals/appeal-details/issue-decision/__tests__/issue-decision.test.js
+++ b/appeals/web/src/server/appeals/appeal-details/issue-decision/__tests__/issue-decision.test.js
@@ -860,10 +860,27 @@ describe('issue-decision', () => {
 		let issueDecisionAppealData;
 
 		beforeEach(() => {
+			nock.cleanAll();
+
 			issueDecisionAppealData = structuredClone(appealData);
 			issueDecisionAppealData.costs.appellantApplicationFolder.documents = [{}];
 			issueDecisionAppealData.costs.lpaApplicationFolder.documents = [{}];
-			nock.cleanAll();
+
+			nock('http://test/').get('/appeals/1/case-team-email').reply(200, {
+				id: 1,
+				email: 'caseofficers@planninginspectorate.gov.uk',
+				name: 'standard email'
+			});
+
+			nock('http://test/')
+				.post('/appeals/1/decision/preview')
+				.reply(200, {
+					previews: {
+						appellant: '<p>Appellant email preview</p>',
+						lpa: '<p>LPA email preview</p>',
+						interestedParty: '<p>Interested party email preview</p>'
+					}
+				});
 		});
 
 		afterEach(teardown);
@@ -1363,6 +1380,22 @@ describe('issue-decision', () => {
 				.reply(200, documentRedactionStatuses)
 				.persist();
 
+			nock('http://test/').get('/appeals/1/case-team-email').reply(200, {
+				id: 1,
+				email: 'caseofficers@planninginspectorate.gov.uk',
+				name: 'standard email'
+			});
+
+			nock('http://test/')
+				.post('/appeals/1/decision/preview')
+				.reply(200, {
+					previews: {
+						appellant: '<p>Appellant email preview</p>',
+						lpa: '<p>LPA email preview</p>',
+						interestedParty: '<p>Interested party email preview</p>'
+					}
+				});
+
 			uploadAppellantCostsDecisionLetterResponse = await request
 				.post(`${baseUrl}/1${issueDecisionPath}${appellantCostsDecisionLetterUploadPath}`)
 				.send({
@@ -1577,6 +1610,22 @@ describe('issue-decision', () => {
 				.send({
 					'upload-info':
 						'[{"name": "test-document-lpa.pdf", "GUID": "2", "blobStoreUrl": "/", "mimeType": "pdf", "documentType": "lpaCostsDecisionLetter", "size": 1, "stage": "lpa-case"}]'
+				});
+
+			nock('http://test/').get('/appeals/1/case-team-email').reply(200, {
+				id: 1,
+				email: 'caseofficers@planninginspectorate.gov.uk',
+				name: 'standard email'
+			});
+
+			nock('http://test/')
+				.post('/appeals/1/decision/preview')
+				.reply(200, {
+					previews: {
+						appellant: '<p>Appellant email preview</p>',
+						lpa: '<p>LPA email preview</p>',
+						interestedParty: '<p>Interested party email preview</p>'
+					}
 				});
 		});
 

--- a/appeals/web/src/server/appeals/appeal-details/issue-decision/issue-decision.controller.js
+++ b/appeals/web/src/server/appeals/appeal-details/issue-decision/issue-decision.controller.js
@@ -11,6 +11,7 @@ import {
 	lpaCostsDecisionPage,
 	viewDecisionPage
 } from './issue-decision.mapper.js';
+
 import { postInspectorDecision } from './issue-decision.service.js';
 
 import { createNewDocument } from '#app/components/file-uploader.component.js';
@@ -31,6 +32,7 @@ import {
 import { isFeatureActive } from '#common/feature-flags.js';
 import { isStatePassed } from '#lib/appeal-status.js';
 import { getOriginalAndLatestLetterDatesObject, getTodaysISOString } from '#lib/dates.js';
+import { detailsComponent } from '#lib/mappers/components/page-components/details.js';
 import { preHeadingText } from '#lib/mappers/utils/appeal-preheading.js';
 import { mapFileUploadInfoToMappedDocuments } from '#lib/mappers/utils/file-upload-info-to-documents.js';
 import { isParentAppeal } from '#lib/mappers/utils/is-linked-appeal.js';
@@ -752,7 +754,31 @@ export const renderCheckDecision = async (request, response) => {
 		return response.status(500).render('app/500.njk');
 	}
 
-	const mappedPageContent = checkAndConfirmPage(currentAppeal, request);
+	const { previews } = await request.apiClient
+		.post(`appeals/${currentAppeal.appealId}/decision/preview`, {
+			json: {
+				outcome: session.inspectorDecision.outcome,
+				invalidDecisionReason: session.inspectorDecision.invalidReason
+			}
+		})
+		.json();
+
+	const emailPreviewComponents = [
+		detailsComponent({
+			summaryText: 'Preview email to appellant',
+			html: previews.appellant
+		}),
+		detailsComponent({
+			summaryText: 'Preview email to LPA',
+			html: previews.lpa
+		}),
+		detailsComponent({
+			summaryText: 'Preview email to interested parties',
+			html: previews.interestedParty
+		})
+	];
+
+	const mappedPageContent = checkAndConfirmPage(currentAppeal, request, emailPreviewComponents);
 
 	return response.status(200).render('appeals/appeal/issue-decision.njk', {
 		pageContent: mappedPageContent,
@@ -814,13 +840,37 @@ export const postCostsCheckDecision = async (request, response) => {
  * @param {import('@pins/express/types/express.js').RenderedResponse<any, any, Number>} response
  */
 export const renderCostsCheckDecision = async (request, response) => {
-	const { errors, currentAppeal } = request;
+	const { errors, currentAppeal, session } = request;
 
 	if (!currentAppeal) {
 		return response.status(404).render('app/404.njk');
 	}
 
-	const mappedPageContent = checkAndConfirmPage(currentAppeal, request);
+	const { previews } = await request.apiClient
+		.post(`appeals/${currentAppeal.appealId}/decision/preview`, {
+			json: {
+				outcome: session.inspectorDecision?.outcome,
+				invalidDecisionReason: session.inspectorDecision?.invalidReason
+			}
+		})
+		.json();
+
+	const emailPreviewComponents = [
+		detailsComponent({
+			summaryText: 'Preview email to appellant',
+			html: previews.appellant
+		}),
+		detailsComponent({
+			summaryText: 'Preview email to LPA',
+			html: previews.lpa
+		}),
+		detailsComponent({
+			summaryText: 'Preview email to interested parties',
+			html: previews.interestedParty
+		})
+	];
+
+	const mappedPageContent = checkAndConfirmPage(currentAppeal, request, emailPreviewComponents);
 
 	return response.status(200).render('appeals/appeal/issue-decision.njk', {
 		pageContent: mappedPageContent,

--- a/appeals/web/src/server/appeals/appeal-details/issue-decision/issue-decision.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/issue-decision/issue-decision.mapper.js
@@ -629,9 +629,10 @@ function checkAndConfirmPageRows(appealData, request) {
 /**
  * @param {Appeal} appealData
  * @param {Request} request
+ * @param {PageComponent[]} [emailPreviewComponents]
  * @returns {PageContent}
  */
-export function checkAndConfirmPage(appealData, request) {
+export function checkAndConfirmPage(appealData, request, emailPreviewComponents = []) {
 	const { currentAppeal, specificDecisionType } = request;
 
 	const {
@@ -668,7 +669,7 @@ export function checkAndConfirmPage(appealData, request) {
 		preHeading: preHeadingText(appealData),
 		heading: title,
 		submitButtonText: `Issue ${decisionTypeText}`,
-		pageComponents: [summaryListComponent]
+		pageComponents: [summaryListComponent, ...emailPreviewComponents]
 	};
 
 	return pageContent;

--- a/appeals/web/src/server/views/appeals/appeal/issue-decision.njk
+++ b/appeals/web/src/server/views/appeals/appeal/issue-decision.njk
@@ -34,7 +34,7 @@
 			{%- endif -%}
 		{%- endfor -%}
 		{%- if not viewOnly -%}
-		<p class="govuk-body">We'll send an email to the appellant and LPA to tell them about the decision.</p>
+		<p class="govuk-body">We'll send an email to the appellant, LPA and any interested parties to tell them about the decision.</p>
 		{{ govukButton({
 			text: pageContent.submitButtonText if pageContent.submitButtonText else "Continue",
 			type: "submit"

--- a/docs/notifications-and-triggers.md
+++ b/docs/notifications-and-triggers.md
@@ -1,27 +1,32 @@
 # Notifications and triggers
 
-The following notifications are sent from the back-office using these [Notify Templates](../appeals/api/src/server/notify/templates):
+The following notifications are sent from the back-office using
+these [Notify Templates](../appeals/api/src/server/notify/templates):
 
 ## Change appeal type
 
 ### Appeal type change
 
 - **Appeal type:** all
-- **Notify Template:** [appeal-type-change-non-has](../appeals/api/src/server/notify/templates/appeal-type-change-non-has.content.md)
-- **Trigger:** Click "Change" in the Appeal type row within the overview section, select the new type, select yes to resubmit and confirm.
+- **Notify Template:
+  ** [appeal-type-change-non-has](../appeals/api/src/server/notify/templates/appeal-type-change-non-has.content.md)
+- **Trigger:** Click "Change" in the Appeal type row within the overview section, select the new type, select yes to
+  resubmit and confirm.
 
 ## Withdrawal
 
 ### Appeal withdrawn appellant
 
 - **Appeal type:** all
-- **Notify Template:** [appeal-withdrawn-appellant](../appeals/api/src/server/notify/templates/appeal-withdrawn-appellant.content.md)
+- **Notify Template:
+  ** [appeal-withdrawn-appellant](../appeals/api/src/server/notify/templates/appeal-withdrawn-appellant.content.md)
 - **Trigger:** Click "Start" in the Appeal withdrawal row within the case management section and confirm.
 
 ### Appeal withdrawn lpa
 
 - **Appeal type:** all
-- **Notify Template:** [appeal-withdrawn-lpa](../appeals/api/src/server/notify/templates/appeal-withdrawn-lpa.content.md)
+- **Notify Template:
+  ** [appeal-withdrawn-lpa](../appeals/api/src/server/notify/templates/appeal-withdrawn-lpa.content.md)
 - **Trigger:** Click "Start" in the Appeal withdrawal row within the case management section and confirm.
 
 ## Cancellation
@@ -29,7 +34,8 @@ The following notifications are sent from the back-office using these [Notify Te
 ### Enforcement notice withdrawn
 
 - **Appeal type:** enforcement types
-- **Notify Template:** [appeal-cancelled-enforcement-notice-withdrawn](../appeals/api/src/server/notify/templates/appeal-cancelled-enforcement-notice-withdrawn.content.md)
+- **Notify Template:
+  ** [appeal-cancelled-enforcement-notice-withdrawn](../appeals/api/src/server/notify/templates/appeal-cancelled-enforcement-notice-withdrawn.content.md)
 - **Trigger:** Cancel appeal and select "LPA has withdrawn the enforcement notice" and confirm.
 
 ## Validation
@@ -38,19 +44,22 @@ The following notifications are sent from the back-office using these [Notify Te
 
 - **Appeal type:** all
 - **Notify Template:** [appeal-incomplete](../appeals/api/src/server/notify/templates/appeal-incomplete.content.md)
-- **Trigger:** Select "Incomplete" when answering "What is the outcome of your review?", Pick some reasons and then confirm.
+- **Trigger:** Select "Incomplete" when answering "What is the outcome of your review?", Pick some reasons and then
+  confirm.
 
 ### Appeal invalid
 
 - **Appeal type:** all
 - **Notify Template:** [appeal-invalid](../appeals/api/src/server/notify/templates/appeal-invalid.content.md)
-- **Trigger:** Select "Invalid" when answering "What is the outcome of your review?", Pick some reasons and then confirm.
+- **Trigger:** Select "Invalid" when answering "What is the outcome of your review?", Pick some reasons and then
+  confirm.
 
 ### Appeal invalid lpa
 
 - **Appeal type:** all
 - **Notify Template:** [appeal-invalid-lpa](../appeals/api/src/server/notify/templates/appeal-invalid-lpa.content.md)
-- **Trigger:** Select "Invalid" when answering "What is the outcome of your review?", Pick some reasons and then confirm.
+- **Trigger:** Select "Invalid" when answering "What is the outcome of your review?", Pick some reasons and then
+  confirm.
 
 ### Appeal confirmed
 
@@ -63,25 +72,29 @@ The following notifications are sent from the back-office using these [Notify Te
 ### Appeal valid start case s78 appellant
 
 - **Appeal type:** s78, s20
-- **Notify Template:** [appeal-valid-start-case-s78-appellant](../appeals/api/src/server/notify/templates/appeal-valid-start-case-s78-appellant.content.md)
+- **Notify Template:
+  ** [appeal-valid-start-case-s78-appellant](../appeals/api/src/server/notify/templates/appeal-valid-start-case-s78-appellant.content.md)
 - **Trigger:** Start a full planning or listed building case, select an appeal procedure, and confirm.
 
 ### Appeal valid start case s78 lpa
 
 - **Appeal type:** s78, s20
-- **Notify Template:** [appeal-valid-start-case-s78-lpa](../appeals/api/src/server/notify/templates/appeal-valid-start-case-s78-lpa.content.md)
+- **Notify Template:
+  ** [appeal-valid-start-case-s78-lpa](../appeals/api/src/server/notify/templates/appeal-valid-start-case-s78-lpa.content.md)
 - **Trigger:** Start a full planning or listed building case, select an appeal procedure, and confirm.
 
 ### Appeal valid start case householder appellant
 
 - **Appeal type:** householder, CAS planning, CAS advert, Full advert
-- **Notify Template:** [appeal-valid-start-case-appellant](../appeals/api/src/server/notify/templates/appeal-valid-start-case-appellant.content.md)
+- **Notify Template:
+  ** [appeal-valid-start-case-appellant](../appeals/api/src/server/notify/templates/appeal-valid-start-case-appellant.content.md)
 - **Trigger:** Start a householder case, select an appeal procedure, and confirm.
 
 ### Appeal valid start case householder lpa
 
 - **Appeal type:** householder, CAS planning, CAS advert, Full advert
-- **Notify Template:** [appeal-valid-start-case-lpa](../appeals/api/src/server/notify/templates/appeal-valid-start-case-lpa.content.md)
+- **Notify Template:
+  ** [appeal-valid-start-case-lpa](../appeals/api/src/server/notify/templates/appeal-valid-start-case-lpa.content.md)
 - **Trigger:** Start a householder case, select an appeal procedure, and confirm.
 
 ## Timetable updated
@@ -90,33 +103,39 @@ The following notifications are sent from the back-office using these [Notify Te
 
 - **Appeal type:** s78, s20
 - **Procedure:** Written
-- **Notify Template:** [appeal-timetable-updated](../appeals/api/src/server/notify/templates/appeal-timetable-updated.content.md)
+- **Notify Template:
+  ** [appeal-timetable-updated](../appeals/api/src/server/notify/templates/appeal-timetable-updated.content.md)
 - **Trigger:** Update timetable dates from the timetable section of the appeal. Sent to appellant/agent and LPA.
 
 ### Timetable updated - s78/s20 inquiry
 
 - **Appeal type:** s78, s20
 - **Procedure:** Inquiry
-- **Notify Template:** [appeal-timetable-updated-inquiry](../appeals/api/src/server/notify/templates/appeal-timetable-updated-inquiry.content.md)
-- **Trigger:** Update timetable dates from the timetable section of the appeal. Sent to appellant/agent, LPA, and any Rule 6 parties.
+- **Notify Template:
+  ** [appeal-timetable-updated-inquiry](../appeals/api/src/server/notify/templates/appeal-timetable-updated-inquiry.content.md)
+- **Trigger:** Update timetable dates from the timetable section of the appeal. Sent to appellant/agent, LPA, and any
+  Rule 6 parties.
 
 ### Timetable updated - s78/s20 hearing
 
 - **Appeal type:** s78, s20
 - **Procedure:** Hearing
-- **Notify Template:** [appeal-timetable-updated-hearing](../appeals/api/src/server/notify/templates/appeal-timetable-updated-hearing.content.md)
+- **Notify Template:
+  ** [appeal-timetable-updated-hearing](../appeals/api/src/server/notify/templates/appeal-timetable-updated-hearing.content.md)
 - **Trigger:** Update timetable dates from the timetable section of the appeal. Sent to appellant/agent and LPA.
 
 ### Timetable updated - householder/CAS
 
 - **Appeal type:** householder, CAS planning, CAS advert
-- **Notify Template:** [has-appeal-timetable-updated](../appeals/api/src/server/notify/templates/has-appeal-timetable-updated.content.md)
+- **Notify Template:
+  ** [has-appeal-timetable-updated](../appeals/api/src/server/notify/templates/has-appeal-timetable-updated.content.md)
 - **Trigger:** Update timetable dates from the timetable section of the appeal. Sent to appellant/agent and LPA.
 
 ### Timetable updated - full advert
 
 - **Appeal type:** full advert
-- **Notify Template:** [advertisement-appeal-timetable-updated](../appeals/api/src/server/notify/templates/advertisement-appeal-timetable-updated.content.md)
+- **Notify Template:
+  ** [advertisement-appeal-timetable-updated](../appeals/api/src/server/notify/templates/advertisement-appeal-timetable-updated.content.md)
 - **Trigger:** Update timetable dates from the timetable section of the appeal. Sent to appellant/agent and LPA.
 
 ## LPA questionnaire
@@ -124,25 +143,29 @@ The following notifications are sent from the back-office using these [Notify Te
 ### Appeal start date change appellant
 
 - **Appeal type:** all
-- **Notify Template:** [appeal-start-date-change-appellant](../appeals/api/src/server/notify/templates/appeal-start-date-change-appellant.content.md)
+- **Notify Template:
+  ** [appeal-start-date-change-appellant](../appeals/api/src/server/notify/templates/appeal-start-date-change-appellant.content.md)
 - **Trigger:** Click "Change" in the Start date row within the timetable and confirm.
 
 ### Appeal start date change lpa
 
 - **Appeal type:** all
-- **Notify Template:** [appeal-start-date-change-lpa](../appeals/api/src/server/notify/templates/appeal-start-date-change-lpa.content.md)
+- **Notify Template:
+  ** [appeal-start-date-change-lpa](../appeals/api/src/server/notify/templates/appeal-start-date-change-lpa.content.md)
 - **Trigger:** Click "Change" in the Start date row within the timetable and confirm.
 
 ### Lpaq complete s78 appellant
 
 - **Appeal type:** s78, s20
-- **Notify Template:** [lpaq-complete-appellant](../appeals/api/src/server/notify/templates/lpaq-complete-appellant.content.md)
+- **Notify Template:
+  ** [lpaq-complete-appellant](../appeals/api/src/server/notify/templates/lpaq-complete-appellant.content.md)
 - **Trigger:** Review a Lpaq and mark it as complete by selecting "Complete" and continue
 
 ### Lpaq complete householder appellant
 
 - **Appeal type:** householder, CAS planning, CAS advert, Full advert
-- **Notify Template:** [lpaq-complete-has-appellant](../appeals/api/src/server/notify/templates/lpaq-complete-has-appellant.content.md)
+- **Notify Template:
+  ** [lpaq-complete-has-appellant](../appeals/api/src/server/notify/templates/lpaq-complete-has-appellant.content.md)
 - **Trigger:** Review a Lpaq and mark it as complete by selecting "Complete" and continue
 
 ### Lpaq complete lpa
@@ -162,7 +185,8 @@ The following notifications are sent from the back-office using these [Notify Te
 ### Lpa statement incomplete
 
 - **Appeal type:** s78, s20
-- **Notify Template:** [lpa-statement-incomplete](../appeals/api/src/server/notify/templates/lpa-statement-incomplete.content.md)
+- **Notify Template:
+  ** [lpa-statement-incomplete](../appeals/api/src/server/notify/templates/lpa-statement-incomplete.content.md)
 - **Trigger:** Review a lpa statement and mark it as incomplete by selecting "Incomplete" and continue
 
 ### Ip comment rejected
@@ -174,174 +198,236 @@ The following notifications are sent from the back-office using these [Notify Te
 ### Ip comment rejected deadline extended
 
 - **Appeal type:** s78, s20
-- **Notify Template:** [ip-comment-rejected-deadline-extended](../appeals/api/src/server/notify/templates/ip-comment-rejected-deadline-extended.content.md)
-- **Trigger:** Update and extend the ip comment due date and then review an ip comment and mark it as rejected by selecting "Reject" and continue
+- **Notify Template:
+  ** [ip-comment-rejected-deadline-extended](../appeals/api/src/server/notify/templates/ip-comment-rejected-deadline-extended.content.md)
+- **Trigger:** Update and extend the ip comment due date and then review an ip comment and mark it as rejected by
+  selecting "Reject" and continue
 
 ## Site visit
 
 ### Site visit access required date change appellant
 
 - **Appeal type:** all
-- **Notify Template:** [site-visit-change-access-required-date-change-appellant](../appeals/api/src/server/notify/templates/site-visit-change-access-required-date-change-appellant.content.md)
-- **Trigger:** A site visit is already set up and the CO edits the site visit to update the date/time. Confirming the change from the ‘Check details and update site visit’ page triggers this email.
+- **Notify Template:
+  ** [site-visit-change-access-required-date-change-appellant](../appeals/api/src/server/notify/templates/site-visit-change-access-required-date-change-appellant.content.md)
+- **Trigger:** A site visit is already set up and the CO edits the site visit to update the date/time. Confirming the
+  change from the ‘Check details and update site visit’ page triggers this email.
 
 ### Site visit access required to accompanied appellant
 
 - **Appeal type:** all
-- **Notify Template:** [site-visit-change-access-required-to-accompanied-appellant](../appeals/api/src/server/notify/templates/site-visit-change-access-required-to-accompanied-appellant.content.md)
-- **Trigger:** A site visit is already set up and the CO edits the site visit to update the site visit type from access required to accompanied. Confirming the change from the ‘Check details and update site visit’ page triggers this email.
+- **Notify Template:
+  ** [site-visit-change-access-required-to-accompanied-appellant](../appeals/api/src/server/notify/templates/site-visit-change-access-required-to-accompanied-appellant.content.md)
+- **Trigger:** A site visit is already set up and the CO edits the site visit to update the site visit type from access
+  required to accompanied. Confirming the change from the ‘Check details and update site visit’ page triggers this
+  email.
 
 ### Site visit access required to accompanied lpa
 
 - **Appeal type:** all
-- **Notify Template:** [site-visit-change-access-required-to-accompanied-lpa](../appeals/api/src/server/notify/templates/site-visit-change-access-required-to-accompanied-lpa.content.md)
-- **Trigger:** A site visit is already set up and the CO edits the site visit to update the site visit type from access required to accompanied. Confirming the change from the ‘Check details and update site visit’ page triggers this email.
+- **Notify Template:
+  ** [site-visit-change-access-required-to-accompanied-lpa](../appeals/api/src/server/notify/templates/site-visit-change-access-required-to-accompanied-lpa.content.md)
+- **Trigger:** A site visit is already set up and the CO edits the site visit to update the site visit type from access
+  required to accompanied. Confirming the change from the ‘Check details and update site visit’ page triggers this
+  email.
 
 ### Site visit access required to unaccompanied appellant
 
 - **Appeal type:** all
-- **Notify Template:** [site-visit-change-access-required-to-unaccompanied-appellant](../appeals/api/src/server/notify/templates/site-visit-change-access-required-to-unaccompanied-appellant.content.md)
-- **Trigger:** A site visit is already set up and the CO edits the site visit to update the site visit type from access required to unaccompanied. Confirming the change from the ‘Check details and update site visit’ page triggers this email.
+- **Notify Template:
+  ** [site-visit-change-access-required-to-unaccompanied-appellant](../appeals/api/src/server/notify/templates/site-visit-change-access-required-to-unaccompanied-appellant.content.md)
+- **Trigger:** A site visit is already set up and the CO edits the site visit to update the site visit type from access
+  required to unaccompanied. Confirming the change from the ‘Check details and update site visit’ page triggers this
+  email.
 
 ### Site visit accompanied date change appellant
 
 - **Appeal type:** all
-- **Notify Template:** [site-visit-change-accompanied-date-change-appellant](../appeals/api/src/server/notify/templates/site-visit-change-accompanied-date-change-appellant.content.md)
-- **Trigger:** A site visit is already set up and the CO edits the site visit to update the date/time. Confirming the change from the ‘Check details and update site visit’ page triggers this email.
+- **Notify Template:
+  ** [site-visit-change-accompanied-date-change-appellant](../appeals/api/src/server/notify/templates/site-visit-change-accompanied-date-change-appellant.content.md)
+- **Trigger:** A site visit is already set up and the CO edits the site visit to update the date/time. Confirming the
+  change from the ‘Check details and update site visit’ page triggers this email.
 
 ### Site visit accompanied date change lpa
 
 - **Appeal type:** all
-- **Notify Template:** [site-visit-change-accompanied-date-change-lpa](../appeals/api/src/server/notify/templates/site-visit-change-accompanied-date-change-lpa.content.md)
-- **Trigger:** A site visit is already set up and the CO edits the site visit to update the date/time. Confirming the change from the ‘Check details and update site visit’ page triggers this email.
+- **Notify Template:
+  ** [site-visit-change-accompanied-date-change-lpa](../appeals/api/src/server/notify/templates/site-visit-change-accompanied-date-change-lpa.content.md)
+- **Trigger:** A site visit is already set up and the CO edits the site visit to update the date/time. Confirming the
+  change from the ‘Check details and update site visit’ page triggers this email.
 
 ### Site visit accompanied to access required appellant
 
 - **Appeal type:** all
-- **Notify Template:** [site-visit-change-accompanied-to-access-required-appellant](../appeals/api/src/server/notify/templates/site-visit-change-accompanied-to-access-required-appellant.content.md)
-- **Trigger:** A site visit is already set up and the CO edits the site visit to update the site visit type from accompanied to access required. Confirming the change from the ‘Check details and update site visit’ page triggers this email.
+- **Notify Template:
+  ** [site-visit-change-accompanied-to-access-required-appellant](../appeals/api/src/server/notify/templates/site-visit-change-accompanied-to-access-required-appellant.content.md)
+- **Trigger:** A site visit is already set up and the CO edits the site visit to update the site visit type from
+  accompanied to access required. Confirming the change from the ‘Check details and update site visit’ page triggers
+  this email.
 
 ### Site visit accompanied to access required lpa
 
 - **Appeal type:** all
-- **Notify Template:** [site-visit-change-accompanied-to-access-required-lpa](../appeals/api/src/server/notify/templates/site-visit-change-accompanied-to-access-required-lpa.content.md)
-- **Trigger:** A site visit is already set up and the CO edits the site visit to update the site visit type from accompanied to access required. Confirming the change from the ‘Check details and update site visit’ page triggers this email.
+- **Notify Template:
+  ** [site-visit-change-accompanied-to-access-required-lpa](../appeals/api/src/server/notify/templates/site-visit-change-accompanied-to-access-required-lpa.content.md)
+- **Trigger:** A site visit is already set up and the CO edits the site visit to update the site visit type from
+  accompanied to access required. Confirming the change from the ‘Check details and update site visit’ page triggers
+  this email.
 
 ### Site visit accompanied to unaccompanied appellant
 
 - **Appeal type:** all
-- **Notify Template:** [site-visit-change-accompanied-to-unaccompanied-appellant](../appeals/api/src/server/notify/templates/site-visit-change-accompanied-to-unaccompanied-appellant.content.md)
-- **Trigger:** A site visit is already set up and the CO edits the site visit to update the site visit type from accompanied to unaccompanied. Confirming the change from the ‘Check details and update site visit’ page triggers this email.
+- **Notify Template:
+  ** [site-visit-change-accompanied-to-unaccompanied-appellant](../appeals/api/src/server/notify/templates/site-visit-change-accompanied-to-unaccompanied-appellant.content.md)
+- **Trigger:** A site visit is already set up and the CO edits the site visit to update the site visit type from
+  accompanied to unaccompanied. Confirming the change from the ‘Check details and update site visit’ page triggers this
+  email.
 
 ### Site visit accompanied to unaccompanied lpa
 
 - **Appeal type:** all
-- **Notify Template:** [site-visit-change-accompanied-to-unaccompanied-lpa](../appeals/api/src/server/notify/templates/site-visit-change-accompanied-to-unaccompanied-lpa.content.md)
-- **Trigger:** A site visit is already set up and the CO edits the site visit to update the site visit type from accompanied to unaccompanied. Confirming the change from the ‘Check details and update site visit’ page triggers this email.
+- **Notify Template:
+  ** [site-visit-change-accompanied-to-unaccompanied-lpa](../appeals/api/src/server/notify/templates/site-visit-change-accompanied-to-unaccompanied-lpa.content.md)
+- **Trigger:** A site visit is already set up and the CO edits the site visit to update the site visit type from
+  accompanied to unaccompanied. Confirming the change from the ‘Check details and update site visit’ page triggers this
+  email.
 
 ### Site visit unaccompanied to access required appellant
 
 - **Appeal type:** all
-- **Notify Template:** [site-visit-change-unaccompanied-to-access-required-appellant](../appeals/api/src/server/notify/templates/site-visit-change-unaccompanied-to-access-required-appellant.content.md)
-- **Trigger:** A site visit is already set up and the CO edits the site visit to update the site visit type from unaccompanied to access required. Confirming the change from the ‘Check details and update site visit’ page triggers this email.
+- **Notify Template:
+  ** [site-visit-change-unaccompanied-to-access-required-appellant](../appeals/api/src/server/notify/templates/site-visit-change-unaccompanied-to-access-required-appellant.content.md)
+- **Trigger:** A site visit is already set up and the CO edits the site visit to update the site visit type from
+  unaccompanied to access required. Confirming the change from the ‘Check details and update site visit’ page triggers
+  this email.
 
 ### Site visit unaccompanied to accompanied appellant
 
 - **Appeal type:** all
-- **Notify Template:** [site-visit-change-unaccompanied-to-accompanied-appellant](../appeals/api/src/server/notify/templates/site-visit-change-unaccompanied-to-accompanied-appellant.content.md)
-- **Trigger:** A site visit is already set up and the CO edits the site visit to update the site visit type from unaccompanied to accompanied. Confirming the change from the ‘Check details and update site visit’ page triggers this email.
+- **Notify Template:
+  ** [site-visit-change-unaccompanied-to-accompanied-appellant](../appeals/api/src/server/notify/templates/site-visit-change-unaccompanied-to-accompanied-appellant.content.md)
+- **Trigger:** A site visit is already set up and the CO edits the site visit to update the site visit type from
+  unaccompanied to accompanied. Confirming the change from the ‘Check details and update site visit’ page triggers this
+  email.
 
 ### Site visit unaccompanied to accompanied lpa
 
 - **Appeal type:** all
-- **Notify Template:** [site-visit-change-unaccompanied-to-accompanied-lpa](../appeals/api/src/server/notify/templates/site-visit-change-unaccompanied-to-accompanied-lpa.content.md)
-- **Trigger:** A site visit is already set up and the CO edits the site visit to update the site visit type from unaccompanied to accompanied. Confirming the change from the ‘Check details and update site visit’ page triggers this email.
+- **Notify Template:
+  ** [site-visit-change-unaccompanied-to-accompanied-lpa](../appeals/api/src/server/notify/templates/site-visit-change-unaccompanied-to-accompanied-lpa.content.md)
+- **Trigger:** A site visit is already set up and the CO edits the site visit to update the site visit type from
+  unaccompanied to accompanied. Confirming the change from the ‘Check details and update site visit’ page triggers this
+  email.
 
 ### Site visit access required appellant
 
 - **Appeal type:** all
-- **Notify Template:** [site-visit-schedule-access-required-appellant](../appeals/api/src/server/notify/templates/site-visit-schedule-access-required-appellant.content.md)
-- **Trigger:** A site visit is not set up and the CO sets up an access required site visit. Confirming the change from the ‘Check details and set up site visit’ page triggers this email.
+- **Notify Template:
+  ** [site-visit-schedule-access-required-appellant](../appeals/api/src/server/notify/templates/site-visit-schedule-access-required-appellant.content.md)
+- **Trigger:** A site visit is not set up and the CO sets up an access required site visit. Confirming the change from
+  the ‘Check details and set up site visit’ page triggers this email.
 
 ### Site visit accompanied appellant
 
 - **Appeal type:** all
-- **Notify Template:** [site-visit-schedule-accompanied-appellant](../appeals/api/src/server/notify/templates/site-visit-schedule-accompanied-appellant.content.md)
-- **Trigger:** A site visit is not set up and the CO sets up an accompanied site visit. Confirming the change from the ‘Check details and set up site visit’ page triggers this email.
+- **Notify Template:
+  ** [site-visit-schedule-accompanied-appellant](../appeals/api/src/server/notify/templates/site-visit-schedule-accompanied-appellant.content.md)
+- **Trigger:** A site visit is not set up and the CO sets up an accompanied site visit. Confirming the change from the
+  ‘Check details and set up site visit’ page triggers this email.
 
 ### Site visit accompanied lpa
 
 - **Appeal type:** all
-- **Notify Template:** [site-visit-schedule-accompanied-lpa](../appeals/api/src/server/notify/templates/site-visit-schedule-accompanied-lpa.content.md)
-- **Trigger:** A site visit is not set up and the CO sets up an accompanied site visit. Confirming the change from the ‘Check details and set up site visit’ page triggers this email.
+- **Notify Template:
+  ** [site-visit-schedule-accompanied-lpa](../appeals/api/src/server/notify/templates/site-visit-schedule-accompanied-lpa.content.md)
+- **Trigger:** A site visit is not set up and the CO sets up an accompanied site visit. Confirming the change from the
+  ‘Check details and set up site visit’ page triggers this email.
 
 ### Site visit unaccompanied appellant
 
 - **Appeal type:** all
-- **Notify Template:** [site-visit-schedule-unaccompanied-appellant](../appeals/api/src/server/notify/templates/site-visit-schedule-unaccompanied-appellant.content.md)
-- **Trigger:** A site visit is not set up and the CO sets up an unaccompanied site visit. Confirming the change from the ‘Check details and set up site visit’ page triggers this email.
+- **Notify Template:
+  ** [site-visit-schedule-unaccompanied-appellant](../appeals/api/src/server/notify/templates/site-visit-schedule-unaccompanied-appellant.content.md)
+- **Trigger:** A site visit is not set up and the CO sets up an unaccompanied site visit. Confirming the change from the
+  ‘Check details and set up site visit’ page triggers this email.
 
 ### Site visit cancellation
 
 - **Appeal type:** all
-- **Notify Template:** [site-visit-cancelled](../appeals/api/src/server/notify/templates/site-visit-cancelled.content.md)
-- **Trigger:** The CO cancels the site visit. Confirming from the 'Confirm that you want to cancel the site visit' page using the 'Cancel site visit' button triggers this email.
+- **Notify Template:
+  ** [site-visit-cancelled](../appeals/api/src/server/notify/templates/site-visit-cancelled.content.md)
+- **Trigger:** The CO cancels the site visit. Confirming from the 'Confirm that you want to cancel the site visit' page
+  using the 'Cancel site visit' button triggers this email.
 
 ### Missed site visit appellant
 
 - **Appeal type:** all
-- **Notify Template:** [record-missed-site-visit-appellant](../appeals/api/src/server/notify/templates/record-missed-site-visit-appellant.content.md)
-- **Trigger:** The CO records that the site visit has been missed by the appellant. Confirming from the 'Check details and record missed site visit' page using the 'Record missed site visit' button triggers this email.
+- **Notify Template:
+  ** [record-missed-site-visit-appellant](../appeals/api/src/server/notify/templates/record-missed-site-visit-appellant.content.md)
+- **Trigger:** The CO records that the site visit has been missed by the appellant. Confirming from the 'Check details
+  and record missed site visit' page using the 'Record missed site visit' button triggers this email.
 
 ### Missed site visit LPA
 
 - **Appeal type:** all
-- **Notify Template:** [record-missed-site-visit-lpa](../appeals/api/src/server/notify/templates/record-missed-site-visit-lpa.content.md)
-- **Trigger:** The CO records that the site visit has been missed by the LPA. Confirming from the 'Check details and record missed site visit' page using the 'Record missed site visit' button triggers this email.
+- **Notify Template:
+  ** [record-missed-site-visit-lpa](../appeals/api/src/server/notify/templates/record-missed-site-visit-lpa.content.md)
+- **Trigger:** The CO records that the site visit has been missed by the LPA. Confirming from the 'Check details and
+  record missed site visit' page using the 'Record missed site visit' button triggers this email.
 
 ### Rearrange missed site visit to unaccompanied appellant
 
 - **Appeal type:** all
-- **Notify Template:** [missed-site-visit-rearranged-unaccompanied-appellant](../appeals/api/src/server/notify/templates/missed-site-visit-rearranged-unaccompanied-appellant.content.md)
-- **Trigger:** Having had a site visit cancelled (of any type) when a new unaccompanied site visit is set up this email is sent. Confirming on the 'Schedule site visit' page triggers this email.
+- **Notify Template:
+  ** [missed-site-visit-rearranged-unaccompanied-appellant](../appeals/api/src/server/notify/templates/missed-site-visit-rearranged-unaccompanied-appellant.content.md)
+- **Trigger:** Having had a site visit cancelled (of any type) when a new unaccompanied site visit is set up this email
+  is sent. Confirming on the 'Schedule site visit' page triggers this email.
 
 ### Rearrange missed site visit appellant
 
 - **Appeal type:** all
-- **Notify Template:** [missed-site-visit-rearranged-appellant](../appeals/api/src/server/notify/templates/missed-site-visit-rearranged-appellant.content.md)
-- **Trigger:** Having had a site visit cancelled (of any type) when a new access required or accompanied site visit is set up this email is sent. Confirming on the 'Schedule site visit' page triggers this email.
+- **Notify Template:
+  ** [missed-site-visit-rearranged-appellant](../appeals/api/src/server/notify/templates/missed-site-visit-rearranged-appellant.content.md)
+- **Trigger:** Having had a site visit cancelled (of any type) when a new access required or accompanied site visit is
+  set up this email is sent. Confirming on the 'Schedule site visit' page triggers this email.
 
 ### Rearrange missed site visit LPA
 
 - **Appeal type:** all
-- **Notify Template:** [missed-site-visit-rearranged-lpa](../appeals/api/src/server/notify/templates/missed-site-visit-rearranged-lpa.content.md)
-- **Trigger:** Having had a site visit cancelled (of any type) when a new accompanied site visit is set up this email is sent. Confirming on the 'Schedule site visit' page triggers this email.
+- **Notify Template:
+  ** [missed-site-visit-rearranged-lpa](../appeals/api/src/server/notify/templates/missed-site-visit-rearranged-lpa.content.md)
+- **Trigger:** Having had a site visit cancelled (of any type) when a new accompanied site visit is set up this email is
+  sent. Confirming on the 'Schedule site visit' page triggers this email.
 
 ## Final comments
 
 ### Final comments done appellant
 
 - **Appeal type:** s78, s20
-- **Notify Template:** [final-comments-done-appellant](../appeals/api/src/server/notify/templates/final-comments-done-appellant.content.md)
+- **Notify Template:
+  ** [final-comments-done-appellant](../appeals/api/src/server/notify/templates/final-comments-done-appellant.content.md)
 - **Trigger:** Review final comments and mark as accepted and continue
 
 ### Final comments done lpa
 
 - **Appeal type:** s78, s20
-- **Notify Template:** [final-comments-done-lpa](../appeals/api/src/server/notify/templates/final-comments-done-lpa.content.md)
+- **Notify Template:
+  ** [final-comments-done-lpa](../appeals/api/src/server/notify/templates/final-comments-done-lpa.content.md)
 - **Trigger:** Review final comments and mark as accepted and continue
 
 ### Final comment rejected appellant
 
 - **Appeal type:** s78, s20
-- **Notify Template:** [final-comment-rejected-appellant](../appeals/api/src/server/notify/templates/final-comment-rejected-appellant.content.md)
+- **Notify Template:
+  ** [final-comment-rejected-appellant](../appeals/api/src/server/notify/templates/final-comment-rejected-appellant.content.md)
 - **Trigger:** Review final comments and mark as rejected, add some reasons and continue
 -
 
 ### Final comment rejected lpa
 
 - **Appeal type:** s78, s20
-- **Notify Template:** [final-comment-rejected-lpa](../appeals/api/src/server/notify/templates/final-comment-rejected-lpa.content.md)
+- **Notify Template:
+  ** [final-comment-rejected-lpa](../appeals/api/src/server/notify/templates/final-comment-rejected-lpa.content.md)
 - **Trigger:** Review final comments and mark as rejected, add some reasons and continue
 
 ## Decision
@@ -349,25 +435,43 @@ The following notifications are sent from the back-office using these [Notify Te
 ### Decision is (allowed, split, or dismissed) appellant
 
 - **Appeal type:** all
-- **Notify Template:** [decision-is-allowed-split-dismissed-appellant](../appeals/api/src/server/notify/templates/decision-is-allowed-split-dismissed-appellant.content.md)
+- **Notify Template:
+  ** [decision-is-allowed-split-dismissed-appellant](../appeals/api/src/server/notify/templates/decision-is-allowed-split-dismissed-appellant.content.md)
 - **Trigger:** Issue decision and select allowed, split, or dismissed and continue
 
 ### Decision is (allowed, split, or dismissed) lpa
 
 - **Appeal type:** all
-- **Notify Template:** [decision-is-allowed-split-dismissed-lpa](../appeals/api/src/server/notify/templates/decision-is-allowed-split-dismissed-lpa.content.md)
+- **Notify Template:
+  ** [decision-is-allowed-split-dismissed-lpa](../appeals/api/src/server/notify/templates/decision-is-allowed-split-dismissed-lpa.content.md)
+- **Trigger:** Issue decision and select allowed, split, or dismissed and continue
+
+### Decision is (allowed, split, or dismissed) interested party
+
+- **Appeal type:** all
+- **Notify Template:
+  ** [decision-is-allowed-split-dismissed-interested-party](../appeals/api/src/server/notify/templates/decision-is-allowed-split-dismissed-interested-party.content.md)
 - **Trigger:** Issue decision and select allowed, split, or dismissed and continue
 
 ### Decision is invalid appellant
 
 - **Appeal type:** all
-- **Notify Template:** [decision-is-invalid-appellant](../appeals/api/src/server/notify/templates/decision-is-invalid-appellant.content.md)
+- **Notify Template:
+  ** [decision-is-invalid-appellant](../appeals/api/src/server/notify/templates/decision-is-invalid-appellant.content.md)
 - **Trigger:** Issue decision and select invalid and continue
 
 ### Decision is invalid lpa
 
 - **Appeal type:** all
-- **Notify Template:** [decision-is-invalid-lpa](../appeals/api/src/server/notify/templates/decision-is-invalid-lpa.content.md)
+- **Notify Template:
+  ** [decision-is-invalid-lpa](../appeals/api/src/server/notify/templates/decision-is-invalid-lpa.content.md)
+- **Trigger:** Issue decision and select invalid and continue
+
+### Decision is invalid interested party
+
+- **Appeal type:** all
+- **Notify Template:
+  ** [decision-is-invalid-interested-party](../appeals/api/src/server/notify/templates/decision-is-invalid-interested-party.content.md)
 - **Trigger:** Issue decision and select invalid and continue
 
 ## Missed site visit
@@ -375,25 +479,29 @@ The following notifications are sent from the back-office using these [Notify Te
 ### Record missed site visit appellant
 
 - **Appeal type:** all
-- **Notify Template:** [record-missed-site-visit-appellant](../appeals/api/src/server/notify/templates/decision-is-allowed-split-dismissed-appellant.content.md)
+- **Notify Template:
+  ** [record-missed-site-visit-appellant](../appeals/api/src/server/notify/templates/decision-is-allowed-split-dismissed-appellant.content.md)
 - **Trigger:** Record missed site visit for appellant
 
 ### Record missed site visit lpa
 
 - **Appeal type:** all
-- **Notify Template:** [record-missed-site-visit-lpa](../appeals/api/src/server/notify/templates/decision-is-allowed-split-dismissed-lpa.content.md)
+- **Notify Template:
+  ** [record-missed-site-visit-lpa](../appeals/api/src/server/notify/templates/decision-is-allowed-split-dismissed-lpa.content.md)
 - **Trigger:** Record missed site visit for lpa
 
 ### Rearrange missed site visit appellant
 
 - **Appeal type:** all
-- **Notify Template:** [rearrange-missed-site-visit-appellant](../appeals/api/src/server/notify/templates/rearrange-missed-site-visit-appellant.content.md)
+- **Notify Template:
+  ** [rearrange-missed-site-visit-appellant](../appeals/api/src/server/notify/templates/rearrange-missed-site-visit-appellant.content.md)
 - **Trigger:** Setting up a site visit after recording a missed site visit
 
 ### Rearrange missed site visit lpa
 
 - **Appeal type:** all
-- **Notify Template:** [rearrange-missed-site-visit-lpa](../appeals/api/src/server/notify/templates/rearrange-missed-site-visit-lpa.content.md)
+- **Notify Template:
+  ** [rearrange-missed-site-visit-lpa](../appeals/api/src/server/notify/templates/rearrange-missed-site-visit-lpa.content.md)
 - **Trigger:** Setting up a site visit after recording a missed site visit
 
 ## Rule 6 Party
@@ -401,17 +509,20 @@ The following notifications are sent from the back-office using these [Notify Te
 ### Rule 6 Party admitted - Rule 6 party
 
 - **Appeal type:** Inquiry
-- **Notify Template:** [rule-6-status-accepted-rule-6-party](../appeals/api/src/server/notify/templates/rule-6-status-accepted-rule-6-party.content.md)
+- **Notify Template:
+  ** [rule-6-status-accepted-rule-6-party](../appeals/api/src/server/notify/templates/rule-6-status-accepted-rule-6-party.content.md)
 - **Trigger:** Added a Rule 6 party to the appeal
 
 ### Rule 6 Party admitted - Main parties
 
 - **Appeal type:** Inquiry
-- **Notify Template:** [rule-6-status-accepted-main-parties](../appeals/api/src/server/notify/templates/rule-6-status-accepted-main-parties.content.md)
+- **Notify Template:
+  ** [rule-6-status-accepted-main-parties](../appeals/api/src/server/notify/templates/rule-6-status-accepted-main-parties.content.md)
 - **Trigger:** Added a Rule 6 party to the appeal
 
 ### Rule 6 Party updated
 
 - **Appeal type:** Inquiry
-- **Notify Template:** [rule-6-party-updated](../appeals/api/src/server/notify/templates/rule-6-party-updated.content.md)
+- **Notify Template:
+  ** [rule-6-party-updated](../appeals/api/src/server/notify/templates/rule-6-party-updated.content.md)
 - **Trigger:** Updated Rule 6 party details

--- a/packages/appeals/constants/common.js
+++ b/packages/appeals/constants/common.js
@@ -177,6 +177,9 @@ export const FEEDBACK_FORM_LINKS = Object.freeze({
 
 	LAWFUL_DEVELOPMENT_CERTIFICATE: 'https://forms.cloud.microsoft/e/J5EwyG3e0e',
 
+	COMMENT_ON_APPEAL:
+		'https://forms.office.com/pages/responsepage.aspx?id=mN94WIhvq0iTIpmM5VcIjYt1ax_BPvtOqhVjfvzyJN5UQVU3UkdCT0FPVlYwQUsxUDYySDA1V1NXWC4u',
+
 	ENFORCEMENT_LISTED_BUILDING:
 		'https://forms.cloud.microsoft/pages/responsepage.aspx?id=mN94WIhvq0iTIpmM5VcIjYt1ax_BPvtOqhVjfvzyJN5UNDJFTjBCRTlFV1pYVjVWRkhKQVBYTVRKUC4u&route=shorturl'
 });


### PR DESCRIPTION
(A2-3000)

## Describe your changes

This PR adds an additional notify that is sent out to interested parties when a decision has been reached on an appeal. The email goes to interested parties who had a comment approved and left an email address.

It also adds a preview section for all 3 emails (appellant, lpa and interested-pary) sent out in the notifies.

_Note - at the moment a row is being rendered in the appeal's case history for each interested party who is sent the notify. I have [created a separate ticket](https://pins-ds.atlassian.net/browse/A2-7847) to improve this UX as when there are many interested parties who are notified, it creates a lot of duplicate information clogging the audit logs._

## Issue ticket number and link

[Ticket](https://pins-ds.atlassian.net/browse/A2-3000)
