### PR TITLE
fix(api): fix validation errors message (A2-7611)

### DIFF
--- a/appeals/api/src/server/middleware/error-handler.js
+++ b/appeals/api/src/server/middleware/error-handler.js
@@ -68,7 +68,7 @@ const validationErrorHandlerTemplate = (request, response, next, status) => {
 	const result = validationResult(request).formatWith(({ msg }) => msg);
 
 	if (!result.isEmpty()) {
-		logger.error('Validation errors', result);
+		logger.error({ errors: result.mapped() }, 'Validation errors');
 		response.status(status).send({ errors: result.mapped() });
 	} else {
 		next();


### PR DESCRIPTION
## Describe your changes

Small fix to correct the message logged with there is an express middleware validation error.  Prior to this it simply wrote "Validation errors" in the log, and did not write out the actual error.

## Issue ticket number and link
## A2-7611 BO Tech Debt: Error message just says Validation errors and not the actual errors

[Ticket](https://pins-ds.atlassian.net/browse/A2-7611)
