### PR TITLE
feat(api): don't broadcast submission docs until after scan (A2-7132)

### DIFF
--- a/appeals/api/src/server/endpoints/documents/__tests__/documents.test.js
+++ b/appeals/api/src/server/endpoints/documents/__tests__/documents.test.js
@@ -485,6 +485,13 @@ describe('appeals documents', () => {
 	});
 
 	describe('documents AV scanning', () => {
+		beforeEach(() => {
+			jest.clearAllMocks();
+		});
+		afterEach(() => {
+			jest.clearAllMocks();
+		});
+
 		test('validate AV scan result: no UUID provided', async () => {
 			databaseConnector.document.findUnique.mockReturnValue(null);
 			const requestBody = {
@@ -559,6 +566,7 @@ describe('appeals documents', () => {
 
 			expect(databaseConnector.documentVersionAvScan.upsert).toHaveBeenCalled();
 			expect(response.status).toEqual(200);
+			expect(mockBroadcasters.broadcastDocument).not.toHaveBeenCalled();
 		});
 		test('validate AV scan result: version not found / scan result requested', async () => {
 			databaseConnector.document.findUnique.mockReturnValue(documentCreated);
@@ -579,6 +587,7 @@ describe('appeals documents', () => {
 
 			expect(databaseConnector.documentVersionAvScan.upsert).toHaveBeenCalled();
 			expect(response.status).toEqual(200);
+			expect(mockBroadcasters.broadcastDocument).not.toHaveBeenCalled();
 		});
 		test('validate AV scan result: document found', async () => {
 			databaseConnector.document.findUnique.mockReturnValue({
@@ -610,6 +619,7 @@ describe('appeals documents', () => {
 			expect(databaseConnector.documentVersionAvScan.upsert).toHaveBeenCalled();
 			expect(databaseConnector.document.findUnique).toHaveBeenCalled();
 			expect(response.status).toEqual(200);
+			expect(mockBroadcasters.broadcastDocument).not.toHaveBeenCalled();
 		});
 
 		test('updates AV scan document not yet saved', async () => {
@@ -639,6 +649,7 @@ describe('appeals documents', () => {
 				]
 			});
 			expect(response.status).toEqual(200);
+			expect(mockBroadcasters.broadcastDocument).not.toHaveBeenCalled();
 		});
 
 		test('updates AV scan document already saved', async () => {
@@ -678,6 +689,7 @@ describe('appeals documents', () => {
 				]
 			});
 			expect(response.status).toEqual(200);
+			expect(mockBroadcasters.broadcastDocument).toHaveBeenCalled();
 		});
 	});
 

--- a/appeals/api/src/server/endpoints/documents/documents.controller.js
+++ b/appeals/api/src/server/endpoints/documents/documents.controller.js
@@ -498,7 +498,7 @@ export const updateDocumentsAvCheckStatus = async (req, res) => {
 			const versionList = latestDocument?.versions?.map((v) => v.version);
 			if (versionList && versionList.indexOf(document.version) > -1) {
 				await documentRepository.updateDocumentAvStatus(document);
-				await broadcasters.broadcastDocument(document.id, document.version, EventType.Update);
+				await broadcasters.broadcastDocument(document.id, document.version, EventType.Create);
 			}
 
 			responseDocuments.push({

--- a/appeals/api/src/server/endpoints/integrations/integrations.controller.js
+++ b/appeals/api/src/server/endpoints/integrations/integrations.controller.js
@@ -118,10 +118,7 @@ const importIndividualAppeal = async (data) => {
 
 	await Promise.all(
 		documentVersions.map(async (document) => {
-			await Promise.all([
-				broadcasters.broadcastDocument(document.documentGuid, 1, EventType.Create),
-				writeDocumentAuditTrail(id, document, AUDIT_TRIAL_APPELLANT_UUID)
-			]);
+			await writeDocumentAuditTrail(id, document, AUDIT_TRIAL_APPELLANT_UUID);
 		})
 	);
 
@@ -308,10 +305,7 @@ export const importIndividualLpaqSubmission = async (
 
 	await Promise.all(
 		documentVersions.map(async (document) => {
-			await Promise.all([
-				broadcasters.broadcastDocument(document.documentGuid, 1, EventType.Create),
-				writeDocumentAuditTrail(id, document, AUDIT_TRAIL_LPA_UUID)
-			]);
+			await writeDocumentAuditTrail(id, document, AUDIT_TRAIL_LPA_UUID);
 		})
 	);
 
@@ -530,12 +524,6 @@ export const importRepresentation = async (req, res) => {
 		broadcasters.broadcastRepresentation(repId, EventType.Create),
 		integrationService.importDocuments(attachments, documentVersions)
 	]);
-
-	await Promise.all(
-		documentVersions.map(async (document) => {
-			await broadcasters.broadcastDocument(document.documentGuid, 1, EventType.Create);
-		})
-	);
 
 	if (repType === APPEAL_REPRESENTATION_TYPE.RULE_6_PARTY_STATEMENT) {
 		await sendRepresentationReceivedNotifications(


### PR DESCRIPTION
## Describe your changes

- don't broadcast documents from external submissions, wait for virus scan
- manually uploaded docs in BO will more than likely virus scan before upload as it's done client side, broadcast will happen after check your answers instead
- if a manual upload is saved before the virus scan is complete, the virus scan will rebroadcast

## Issue ticket number and link

[Ticket](https://pins-ds.atlassian.net/browse/A2-7132)
