### PR TITLE
feat(api): expedited appeals - update data mapping for BO - FO integration (A2-7766)

### DIFF
--- a/appeals/api/src/server/endpoints/integrations/__tests__/integrations.broadcasters/appeal.test.js
+++ b/appeals/api/src/server/endpoints/integrations/__tests__/integrations.broadcasters/appeal.test.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import { producers } from '#infrastructure/topics.js';
 import { fullPlanningAppeal, householdAppeal } from '#tests/appeals/mocks.js';
 import { jest } from '@jest/globals';
@@ -48,12 +49,51 @@ describe('broadcastAppeal', () => {
 		jest.clearAllMocks();
 	});
 
-	it.each(caseTypes)(
-		'broadcasts correct schema and topic for appeal type %s',
-		async ({ expectedTopic, mockAppeal }) => {
+	const expeditedCaseTypes = caseTypes.filter((c) => c.type === APPEAL_CASE_TYPE.W);
+	const standardCaseTypes = caseTypes.filter((c) => c.type !== APPEAL_CASE_TYPE.W);
+
+	it.each(expeditedCaseTypes)(
+		'broadcasts correct schema and topic for expedited appeal type %s',
+		async ({ type, expectedTopic, mockAppeal }) => {
 			const testCase = structuredClone(mockAppeal);
 			// @ts-ignore
-			testCase.appealType = { key: mockAppeal.appealType.key };
+			testCase.appealType = { key: type };
+
+			testCase.appellantCase.reasonForAppealAppellant = 'S78 reason';
+			testCase.appellantCase.anySignificantChanges = 'Yes';
+			testCase.appellantCase.anySignificantChanges_localPlanSignificantChanges = 'lp changes';
+			testCase.appellantCase.screeningOpinionIndicatesEiaRequired = true;
+			testCase.appellantCase.ownershipCertificate = true;
+
+			// @ts-ignore
+			databaseConnector.appeal.findUnique.mockResolvedValue(testCase);
+
+			await broadcastAppeal(123);
+
+			const expectedFields = {
+				reasonForAppealAppellant: expect.any(String),
+				screeningOpinionIndicatesEiaRequired: expect.any(Boolean),
+				ownershipCertificate: expect.any(Boolean),
+				significantChangesAffectingApplicationAppellant: expect.any(Array)
+			};
+
+			// @ts-ignore
+			expect(global.mockSendEvents).toHaveBeenCalledWith(
+				expectedTopic,
+				expect.arrayContaining([expect.objectContaining(expectedFields)]),
+				expect.any(String),
+				expect.any(Object)
+			);
+		}
+	);
+
+	it.each(standardCaseTypes)(
+		'broadcasts correct schema and topic for appeal type %s',
+		async ({ type, expectedTopic, mockAppeal }) => {
+			const testCase = structuredClone(mockAppeal);
+			// @ts-ignore
+			testCase.appealType = { key: type };
+
 			// @ts-ignore
 			databaseConnector.appeal.findUnique.mockResolvedValue(testCase);
 
@@ -62,12 +102,40 @@ describe('broadcastAppeal', () => {
 			// @ts-ignore
 			expect(global.mockSendEvents).toHaveBeenCalledWith(
 				expectedTopic,
-				expect.any(Array),
+				expect.arrayContaining([expect.objectContaining({})]),
 				expect.any(String),
 				expect.any(Object)
 			);
+
+			// @ts-ignore
+			const sentEvent = global.mockSendEvents.mock.calls[0][1][0];
+
+			expect(sentEvent).not.toHaveProperty('reasonForAppealAppellant');
+			expect(sentEvent).not.toHaveProperty('screeningOpinionIndicatesEiaRequired');
+			expect(sentEvent).not.toHaveProperty('ownershipCertificate');
+			expect(sentEvent).not.toHaveProperty('significantChangesAffectingApplicationAppellant');
 		}
 	);
+
+	it('does not broadcast significant changes details if anySignificantChanges is No', async () => {
+		const testCase = structuredClone(fullPlanningAppeal);
+		// @ts-ignore
+		testCase.appealType = { key: APPEAL_CASE_TYPE.W };
+		testCase.appellantCase.reasonForAppealAppellant = 'S78 reason';
+		testCase.appellantCase.anySignificantChanges = 'No';
+		testCase.appellantCase.anySignificantChanges_localPlanSignificantChanges = 'Should be ignored';
+		testCase.appellantCase.screeningOpinionIndicatesEiaRequired = true;
+		testCase.appellantCase.ownershipCertificate = true;
+
+		// @ts-ignore
+		databaseConnector.appeal.findUnique.mockResolvedValue(testCase);
+
+		await broadcastAppeal(123);
+
+		// @ts-ignore
+		const sentEvent = global.mockSendEvents.mock.calls[0][1][0];
+		expect(sentEvent.significantChangesAffectingApplicationAppellant).toEqual([]);
+	});
 
 	it('does not broadcast if appeal not found', async () => {
 		// @ts-ignore

--- a/appeals/api/src/server/mappers/integration/s78/map-appellant-case.js
+++ b/appeals/api/src/server/mappers/integration/s78/map-appellant-case.js
@@ -22,16 +22,29 @@ export const mapAppellantCase = (data) => {
 		tenantAgriculturalHolding: casedata?.tenantAgriculturalHolding ?? null,
 		otherTenantsAgriculturalHolding: casedata?.otherTenantsAgriculturalHolding ?? null,
 		reasonForAppealAppellant: casedata?.reasonForAppealAppellant ?? null,
-		anySignificantChanges: casedata?.anySignificantChanges ?? null,
-		anySignificantChanges_otherSignificantChanges:
-			casedata?.anySignificantChanges_otherSignificantChanges ?? null,
-		anySignificantChanges_localPlanSignificantChanges:
-			casedata?.anySignificantChanges_localPlanSignificantChanges ?? null,
-		anySignificantChanges_nationalPolicySignificantChanges:
-			casedata?.anySignificantChanges_nationalPolicySignificantChanges ?? null,
-		anySignificantChanges_courtJudgementSignificantChanges:
-			casedata?.anySignificantChanges_courtJudgementSignificantChanges ?? null,
 		screeningOpinionIndicatesEiaRequired: casedata?.screeningOpinionIndicatesEiaRequired ?? null,
-		ownershipCertificate: casedata?.ownershipCertificate ?? null
+		ownershipCertificate: casedata?.ownershipCertificate ?? null,
+		/** @type {any[]} */
+		significantChangesAffectingApplicationAppellant:
+			casedata?.anySignificantChanges === 'Yes'
+				? [
+						{
+							value: 'adopted-a-new-local-plan',
+							comment: casedata?.anySignificantChanges_localPlanSignificantChanges ?? null
+						},
+						{
+							value: 'national-policy-change',
+							comment: casedata?.anySignificantChanges_nationalPolicySignificantChanges ?? null
+						},
+						{
+							value: 'court-judgement',
+							comment: casedata?.anySignificantChanges_courtJudgementSignificantChanges ?? null
+						},
+						{
+							value: 'other',
+							comment: casedata?.anySignificantChanges_otherSignificantChanges ?? null
+						}
+					].filter((c) => c.comment !== null)
+				: []
 	};
 };

--- a/appeals/api/src/server/tests/appeals/advert.js
+++ b/appeals/api/src/server/tests/appeals/advert.js
@@ -95,7 +95,15 @@ export default {
 			key: 'some',
 			name: 'Some'
 		},
-		knowsAllOwners: null
+		knowsAllOwners: null,
+		reasonForAppealAppellant: null,
+		anySignificantChanges: null,
+		anySignificantChanges_otherSignificantChanges: null,
+		anySignificantChanges_localPlanSignificantChanges: null,
+		anySignificantChanges_nationalPolicySignificantChanges: null,
+		anySignificantChanges_courtJudgementSignificantChanges: null,
+		screeningOpinionIndicatesEiaRequired: null,
+		ownershipCertificate: null
 	},
 	appellant: {
 		id: 2,

--- a/appeals/api/src/server/tests/appeals/enforcement-listed.js
+++ b/appeals/api/src/server/tests/appeals/enforcement-listed.js
@@ -79,7 +79,15 @@ export default {
 			id: 1,
 			name: 'Valid'
 		},
-		enforcementReference: 'Reference'
+		enforcementReference: 'Reference',
+		reasonForAppealAppellant: null,
+		anySignificantChanges: null,
+		anySignificantChanges_otherSignificantChanges: null,
+		anySignificantChanges_localPlanSignificantChanges: null,
+		anySignificantChanges_nationalPolicySignificantChanges: null,
+		anySignificantChanges_courtJudgementSignificantChanges: null,
+		screeningOpinionIndicatesEiaRequired: null,
+		ownershipCertificate: null
 	},
 	appellant: {
 		id: 1,

--- a/appeals/api/src/server/tests/appeals/has.js
+++ b/appeals/api/src/server/tests/appeals/has.js
@@ -92,7 +92,15 @@ export default {
 			key: 'some',
 			name: 'Some'
 		},
-		knowsAllOwners: null
+		knowsAllOwners: null,
+		reasonForAppealAppellant: null,
+		anySignificantChanges: null,
+		anySignificantChanges_otherSignificantChanges: null,
+		anySignificantChanges_localPlanSignificantChanges: null,
+		anySignificantChanges_nationalPolicySignificantChanges: null,
+		anySignificantChanges_courtJudgementSignificantChanges: null,
+		screeningOpinionIndicatesEiaRequired: null,
+		ownershipCertificate: null
 	},
 	appellant: {
 		id: 1,

--- a/appeals/api/src/server/tests/appeals/mocks.js
+++ b/appeals/api/src/server/tests/appeals/mocks.js
@@ -193,7 +193,15 @@ export const householdAppeal = {
 		appellantProcedurePreferenceDuration: 5,
 		appellantProcedurePreferenceWitnessCount: 1,
 		typeOfPlanningApplication: APPEAL_TYPE_OF_PLANNING_APPLICATION.HOUSEHOLDER_PLANNING,
-		numberOfResidencesNetChange: 5
+		numberOfResidencesNetChange: 5,
+		reasonForAppealAppellant: null,
+		anySignificantChanges: null,
+		anySignificantChanges_otherSignificantChanges: null,
+		anySignificantChanges_localPlanSignificantChanges: null,
+		anySignificantChanges_nationalPolicySignificantChanges: null,
+		anySignificantChanges_courtJudgementSignificantChanges: null,
+		screeningOpinionIndicatesEiaRequired: null,
+		ownershipCertificate: null
 	},
 	caseOfficer: {
 		id: 1,

--- a/appeals/api/src/server/tests/appeals/s20.js
+++ b/appeals/api/src/server/tests/appeals/s20.js
@@ -91,7 +91,15 @@ export default {
 			key: 'some',
 			name: 'Some'
 		},
-		knowsAllOwners: null
+		knowsAllOwners: null,
+		reasonForAppealAppellant: null,
+		anySignificantChanges: null,
+		anySignificantChanges_otherSignificantChanges: null,
+		anySignificantChanges_localPlanSignificantChanges: null,
+		anySignificantChanges_nationalPolicySignificantChanges: null,
+		anySignificantChanges_courtJudgementSignificantChanges: null,
+		screeningOpinionIndicatesEiaRequired: null,
+		ownershipCertificate: null
 	},
 	appellant: {
 		id: 2,

--- a/appeals/api/src/server/tests/appeals/s78.js
+++ b/appeals/api/src/server/tests/appeals/s78.js
@@ -95,7 +95,15 @@ export default {
 			key: 'some',
 			name: 'Some'
 		},
-		knowsAllOwners: null
+		knowsAllOwners: null,
+		reasonForAppealAppellant: null,
+		anySignificantChanges: null,
+		anySignificantChanges_otherSignificantChanges: null,
+		anySignificantChanges_localPlanSignificantChanges: null,
+		anySignificantChanges_nationalPolicySignificantChanges: null,
+		anySignificantChanges_courtJudgementSignificantChanges: null,
+		screeningOpinionIndicatesEiaRequired: null,
+		ownershipCertificate: null
 	},
 	appellant: {
 		id: 2,


### PR DESCRIPTION
## Describe your changes

Add functionality to broadcast expedited appellant case to the FO for s78 appeals.
Update unit tests to accommodate new fields.
Add new tests for expedited appeal and update existing tests to cover new appeal type.


## Issue ticket number and link

[Ticket](https://pins-ds.atlassian.net/browse/A2-7766)
