### PR TITLE
feat(web): add expedited check to start page (A2-7866)

### DIFF
--- a/appeals/e2e/cypress/e2e/back-office-appeals/nationalListSearch.spec.js
+++ b/appeals/e2e/cypress/e2e/back-office-appeals/nationalListSearch.spec.js
@@ -62,26 +62,35 @@ describe('All cases search', () => {
 	});
 
 	it('check Part 1 filter visible', () => {
-		cy.createCase({ caseType: 'W' }).then((caseObj) => {
-			appeal = caseObj;
-			cy.assignCaseOfficerViaApi(caseObj);
-			cy.validateAppeal(caseObj);
-			happyPathHelper.viewCaseDetails(caseObj);
-			happyPathHelper.startCaseWithProcedureType(caseObj, 'Part 1');
-			const testData = { rowIndex: 0, cellIndex: 0, textToMatch: caseObj.reference, strict: true };
-			cy.visit(urlPaths.appealsList);
-			listCasesPage.filterByAppealProcedure('Part 1');
-			listCasesPage.verifyTableCellText(testData);
-		});
+		cy.createCase({ caseType: 'W', applicationDate: '2026-04-01T00:00:00.000Z' }).then(
+			(caseObj) => {
+				appeal = caseObj;
+				cy.assignCaseOfficerViaApi(caseObj);
+				cy.validateAppeal(caseObj);
+				happyPathHelper.viewCaseDetails(caseObj);
+				happyPathHelper.startCaseWithProcedureType(caseObj, 'Part 1');
+				const testData = {
+					rowIndex: 0,
+					cellIndex: 0,
+					textToMatch: caseObj.reference,
+					strict: true
+				};
+				cy.visit(urlPaths.appealsList);
+				listCasesPage.filterByAppealProcedure('Part 1');
+				listCasesPage.verifyTableCellText(testData);
+			}
+		);
 	});
 
 	it('should not show case under Part 1 filter if case type is Y', () => {
-		cy.createCase({ caseType: 'Y' }).then((caseObj) => {
-			appeal = caseObj;
-			cy.visit(urlPaths.appealsList);
-			listCasesPage.filterByAppealProcedure('Part 1');
-			cy.contains(caseObj.reference).should('not.exist');
-		});
+		cy.createCase({ caseType: 'Y', applicationDate: '2026-04-01T00:00:00.000Z' }).then(
+			(caseObj) => {
+				appeal = caseObj;
+				cy.visit(urlPaths.appealsList);
+				listCasesPage.filterByAppealProcedure('Part 1');
+				cy.contains(caseObj.reference).should('not.exist');
+			}
+		);
 	});
 
 	const setupTestCase = () => {

--- a/appeals/e2e/cypress/e2e/back-office-appeals/part1.spec.js
+++ b/appeals/e2e/cypress/e2e/back-office-appeals/part1.spec.js
@@ -21,19 +21,25 @@ describe('part1 appeal', () => {
 	const appealTypeS78 = 'S78';
 	const setupTestCase = (appealType = appealTypeS78, caseType = 'W') => {
 		cy.login(users.appeals.caseAdmin);
-		return cy.createCase({ caseType, planningObligation: true }).then((ref) => {
-			caseObj = ref;
-			appeal = caseObj;
-			cases.push(caseObj.id);
-			happyPathHelper.advanceTo(
-				caseObj,
-				'ASSIGN_CASE_OFFICER',
-				'READY_TO_START',
-				appealType,
-				'INQUIRY'
-			);
-			caseDetailsPage.checkStatusOfCase('Ready to start', 0);
-		});
+		return cy
+			.createCase({
+				caseType,
+				applicationDate: '2026-04-01T00:00:00.000Z',
+				planningObligation: true
+			})
+			.then((ref) => {
+				caseObj = ref;
+				appeal = caseObj;
+				cases.push(caseObj.id);
+				happyPathHelper.advanceTo(
+					caseObj,
+					'ASSIGN_CASE_OFFICER',
+					'READY_TO_START',
+					appealType,
+					'INQUIRY'
+				);
+				caseDetailsPage.checkStatusOfCase('Ready to start', 0);
+			});
 	};
 
 	it('check Part 1 radio button', { tags: tag.smoke }, () => {

--- a/appeals/web/src/server/appeals/appeal-details/start-case/__tests__/start-case.test.js
+++ b/appeals/web/src/server/appeals/appeal-details/start-case/__tests__/start-case.test.js
@@ -19,7 +19,19 @@ const appealDataWithoutStartDate = {
 };
 
 describe('start-case', () => {
-	afterEach(teardown);
+	afterEach(() => {
+		teardown();
+		jest.restoreAllMocks();
+	});
+
+	beforeEach(() => {
+		jest.spyOn(featureFlags, 'isFeatureActive').mockImplementation((flag) => {
+			if (flag === 'featureFlagExpeditedAppeals') {
+				return true;
+			}
+			return true;
+		});
+	});
 
 	describe('GET /start-case/add', () => {
 		it('should render the start case page with the expected content if the appeal type is Householder', async () => {
@@ -335,6 +347,11 @@ describe('start-case', () => {
 			getEnabledHearingAppealTypes.mockReturnValue([APPEAL_TYPE.S78]);
 			// @ts-ignore
 			getEnabledInquiryAppealTypes.mockReturnValue([APPEAL_TYPE.S78]);
+
+			nock('http://test/').get('/appeals/1/appellant-cases/0').reply(200, {
+				applicationDate: '2026-04-01',
+				applicationDecision: 'refused'
+			});
 		});
 
 		afterEach(() => {
@@ -342,6 +359,11 @@ describe('start-case', () => {
 		});
 
 		it('should render the select procedure page with the expected content', async () => {
+			nock('http://test/').get('/appeals/1/appellant-cases/0').reply(200, {
+				applicationDate: '2026-04-01',
+				applicationDecision: 'refused'
+			});
+
 			nock('http://test/')
 				.get('/appeals/1?include=all')
 				.reply(200, {
@@ -386,7 +408,43 @@ describe('start-case', () => {
 			expect(unprettifiedElement.innerHTML).toContain('Continue</button>');
 		});
 
+		it('should render the select procedure page with the expected content if the appeal is S78 and is NOT expedited', async () => {
+			nock.cleanAll();
+			nock('http://test/')
+				.get('/appeals/1?include=all')
+				.reply(200, {
+					...appealDataWithoutStartDate,
+					appealType: 'Planning appeal'
+				});
+			nock('http://test/').get('/appeals/1/appellant-cases/0').reply(200, {
+				applicationDate: '2026-03-31',
+				applicationDecision: 'refused'
+			});
+
+			const response = await request.get(
+				'/appeals-service/appeal-details/1/start-case/select-procedure'
+			);
+
+			expect(response.statusCode).toBe(200);
+
+			const unprettifiedElement = parseHtml(response.text, {
+				rootElement: 'body',
+				skipPrettyPrint: true
+			});
+
+			expect(unprettifiedElement.innerHTML).toContain(
+				'name="appealProcedure" type="radio" value="written">'
+			);
+			expect(unprettifiedElement.innerHTML).not.toContain(
+				'name="appealProcedure" type="radio" value="writtenPart1">'
+			);
+		});
+
 		it('should render the select procedure page with the expected back link URL, if the backLink query parameter was saved', async () => {
+			nock('http://test/').get('/appeals/1/appellant-cases/0').reply(200, {
+				applicationDate: '2026-04-01',
+				applicationDecision: 'refused'
+			});
 			nock('http://test/')
 				.get('/appeals/1?include=all')
 				.twice()
@@ -451,6 +509,11 @@ describe('start-case', () => {
 						`Found. Redirecting to /appeals-service/appeal-details/1/start-case/${redirectPath}`
 					);
 
+					nock('http://test/').get('/appeals/1/appellant-cases/0').reply(200, {
+						applicationDate: '2026-04-01',
+						applicationDecision: 'refused'
+					});
+
 					nock('http://test/')
 						.get('/appeals/1?include=all')
 						.reply(200, {
@@ -481,7 +544,7 @@ describe('start-case', () => {
 		});
 
 		it('should render the select procedure page with no option preselected if the flow was restarted after submitting the select procedure page with an option selected', async () => {
-			featureFlags.isFeatureActive = () => true;
+			jest.spyOn(featureFlags, 'isFeatureActive').mockReturnValue(true);
 
 			nock('http://test/')
 				.get('/appeals/1?include=all')
@@ -716,7 +779,11 @@ describe('start-case', () => {
 					.get('/appeals/1?include=all')
 					.reply(200, {
 						...appealDataWithoutStartDate,
-						appealType: APPEAL_TYPE.S78
+						appealType: APPEAL_TYPE.S78,
+						appellantCase: {
+							applicationDate: '2026-04-01',
+							applicationDecision: 'refused'
+						}
 					});
 
 				const response = await request.get(
@@ -833,6 +900,11 @@ describe('start-case', () => {
 					...appealDataWithoutStartDate,
 					appealType: 'Planning appeal'
 				});
+
+			nock('http://test/').get('/appeals/1/appellant-cases/0').reply(200, {
+				applicationDate: '2026-04-01',
+				applicationDecision: 'refused'
+			});
 
 			const response = await request
 				.post('/appeals-service/appeal-details/1/start-case/select-procedure')

--- a/appeals/web/src/server/appeals/appeal-details/start-case/start-case.controller.js
+++ b/appeals/web/src/server/appeals/appeal-details/start-case/start-case.controller.js
@@ -20,6 +20,7 @@ import { APPEAL_TYPE, FEATURE_FLAG_NAMES } from '@pins/appeals/constants/common.
 import { isAnyEnforcementAppealType } from '@pins/appeals/utils/appeal-type-checks.js';
 import { recalculateDateIfNotBusinessDay } from '@pins/appeals/utils/business-days.js';
 import { APPEAL_CASE_PROCEDURE } from '@planning-inspectorate/data-model';
+import { getAppellantCaseFromAppealId } from '../appellant-case/appellant-case.service.js';
 import {
 	changeDatePage,
 	confirmProcedurePage,
@@ -206,9 +207,14 @@ export const getSelectProcedure = async (request, response) => {
  */
 const renderSelectProcedure = async (request, response) => {
 	const {
-		currentAppeal: { appealId, appealReference, appealType },
+		currentAppeal: { appealId, appealReference, appealType, appellantCaseId },
 		errors
 	} = request;
+	const appellantCase = await getAppellantCaseFromAppealId(
+		request.apiClient,
+		appealId,
+		appellantCaseId
+	);
 
 	const sessionValues = getSessionValuesForAppeal(request, 'startCaseAppealProcedure', appealId);
 	const isLinked = isLinkedAppeal(request.currentAppeal);
@@ -225,6 +231,7 @@ const renderSelectProcedure = async (request, response) => {
 		isLinked,
 		backUrl,
 		{ appealProcedure: sessionValues?.appealProcedure },
+		appellantCase,
 		errors ? errors['appealProcedure']?.msg : undefined
 	);
 

--- a/appeals/web/src/server/appeals/appeal-details/start-case/start-case.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/start-case/start-case.mapper.js
@@ -9,6 +9,7 @@ import { radiosInput } from '#lib/mappers/components/page-components/radio.js';
 import { simpleHtmlComponent, textSummaryListItem } from '#lib/mappers/index.js';
 import { capitalizeFirstLetter } from '#lib/string-utilities.js';
 import { APPEAL_TYPE, FEATURE_FLAG_NAMES } from '@pins/appeals/constants/common.js';
+import { isS78ExpeditedAppealType } from '@pins/appeals/utils/appeal-type-checks.js';
 import { APPEAL_CASE_PROCEDURE } from '@planning-inspectorate/data-model';
 
 /**
@@ -97,6 +98,7 @@ export function changeDatePage(appealId, appealReference, today) {
  * @param {boolean} isLinkedAppeal
  * @param {string} backLinkUrl
  * @param {{appealProcedure: string}} [storedSessionData]
+ * @param {import('@pins/appeals.api').Appeals.SingleAppellantCaseResponse} [appellantCase]
  * @param {string|undefined} errorMessage
  * @returns {PageContent}
  */
@@ -106,14 +108,27 @@ export function selectProcedurePage(
 	isLinkedAppeal,
 	backLinkUrl,
 	storedSessionData,
+	appellantCase,
 	errorMessage = undefined
 ) {
+	const showPart1 =
+		appellantCase &&
+		isS78ExpeditedAppealType(
+			appealType,
+			appellantCase.applicationDate,
+			appellantCase.applicationDecision
+		);
+
 	const dataMappers = [
-		{
-			case: APPEAL_CASE_PROCEDURE.WRITTEN_PART_1,
-			featureFlag: FEATURE_FLAG_NAMES.EXPEDITED_APPEALS,
-			appeals: [APPEAL_TYPE.S78]
-		},
+		...(showPart1
+			? [
+					{
+						case: APPEAL_CASE_PROCEDURE.WRITTEN_PART_1,
+						featureFlag: FEATURE_FLAG_NAMES.EXPEDITED_APPEALS,
+						appeals: [APPEAL_TYPE.S78]
+					}
+				]
+			: []),
 		{
 			case: APPEAL_CASE_PROCEDURE.WRITTEN,
 			featureFlag: FEATURE_FLAG_NAMES.SECTION_78,


### PR DESCRIPTION
## Describe your changes

Add isS78Expedited check to the start case page to only display Part 1 expedited option for appeals that are eligible.

Tests:
Added unit test to cover scenario for non expedited appeals 
Updated existing unit test to not fail

## Issue ticket number and link

[Ticket](https://pins-ds.atlassian.net/browse/A2-7866)
