### PR TITLE
fix(api): link on IP correction notify (A2-7760)

### DIFF
--- a/appeals/api/src/server/notify/templates/__tests__/correction-notice-decision-interested-party.test.js
+++ b/appeals/api/src/server/notify/templates/__tests__/correction-notice-decision-interested-party.test.js
@@ -1,7 +1,7 @@
 import { notifySend } from '#notify/notify-send.js';
 import { jest } from '@jest/globals';
 
-describe('correction-notice-decision.md', () => {
+describe('correction-notice-decision-interested-part.md', () => {
 	test('should call notify sendEmail with the correct data', async () => {
 		const notifySendData = {
 			doNotMockNotifySend: true,
@@ -41,7 +41,7 @@ describe('correction-notice-decision.md', () => {
 			'',
 			'There has been a mistake - but we fixed it thanks',
 			'',
-			'[Sign in to our service](/mock-front-office-url) to view the decision letter dated 01 January 2025.',
+			'[Sign in to our service](/mock-front-office-url/comment-planning-appeal/enter-appeal-reference) to view the decision letter dated 01 January 2025.',
 			'',
 			"# The Planning Inspectorate's role",
 			'',

--- a/appeals/api/src/server/notify/templates/__tests__/notify-decision-is-allowed-split-dismissed-interested-party.test.js
+++ b/appeals/api/src/server/notify/templates/__tests__/notify-decision-is-allowed-split-dismissed-interested-party.test.js
@@ -33,7 +33,7 @@ const expectedContentRows = (replacementRows) => [
 	'',
 	...replacementRows,
 	'',
-	'[View the decision letter](/mock-front-office-url/appeals/ABC45678) dated 01 January 2021.',
+	'[View the decision letter](/mock-front-office-url/comment-planning-appeal/enter-appeal-reference) dated 01 January 2021.',
 	'',
 	'We have informed the appellant and local planning authority about the decision.',
 	'',

--- a/appeals/api/src/server/notify/templates/correction-notice-decision-interested-party.content.md
+++ b/appeals/api/src/server/notify/templates/correction-notice-decision-interested-party.content.md
@@ -10,7 +10,7 @@ Planning application reference: {{lpa_reference}}
 
 {{correction_notice_reason}}
 
-[Sign in to our service]({{front_office_url}}) to view the decision letter dated {{decision_date}}.
+[Sign in to our service]({{front_office_url}}/comment-planning-appeal/enter-appeal-reference) to view the decision letter dated {{decision_date}}.
 
 # The Planning Inspectorate's role
 

--- a/appeals/api/src/server/notify/templates/decision-is-allowed-split-dismissed-interested-party.content.md
+++ b/appeals/api/src/server/notify/templates/decision-is-allowed-split-dismissed-interested-party.content.md
@@ -14,7 +14,7 @@ We have made a decision on the following appeals:
 
 We have made a decision on this appeal {%- endif %}
 
-[View the decision letter]({{front_office_url}}/appeals/{{appeal_reference_number}}) dated {{decision_date}}.
+[View the decision letter]({{front_office_url}}/comment-planning-appeal/enter-appeal-reference) dated {{decision_date}}.
 
 We have informed the appellant and local planning authority about the decision.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
 			],
 			"dependencies": {
 				"@badeball/cypress-cucumber-preprocessor": "23.2.0",
-				"@planning-inspectorate/data-model": "^2.31.2",
+				"@planning-inspectorate/data-model": "^2.32.0",
 				"cypress": "15.3.0",
 				"got": "^12.5.2",
 				"joi": "^17.7.0",
@@ -7669,9 +7669,9 @@
 			}
 		},
 		"node_modules/@planning-inspectorate/data-model": {
-			"version": "2.31.2",
-			"resolved": "https://registry.npmjs.org/@planning-inspectorate/data-model/-/data-model-2.31.2.tgz",
-			"integrity": "sha512-p/0Pka6OqLrlIHX49DzRMxAAf0ExwZG2x867dRIuXyIooDXD8IzJo1WQX7GvCYG97eVIztpJG2wTeVvgdBFGiw==",
+			"version": "2.32.0",
+			"resolved": "https://registry.npmjs.org/@planning-inspectorate/data-model/-/data-model-2.32.0.tgz",
+			"integrity": "sha512-n1Mwhe9Z9sdssIB+uhIeixA4LsW7vsDlgTaNkU1yvg7esvuQTAMYqYKpnqrEeqQsDcSM7P8fX4ugykMGXLmEsw==",
 			"license": "MIT",
 			"dependencies": {
 				"jsonc-parser": "^3.3.1"
@@ -36223,9 +36223,9 @@
 			"dev": true
 		},
 		"@planning-inspectorate/data-model": {
-			"version": "2.31.2",
-			"resolved": "https://registry.npmjs.org/@planning-inspectorate/data-model/-/data-model-2.31.2.tgz",
-			"integrity": "sha512-p/0Pka6OqLrlIHX49DzRMxAAf0ExwZG2x867dRIuXyIooDXD8IzJo1WQX7GvCYG97eVIztpJG2wTeVvgdBFGiw==",
+			"version": "2.32.0",
+			"resolved": "https://registry.npmjs.org/@planning-inspectorate/data-model/-/data-model-2.32.0.tgz",
+			"integrity": "sha512-n1Mwhe9Z9sdssIB+uhIeixA4LsW7vsDlgTaNkU1yvg7esvuQTAMYqYKpnqrEeqQsDcSM7P8fX4ugykMGXLmEsw==",
 			"requires": {
 				"jsonc-parser": "^3.3.1"
 			}

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
 	},
 	"dependencies": {
 		"@badeball/cypress-cucumber-preprocessor": "23.2.0",
-		"@planning-inspectorate/data-model": "^2.31.2",
+		"@planning-inspectorate/data-model": "^2.32.0",
 		"cypress": "15.3.0",
 		"got": "^12.5.2",
 		"joi": "^17.7.0",


### PR DESCRIPTION
## Describe your changes

Small fix to correct links in notifies sent to interested parties when a decision or a correction on a decision is issued.
Both now link directly to IP dashboard.

## Issue ticket number and link
##Tickets A2-7760 and A2-7797

[Ticket](https://pins-ds.atlassian.net/browse/A2-7760)
and 
[Ticket](https://pins-ds.atlassian.net/browse/A2-7977)
