### PR TITLE
fix(api): remove unneccessary params in transition state (A2-7915)

### DIFF
--- a/appeals/api/src/server/state/__tests__/transition-state.test.js
+++ b/appeals/api/src/server/state/__tests__/transition-state.test.js
@@ -1,4 +1,5 @@
 // @ts-nocheck
+import appealRepository from '#repositories/appeal.repository.js';
 import { jest } from '@jest/globals';
 import {
 	CASE_RELATIONSHIP_LINKED,
@@ -275,6 +276,26 @@ describe('transitionState', () => {
 
 				expect(databaseConnector.appeal.findUnique).not.toHaveBeenCalled();
 			});
+		});
+	});
+
+	describe('transitionState repository call', () => {
+		beforeEach(() => {
+			jest.clearAllMocks();
+			jest.spyOn(appealRepository, 'getAppealById').mockResolvedValue(appealFixture);
+		});
+
+		test('calls getAppealById with only required fields', async () => {
+			await transitionState(11, 'user-123', VALIDATION_OUTCOME_VALID);
+			expect(appealRepository.getAppealById).toHaveBeenCalledWith(11, true, [
+				'appealStatus',
+				'appealType',
+				'procedureType',
+				'siteVisit',
+				'hearing',
+				'inquiry',
+				'childAppeals'
+			]);
 		});
 	});
 });

--- a/appeals/api/src/server/state/transition-state.js
+++ b/appeals/api/src/server/state/transition-state.js
@@ -37,7 +37,15 @@ import createStateMachine from './create-state-machine.js';
  * @param {string} trigger
  */
 const transitionState = async (appealId, azureAdUserId, trigger) => {
-	const appeal = await appealRepository.getAppealById(appealId);
+	const appeal = await appealRepository.getAppealById(appealId, true, [
+		'appealStatus',
+		'appealType',
+		'procedureType',
+		'siteVisit',
+		'hearing',
+		'inquiry',
+		'childAppeals'
+	]);
 
 	if (!appeal) {
 		throw new Error(`no appeal exists with ID: ${appealId}`);


### PR DESCRIPTION
## Describe your changes

This PR aims to reduce failure of update-completed-events job by reducing data returned in when transitioning appeal state.
It does this by parsing params in to the `getAppealById` db call, so only relevant keys are selected.

## Issue ticket number and link

[Ticket](https://pins-ds.atlassian.net/browse/A2-7915)
