### PR TITLE
feat(appeals): gender neutral formatted name passed to api and inserted into templates (A2-6114)

### DIFF
--- a/appeals/api/src/server/endpoints/Inquiry/__tests__/inquiry.test.js
+++ b/appeals/api/src/server/endpoints/Inquiry/__tests__/inquiry.test.js
@@ -87,6 +87,7 @@ describe('inquiry routes', () => {
 			requestData = {
 				inquiryStartTime: '2999-01-01T13:00:00.000Z',
 				address: inquiryAddress,
+				inspector_name: null,
 				ipCommentsDueDate: new Date('2999-01-01T14:00:00.000Z'),
 				lpaQuestionnaireDueDate: new Date('2999-01-01T15:00:00.000Z'),
 				planningObligationDueDate: new Date('2999-01-01T16:00:00.000Z'),
@@ -135,6 +136,7 @@ describe('inquiry routes', () => {
 					lpa_reference: '48269/APP/2021/1482',
 					inquiry_date: '1 January 2999',
 					inquiry_time: '1:00pm',
+					inspector_name: null,
 					inquiry_address:
 						'Court 2, 24 Court Street, Test Town, Test County, AB12 3CD, United Kingdom',
 					team_email_address: 'caseofficers@planninginspectorate.gov.uk',
@@ -893,6 +895,7 @@ describe('inquiry routes', () => {
 				);
 				const personalisation = {
 					appeal_reference_number: '1345264',
+					inspector_name: null,
 					appeal_type: 'Planning',
 					site_address: '96 The Avenue, Leftfield, Maidstone, Kent, MD21 5XY, United Kingdom',
 					lpa_reference: '48269/APP/2021/1482',
@@ -1676,6 +1679,7 @@ describe('inquiry routes', () => {
 
 				const personalisation = {
 					appeal_reference_number: '1345264',
+					inspector_name: null,
 					site_address: '96 The Avenue, Leftfield, Maidstone, Kent, MD21 5XY, United Kingdom',
 					lpa_reference: '48269/APP/2021/1482',
 					team_email_address: 'caseofficers@planninginspectorate.gov.uk',
@@ -2183,6 +2187,7 @@ describe('inquiry routes', () => {
 
 				const personalisation = {
 					appeal_reference_number: '1345264',
+					inspector_name: null,
 					site_address: '96 The Avenue, Leftfield, Maidstone, Kent, MD21 5XY, United Kingdom',
 					lpa_reference: '48269/APP/2021/1482',
 					team_email_address: 'caseofficers@planninginspectorate.gov.uk',

--- a/appeals/api/src/server/endpoints/Inquiry/inquiry.controller.js
+++ b/appeals/api/src/server/endpoints/Inquiry/inquiry.controller.js
@@ -92,6 +92,7 @@ export const postInquiry = async (req, res) => {
 				})
 			},
 			appeal,
+			req.body.inspectorName,
 			req.notifyClient,
 			req.get('azureAdUserId') || ''
 		);
@@ -155,6 +156,7 @@ export const patchInquiry = async (req, res) => {
 			},
 			req.notifyClient,
 			appeal,
+			req.body.inspectorName,
 			existingAddressId
 		);
 

--- a/appeals/api/src/server/endpoints/Inquiry/inquiry.service.js
+++ b/appeals/api/src/server/endpoints/Inquiry/inquiry.service.js
@@ -40,6 +40,7 @@ import { APPEAL_CASE_STATUS, APPEAL_CASE_TYPE } from '@planning-inspectorate/dat
  * @param {import('#endpoints/appeals.js').NotifyClient} notifyClient
  * @param {string} templateName
  * @param {Appeal} appeal
+ * @param {string} inspectorName
  * @param {string | Date} inquiryStartTime
  * @param {string} estimatedDays
  * @param {TimetableData | undefined} timetableData
@@ -51,6 +52,7 @@ const sendInquiryDetailsNotifications = async (
 	notifyClient,
 	templateName,
 	appeal,
+	inspectorName,
 	inquiryStartTime,
 	estimatedDays,
 	timetableData,
@@ -119,7 +121,8 @@ const sendInquiryDetailsNotifications = async (
 					: timetableData?.planningObligationDueDate.toISOString()
 				: ''
 		),
-		team_email_address: await getTeamEmailFromAppealId(appeal.id)
+		team_email_address: await getTeamEmailFromAppealId(appeal.id),
+		inspector_name: inspectorName ? inspectorName : null
 	};
 	await sendInquiryNotifications(notifyClient, templateName, appeal, personalisation);
 };
@@ -149,7 +152,7 @@ const checkInquiryExists = async (req, res, next) => {
  * @param {import('#endpoints/appeals.js').NotifyClient} notifyClient
  * @param {string} templateName
  * @param {Appeal} appeal
- * @param {Record<string, string>} [personalisation]
+ * @param {Record<string, string | null>} [personalisation]
  * @returns {Promise<void>}
  */
 const sendInquiryNotifications = async (
@@ -200,9 +203,16 @@ const sendInquiryNotifications = async (
  * @param {Appeal} appeal
  * @param {import('#endpoints/appeals.js').NotifyClient} notifyClient
  * @param {string} azureAdUserId
+ * @param {string} inspectorName
  * @returns {Promise<void>}
  */
-const createInquiry = async (createInquiryData, appeal, notifyClient, azureAdUserId) => {
+const createInquiry = async (
+	createInquiryData,
+	appeal,
+	inspectorName,
+	notifyClient,
+	azureAdUserId
+) => {
 	try {
 		const appealId = createInquiryData.appealId;
 		const inquiryStartTime = createInquiryData.inquiryStartTime;
@@ -305,6 +315,7 @@ const createInquiry = async (createInquiryData, appeal, notifyClient, azureAdUse
 				notifyClient,
 				appellantTemplate,
 				appeal,
+				inspectorName,
 				inquiryStartTime,
 				estimatedDays,
 				timetableData,
@@ -316,6 +327,7 @@ const createInquiry = async (createInquiryData, appeal, notifyClient, azureAdUse
 				notifyClient,
 				'inquiry-set-up',
 				appeal,
+				inspectorName,
 				inquiryStartTime,
 				estimatedDays,
 				timetableData,
@@ -335,10 +347,17 @@ const createInquiry = async (createInquiryData, appeal, notifyClient, azureAdUse
  * @param {UpdateInquiry | Omit<UpdateInquiry, 'address'>} updateInquiryData
  * @param {import('#endpoints/appeals.js').NotifyClient} notifyClient
  * @param {Appeal} appeal
+ * @param {string} inspectorName
  * @param {number | null | undefined} existingAddressId
  * @returns {Promise<void>}
  */
-const updateInquiry = async (updateInquiryData, notifyClient, appeal, existingAddressId) => {
+const updateInquiry = async (
+	updateInquiryData,
+	notifyClient,
+	appeal,
+	inspectorName,
+	existingAddressId
+) => {
 	try {
 		const appealId = updateInquiryData.appealId;
 		const inquiryId = updateInquiryData.inquiryId;
@@ -371,6 +390,7 @@ const updateInquiry = async (updateInquiryData, notifyClient, appeal, existingAd
 				notifyClient,
 				'inquiry-updated',
 				appeal,
+				inspectorName,
 				inquiryStartTime,
 				result?.estimatedDays ? result?.estimatedDays.toString() : '',
 				undefined,

--- a/appeals/api/src/server/endpoints/appeal-timetables/__tests__/appeal-timetables.test.js
+++ b/appeals/api/src/server/endpoints/appeal-timetables/__tests__/appeal-timetables.test.js
@@ -760,6 +760,7 @@ describe('appeal timetables routes', () => {
 							notifyClient: expect.anything(),
 							personalisation: {
 								appeal_reference_number: appeal.reference,
+								inspector_name: null,
 								appeal_type: trimAppealType(appeal.appealType.type),
 								appellant_email_address: appeal.appellant.email,
 								child_appeals: [],
@@ -798,6 +799,7 @@ describe('appeal timetables routes', () => {
 							notifyClient: expect.anything(),
 							personalisation: {
 								appeal_reference_number: appeal.reference,
+								inspector_name: null,
 								appeal_type: trimAppealType(appeal.appealType.type),
 								appellant_email_address: appeal.appellant.email,
 								child_appeals: [],
@@ -857,6 +859,7 @@ describe('appeal timetables routes', () => {
 							notifyClient: expect.anything(),
 							personalisation: {
 								appeal_reference_number: appeal.reference,
+								inspector_name: null,
 								appeal_type: trimAppealType(appeal.appealType.type),
 								appellant_email_address: appeal.appellant.email,
 								child_appeals: [],
@@ -895,6 +898,7 @@ describe('appeal timetables routes', () => {
 							notifyClient: expect.anything(),
 							personalisation: {
 								appeal_reference_number: appeal.reference,
+								inspector_name: null,
 								appeal_type: trimAppealType(appeal.appealType.type),
 								appellant_email_address: appeal.appellant.email,
 								child_appeals: [],
@@ -1027,6 +1031,7 @@ describe('appeal timetables routes', () => {
 						notifyClient: expect.anything(),
 						personalisation: {
 							appeal_reference_number: appeal.reference,
+							inspector_name: null,
 							appeal_type: trimAppealType(appeal.appealType.type),
 							appellant_email_address: appeal.appellant.email,
 							child_appeals: [],
@@ -1063,6 +1068,7 @@ describe('appeal timetables routes', () => {
 						notifyClient: expect.anything(),
 						personalisation: {
 							appeal_reference_number: appeal.reference,
+							inspector_name: null,
 							appeal_type: trimAppealType(appeal.appealType.type),
 							appellant_email_address: appeal.appellant.email,
 							child_appeals: [],
@@ -1169,6 +1175,7 @@ describe('appeal timetables routes', () => {
 						notifyClient: expect.anything(),
 						personalisation: {
 							appeal_reference_number: '1345264',
+							inspector_name: null,
 							appeal_type: trimAppealType(appeal.appealType.type),
 							appellant_email_address: appeal.appellant.email,
 							child_appeals: [],
@@ -1205,6 +1212,7 @@ describe('appeal timetables routes', () => {
 						notifyClient: expect.anything(),
 						personalisation: {
 							appeal_reference_number: appeal.reference,
+							inspector_name: null,
 							appeal_type: trimAppealType(appeal.appealType.type),
 							appellant_email_address: appeal.appellant.email,
 							child_appeals: [],
@@ -1437,6 +1445,7 @@ describe('appeal timetables routes', () => {
 							notifyClient: expect.anything(),
 							personalisation: {
 								appeal_reference_number: appeal.reference,
+								inspector_name: null,
 								appeal_type: trimAppealType(appeal.appealType.type),
 								appellant_email_address: appeal.appellant.email,
 								child_appeals: [],
@@ -1475,6 +1484,7 @@ describe('appeal timetables routes', () => {
 							notifyClient: expect.anything(),
 							personalisation: {
 								appeal_reference_number: appeal.reference,
+								inspector_name: null,
 								appeal_type: trimAppealType(appeal.appealType.type),
 								appellant_email_address: appeal.appellant.email,
 								child_appeals: [],
@@ -1590,6 +1600,7 @@ describe('appeal timetables routes', () => {
 							notifyClient: expect.anything(),
 							personalisation: {
 								appeal_reference_number: appeal.reference,
+								inspector_name: null,
 								appeal_type: trimAppealType(appeal.appealType.type),
 								appellant_email_address: appeal.appellant.email,
 								child_appeals: [],
@@ -1631,6 +1642,7 @@ describe('appeal timetables routes', () => {
 							notifyClient: expect.anything(),
 							personalisation: {
 								appeal_reference_number: appeal.reference,
+								inspector_name: null,
 								appeal_type: trimAppealType(appeal.appealType.type),
 								appellant_email_address: appeal.appellant.email,
 								child_appeals: [],
@@ -1772,6 +1784,7 @@ describe('appeal timetables routes', () => {
 							notifyClient: expect.anything(),
 							personalisation: {
 								appeal_reference_number: appeal.reference,
+								inspector_name: null,
 								appeal_type: trimAppealType(appeal.appealType.type),
 								appellant_email_address: appeal.appellant.email,
 								child_appeals: [],
@@ -1810,6 +1823,7 @@ describe('appeal timetables routes', () => {
 							notifyClient: expect.anything(),
 							personalisation: {
 								appeal_reference_number: appeal.reference,
+								inspector_name: null,
 								appeal_type: trimAppealType(appeal.appealType.type),
 								appellant_email_address: appeal.appellant.email,
 								child_appeals: [],
@@ -1899,6 +1913,7 @@ describe('appeal timetables routes', () => {
 							notifyClient: expect.anything(),
 							personalisation: {
 								appeal_reference_number: appeal.reference,
+								inspector_name: null,
 								appeal_type: trimAppealType(appeal.appealType.type),
 								appellant_email_address: appeal.appellant.email,
 								child_appeals: ['1111111', '3333333'],
@@ -1937,6 +1952,7 @@ describe('appeal timetables routes', () => {
 							notifyClient: expect.anything(),
 							personalisation: {
 								appeal_reference_number: appeal.reference,
+								inspector_name: null,
 								appeal_type: trimAppealType(appeal.appealType.type),
 								appellant_email_address: appeal.appellant.email,
 								child_appeals: ['1111111', '3333333'],
@@ -2091,6 +2107,7 @@ describe('appeal timetables routes', () => {
 						notifyClient: expect.anything(),
 						personalisation: {
 							appeal_reference_number: appeal.reference,
+							inspector_name: null,
 							appeal_type: trimAppealType(appeal.appealType.type),
 							appellant_email_address: appeal.appellant.email,
 							child_appeals: [],
@@ -2130,6 +2147,7 @@ describe('appeal timetables routes', () => {
 						notifyClient: expect.anything(),
 						personalisation: {
 							appeal_reference_number: appeal.reference,
+							inspector_name: null,
 							appeal_type: trimAppealType(appeal.appealType.type),
 							appellant_email_address: appeal.appellant.email,
 							child_appeals: [],
@@ -2244,6 +2262,7 @@ describe('appeal timetables routes', () => {
 						notifyClient: expect.anything(),
 						personalisation: {
 							appeal_reference_number: appeal.reference,
+							inspector_name: null,
 							appeal_type: trimAppealType(appeal.appealType.type),
 							appellant_email_address: appeal.appellant.email,
 							child_appeals: [],
@@ -2286,6 +2305,7 @@ describe('appeal timetables routes', () => {
 						notifyClient: expect.anything(),
 						personalisation: {
 							appeal_reference_number: appeal.reference,
+							inspector_name: null,
 							appeal_type: trimAppealType(appeal.appealType.type),
 							appellant_email_address: appeal.appellant.email,
 							child_appeals: [],
@@ -2380,6 +2400,7 @@ describe('appeal timetables routes', () => {
 						notifyClient: expect.anything(),
 						personalisation: {
 							appeal_reference_number: appeal.reference,
+							inspector_name: null,
 							appeal_type: trimAppealType(appeal.appealType.type),
 							appellant_email_address: appeal.appellant.email,
 							child_appeals: [],
@@ -2422,6 +2443,7 @@ describe('appeal timetables routes', () => {
 						notifyClient: expect.anything(),
 						personalisation: {
 							appeal_reference_number: appeal.reference,
+							inspector_name: null,
 							appeal_type: trimAppealType(appeal.appealType.type),
 							appellant_email_address: appeal.appellant.email,
 							child_appeals: [],
@@ -2528,6 +2550,7 @@ describe('appeal timetables routes', () => {
 						notifyClient: expect.anything(),
 						personalisation: {
 							appeal_reference_number: appeal.reference,
+							inspector_name: null,
 							appeal_type: trimAppealType(appeal.appealType.type),
 							appellant_email_address: appeal.appellant.email,
 							child_appeals: [],
@@ -2567,6 +2590,7 @@ describe('appeal timetables routes', () => {
 						notifyClient: expect.anything(),
 						personalisation: {
 							appeal_reference_number: appeal.reference,
+							inspector_name: null,
 							appeal_type: trimAppealType(appeal.appealType.type),
 							appellant_email_address: appeal.appellant.email,
 							child_appeals: [],
@@ -2655,6 +2679,7 @@ describe('appeal timetables routes', () => {
 						notifyClient: expect.anything(),
 						personalisation: {
 							appeal_reference_number: restartedAppeal.reference,
+							inspector_name: null,
 							appeal_type: trimAppealType(restartedAppeal.appealType.type),
 							appellant_email_address: restartedAppeal.appellant.email,
 							child_appeals: [],
@@ -2694,6 +2719,7 @@ describe('appeal timetables routes', () => {
 						notifyClient: expect.anything(),
 						personalisation: {
 							appeal_reference_number: restartedAppeal.reference,
+							inspector_name: null,
 							appeal_type: trimAppealType(restartedAppeal.appealType.type),
 							appellant_email_address: restartedAppeal.appellant.email,
 							child_appeals: [],

--- a/appeals/api/src/server/endpoints/appeal-timetables/appeal-timetables.controller.js
+++ b/appeals/api/src/server/endpoints/appeal-timetables/appeal-timetables.controller.js
@@ -49,7 +49,8 @@ const startAppeal = async (req, res) => {
 							req.get('azureAdUserId') || '',
 							body.procedureType || appeal.procedureType?.key,
 							body.hearingStartTime,
-							body.hearingEstimatedDays
+							body.hearingEstimatedDays,
+							body.inspectorName
 						)
 					)
 				);
@@ -77,7 +78,8 @@ const startAppeal = async (req, res) => {
 				req.get('azureAdUserId') || '',
 				body.procedureType || appeal.procedureType?.key,
 				body.hearingStartTime,
-				body.hearingEstimatedDays
+				body.hearingEstimatedDays,
+				body.inspectorName
 			);
 
 			if (result.success) {
@@ -115,7 +117,8 @@ const startAppealNotifyPreview = async (req, res) => {
 				body.procedureType || appeal.procedureType?.key,
 				body.hearingStartTime,
 				body.hearingEstimatedDays,
-				body.inquiry
+				body.inquiry,
+				body.inspectorName
 			);
 			return res.status(200).send(result);
 		} catch (/** @type {any} */ error) {

--- a/appeals/api/src/server/endpoints/appeal-timetables/appeal-timetables.service.js
+++ b/appeals/api/src/server/endpoints/appeal-timetables/appeal-timetables.service.js
@@ -84,20 +84,21 @@ const checkAppealTimetableExists = async (req, res, next) => {
 };
 
 /**
- *
- * @param {Appeal} appeal
- * @param {string} startDate
- * @param {import('#endpoints/appeals.js').NotifyClient} notifyClient
- * @param {string} siteAddress
- * @param {string} azureAdUserId
- * @param {TimetableDeadlineDate} timetable
- * @param {string} [procedureType]
- * @param {string} [hearingStartTime]
- * @param {string | number} [hearingEstimatedDays]
- * @param {any} [inquiry]
+ * @param {Object} params
+ * @param {Appeal} params.appeal
+ * @param {string} params.startDate
+ * @param {import('#endpoints/appeals.js').NotifyClient} params.notifyClient
+ * @param {string} params.siteAddress
+ * @param {string} params.azureAdUserId
+ * @param {TimetableDeadlineDate} params.timetable
+ * @param {string} [params.procedureType]
+ * @param {string} [params.hearingStartTime]
+ * @param {string | number} [params.hearingEstimatedDays]
+ * @param {any} [params.inquiry]
+ * @param {string | null | undefined} params.inspectorName
  * @returns
  */
-const getStartCaseNotifyParams = async (
+const getStartCaseNotifyParams = async ({
 	appeal,
 	startDate,
 	notifyClient,
@@ -107,8 +108,9 @@ const getStartCaseNotifyParams = async (
 	procedureType,
 	hearingStartTime,
 	hearingEstimatedDays,
-	inquiry
-) => {
+	inquiry,
+	inspectorName = null
+}) => {
 	const hearingSuffix = hearingStartTime ? '-hearing' : '';
 	const inquirySuffix =
 		appeal.procedureType?.key === APPEAL_CASE_PROCEDURE.INQUIRY ||
@@ -144,6 +146,7 @@ const getStartCaseNotifyParams = async (
 	// Note that those properties not used within the specified template will be ignored
 	const commonEmailVariables = {
 		appeal_reference_number: appeal.reference,
+		inspector_name: inspectorName ? inspectorName : null,
 		lpa_reference: appeal.applicationReference || '',
 		site_address: siteAddress,
 		start_date: formatDate(new Date(startDate || ''), false),
@@ -261,7 +264,6 @@ const getStartCaseNotifyParams = async (
 };
 
 /**
- *
  * @param {Appeal} appeal
  * @param {string} startDate
  * @param {import('#endpoints/appeals.js').NotifyClient} notifyClient
@@ -271,6 +273,7 @@ const getStartCaseNotifyParams = async (
  * @param {string} [procedureType]
  * @param {string} [hearingStartTime]
  * @param {string | number} [hearingEstimatedDays]
+ * @param {string | null | undefined} inspectorName
  * @returns
  */
 const sendStartCaseNotifies = async (
@@ -282,9 +285,10 @@ const sendStartCaseNotifies = async (
 	timetable,
 	procedureType,
 	hearingStartTime,
-	hearingEstimatedDays
+	hearingEstimatedDays,
+	inspectorName = null
 ) => {
-	const { appellant, lpa } = await getStartCaseNotifyParams(
+	const { appellant, lpa } = await getStartCaseNotifyParams({
 		appeal,
 		startDate,
 		notifyClient,
@@ -293,8 +297,9 @@ const sendStartCaseNotifies = async (
 		timetable,
 		procedureType,
 		hearingStartTime,
-		hearingEstimatedDays
-	);
+		hearingEstimatedDays,
+		inspectorName
+	});
 
 	if (appellant) {
 		await notifySend(appellant);
@@ -317,6 +322,7 @@ const sendStartCaseNotifies = async (
  * @param {string} [hearingStartTime]
  * @param {string | number} [hearingEstimatedDays]
  * @param {string} [inquiry]
+ * @param {string | null | undefined} inspectorName
  * @returns {Promise<{appellant?: string, lpa?: string}>}
  */
 const generateStartCaseNotifyPreviews = async (
@@ -329,9 +335,10 @@ const generateStartCaseNotifyPreviews = async (
 	procedureType,
 	hearingStartTime,
 	hearingEstimatedDays,
-	inquiry
+	inquiry,
+	inspectorName = null
 ) => {
-	const { appellant, lpa } = await getStartCaseNotifyParams(
+	const { appellant, lpa } = await getStartCaseNotifyParams({
 		appeal,
 		startDate,
 		notifyClient,
@@ -341,11 +348,13 @@ const generateStartCaseNotifyPreviews = async (
 		procedureType,
 		hearingStartTime,
 		hearingEstimatedDays,
-		inquiry
-	);
+		inquiry,
+		inspectorName
+	});
 
 	const commonPersonalisation = {
-		front_office_url: environment.FRONT_OFFICE_URL || ''
+		front_office_url: environment.FRONT_OFFICE_URL || '',
+		inspectorName: inspectorName ? inspectorName : null
 	};
 	const appellantTemplate = appellant
 		? renderTemplate(`${appellant.templateName}.content.md`, {
@@ -375,6 +384,7 @@ const generateStartCaseNotifyPreviews = async (
  * @param {string} [procedureType]
  * @param {string} [hearingStartTime]
  * @param {string} [hearingEstimatedDays]
+ * @param {string | null | undefined} inspectorName
  * @returns
  */
 const startCase = async (
@@ -384,7 +394,8 @@ const startCase = async (
 	azureAdUserId,
 	procedureType,
 	hearingStartTime,
-	hearingEstimatedDays
+	hearingEstimatedDays,
+	inspectorName = null
 ) => {
 	try {
 		const isChildAppeal = isLinkedAppealsActive(appeal) && Boolean(appeal?.parentAppeals?.length);
@@ -456,7 +467,8 @@ const startCase = async (
 					timetable,
 					procedureType,
 					hearingStartTime,
-					hearingEstimatedDays
+					hearingEstimatedDays,
+					inspectorName
 				);
 			}
 
@@ -480,6 +492,7 @@ const startCase = async (
  * @param {string} [hearingStartTime]
  * @param {string | number} [hearingEstimatedDays]
  * @param {any} [inquiry]
+ * @param {string | null | undefined} inspectorName
  * @returns {Promise<{appellant?: string, lpa?: string}>}
  */
 const getStartCaseNotifyPreviews = async (
@@ -490,7 +503,8 @@ const getStartCaseNotifyPreviews = async (
 	procedureType,
 	hearingStartTime,
 	hearingEstimatedDays,
-	inquiry
+	inquiry,
+	inspectorName = null
 ) => {
 	try {
 		const isChildAppeal = isLinkedAppealsActive(appeal) && Boolean(appeal?.parentAppeals?.length);
@@ -531,7 +545,8 @@ const getStartCaseNotifyPreviews = async (
 			procedureType,
 			hearingStartTime,
 			hearingEstimatedDays,
-			inquiry
+			inquiry,
+			inspectorName
 		);
 	} catch (/** @type {any} */ error) {
 		logger.error(`Error generating notify previews for appeal ID ${appeal.id}: ${error}`);

--- a/appeals/api/src/server/endpoints/hearings/__tests__/hearing.test.js
+++ b/appeals/api/src/server/endpoints/hearings/__tests__/hearing.test.js
@@ -226,6 +226,7 @@ describe('hearing routes', () => {
 					lpa_reference: '48269/APP/2021/1482',
 					hearing_date: '1 January 2999',
 					hearing_time: '12:00pm',
+					inspector_name: null,
 					hearing_expected_days: '',
 					hearing_address:
 						'Court 2, 24 Court Street, Test Town, Test County, AB12 3CD, United Kingdom',
@@ -347,6 +348,7 @@ describe('hearing routes', () => {
 					lpa_reference: '48269/APP/2021/1482',
 					hearing_date: '2 January 2999',
 					hearing_time: '12:00pm',
+					inspector_name: null,
 					hearing_expected_days: '',
 					hearing_address:
 						'Court 2, 24 Court Street, Test Town, Test County, AB12 3CD, United Kingdom',
@@ -399,6 +401,7 @@ describe('hearing routes', () => {
 					lpa_reference: '48269/APP/2021/1482',
 					hearing_date: '3 January 2999',
 					hearing_time: '12:00pm',
+					inspector_name: null,
 					hearing_expected_days: '',
 					hearing_address: '',
 					team_email_address: 'caseofficers@planninginspectorate.gov.uk'
@@ -1188,6 +1191,7 @@ describe('hearing routes', () => {
 					lpa_reference: '48269/APP/2021/1482',
 					hearing_date: '1 January 2999',
 					hearing_time: '1:00pm',
+					inspector_name: null,
 					hearing_expected_days: '',
 					hearing_address:
 						'Court 2, 24 Court Street, Test Town, Test County, AB12 3CD, United Kingdom',
@@ -1250,6 +1254,7 @@ describe('hearing routes', () => {
 					lpa_reference: '48269/APP/2021/1482',
 					hearing_date: '1 January 2999',
 					hearing_time: '12:00pm',
+					inspector_name: null,
 					hearing_expected_days: '',
 					hearing_address: '',
 					team_email_address: 'caseofficers@planninginspectorate.gov.uk'

--- a/appeals/api/src/server/endpoints/hearings/hearing.controller.js
+++ b/appeals/api/src/server/endpoints/hearings/hearing.controller.js
@@ -75,6 +75,7 @@ export const postHearing = async (req, res) => {
 				})
 			},
 			appeal,
+			req.body.inspectorName,
 			req.notifyClient,
 			azureAdUserId
 		);
@@ -139,6 +140,7 @@ export const rearrangeHearing = async (req, res) => {
 				})
 			},
 			appeal,
+			req.body.inspectorName,
 			req.notifyClient,
 			azureAdUserId,
 			existingAddressId

--- a/appeals/api/src/server/endpoints/hearings/hearing.service.js
+++ b/appeals/api/src/server/endpoints/hearings/hearing.service.js
@@ -48,6 +48,7 @@ const checkHearingExists = async (req, res, next) => {
  * @param {import('#endpoints/appeals.js').NotifyClient} notifyClient
  * @param {string} templateName
  * @param {Appeal} appeal
+ * @param {string} inspectorName
  * @param {string | Date | null} hearingStartTime
  * @param {string} estimatedDays
  * @param {Omit<import('@pins/appeals.api').Schema.Address, 'id'> | null} address
@@ -58,6 +59,7 @@ const sendHearingDetailsNotifications = async (
 	notifyClient,
 	templateName,
 	appeal,
+	inspectorName,
 	hearingStartTime,
 	estimatedDays,
 	address,
@@ -75,7 +77,8 @@ const sendHearingDetailsNotifications = async (
 				)
 			: 'Not set',
 		hearing_expected_days: estimatedDays ?? '',
-		hearing_address: address ? formatAddressSingleLine({ ...address, id: 0 }) : ''
+		hearing_address: address ? formatAddressSingleLine({ ...address, id: 0 }) : '',
+		inspector_name: inspectorName ? inspectorName : null
 	};
 	await sendHearingNotifications(
 		notifyClient,
@@ -92,7 +95,7 @@ const sendHearingDetailsNotifications = async (
  * @param {string} templateName
  * @param {Appeal} appeal
  * @param {string} azureAdUserId
- * @param {Record<string, string>} [personalisation]
+ * @param {Record<string, string | null>} [personalisation]
  * @param {boolean} [includeRecipientRole]
  * @returns {Promise<void>}
  */
@@ -141,11 +144,18 @@ const sendHearingNotifications = async (
 /**
  * @param {CreateHearing} createHearingData
  * @param {Appeal} appeal
+ * @param {string} inspectorName
  * @param {import('#endpoints/appeals.js').NotifyClient} notifyClient
  * @param {string} azureAdUserId
  * @returns {Promise<void>}
  */
-const createHearing = async (createHearingData, appeal, notifyClient, azureAdUserId) => {
+const createHearing = async (
+	createHearingData,
+	appeal,
+	inspectorName,
+	notifyClient,
+	azureAdUserId
+) => {
 	try {
 		const appealId = createHearingData.appealId;
 		const hearingStartTime = createHearingData.hearingStartTime;
@@ -169,6 +179,7 @@ const createHearing = async (createHearingData, appeal, notifyClient, azureAdUse
 			notifyClient,
 			'hearing-set-up',
 			appeal,
+			inspectorName,
 			hearingStartTime,
 			estimatedDays ?? '',
 			address || null,
@@ -183,6 +194,7 @@ const createHearing = async (createHearingData, appeal, notifyClient, azureAdUse
 /**
  * @param {UpdateHearing} updateHearingData
  * @param {Appeal} appeal
+ * @param {string} inspectorName
  * @param {import('#endpoints/appeals.js').NotifyClient} notifyClient
  * @param {string} azureAdUserId
  * @param {number | null | undefined} existingAddressId
@@ -190,6 +202,7 @@ const createHearing = async (createHearingData, appeal, notifyClient, azureAdUse
 const updateHearing = async (
 	updateHearingData,
 	appeal,
+	inspectorName,
 	notifyClient,
 	azureAdUserId,
 	existingAddressId
@@ -224,6 +237,7 @@ const updateHearing = async (
 			notifyClient,
 			'hearing-updated',
 			appeal,
+			inspectorName,
 			hearingStartTime,
 			estimatedDays ? String(estimatedDays) : '',
 			result.address,

--- a/appeals/api/src/server/endpoints/notify-preview/__tests__/__snapshots__/notify-preview.test.js.snap
+++ b/appeals/api/src/server/endpoints/notify-preview/__tests__/__snapshots__/notify-preview.test.js.snap
@@ -10,23 +10,22 @@ exports[`notify preview tests /appeals/notify-preview/correction-notice-decision
 Appeal reference number: 12345 <br>
 Address: 2222<br>
 Planning application reference: planningApplicationReference<br>
-
+</div>
 <h3> Why we corrected the appeal decision letter</h3>
 
-correctionNotice<br>
+<p>correctionNotice</p>
 
-<a href="/manage-appeals/12345" class="govuk-link">Sign in to our service</a> to view the decision letter dated dateISOStringToDisplayDate(file.receivedDate).<br>
+<p><a href="/manage-appeals/12345" class="govuk-link">Sign in to our service</a> to view the decision letter dated dateISOStringToDisplayDate(file.receivedDate).</p>
 
 <h3> The Planning Inspectorate's role</h3>
 
-The Planning Inspectorate cannot change or revoke the decision. Only the High Court can change this decision.<br>
+<p>The Planning Inspectorate cannot change or revoke the decision. Only the High Court can change this decision.</p>
 
 <h3> Feedback</h3>
 
-We welcome your feedback on our appeals service. Tell us on this short <a href="/mock-feedback-link" class="govuk-link">feedback form</a>.<br>
+<p>We welcome your feedback on our appeals service. Tell us on this short <a href="/mock-feedback-link" class="govuk-link">feedback form</a>.</p>
 
-The Planning Inspectorate<br>
-lpa@planninginspectorate.gov.uk<br>
-</div> </div>",
+<p>The Planning Inspectorate</p>
+<p>lpa@planninginspectorate.gov.uk</p> </div>",
 }
 `;

--- a/appeals/api/src/server/endpoints/notify-preview/__tests__/__snapshots__/notify-preview.test.js.snap
+++ b/appeals/api/src/server/endpoints/notify-preview/__tests__/__snapshots__/notify-preview.test.js.snap
@@ -10,22 +10,23 @@ exports[`notify preview tests /appeals/notify-preview/correction-notice-decision
 Appeal reference number: 12345 <br>
 Address: 2222<br>
 Planning application reference: planningApplicationReference<br>
-</div>
+
 <h3> Why we corrected the appeal decision letter</h3>
 
-<p>correctionNotice</p>
+correctionNotice<br>
 
-<p><a href="/manage-appeals/12345" class="govuk-link">Sign in to our service</a> to view the decision letter dated dateISOStringToDisplayDate(file.receivedDate).</p>
+<a href="/manage-appeals/12345" class="govuk-link">Sign in to our service</a> to view the decision letter dated dateISOStringToDisplayDate(file.receivedDate).<br>
 
 <h3> The Planning Inspectorate's role</h3>
 
-<p>The Planning Inspectorate cannot change or revoke the decision. Only the High Court can change this decision.</p>
+The Planning Inspectorate cannot change or revoke the decision. Only the High Court can change this decision.<br>
 
 <h3> Feedback</h3>
 
-<p>We welcome your feedback on our appeals service. Tell us on this short <a href="/mock-feedback-link" class="govuk-link">feedback form</a>.</p>
+We welcome your feedback on our appeals service. Tell us on this short <a href="/mock-feedback-link" class="govuk-link">feedback form</a>.<br>
 
-<p>The Planning Inspectorate</p>
-<p>lpa@planninginspectorate.gov.uk</p> </div>",
+The Planning Inspectorate<br>
+lpa@planninginspectorate.gov.uk<br>
+</div> </div>",
 }
 `;

--- a/appeals/api/src/server/notify/templates/__tests__/notify-hearing-set-up.test.js
+++ b/appeals/api/src/server/notify/templates/__tests__/notify-hearing-set-up.test.js
@@ -12,6 +12,7 @@ describe('hearing-set-up.md', () => {
 			recipientEmail: 'test@136s7.com',
 			personalisation: {
 				appeal_reference_number: 'ABC45678',
+				inspector_name: 'B. Jones',
 				site_address: '10, Test Street',
 				lpa_reference: '12345XYZ',
 				hearing_date: '31 January 2025',
@@ -29,6 +30,7 @@ describe('hearing-set-up.md', () => {
 			'^Appeal reference number: ABC45678',
 			'Address: 10, Test Street',
 			'Planning application reference: 12345XYZ',
+			'Inspector: B. Jones',
 			'',
 			'# Hearing details',
 			'',

--- a/appeals/api/src/server/notify/templates/__tests__/notify-site-visit-schedule-access-required-appellant.test.js
+++ b/appeals/api/src/server/notify/templates/__tests__/notify-site-visit-schedule-access-required-appellant.test.js
@@ -12,6 +12,7 @@ describe('site-visit-schedule-access-required-appellant.md', () => {
 			recipientEmail: 'appellant@example.com',
 			personalisation: {
 				appeal_reference_number: 'ZZZ99123',
+				inspector_name: 'B. Jones',
 				site_address: '18, Field Lane',
 				lpa_reference: 'LPA-77889',
 				visit_date: '9 October 2025',
@@ -30,7 +31,7 @@ describe('site-visit-schedule-access-required-appellant.md', () => {
 			'',
 			'# When we will visit',
 			'',
-			'The inspector (or their representative) will visit 18, Field Lane between 8:30am and 12:30pm on 9 October 2025.',
+			'The inspector B. Jones (or their representative) will visit 18, Field Lane between 8:30am and 12:30pm on 9 October 2025.',
 			'',
 			'# Give the inspector access to the site',
 			'',

--- a/appeals/api/src/server/notify/templates/__tests__/notify-site-visit-schedule-accompanied-appellant.test.js
+++ b/appeals/api/src/server/notify/templates/__tests__/notify-site-visit-schedule-accompanied-appellant.test.js
@@ -12,6 +12,7 @@ describe('site-visit-schedule-accompanied-appellant.md', () => {
 			recipientEmail: 'appellant@example.com',
 			personalisation: {
 				appeal_reference_number: 'AAA11234',
+				inspector_name: 'B. Jones',
 				site_address: '45, Hearing Road',
 				lpa_reference: 'PLAN-12345',
 				visit_date: '15 October 2025',
@@ -29,7 +30,7 @@ describe('site-visit-schedule-accompanied-appellant.md', () => {
 			'',
 			'# About the visit',
 			'',
-			'Our inspector (or their representative) will visit 45, Hearing Road at 11:00am on 15 October 2025.',
+			'Our inspector B. Jones (or their representative) will visit 45, Hearing Road at 11:00am on 15 October 2025.',
 			'',
 			'You cannot give the inspector any documents or discuss the appeal with them.',
 			'',

--- a/appeals/api/src/server/notify/templates/appeal-valid-start-case-s78-appellant-hearing.content.md
+++ b/appeals/api/src/server/notify/templates/appeal-valid-start-case-s78-appellant-hearing.content.md
@@ -5,7 +5,9 @@ Your appeal started on {{start_date}}. The timetable for the appeal begins from 
 Your appeal procedure is a hearing.
 
 {% include 'parts/appeal-details.md' %}
-
+{% if inspector_name -%}
+Inspector: {{inspector_name}}
+{% endif %}
 # Timetable
 
 ## Local planning authority questionnaire

--- a/appeals/api/src/server/notify/templates/appeal-valid-start-case-s78-appellant.content.md
+++ b/appeals/api/src/server/notify/templates/appeal-valid-start-case-s78-appellant.content.md
@@ -5,7 +5,9 @@ Your appeal started on {{start_date}}. The timetable for the appeal begins from 
 Your appeal procedure is {{procedure_type}}.
 
 {% include 'parts/appeal-details.md' %}
-
+{% if inspector_name -%}
+Inspector: {{inspector_name}}
+{% endif %}
 # Timetable
 
 {%- if child_appeals.length === 1 %}

--- a/appeals/api/src/server/notify/templates/appeal-valid-start-case-s78-inquiry.content.md
+++ b/appeals/api/src/server/notify/templates/appeal-valid-start-case-s78-inquiry.content.md
@@ -10,7 +10,9 @@ We have set up your timetable.
 {% if is_lpa -%}
 Start date: {{start_date}}
 {% endif %}
-# Timetable
+{% if inspector_name -%}
+Inspector: {{inspector_name}}
+{% endif %}# Timetable
 
 ## Local planning authority questionnaire
 

--- a/appeals/api/src/server/notify/templates/appeal-valid-start-case-s78-lpa-hearing.content.md
+++ b/appeals/api/src/server/notify/templates/appeal-valid-start-case-s78-lpa-hearing.content.md
@@ -4,7 +4,9 @@ We will decide the appeal by a hearing. You can tell us if you think a different
 
 {% include 'parts/appeal-details.md' %}
 Start date: {{start_date}}
-
+{% if inspector_name -%}
+Inspector: {{inspector_name}}
+{% endif %}
 # Timetable
 
 ## Local planning authority questionnaire

--- a/appeals/api/src/server/notify/templates/appeal-valid-start-case-s78-lpa.content.md
+++ b/appeals/api/src/server/notify/templates/appeal-valid-start-case-s78-lpa.content.md
@@ -4,7 +4,9 @@ We will decide the appeal by {{procedure_type}}. You can tell us if you think a 
 
 {% include 'parts/appeal-details.md' %}
 Start date: {{start_date}}
-
+{% if inspector_name -%}
+Inspector: {{inspector_name}}
+{% endif %}
 # Timetable
 
 {%- if child_appeals.length === 1 %}

--- a/appeals/api/src/server/notify/templates/hearing-set-up.content.md
+++ b/appeals/api/src/server/notify/templates/hearing-set-up.content.md
@@ -1,6 +1,8 @@
 
 {% include 'parts/appeal-details.md' %}
-
+{% if inspector_name -%}
+Inspector: {{inspector_name}}
+{% endif %}
 # Hearing details
 
 ^Date: {{hearing_date}}

--- a/appeals/api/src/server/notify/templates/hearing-updated.content.md
+++ b/appeals/api/src/server/notify/templates/hearing-updated.content.md
@@ -1,6 +1,8 @@
 
 {% include 'parts/appeal-details.md' %}
-
+{% if inspector_name -%}
+Inspector: {{inspector_name}}
+{% endif %}
 # Hearing details
 
 ^Date: {{hearing_date}}

--- a/appeals/api/src/server/notify/templates/inquiry-set-up.content.md
+++ b/appeals/api/src/server/notify/templates/inquiry-set-up.content.md
@@ -1,6 +1,8 @@
 
 {% include 'parts/appeal-details.md' %}
-
+{% if inspector_name -%}
+Inspector: {{inspector_name}}
+{% endif %}
 # About the inquiry
 
 ^Date: {{inquiry_date}}

--- a/appeals/api/src/server/notify/templates/inquiry-updated.content.md
+++ b/appeals/api/src/server/notify/templates/inquiry-updated.content.md
@@ -1,6 +1,8 @@
 
 {% include 'parts/appeal-details.md' %}
-
+{% if inspector_name -%}
+Inspector: {{inspector_name}}
+{% endif %}
 # About the inquiry
 
 ^Date: {{inquiry_date}}

--- a/appeals/api/src/server/notify/templates/site-visit-schedule-access-required-appellant.content.md
+++ b/appeals/api/src/server/notify/templates/site-visit-schedule-access-required-appellant.content.md
@@ -2,7 +2,7 @@
 
 # When we will visit
 
-The inspector (or their representative) will visit {{site_address}} between {{start_time}} and {{end_time}} on {{visit_date}}.
+The inspector {% if inspector_name -%}{{inspector_name}} {% endif %}(or their representative) will visit {{site_address}} between {{start_time}} and {{end_time}} on {{visit_date}}.
 
 # Give the inspector access to the site
 

--- a/appeals/api/src/server/notify/templates/site-visit-schedule-accompanied-appellant.content.md
+++ b/appeals/api/src/server/notify/templates/site-visit-schedule-accompanied-appellant.content.md
@@ -2,7 +2,7 @@
 
 # About the visit
 
-Our inspector (or their representative) will visit {{site_address}} at {{start_time}} on {{visit_date}}.
+Our inspector {% if inspector_name -%}{{inspector_name}} {% endif %}(or their representative) will visit {{site_address}} at {{start_time}} on {{visit_date}}.
 
 You cannot give the inspector any documents or discuss the appeal with them.
 

--- a/appeals/api/src/server/notify/templates/site-visit-schedule-accompanied-lpa.content.md
+++ b/appeals/api/src/server/notify/templates/site-visit-schedule-accompanied-lpa.content.md
@@ -2,7 +2,7 @@
 
 # Visit details
 
-Our inspector (or their representative) will visit {{site_address}} at {{start_time}} on {{visit_date}}.
+Our inspector {% if inspector_name -%}{{inspector_name}} {% endif %}(or their representative) will visit {{site_address}} at {{start_time}} on {{visit_date}}.
 
 # Who will attend
 

--- a/appeals/web/src/server/appeals/appeal-details/__tests__/appeal-details.test.js
+++ b/appeals/web/src/server/appeals/appeal-details/__tests__/appeal-details.test.js
@@ -1079,7 +1079,8 @@ describe('appeal-details', () => {
 					nock('http://test/')
 						.post(`/appeals/${appealId}/hearing`, {
 							hearingStartTime: '3025-02-01T12:00:00.000Z',
-							address: { ...omit(addressValues, 'postCode'), postcode: addressValues.postCode }
+							address: { ...omit(addressValues, 'postCode'), postcode: addressValues.postCode },
+							inspectorName: null
 						})
 						.reply(201, { hearingId: 1 });
 					nock('http://test/').get(`/appeals/1?include=all`).reply(200, appealData).persist();
@@ -1132,7 +1133,8 @@ describe('appeal-details', () => {
 					nock('http://test/')
 						.patch(`/appeals/${appealId}/hearing/0`, {
 							hearingStartTime: '3025-02-01T12:00:00.000Z',
-							address: { ...omit(addressValues, 'postCode'), postcode: addressValues.postCode }
+							address: { ...omit(addressValues, 'postCode'), postcode: addressValues.postCode },
+							inspectorName: null
 						})
 						.reply(201, { hearingId: 1 });
 					nock('http://test/').get(`/appeals/1?include=all`).reply(200, appealData).persist();

--- a/appeals/web/src/server/appeals/appeal-details/hearing/setup/__tests__/change-hearing.test.js
+++ b/appeals/web/src/server/appeals/appeal-details/hearing/setup/__tests__/change-hearing.test.js
@@ -1002,6 +1002,7 @@ describe('change hearing', () => {
 			});
 		});
 	});
+
 	describe('POST /hearing/change/check-details', () => {
 		const dateValues = {
 			'hearing-date-day': '01',
@@ -1029,7 +1030,8 @@ describe('change hearing', () => {
 			nock('http://test/')
 				.patch(`/appeals/${appealId}/hearing/${appealWithHearing.hearing.hearingId}`, {
 					hearingStartTime: '3025-02-01T12:00:00.000Z',
-					address: { ...omit(addressValues, 'postCode'), postcode: addressValues.postCode }
+					address: { ...omit(addressValues, 'postCode'), postcode: addressValues.postCode },
+					inspectorName: null
 				})
 				.reply(200, { hearingId: 1 });
 
@@ -1052,7 +1054,8 @@ describe('change hearing', () => {
 			nock('http://test/')
 				.patch(`/appeals/${appealId}/hearing/${appealWithHearing.hearing.hearingId}`, {
 					hearingStartTime: '3025-02-01T12:00:00.000Z',
-					address: null
+					address: null,
+					inspectorName: null
 				})
 				.reply(200, { hearingId: 1 });
 
@@ -1071,7 +1074,8 @@ describe('change hearing', () => {
 		it('should redirect to appeal details page after submission with unchanged address', async () => {
 			nock('http://test/')
 				.patch(`/appeals/${appealId}/hearing/${appealWithHearing.hearing.hearingId}`, {
-					hearingStartTime: '3025-02-01T12:00:00.000Z' // address not sent if unchanged
+					hearingStartTime: '3025-02-01T12:00:00.000Z', // address not sent if unchanged
+					inspectorName: null
 				})
 				.reply(200, { hearingId: 1 });
 
@@ -1095,7 +1099,8 @@ describe('change hearing', () => {
 			nock('http://test/')
 				.patch(`/appeals/${appealId}/hearing/${appealWithHearing.hearing.hearingId}`, {
 					hearingStartTime: '3024-03-02T08:54:00.000Z', // original date and time
-					address: { ...omit(addressValues, 'postCode'), postcode: addressValues.postCode }
+					address: { ...omit(addressValues, 'postCode'), postcode: addressValues.postCode },
+					inspectorName: null
 				})
 				.reply(200, { hearingId: 1 });
 
@@ -1114,7 +1119,8 @@ describe('change hearing', () => {
 			nock('http://test/')
 				.patch(`/appeals/${appealId}/hearing/${appealWithHearing.hearing.hearingId}`, {
 					hearingStartTime: '3024-03-02T08:54:00.000Z', // original date and time
-					address: { ...omit(addressValues, 'postCode'), postcode: addressValues.postCode }
+					address: { ...omit(addressValues, 'postCode'), postcode: addressValues.postCode },
+					inspectorName: null
 				})
 				.reply(200, { hearingId: 1 });
 
@@ -1136,7 +1142,8 @@ describe('change hearing', () => {
 			nock('http://test/')
 				.patch(`/appeals/${appealId}/hearing/${appealWithHearing.hearing.hearingId}`, {
 					hearingStartTime: '3024-03-02T08:54:00.000Z', // original date and time
-					address: null
+					address: null,
+					inspectorName: null
 				})
 				.reply(200, { hearingId: 1 });
 

--- a/appeals/web/src/server/appeals/appeal-details/hearing/setup/__tests__/set-up-hearing.test.js
+++ b/appeals/web/src/server/appeals/appeal-details/hearing/setup/__tests__/set-up-hearing.test.js
@@ -787,7 +787,8 @@ describe('set up hearing', () => {
 			nock('http://test/')
 				.post(`/appeals/${appealId}/hearing`, {
 					hearingStartTime: '3025-02-01T12:00:00.000Z',
-					address: { ...omit(addressValues, 'postCode'), postcode: addressValues.postCode }
+					address: { ...omit(addressValues, 'postCode'), postcode: addressValues.postCode },
+					inspectorName: null
 				})
 				.reply(201, { hearingId: 1 });
 
@@ -809,7 +810,8 @@ describe('set up hearing', () => {
 		it('should redirect to appeal details page after submission with no address', async () => {
 			nock('http://test/')
 				.post(`/appeals/${appealId}/hearing`, {
-					hearingStartTime: '3025-02-01T12:00:00.000Z'
+					hearingStartTime: '3025-02-01T12:00:00.000Z',
+					inspectorName: null
 				})
 				.reply(201, { hearingId: 1 });
 

--- a/appeals/web/src/server/appeals/appeal-details/hearing/setup/hearing.service.js
+++ b/appeals/web/src/server/appeals/appeal-details/hearing/setup/hearing.service.js
@@ -1,6 +1,6 @@
 /**
  * @param {import('@pins/express/types/express.js').Request} request
- * @param {{hearingStartTime: string, estimatedDays?: string, address?: {addressLine1: string, addressLine2?: string, town: string, county?: string, postcode: string}}} hearingDetails
+ * @param {{hearingStartTime: string, estimatedDays?: string, address?: {addressLine1: string, addressLine2?: string, town: string, county?: string, postcode: string}, inspectorName: string | null | undefined}} hearingDetails
  * @returns {Promise<{hearingEstimateId: number}>}
  */
 export const createHearing = async (request, hearingDetails) => {
@@ -17,7 +17,7 @@ export const createHearing = async (request, hearingDetails) => {
 /**
  * @param {import('@pins/express/types/express.js').Request} request
  * @param {string} hearingId
- * @param {{hearingStartTime?: string, estimatedDays?: string, address?: {addressLine1: string, addressLine2?: string, town: string, county?: string, postcode: string} | null, addressId?: string}} hearingDetails
+ * @param {{hearingStartTime?: string, estimatedDays?: string, inspectorName: string | null | undefined,  address?: {addressLine1: string, addressLine2?: string, town: string, county?: string, postcode: string} | null, addressId?: string}} hearingDetails
  * @returns {Promise<{hearingEstimateId: number}>}
  */
 export const updateHearing = async (request, hearingId, hearingDetails) => {

--- a/appeals/web/src/server/appeals/appeal-details/hearing/setup/set-up-hearing.controller.js
+++ b/appeals/web/src/server/appeals/appeal-details/hearing/setup/set-up-hearing.controller.js
@@ -1,4 +1,3 @@
-import usersService from '#appeals/appeal-users/users-service.js';
 import {
 	dateISOStringToDayMonthYearHourMinute,
 	dayMonthYearHourMinuteToISOString
@@ -10,8 +9,8 @@ import {
 	isAtEditEntrypoint
 } from '#lib/edit-utilities.js';
 import logger from '#lib/logger.js';
+import { getInspectorFormattedEmailName } from '#lib/service-user-formatter.js';
 import { addNotificationBannerToSession } from '#lib/session-utilities.js';
-import { formatFirstInitialLastName } from '#lib/string-utilities.js';
 import { preserveQueryString } from '#lib/url-utilities.js';
 import { has, isEmpty, isEqual, pick } from 'lodash-es';
 import { createHearing, updateHearing } from './hearing.service.js';
@@ -607,13 +606,7 @@ export const postHearingCheckDetails = async (request, response) => {
 		return renderAlreadySubmittedError(request, response);
 	}
 
-	let inspectorEmailName;
-	if (inspector) {
-		const assignedInspector = await usersService.getUserById(inspector, request.session);
-		inspectorEmailName = assignedInspector
-			? formatFirstInitialLastName(assignedInspector?.name)
-			: null;
-	}
+	const inspectorName = await getInspectorFormattedEmailName(inspector, request);
 
 	try {
 		const submittedAddress = {
@@ -634,7 +627,7 @@ export const postHearingCheckDetails = async (request, response) => {
 				estimatedDays: hearing.hearingEstimationDays
 			}),
 			...(hearing.addressKnown === 'yes' && submittedAddress),
-			inspectorName: inspectorEmailName
+			inspectorName
 		});
 
 		addNotificationBannerToSession({
@@ -676,13 +669,7 @@ export const postChangeHearingCheckDetails = async (request, response) => {
 		address = submittedAddress;
 	}
 
-	let inspectorEmailName;
-	if (inspector) {
-		const assignedInspector = await usersService.getUserById(inspector, request.session);
-		inspectorEmailName = assignedInspector
-			? formatFirstInitialLastName(assignedInspector?.name)
-			: null;
-	}
+	const inspectorName = await getInspectorFormattedEmailName(inspector, request);
 
 	try {
 		await updateHearing(request, request.currentAppeal.hearing.hearingId, {
@@ -691,7 +678,7 @@ export const postChangeHearingCheckDetails = async (request, response) => {
 				estimatedDays: sessionData.hearingEstimationDays
 			}),
 			address,
-			inspectorName: inspectorEmailName
+			inspectorName
 		});
 
 		addNotificationBannerToSession({

--- a/appeals/web/src/server/appeals/appeal-details/hearing/setup/set-up-hearing.controller.js
+++ b/appeals/web/src/server/appeals/appeal-details/hearing/setup/set-up-hearing.controller.js
@@ -1,3 +1,4 @@
+import usersService from '#appeals/appeal-users/users-service.js';
 import {
 	dateISOStringToDayMonthYearHourMinute,
 	dayMonthYearHourMinuteToISOString
@@ -10,6 +11,7 @@ import {
 } from '#lib/edit-utilities.js';
 import logger from '#lib/logger.js';
 import { addNotificationBannerToSession } from '#lib/session-utilities.js';
+import { formatFirstInitialLastName } from '#lib/string-utilities.js';
 import { preserveQueryString } from '#lib/url-utilities.js';
 import { has, isEmpty, isEqual, pick } from 'lodash-es';
 import { createHearing, updateHearing } from './hearing.service.js';
@@ -598,11 +600,19 @@ export const getChangeHearingCheckDetails = async (request, response) => {
  * @param {import('@pins/express/types/express.js').RenderedResponse<any, any, Number>} response
  */
 export const postHearingCheckDetails = async (request, response) => {
-	const { appealId } = request.currentAppeal;
+	const { appealId, inspector } = request.currentAppeal;
 	const hearing = request.session.setUpHearing;
 
 	if (!hearing) {
 		return renderAlreadySubmittedError(request, response);
+	}
+
+	let inspectorEmailName;
+	if (inspector) {
+		const assignedInspector = await usersService.getUserById(inspector, request.session);
+		inspectorEmailName = assignedInspector
+			? formatFirstInitialLastName(assignedInspector?.name)
+			: null;
 	}
 
 	try {
@@ -623,7 +633,8 @@ export const postHearingCheckDetails = async (request, response) => {
 			...(hearing.hearingEstimationYesNo === 'yes' && {
 				estimatedDays: hearing.hearingEstimationDays
 			}),
-			...(hearing.addressKnown === 'yes' && submittedAddress)
+			...(hearing.addressKnown === 'yes' && submittedAddress),
+			inspectorName: inspectorEmailName
 		});
 
 		addNotificationBannerToSession({
@@ -647,7 +658,7 @@ export const postHearingCheckDetails = async (request, response) => {
  * @param {import('@pins/express/types/express.js').RenderedResponse<any, any, Number>} response
  */
 export const postChangeHearingCheckDetails = async (request, response) => {
-	const { appealId, hearing } = request.currentAppeal;
+	const { appealId, hearing, inspector } = request.currentAppeal;
 	const sessionData = request.session.changeHearing;
 
 	if (!sessionData) {
@@ -665,13 +676,22 @@ export const postChangeHearingCheckDetails = async (request, response) => {
 		address = submittedAddress;
 	}
 
+	let inspectorEmailName;
+	if (inspector) {
+		const assignedInspector = await usersService.getUserById(inspector, request.session);
+		inspectorEmailName = assignedInspector
+			? formatFirstInitialLastName(assignedInspector?.name)
+			: null;
+	}
+
 	try {
 		await updateHearing(request, request.currentAppeal.hearing.hearingId, {
 			hearingStartTime: hearingStartTimeForUpdate(sessionData, hearing.hearingStartTime),
 			...(sessionData.hearingEstimationYesNo === 'yes' && {
 				estimatedDays: sessionData.hearingEstimationDays
 			}),
-			address
+			address,
+			inspectorName: inspectorEmailName
 		});
 
 		addNotificationBannerToSession({

--- a/appeals/web/src/server/appeals/appeal-details/inquiry/setup/__tests__/change-inquiry.test.js
+++ b/appeals/web/src/server/appeals/appeal-details/inquiry/setup/__tests__/change-inquiry.test.js
@@ -977,7 +977,8 @@ describe('change inquiry', () => {
 				.patch(`/appeals/${appealId}/inquiry/${appealWithInquiry.inquiry.inquiryId}`, {
 					inquiryStartTime: '3025-02-01T12:00:00.000Z',
 					estimatedDays: 6,
-					address: { ...omit(addressValues, 'postCode'), postcode: addressValues.postCode }
+					address: { ...omit(addressValues, 'postCode'), postcode: addressValues.postCode },
+					inspectorName: null
 				})
 				.reply(200, { inquiryId: 1 });
 
@@ -1001,7 +1002,8 @@ describe('change inquiry', () => {
 				.patch(`/appeals/${appealId}/inquiry/${appealWithInquiry.inquiry.inquiryId}`, {
 					inquiryStartTime: '3025-02-01T12:00:00.000Z',
 					estimatedDays: 6,
-					address: null
+					address: null,
+					inspectorName: null
 				})
 				.reply(200, { inquiryId: 1 });
 
@@ -1021,7 +1023,8 @@ describe('change inquiry', () => {
 			nock('http://test/')
 				.patch(`/appeals/${appealId}/inquiry/${appealWithInquiry.inquiry.inquiryId}`, {
 					inquiryStartTime: '3025-02-01T12:00:00.000Z', // address not sent if unchanged
-					estimatedDays: 6
+					estimatedDays: 6,
+					inspectorName: null
 				})
 				.reply(200, { inquiryId: 1 });
 
@@ -1046,7 +1049,8 @@ describe('change inquiry', () => {
 				.patch(`/appeals/${appealId}/inquiry/${appealWithInquiry.inquiry.inquiryId}`, {
 					inquiryStartTime: '3024-03-02T08:54:00.000Z', // original date and time
 					address: { ...omit(addressValues, 'postCode'), postcode: addressValues.postCode },
-					estimatedDays: 6
+					estimatedDays: 6,
+					inspectorName: null
 				})
 				.reply(200, { inquiryId: 1 });
 
@@ -1066,7 +1070,8 @@ describe('change inquiry', () => {
 				.patch(`/appeals/${appealId}/inquiry/${appealWithInquiry.inquiry.inquiryId}`, {
 					inquiryStartTime: '3024-03-02T08:54:00.000Z', // original date and time
 					address: { ...omit(addressValues, 'postCode'), postcode: addressValues.postCode },
-					estimatedDays: 6
+					estimatedDays: 6,
+					inspectorName: null
 				})
 				.reply(200, { inquiryId: 1 });
 
@@ -1089,7 +1094,8 @@ describe('change inquiry', () => {
 				.patch(`/appeals/${appealId}/inquiry/${appealWithInquiry.inquiry.inquiryId}`, {
 					inquiryStartTime: '3024-03-02T08:54:00.000Z', // original date and time
 					estimatedDays: 6,
-					address: null
+					address: null,
+					inspectorName: null
 				})
 				.reply(200, { inquiryId: 1 });
 

--- a/appeals/web/src/server/appeals/appeal-details/inquiry/setup/set-up-inquiry.controller.js
+++ b/appeals/web/src/server/appeals/appeal-details/inquiry/setup/set-up-inquiry.controller.js
@@ -1,5 +1,4 @@
 import { getStartCaseNotifyPreviews } from '#appeals/appeal-details/start-case/start-case.service.js';
-import usersService from '#appeals/appeal-users/users-service.js';
 import { addressToString } from '#lib/address-formatter.js';
 import {
 	dateISOStringToDayMonthYearHourMinute,
@@ -10,8 +9,8 @@ import { applyEditsForAppeal, clearEdits, getSessionValuesForAppeal } from '#lib
 import logger from '#lib/logger.js';
 import { backLinkGenerator } from '#lib/middleware/save-back-url.js';
 import { resolveAppealId } from '#lib/resolveAppealId.js';
+import { getInspectorFormattedEmailName } from '#lib/service-user-formatter.js';
 import { addNotificationBannerToSession } from '#lib/session-utilities.js';
-import { formatFirstInitialLastName } from '#lib/string-utilities.js';
 import { preserveQueryString } from '#lib/url-utilities.js';
 import { APPEAL_CASE_PROCEDURE } from '@planning-inspectorate/data-model';
 import { isEmpty, isEqual, pick } from 'lodash-es';
@@ -725,13 +724,7 @@ export const getInquiryCheckDetails = async (request, response) => {
 	if (procedureType.toLowerCase() !== APPEAL_CASE_PROCEDURE.INQUIRY) {
 		const errorMessage = 'Failed to generate email preview';
 		try {
-			let inspectorName;
-			if (inspector) {
-				const assignedInspector = await usersService.getUserById(inspector, request.session);
-				inspectorName = assignedInspector
-					? formatFirstInitialLastName(assignedInspector.name)
-					: null;
-			}
+			const inspectorName = await getInspectorFormattedEmailName(inspector, request);
 
 			const result = await getStartCaseNotifyPreviews(
 				request.apiClient,
@@ -891,12 +884,7 @@ export const postInquiryCheckDetails = async (request, response) => {
 			isStartCase
 		};
 
-		if (inspector) {
-			const assignedInspector = await usersService.getUserById(inspector, request.session);
-			request.currentAppeal.inspectorName = assignedInspector
-				? formatFirstInitialLastName(assignedInspector.name)
-				: null;
-		}
+		request.currentAppeal.inspectorName = await getInspectorFormattedEmailName(inspector, request);
 
 		//Create Inquiry
 		await createInquiry(request, inquiryRequest);
@@ -963,12 +951,7 @@ export const postChangeInquiryCheckDetails = async (request, response) => {
 			return renderAlreadySubmittedError(request, response);
 		}
 
-		if (inspector) {
-			const assignedInspector = await usersService.getUserById(inspector, request.session);
-			request.currentAppeal.inspectorName = assignedInspector
-				? formatFirstInitialLastName(assignedInspector.name)
-				: null;
-		}
+		request.currentAppeal.inspectorName = await getInspectorFormattedEmailName(inspector, request);
 
 		// Update Inquiry
 		await updateInquiry(request, buildChangeInquiryRequest(inquiry, request.currentAppeal));

--- a/appeals/web/src/server/appeals/appeal-details/inquiry/setup/set-up-inquiry.controller.js
+++ b/appeals/web/src/server/appeals/appeal-details/inquiry/setup/set-up-inquiry.controller.js
@@ -1,4 +1,5 @@
 import { getStartCaseNotifyPreviews } from '#appeals/appeal-details/start-case/start-case.service.js';
+import usersService from '#appeals/appeal-users/users-service.js';
 import { addressToString } from '#lib/address-formatter.js';
 import {
 	dateISOStringToDayMonthYearHourMinute,
@@ -10,6 +11,7 @@ import logger from '#lib/logger.js';
 import { backLinkGenerator } from '#lib/middleware/save-back-url.js';
 import { resolveAppealId } from '#lib/resolveAppealId.js';
 import { addNotificationBannerToSession } from '#lib/session-utilities.js';
+import { formatFirstInitialLastName } from '#lib/string-utilities.js';
 import { preserveQueryString } from '#lib/url-utilities.js';
 import { APPEAL_CASE_PROCEDURE } from '@planning-inspectorate/data-model';
 import { isEmpty, isEqual, pick } from 'lodash-es';
@@ -699,7 +701,7 @@ export const postChangeInquiryAddressDetails = async (request, response) => {
  */
 export const getInquiryCheckDetails = async (request, response) => {
 	const {
-		currentAppeal: { appealId, appealReference, procedureType },
+		currentAppeal: { appealId, appealReference, procedureType, inspector },
 		session,
 		errors
 	} = request;
@@ -723,6 +725,14 @@ export const getInquiryCheckDetails = async (request, response) => {
 	if (procedureType.toLowerCase() !== APPEAL_CASE_PROCEDURE.INQUIRY) {
 		const errorMessage = 'Failed to generate email preview';
 		try {
+			let inspectorName;
+			if (inspector) {
+				const assignedInspector = await usersService.getUserById(inspector, request.session);
+				inspectorName = assignedInspector
+					? formatFirstInitialLastName(assignedInspector.name)
+					: null;
+			}
+
 			const result = await getStartCaseNotifyPreviews(
 				request.apiClient,
 				appealId,
@@ -795,7 +805,8 @@ export const getInquiryCheckDetails = async (request, response) => {
 							year: session.setUpInquiry?.[appealId]['planning-obligation-due-date-year']
 						})
 					}
-				}
+				},
+				inspectorName
 			);
 			appellantPreview = result.appellant || errorMessage;
 			lpaPreview = result.lpa || errorMessage;
@@ -856,7 +867,7 @@ export const getChangeInquiryCheckDetails = async (request, response) => {
 export const postInquiryCheckDetails = async (request, response) => {
 	try {
 		const {
-			currentAppeal: { appealId, procedureType }
+			currentAppeal: { appealId, procedureType, inspector }
 		} = request;
 
 		const { session } = request;
@@ -879,6 +890,14 @@ export const postInquiryCheckDetails = async (request, response) => {
 			startDate: getTodaysISOString(),
 			isStartCase
 		};
+
+		if (inspector) {
+			const assignedInspector = await usersService.getUserById(inspector, request.session);
+			request.currentAppeal.inspectorName = assignedInspector
+				? formatFirstInitialLastName(assignedInspector.name)
+				: null;
+		}
+
 		//Create Inquiry
 		await createInquiry(request, inquiryRequest);
 
@@ -934,7 +953,7 @@ export const postInquiryCheckDetails = async (request, response) => {
 export const postChangeInquiryCheckDetails = async (request, response) => {
 	try {
 		const {
-			currentAppeal: { appealId }
+			currentAppeal: { appealId, inspector }
 		} = request;
 
 		const { session } = request;
@@ -942,6 +961,13 @@ export const postChangeInquiryCheckDetails = async (request, response) => {
 
 		if (!inquiry) {
 			return renderAlreadySubmittedError(request, response);
+		}
+
+		if (inspector) {
+			const assignedInspector = await usersService.getUserById(inspector, request.session);
+			request.currentAppeal.inspectorName = assignedInspector
+				? formatFirstInitialLastName(assignedInspector.name)
+				: null;
 		}
 
 		// Update Inquiry
@@ -1041,7 +1067,7 @@ const buildInquiryRequest = (inquiry, hasObligation) => {
 /**
  * @param {any} inquiry
  * @param {any} currentAppeal
- * @returns {{estimatedDays?: string, addressId?: number, inquiryStartTime: string, address?: {addressLine1: string, addressLine2?: string, town: string, county?: string, postcode: string}  | null}}
+ * @returns {{inspectorName: string | null | undefined, estimatedDays?: string, addressId?: number, inquiryStartTime: string, address?: {addressLine1: string, addressLine2?: string, town: string, county?: string, postcode: string}  | null}}
  */
 const buildChangeInquiryRequest = (inquiry, currentAppeal) => {
 	const submittedAddress = {
@@ -1067,7 +1093,8 @@ const buildChangeInquiryRequest = (inquiry, currentAppeal) => {
 		address,
 		...(inquiry.inquiryEstimationYesNo === 'yes' && {
 			estimatedDays: inquiry.inquiryEstimationDays
-		})
+		}),
+		inspectorName: currentAppeal.inspectorName
 	};
 };
 

--- a/appeals/web/src/server/appeals/appeal-details/inquiry/setup/set-up-inquiry.service.js
+++ b/appeals/web/src/server/appeals/appeal-details/inquiry/setup/set-up-inquiry.service.js
@@ -2,7 +2,7 @@ import { getAppellantCaseFromAppealId } from '#appeals/appeal-details/appellant-
 
 /**
  * @param {import('@pins/express/types/express.js').Request} request
- * @param {{startDate: string, estimatedDays?: string, inquiryStartTime: string, lpaQuestionnaireDueDate: string, statementDueDate: string, ipCommentsDueDate: string, statementOfCommonGroundDueDate: string, proofOfEvidenceAndWitnessesDueDate: string, caseManagementConferenceDueDate: string, planningObligationDueDate?: string, isStartCase: boolean, address?: {addressLine1: string, addressLine2?: string, town: string, county?: string, postcode: string}}} inquiryDetails
+ * @param {{inspectorName?: string | null | undefined, startDate: string, estimatedDays?: string, inquiryStartTime: string, lpaQuestionnaireDueDate: string, statementDueDate: string, ipCommentsDueDate: string, statementOfCommonGroundDueDate: string, proofOfEvidenceAndWitnessesDueDate: string, caseManagementConferenceDueDate: string, planningObligationDueDate?: string, isStartCase: boolean, address?: {addressLine1: string, addressLine2?: string, town: string, county?: string, postcode: string}}} inquiryDetails
  * @returns {Promise<{inquiryId: number}>}
  */
 export const createInquiry = async (request, inquiryDetails) => {
@@ -17,7 +17,7 @@ export const createInquiry = async (request, inquiryDetails) => {
 
 /**
  * @param {import('@pins/express/types/express.js').Request} request
- * @param {{estimatedDays?: string, addressId?: number, inquiryStartTime: string, address?: {addressLine1: string, addressLine2?: string, town: string, county?: string, postcode: string} | null}} inquiryDetails
+ * @param {{inspectorName?: string | null | undefined, estimatedDays?: string, addressId?: number, inquiryStartTime: string, address?: {addressLine1: string, addressLine2?: string, town: string, county?: string, postcode: string} | null}} inquiryDetails
  * @returns {Promise<{inquiryId: number}>}
  */
 export const updateInquiry = async (request, inquiryDetails) => {

--- a/appeals/web/src/server/appeals/appeal-details/site-visit/schedule/schedule.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/site-visit/schedule/schedule.mapper.js
@@ -5,7 +5,11 @@ import {
 } from '#lib/dates.js';
 import { timeInput } from '#lib/mappers/components/page-components/time.js';
 import { dateInput, yesNoInput } from '#lib/mappers/index.js';
-import { capitalizeFirstLetter, padNumberWithZero } from '#lib/string-utilities.js';
+import {
+	capitalizeFirstLetter,
+	formatFirstInitialLastName,
+	padNumberWithZero
+} from '#lib/string-utilities.js';
 import { getBackLinkUrlFromQuery } from '#lib/url-utilities.js';
 import { mapVisitTypeToReadable } from '../site-visit.mapper.js';
 import { siteVisitDateField } from '../site-visits.constants.js';
@@ -416,7 +420,7 @@ export function mapPostScheduleOrManageSiteVisitCommonParameters(
 				: '',
 		apiVisitType: mapWebVisitTypeToApiVisitType(visitType),
 		previousVisitType: '',
-		inspectorName
+		inspectorName: formatFirstInitialLastName(inspectorName)
 	};
 }
 /**

--- a/appeals/web/src/server/appeals/appeal-details/start-case/hearing/hearing.controller.js
+++ b/appeals/web/src/server/appeals/appeal-details/start-case/hearing/hearing.controller.js
@@ -1,7 +1,6 @@
 import { appealProcedureToLabelText } from '#appeals/appeal-details/change-procedure-type/change-procedure-check-and-confirm/change-procedure-check-and-confirm.mapper.js';
 import { sessionValuesToDateTime } from '#appeals/appeal-details/hearing/setup/set-up-hearing.controller.js';
 import { hearingDatePage } from '#appeals/appeal-details/hearing/setup/set-up-hearing.mapper.js';
-import usersService from '#appeals/appeal-users/users-service.js';
 import { appealShortReference } from '#lib/appeals-formatter.js';
 import {
 	dateISOStringToDisplayDate,
@@ -19,8 +18,8 @@ import logger from '#lib/logger.js';
 import { renderCheckYourAnswersComponent } from '#lib/mappers/components/page-components/check-your-answers.js';
 import { detailsComponent } from '#lib/mappers/components/page-components/details.js';
 import { simpleHtmlComponent } from '#lib/mappers/index.js';
+import { getInspectorFormattedEmailName } from '#lib/service-user-formatter.js';
 import { addNotificationBannerToSession } from '#lib/session-utilities.js';
-import { formatFirstInitialLastName } from '#lib/string-utilities.js';
 import { preserveQueryString } from '#lib/url-utilities.js';
 import { capitalize } from 'lodash-es';
 import * as startCaseService from '../start-case.service.js';
@@ -239,12 +238,7 @@ export const getHearingConfirm = async (request, response) => {
 	/** @type {string} */
 	let lpaPreview = errorMessage;
 
-	const inspector = currentAppeal.inspector;
-	let inspectorName;
-	if (inspector) {
-		const assignedInspector = await usersService.getUserById(inspector, request.session);
-		inspectorName = assignedInspector ? formatFirstInitialLastName(assignedInspector.name) : null;
-	}
+	const inspectorName = await getInspectorFormattedEmailName(currentAppeal.inspector, request);
 
 	try {
 		const result = await getStartCaseNotifyPreviews(
@@ -400,11 +394,7 @@ export const postHearingConfirm = async (request, response) => {
 		const hearingStartTime =
 			sessionValues?.dateKnown === 'yes' ? hearingStartTimeFromSession(sessionValues) : undefined;
 
-		let inspectorName;
-		if (inspector) {
-			const assignedInspector = await usersService.getUserById(inspector, request.session);
-			inspectorName = assignedInspector ? formatFirstInitialLastName(assignedInspector.name) : null;
-		}
+		const inspectorName = await getInspectorFormattedEmailName(inspector, request);
 
 		await startCaseService.setStartDate(
 			request.apiClient,

--- a/appeals/web/src/server/appeals/appeal-details/start-case/hearing/hearing.controller.js
+++ b/appeals/web/src/server/appeals/appeal-details/start-case/hearing/hearing.controller.js
@@ -1,6 +1,7 @@
 import { appealProcedureToLabelText } from '#appeals/appeal-details/change-procedure-type/change-procedure-check-and-confirm/change-procedure-check-and-confirm.mapper.js';
 import { sessionValuesToDateTime } from '#appeals/appeal-details/hearing/setup/set-up-hearing.controller.js';
 import { hearingDatePage } from '#appeals/appeal-details/hearing/setup/set-up-hearing.mapper.js';
+import usersService from '#appeals/appeal-users/users-service.js';
 import { appealShortReference } from '#lib/appeals-formatter.js';
 import {
 	dateISOStringToDisplayDate,
@@ -19,9 +20,11 @@ import { renderCheckYourAnswersComponent } from '#lib/mappers/components/page-co
 import { detailsComponent } from '#lib/mappers/components/page-components/details.js';
 import { simpleHtmlComponent } from '#lib/mappers/index.js';
 import { addNotificationBannerToSession } from '#lib/session-utilities.js';
+import { formatFirstInitialLastName } from '#lib/string-utilities.js';
 import { preserveQueryString } from '#lib/url-utilities.js';
 import { capitalize } from 'lodash-es';
-import { getStartCaseNotifyPreviews, setStartDate } from '../start-case.service.js';
+import * as startCaseService from '../start-case.service.js';
+import { getStartCaseNotifyPreviews } from '../start-case.service.js';
 import { dateKnownPage, estimationPage } from './hearing.mapper.js';
 
 /** @typedef {import('@pins/express').ValidationErrors} ValidationErrors */
@@ -235,6 +238,14 @@ export const getHearingConfirm = async (request, response) => {
 	let appellantPreview = errorMessage;
 	/** @type {string} */
 	let lpaPreview = errorMessage;
+
+	const inspector = currentAppeal.inspector;
+	let inspectorName;
+	if (inspector) {
+		const assignedInspector = await usersService.getUserById(inspector, request.session);
+		inspectorName = assignedInspector ? formatFirstInitialLastName(assignedInspector.name) : null;
+	}
+
 	try {
 		const result = await getStartCaseNotifyPreviews(
 			request.apiClient,
@@ -242,7 +253,9 @@ export const getHearingConfirm = async (request, response) => {
 			undefined,
 			sessionValues?.appealProcedure,
 			dateKnown ? hearingStartTime : undefined,
-			hearingEstimatedDays
+			hearingEstimatedDays,
+			null,
+			inspectorName
 		);
 		appellantPreview = result.appellant || '';
 		lpaPreview = result.lpa || '';
@@ -370,7 +383,7 @@ export const getHearingConfirm = async (request, response) => {
 export const postHearingConfirm = async (request, response) => {
 	try {
 		const {
-			currentAppeal: { appealId }
+			currentAppeal: { appealId, inspector }
 		} = request;
 
 		const sessionValues = getSessionValuesForAppeal(request, 'startCaseAppealProcedure', appealId);
@@ -387,13 +400,20 @@ export const postHearingConfirm = async (request, response) => {
 		const hearingStartTime =
 			sessionValues?.dateKnown === 'yes' ? hearingStartTimeFromSession(sessionValues) : undefined;
 
-		await setStartDate(
+		let inspectorName;
+		if (inspector) {
+			const assignedInspector = await usersService.getUserById(inspector, request.session);
+			inspectorName = assignedInspector ? formatFirstInitialLastName(assignedInspector.name) : null;
+		}
+
+		await startCaseService.setStartDate(
 			request.apiClient,
 			appealId,
 			getTodaysISOString(),
 			sessionValues?.appealProcedure,
 			hearingStartTime,
-			hearingEstimatedDays
+			hearingEstimatedDays,
+			inspectorName
 		);
 
 		addNotificationBannerToSession({

--- a/appeals/web/src/server/appeals/appeal-details/start-case/start-case.controller.js
+++ b/appeals/web/src/server/appeals/appeal-details/start-case/start-case.controller.js
@@ -1,3 +1,4 @@
+import usersService from '#appeals/appeal-users/users-service.js';
 import featureFlags from '#common/feature-flags.js';
 import { getEnabledHearingAppealTypes } from '#common/hearing-appeal-types.js';
 import { getEnabledInquiryAppealTypes } from '#common/inquiry-appeal-types.js';
@@ -11,6 +12,7 @@ import logger from '#lib/logger.js';
 import isLinkedAppeal from '#lib/mappers/utils/is-linked-appeal.js';
 import { backLinkGenerator } from '#lib/middleware/save-back-url.js';
 import { addNotificationBannerToSession } from '#lib/session-utilities.js';
+import { formatFirstInitialLastName } from '#lib/string-utilities.js';
 import {
 	addBackLinkQueryToUrl,
 	getBackLinkUrlFromQuery,
@@ -328,7 +330,7 @@ export const getConfirmProcedure = async (request, response) => {
  */
 const renderConfirmProcedure = async (request, response) => {
 	const {
-		currentAppeal: { appealId, appealReference, appealType },
+		currentAppeal: { appealId, appealReference, appealType, inspector },
 		errors
 	} = request;
 
@@ -345,6 +347,12 @@ const renderConfirmProcedure = async (request, response) => {
 	/** @type {{appellant: string, lpa: string} | undefined} */
 	let emailPreviews;
 
+	let inspectorName;
+	if (inspector) {
+		const assignedInspector = await usersService.getUserById(inspector, request.session);
+		inspectorName = assignedInspector ? formatFirstInitialLastName(assignedInspector.name) : null;
+	}
+
 	if (showEmailPreviews) {
 		const errorMessage = 'Failed to generate email preview';
 		try {
@@ -352,7 +360,11 @@ const renderConfirmProcedure = async (request, response) => {
 				request.apiClient,
 				appealId,
 				undefined,
-				sessionValues?.appealProcedure
+				sessionValues?.appealProcedure,
+				null,
+				null,
+				null,
+				inspectorName
 			);
 			emailPreviews = {
 				appellant: result.appellant || errorMessage,
@@ -381,7 +393,7 @@ const renderConfirmProcedure = async (request, response) => {
 export const postConfirmProcedure = async (request, response) => {
 	try {
 		const {
-			currentAppeal: { appealId }
+			currentAppeal: { appealId, inspector }
 		} = request;
 
 		const sessionValues = getSessionValuesForAppeal(request, 'startCaseAppealProcedure', appealId);
@@ -390,11 +402,20 @@ export const postConfirmProcedure = async (request, response) => {
 			return response.status(500).render('app/500.njk');
 		}
 
+		let inspectorName;
+		if (inspector) {
+			const assignedInspector = await usersService.getUserById(inspector, request.session);
+			inspectorName = assignedInspector ? formatFirstInitialLastName(assignedInspector.name) : null;
+		}
+
 		await startCaseService.setStartDate(
 			request.apiClient,
 			appealId,
 			getTodaysISOString(),
-			sessionValues?.appealProcedure
+			sessionValues?.appealProcedure,
+			null,
+			null,
+			inspectorName
 		);
 
 		addNotificationBannerToSession({

--- a/appeals/web/src/server/appeals/appeal-details/start-case/start-case.controller.js
+++ b/appeals/web/src/server/appeals/appeal-details/start-case/start-case.controller.js
@@ -1,4 +1,3 @@
-import usersService from '#appeals/appeal-users/users-service.js';
 import featureFlags from '#common/feature-flags.js';
 import { getEnabledHearingAppealTypes } from '#common/hearing-appeal-types.js';
 import { getEnabledInquiryAppealTypes } from '#common/inquiry-appeal-types.js';
@@ -11,8 +10,8 @@ import {
 import logger from '#lib/logger.js';
 import isLinkedAppeal from '#lib/mappers/utils/is-linked-appeal.js';
 import { backLinkGenerator } from '#lib/middleware/save-back-url.js';
+import { getInspectorFormattedEmailName } from '#lib/service-user-formatter.js';
 import { addNotificationBannerToSession } from '#lib/session-utilities.js';
-import { formatFirstInitialLastName } from '#lib/string-utilities.js';
 import {
 	addBackLinkQueryToUrl,
 	getBackLinkUrlFromQuery,
@@ -347,11 +346,7 @@ const renderConfirmProcedure = async (request, response) => {
 	/** @type {{appellant: string, lpa: string} | undefined} */
 	let emailPreviews;
 
-	let inspectorName;
-	if (inspector) {
-		const assignedInspector = await usersService.getUserById(inspector, request.session);
-		inspectorName = assignedInspector ? formatFirstInitialLastName(assignedInspector.name) : null;
-	}
+	const inspectorName = await getInspectorFormattedEmailName(inspector, request);
 
 	if (showEmailPreviews) {
 		const errorMessage = 'Failed to generate email preview';
@@ -402,11 +397,7 @@ export const postConfirmProcedure = async (request, response) => {
 			return response.status(500).render('app/500.njk');
 		}
 
-		let inspectorName;
-		if (inspector) {
-			const assignedInspector = await usersService.getUserById(inspector, request.session);
-			inspectorName = assignedInspector ? formatFirstInitialLastName(assignedInspector.name) : null;
-		}
+		const inspectorName = await getInspectorFormattedEmailName(inspector, request);
 
 		await startCaseService.setStartDate(
 			request.apiClient,

--- a/appeals/web/src/server/appeals/appeal-details/start-case/start-case.service.js
+++ b/appeals/web/src/server/appeals/appeal-details/start-case/start-case.service.js
@@ -19,9 +19,10 @@
  * @param {import('got').Got} apiClient
  * @param {string} appealId
  * @param {string} dateISOString
- * @param {string} [procedureType]
- * @param {string} [hearingStartTime]
- * @param {string} [hearingEstimatedDays]
+ * @param {string | null} [procedureType]
+ * @param {string | null} [hearingStartTime]
+ * @param {string | null} [hearingEstimatedDays]
+ * @param {string | null | undefined} inspectorName
  * @returns {Promise<Appeal>}
  */
 export async function setStartDate(
@@ -30,7 +31,8 @@ export async function setStartDate(
 	dateISOString,
 	procedureType,
 	hearingStartTime,
-	hearingEstimatedDays
+	hearingEstimatedDays,
+	inspectorName = null
 ) {
 	return await apiClient
 		.post(`appeals/${appealId}/appeal-timetables`, {
@@ -38,7 +40,8 @@ export async function setStartDate(
 				startDate: dateISOString,
 				...(procedureType && { procedureType }),
 				...(hearingStartTime && { hearingStartTime }),
-				...(hearingEstimatedDays && { hearingEstimatedDays })
+				...(hearingEstimatedDays && { hearingEstimatedDays }),
+				...(inspectorName && { inspectorName })
 			}
 		})
 		.json();
@@ -49,10 +52,11 @@ export async function setStartDate(
  * @param {import('got').Got} apiClient
  * @param {string} appealId
  * @param {string} [startDate]
- * @param {string} [procedureType]
- * @param {string} [hearingStartTime]
- * @param {string} [hearingEstimatedDays]
+ * @param {string | null} [procedureType]
+ * @param {string | null} [hearingStartTime]
+ * @param {string | null} [hearingEstimatedDays]
  * @param {any} [inquiry]
+ * @param {string | null | undefined} inspectorName
  * @returns {Promise<{appellant?: string, lpa?: string}>}
  */
 export async function getStartCaseNotifyPreviews(
@@ -62,7 +66,8 @@ export async function getStartCaseNotifyPreviews(
 	procedureType,
 	hearingStartTime,
 	hearingEstimatedDays,
-	inquiry
+	inquiry,
+	inspectorName = null
 ) {
 	const result = await apiClient
 		.post(`appeals/${appealId}/appeal-timetables/notify-preview`, {
@@ -71,7 +76,8 @@ export async function getStartCaseNotifyPreviews(
 				...(procedureType && { procedureType }),
 				...(hearingStartTime && { hearingStartTime }),
 				...(hearingEstimatedDays && { hearingEstimatedDays }),
-				...(inquiry && { inquiry })
+				...(inquiry && { inquiry }),
+				...(inspectorName && { inspectorName })
 			}
 		})
 		.json();

--- a/appeals/web/src/server/lib/__tests__/string-utilities.test.js
+++ b/appeals/web/src/server/lib/__tests__/string-utilities.test.js
@@ -1,0 +1,27 @@
+import { formatFirstInitialLastName } from '../string-utilities.js';
+
+describe('formatFirstInitialLastName', () => {
+	it('formats a standard first and last name', () => {
+		expect(formatFirstInitialLastName('John Smith')).toBe('J. Smith');
+	});
+
+	it('formats a name with multiple middle names', () => {
+		expect(formatFirstInitialLastName('Mary Jane Watson')).toBe('M. Watson');
+	});
+
+	it('formats a single name', () => {
+		expect(formatFirstInitialLastName('Cher')).toBe('C. Cher');
+	});
+
+	it('trims extra spaces and formats correctly', () => {
+		expect(formatFirstInitialLastName('  Alice   ')).toBe('A. Alice');
+	});
+
+	it('returns empty string for empty input', () => {
+		expect(formatFirstInitialLastName('')).toBe('');
+	});
+
+	it('handles names with mixed case', () => {
+		expect(formatFirstInitialLastName('ALICE Johnson')).toBe('A. Johnson');
+	});
+});

--- a/appeals/web/src/server/lib/service-user-formatter.js
+++ b/appeals/web/src/server/lib/service-user-formatter.js
@@ -1,3 +1,6 @@
+import usersService from '#appeals/appeal-users/users-service.js';
+import { formatFirstInitialLastName } from '#lib/string-utilities.js';
+
 /**
  *
  * @param {import("@pins/appeals.api/src/server/endpoints/appeals.js").ServiceUserResponse} serviceUser
@@ -32,4 +35,15 @@ export const formatServiceUserAsHtmlList = (serviceUser) => {
 		serviceUser.phoneNumber ? '<li>' + serviceUser.phoneNumber + '</li>' : ''
 	}`;
 	return `<ul class="govuk-list">${name}${organisationName}${email}${phoneNumber}</ul>`;
+};
+
+/**
+ * @param {string | undefined | null} inspector
+ * @param {import('@pins/express/types/express.js').Request} request
+ */
+export const getInspectorFormattedEmailName = async (inspector, request) => {
+	const assignedInspector = inspector
+		? await usersService.getUserById(inspector, request.session)
+		: null;
+	return assignedInspector ? formatFirstInitialLastName(assignedInspector?.name) : null;
 };

--- a/appeals/web/src/server/lib/string-utilities.js
+++ b/appeals/web/src/server/lib/string-utilities.js
@@ -1,6 +1,20 @@
 import { escape } from 'lodash-es';
 
 /**
+ * @param {string} name
+ * @returns {string}
+ */
+export const formatFirstInitialLastName = (name) => {
+	if (!name || typeof name !== 'string') return '';
+	const parts = name.trim().split(/\s+/).filter(Boolean);
+	if (parts.length === 0) return '';
+	const firstInitial = parts[0].charAt(0).toUpperCase();
+	const lastNameRaw = parts.length > 1 ? parts[parts.length - 1] : parts[0];
+	const lastName = lastNameRaw.charAt(0).toUpperCase() + lastNameRaw.slice(1).toLowerCase();
+	return `${firstInitial}. ${lastName}`;
+};
+
+/**
  * @param {string} str
  * @returns {boolean}
  */


### PR DESCRIPTION

- **Name formatting function added to create gender neutral name style: (John Smith > J. Smith)**
- **Test file added: string-utilities.test.js containing test for new function**
- **Name formatting function called on web-side CYA posts:**
1. _Inquiry start case_ 
2. _Inquiry set up_
3. _Inquiry update_
4. _Hearing start case_
5. _Hearing set up_
6. _Hearing update_
7. _Site visit scheduled: accompanied_
8. _Site visit scheduled - access required_
9. _Site visit scheduled - accompanied_
- **Value passed to corresponding API notify functions**
- **Value inserted into corresponding notify templates for LPA and appellant**
- **Tests updated to include new value passed to notify templates**

Ticket:
https://pins-ds.atlassian.net/browse/A2-6114
