### PR TITLE
fix(web): update notify preview invalid enforcement notice appeal (A2…

### DIFF
--- a/appeals/web/src/server/appeals/appeal-details/appellant-case/appellant-case.controller.js
+++ b/appeals/web/src/server/appeals/appeal-details/appellant-case/appellant-case.controller.js
@@ -167,7 +167,9 @@ const renderCheckAndConfirm = async (request, response) => {
 					webAppellantCaseReviewOutcome.reasonsText
 				),
 				team_email_address: assignedTeamEmail,
-				ground_a_barred: webAppellantCaseReviewOutcome.reasons.includes(GROUND_A_BARRED_REASON_ID),
+				ground_a_barred: webAppellantCaseReviewOutcome.reasons.includes(
+					GROUND_A_BARRED_REASON_ID.toString()
+				),
 				other_live_appeals: webAppellantCaseReviewOutcome.otherLiveAppeals === 'yes',
 				effective_date: currentAppeal.enforcementNotice?.appellantCase?.effectiveDate
 					? formatDate(


### PR DESCRIPTION
…-7867)

Small change to the 'ground_a_barred' check when generating notify preview for invalid enforcement notice appeal - reason id is a string in webAppellantCaseReviewOutcome reasons array and ground_a id was not being picked up if multiple reasons.

## Issue ticket number and link

[Ticket](https://pins-ds.atlassian.net/browse/A2-7867)
