### PR TITLE
fix(api): use correct date in enforcement notice withdrawn notify (A2…

### DIFF
--- a/appeals/api/src/server/endpoints/cancel/cancel.service.js
+++ b/appeals/api/src/server/endpoints/cancel/cancel.service.js
@@ -101,8 +101,8 @@ export const enforcementNoticeWithdrawn = async (
 		appeal_reference_number: appeal.reference,
 		local_planning_authority: appeal.lpa?.name || '',
 		enforcement_reference: appellantCase.enforcementReference || '',
-		effective_date: appellantCase.enforcementEffectiveDate
-			? formatDate(new Date(appellantCase.enforcementEffectiveDate), false)
+		issue_date: appellantCase.enforcementIssueDate
+			? formatDate(new Date(appellantCase.enforcementIssueDate), false)
 			: undefined,
 		site_address: siteAddress,
 		event_type: eventType,

--- a/appeals/api/src/server/notify/templates/__tests__/notify-appeal-cancelled-enforcement-notice-withdrawn.test.js
+++ b/appeals/api/src/server/notify/templates/__tests__/notify-appeal-cancelled-enforcement-notice-withdrawn.test.js
@@ -14,7 +14,7 @@ describe('appeal-cancelled-enforcement-notice-withdrawn.content.md', () => {
 				appeal_reference_number: '134526',
 				local_planning_authority: 'Bristol City Council',
 				enforcement_reference: 'ENF/2025/123456',
-				effective_date: '01 January 2025',
+				issue_date: '01 January 2025',
 				site_address: '96 The Avenue, Leftfield, Maidstone, Kent, MD21 5XY, United Kingdom',
 				event_type: 'site visit',
 				team_email_address: 'caseofficers@planninginspectorate.gov.uk'
@@ -72,7 +72,7 @@ describe('appeal-cancelled-enforcement-notice-withdrawn.content.md', () => {
 				appeal_reference_number: '134526',
 				local_planning_authority: 'Bristol City Council',
 				enforcement_reference: 'ENF/2025/123456',
-				effective_date: '01 January 2025',
+				issue_date: '01 January 2025',
 				site_address: '96 The Avenue, Leftfield, Maidstone, Kent, MD21 5XY, United Kingdom',
 				event_type: '',
 				team_email_address: 'caseofficers@planninginspectorate.gov.uk'

--- a/appeals/api/src/server/notify/templates/appeal-cancelled-enforcement-notice-withdrawn.content.md
+++ b/appeals/api/src/server/notify/templates/appeal-cancelled-enforcement-notice-withdrawn.content.md
@@ -1,6 +1,6 @@
 {{local_planning_authority}} has withdrawn the enforcement notice.
 
-The enforcement notice issued on {{effective_date}} will not take effect.
+The enforcement notice issued on {{issue_date}} will not take effect.
 
 {% include 'parts/appeal-details.md' %}
 


### PR DESCRIPTION
…-7713)

## Describe your changes

Uses enforcement issue date (rather than effective date) in enforcement notice withdrawn notify.

## Issue ticket number and link

[A2-7713](https://pins-ds.atlassian.net/browse/A2-7713)


[A2-7713]: https://pins-ds.atlassian.net/browse/A2-7713?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ