### PR TITLE
fix(web): correct copy for LDC section type codes (A2-7870)

### DIFF
--- a/appeals/web/src/server/appeals/appeal-details/appellant-case/ldc-type/__tests__/__snapshots__/ldc-type.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/appellant-case/ldc-type/__tests__/__snapshots__/ldc-type.test.js.snap
@@ -25,12 +25,12 @@ exports[`interest-in-land GET /change should render the ldc type page 1`] = `
                                     <div class="govuk-radios__item">
                                         <input class="govuk-radios__input" id="application-made-under-act-section-2"
                                         name="applicationMadeUnderActSection" type="radio" value="proposed-changes-to-a-listed-building">
-                                        <label class="govuk-label govuk-radios__label" for="application-made-under-act-section-2">Proposed changes to a listed building (section 192)</label>
+                                        <label class="govuk-label govuk-radios__label" for="application-made-under-act-section-2">Proposed changes to a listed building (section 26H)</label>
                                     </div>
                                     <div class="govuk-radios__item">
                                         <input class="govuk-radios__input" id="application-made-under-act-section-3"
                                         name="applicationMadeUnderActSection" type="radio" value="proposed-use-of-a-development">
-                                        <label class="govuk-label govuk-radios__label" for="application-made-under-act-section-3">Proposed use of a development (section 26H)</label>
+                                        <label class="govuk-label govuk-radios__label" for="application-made-under-act-section-3">Proposed use of a development (section 192)</label>
                                     </div>
                                 </div>
                             </fieldset>
@@ -85,12 +85,12 @@ exports[`interest-in-land POST /change should re-render the page with an error i
                                     <div class="govuk-radios__item">
                                         <input class="govuk-radios__input" id="application-made-under-act-section-2"
                                         name="applicationMadeUnderActSection" type="radio" value="proposed-changes-to-a-listed-building">
-                                        <label class="govuk-label govuk-radios__label" for="application-made-under-act-section-2">Proposed changes to a listed building (section 192)</label>
+                                        <label class="govuk-label govuk-radios__label" for="application-made-under-act-section-2">Proposed changes to a listed building (section 26H)</label>
                                     </div>
                                     <div class="govuk-radios__item">
                                         <input class="govuk-radios__input" id="application-made-under-act-section-3"
                                         name="applicationMadeUnderActSection" type="radio" value="proposed-use-of-a-development">
-                                        <label class="govuk-label govuk-radios__label" for="application-made-under-act-section-3">Proposed use of a development (section 26H)</label>
+                                        <label class="govuk-label govuk-radios__label" for="application-made-under-act-section-3">Proposed use of a development (section 192)</label>
                                     </div>
                                 </div>
                             </fieldset>

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/ldc-type/__tests__/__snapshots__/ldc-type.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/ldc-type/__tests__/__snapshots__/ldc-type.test.js.snap
@@ -25,12 +25,12 @@ exports[`appeal-under-act-section GET /change should render the ldc type page 1`
                                     <div class="govuk-radios__item">
                                         <input class="govuk-radios__input" id="appeal-under-act-section-2" name="appealUnderActSection"
                                         type="radio" value="proposed-changes-to-a-listed-building">
-                                        <label class="govuk-label govuk-radios__label" for="appeal-under-act-section-2">Proposed changes to a listed building (section 192)</label>
+                                        <label class="govuk-label govuk-radios__label" for="appeal-under-act-section-2">Proposed changes to a listed building (section 26H)</label>
                                     </div>
                                     <div class="govuk-radios__item">
                                         <input class="govuk-radios__input" id="appeal-under-act-section-3" name="appealUnderActSection"
                                         type="radio" value="proposed-use-of-a-development">
-                                        <label class="govuk-label govuk-radios__label" for="appeal-under-act-section-3">Proposed use of a development (section 26H)</label>
+                                        <label class="govuk-label govuk-radios__label" for="appeal-under-act-section-3">Proposed use of a development (section 192)</label>
                                     </div>
                                 </div>
                             </fieldset>
@@ -85,12 +85,12 @@ exports[`appeal-under-act-section POST /change should re-render the page with an
                                     <div class="govuk-radios__item">
                                         <input class="govuk-radios__input" id="appeal-under-act-section-2" name="appealUnderActSection"
                                         type="radio" value="proposed-changes-to-a-listed-building">
-                                        <label class="govuk-label govuk-radios__label" for="appeal-under-act-section-2">Proposed changes to a listed building (section 192)</label>
+                                        <label class="govuk-label govuk-radios__label" for="appeal-under-act-section-2">Proposed changes to a listed building (section 26H)</label>
                                     </div>
                                     <div class="govuk-radios__item">
                                         <input class="govuk-radios__input" id="appeal-under-act-section-3" name="appealUnderActSection"
                                         type="radio" value="proposed-use-of-a-development">
-                                        <label class="govuk-label govuk-radios__label" for="appeal-under-act-section-3">Proposed use of a development (section 26H)</label>
+                                        <label class="govuk-label govuk-radios__label" for="appeal-under-act-section-3">Proposed use of a development (section 192)</label>
                                     </div>
                                 </div>
                             </fieldset>

--- a/appeals/web/src/server/lib/mappers/data/appeal/submappers/__tests__/application-made-under-act-section.test.js
+++ b/appeals/web/src/server/lib/mappers/data/appeal/submappers/__tests__/application-made-under-act-section.test.js
@@ -5,9 +5,9 @@ describe('mapApplicationMadeUnderActSection', () => {
 		['existing-development', 'Existing development (section 191)'],
 		[
 			'proposed-changes-to-a-listed-building',
-			'Proposed changes to a listed building (section 192)'
+			'Proposed changes to a listed building (section 26H)'
 		],
-		['proposed-use-of-a-development', 'Proposed use of a development (section 26H)']
+		['proposed-use-of-a-development', 'Proposed use of a development (section 192)']
 	])(
 		'should return a summary list item with the correct values when applicationMadeUnderActSection is valid',
 		(value, expectedText) => {

--- a/appeals/web/src/server/lib/mappers/utils/map-application-made-under-act-section.js
+++ b/appeals/web/src/server/lib/mappers/utils/map-application-made-under-act-section.js
@@ -9,8 +9,8 @@ export const formatAppealUnderActSection = (appealUnderActSection) => {
 		case APPEAL_APPEAL_UNDER_ACT_SECTION.EXISTING_DEVELOPMENT:
 			return 'Existing development (section 191)';
 		case APPEAL_APPEAL_UNDER_ACT_SECTION.PROPOSED_CHANGES_TO_A_LISTED_BUILDING:
-			return 'Proposed changes to a listed building (section 192)';
+			return 'Proposed changes to a listed building (section 26H)';
 		case APPEAL_APPEAL_UNDER_ACT_SECTION.PROPOSED_USE_OF_A_DEVELOPMENT:
-			return 'Proposed use of a development (section 26H)';
+			return 'Proposed use of a development (section 192)';
 	}
 };


### PR DESCRIPTION
## Describe your changes

This PR corrects the section type codes for LDC which were previously the wrong way round. 
Updated copy reads:
- Proposed use of a development (section 192)

- Proposed changes to a listed building (section 26H)

## Issue ticket number and link

[Ticket](https://pins-ds.atlassian.net/browse/A2-7870)
