### PR TITLE
feat(appeals): remove hearing date known from select procedure flow

### DIFF
--- a/appeals/e2e/cypress/support/happyPathHelper.js
+++ b/appeals/e2e/cypress/support/happyPathHelper.js
@@ -107,14 +107,10 @@ export const happyPathHelper = {
 			startCase: true
 		}
 	) {
-		// proceed to setup hrearing
+		// proceed to setup hearing
 		happyPathHelper.viewCaseDetails(caseObj);
 		caseDetailsPage.clickReadyToStartCase();
 		caseDetailsPage.selectRadioButtonByValue(procedureType);
-
-		// check if date is known and if so enter date and time
-		caseDetailsPage.clickButtonByText('Continue');
-		caseDetailsPage.selectRadioButtonByValue(hearingProperties.date ? 'yes' : 'no');
 		caseDetailsPage.clickButtonByText('Continue');
 
 		if (hearingProperties.date) {

--- a/appeals/web/src/server/appeals/appeal-details/start-case/__tests__/start-case.test.js
+++ b/appeals/web/src/server/appeals/appeal-details/start-case/__tests__/start-case.test.js
@@ -535,7 +535,7 @@ describe('start-case', () => {
 
 		[
 			['false', 'select-procedure/check-and-confirm'],
-			['true', 'hearing']
+			['true', 'hearing/date']
 		].forEach(([featureFlag, redirectPath]) => {
 			describe(`with featureFlagHearingPostMvp set to ${featureFlag}`, () => {
 				it('should render the select procedure page with the expected radio option preselected if an appeal procedure is found in the session', async () => {
@@ -987,7 +987,7 @@ describe('start-case', () => {
 
 		[
 			['false', 'select-procedure/check-and-confirm'],
-			['true', 'hearing']
+			['true', 'hearing/date']
 		].forEach(([featureFlag, redirectPath]) => {
 			describe(`with featureFlagHearingPostMvp set to ${featureFlag}`, () => {
 				it(`should redirect to ${redirectPath} if a radio option was selected`, async () => {

--- a/appeals/web/src/server/appeals/appeal-details/start-case/hearing/__tests__/__snapshots__/start-case-hearing.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/start-case/hearing/__tests__/__snapshots__/start-case-hearing.test.js.snap
@@ -1,45 +1,5 @@
 // Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
-exports[`start case hearing flow GET /start-case/hearing should render the date known page 1`] = `
-"<main class="govuk-main-wrapper" id="main-content">
-    <div class="govuk-grid-row">
-        <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Appeal 351062 - start case</span>
-        </div>
-    </div>
-    <div class="govuk-grid-row">
-        <div class="govuk-grid-column-two-thirds">
-            <div class="govuk-grid-row">
-                <div class="govuk-grid-column-full">
-                    <form method="POST" novalidate="novalidate">
-                        <div class="govuk-form-group">
-                            <fieldset class="govuk-fieldset">
-                                <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
-                                    <h1 class="govuk-fieldset__heading"> Do you know the date and time of the hearing?</h1>
-                                </legend>
-                                <div class="govuk-radios" data-module="govuk-radios">
-                                    <div class="govuk-radios__item">
-                                        <input class="govuk-radios__input" id="date-known" name="dateKnown" type="radio"
-                                        value="yes">
-                                        <label class="govuk-label govuk-radios__label" for="date-known">Yes</label>
-                                    </div>
-                                    <div class="govuk-radios__item">
-                                        <input class="govuk-radios__input" id="date-known-2" name="dateKnown"
-                                        type="radio" value="no">
-                                        <label class="govuk-label govuk-radios__label" for="date-known-2">No</label>
-                                    </div>
-                                </div>
-                            </fieldset>
-                        </div>
-                        <button type="submit" data-prevent-double-click="true" class="govuk-button"
-                        data-module="govuk-button">Continue</button>
-                    </form>
-                </div>
-            </div>
-        </div>
-    </div>
-</main>"
-`;
-
 exports[`start case hearing flow GET /start-case/hearing/confirm should render an error message when the email preview fails 1`] = `
 "<main class="govuk-main-wrapper" id="main-content">
     <div class="govuk-grid-row">
@@ -56,11 +16,17 @@ exports[`start case hearing flow GET /start-case/hearing/confirm should render a
                         data-cy="change-appeal-procedure">Change <span class="govuk-visually-hidden">Appeal procedure</span></a>
                     </dd>
                 </div>
-                <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Do you know the date and time of the hearing?</dt>
-                    <dd                     class="govuk-summary-list__value">No</dd>
-                        <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/start-case/hearing?editEntrypoint=%2Fappeals-service%2Fappeal-details%2F1%2Fstart-case%2Fhearing"
-                            data-cy="change-date-known">Change <span class="govuk-visually-hidden">Do you know the date and time of the hearing?</span></a>
-                        </dd>
+                <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Hearing date</dt>
+                    <dd class="govuk-summary-list__value">1 February 3025</dd>
+                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/start-case/hearing/date?editEntrypoint=%2Fappeals-service%2Fappeal-details%2F1%2Fstart-case%2Fhearing%2Fdate"
+                        data-cy="change-hearing-date">Change <span class="govuk-visually-hidden">Hearing date</span></a>
+                    </dd>
+                </div>
+                <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Hearing time</dt>
+                    <dd class="govuk-summary-list__value">12:00pm</dd>
+                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/start-case/hearing/date?editEntrypoint=%2Fappeals-service%2Fappeal-details%2F1%2Fstart-case%2Fhearing%2Fdate"
+                        data-cy="change-hearing-time">Change <span class="govuk-visually-hidden">Hearing time</span></a>
+                    </dd>
                 </div>
                 <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Do you know the expected number of days to carry out the hearing?</dt>
                     <dd                     class="govuk-summary-list__value">No</dd>
@@ -100,7 +66,7 @@ exports[`start case hearing flow GET /start-case/hearing/confirm should render a
 </main>"
 `;
 
-exports[`start case hearing flow GET /start-case/hearing/confirm should render the confirm page when date is known 1`] = `
+exports[`start case hearing flow GET /start-case/hearing/confirm should render the confirm page 1`] = `
 "<main class="govuk-main-wrapper" id="main-content">
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Appeal 351062</span>
@@ -115,12 +81,6 @@ exports[`start case hearing flow GET /start-case/hearing/confirm should render t
                     <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/start-case/select-procedure?editEntrypoint=%2Fappeals-service%2Fappeal-details%2F1%2Fstart-case%2Fselect-procedure"
                         data-cy="change-appeal-procedure">Change <span class="govuk-visually-hidden">Appeal procedure</span></a>
                     </dd>
-                </div>
-                <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Do you know the date and time of the hearing?</dt>
-                    <dd                     class="govuk-summary-list__value">Yes</dd>
-                        <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/start-case/hearing?editEntrypoint=%2Fappeals-service%2Fappeal-details%2F1%2Fstart-case%2Fhearing"
-                            data-cy="change-date-known">Change <span class="govuk-visually-hidden">Do you know the date and time of the hearing?</span></a>
-                        </dd>
                 </div>
                 <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Hearing date</dt>
                     <dd class="govuk-summary-list__value">1 February 3025</dd>
@@ -144,66 +104,6 @@ exports[`start case hearing flow GET /start-case/hearing/confirm should render t
                     <dd                     class="govuk-summary-list__value">3</dd>
                         <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/start-case/hearing/estimation?editEntrypoint=%2Fappeals-service%2Fappeal-details%2F1%2Fstart-case%2Fhearing%2Festimation"
                             data-cy="change-hearing-estimation-days">Change <span class="govuk-visually-hidden">Expected number of days to carry out the hearing</span></a>
-                        </dd>
-                </div>
-            </dl>
-            <p class="govuk-body" data-cy="start-timetable-info">We’ll start the timetable now and send emails to the relevant parties.</p>
-            <div             class="govuk-grid-row">
-                <div class="govuk-grid-column-full">
-                    <details class="govuk-details" data-cy="preview-email-to-appellant">
-                        <summary class="govuk-details__summary"><span class="govuk-details__summary-text"> Preview email to appellant</span>
-                        </summary>
-                        <div class="govuk-details__text">Rendered HTML for appellant preview</div>
-                    </details>
-                </div>
-        </div>
-        <div class="govuk-grid-row">
-            <div class="govuk-grid-column-full">
-                <details class="govuk-details" data-cy="preview-email-to-lpa">
-                    <summary class="govuk-details__summary"><span class="govuk-details__summary-text"> Preview email to LPA</span>
-                    </summary>
-                    <div class="govuk-details__text">Rendered HTML for LPA preview</div>
-                </details>
-            </div>
-        </div>
-        <div class="govuk-grid-row">
-            <div class="govuk-grid-column-full">
-                <form method="post" novalidate="novalidate">
-                    <button type="submit" class="govuk-button" data-module="govuk-button">Start case</button>
-                </form>
-            </div>
-        </div>
-    </div>
-    </div>
-</main>"
-`;
-
-exports[`start case hearing flow GET /start-case/hearing/confirm should render the confirm page when date is not known 1`] = `
-"<main class="govuk-main-wrapper" id="main-content">
-    <div class="govuk-grid-row">
-        <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Appeal 351062</span>
-            <h1 class="govuk-heading-l">Check details and start case</h1>
-        </div>
-    </div>
-    <div class="govuk-grid-row">
-        <div class="govuk-grid-column-two-thirds">
-            <dl class="govuk-summary-list">
-                <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Appeal procedure</dt>
-                    <dd class="govuk-summary-list__value">Hearing</dd>
-                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/start-case/select-procedure?editEntrypoint=%2Fappeals-service%2Fappeal-details%2F1%2Fstart-case%2Fselect-procedure"
-                        data-cy="change-appeal-procedure">Change <span class="govuk-visually-hidden">Appeal procedure</span></a>
-                    </dd>
-                </div>
-                <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Do you know the date and time of the hearing?</dt>
-                    <dd                     class="govuk-summary-list__value">No</dd>
-                        <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/start-case/hearing?editEntrypoint=%2Fappeals-service%2Fappeal-details%2F1%2Fstart-case%2Fhearing"
-                            data-cy="change-date-known">Change <span class="govuk-visually-hidden">Do you know the date and time of the hearing?</span></a>
-                        </dd>
-                </div>
-                <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Do you know the expected number of days to carry out the hearing?</dt>
-                    <dd                     class="govuk-summary-list__value">No</dd>
-                        <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/start-case/hearing/estimation?editEntrypoint=%2Fappeals-service%2Fappeal-details%2F1%2Fstart-case%2Fhearing%2Festimation"
-                            data-cy="change-hearing-estimation-known">Change <span class="govuk-visually-hidden">Do you know the expected number of days to carry out the hearing?</span></a>
                         </dd>
                 </div>
             </dl>

--- a/appeals/web/src/server/appeals/appeal-details/start-case/hearing/__tests__/start-case-hearing.test.js
+++ b/appeals/web/src/server/appeals/appeal-details/start-case/hearing/__tests__/start-case-hearing.test.js
@@ -43,163 +43,6 @@ describe('start case hearing flow', () => {
 		jest.useRealTimers();
 	});
 
-	const editEntrypoint = encodeURIComponent(`${baseUrl}/1/start-case/hearing`);
-	describe('GET /start-case/hearing', () => {
-		it('should render the date known page', async () => {
-			const response = await request.get(`${baseUrl}/1/start-case/hearing`);
-			expect(response.statusCode).toBe(200);
-
-			const mainHtml = parseHtml(response.text).innerHTML;
-			expect(mainHtml).toMatchSnapshot();
-
-			const pageHtml = parseHtml(response.text, { rootElement: 'body' });
-			expect(pageHtml.querySelector('.govuk-caption-l')?.innerHTML.trim()).toBe(
-				'Appeal 351062 - start case'
-			);
-			expect(pageHtml.querySelector('main h1')?.innerHTML.trim()).toBe(
-				'Do you know the date and time of the hearing?'
-			);
-			expect(pageHtml.querySelector('input#date-known')).not.toBeNull();
-			expect(pageHtml.querySelector('button:contains("Continue")')).not.toBeNull();
-			expect(pageHtml.querySelector('a.govuk-back-link')?.getAttribute('href')).toBe(
-				`${baseUrl}/1/start-case/select-procedure`
-			);
-		});
-
-		it('should preselect a previously entered value', async () => {
-			nock('http://test/')
-				.get('/appeals/1?include=all')
-				.reply(200, {
-					...appealDataWithoutStartDate,
-					appealType: 'Planning appeal'
-				});
-
-			await request.post(`${baseUrl}/1/start-case/hearing`).send({ dateKnown: 'yes' });
-
-			const response = await request.get(`${baseUrl}/1/start-case/hearing`);
-			expect(response.statusCode).toBe(200);
-
-			const pageHtml = parseHtml(response.text, { rootElement: 'body' });
-			expect(
-				pageHtml.querySelector('input[name="dateKnown"][value="yes"]')?.getAttribute('checked')
-			).toBeDefined();
-		});
-
-		it('should not preselect a previously entered value for a different appeal', async () => {
-			nock('http://test/')
-				.get('/appeals/1?include=all')
-				.reply(200, {
-					...appealDataWithoutStartDate,
-					appealType: 'Planning appeal'
-				});
-			nock('http://test/')
-				.get('/appeals/2?include=all')
-				.reply(200, {
-					...appealDataWithoutStartDate,
-					appealType: 'Planning appeal'
-				});
-
-			await request.post(`${baseUrl}/2/start-case/hearing`).send({ dateKnown: 'yes' });
-
-			const response = await request.get(`${baseUrl}/1/start-case/hearing`);
-			expect(response.statusCode).toBe(200);
-
-			const pageHtml = parseHtml(response.text, { rootElement: 'body' });
-			expect(
-				pageHtml.querySelector('input[name="dateKnown"][value="yes"]')?.getAttribute('checked')
-			).toBeUndefined();
-		});
-
-		it('should render an edited value', async () => {
-			nock('http://test/')
-				.get('/appeals/1?include=all')
-				.twice()
-				.reply(200, {
-					...appealDataWithoutStartDate,
-					appealType: 'Planning appeal'
-				});
-
-			await request.post(`${baseUrl}/1/start-case/hearing`).send({ dateKnown: 'no' });
-			await request
-				.post(`${baseUrl}/1/start-case/hearing?editEntrypoint=${editEntrypoint}`)
-				.send({ dateKnown: 'yes' });
-
-			const response = await request.get(
-				`${baseUrl}/1/start-case/hearing?editEntrypoint=${editEntrypoint}`
-			);
-			expect(response.statusCode).toBe(200);
-
-			const pageHtml = parseHtml(response.text, { rootElement: 'body' });
-			expect(
-				pageHtml.querySelector('input[name="dateKnown"][value="yes"]')?.getAttribute('checked')
-			).toBeDefined();
-		});
-
-		it('should have a back link to the CYA page when editing', async () => {
-			const response = await request.get(
-				`${baseUrl}/1/start-case/hearing?editEntrypoint=${editEntrypoint}`
-			);
-			const pageHtml = parseHtml(response.text, { rootElement: 'body' });
-			expect(pageHtml.querySelector('.govuk-back-link')?.getAttribute('href')).toBe(
-				`${baseUrl}/1/start-case/hearing/confirm`
-			);
-		});
-	});
-
-	describe('POST /start-case/hearing', () => {
-		it('should redirect to the date page when the date is known', async () => {
-			nock('http://test/')
-				.get('/appeals/1?include=all')
-				.reply(200, {
-					...appealDataWithoutStartDate,
-					appealType: 'Planning appeal'
-				});
-
-			const response = await request
-				.post(`${baseUrl}/1/start-case/hearing`)
-				.send({ dateKnown: 'yes' });
-			expect(response.statusCode).toBe(302);
-			expect(response.headers.location).toBe(`${baseUrl}/1/start-case/hearing/date`);
-		});
-
-		it('should redirect to the estimation page when the date is not known', async () => {
-			nock('http://test/')
-				.get('/appeals/1?include=all')
-				.reply(200, {
-					...appealDataWithoutStartDate,
-					appealType: 'Planning appeal'
-				});
-
-			const response = await request
-				.post(`${baseUrl}/1/start-case/hearing`)
-				.send({ dateKnown: 'no' });
-			expect(response.statusCode).toBe(302);
-			expect(response.headers.location).toBe(`${baseUrl}/1/start-case/hearing/estimation`);
-		});
-
-		it('should return 400 on missing dateKnown with appropriate error message', async () => {
-			nock('http://test/')
-				.get('/appeals/1?include=all')
-				.reply(200, {
-					...appealDataWithoutStartDate,
-					appealType: 'Planning appeal'
-				});
-
-			const response = await request.post(`${baseUrl}/1/start-case/hearing`).send({});
-			expect(response.statusCode).toBe(400);
-
-			const errorSummaryHtml = parseHtml(response.text, {
-				rootElement: '.govuk-error-summary',
-				skipPrettyPrint: true
-			});
-
-			expect(errorSummaryHtml.querySelector('h2')?.innerHTML.trim()).toBe('There is a problem');
-			expect(errorSummaryHtml.querySelector('.govuk-error-summary li')?.innerHTML.trim()).toContain(
-				'Select yes if you know the date and time the hearing will take place'
-			);
-		});
-	});
-
 	describe('GET /start-case/hearing/date', () => {
 		const editEntrypoint = encodeURIComponent(`${baseUrl}/1/start-case/hearing/date`);
 
@@ -222,7 +65,7 @@ describe('start case hearing flow', () => {
 			expect(pageHtml.querySelector('input#hearing-time-minute')).not.toBeNull();
 			expect(pageHtml.querySelector('button:contains("Continue")')).not.toBeNull();
 			expect(pageHtml.querySelector('a.govuk-back-link')?.getAttribute('href')).toBe(
-				`${baseUrl}/1/start-case/hearing`
+				`${baseUrl}/1/start-case/select-procedure`
 			);
 		});
 
@@ -290,18 +133,6 @@ describe('start case hearing flow', () => {
 			expect(pageHtml.querySelector('input#hearing-date-year')?.getAttribute('value')).toBe('3025');
 			expect(pageHtml.querySelector('input#hearing-time-hour')?.getAttribute('value')).toBe('13');
 			expect(pageHtml.querySelector('input#hearing-time-minute')?.getAttribute('value')).toBe('00');
-		});
-
-		it('should have a back link to the CYA page when editing', async () => {
-			const response = await request.get(
-				`${baseUrl}/1/start-case/hearing/date?editEntrypoint=${editEntrypoint}`
-			);
-			expect(response.statusCode).toBe(200);
-
-			const pageHtml = parseHtml(response.text, { rootElement: 'body' });
-			expect(pageHtml.querySelector('.govuk-back-link')?.getAttribute('href')).toBe(
-				`${baseUrl}/1/start-case/hearing/confirm`
-			);
 		});
 	});
 
@@ -435,7 +266,7 @@ describe('start case hearing flow', () => {
 			expect(pageHtml.querySelector('button:contains("Continue")')).not.toBeNull();
 		});
 
-		it('should have a back link to hearing date when date is known', async () => {
+		it('should have a back link to hearing date', async () => {
 			nock('http://test/')
 				.get('/appeals/1?include=all')
 				.reply(200, {
@@ -443,31 +274,19 @@ describe('start case hearing flow', () => {
 					appealType: 'Planning appeal'
 				});
 
-			await request.post(`${baseUrl}/1/start-case/hearing`).send({ dateKnown: 'yes' });
+			await request.post(`${baseUrl}/1/start-case/hearing/date`).send({
+				'hearing-date-day': '01',
+				'hearing-date-month': '02',
+				'hearing-date-year': '3025',
+				'hearing-time-hour': '12',
+				'hearing-time-minute': '00'
+			});
 			const response = await request.get(`${baseUrl}/1/start-case/hearing/estimation`);
 			expect(response.statusCode).toBe(200);
 
 			const pageHtml = parseHtml(response.text, { rootElement: 'body' });
 			expect(pageHtml.querySelector('.govuk-back-link')?.getAttribute('href')).toBe(
 				`${baseUrl}/1/start-case/hearing/date`
-			);
-		});
-
-		it('should have a back link to hearing known page when date is not known', async () => {
-			nock('http://test/')
-				.get('/appeals/1?include=all')
-				.reply(200, {
-					...appealDataWithoutStartDate,
-					appealType: 'Planning appeal'
-				});
-
-			await request.post(`${baseUrl}/1/start-case/hearing`).send({ dateKnown: 'no' });
-			const response = await request.get(`${baseUrl}/1/start-case/hearing/estimation`);
-			expect(response.statusCode).toBe(200);
-
-			const pageHtml = parseHtml(response.text, { rootElement: 'body' });
-			expect(pageHtml.querySelector('.govuk-back-link')?.getAttribute('href')).toBe(
-				`${baseUrl}/1/start-case/hearing`
 			);
 		});
 
@@ -554,7 +373,7 @@ describe('start case hearing flow', () => {
 	});
 
 	describe('GET /start-case/hearing/confirm', () => {
-		it('should render the confirm page when date is known', async () => {
+		it('should render the confirm page', async () => {
 			nock('http://test/').get('/appeals/1/case-team-email').reply(200, {
 				id: 1,
 				email: 'caseofficers@planninginspectorate.gov.uk',
@@ -581,7 +400,6 @@ describe('start case hearing flow', () => {
 			await request
 				.post(`${baseUrl}/1/start-case/select-procedure`)
 				.send({ appealProcedure: 'hearing' });
-			await request.post(`${baseUrl}/1/start-case/hearing`).send({ dateKnown: 'yes' });
 			await request.post(`${baseUrl}/1/start-case/hearing/date`).send({
 				'hearing-date-day': '01',
 				'hearing-date-month': '02',
@@ -609,9 +427,6 @@ describe('start case hearing flow', () => {
 			).toBe(
 				`${baseUrl}/1/start-case/select-procedure?editEntrypoint=%2Fappeals-service%2Fappeal-details%2F1%2Fstart-case%2Fselect-procedure`
 			);
-			expect(pageHtml.querySelector('a[data-cy="change-date-known"]')?.getAttribute('href')).toBe(
-				`${baseUrl}/1/start-case/hearing?editEntrypoint=%2Fappeals-service%2Fappeal-details%2F1%2Fstart-case%2Fhearing`
-			);
 			expect(pageHtml.querySelector('a[data-cy="change-hearing-date"]')?.getAttribute('href')).toBe(
 				`${baseUrl}/1/start-case/hearing/date?editEntrypoint=%2Fappeals-service%2Fappeal-details%2F1%2Fstart-case%2Fhearing%2Fdate`
 			);
@@ -628,83 +443,6 @@ describe('start case hearing flow', () => {
 			).toBe(
 				`${baseUrl}/1/start-case/hearing/estimation?editEntrypoint=%2Fappeals-service%2Fappeal-details%2F1%2Fstart-case%2Fhearing%2Festimation`
 			);
-			expect(pageHtml.innerHTML).toContain(
-				'We’ll start the timetable now and send emails to the relevant parties.'
-			);
-			expect(pageHtml.querySelector('button:contains("Start case")')).not.toBeNull();
-
-			expect(
-				pageHtml.querySelector('details[data-cy="preview-email-to-appellant"]')
-			).not.toBeNull();
-			expect(pageHtml.querySelector('details[data-cy="preview-email-to-lpa"]')).not.toBeNull();
-
-			const appellantPreview = pageHtml.querySelector(
-				'details[data-cy="preview-email-to-appellant"] .govuk-details__text'
-			)?.innerHTML;
-			const lpaPreview = pageHtml.querySelector(
-				'details[data-cy="preview-email-to-lpa"] .govuk-details__text'
-			)?.innerHTML;
-			expect(appellantPreview).toContain('Rendered HTML for appellant preview');
-			expect(lpaPreview).toContain('Rendered HTML for LPA preview');
-		});
-
-		it('should render the confirm page when date is not known', async () => {
-			nock('http://test/').get('/appeals/1/case-team-email').reply(200, {
-				id: 1,
-				email: 'caseofficers@planninginspectorate.gov.uk',
-				name: 'standard email'
-			});
-			nock('http://test/')
-				.get('/appeals/1?include=all')
-				.times(4)
-				.reply(200, {
-					...appealDataWithoutStartDate,
-					appealType: 'Planning appeal'
-				});
-			nock('http://test/')
-				.post('/appeals/1/appeal-timetables/notify-preview', {
-					procedureType: 'hearing'
-				})
-				.reply(200, {
-					appellant: 'Rendered HTML for appellant preview',
-					lpa: 'Rendered HTML for LPA preview'
-				});
-
-			// Set up the session values
-			await request
-				.post(`${baseUrl}/1/start-case/select-procedure`)
-				.send({ appealProcedure: 'hearing' });
-			await request.post(`${baseUrl}/1/start-case/hearing`).send({ dateKnown: 'no' });
-			await request
-				.post(`${baseUrl}/1/start-case/hearing/estimation`)
-				.send({ hearingEstimationYesNo: 'no' });
-			const response = await request.get(`${baseUrl}/1/start-case/hearing/confirm`);
-
-			expect(response.statusCode).toBe(200);
-			const mainHtml = parseHtml(response.text).innerHTML;
-			expect(mainHtml).toMatchSnapshot();
-
-			const pageHtml = parseHtml(response.text, { rootElement: 'body' });
-			expect(pageHtml.querySelector('.govuk-caption-l')?.innerHTML.trim()).toBe('Appeal 351062');
-			expect(pageHtml.querySelector('main h1')?.innerHTML.trim()).toBe(
-				'Check details and start case'
-			);
-			expect(
-				pageHtml.querySelector('a[data-cy="change-appeal-procedure"]')?.getAttribute('href')
-			).toBe(
-				`${baseUrl}/1/start-case/select-procedure?editEntrypoint=%2Fappeals-service%2Fappeal-details%2F1%2Fstart-case%2Fselect-procedure`
-			);
-			expect(pageHtml.querySelector('a[data-cy="change-date-known"]')?.getAttribute('href')).toBe(
-				`${baseUrl}/1/start-case/hearing?editEntrypoint=%2Fappeals-service%2Fappeal-details%2F1%2Fstart-case%2Fhearing`
-			);
-			expect(pageHtml.querySelector('a[data-cy="change-hearing-date"]')).toBeNull();
-			expect(pageHtml.querySelector('a[data-cy="change-hearing-time"]')).toBeNull();
-			expect(
-				pageHtml.querySelector('a[data-cy="change-hearing-estimation-known"]')?.getAttribute('href')
-			).toBe(
-				`${baseUrl}/1/start-case/hearing/estimation?editEntrypoint=%2Fappeals-service%2Fappeal-details%2F1%2Fstart-case%2Fhearing%2Festimation`
-			);
-			expect(pageHtml.querySelector('a[data-cy="change-hearing-estimation-days"]')).toBeNull();
 			expect(pageHtml.innerHTML).toContain(
 				'We’ll start the timetable now and send emails to the relevant parties.'
 			);
@@ -777,7 +515,13 @@ describe('start case hearing flow', () => {
 			await request
 				.post(`${baseUrl}/1/start-case/select-procedure`)
 				.send({ appealProcedure: 'hearing' });
-			await request.post(`${baseUrl}/1/start-case/hearing`).send({ dateKnown: 'no' });
+			await request.post(`${baseUrl}/1/start-case/hearing/date`).send({
+				'hearing-date-day': '01',
+				'hearing-date-month': '02',
+				'hearing-date-year': '3025',
+				'hearing-time-hour': '12',
+				'hearing-time-minute': '00'
+			});
 			await request
 				.post(`${baseUrl}/1/start-case/hearing/estimation`)
 				.send({ hearingEstimationYesNo: 'no' });
@@ -847,7 +591,6 @@ describe('start case hearing flow', () => {
 			await request
 				.post(`${baseUrl}/1/start-case/select-procedure`)
 				.send({ appealProcedure: 'hearing' });
-			await request.post(`${baseUrl}/1/start-case/hearing`).send({ dateKnown: 'yes' });
 			await request.post(`${baseUrl}/1/start-case/hearing/date`).send({
 				'hearing-date-day': '01',
 				'hearing-date-month': '02',

--- a/appeals/web/src/server/appeals/appeal-details/start-case/hearing/hearing.controller.js
+++ b/appeals/web/src/server/appeals/appeal-details/start-case/hearing/hearing.controller.js
@@ -24,7 +24,7 @@ import { preserveQueryString } from '#lib/url-utilities.js';
 import { capitalize } from 'lodash-es';
 import * as startCaseService from '../start-case.service.js';
 import { getStartCaseNotifyPreviews } from '../start-case.service.js';
-import { dateKnownPage, estimationPage } from './hearing.mapper.js';
+import { estimationPage } from './hearing.mapper.js';
 
 /** @typedef {import('@pins/express').ValidationErrors} ValidationErrors */
 
@@ -36,59 +36,6 @@ import { dateKnownPage, estimationPage } from './hearing.mapper.js';
 const getBackLinkUrl = (request, prevPagePath) => {
 	const baseUrl = `/appeals-service/appeal-details/${request.currentAppeal.appealId}/start-case`;
 	return isAtEditEntrypoint(request) ? `${baseUrl}/hearing/confirm` : `${baseUrl}/${prevPagePath}`;
-};
-
-/**
- * @param {import('@pins/express/types/express.js').Request} request
- * @param {import('@pins/express/types/express.js').RenderedResponse<any, any, Number>} response
- */
-export const getHearingDateKnown = async (request, response) => {
-	return renderHearingDateKnown(request, response);
-};
-
-/**
- * @param {import('@pins/express/types/express.js').Request} request
- * @param {import('@pins/express/types/express.js').RenderedResponse<any, any, Number>} response
- */
-export const renderHearingDateKnown = async (request, response) => {
-	const { errors } = request;
-
-	const appealDetails = request.currentAppeal;
-	const backLinkUrl = getBackLinkUrl(request, 'select-procedure');
-	const sessionValues = getSessionValuesForAppeal(
-		request,
-		'startCaseAppealProcedure',
-		appealDetails.appealId
-	);
-
-	const mappedPageContent = dateKnownPage(appealDetails, backLinkUrl, sessionValues);
-
-	return response.status(errors ? 400 : 200).render('patterns/change-page.pattern.njk', {
-		pageContent: mappedPageContent,
-		errors
-	});
-};
-
-/**
- * @param {import('@pins/express/types/express.js').Request} request
- * @param {import('@pins/express/types/express.js').RenderedResponse<any, any, Number>} response
- */
-export const postHearingDateKnown = async (request, response) => {
-	if (request.errors) {
-		return renderHearingDateKnown(request, response);
-	}
-
-	const { appealId } = request.currentAppeal;
-
-	const baseUrl = `/appeals-service/appeal-details/${appealId}/start-case/hearing`;
-
-	if (request.body.dateKnown === 'yes') {
-		// Answer was yes so we progress to the next page
-		return response.redirect(preserveQueryString(request, `${baseUrl}/date`));
-	}
-
-	// Answer was no so we skip date and proceed to estimation
-	return response.redirect(preserveQueryString(request, `${baseUrl}/estimation`));
 };
 
 /**
@@ -107,7 +54,7 @@ export const renderHearingDate = async (request, response) => {
 	const { errors } = request;
 
 	const appealDetails = request.currentAppeal;
-	const backLinkUrl = getBackLinkUrl(request, 'hearing');
+	const backLinkUrl = getBackLinkUrl(request, 'select-procedure');
 	const sessionValues = getSessionValuesForAppeal(
 		request,
 		'startCaseAppealProcedure',
@@ -168,10 +115,7 @@ export const renderHearingEstimation = async (request, response) => {
 		'startCaseAppealProcedure',
 		appealDetails.appealId
 	);
-	const backLinkUrl = getBackLinkUrl(
-		request,
-		sessionValues?.dateKnown === 'yes' ? 'hearing/date' : 'hearing'
-	);
+	const backLinkUrl = getBackLinkUrl(request, 'hearing/date');
 
 	const mappedPageContent = estimationPage(appealDetails, backLinkUrl, errors, sessionValues || {});
 
@@ -223,7 +167,6 @@ export const getHearingConfirm = async (request, response) => {
 		'startCaseAppealProcedure',
 		currentAppeal.appealId
 	);
-	const dateKnown = sessionValues?.dateKnown === 'yes';
 	const hearingEstimationYesNo = sessionValues?.hearingEstimationYesNo;
 	const hearingEstimationDays = sessionValues?.hearingEstimationDays;
 	const baseUrl = `/appeals-service/appeal-details/${currentAppeal.appealId}/start-case`;
@@ -246,7 +189,7 @@ export const getHearingConfirm = async (request, response) => {
 			currentAppeal.appealId,
 			undefined,
 			sessionValues?.appealProcedure,
-			dateKnown ? hearingStartTime : undefined,
+			hearingStartTime,
 			hearingEstimatedDays,
 			null,
 			inspectorName
@@ -277,46 +220,31 @@ export const getHearingConfirm = async (request, response) => {
 						}
 					}
 				},
-				'Do you know the date and time of the hearing?': {
-					value: dateKnown ? 'Yes' : 'No',
+				'Hearing date': {
+					value: dateISOStringToDisplayDate(hearingStartTime),
 					actions: {
 						Change: {
-							href: editLink(baseUrl, 'hearing'),
-							visuallyHiddenText: 'Do you know the date and time of the hearing?',
+							href: editLink(baseUrl, 'hearing/date'),
+							visuallyHiddenText: 'Hearing date',
 							attributes: {
-								'data-cy': 'change-date-known'
+								'data-cy': 'change-hearing-date'
 							}
 						}
 					}
 				},
-				...(dateKnown
-					? {
-							'Hearing date': {
-								value: dateISOStringToDisplayDate(hearingStartTime),
-								actions: {
-									Change: {
-										href: editLink(baseUrl, 'hearing/date'),
-										visuallyHiddenText: 'Hearing date',
-										attributes: {
-											'data-cy': 'change-hearing-date'
-										}
-									}
-								}
-							},
-							'Hearing time': {
-								value: dateISOStringToDisplayTime12hr(hearingStartTime),
-								actions: {
-									Change: {
-										href: editLink(baseUrl, 'hearing/date'),
-										visuallyHiddenText: 'Hearing time',
-										attributes: {
-											'data-cy': 'change-hearing-time'
-										}
-									}
-								}
+				'Hearing time': {
+					value: dateISOStringToDisplayTime12hr(hearingStartTime),
+					actions: {
+						Change: {
+							href: editLink(baseUrl, 'hearing/date'),
+							visuallyHiddenText: 'Hearing time',
+							attributes: {
+								'data-cy': 'change-hearing-time'
 							}
 						}
-					: {}),
+					}
+				},
+
 				'Do you know the expected number of days to carry out the hearing?': {
 					value: capitalize(hearingEstimationYesNo || ''),
 					actions: {
@@ -391,8 +319,7 @@ export const postHearingConfirm = async (request, response) => {
 				? sessionValues?.hearingEstimationDays
 				: undefined;
 
-		const hearingStartTime =
-			sessionValues?.dateKnown === 'yes' ? hearingStartTimeFromSession(sessionValues) : undefined;
+		const hearingStartTime = hearingStartTimeFromSession(sessionValues);
 
 		const inspectorName = await getInspectorFormattedEmailName(inspector, request);
 

--- a/appeals/web/src/server/appeals/appeal-details/start-case/hearing/hearing.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/start-case/hearing/hearing.mapper.js
@@ -1,38 +1,5 @@
 import { appealShortReference } from '#lib/appeals-formatter.js';
-import { yesNoInput } from '#lib/mappers/index.js';
 import { renderPageComponentsToHtml } from '#lib/nunjucks-template-builders/page-component-rendering.js';
-
-/**
- * @param {import('../../appeal-details.types.js').WebAppeal} appealDetails
- * @param {string} backLinkUrl
- * @param {Record<string, string>} [values]
- * @returns {PageContent}
- */
-export const dateKnownPage = (appealDetails, backLinkUrl, values) => {
-	const shortAppealReference = appealShortReference(appealDetails.appealReference);
-
-	const dateKnownComponent = yesNoInput({
-		name: 'dateKnown',
-		id: 'date-known',
-		legendText: 'Do you know the date and time of the hearing?',
-		legendIsPageHeading: true,
-		value: values?.dateKnown
-	});
-
-	/** @type {PageContent} */
-	const pageContent = {
-		title: `Appeal ${shortAppealReference} - start case`,
-		backLinkUrl,
-		preHeading: `Appeal ${shortAppealReference} - start case`,
-		pageComponents: [dateKnownComponent],
-		submitButtonProperties: {
-			text: 'Continue',
-			id: 'continue'
-		}
-	};
-
-	return pageContent;
-};
 
 /**
  * @param {import('../../appeal-details.types.js').WebAppeal} appealDetails

--- a/appeals/web/src/server/appeals/appeal-details/start-case/hearing/hearing.router.js
+++ b/appeals/web/src/server/appeals/appeal-details/start-case/hearing/hearing.router.js
@@ -9,15 +9,6 @@ import * as validators from './hearing.validators.js';
 const router = createRouter({ mergeParams: true });
 
 router
-	.route('/')
-	.get(asyncHandler(controller.getHearingDateKnown))
-	.post(
-		validators.validateDateKnown,
-		saveBodyToSession('startCaseAppealProcedure', { scopeToAppeal: true }),
-		asyncHandler(controller.postHearingDateKnown)
-	);
-
-router
 	.route('/date')
 	.get(asyncHandler(controller.getHearingDate))
 	.post(

--- a/appeals/web/src/server/appeals/appeal-details/start-case/hearing/hearing.validators.js
+++ b/appeals/web/src/server/appeals/appeal-details/start-case/hearing/hearing.validators.js
@@ -3,13 +3,6 @@ import { createValidator } from '@pins/express';
 import { body } from 'express-validator';
 import { capitalize } from 'lodash-es';
 
-export const validateDateKnown = createValidator(
-	createYesNoRadioValidator(
-		'dateKnown',
-		'Select yes if you know the date and time the hearing will take place'
-	)
-);
-
 export const validateEstimationYesNo = createValidator(
 	createYesNoRadioValidator(
 		'hearingEstimationYesNo',

--- a/appeals/web/src/server/appeals/appeal-details/start-case/start-case.controller.js
+++ b/appeals/web/src/server/appeals/appeal-details/start-case/start-case.controller.js
@@ -307,7 +307,7 @@ const redirectionTarget = (request) => {
 		sessionValues?.appealProcedure === APPEAL_CASE_PROCEDURE.HEARING &&
 		useNewHearingRoute(request)
 	) {
-		return `/appeals-service/appeal-details/${appealId}/start-case/hearing`;
+		return `/appeals-service/appeal-details/${appealId}/start-case/hearing/date`;
 	}
 
 	applyEditsForAppeal(request, 'startCaseAppealProcedure', appealId);


### PR DESCRIPTION
…low (A2-7926)

## Describe your changes

This PR simplifies the hearing start-case flow by removing the intermediate “Do you know the date and time of the hearing?” step. Users now go straight from selecting the hearing procedure to entering the hearing date/time, and the confirmation page has been updated to reflect that simpler journey.

- Removed the /start-case/hearing “date known” step and its related controller, router, validator, and mapper code
- Updated the flow so hearing cases now go directly from select procedure to hearing/date
- Simplified back-link logic so the date and estimation steps point to the new streamlined route
- Updated the confirmation page to always show hearing date and hearing time, instead of conditionally showing whether the date was known
- Removed and updated tests/snapshots to match the new hearing journey

<!--
    Please include a summary of the change along with any relevant context.
    List any dependencies that are required for this change.
-->

## Issue ticket number and link

[Ticket](https://pins-ds.atlassian.net/browse/A2-7926)
