### PR TITLE
fix(api): add missing enforcement ref to start date change notify ELB

### DIFF
--- a/appeals/api/src/server/notify/templates/appeal-start-date-change-lpa.content.md
+++ b/appeals/api/src/server/notify/templates/appeal-start-date-change-lpa.content.md
@@ -1,6 +1,6 @@
 # New start date for appeal
 
-There is a new start date for the {{appeal_type}} appeal against the planning application {{lpa_reference}}.
+There is a new start date for the {{appeal_type}} appeal against the planning application {%-if enforcement_reference %} {{ enforcement_reference}}{%- else %} {{ lpa_reference}}{% endif %}.
 
 The new start date is {{start_date}}.
 


### PR DESCRIPTION
… (A2-7893)

## Describe your changes

This pull request updates the appeal start date change notification template to display the correct reference number depending on the type of appeal. Now, if an `enforcement_reference` is present, it will be shown instead of the `lpa_reference`.

## Issue ticket number and link

[Ticket](https://pins-ds.atlassian.net/browse/A2-7893)
