### PR TITLE
fix(web): stopping site visit CTAs showing on child appeals+adding te…

### DIFF
--- a/appeals/web/src/server/lib/mappers/utils/__tests__/map-status-dependent-notifications.test.js
+++ b/appeals/web/src/server/lib/mappers/utils/__tests__/map-status-dependent-notifications.test.js
@@ -11,9 +11,22 @@ describe('mapStatusDependentNotifications', () => {
 	};
 	const testCases = [
 		{
+			bannerKey: 'awaitingLinkedAppeal',
+			requiredAction: 'awaitingLinkedAppeal',
+			expectedContainedHtml:
+				'<p class="govuk-notification-banner__heading">Awaiting linked appeal</p>',
+			bannerShouldNotDisplayWhenChildLinkedAppeal: false
+		},
+		{
 			bannerKey: 'appealAwaitingTransfer',
 			requiredAction: 'addHorizonReference',
 			expectedContainedHtml: `<p class="govuk-notification-banner__heading"><a class="govuk-link" data-cy="awaiting-transfer" href="/appeals-service/appeal-details/${mockAppealData.appealId}/change-appeal-type/add-horizon-reference?backUrl=%2Fappeals-service%2Fappeal-details%2F1">Mark as transferred</a></p>`
+		},
+		{
+			bannerKey: 'appealValidated',
+			requiredAction: 'appealValidated',
+			expectedContainedHtml: '<p class="govuk-notification-banner__heading">Appeal valid</p>',
+			bannerShouldNotDisplayWhenChildLinkedAppeal: true
 		},
 		{
 			bannerKey: 'readyForSetUpSiteVisit',
@@ -36,6 +49,32 @@ describe('mapStatusDependentNotifications', () => {
 			bannerShouldNotDisplayWhenChildLinkedAppeal: true
 		},
 		{
+			bannerKey: 'issueAppellantCostsDecision',
+			requiredAction: 'issueAppellantCostsDecision',
+			mockData: {
+				appealId: 1,
+				appealStatus: APPEAL_CASE_STATUS.COMPLETE,
+				costsDecision: {
+					awaitingAppellantCostsDecision: true
+				}
+			},
+			expectedContainedHtml: `<a class="govuk-notification-banner__link" data-cy="issue-appellant-costs-decision" href="/appeals-service/appeal-details/${mockAppealData.appealId}/issue-decision/issue-appellant-costs-decision-letter-upload?backUrl=%2Fappeals-service%2Fappeal-details%2F1">Issue appellant costs decision</a>`,
+			bannerShouldNotDisplayWhenChildLinkedAppeal: true
+		},
+		{
+			bannerKey: 'issueLpaCostsDecision',
+			requiredAction: 'issueLpaCostsDecision',
+			mockData: {
+				appealId: 1,
+				appealStatus: APPEAL_CASE_STATUS.COMPLETE,
+				costsDecision: {
+					awaitingLpaCostsDecision: true
+				}
+			},
+			expectedContainedHtml: `<a class="govuk-notification-banner__link" data-cy="issue-lpa-costs-decision" href="/appeals-service/appeal-details/${mockAppealData.appealId}/issue-decision/issue-lpa-costs-decision-letter-upload?backUrl=%2Fappeals-service%2Fappeal-details%2F1">Issue LPA costs decision</a>`,
+			bannerShouldNotDisplayWhenChildLinkedAppeal: true
+		},
+		{
 			bannerKey: 'progressFromFinalComments',
 			requiredAction: 'progressFromFinalComments',
 			expectedContainedHtml: `<a href="/appeals-service/appeal-details/${mockAppealData.appealId}/share?backUrl=%2Fappeals-service%2Fappeal-details%2F${mockAppealData.appealId}" class="govuk-heading-s govuk-notification-banner__link">Progress case</a>`,
@@ -45,6 +84,42 @@ describe('mapStatusDependentNotifications', () => {
 			bannerKey: 'progressFromStatements',
 			requiredAction: 'progressFromStatements',
 			expectedContainedHtml: `<a href="/appeals-service/appeal-details/${mockAppealData.appealId}/share?backUrl=%2Fappeals-service%2Fappeal-details%2F${mockAppealData.appealId}" class="govuk-heading-s govuk-notification-banner__link">Progress to final comments</a>`,
+			bannerShouldNotDisplayWhenChildLinkedAppeal: true
+		},
+		{
+			bannerKey: 'progressHearingCaseWithNoRepsFromStatements',
+			requiredAction: 'progressHearingCaseWithNoRepsFromStatements',
+			mockData: {
+				appealId: 1,
+				appealStatus: APPEAL_CASE_STATUS.STATEMENTS,
+				procedureType: 'Hearing',
+				appealTimetable: {
+					ipCommentsDueDate: '2000-01-01',
+					lpaStatementDueDate: '2000-01-01'
+				},
+				documentationSummary: {}
+			},
+			expectedContainedHtml: `<a href="/appeals-service/appeal-details/${mockAppealData.appealId}/share?backUrl=%2Fappeals-service%2Fappeal-details%2F1" class="govuk-heading-s govuk-notification-banner__link">Progress to hearing ready to set up</a>`,
+			bannerShouldNotDisplayWhenChildLinkedAppeal: true
+		},
+		{
+			bannerKey: 'progressHearingCaseWithNoRepsAndHearingSetUpFromStatements',
+			requiredAction: 'progressHearingCaseWithNoRepsAndHearingSetUpFromStatements',
+			mockData: {
+				appealId: 1,
+				appealStatus: APPEAL_CASE_STATUS.STATEMENTS,
+				procedureType: 'Hearing',
+				hearing: {
+					hearingStartTime: '13:00',
+					addressId: 1
+				},
+				appealTimetable: {
+					ipCommentsDueDate: '2000-01-01',
+					lpaStatementDueDate: '2000-01-01'
+				},
+				documentationSummary: {}
+			},
+			expectedContainedHtml: `<a href="/appeals-service/appeal-details/${mockAppealData.appealId}/share?backUrl=%2Fappeals-service%2Fappeal-details%2F1" class="govuk-heading-s govuk-notification-banner__link">Progress to awaiting hearing</a>`,
 			bannerShouldNotDisplayWhenChildLinkedAppeal: true
 		},
 		{
@@ -131,12 +206,6 @@ describe('mapStatusDependentNotifications', () => {
 			bannerShouldNotDisplayWhenChildLinkedAppeal: true
 		},
 		{
-			bannerKey: 'awaitingLinkedAppeal',
-			requiredAction: 'awaitingLinkedAppeal',
-			expectedContainedHtml:
-				'<p class="govuk-notification-banner__heading">Awaiting linked appeal</p>'
-		},
-		{
 			bannerKey: 'updateLpaStatement',
 			requiredAction: 'updateLpaStatement',
 			expectedContainedHtml:
@@ -148,6 +217,24 @@ describe('mapStatusDependentNotifications', () => {
 			requiredAction: 'updateAppellantStatement',
 			expectedContainedHtml:
 				'<p class="govuk-notification-banner__heading">Appellant statement incomplete</p>',
+			bannerShouldNotDisplayWhenChildLinkedAppeal: true
+		},
+		{
+			bannerKey: 'addHearingAddress',
+			requiredAction: 'addHearingAddress',
+			mockData: {
+				appealId: 1,
+				appealStatus: APPEAL_CASE_STATUS.EVENT,
+				procedureType: 'Hearing',
+				hearing: {}
+			},
+			expectedContainedHtml: `<a class="govuk-link" data-cy="add-hearing-address" href="/appeals-service/appeal-details/${mockAppealData.appealId}/hearing/change/address-details?backUrl=%2Fappeals-service%2Fappeal-details%2F1">Add hearing address</a>`,
+			bannerShouldNotDisplayWhenChildLinkedAppeal: true
+		},
+		{
+			bannerKey: 'setupHearing',
+			requiredAction: 'setupHearing',
+			expectedContainedHtml: `<a class="govuk-link" data-cy="setup-hearing" href="/appeals-service/appeal-details/${mockAppealData.appealId}/hearing/setup/date?backUrl=%2Fappeals-service%2Fappeal-details%2F1">Set up hearing</a>`,
 			bannerShouldNotDisplayWhenChildLinkedAppeal: true
 		},
 		{
@@ -199,16 +286,45 @@ describe('mapStatusDependentNotifications', () => {
 			bannerShouldNotDisplayWhenChildLinkedAppeal: true
 		},
 		{
+			bannerKey: 'addInquiryAddress',
+			requiredAction: 'addInquiryAddress',
+			expectedContainedHtml: `<a class="govuk-link" data-cy="add-inquiry-address" href="/appeals-service/appeal-details/${mockAppealData.appealId}/inquiry/change/address-details?backUrl=%2Fappeals-service%2Fappeal-details%2F1">Add inquiry address</a>`,
+			bannerShouldNotDisplayWhenChildLinkedAppeal: true
+		},
+		{
 			bannerKey: 'setupInquiry',
 			requiredAction: 'setupInquiry',
 			expectedContainedHtml: `<a class="govuk-link" data-cy="setup-inquiry" href="/appeals-service/appeal-details/${mockAppealData.appealId}/inquiry/setup/date?backUrl=%2Fappeals-service%2Fappeal-details%2F1">Set up inquiry</a>`,
-			bannerShouldNotDisplayWhenChildLinkedAppeal: false
+			bannerShouldNotDisplayWhenChildLinkedAppeal: true
 		},
 		{
 			bannerKey: 'addInquiryAddress',
 			requiredAction: 'addInquiryAddress',
 			expectedContainedHtml: `<a class="govuk-link" data-cy="add-inquiry-address" href="/appeals-service/appeal-details/${mockAppealData.appealId}/inquiry/change/address-details?backUrl=%2Fappeals-service%2Fappeal-details%2F1">Add inquiry address</a>`,
-			bannerShouldNotDisplayWhenChildLinkedAppeal: false
+			bannerShouldNotDisplayWhenChildLinkedAppeal: true
+		},
+		{
+			bannerKey: 'addSiteVisitTime',
+			requiredAction: 'addSiteVisitTime',
+			mockData: {
+				appealId: 1,
+				siteVisit: {
+					visitDate: '2026-01-01'
+				}
+			},
+			expectedContainedHtml: `<a class="govuk-heading-s govuk-notification-banner__link" data-cy="add-site-visit-time" href="/appeals-service/appeal-details/${mockAppealData.appealId}/site-visit/schedule/schedule-visit-date?backUrl=%2Fappeals-service%2Fappeal-details%2F1">Add site visit time</a>`,
+			bannerShouldNotDisplayWhenChildLinkedAppeal: true
+		},
+		{
+			bannerKey: 'addSiteVisitDateTime',
+			requiredAction: 'addSiteVisitDateTime',
+			mockData: {
+				appealId: 1,
+				appealStatus: APPEAL_CASE_STATUS.INVALID,
+				siteVisit: {}
+			},
+			expectedContainedHtml: `<a class="govuk-heading-s govuk-notification-banner__link" data-cy="add-site-visit-date-time" href="/appeals-service/appeal-details/${mockAppealData.appealId}/site-visit/schedule/schedule-visit-date?backUrl=%2Fappeals-service%2Fappeal-details%2F1">Add site visit date and time</a>`,
+			bannerShouldNotDisplayWhenChildLinkedAppeal: true
 		},
 		{
 			bannerKey: 'reviewRule6PartyStatement',
@@ -314,13 +430,12 @@ describe('mapStatusDependentNotifications', () => {
 
 	for (const testCase of testCases) {
 		it(`should return "${testCase.bannerKey}" banner when getRequiredActionsForAppeal returns "${testCase.requiredAction}"`, async () => {
-			const result = mapStatusDependentNotifications(
-				appealDataToGetRequiredActions[testCase.requiredAction],
-				{
-					originalUrl: `/appeals-service/appeal-details/${mockAppealData.appealId}`,
-					session: {}
-				}
-			);
+			const appealData =
+				testCase.mockData || appealDataToGetRequiredActions[testCase.requiredAction];
+			const result = mapStatusDependentNotifications(appealData, {
+				originalUrl: `/appeals-service/appeal-details/${mockAppealData.appealId}`,
+				session: {}
+			});
 
 			expect(Array.isArray(result)).toBe(true);
 			expect(result[0]?.type).toBe('notification-banner');
@@ -333,8 +448,10 @@ describe('mapStatusDependentNotifications', () => {
 		(testCase) => !testCase.bannerShouldNotDisplayWhenChildLinkedAppeal
 	)) {
 		it(`should return "${testCase.bannerKey}" banner when getRequiredActionsForAppeal returns "${testCase.requiredAction} when the appeal is a child linked appeal"`, async () => {
+			const appealData =
+				testCase.mockData || appealDataToGetRequiredActions[testCase.requiredAction];
 			const result = mapStatusDependentNotifications(
-				{ ...appealDataToGetRequiredActions[testCase.requiredAction], isChildAppeal: true },
+				{ ...appealData, isChildAppeal: true },
 				{
 					originalUrl: `/appeals-service/appeal-details/${mockAppealData.appealId}`
 				}
@@ -351,8 +468,10 @@ describe('mapStatusDependentNotifications', () => {
 		(testCase) => testCase.bannerShouldNotDisplayWhenChildLinkedAppeal
 	)) {
 		it(`should not return "${testCase.bannerKey}" banner when getRequiredActionsForAppeal returns "${testCase.requiredAction} when the appeal is a child linked appeal"`, async () => {
+			const appealData =
+				testCase.mockData || appealDataToGetRequiredActions[testCase.requiredAction];
 			const result = mapStatusDependentNotifications(
-				{ ...appealDataToGetRequiredActions[testCase.requiredAction], isChildAppeal: true },
+				{ ...appealData, isChildAppeal: true },
 				{
 					originalUrl: `/appeals-service/appeal-details/${mockAppealData.appealId}`
 				}

--- a/appeals/web/src/server/lib/mappers/utils/__tests__/required-actions.test.js
+++ b/appeals/web/src/server/lib/mappers/utils/__tests__/required-actions.test.js
@@ -4,9 +4,73 @@ import { appealData, appealDataEnforcementNotice } from '#testing/app/fixtures/r
 import { APPEAL_TYPE } from '@pins/appeals/constants/common.js';
 import { APPEAL_CASE_PROCEDURE, APPEAL_CASE_STATUS } from '@planning-inspectorate/data-model';
 import { addDays } from 'date-fns';
-import { getRequiredActionsForAppeal } from '../required-actions.js';
+import { canDisplayAction, getRequiredActionsForAppeal } from '../required-actions.js';
 
 describe('required actions', () => {
+	describe('canDisplayAction', () => {
+		it('returns true for non-child appeals', () => {
+			expect(
+				canDisplayAction({
+					appealStatus: APPEAL_CASE_STATUS.EVENT,
+					appealType: APPEAL_TYPE.ENFORCEMENT_NOTICE,
+					isChildAppeal: false
+				})
+			).toBe(true);
+		});
+		it.each([
+			[
+				'true for non-enforcement child appeal in status VALIDATION, validation on each appeal',
+				APPEAL_CASE_STATUS.VALIDATION,
+				APPEAL_TYPE.S78,
+				true
+			],
+			[
+				'false for enforcement notice child appeal in status VALIDATION, validation only on the lead',
+				APPEAL_CASE_STATUS.VALIDATION,
+				APPEAL_TYPE.ENFORCEMENT_NOTICE,
+				false
+			],
+			[
+				'true for child appeal in status AWAITING_TRANSFER, awaiting transfer on each appeal',
+				APPEAL_CASE_STATUS.AWAITING_TRANSFER,
+				APPEAL_TYPE.ENFORCEMENT_NOTICE,
+				true
+			],
+			[
+				'true for non-enforcement child appeal in status LPA_QUESTIONNAIRE, lpaq on each appeal',
+				APPEAL_CASE_STATUS.LPA_QUESTIONNAIRE,
+				APPEAL_TYPE.S78,
+				true
+			],
+			[
+				'false for enforcement notice child appeal in status LPA_QUESTIONNAIRE, lpaq only submitted on the lead',
+				APPEAL_CASE_STATUS.LPA_QUESTIONNAIRE,
+				APPEAL_TYPE.ENFORCEMENT_NOTICE,
+				false
+			],
+			[
+				'false for child appeal in status EVENT, event only set up on the lead',
+				APPEAL_CASE_STATUS.EVENT,
+				APPEAL_TYPE.S78,
+				false
+			],
+			[
+				'false for child appeal in any other status',
+				APPEAL_CASE_STATUS.COMPLETE,
+				APPEAL_TYPE.S78,
+				false
+			]
+		])('returns %s', (_, appealStatus, appealType, expectedResult) => {
+			expect(
+				canDisplayAction({
+					appealStatus,
+					appealType,
+					isChildAppeal: true
+				})
+			).toBe(expectedResult);
+		});
+	});
+
 	describe('getRequiredActionsForAppeal', () => {
 		const pastDate = '2025-01-06T23:59:00.000Z';
 		const futureDate = '3000-01-06T23:59:00.000Z';

--- a/appeals/web/src/server/lib/mappers/utils/required-actions.js
+++ b/appeals/web/src/server/lib/mappers/utils/required-actions.js
@@ -45,7 +45,7 @@ export function canDisplayAction(appeal) {
 		case APPEAL_CASE_STATUS.LPA_QUESTIONNAIRE:
 			return appeal.appealType !== APPEAL_TYPE.ENFORCEMENT_NOTICE;
 		case APPEAL_CASE_STATUS.EVENT:
-			return appeal.procedureType !== APPEAL_CASE_PROCEDURE.WRITTEN;
+			return false; // one site visit, hearing or inquiry event recorded against lead appeal
 		default:
 			return false;
 	}


### PR DESCRIPTION
…sts (A2-8098)

## Describe your changes

- Correcting the logic in the canDisplayAction function to not display event set up CTAs on child appeals
- Adding tests for the canDisplayAction function

Tested locally:
CTA banner still showing on lead
<img width="1117" height="467" alt="image" src="https://github.com/user-attachments/assets/17e0284c-bb79-4c3e-96b2-7681520cec85" />

CTA banner not showing on child
<img width="1312" height="423" alt="image" src="https://github.com/user-attachments/assets/9ebd05e5-ab1b-4d3a-8f16-48947a383533" />

Personal list only showing the CTA on the lead appeal
<img width="1262" height="476" alt="image" src="https://github.com/user-attachments/assets/e772e87f-f50e-4e00-857c-7ce103d4ee05" />

## Issue ticket number and link

[Ticket](https://pins-ds.atlassian.net/browse/A2-8098)
