### PR TITLE
feat(web): updated written representation display names (a2-8052)

### DIFF
--- a/appeals/web/src/server/appeals/appeal-details/__tests__/__snapshots__/appeal-details.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/__tests__/__snapshots__/appeal-details.test.js.snap
@@ -912,7 +912,7 @@ exports[`appeal-details GET /:appealId Linked appeals should not render a "Appea
             <dd class="govuk-summary-list__value">Householder</dd>
         </div>
         <div class="govuk-summary-list__row govuk-summary-list__row--no-actions appeal-case-procedure"><dt class="govuk-summary-list__key"> Appeal procedure</dt>
-            <dd class="govuk-summary-list__value">Written</dd>
+            <dd class="govuk-summary-list__value">Written representations (Part 2)</dd>
         </div>
         <div class="govuk-summary-list__row appeal-allocation-details"><dt class="govuk-summary-list__key"> Allocation level</dt>
             <dd class="govuk-summary-list__value">
@@ -1144,7 +1144,7 @@ exports[`appeal-details GET /:appealId Linked appeals should not render action l
             </dd>
         </div>
         <div class="govuk-summary-list__row govuk-summary-list__row--no-actions appeal-case-procedure"><dt class="govuk-summary-list__key"> Appeal procedure</dt>
-            <dd class="govuk-summary-list__value">Written</dd>
+            <dd class="govuk-summary-list__value">Written representations (Part 2)</dd>
         </div>
         <div class="govuk-summary-list__row appeal-allocation-details"><dt class="govuk-summary-list__key"> Allocation level</dt>
             <dd class="govuk-summary-list__value">
@@ -1544,7 +1544,7 @@ exports[`appeal-details GET /:appealId Linked appeals should render a child tag 
             <dd class="govuk-summary-list__value">Householder</dd>
         </div>
         <div class="govuk-summary-list__row govuk-summary-list__row--no-actions appeal-case-procedure"><dt class="govuk-summary-list__key"> Appeal procedure</dt>
-            <dd class="govuk-summary-list__value">Written</dd>
+            <dd class="govuk-summary-list__value">Written representations (Part 2)</dd>
         </div>
         <div class="govuk-summary-list__row appeal-allocation-details"><dt class="govuk-summary-list__key"> Allocation level</dt>
             <dd class="govuk-summary-list__value">
@@ -1773,7 +1773,7 @@ exports[`appeal-details GET /:appealId Linked appeals should render a lead tag n
             <dd class="govuk-summary-list__value">Householder</dd>
         </div>
         <div class="govuk-summary-list__row govuk-summary-list__row--no-actions appeal-case-procedure"><dt class="govuk-summary-list__key"> Appeal procedure</dt>
-            <dd class="govuk-summary-list__value">Written</dd>
+            <dd class="govuk-summary-list__value">Written representations (Part 2)</dd>
         </div>
         <div class="govuk-summary-list__row appeal-allocation-details"><dt class="govuk-summary-list__key"> Allocation level</dt>
             <dd class="govuk-summary-list__value">
@@ -2172,7 +2172,7 @@ exports[`appeal-details GET /:appealId Linked appeals should render an action li
             <dd class="govuk-summary-list__value">Householder</dd>
         </div>
         <div class="govuk-summary-list__row govuk-summary-list__row--no-actions appeal-case-procedure"><dt class="govuk-summary-list__key"> Appeal procedure</dt>
-            <dd class="govuk-summary-list__value">Written</dd>
+            <dd class="govuk-summary-list__value">Written representations (Part 2)</dd>
         </div>
         <div class="govuk-summary-list__row appeal-allocation-details"><dt class="govuk-summary-list__key"> Allocation level</dt>
             <dd class="govuk-summary-list__value">
@@ -2585,7 +2585,7 @@ exports[`appeal-details GET /:appealId Linked appeals should render an action li
             </dd>
         </div>
         <div class="govuk-summary-list__row govuk-summary-list__row--no-actions appeal-case-procedure"><dt class="govuk-summary-list__key"> Appeal procedure</dt>
-            <dd class="govuk-summary-list__value">Written</dd>
+            <dd class="govuk-summary-list__value">Written representations (Part 2)</dd>
         </div>
         <div class="govuk-summary-list__row appeal-allocation-details"><dt class="govuk-summary-list__key"> Allocation level</dt>
             <dd class="govuk-summary-list__value">
@@ -3005,7 +3005,7 @@ exports[`appeal-details GET /:appealId Linked appeals should render the case ref
             </dd>
         </div>
         <div class="govuk-summary-list__row govuk-summary-list__row--no-actions appeal-case-procedure"><dt class="govuk-summary-list__key"> Appeal procedure</dt>
-            <dd class="govuk-summary-list__value">Written</dd>
+            <dd class="govuk-summary-list__value">Written representations (Part 2)</dd>
         </div>
         <div class="govuk-summary-list__row appeal-allocation-details"><dt class="govuk-summary-list__key"> Allocation level</dt>
             <dd class="govuk-summary-list__value">
@@ -3416,7 +3416,7 @@ exports[`appeal-details GET /:appealId Linked appeals should render the lead or 
             </dd>
         </div>
         <div class="govuk-summary-list__row govuk-summary-list__row--no-actions appeal-case-procedure"><dt class="govuk-summary-list__key"> Appeal procedure</dt>
-            <dd class="govuk-summary-list__value">Written</dd>
+            <dd class="govuk-summary-list__value">Written representations (Part 2)</dd>
         </div>
         <div class="govuk-summary-list__row appeal-allocation-details"><dt class="govuk-summary-list__key"> Allocation level</dt>
             <dd class="govuk-summary-list__value">
@@ -3827,7 +3827,7 @@ exports[`appeal-details GET /:appealId Linked appeals should render the received
             </dd>
         </div>
         <div class="govuk-summary-list__row govuk-summary-list__row--no-actions appeal-case-procedure"><dt class="govuk-summary-list__key"> Appeal procedure</dt>
-            <dd class="govuk-summary-list__value">Written</dd>
+            <dd class="govuk-summary-list__value">Written representations (Part 2)</dd>
         </div>
         <div class="govuk-summary-list__row appeal-allocation-details"><dt class="govuk-summary-list__key"> Allocation level</dt>
             <dd class="govuk-summary-list__value">
@@ -4251,7 +4251,7 @@ exports[`appeal-details GET /:appealId Linked appeals should render the received
             </dd>
         </div>
         <div class="govuk-summary-list__row govuk-summary-list__row--no-actions appeal-case-procedure"><dt class="govuk-summary-list__key"> Appeal procedure</dt>
-            <dd class="govuk-summary-list__value">Written</dd>
+            <dd class="govuk-summary-list__value">Written representations (Part 2)</dd>
         </div>
         <div class="govuk-summary-list__row appeal-allocation-details"><dt class="govuk-summary-list__key"> Allocation level</dt>
             <dd class="govuk-summary-list__value">
@@ -4604,7 +4604,7 @@ exports[`appeal-details GET /:appealId Linked appeals should render the received
             </dd>
         </div>
         <div class="govuk-summary-list__row govuk-summary-list__row--no-actions appeal-case-procedure"><dt class="govuk-summary-list__key"> Appeal procedure</dt>
-            <dd class="govuk-summary-list__value">Written</dd>
+            <dd class="govuk-summary-list__value">Written representations (Part 2)</dd>
         </div>
         <div class="govuk-summary-list__row appeal-allocation-details"><dt class="govuk-summary-list__key"> Allocation level</dt>
             <dd class="govuk-summary-list__value">
@@ -5140,7 +5140,7 @@ exports[`appeal-details GET /:appealId Notification banners Important banners sh
             </dd>
         </div>
         <div class="govuk-summary-list__row govuk-summary-list__row--no-actions appeal-case-procedure"><dt class="govuk-summary-list__key"> Appeal procedure</dt>
-            <dd class="govuk-summary-list__value">Written</dd>
+            <dd class="govuk-summary-list__value">Written representations (Part 2)</dd>
         </div>
         <div class="govuk-summary-list__row appeal-allocation-details"><dt class="govuk-summary-list__key"> Allocation level</dt>
             <dd class="govuk-summary-list__value">
@@ -6134,7 +6134,7 @@ exports[`appeal-details GET /:appealId should render a Decision inset panel when
             </dd>
         </div>
         <div class="govuk-summary-list__row govuk-summary-list__row--no-actions appeal-case-procedure"><dt class="govuk-summary-list__key"> Appeal procedure</dt>
-            <dd class="govuk-summary-list__value">Written</dd>
+            <dd class="govuk-summary-list__value">Written representations (Part 2)</dd>
         </div>
         <div class="govuk-summary-list__row appeal-allocation-details"><dt class="govuk-summary-list__key"> Allocation level</dt>
             <dd class="govuk-summary-list__value">
@@ -6493,7 +6493,7 @@ exports[`appeal-details GET /:appealId should render a Decision inset panel when
             </dd>
         </div>
         <div class="govuk-summary-list__row govuk-summary-list__row--no-actions appeal-case-procedure"><dt class="govuk-summary-list__key"> Appeal procedure</dt>
-            <dd class="govuk-summary-list__value">Written</dd>
+            <dd class="govuk-summary-list__value">Written representations (Part 2)</dd>
         </div>
         <div class="govuk-summary-list__row appeal-allocation-details"><dt class="govuk-summary-list__key"> Allocation level</dt>
             <dd class="govuk-summary-list__value">
@@ -6846,7 +6846,7 @@ exports[`appeal-details GET /:appealId should render a Decision inset panel when
             </dd>
         </div>
         <div class="govuk-summary-list__row govuk-summary-list__row--no-actions appeal-case-procedure"><dt class="govuk-summary-list__key"> Appeal procedure</dt>
-            <dd class="govuk-summary-list__value">Written</dd>
+            <dd class="govuk-summary-list__value">Written representations (Part 2)</dd>
         </div>
         <div class="govuk-summary-list__row appeal-allocation-details"><dt class="govuk-summary-list__key"> Allocation level</dt>
             <dd class="govuk-summary-list__value">
@@ -7205,7 +7205,7 @@ exports[`appeal-details GET /:appealId should render a Decision inset panel when
             </dd>
         </div>
         <div class="govuk-summary-list__row govuk-summary-list__row--no-actions appeal-case-procedure"><dt class="govuk-summary-list__key"> Appeal procedure</dt>
-            <dd class="govuk-summary-list__value">Written</dd>
+            <dd class="govuk-summary-list__value">Written representations (Part 2)</dd>
         </div>
         <div class="govuk-summary-list__row appeal-allocation-details"><dt class="govuk-summary-list__key"> Allocation level</dt>
             <dd class="govuk-summary-list__value">
@@ -7569,7 +7569,7 @@ exports[`appeal-details GET /:appealId should render the appellant case status a
             </dd>
         </div>
         <div class="govuk-summary-list__row govuk-summary-list__row--no-actions appeal-case-procedure"><dt class="govuk-summary-list__key"> Appeal procedure</dt>
-            <dd class="govuk-summary-list__value">Written</dd>
+            <dd class="govuk-summary-list__value">Written representations (Part 2)</dd>
         </div>
         <div class="govuk-summary-list__row appeal-allocation-details"><dt class="govuk-summary-list__key"> Allocation level</dt>
             <dd class="govuk-summary-list__value">
@@ -7921,7 +7921,7 @@ exports[`appeal-details GET /:appealId should render the appellant case status a
             </dd>
         </div>
         <div class="govuk-summary-list__row govuk-summary-list__row--no-actions appeal-case-procedure"><dt class="govuk-summary-list__key"> Appeal procedure</dt>
-            <dd class="govuk-summary-list__value">Written</dd>
+            <dd class="govuk-summary-list__value">Written representations (Part 2)</dd>
         </div>
         <div class="govuk-summary-list__row appeal-allocation-details"><dt class="govuk-summary-list__key"> Allocation level</dt>
             <dd class="govuk-summary-list__value">
@@ -8300,7 +8300,7 @@ exports[`appeal-details GET /:appealId should render the received appeal details
             </dd>
         </div>
         <div class="govuk-summary-list__row govuk-summary-list__row--no-actions appeal-case-procedure"><dt class="govuk-summary-list__key"> Appeal procedure</dt>
-            <dd class="govuk-summary-list__value">Written</dd>
+            <dd class="govuk-summary-list__value">Written representations (Part 2)</dd>
         </div>
         <div class="govuk-summary-list__row appeal-allocation-details"><dt class="govuk-summary-list__key"> Allocation level</dt>
             <dd class="govuk-summary-list__value">
@@ -8704,7 +8704,7 @@ exports[`appeal-details should not render a back button 1`] = `
                         </dd>
                     </div>
                     <div class="govuk-summary-list__row govuk-summary-list__row--no-actions appeal-case-procedure"><dt class="govuk-summary-list__key"> Appeal procedure</dt>
-                        <dd class="govuk-summary-list__value">Written</dd>
+                        <dd class="govuk-summary-list__value">Written representations (Part 2)</dd>
                     </div>
                     <div class="govuk-summary-list__row appeal-allocation-details"><dt class="govuk-summary-list__key"> Allocation level</dt>
                         <dd class="govuk-summary-list__value">

--- a/appeals/web/src/server/appeals/appeal-details/audit/audit.controller.js
+++ b/appeals/web/src/server/appeals/appeal-details/audit/audit.controller.js
@@ -3,6 +3,7 @@ import { getAppealCaseNotes } from '#appeals/appeal-details/case-notes/case-note
 import config from '#environment/config.js';
 import { appealShortReference } from '#lib/appeals-formatter.js';
 import { dateISOStringToDisplayDate, dateISOStringToDisplayTime12hr } from '#lib/dates.js';
+import { getWrittenProcedureTypeDisplayLabel } from '#lib/procedure-type-display-name-formatter.js';
 import { APPEAL_TYPE } from '@pins/appeals/constants/common.js';
 import { utcToZonedTime } from 'date-fns-tz';
 import * as interestedPartyCommentsService from '../representations/interested-party-comments/interested-party-comments.service.js';
@@ -88,6 +89,16 @@ export const renderAudit = async (request, response) => {
 					}
 				});
 			}
+
+			let writtenDisplayName;
+			if (detailsHtml.includes('Part 1')) {
+				writtenDisplayName = getWrittenProcedureTypeDisplayLabel('Part 1');
+				detailsHtml = detailsHtml.replace('Part 1', writtenDisplayName ?? '');
+			} else if (detailsHtml.includes('written')) {
+				writtenDisplayName = getWrittenProcedureTypeDisplayLabel('Written');
+				detailsHtml = detailsHtml.replace('written', writtenDisplayName ?? '');
+			}
+
 			const loggedDate = utcToZonedTime(audit.loggedDate, 'Europe/London');
 			return {
 				dateTime: loggedDate.getTime(),

--- a/appeals/web/src/server/appeals/appeal-details/audit/audit.controller.js
+++ b/appeals/web/src/server/appeals/appeal-details/audit/audit.controller.js
@@ -3,8 +3,8 @@ import { getAppealCaseNotes } from '#appeals/appeal-details/case-notes/case-note
 import config from '#environment/config.js';
 import { appealShortReference } from '#lib/appeals-formatter.js';
 import { dateISOStringToDisplayDate, dateISOStringToDisplayTime12hr } from '#lib/dates.js';
-import { getWrittenProcedureTypeDisplayLabel } from '#lib/procedure-type-display-name-formatter.js';
-import { APPEAL_TYPE } from '@pins/appeals/constants/common.js';
+import { appealProcedureNameToLabelText } from '#lib/procedure-type-display-name-formatter.js';
+import { APPEAL_TYPE, PROCEDURE_TYPE_DISPLAY_NAME } from '@pins/appeals/constants/common.js';
 import { utcToZonedTime } from 'date-fns-tz';
 import * as interestedPartyCommentsService from '../representations/interested-party-comments/interested-party-comments.service.js';
 import { mapMessageContent, tryMapUsers } from './audit.mapper.js';
@@ -90,13 +90,16 @@ export const renderAudit = async (request, response) => {
 				});
 			}
 
-			let writtenDisplayName;
-			if (detailsHtml.includes('Part 1')) {
-				writtenDisplayName = getWrittenProcedureTypeDisplayLabel('Part 1');
-				detailsHtml = detailsHtml.replace('Part 1', writtenDisplayName ?? '');
-			} else if (detailsHtml.includes('written')) {
-				writtenDisplayName = getWrittenProcedureTypeDisplayLabel('Written');
-				detailsHtml = detailsHtml.replace('written', writtenDisplayName ?? '');
+			if (detailsHtml.includes(PROCEDURE_TYPE_DISPLAY_NAME.WRITTEN_PART_1)) {
+				const displayName =
+					appealProcedureNameToLabelText(PROCEDURE_TYPE_DISPLAY_NAME.WRITTEN_PART_1) ||
+					PROCEDURE_TYPE_DISPLAY_NAME.WRITTEN_PART_1;
+				detailsHtml = detailsHtml.replace(PROCEDURE_TYPE_DISPLAY_NAME.WRITTEN_PART_1, displayName);
+			} else if (detailsHtml.includes(PROCEDURE_TYPE_DISPLAY_NAME.WRITTEN_PART_2)) {
+				const displayName =
+					appealProcedureNameToLabelText(PROCEDURE_TYPE_DISPLAY_NAME.WRITTEN_PART_2) ||
+					PROCEDURE_TYPE_DISPLAY_NAME.WRITTEN_PART_2;
+				detailsHtml = detailsHtml.replace(PROCEDURE_TYPE_DISPLAY_NAME.WRITTEN_PART_2, displayName);
 			}
 
 			const loggedDate = utcToZonedTime(audit.loggedDate, 'Europe/London');

--- a/appeals/web/src/server/appeals/appeal-details/audit/audit.controller.js
+++ b/appeals/web/src/server/appeals/appeal-details/audit/audit.controller.js
@@ -4,7 +4,7 @@ import config from '#environment/config.js';
 import { appealShortReference } from '#lib/appeals-formatter.js';
 import { dateISOStringToDisplayDate, dateISOStringToDisplayTime12hr } from '#lib/dates.js';
 import { appealProcedureNameToLabelText } from '#lib/procedure-type-display-name-formatter.js';
-import { APPEAL_TYPE, PROCEDURE_TYPE_DISPLAY_NAME } from '@pins/appeals/constants/common.js';
+import { APPEAL_TYPE, PROCEDURE_TYPE_NAME } from '@pins/appeals/constants/common.js';
 import { utcToZonedTime } from 'date-fns-tz';
 import * as interestedPartyCommentsService from '../representations/interested-party-comments/interested-party-comments.service.js';
 import { mapMessageContent, tryMapUsers } from './audit.mapper.js';
@@ -90,16 +90,16 @@ export const renderAudit = async (request, response) => {
 				});
 			}
 
-			if (detailsHtml.includes(PROCEDURE_TYPE_DISPLAY_NAME.WRITTEN_PART_1)) {
+			if (detailsHtml.includes(PROCEDURE_TYPE_NAME.WRITTEN_PART_1)) {
 				const displayName =
-					appealProcedureNameToLabelText(PROCEDURE_TYPE_DISPLAY_NAME.WRITTEN_PART_1) ||
-					PROCEDURE_TYPE_DISPLAY_NAME.WRITTEN_PART_1;
-				detailsHtml = detailsHtml.replace(PROCEDURE_TYPE_DISPLAY_NAME.WRITTEN_PART_1, displayName);
-			} else if (detailsHtml.includes(PROCEDURE_TYPE_DISPLAY_NAME.WRITTEN_PART_2)) {
+					appealProcedureNameToLabelText(PROCEDURE_TYPE_NAME.WRITTEN_PART_1) ||
+					PROCEDURE_TYPE_NAME.WRITTEN_PART_1;
+				detailsHtml = detailsHtml.replace(PROCEDURE_TYPE_NAME.WRITTEN_PART_1, displayName);
+			} else if (detailsHtml.includes(PROCEDURE_TYPE_NAME.WRITTEN_PART_2)) {
 				const displayName =
-					appealProcedureNameToLabelText(PROCEDURE_TYPE_DISPLAY_NAME.WRITTEN_PART_2) ||
-					PROCEDURE_TYPE_DISPLAY_NAME.WRITTEN_PART_2;
-				detailsHtml = detailsHtml.replace(PROCEDURE_TYPE_DISPLAY_NAME.WRITTEN_PART_2, displayName);
+					appealProcedureNameToLabelText(PROCEDURE_TYPE_NAME.WRITTEN_PART_2) ||
+					PROCEDURE_TYPE_NAME.WRITTEN_PART_2;
+				detailsHtml = detailsHtml.replace(PROCEDURE_TYPE_NAME.WRITTEN_PART_2, displayName);
 			}
 
 			const loggedDate = utcToZonedTime(audit.loggedDate, 'Europe/London');

--- a/appeals/web/src/server/appeals/appeal-details/start-case/__tests__/__snapshots__/start-case.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/start-case/__tests__/__snapshots__/start-case.test.js.snap
@@ -20,12 +20,12 @@ exports[`start-case GET /start-case/select-procedure should render the select pr
                                     <div class="govuk-radios__item">
                                         <input class="govuk-radios__input" id="appeal-procedure" name="appealProcedure"
                                         type="radio" value="writtenPart1">
-                                        <label class="govuk-label govuk-radios__label" for="appeal-procedure">Part 1</label>
+                                        <label class="govuk-label govuk-radios__label" for="appeal-procedure">Written representations (Part 1)</label>
                                     </div>
                                     <div class="govuk-radios__item">
                                         <input class="govuk-radios__input" id="appeal-procedure-2" name="appealProcedure"
                                         type="radio" value="written">
-                                        <label class="govuk-label govuk-radios__label" for="appeal-procedure-2">Written representations</label>
+                                        <label class="govuk-label govuk-radios__label" for="appeal-procedure-2">Written representations (Part 2)</label>
                                     </div>
                                     <div class="govuk-radios__item">
                                         <input class="govuk-radios__input" id="appeal-procedure-3" name="appealProcedure"
@@ -64,7 +64,7 @@ exports[`start-case GET /start-case/select-procedure/check-and-confirm should re
                     <form method="POST" novalidate="novalidate">
                         <dl class="govuk-summary-list">
                             <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Appeal procedure</dt>
-                                <dd class="govuk-summary-list__value">Written representations</dd>
+                                <dd class="govuk-summary-list__value">Written representations (Part 2)</dd>
                             </div>
                         </dl>
                         <p class="govuk-body">We’ll start the timetable now and send emails to the relevant parties.</p>
@@ -110,7 +110,7 @@ exports[`start-case GET /start-case/select-procedure/check-and-confirm should re
                     <form method="POST" novalidate="novalidate">
                         <dl class="govuk-summary-list">
                             <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Appeal procedure</dt>
-                                <dd class="govuk-summary-list__value">Written representations</dd>
+                                <dd class="govuk-summary-list__value">Written representations (Part 2)</dd>
                             </div>
                         </dl>
                         <p class="govuk-body">We’ll start the timetable now and send emails to the relevant parties.</p>
@@ -208,7 +208,7 @@ exports[`start-case POST /start-case/select-procedure should re-render the selec
                                     <div class="govuk-radios__item">
                                         <input class="govuk-radios__input" id="appeal-procedure" name="appealProcedure"
                                         type="radio" value="written">
-                                        <label class="govuk-label govuk-radios__label" for="appeal-procedure">Written representations</label>
+                                        <label class="govuk-label govuk-radios__label" for="appeal-procedure">Written representations (Part 2)</label>
                                     </div>
                                     <div class="govuk-radios__item">
                                         <input class="govuk-radios__input" id="appeal-procedure-2" name="appealProcedure"

--- a/appeals/web/src/server/appeals/appeal-details/start-case/hearing/__tests__/__snapshots__/start-case-hearing.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/start-case/hearing/__tests__/__snapshots__/start-case-hearing.test.js.snap
@@ -404,7 +404,7 @@ exports[`start case hearing flow POST /start-case/hearing/confirm should redirec
             </dd>
         </div>
         <div class="govuk-summary-list__row appeal-case-procedure"><dt class="govuk-summary-list__key"> Appeal procedure</dt>
-            <dd class="govuk-summary-list__value">Written representations (Part 2)</dd>
+            <dd class="govuk-summary-list__value">Hearing</dd>
             <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/change-appeal-procedure-type/change-selected-procedure-type"
                 data-cy="change-case-procedure">Change<span class="govuk-visually-hidden"> Appeal procedure</span></a>
             </dd>

--- a/appeals/web/src/server/appeals/appeal-details/start-case/hearing/__tests__/__snapshots__/start-case-hearing.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/start-case/hearing/__tests__/__snapshots__/start-case-hearing.test.js.snap
@@ -404,7 +404,7 @@ exports[`start case hearing flow POST /start-case/hearing/confirm should redirec
             </dd>
         </div>
         <div class="govuk-summary-list__row appeal-case-procedure"><dt class="govuk-summary-list__key"> Appeal procedure</dt>
-            <dd class="govuk-summary-list__value">Written</dd>
+            <dd class="govuk-summary-list__value">Written representations (Part 2)</dd>
             <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/change-appeal-procedure-type/change-selected-procedure-type"
                 data-cy="change-case-procedure">Change<span class="govuk-visually-hidden"> Appeal procedure</span></a>
             </dd>

--- a/appeals/web/src/server/appeals/appeal-details/start-case/hearing/__tests__/start-case-hearing.test.js
+++ b/appeals/web/src/server/appeals/appeal-details/start-case/hearing/__tests__/start-case-hearing.test.js
@@ -557,7 +557,8 @@ describe('start case hearing flow', () => {
 				.reply(200, {
 					...appealDataWithoutStartDate,
 					appealType: 'Planning appeal',
-					completedStateList: ['lpa_questionnaire']
+					completedStateList: ['lpa_questionnaire'],
+					procedureType: 'Hearing'
 				});
 			nock('http://test/')
 				.post('/appeals/1/appeal-timetables', {

--- a/appeals/web/src/server/appeals/appeal-details/start-case/start-case.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/start-case/start-case.mapper.js
@@ -7,8 +7,7 @@ import { editLink } from '#lib/edit-utilities.js';
 import { detailsComponent } from '#lib/mappers/components/page-components/details.js';
 import { radiosInput } from '#lib/mappers/components/page-components/radio.js';
 import { simpleHtmlComponent, textSummaryListItem } from '#lib/mappers/index.js';
-import { getWrittenProcedureTypeDisplayLabel } from '#lib/procedure-type-display-name-formatter.js';
-import { capitalizeFirstLetter } from '#lib/string-utilities.js';
+import { appealProcedureKeyToLabelText } from '#lib/procedure-type-display-name-formatter.js';
 import { APPEAL_TYPE, FEATURE_FLAG_NAMES } from '@pins/appeals/constants/common.js';
 import { isS78ExpeditedAppealType } from '@pins/appeals/utils/appeal-type-checks.js';
 import { APPEAL_CASE_PROCEDURE } from '@planning-inspectorate/data-model';
@@ -154,14 +153,9 @@ export function selectProcedurePage(
 			(!item.featureFlag || featureFlags.isFeatureActive(item.featureFlag)) &&
 			item.appeals.includes(appealType)
 		) {
-			let procedureTypeDisplayText;
-			procedureTypeDisplayText = appealProcedureToLabelText(item.case);
-			procedureTypeDisplayText === 'Part 1' || procedureTypeDisplayText === 'Written'
-				? getWrittenProcedureTypeDisplayLabel(item.case)
-				: procedureTypeDisplayText;
 			radioItems.push({
 				value: item.case,
-				text: procedureTypeDisplayText,
+				text: appealProcedureKeyToLabelText(item.case),
 				checked:
 					storedSessionData?.appealProcedure && storedSessionData?.appealProcedure === item.case
 			});
@@ -221,11 +215,6 @@ export function confirmProcedurePage(
 		APPEAL_TYPE.ENFORCEMENT_LISTED_BUILDING
 	].includes(appealType);
 
-	let procedureTypeDisplayText = appealProcedureToLabelText(procedureType);
-	procedureTypeDisplayText === 'Part 1' || procedureTypeDisplayText === 'Written'
-		? getWrittenProcedureTypeDisplayLabel(procedureType)
-		: procedureTypeDisplayText;
-
 	/** @type {PageContent} */
 	const pageContent = {
 		title: 'Check details and start case',
@@ -240,7 +229,7 @@ export function confirmProcedurePage(
 						textSummaryListItem({
 							id: 'appeal-procedure',
 							text: 'Appeal procedure',
-							value: procedureTypeDisplayText,
+							value: appealProcedureKeyToLabelText(procedureType) || 'No data',
 							link: editLink(
 								`/appeals-service/appeal-details/${appealId}/start-case/select-procedure`
 							),
@@ -262,22 +251,4 @@ export function confirmProcedurePage(
 	};
 
 	return pageContent;
-}
-
-/**
- * @param {string} procedureType
- * @returns {string}
- */
-function appealProcedureToLabelText(procedureType) {
-	switch (procedureType) {
-		case APPEAL_CASE_PROCEDURE.WRITTEN:
-			return 'Written representations';
-		case APPEAL_CASE_PROCEDURE.WRITTEN_PART_1:
-			return 'Part 1';
-		case APPEAL_CASE_PROCEDURE.HEARING:
-		case APPEAL_CASE_PROCEDURE.INQUIRY:
-			return capitalizeFirstLetter(procedureType);
-		default:
-			return '';
-	}
 }

--- a/appeals/web/src/server/appeals/appeal-details/start-case/start-case.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/start-case/start-case.mapper.js
@@ -7,6 +7,7 @@ import { editLink } from '#lib/edit-utilities.js';
 import { detailsComponent } from '#lib/mappers/components/page-components/details.js';
 import { radiosInput } from '#lib/mappers/components/page-components/radio.js';
 import { simpleHtmlComponent, textSummaryListItem } from '#lib/mappers/index.js';
+import { getWrittenProcedureTypeDisplayLabel } from '#lib/procedure-type-display-name-formatter.js';
 import { capitalizeFirstLetter } from '#lib/string-utilities.js';
 import { APPEAL_TYPE, FEATURE_FLAG_NAMES } from '@pins/appeals/constants/common.js';
 import { isS78ExpeditedAppealType } from '@pins/appeals/utils/appeal-type-checks.js';
@@ -153,9 +154,14 @@ export function selectProcedurePage(
 			(!item.featureFlag || featureFlags.isFeatureActive(item.featureFlag)) &&
 			item.appeals.includes(appealType)
 		) {
+			let procedureTypeDisplayText;
+			procedureTypeDisplayText = appealProcedureToLabelText(item.case);
+			procedureTypeDisplayText === 'Part 1' || procedureTypeDisplayText === 'Written'
+				? getWrittenProcedureTypeDisplayLabel(item.case)
+				: procedureTypeDisplayText;
 			radioItems.push({
 				value: item.case,
-				text: appealProcedureToLabelText(item.case),
+				text: procedureTypeDisplayText,
 				checked:
 					storedSessionData?.appealProcedure && storedSessionData?.appealProcedure === item.case
 			});
@@ -215,6 +221,11 @@ export function confirmProcedurePage(
 		APPEAL_TYPE.ENFORCEMENT_LISTED_BUILDING
 	].includes(appealType);
 
+	let procedureTypeDisplayText = appealProcedureToLabelText(procedureType);
+	procedureTypeDisplayText === 'Part 1' || procedureTypeDisplayText === 'Written'
+		? getWrittenProcedureTypeDisplayLabel(procedureType)
+		: procedureTypeDisplayText;
+
 	/** @type {PageContent} */
 	const pageContent = {
 		title: 'Check details and start case',
@@ -229,7 +240,7 @@ export function confirmProcedurePage(
 						textSummaryListItem({
 							id: 'appeal-procedure',
 							text: 'Appeal procedure',
-							value: appealProcedureToLabelText(procedureType),
+							value: procedureTypeDisplayText,
 							link: editLink(
 								`/appeals-service/appeal-details/${appealId}/start-case/select-procedure`
 							),

--- a/appeals/web/src/server/appeals/national-list/__tests__/__snapshots__/national-list.test.js.snap
+++ b/appeals/web/src/server/appeals/national-list/__tests__/__snapshots__/national-list.test.js.snap
@@ -58,7 +58,7 @@ exports[`national-list GET / should render national list - 10 pages - all page i
                             <select class="govuk-select" id="appeal-procedure-filter"
                             name="appealProcedureFilter" data-cy="filter-by-appeal-procedure">
                                 <option value="all">All</option>
-                                <option value="1">Written</option>
+                                <option value="1">Written representations (Part 2)</option>
                                 <option value="2">Hearing</option>
                                 <option value="3">Inquiry</option>
                             </select>
@@ -290,7 +290,7 @@ exports[`national-list GET / should render national list - 15 pages - pagination
                             <select class="govuk-select" id="appeal-procedure-filter"
                             name="appealProcedureFilter" data-cy="filter-by-appeal-procedure">
                                 <option value="all">All</option>
-                                <option value="1">Written</option>
+                                <option value="1">Written representations (Part 2)</option>
                                 <option value="2">Hearing</option>
                                 <option value="3">Inquiry</option>
                             </select>
@@ -505,7 +505,7 @@ exports[`national-list GET / should render national list - appeal procedure type
                             <select class="govuk-select" id="appeal-procedure-filter"
                             name="appealProcedureFilter" data-cy="filter-by-appeal-procedure">
                                 <option value="all">All</option>
-                                <option value="1" selected>Written</option>
+                                <option value="1" selected>Written representations (Part 2)</option>
                                 <option value="2">Hearing</option>
                                 <option value="3">Inquiry</option>
                             </select>
@@ -681,7 +681,7 @@ exports[`national-list GET / should render national list - appeal type filter ap
                             <select class="govuk-select" id="appeal-procedure-filter"
                             name="appealProcedureFilter" data-cy="filter-by-appeal-procedure">
                                 <option value="all">All</option>
-                                <option value="1">Written</option>
+                                <option value="1">Written representations (Part 2)</option>
                                 <option value="2">Hearing</option>
                                 <option value="3">Inquiry</option>
                             </select>
@@ -857,7 +857,7 @@ exports[`national-list GET / should render national list - case team filter appl
                             <select class="govuk-select" id="appeal-procedure-filter"
                             name="appealProcedureFilter" data-cy="filter-by-appeal-procedure">
                                 <option value="all">All</option>
-                                <option value="1">Written</option>
+                                <option value="1">Written representations (Part 2)</option>
                                 <option value="2">Hearing</option>
                                 <option value="3">Inquiry</option>
                             </select>
@@ -1030,7 +1030,7 @@ exports[`national-list GET / should render national list - no pagination 1`] = `
                             <select class="govuk-select" id="appeal-procedure-filter"
                             name="appealProcedureFilter" data-cy="filter-by-appeal-procedure">
                                 <option value="all">All</option>
-                                <option value="1">Written</option>
+                                <option value="1">Written representations (Part 2)</option>
                                 <option value="2">Hearing</option>
                                 <option value="3">Inquiry</option>
                             </select>
@@ -1224,7 +1224,7 @@ exports[`national-list GET / should render national list - no search term - filt
                             <select class="govuk-select" id="appeal-procedure-filter"
                             name="appealProcedureFilter" data-cy="filter-by-appeal-procedure">
                                 <option value="all">All</option>
-                                <option value="1">Written</option>
+                                <option value="1">Written representations (Part 2)</option>
                                 <option value="2">Hearing</option>
                                 <option value="3">Inquiry</option>
                             </select>
@@ -1412,7 +1412,7 @@ exports[`national-list GET / should render national list - search term - filter 
                             <select class="govuk-select" id="appeal-procedure-filter"
                             name="appealProcedureFilter" data-cy="filter-by-appeal-procedure">
                                 <option value="all">All</option>
-                                <option value="1">Written</option>
+                                <option value="1">Written representations (Part 2)</option>
                                 <option value="2">Hearing</option>
                                 <option value="3">Inquiry</option>
                             </select>
@@ -1600,7 +1600,7 @@ exports[`national-list GET / should render national list - search term - no resu
                             <select class="govuk-select" id="appeal-procedure-filter"
                             name="appealProcedureFilter" data-cy="filter-by-appeal-procedure">
                                 <option value="all">All</option>
-                                <option value="1">Written</option>
+                                <option value="1">Written representations (Part 2)</option>
                                 <option value="2">Hearing</option>
                                 <option value="3">Inquiry</option>
                             </select>
@@ -1745,7 +1745,7 @@ exports[`national-list GET / should render national list - search term 1`] = `
                             <select class="govuk-select" id="appeal-procedure-filter"
                             name="appealProcedureFilter" data-cy="filter-by-appeal-procedure">
                                 <option value="all">All</option>
-                                <option value="1">Written</option>
+                                <option value="1">Written representations (Part 2)</option>
                                 <option value="2">Hearing</option>
                                 <option value="3">Inquiry</option>
                             </select>
@@ -1936,7 +1936,7 @@ exports[`national-list GET / should render the header with navigation containing
                             <select class="govuk-select" id="appeal-procedure-filter"
                             name="appealProcedureFilter" data-cy="filter-by-appeal-procedure">
                                 <option value="all">All</option>
-                                <option value="1">Written</option>
+                                <option value="1">Written representations (Part 2)</option>
                                 <option value="2">Hearing</option>
                                 <option value="3">Inquiry</option>
                             </select>
@@ -2127,7 +2127,7 @@ exports[`national-list GET / should show enforcement reference instead of planni
                             <select class="govuk-select" id="appeal-procedure-filter"
                             name="appealProcedureFilter" data-cy="filter-by-appeal-procedure">
                                 <option value="all">All</option>
-                                <option value="1">Written</option>
+                                <option value="1">Written representations (Part 2)</option>
                                 <option value="2">Hearing</option>
                                 <option value="3">Inquiry</option>
                             </select>
@@ -2300,7 +2300,7 @@ exports[`national-list GET / should show enforcement reference instead of planni
                             <select class="govuk-select" id="appeal-procedure-filter"
                             name="appealProcedureFilter" data-cy="filter-by-appeal-procedure">
                                 <option value="all">All</option>
-                                <option value="1">Written</option>
+                                <option value="1">Written representations (Part 2)</option>
                                 <option value="2">Hearing</option>
                                 <option value="3">Inquiry</option>
                             </select>

--- a/appeals/web/src/server/appeals/national-list/__tests__/national-list.test.js
+++ b/appeals/web/src/server/appeals/national-list/__tests__/national-list.test.js
@@ -159,7 +159,7 @@ describe('national-list', () => {
 
 			expect(unprettifiedElement.innerHTML).toContain('Hearing</option>');
 			expect(unprettifiedElement.innerHTML).toContain('Inquiry</option>');
-			expect(unprettifiedElement.innerHTML).toContain('Written</option>');
+			expect(unprettifiedElement.innerHTML).toContain('Written representations (Part 2)');
 		});
 
 		it('should render national list - search term', async () => {

--- a/appeals/web/src/server/appeals/national-list/national-list.mapper.js
+++ b/appeals/web/src/server/appeals/national-list/national-list.mapper.js
@@ -6,7 +6,7 @@ import { addressToString } from '#lib/address-formatter.js';
 import { mapStatusFilterLabel, mapStatusText } from '#lib/appeal-status.js';
 import { appealShortReference } from '#lib/appeals-formatter.js';
 import { preRenderPageComponents } from '#lib/nunjucks-template-builders/page-component-rendering.js';
-import { getWrittenProcedureTypeDisplayLabel } from '#lib/procedure-type-display-name-formatter.js';
+import { appealProcedureNameToLabelText } from '#lib/procedure-type-display-name-formatter.js';
 import { capitalizeFirstLetter } from '#lib/string-utilities.js';
 import { APPEAL_TYPE, FEATURE_FLAG_NAMES } from '@pins/appeals/constants/common.js';
 import { APPEAL_CASE_PROCEDURE } from '@planning-inspectorate/data-model';
@@ -183,10 +183,7 @@ export function nationalListPage(
 		...appealProcedureTypes
 			.filter(({ key }) => enabledAppealProcedures.includes(key))
 			.map(({ name, id }) => ({
-				text:
-					name.includes('Part 1') || name.includes('Written')
-						? getWrittenProcedureTypeDisplayLabel(name)
-						: name,
+				text: appealProcedureNameToLabelText(name),
 				value: id.toString(),
 				selected: appealProcedureFilter === id.toString()
 			}))

--- a/appeals/web/src/server/appeals/national-list/national-list.mapper.js
+++ b/appeals/web/src/server/appeals/national-list/national-list.mapper.js
@@ -6,6 +6,7 @@ import { addressToString } from '#lib/address-formatter.js';
 import { mapStatusFilterLabel, mapStatusText } from '#lib/appeal-status.js';
 import { appealShortReference } from '#lib/appeals-formatter.js';
 import { preRenderPageComponents } from '#lib/nunjucks-template-builders/page-component-rendering.js';
+import { getWrittenProcedureTypeDisplayLabel } from '#lib/procedure-type-display-name-formatter.js';
 import { capitalizeFirstLetter } from '#lib/string-utilities.js';
 import { APPEAL_TYPE, FEATURE_FLAG_NAMES } from '@pins/appeals/constants/common.js';
 import { APPEAL_CASE_PROCEDURE } from '@planning-inspectorate/data-model';
@@ -182,7 +183,10 @@ export function nationalListPage(
 		...appealProcedureTypes
 			.filter(({ key }) => enabledAppealProcedures.includes(key))
 			.map(({ name, id }) => ({
-				text: name,
+				text:
+					name.includes('Part 1') || name.includes('Written')
+						? getWrittenProcedureTypeDisplayLabel(name)
+						: name,
 				value: id.toString(),
 				selected: appealProcedureFilter === id.toString()
 			}))

--- a/appeals/web/src/server/lib/mappers/data/appeal/submappers/__tests__/case-procedure.mapper.test.js
+++ b/appeals/web/src/server/lib/mappers/data/appeal/submappers/__tests__/case-procedure.mapper.test.js
@@ -2,9 +2,8 @@
 import { mapCaseProcedure } from '#lib/mappers/data/appeal/submappers/case-procedure.mapper.js';
 import { jest } from '@jest/globals';
 import config from '@pins/appeals.web/environment/config.js';
-import { APPEAL_TYPE } from '@pins/appeals/constants/common.js';
+import { APPEAL_TYPE, PROCEDURE_TYPE_DISPLAY_NAME } from '@pins/appeals/constants/common.js';
 import { DOCUMENT_STATUS_RECEIVED } from '@pins/appeals/constants/support.js';
-import { APPEAL_CASE_PROCEDURE } from '@planning-inspectorate/data-model';
 
 describe('case-procedure.mapper', () => {
 	let params;
@@ -21,7 +20,7 @@ describe('case-procedure.mapper', () => {
 		params = {
 			appealDetails: {
 				startedAt: new Date('2025-01-01'),
-				procedureType: APPEAL_CASE_PROCEDURE.HEARING,
+				procedureType: PROCEDURE_TYPE_DISPLAY_NAME.HEARING,
 				appealTimetable: {},
 				appealType: APPEAL_TYPE.S78,
 				documentationSummary: {
@@ -69,7 +68,7 @@ describe('case-procedure.mapper', () => {
 						text: 'Appeal procedure'
 					},
 					value: {
-						text: 'hearing'
+						text: 'Hearing'
 					}
 				}
 			},
@@ -120,7 +119,7 @@ describe('case-procedure.mapper', () => {
 						text: 'Appeal procedure'
 					},
 					value: {
-						text: 'hearing'
+						text: 'Hearing'
 					}
 				}
 			},
@@ -142,7 +141,7 @@ describe('case-procedure.mapper', () => {
 						text: 'Appeal procedure'
 					},
 					value: {
-						text: 'hearing'
+						text: 'Hearing'
 					}
 				}
 			},

--- a/appeals/web/src/server/lib/mappers/data/appeal/submappers/__tests__/case-procedure.mapper.test.js
+++ b/appeals/web/src/server/lib/mappers/data/appeal/submappers/__tests__/case-procedure.mapper.test.js
@@ -2,7 +2,7 @@
 import { mapCaseProcedure } from '#lib/mappers/data/appeal/submappers/case-procedure.mapper.js';
 import { jest } from '@jest/globals';
 import config from '@pins/appeals.web/environment/config.js';
-import { APPEAL_TYPE, PROCEDURE_TYPE_DISPLAY_NAME } from '@pins/appeals/constants/common.js';
+import { APPEAL_TYPE, PROCEDURE_TYPE_NAME } from '@pins/appeals/constants/common.js';
 import { DOCUMENT_STATUS_RECEIVED } from '@pins/appeals/constants/support.js';
 
 describe('case-procedure.mapper', () => {
@@ -20,7 +20,7 @@ describe('case-procedure.mapper', () => {
 		params = {
 			appealDetails: {
 				startedAt: new Date('2025-01-01'),
-				procedureType: PROCEDURE_TYPE_DISPLAY_NAME.HEARING,
+				procedureType: PROCEDURE_TYPE_NAME.HEARING,
 				appealTimetable: {},
 				appealType: APPEAL_TYPE.S78,
 				documentationSummary: {

--- a/appeals/web/src/server/lib/mappers/data/appeal/submappers/case-procedure.mapper.js
+++ b/appeals/web/src/server/lib/mappers/data/appeal/submappers/case-procedure.mapper.js
@@ -1,6 +1,7 @@
 import featureFlags from '#common/feature-flags.js';
 import { textSummaryListItem } from '#lib/mappers/index.js';
 import isLinkedAppeal from '#lib/mappers/utils/is-linked-appeal.js';
+import { getWrittenProcedureTypeDisplayLabel } from '#lib/procedure-type-display-name-formatter.js';
 import { APPEAL_TYPE, FEATURE_FLAG_NAMES } from '@pins/appeals/constants/common.js';
 
 /**
@@ -24,10 +25,15 @@ export const mapCaseProcedure = ({ appealDetails, currentRoute, userHasUpdateCas
 		return { id: 'case-procedure', display: {} };
 	}
 
+	let procedureTypeDisplayText =
+		appealDetails.procedureType === 'Part 1' || appealDetails.procedureType === 'Written'
+			? getWrittenProcedureTypeDisplayLabel(appealDetails.procedureType)
+			: appealDetails.procedureType;
+
 	return textSummaryListItem({
 		id: 'case-procedure',
 		text: 'Appeal procedure',
-		value: appealDetails.procedureType || 'No data',
+		value: procedureTypeDisplayText || 'No data',
 		link: `${currentRoute}/change-appeal-procedure-type/change-selected-procedure-type`,
 		editable:
 			userHasUpdateCasePermission &&

--- a/appeals/web/src/server/lib/mappers/data/appeal/submappers/case-procedure.mapper.js
+++ b/appeals/web/src/server/lib/mappers/data/appeal/submappers/case-procedure.mapper.js
@@ -1,7 +1,7 @@
 import featureFlags from '#common/feature-flags.js';
 import { textSummaryListItem } from '#lib/mappers/index.js';
 import isLinkedAppeal from '#lib/mappers/utils/is-linked-appeal.js';
-import { getWrittenProcedureTypeDisplayLabel } from '#lib/procedure-type-display-name-formatter.js';
+import { appealProcedureNameToLabelText } from '#lib/procedure-type-display-name-formatter.js';
 import { APPEAL_TYPE, FEATURE_FLAG_NAMES } from '@pins/appeals/constants/common.js';
 
 /**
@@ -25,15 +25,10 @@ export const mapCaseProcedure = ({ appealDetails, currentRoute, userHasUpdateCas
 		return { id: 'case-procedure', display: {} };
 	}
 
-	let procedureTypeDisplayText =
-		appealDetails.procedureType === 'Part 1' || appealDetails.procedureType === 'Written'
-			? getWrittenProcedureTypeDisplayLabel(appealDetails.procedureType)
-			: appealDetails.procedureType;
-
 	return textSummaryListItem({
 		id: 'case-procedure',
 		text: 'Appeal procedure',
-		value: procedureTypeDisplayText || 'No data',
+		value: appealProcedureNameToLabelText(appealDetails.procedureType || '') || 'No data',
 		link: `${currentRoute}/change-appeal-procedure-type/change-selected-procedure-type`,
 		editable:
 			userHasUpdateCasePermission &&

--- a/appeals/web/src/server/lib/procedure-type-display-name-formatter.js
+++ b/appeals/web/src/server/lib/procedure-type-display-name-formatter.js
@@ -1,19 +1,19 @@
 import { capitalizeFirstLetter } from '#lib/string-utilities.js';
-import { PROCEDURE_TYPE_DISPLAY_NAME } from '@pins/appeals/constants/common.js';
+import { PROCEDURE_TYPE_NAME } from '@pins/appeals/constants/common.js';
 import { APPEAL_CASE_PROCEDURE } from '@planning-inspectorate/data-model';
 
 /**
- * @param {"Written" | "Part 1" | "Hearing" | "Inquiry" | string} procedureTypeName
+ * @param {string} procedureTypeName
  * @returns string | null
  */
 export function appealProcedureNameToLabelText(procedureTypeName) {
 	switch (procedureTypeName) {
-		case PROCEDURE_TYPE_DISPLAY_NAME.WRITTEN_PART_2:
+		case PROCEDURE_TYPE_NAME.WRITTEN_PART_2:
 			return 'Written representations (Part 2)';
-		case PROCEDURE_TYPE_DISPLAY_NAME.WRITTEN_PART_1:
+		case PROCEDURE_TYPE_NAME.WRITTEN_PART_1:
 			return 'Written representations (Part 1)';
-		case PROCEDURE_TYPE_DISPLAY_NAME.HEARING:
-		case PROCEDURE_TYPE_DISPLAY_NAME.INQUIRY:
+		case PROCEDURE_TYPE_NAME.HEARING:
+		case PROCEDURE_TYPE_NAME.INQUIRY:
 			return procedureTypeName;
 		default:
 			return null;

--- a/appeals/web/src/server/lib/procedure-type-display-name-formatter.js
+++ b/appeals/web/src/server/lib/procedure-type-display-name-formatter.js
@@ -1,11 +1,39 @@
+import { capitalizeFirstLetter } from '#lib/string-utilities.js';
+import { PROCEDURE_TYPE_DISPLAY_NAME } from '@pins/appeals/constants/common.js';
+import { APPEAL_CASE_PROCEDURE } from '@planning-inspectorate/data-model';
+
 /**
- * @param {"Written" | "Part 1" | string} procedureTypeDisplayName
- * @returns (substring: string, ...args: any[]) => string
+ * @param {"Written" | "Part 1" | "Hearing" | "Inquiry" | string} procedureTypeName
+ * @returns string | null
  */
-export const getWrittenProcedureTypeDisplayLabel = (procedureTypeDisplayName) => {
-	if (procedureTypeDisplayName === 'Written') {
-		return 'Written representations (Part 2)';
-	} else if (procedureTypeDisplayName === 'Part 1') {
-		return 'Written representations (Part 1)';
+export function appealProcedureNameToLabelText(procedureTypeName) {
+	switch (procedureTypeName) {
+		case PROCEDURE_TYPE_DISPLAY_NAME.WRITTEN_PART_2:
+			return 'Written representations (Part 2)';
+		case PROCEDURE_TYPE_DISPLAY_NAME.WRITTEN_PART_1:
+			return 'Written representations (Part 1)';
+		case PROCEDURE_TYPE_DISPLAY_NAME.HEARING:
+		case PROCEDURE_TYPE_DISPLAY_NAME.INQUIRY:
+			return procedureTypeName;
+		default:
+			return null;
 	}
-};
+}
+
+/**
+ * @param {string} procedureTypeKey
+ * @returns string
+ */
+export function appealProcedureKeyToLabelText(procedureTypeKey) {
+	switch (procedureTypeKey) {
+		case APPEAL_CASE_PROCEDURE.WRITTEN:
+			return 'Written representations (Part 2)';
+		case APPEAL_CASE_PROCEDURE.WRITTEN_PART_1:
+			return 'Written representations (Part 1)';
+		case APPEAL_CASE_PROCEDURE.HEARING:
+		case APPEAL_CASE_PROCEDURE.INQUIRY:
+			return capitalizeFirstLetter(procedureTypeKey);
+		default:
+			return '';
+	}
+}

--- a/appeals/web/src/server/lib/procedure-type-display-name-formatter.js
+++ b/appeals/web/src/server/lib/procedure-type-display-name-formatter.js
@@ -1,0 +1,11 @@
+/**
+ * @param {"Written" | "Part 1" | string} procedureTypeDisplayName
+ * @returns (substring: string, ...args: any[]) => string
+ */
+export const getWrittenProcedureTypeDisplayLabel = (procedureTypeDisplayName) => {
+	if (procedureTypeDisplayName === 'Written') {
+		return 'Written representations (Part 2)';
+	} else if (procedureTypeDisplayName === 'Part 1') {
+		return 'Written representations (Part 1)';
+	}
+};

--- a/packages/appeals/constants/common.js
+++ b/packages/appeals/constants/common.js
@@ -87,7 +87,7 @@ export const PROCEDURE_TYPE_MAP = Object.freeze({
 	inquiry: 'an inquiry'
 });
 
-export const PROCEDURE_TYPE_DISPLAY_NAME = Object.freeze({
+export const PROCEDURE_TYPE_NAME = Object.freeze({
 	WRITTEN_PART_2: 'Written',
 	WRITTEN_PART_1: 'Part 1',
 	HEARING: 'Hearing',

--- a/packages/appeals/constants/common.js
+++ b/packages/appeals/constants/common.js
@@ -87,6 +87,13 @@ export const PROCEDURE_TYPE_MAP = Object.freeze({
 	inquiry: 'an inquiry'
 });
 
+export const PROCEDURE_TYPE_DISPLAY_NAME = Object.freeze({
+	WRITTEN_PART_2: 'Written',
+	WRITTEN_PART_1: 'Part 1',
+	HEARING: 'Hearing',
+	INQUIRY: 'Inquiry'
+});
+
 export const PROCEDURE_TYPE_ID_MAP = Object.freeze({
 	hearing: 1,
 	inquiry: 2,


### PR DESCRIPTION
1. Updated display name applied to:
- Start case > select procedure flow
- Case history procedure type logs
- Case overview procedure type display
- All cases dropdown filter box
2. Util function added for quick access method of changing written rep display names
3. Updates snapshots


Ticket: https://pins-ds.atlassian.net/browse/A2-8052