### PR TITLE
feat(appeals): add middleware that checks appeal exists only (a2-4177)

### DIFF
--- a/appeals/api/src/server/endpoints/appeal-details/__tests__/appeals-details.test.js
+++ b/appeals/api/src/server/endpoints/appeal-details/__tests__/appeals-details.test.js
@@ -1378,6 +1378,50 @@ describe('Appeal detail routes', () => {
 			});
 		});
 	});
+
+	describe('/appeals/:appealId/exists', () => {
+		describe('GET', () => {
+			test('checks an appeal exists', async () => {
+				databaseConnector.appeal.findUnique.mockResolvedValue({
+					...mocks.householdAppeal,
+					folders
+				});
+
+				const response = await request
+					.get(`/appeals/${mocks.householdAppeal.id}/exists`)
+					.set('azureAdUserId', azureAdUserId);
+
+				expect(response.status).toEqual(200);
+				expect(response.body).toEqual({ id: mocks.householdAppeal.id });
+			});
+
+			test('returns an error if appealId is not numeric', async () => {
+				const response = await request
+					.get('/appeals/one/exists')
+					.set('azureAdUserId', azureAdUserId);
+
+				expect(response.status).toEqual(400);
+				expect(response.body).toEqual({
+					errors: {
+						appealId: ERROR_MUST_BE_NUMBER
+					}
+				});
+			});
+
+			test('returns an error if appealId is not found', async () => {
+				databaseConnector.appeal.findUnique.mockResolvedValue(null);
+
+				const response = await request.get('/appeals/3/exists').set('azureAdUserId', azureAdUserId);
+
+				expect(response.status).toEqual(404);
+				expect(response.body).toEqual({
+					errors: {
+						appealId: ERROR_NOT_FOUND
+					}
+				});
+			});
+		});
+	});
 });
 
 describe('appeals/case-reference/:caseReference', () => {

--- a/appeals/api/src/server/endpoints/appeal-details/appeal-details.routes.js
+++ b/appeals/api/src/server/endpoints/appeal-details/appeal-details.routes.js
@@ -1,5 +1,6 @@
 import {
 	checkAppealExistsByCaseReferenceAndAddToRequest,
+	checkAppealExistsById,
 	checkAppealExistsByIdAndAddPartialToRequest
 } from '#middleware/check-appeal-exists-and-add-to-request.js';
 import { asyncHandler } from '@pins/express';
@@ -12,6 +13,40 @@ import {
 } from './appeal-details.validators.js';
 
 const router = createRouter();
+
+router.get(
+	'/:appealId/exists',
+	/*
+		#swagger.tags = ['Appeal Details']
+		#swagger.path = '/appeals/{appealId}/exists'
+		#swagger.description = Checks if an appeal exists by ID
+		#swagger.parameters['azureAdUserId'] = {
+			in: 'header',
+			required: true,
+			example: '434bff4e-8191-4ce0-9a0a-91e5d6cdd882'
+		}
+		#swagger.responses[200] = {
+			description: '200 if appeal exists'
+			schema: {
+				type: 'object',
+				properties: {
+					id: { type: 'integer', example: 123 }
+				},
+				required: ['id']
+			}
+		}
+		#swagger.responses[400] = {}
+		#swagger.responses[404] = {}
+	 */
+	getAppealValidator,
+	asyncHandler(checkAppealExistsById),
+	/** @type {import("express").RequestHandler} */
+	(req, res) => {
+		return res.status(200).send({
+			id: Number(req.params.appealId)
+		});
+	}
+);
 
 router.get(
 	'/:appealId',

--- a/appeals/api/src/server/middleware/check-appeal-exists-and-add-to-request.js
+++ b/appeals/api/src/server/middleware/check-appeal-exists-and-add-to-request.js
@@ -83,3 +83,20 @@ export const checkAppealExistsByIdAndAddPartialToRequest =
 		req.appeal = appeal;
 		next();
 	};
+
+/**
+ * @type {import('express').Handler}
+ */
+export const checkAppealExistsById = async (req, res, next) => {
+	const {
+		params: { appealId }
+	} = req;
+
+	const appeal = await appealRepository.checkAppealExistsById(Number(appealId));
+
+	if (!appeal) {
+		return res.status(404).send({ errors: { appealId: ERROR_NOT_FOUND } });
+	}
+
+	next();
+};

--- a/appeals/api/src/server/openapi.json
+++ b/appeals/api/src/server/openapi.json
@@ -142,6 +142,36 @@
 				}
 			}
 		},
+		"/appeals/{appealId}/exists": {
+			"get": {
+				"tags": ["Appeal Details"],
+				"description": "Checks if an appeal exists by ID",
+				"parameters": [
+					{
+						"name": "appealId",
+						"in": "path",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"name": "azureAdUserId",
+						"in": "header",
+						"required": true,
+						"example": "434bff4e-8191-4ce0-9a0a-91e5d6cdd882",
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK"
+					}
+				}
+			}
+		},
 		"/appeals/{appealId}": {
 			"get": {
 				"tags": ["Appeal Details"],

--- a/appeals/api/src/server/repositories/appeal.repository.js
+++ b/appeals/api/src/server/repositories/appeal.repository.js
@@ -427,6 +427,21 @@ const getAppealById = async (id, includeDetails = true, selectedKeys = [], selec
 };
 
 /**
+ * @param {number} id
+ * @returns {Promise<{id: number} | null>}
+ */
+const checkAppealExistsById = async (id) => {
+	return databaseConnector.appeal.findUnique({
+		where: {
+			id
+		},
+		select: {
+			id: true
+		}
+	});
+};
+
+/**
  * @deprecated too inefficient do not use, use getAppealById with specific includes only
  * @description DO NOT USE. Gets an appeal and all it's related entities
  * @param {number} id
@@ -954,6 +969,7 @@ const getAppealReference = async (appealId) => {
 };
 
 export default {
+	checkAppealExistsById,
 	getLinkedAppeals,
 	getLinkedAppealsById,
 	getAppealById,

--- a/appeals/web/src/server/appeals/appeal-details/appeal-details.middleware.js
+++ b/appeals/web/src/server/appeals/appeal-details/appeal-details.middleware.js
@@ -1,5 +1,6 @@
 import { areIdParamsValid } from '#lib/validators/id-param.validator.js';
 import {
+	checkAppealExists,
 	deprecatedGetAppealDetailsFromId,
 	getAppealDetailsFromId
 } from './appeal-details.service.js';
@@ -15,6 +16,10 @@ export const validateAppeal = async (req, res, next) => {
 
 	if (!areIdParamsValid(appealId || caseId)) {
 		return res.status(400).render('app/400.njk');
+	}
+
+	if (req.currentAppeal) {
+		throw new Error('validateAppeal should only be called once per request');
 	}
 
 	try {
@@ -50,6 +55,10 @@ export const validateAppealWithInclude =
 			return res.status(400).render('app/400.njk');
 		}
 
+		if (req.currentAppeal) {
+			throw new Error('validateAppealWithInclude should only be called once per request');
+		}
+
 		const include = keysToInclude.join(',');
 
 		try {
@@ -68,3 +77,34 @@ export const validateAppealWithInclude =
 			}
 		}
 	};
+
+/**
+ * @type {import("express").RequestHandler}
+ */
+export const validateAppealExists = async (req, res, next) => {
+	const { appealId, caseId } = req.params;
+
+	if (!areIdParamsValid(appealId || caseId)) {
+		return res.status(400).render('app/400.njk');
+	}
+
+	if (req.currentAppeal) {
+		throw new Error('validateAppealExists should only be called once per request');
+	}
+
+	try {
+		const appeal = await checkAppealExists(req.apiClient, appealId || caseId);
+		if (!appeal) {
+			return res.status(404).render('app/404.njk');
+		}
+		req.currentAppeal = appeal;
+		next();
+	} catch (/** @type {any} */ error) {
+		switch (error?.response?.statusCode) {
+			case 404:
+				return res.status(404).render('app/404.njk');
+			default:
+				return res.status(500).render('app/500.njk');
+		}
+	}
+};

--- a/appeals/web/src/server/appeals/appeal-details/appeal-details.service.js
+++ b/appeals/web/src/server/appeals/appeal-details/appeal-details.service.js
@@ -32,6 +32,19 @@ export function deprecatedGetAppealDetailsFromId(apiClient, appealId) {
 }
 
 /**
+ *
+ * @param {import('got').Got} apiClient
+ * @param {string} appealId
+ * @returns {Promise<{appealId: number}>}
+ */
+export function checkAppealExists(apiClient, appealId) {
+	const encodedAppealId = encodeURIComponent(appealId);
+	const url = `appeals/${encodedAppealId}/exists`;
+
+	return apiClient.get(url).json();
+}
+
+/**
  * @param {import('got').Got} apiClient
  * @param {string} appealId
  * @param {boolean} eiaScreeningRequired

--- a/appeals/web/src/server/appeals/appeal-details/change-procedure-type/change-procedure-timetable/change-procedure-timetable.router.js
+++ b/appeals/web/src/server/appeals/appeal-details/change-procedure-type/change-procedure-timetable/change-procedure-timetable.router.js
@@ -1,4 +1,3 @@
-import { validateAppeal } from '#appeals/appeal-details/appeal-details.middleware.js';
 import { addAppellantCaseToLocals } from '#appeals/appeal-details/timetable/timetable.middleware.js';
 import { saveBodyToSession } from '#lib/middleware/save-body-to-session.js';
 import { asyncHandler } from '@pins/express';
@@ -10,9 +9,8 @@ const router = createRouter({ mergeParams: true });
 
 router
 	.route('/')
-	.get(validateAppeal, addAppellantCaseToLocals, asyncHandler(controllers.getChangeAppealTimetable))
+	.get(addAppellantCaseToLocals, asyncHandler(controllers.getChangeAppealTimetable))
 	.post(
-		validateAppeal,
 		addAppellantCaseToLocals,
 		runTimetableValidators,
 		saveBodyToSession('changeProcedureType', { scopeToAppeal: true }),

--- a/appeals/web/src/server/appeals/appeal-details/representations/document-attachments/manage-documents.router.js
+++ b/appeals/web/src/server/appeals/appeal-details/representations/document-attachments/manage-documents.router.js
@@ -1,5 +1,4 @@
 import { assertUserHasPermission } from '#app/auth/auth.guards.js';
-import { validateAppeal } from '#appeals/appeal-details/appeal-details.middleware.js';
 import {
 	validateCaseDocumentId,
 	validateCaseFolderId
@@ -41,13 +40,11 @@ router
 router
 	.route('/change-document-name/:folderId/:documentId')
 	.get(
-		validateAppeal,
 		assertUserHasPermission(permissionNames.updateCase),
 
 		asyncHandler(controller.getChangeDocumentFileNameDetails)
 	)
 	.post(
-		validateAppeal,
 		assertUserHasPermission(permissionNames.updateCase),
 
 		documentsValidators.validateDocumentNameBodyFormat,
@@ -58,13 +55,11 @@ router
 router
 	.route('/change-document-details/:folderId/:documentId')
 	.get(
-		validateAppeal,
 		assertUserHasPermission(permissionNames.updateCase),
 
 		asyncHandler(controller.getChangeDocumentVersionDetails)
 	)
 	.post(
-		validateAppeal,
 		assertUserHasPermission(permissionNames.updateCase),
 
 		documentsValidators.validateDocumentDetailsBodyFormat,
@@ -79,14 +74,12 @@ router
 router
 	.route('/:folderId/:documentId/:versionId/delete')
 	.get(
-		validateAppeal,
 		assertUserHasPermission(permissionNames.updateCase),
 
 		validateCaseDocumentId,
 		asyncHandler(controller.getDeleteDocument)
 	)
 	.post(
-		validateAppeal,
 		assertUserHasPermission(permissionNames.updateCase),
 
 		validateCaseDocumentId,
@@ -96,24 +89,16 @@ router
 
 router
 	.route('/add-documents/:folderId/:documentId')
-	.get(
-		validateAppeal,
-
-		validateCaseDocumentId,
-		asyncHandler(controller.getAddDocumentVersion)
-	)
+	.get(validateCaseDocumentId, asyncHandler(controller.getAddDocumentVersion))
 	.post(
-		validateAppeal,
-
 		assertUserHasPermission(permissionNames.updateCase),
 		asyncHandler(controller.postAddDocumentVersion)
 	);
 
 router
 	.route('/add-document-details/:folderId/:documentId')
-	.get(validateAppeal, asyncHandler(controller.getAddDocumentVersionDetails))
+	.get(asyncHandler(controller.getAddDocumentVersionDetails))
 	.post(
-		validateAppeal,
 		assertUserHasPermission(permissionNames.updateCase),
 
 		documentsValidators.validateDocumentDetailsBodyFormat,
@@ -128,14 +113,10 @@ router
 router
 	.route('/check-your-answers/:folderId/:documentId')
 	.get(
-		validateAppeal,
-
 		assertUserHasPermission(permissionNames.updateCase),
 		asyncHandler(controller.getAddDocumentsCheckAndConfirm)
 	)
 	.post(
-		validateAppeal,
-
 		assertUserHasPermission(permissionNames.updateCase),
 		asyncHandler(controller.postAddDocumentVersionCheckAndConfirm)
 	);

--- a/appeals/web/src/server/appeals/appeal-details/representations/final-comments/final-comments.router.js
+++ b/appeals/web/src/server/appeals/appeal-details/representations/final-comments/final-comments.router.js
@@ -12,13 +12,6 @@ import viewAndReviewFinalCommentsRouter from './view-and-review/view-and-review.
 const router = createRouter({ mergeParams: true });
 
 router.use(
-	'/:finalCommentsType',
-	validateAppeal,
-	withSingularRepresentation,
-	viewAndReviewFinalCommentsRouter
-);
-
-router.use(
 	'/:finalCommentsType/redact',
 	validateAppeal,
 	withSingularRepresentation,
@@ -34,6 +27,7 @@ router.use(
 
 router.use(
 	'/:finalCommentsType/add-document',
+	validateAppeal,
 	withSingularRepresentation,
 	getRepresentationAttachmentsFolder,
 	addDocumentRouter
@@ -41,6 +35,7 @@ router.use(
 
 router.use(
 	'/:finalCommentsType/manage-documents',
+	validateAppeal,
 	withSingularRepresentation,
 	getRepresentationAttachmentsFolder,
 	manageDocumentsRouter
@@ -51,6 +46,13 @@ router.use(
 	validateAppeal,
 	withSingularRepresentation,
 	acceptFinalCommentsRouter
+);
+
+router.use(
+	'/:finalCommentsType',
+	validateAppeal,
+	withSingularRepresentation,
+	viewAndReviewFinalCommentsRouter
 );
 
 export default router;

--- a/appeals/web/src/server/appeals/appeal-details/representations/proof-of-evidence/proof-of-evidence.router.js
+++ b/appeals/web/src/server/appeals/appeal-details/representations/proof-of-evidence/proof-of-evidence.router.js
@@ -65,14 +65,6 @@ router.use(
 );
 
 router.use(
-	'/:proofOfEvidenceType/:rule6PartyId',
-	validateAppeal,
-	validateRule6Party,
-	withSingularRepresentation,
-	viewAndReviewProofOfEvidenceRouter
-);
-
-router.use(
 	'/:proofOfEvidenceType/:rule6PartyId/accept',
 	validateAppeal,
 	validateRule6Party,
@@ -106,6 +98,14 @@ router.use(
 	withSingularRepresentation,
 	getRepresentationAttachmentsFolder,
 	manageDocumentsRouter
+);
+
+router.use(
+	'/:proofOfEvidenceType/:rule6PartyId',
+	validateAppeal,
+	validateRule6Party,
+	withSingularRepresentation,
+	viewAndReviewProofOfEvidenceRouter
 );
 
 router.use(

--- a/appeals/web/src/server/appeals/appeal-details/representations/representations.router.js
+++ b/appeals/web/src/server/appeals/appeal-details/representations/representations.router.js
@@ -2,7 +2,6 @@ import { APPEAL_REPRESENTATION_TYPE } from '@pins/appeals/constants/common.js';
 import { Router } from 'express';
 import appellantStatementRouter from './appellant-statement/appellant-statement.router.js';
 import lpaStatementRouter from './lpa-statement/lpa-statement.router.js';
-import proofOfEvidenceRouter from './proof-of-evidence/proof-of-evidence.router.js';
 import {
 	postShareRepresentations,
 	renderShareRepresentations
@@ -34,8 +33,6 @@ router.use(
 	withSingularRepresentation(APPEAL_REPRESENTATION_TYPE.RULE_6_PARTY_STATEMENT),
 	rule6PartyStatementRouter
 );
-
-router.use('/:appealId/proof-of-evidence', proofOfEvidenceRouter);
 
 router
 	.route('/share')


### PR DESCRIPTION
## Describe your changes

- Adds middleware to check appeal exists without returning data
- Throws an error if validate middleware is called more than once in a request handling chain
- Removed duplicate calls to validate appeal

## Issue ticket number and link

[Ticket](https://pins-ds.atlassian.net/browse/A2-4177)
