### PR TITLE
feat(appeals): reduce case history noise (a2-7777, a2-8089)

### DIFF
--- a/appeals/api/src/server/endpoints/integrations/integrations.controller.js
+++ b/appeals/api/src/server/endpoints/integrations/integrations.controller.js
@@ -1,7 +1,6 @@
 import config from '#config/config.js';
 import { formatAddressSingleLine } from '#endpoints/addresses/addresses.formatter.js';
 import { createAuditTrail } from '#endpoints/audit-trails/audit-trails.service.js';
-import { addDocumentAudit } from '#endpoints/documents/documents.service.js';
 import { commandMappers } from '#mappers/integration/commands/index.js';
 import { serviceUserIdStartRange } from '#mappers/integration/map-service-user-entity.js';
 import { notifySend } from '#notify/notify-send.js';
@@ -15,7 +14,6 @@ import stringTokenReplacement from '#utils/string-token-replacement.js';
 import { APPEAL_REPRESENTATION_TYPE, FEATURE_FLAG_NAMES } from '@pins/appeals/constants/common.js';
 import {
 	AUDIT_TRAIL_APPELLANT_IMPORT_MSG,
-	AUDIT_TRAIL_DOCUMENT_IMPORTED,
 	AUDIT_TRAIL_IP_UUID,
 	AUDIT_TRAIL_LPA_UUID,
 	AUDIT_TRAIL_LPAQ_IMPORT_MSG,
@@ -115,12 +113,6 @@ const importIndividualAppeal = async (data) => {
 			reference
 		);
 	}
-
-	await Promise.all(
-		documentVersions.map(async (document) => {
-			await writeDocumentAuditTrail(id, document, AUDIT_TRIAL_APPELLANT_UUID);
-		})
-	);
 
 	return { id, reference, assignedTeamId, appealTypeId };
 };
@@ -304,12 +296,6 @@ export const importIndividualLpaqSubmission = async (
 		broadcasters.broadcastAppeal(id, EventType.Update),
 		integrationService.importDocuments(documents, documentVersions)
 	]);
-
-	await Promise.all(
-		documentVersions.map(async (document) => {
-			await writeDocumentAuditTrail(id, document, AUDIT_TRAIL_LPA_UUID);
-		})
-	);
 
 	return caseData;
 };
@@ -537,24 +523,6 @@ export const importRepresentation = async (req, res) => {
 	}
 
 	return res.status(201).send(rep);
-};
-
-/**
- *
- * @param {number} appealId
- * @param {{ fileName: string|null, documentGuid: string}} document
- * @param {string} azureAdUserId
- */
-const writeDocumentAuditTrail = async (appealId, document, azureAdUserId) => {
-	const auditTrail = await createAuditTrail({
-		appealId: appealId,
-		azureAdUserId: azureAdUserId,
-		details: stringTokenReplacement(AUDIT_TRAIL_DOCUMENT_IMPORTED, [document.fileName || ''])
-	});
-
-	if (auditTrail) {
-		await addDocumentAudit(document.documentGuid, 1, auditTrail, EventType.Create);
-	}
 };
 
 /**

--- a/appeals/web/src/server/appeals/appeal-details/audit/__tests__/__snapshots__/audit.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/audit/__tests__/__snapshots__/audit.test.js.snap
@@ -32,7 +32,7 @@ exports[`audit GET /:appealId/audit should render the case history page with a r
                         </td>
                         <td class="govuk-table__cell">
                             <div class="pins-show-more" data-label="" data-mode="html" data-toggle-text-collapsed="Show more"
-                            data-toggle-text-expanded="Show less">Thise case has over 300 characters in the details field. This is a test
+                            data-toggle-text-expanded="Show less">This case has over 300 characters in the details field. This is a test
                                 to ensure that the system can handle long text entries without issues.
                                 Case progressed to <strong class="govuk-tag govuk-tag--grey">Awaiting LPA questionnaire</strong>.
                                 There should be over 300 character in this field to test the system's ability
@@ -143,6 +143,22 @@ exports[`audit GET /:appealId/audit should render the case history page with a r
                         </td>
                         <td class="govuk-table__cell">Case progressed to <strong class="govuk-tag govuk-tag--green">Ready to start</strong>
                         </td>
+                        <td class="govuk-table__cell">Smith, John</td>
+                    </tr>
+                    <tr class="govuk-table__row">
+                        <td class="govuk-table__cell">26 May 2025
+                            <br><span>10:55am</span>
+                        </td>
+                        <td class="govuk-table__cell">The <a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/1">LPA questionnaire</a> was
+                            received</td>
+                        <td class="govuk-table__cell">Smith, John</td>
+                    </tr>
+                    <tr class="govuk-table__row">
+                        <td class="govuk-table__cell">25 May 2025
+                            <br><span>10:55am</span>
+                        </td>
+                        <td class="govuk-table__cell">The <a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/">appellant case</a> was
+                            received</td>
                         <td class="govuk-table__cell">Smith, John</td>
                     </tr>
                     <tr class="govuk-table__row">

--- a/appeals/web/src/server/appeals/appeal-details/audit/__tests__/audit.test.js
+++ b/appeals/web/src/server/appeals/appeal-details/audit/__tests__/audit.test.js
@@ -1,6 +1,11 @@
 // @ts-nocheck
 import { mapEmailToRecipientType } from '#appeals/appeal-details/audit/audit.controller.js';
-import { tryMapDocument, tryMapUsers } from '#appeals/appeal-details/audit/audit.mapper.js';
+import {
+	getAppellantCaseLink,
+	getLPAQuestionnaireLink,
+	tryMapDocument,
+	tryMapUsers
+} from '#appeals/appeal-details/audit/audit.mapper.js';
 import { statusFormatMap } from '#appeals/appeal-details/representations/document-attachments/controller/redaction-status.js';
 import usersService from '#appeals/appeal-users/users-service.js';
 import {
@@ -11,7 +16,11 @@ import {
 } from '#testing/app/fixtures/referencedata.js';
 import { createTestEnvironment } from '#testing/index.js';
 import { jest } from '@jest/globals';
-import { AUDIT_TRIAL_RULE_6_PARTY_ID } from '@pins/appeals/constants/support.js';
+import {
+	AUDIT_TRAIL_APPELLANT_IMPORT_MSG,
+	AUDIT_TRAIL_LPAQ_IMPORT_MSG,
+	AUDIT_TRIAL_RULE_6_PARTY_ID
+} from '@pins/appeals/constants/support.js';
 import { parseHtml } from '@pins/platform';
 import nock from 'nock';
 import supertest from 'supertest';
@@ -50,6 +59,35 @@ describe('audit', () => {
 		usersService.getUserByRoleAndId = jest.fn().mockResolvedValue(activeDirectoryUsersData[0]);
 	});
 	afterEach(teardown);
+
+	describe('getAppellantCaseLink', () => {
+		it('should return the correct link for the appellant case', () => {
+			const appeal = { appealId: 1 };
+			const log = AUDIT_TRAIL_APPELLANT_IMPORT_MSG;
+			const result = getAppellantCaseLink(appeal, log);
+			expect(result).toBe(
+				`The <a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/">appellant case</a> was received`
+			);
+		});
+	});
+
+	describe('getLPAQuestionnaireLink', () => {
+		it('should return the correct link for the LPA questionnaire', () => {
+			const appeal = { appealId: 1, lpaQuestionnaireId: 123 };
+			const log = AUDIT_TRAIL_LPAQ_IMPORT_MSG;
+			const result = getLPAQuestionnaireLink(appeal, log);
+			expect(result).toBe(
+				`The <a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/123">LPA questionnaire</a> was received`
+			);
+		});
+
+		it('should return not use link if no lpaq id exists', () => {
+			const appeal = { appealId: 1 };
+			const log = AUDIT_TRAIL_LPAQ_IMPORT_MSG;
+			const result = getLPAQuestionnaireLink(appeal, log);
+			expect(result).toBe('The LPA questionnaire was received');
+		});
+	});
 
 	describe('tryMapDocument', () => {
 		const redactionStatusKeys = Object.keys(statusFormatMap);
@@ -136,7 +174,13 @@ describe('audit', () => {
 
 			expect(unprettifiedHtml).toContain('Case history</h1>');
 			expect(unprettifiedHtml).toContain(
-				'<td class="govuk-table__cell">Case progressed to <strong class="govuk-tag govuk-tag--green">Ready to start</strong></td>'
+				'<td class="govuk-table__cell">Case progressed to <strong class="govuk-tag govuk-tag--green">Issue decision</strong></td>'
+			);
+			expect(unprettifiedHtml).toContain(
+				'<td class="govuk-table__cell">The <a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/">appellant case</a> was received</td>'
+			);
+			expect(unprettifiedHtml).toContain(
+				'<td class="govuk-table__cell">The <a class="govuk-link" href="/appeals-service/appeal-details/1/lpa-questionnaire/1">LPA questionnaire</a> was received</td>'
 			);
 			expect(unprettifiedHtml).toContain('<td class="govuk-table__cell">Case updated</td>');
 			expect(unprettifiedHtml).toContain(

--- a/appeals/web/src/server/appeals/appeal-details/audit/audit.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/audit/audit.mapper.js
@@ -2,8 +2,10 @@ import usersService from '#appeals/appeal-users/users-service.js';
 import { mapStatusText } from '#lib/appeal-status.js';
 import { preRenderPageComponents } from '#lib/nunjucks-template-builders/page-component-rendering.js';
 import {
+	AUDIT_TRAIL_APPELLANT_IMPORT_MSG,
 	AUDIT_TRAIL_IP_UUID,
 	AUDIT_TRAIL_LPA_UUID,
+	AUDIT_TRAIL_LPAQ_IMPORT_MSG,
 	AUDIT_TRAIL_SYSTEM_UUID,
 	AUDIT_TRIAL_APPELLANT_UUID,
 	AUDIT_TRIAL_AUTOMATIC_EVENT_UUID,
@@ -31,6 +33,9 @@ export const mapMessageContent = async (appeal, log, docInfo, session, apiClient
 	if (log.toLowerCase().indexOf('document') === -1) {
 		result = await tryMapUsers(result, session, apiClient);
 	}
+
+	result = getAppellantCaseLink(appeal, result);
+	result = getLPAQuestionnaireLink(appeal, result);
 
 	result = tryMapDocumentRedactionStatus(result);
 	result = tryMapDocument(appeal.appealId, result, docInfo, appeal?.lpaQuestionnaireId || null);
@@ -77,6 +82,35 @@ export const tryMapUsers = async (log, session, apiClient) => {
 	const user = await usersService.getUserById(uuid[2], session);
 
 	return result.replace(uuid[2], user?.name || 'User not found!');
+};
+
+/**
+ * @param {import('../appeal-details.types.js').WebAppeal} appeal
+ * @param {string} log
+ * @returns {string}
+ */
+export const getAppellantCaseLink = (appeal, log) => {
+	if (log !== AUDIT_TRAIL_APPELLANT_IMPORT_MSG) return log;
+
+	return AUDIT_TRAIL_APPELLANT_IMPORT_MSG.replace(
+		'appellant case',
+		`<a class="govuk-link" href="/appeals-service/appeal-details/${appeal.appealId}/appellant-case/">appellant case</a>`
+	);
+};
+
+/**
+ * @param {import('../appeal-details.types.js').WebAppeal} appeal
+ * @param {string} log
+ * @returns {string}
+ */
+export const getLPAQuestionnaireLink = (appeal, log) => {
+	if (log !== AUDIT_TRAIL_LPAQ_IMPORT_MSG) return log;
+	if (!appeal.lpaQuestionnaireId) return log;
+
+	return AUDIT_TRAIL_LPAQ_IMPORT_MSG.replace(
+		'LPA questionnaire',
+		`<a class="govuk-link" href="/appeals-service/appeal-details/${appeal.appealId}/lpa-questionnaire/${appeal.lpaQuestionnaireId}">LPA questionnaire</a>`
+	);
 };
 
 /**

--- a/appeals/web/testing/app/fixtures/referencedata.js
+++ b/appeals/web/testing/app/fixtures/referencedata.js
@@ -5042,8 +5042,18 @@ export const designatedSiteNames = [
 export const caseAuditLog = [
 	{
 		azureAdUserId: activeDirectoryUsersData[0].id,
+		details: 'The appellant case was received',
+		loggedDate: '2025-05-25T09:55:30.175Z'
+	},
+	{
+		azureAdUserId: activeDirectoryUsersData[0].id,
+		details: 'The LPA questionnaire was received',
+		loggedDate: '2025-05-26T09:55:30.175Z'
+	},
+	{
+		azureAdUserId: activeDirectoryUsersData[0].id,
 		details:
-			"Thise case has over 300 characters in the details field. This is a test to ensure that the system can handle long text entries without issues. Case progressed to awaiting_lpa_questionnaire. There should be over 300 character in this field to test the system's ability to handle long text entries without truncation or errors. - it should show the show more compoonent",
+			"This case has over 300 characters in the details field. This is a test to ensure that the system can handle long text entries without issues. Case progressed to awaiting_lpa_questionnaire. There should be over 300 character in this field to test the system's ability to handle long text entries without truncation or errors. - it should show the show more compoonent",
 		loggedDate: '2025-05-27T09:55:30.175Z'
 	},
 	{


### PR DESCRIPTION
## Describe your changes

- Stops every document in appellant case/lpaq submissions from having a separate entry in case history
- Instead links the main record to the page to view what has come in

## Issue ticket number and link

https://pins-ds.atlassian.net/browse/a2-7777
https://pins-ds.atlassian.net/browse/a2-8089
