### PR TITLE
fix(infrastructure): fix for function processing

### DIFF
--- a/infrastructure/function-doc-processing.tf
+++ b/infrastructure/function-doc-processing.tf
@@ -21,11 +21,11 @@ module "function_doc_processing" {
   # networking
   integration_subnet_id      = azurerm_subnet.apps.id
   outbound_vnet_connectivity = true
-  inbound_vnet_connectivity  = true
-  private_endpoint = {
-    private_dns_zone_id = data.azurerm_private_dns_zone.app_service.id
-    subnet_id           = azurerm_subnet.main.id
-  }
+  # inbound_vnet_connectivity  = true
+  # private_endpoint = {
+  #   private_dns_zone_id = data.azurerm_private_dns_zone.app_service.id
+  #   subnet_id           = azurerm_subnet.main.id
+  # }
 
   # monitoring
   action_group_ids            = local.action_group_ids


### PR DESCRIPTION
## Describe your changes

Turning on private endpoints and inbound connectivity cause `pins-func-appeals-bo-doc-processing-` to stop working. Those changes were reversed but not in main branch. As the previous changes are in main, this could cause issues if branching from main for a later change. 

It may also be worth exploring this setting 

`resolution_policy     = "NxDomainRedirect"` 
for 
`resource "azurerm_private_dns_zone_virtual_network_link"`


## Issue ticket number and link

[Ticket](<!--Paste your ticket link here-->)
