### PR TITLE
fix(infrastructure): adding resolution_policy for blob private dns zone vnet link (no-ticket)

### DIFF
--- a/infrastructure/networking.tf
+++ b/infrastructure/networking.tf
@@ -228,6 +228,7 @@ resource "azurerm_private_dns_zone_virtual_network_link" "storage" {
   resource_group_name   = var.tooling_config.network_rg
   private_dns_zone_name = data.azurerm_private_dns_zone.storage.name
   virtual_network_id    = azurerm_virtual_network.main.id
+  resolution_policy     = "NxDomainRedirect"
 
   provider = azurerm.tooling
 }


### PR DESCRIPTION
## Describe your changes

Adding resolution policy to enable fall back to internet for private DNS Zone linked to virtual network.

To is to resolve below error:
When application tries accessing a doc storage, it may get `getaddrinfo ENOTFOUND` error. As DNS cannot be resolved within environment vnet
