### PR TITLE
fix(api): ensure lpaCostsAppliedFor is update when cost documents are added 

### DIFF
--- a/appeals/api/src/server/endpoints/documents/__tests__/documents.test.js
+++ b/appeals/api/src/server/endpoints/documents/__tests__/documents.test.js
@@ -730,5 +730,42 @@ describe('appeals documents', () => {
 				expect(mockBroadcasters.broadcastAppeal).toHaveBeenCalledWith(appealId);
 			}
 		);
+
+		test('sets document visibility for lpa costs', async () => {
+			let appealId = 1;
+			await controller.updateDocumentVisibilityBooleans(
+				[APPEAL_DOCUMENT_TYPE.LPA_COSTS_APPLICATION],
+				appealId,
+				123,
+				true
+			);
+
+			expect(databaseConnector.lPAQuestionnaire.update).toHaveBeenCalledWith({
+				data: {
+					lpaCostsAppliedFor: true
+				},
+				where: { appealId }
+			});
+
+			expect(mockBroadcasters.broadcastAppeal).toHaveBeenCalledWith(appealId);
+
+			appealId++;
+
+			await controller.updateDocumentVisibilityBooleans(
+				[APPEAL_DOCUMENT_TYPE.LPA_COSTS_APPLICATION],
+				appealId,
+				123,
+				false
+			);
+
+			expect(databaseConnector.lPAQuestionnaire.update).toHaveBeenCalledWith({
+				data: {
+					lpaCostsAppliedFor: false
+				},
+				where: { appealId }
+			});
+
+			expect(mockBroadcasters.broadcastAppeal).toHaveBeenCalledWith(appealId);
+		});
 	});
 });

--- a/appeals/api/src/server/endpoints/documents/documents.controller.js
+++ b/appeals/api/src/server/endpoints/documents/documents.controller.js
@@ -19,6 +19,7 @@ import { sendNewDecisionLetter } from '#endpoints/decision/decision.service.js';
 import { broadcasters } from '#endpoints/integrations/integrations.broadcasters.js';
 import appellantCaseRepository from '#repositories/appellant-case.repository.js';
 import * as documentRepository from '#repositories/document.repository.js';
+import lpaQuestionnaireRepository from '#repositories/lpa-questionnaire.repository.js';
 import logger from '#utils/logger.js';
 import stringTokenReplacement from '#utils/string-token-replacement.js';
 import { updatePersonalList } from '#utils/update-personal-list.js';
@@ -569,8 +570,19 @@ export const updateDocumentVisibilityBooleans = async (
 	const appellantCostApplicationDocument = documentTypes.includes(
 		APPEAL_DOCUMENT_TYPE.APPELLANT_COSTS_APPLICATION
 	);
+	const lpaCostApplicationDocument = documentTypes.includes(
+		APPEAL_DOCUMENT_TYPE.LPA_COSTS_APPLICATION
+	);
 
-	if (!(changedDevelopmentDescriptionDocument || appellantCostApplicationDocument)) return;
+	if (
+		!(
+			changedDevelopmentDescriptionDocument ||
+			appellantCostApplicationDocument ||
+			lpaCostApplicationDocument
+		)
+	) {
+		return;
+	}
 
 	if (changedDevelopmentDescriptionDocument) {
 		await setDocumentVisibilityBoolean(
@@ -588,6 +600,12 @@ export const updateDocumentVisibilityBooleans = async (
 			'appellantCostsAppliedFor',
 			visible
 		);
+	}
+
+	if (lpaCostApplicationDocument && appealId) {
+		// if adding or removing an LPA cost document, then set lpaCostsAppliedFor accordingly
+		await lpaQuestionnaireRepository.updateLpaCostsAppliedFor(appealId, visible);
+		await broadcasters.broadcastAppeal(appealId);
 	}
 };
 

--- a/appeals/api/src/server/repositories/lpa-questionnaire.repository.js
+++ b/appeals/api/src/server/repositories/lpa-questionnaire.repository.js
@@ -114,6 +114,20 @@ const updateLPAQuestionnaireById = (id, data) => {
 };
 
 /**
+ * @param {number} appealId
+ * @param {boolean} visible
+ * @returns {Promise<object>}
+ */
+const updateLpaCostsAppliedFor = (appealId, visible) => {
+	return databaseConnector.lPAQuestionnaire.update({
+		where: { appealId },
+		data: {
+			lpaCostsAppliedFor: visible
+		}
+	});
+};
+
+/**
  * @param {number} id
  * @param {LpaQuestionnaireUpdateRequest} data
  * @param {any[]} transaction
@@ -185,4 +199,4 @@ function processDesignatedSites(id, data, transaction) {
 	}
 }
 
-export default { updateLPAQuestionnaireById };
+export default { updateLPAQuestionnaireById, updateLpaCostsAppliedFor };


### PR DESCRIPTION
## Describe your changes

A data issue was identified when testing programme appeals. The lpaCostsAppliedFor field was never updated, even though there is a row to add documents to. The equivalent appellant was implemented correctly, so the pattern has been followed.

**NOTE** This has not been tested locally other than with unit tests, as I do not have document upload functionality setup locally.

## Issue ticket number and link

https://pins-ds.atlassian.net/browse/A2-8333
